### PR TITLE
chore(typescript-estree): update type annotation in index signature

### DIFF
--- a/packages/typescript-eslint-parser/src/visitor-keys.ts
+++ b/packages/typescript-eslint-parser/src/visitor-keys.ts
@@ -76,7 +76,7 @@ export const visitorKeys = eslintVisitorKeys.unionWith({
   TSLiteralType: ['literal'],
   TSIntersectionType: ['types'],
   TSIndexedAccessType: ['indexType', 'objectType'],
-  TSIndexSignature: ['typeAnnotation', 'parameters'],
+  TSIndexSignature: ['parameters', 'typeAnnotation'],
   TSInterfaceBody: ['body'],
   TSInterfaceDeclaration: ['id', 'typeParameters', 'extends', 'body'],
   TSInterfaceHeritage: ['expression', 'typeParameters'],

--- a/packages/typescript-eslint-parser/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-eslint-parser/tests/lib/__snapshots__/typescript.ts.snap
@@ -110090,7 +110090,6 @@ Object {
               27,
             ],
             "type": "TSIndexSignature",
-            "typeAnnotation": null,
           },
         ],
         "range": Array [

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -282,7 +282,7 @@ export default function convert(config: ConvertConfig): ESTreeNode | null {
       return [];
     }
     return parameters.map(param => {
-      const convertedParam = convertChild(param) as ESTreeNode;
+      const convertedParam = convertChild(param)!;
       if (!param.decorators || !param.decorators.length) {
         return convertedParam;
       }
@@ -1881,8 +1881,8 @@ export default function convert(config: ConvertConfig): ESTreeNode | null {
     case SyntaxKind.JsxFragment:
       Object.assign(result, {
         type: AST_NODE_TYPES.JSXFragment,
-        openingFragment: convertChild((node as ts.JsxFragment).openingFragment),
-        closingFragment: convertChild((node as ts.JsxFragment).closingFragment),
+        openingFragment: convertChild(node.openingFragment),
+        closingFragment: convertChild(node.closingFragment),
         children: node.children.map(convertChild)
       });
       break;
@@ -2248,9 +2248,12 @@ export default function convert(config: ConvertConfig): ESTreeNode | null {
     case SyntaxKind.IndexSignature: {
       Object.assign(result, {
         type: AST_NODE_TYPES.TSIndexSignature,
-        parameters: node.parameters.map(convertChild),
-        typeAnnotation: node.type ? convertTypeAnnotation(node.type) : null
+        parameters: node.parameters.map(convertChild)
       });
+
+      if (node.type) {
+        result.typeAnnotation = convertTypeAnnotation(node.type);
+      }
 
       if (hasModifier(SyntaxKind.ReadonlyKeyword, node)) {
         result.readonly = true;

--- a/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
@@ -109676,7 +109676,6 @@ Object {
               27,
             ],
             "type": "TSIndexSignature",
-            "typeAnnotation": null,
           },
         ],
         "range": Array [


### PR DESCRIPTION
This PR corrects order of visiting properties in `TSIndexSignature` and makes `typeAnnotation` property undefined when node is not present