### PR TITLE
chore: ask for lib/Node/npm versions in parser issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
+++ b/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
@@ -3,16 +3,23 @@ name: '@typescript-eslint/parser'
 about: Report an issue with the @typescript-eslint/parser package
 ---
 
-**What version of TypeScript are you using?**
+**What version of Node.js and npm are you using?**
 
-**What version of `@typescript-eslint/parser` are you using?**
+- Node: <!-- Please fill in -->
+- npm: <!-- Please fill in -->
+
+**What version of the following packages are you using?**
+
+- @typescript-eslint/parser: <!-- Please fill in -->
+- TypeScript: <!-- Please fill in -->
+- ESLint: <!-- Please fill in -->
 
 **What code were you trying to parse?**
 
 ```ts
-// Put your code here
+// Please put code here
 ```
 
 **What did you expect to happen?**
 
-**What happened?**
+**What actually happened?**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "precommit": "yarn test && lint-staged",
     "cz": "git-cz",
     "commitmsg": "commitlint -E GIT_PARAMS",
-    "check-format": "prettier --list-different \"./**/*.{ts,js,json,md}\""
+    "check-format": "prettier --list-different \"./**/*.{ts,js,json,md}\"",
+    "format": "prettier --write \"./**/*.{ts,js,json,md}\""
   },
   "lint-staged": {
     "*.{ts,js,json,md}": [


### PR DESCRIPTION
Thought this could yield useful information up front so that maintainers have to spend less time chasing down this info if it's relevant.