### PR TITLE
feat(parser): use monorepo typescript-estree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ script:
   # TODO: Reenable after migrations are complete
   # - commitlint-travis
   - yarn check-format
-  - yarn test
   - yarn build
+  - yarn test
   # TODO: Reimplement automated integration-tests from typescript-eslint-parser
   # for the monorepo, after the migrations are complete
   # yarn integration-tests

--- a/packages/typescript-eslint-parser/package.json
+++ b/packages/typescript-eslint-parser/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "eslint-scope": "^4.0.0",
     "eslint-visitor-keys": "^1.0.0",
-    "typescript-estree": "18.0.0"
+    "typescript-estree": "18.1.0"
   },
   "devDependencies": {
     "@types/eslint": "^4.16.5",

--- a/packages/typescript-eslint-parser/tests/lib/__snapshots__/javascript.ts.snap
+++ b/packages/typescript-eslint-parser/tests/lib/__snapshots__/javascript.ts.snap
@@ -74502,7 +74502,6 @@ Object {
       "type": "ExpressionStatement",
     },
     Object {
-      "directive": "abc",
       "expression": Object {
         "loc": Object {
           "end": Object {
@@ -76058,6 +76057,7 @@ Object {
       "type": "ExpressionStatement",
     },
     Object {
+      "directive": "use strict",
       "expression": Object {
         "loc": Object {
           "end": Object {

--- a/packages/typescript-eslint-parser/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-eslint-parser/tests/lib/__snapshots__/typescript.ts.snap
@@ -716,18 +716,18 @@ Object {
               "key": Object {
                 "loc": Object {
                   "end": Object {
-                    "column": 12,
+                    "column": 24,
                     "line": 2,
                   },
                   "start": Object {
-                    "column": 4,
+                    "column": 13,
                     "line": 2,
                   },
                 },
                 "name": "constructor",
                 "range": Array [
-                  43,
-                  51,
+                  52,
+                  63,
                 ],
                 "type": "Identifier",
               },
@@ -9360,18 +9360,18 @@ Object {
             "key": Object {
               "loc": Object {
                 "end": Object {
-                  "column": 11,
+                  "column": 23,
                   "line": 2,
                 },
                 "start": Object {
-                  "column": 2,
+                  "column": 12,
                   "line": 2,
                 },
               },
               "name": "constructor",
               "range": Array [
-                12,
-                21,
+                22,
+                33,
               ],
               "type": "Identifier",
             },
@@ -9993,6 +9993,40 @@ Object {
                 23,
                 37,
               ],
+              "returnType": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 15,
+                    "line": 2,
+                  },
+                },
+                "range": Array [
+                  25,
+                  33,
+                ],
+                "type": "TSTypeAnnotation",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 23,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 17,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    27,
+                    33,
+                  ],
+                  "type": "TSNumberKeyword",
+                },
+              },
               "type": "FunctionExpression",
             },
           },
@@ -10626,6 +10660,60 @@ Object {
                 32,
               ],
               "type": "FunctionExpression",
+              "typeParameters": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 16,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 13,
+                    "line": 2,
+                  },
+                },
+                "params": Array [
+                  Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 15,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 14,
+                        "line": 2,
+                      },
+                    },
+                    "name": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 15,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 14,
+                          "line": 2,
+                        },
+                      },
+                      "name": "T",
+                      "range": Array [
+                        24,
+                        25,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      24,
+                      25,
+                    ],
+                    "type": "TSTypeParameter",
+                  },
+                ],
+                "range": Array [
+                  23,
+                  26,
+                ],
+                "type": "TSTypeParameterDeclaration",
+              },
             },
           },
           Object {
@@ -14768,7 +14856,7 @@ Object {
           },
           "loc": Object {
             "end": Object {
-              "column": 24,
+              "column": 27,
               "line": 1,
             },
             "start": Object {
@@ -14778,7 +14866,7 @@ Object {
           },
           "range": Array [
             21,
-            24,
+            27,
           ],
           "type": "TSClassImplements",
           "typeParameters": Object {
@@ -15101,7 +15189,7 @@ Object {
           },
           "loc": Object {
             "end": Object {
-              "column": 24,
+              "column": 30,
               "line": 1,
             },
             "start": Object {
@@ -15111,7 +15199,7 @@ Object {
           },
           "range": Array [
             21,
-            24,
+            30,
           ],
           "type": "TSClassImplements",
           "typeParameters": Object {
@@ -51397,7 +51485,7 @@ Object {
           },
           "loc": Object {
             "end": Object {
-              "column": 28,
+              "column": 31,
               "line": 1,
             },
             "start": Object {
@@ -51407,7 +51495,7 @@ Object {
           },
           "range": Array [
             25,
-            28,
+            31,
           ],
           "type": "TSInterfaceHeritage",
           "typeParameters": Object {
@@ -57869,7 +57957,7 @@ Object {
                   "type": "Literal",
                   "value": "constructor",
                 },
-                "kind": "constructor",
+                "kind": "init",
                 "loc": Object {
                   "end": Object {
                     "column": 3,
@@ -57887,6 +57975,60 @@ Object {
                 ],
                 "shorthand": false,
                 "type": "Property",
+                "typeParameters": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 18,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 15,
+                      "line": 2,
+                    },
+                  },
+                  "params": Array [
+                    Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 17,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 16,
+                          "line": 2,
+                        },
+                      },
+                      "name": Object {
+                        "loc": Object {
+                          "end": Object {
+                            "column": 17,
+                            "line": 2,
+                          },
+                          "start": Object {
+                            "column": 16,
+                            "line": 2,
+                          },
+                        },
+                        "name": "T",
+                        "range": Array [
+                          30,
+                          31,
+                        ],
+                        "type": "Identifier",
+                      },
+                      "range": Array [
+                        30,
+                        31,
+                      ],
+                      "type": "TSTypeParameter",
+                    },
+                  ],
+                  "range": Array [
+                    29,
+                    32,
+                  ],
+                  "type": "TSTypeParameterDeclaration",
+                },
                 "value": Object {
                   "async": false,
                   "body": Object {
@@ -57997,60 +58139,6 @@ Object {
                     },
                   },
                   "type": "FunctionExpression",
-                  "typeParameters": Object {
-                    "loc": Object {
-                      "end": Object {
-                        "column": 18,
-                        "line": 2,
-                      },
-                      "start": Object {
-                        "column": 15,
-                        "line": 2,
-                      },
-                    },
-                    "params": Array [
-                      Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 17,
-                            "line": 2,
-                          },
-                          "start": Object {
-                            "column": 16,
-                            "line": 2,
-                          },
-                        },
-                        "name": Object {
-                          "loc": Object {
-                            "end": Object {
-                              "column": 17,
-                              "line": 2,
-                            },
-                            "start": Object {
-                              "column": 16,
-                              "line": 2,
-                            },
-                          },
-                          "name": "T",
-                          "range": Array [
-                            30,
-                            31,
-                          ],
-                          "type": "Identifier",
-                        },
-                        "range": Array [
-                          30,
-                          31,
-                        ],
-                        "type": "TSTypeParameter",
-                      },
-                    ],
-                    "range": Array [
-                      29,
-                      32,
-                    ],
-                    "type": "TSTypeParameterDeclaration",
-                  },
                 },
               },
               Object {
@@ -58091,6 +58179,60 @@ Object {
                 ],
                 "shorthand": false,
                 "type": "Property",
+                "typeParameters": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 8,
+                      "line": 5,
+                    },
+                    "start": Object {
+                      "column": 5,
+                      "line": 5,
+                    },
+                  },
+                  "params": Array [
+                    Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 7,
+                          "line": 5,
+                        },
+                        "start": Object {
+                          "column": 6,
+                          "line": 5,
+                        },
+                      },
+                      "name": Object {
+                        "loc": Object {
+                          "end": Object {
+                            "column": 7,
+                            "line": 5,
+                          },
+                          "start": Object {
+                            "column": 6,
+                            "line": 5,
+                          },
+                        },
+                        "name": "T",
+                        "range": Array [
+                          69,
+                          70,
+                        ],
+                        "type": "Identifier",
+                      },
+                      "range": Array [
+                        69,
+                        70,
+                      ],
+                      "type": "TSTypeParameter",
+                    },
+                  ],
+                  "range": Array [
+                    68,
+                    71,
+                  ],
+                  "type": "TSTypeParameterDeclaration",
+                },
                 "value": Object {
                   "async": false,
                   "body": Object {
@@ -58201,60 +58343,6 @@ Object {
                     },
                   },
                   "type": "FunctionExpression",
-                  "typeParameters": Object {
-                    "loc": Object {
-                      "end": Object {
-                        "column": 8,
-                        "line": 5,
-                      },
-                      "start": Object {
-                        "column": 5,
-                        "line": 5,
-                      },
-                    },
-                    "params": Array [
-                      Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 7,
-                            "line": 5,
-                          },
-                          "start": Object {
-                            "column": 6,
-                            "line": 5,
-                          },
-                        },
-                        "name": Object {
-                          "loc": Object {
-                            "end": Object {
-                              "column": 7,
-                              "line": 5,
-                            },
-                            "start": Object {
-                              "column": 6,
-                              "line": 5,
-                            },
-                          },
-                          "name": "T",
-                          "range": Array [
-                            69,
-                            70,
-                          ],
-                          "type": "Identifier",
-                        },
-                        "range": Array [
-                          69,
-                          70,
-                        ],
-                        "type": "TSTypeParameter",
-                      },
-                    ],
-                    "range": Array [
-                      68,
-                      71,
-                    ],
-                    "type": "TSTypeParameterDeclaration",
-                  },
                 },
               },
               Object {

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -2,7 +2,7 @@
   "name": "typescript-estree",
   "description": "A parser that converts TypeScript source code into an ESTree compatible form",
   "main": "dist/parser.js",
-  "version": "0.0.0-development",
+  "version": "18.1.0",
   "files": [
     "dist",
     "README.md",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6806,14 +6806,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-estree@18.0.0:
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-estree/-/typescript-estree-18.0.0.tgz#a309f6c6502c64d74b3f88c205d871a9af0b1d40"
-  integrity sha512-HxTWrzFyYOPWA91Ij7xL9mNUVpGTKLH2KiaBn28CMbYgX2zgWdJqU9hO7Are+pAPAqY91NxAYoaAyDDZ3rLj2A==
-  dependencies:
-    lodash.unescape "4.0.1"
-    semver "5.5.0"
-
 typescript@~3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"


### PR DESCRIPTION
Start of the "proper" monorepo!

I've verified this works with local rebuilds, make a change in typescript-estree, rebuild and it retriggers the test watcher of tyepscript-eslint-parser, for example.