### PR TITLE
feat(parser): validate options passed to parser

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -32,7 +32,7 @@ By far the most common case will be installing the [@typescript-eslint/eslint-pl
 
 The following additional configuration options are available by specifying them in [`parserOptions`](https://eslint.org/docs/user-guide/configuring#specifying-parser-options) in your ESLint configuration file.
 
-- **`jsx`** - default `false`. Enable parsing JSX when `true`. More details can be found [here](https://www.typescriptlang.org/docs/handbook/jsx.html).
+- **`ecmaFeatures.jsx`** - default `false`. Enable parsing JSX when `true`. More details can be found [here](https://www.typescriptlang.org/docs/handbook/jsx.html).
 
   - It's `false` on `*.ts` files regardless of this option.
   - It's `true` on `*.tsx` files regardless of this option.
@@ -46,7 +46,9 @@ The following additional configuration options are available by specifying them 
 {
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "jsx": true,
+    "ecmaFeatures": {
+      "jsx": true
+    },
     "useJSXTextNode": true
   }
 }

--- a/packages/parser/src/parser-options.ts
+++ b/packages/parser/src/parser-options.ts
@@ -1,17 +1,20 @@
 export interface ParserOptions {
-  useJSXTextNode?: boolean;
-  loc?: true;
-  range?: true;
-  tokens?: true;
-  filePath?: string;
+  loc?: boolean;
+  comment?: boolean;
+  range?: boolean;
+  tokens?: boolean;
   sourceType?: 'script' | 'module';
   ecmaVersion?: number;
   ecmaFeatures?: {
     globalReturn?: boolean;
+    jsx?: boolean;
   };
-  /**
-   * @deprecated We should finalize the work from
-   * https://github.com/eslint/typescript-eslint-parser#595
-   */
-  jsx?: boolean;
+  // ts-estree specific
+  filePath?: string;
+  project?: string | string[];
+  useJSXTextNode?: boolean;
+  errorOnUnknownASTType?: boolean;
+  errorOnTypeScriptSyntacticAndSemanticIssues?: boolean;
+  tsconfigRootDir?: string;
+  extraFileExtensions?: string[];
 }

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -1,5 +1,9 @@
 import traverser from 'eslint/lib/util/traverser';
-import * as typescriptESTree from '@typescript-eslint/typescript-estree';
+import {
+  AST_NODE_TYPES,
+  parseAndGenerateServices,
+  ParserOptions as ParserOptionsTsESTree
+} from '@typescript-eslint/typescript-estree';
 import { analyzeScope } from './analyze-scope';
 import { ParserOptions } from './parser-options';
 import { visitorKeys } from './visitor-keys';
@@ -20,52 +24,88 @@ interface ParseForESLintResult {
   scopeManager: ReturnType<typeof analyzeScope>;
 }
 
+function validateBoolean(
+  value: boolean | undefined,
+  fallback: boolean = false
+): boolean {
+  if (typeof value !== 'boolean') {
+    return fallback;
+  }
+  return value;
+}
+
+//------------------------------------------------------------------------------
+// Public
+//------------------------------------------------------------------------------
+
 export const version = packageJSON.version;
+
+export const Syntax = Object.freeze(AST_NODE_TYPES);
 
 export function parse(code: string, options?: ParserOptions) {
   return parseForESLint(code, options).ast;
 }
 
-export const Syntax = Object.freeze(typescriptESTree.AST_NODE_TYPES);
-
-export function parseForESLint<T extends ParserOptions = ParserOptions>(
+export function parseForESLint(
   code: string,
-  options?: T | null
+  options?: ParserOptions | null
 ): ParseForESLintResult {
-  if (typeof options !== 'object' || options === null) {
-    options = { useJSXTextNode: true } as T;
-  } else if (typeof options.useJSXTextNode !== 'boolean') {
-    options = Object.assign({}, options, { useJSXTextNode: true });
+  if (!options || typeof options !== 'object') {
+    options = {};
   }
-  if (typeof options.filePath === 'string') {
-    const tsx = options.filePath.endsWith('.tsx');
-    if (tsx || options.filePath.endsWith('.ts')) {
-      options = Object.assign({}, options, { jsx: tsx });
-    }
-  }
-
   // https://eslint.org/docs/user-guide/configuring#specifying-parser-options
   // if sourceType is not provided by default eslint expect that it will be set to "script"
-  options.sourceType = options.sourceType || 'script';
   if (options.sourceType !== 'module' && options.sourceType !== 'script') {
     options.sourceType = 'script';
   }
+  if (typeof options.ecmaFeatures !== 'object') {
+    options.ecmaFeatures = {};
+  }
 
-  const { ast, services } = typescriptESTree.parseAndGenerateServices(
-    code,
-    options
-  );
+  const parserOptions: ParserOptionsTsESTree = {
+    useJSXTextNode: validateBoolean(options.useJSXTextNode, true),
+    range: validateBoolean(options.range, true), // TODO: this option is ignored by typescript-estree
+    loc: validateBoolean(options.loc, true), // TODO: this option is ignored by typescript-estree
+    tokens: validateBoolean(options.tokens, true),
+    jsx: validateBoolean(options.ecmaFeatures.jsx),
+    comment: validateBoolean(options.comment, true),
+    errorOnUnknownASTType: validateBoolean(options.errorOnUnknownASTType),
+    errorOnTypeScriptSyntacticAndSemanticIssues: validateBoolean(
+      options.errorOnTypeScriptSyntacticAndSemanticIssues
+    )
+  };
+
+  if (options.project) {
+    parserOptions.project = options.project;
+  }
+
+  if (typeof options.tsconfigRootDir === 'string') {
+    parserOptions.tsconfigRootDir = options.tsconfigRootDir;
+  }
+
+  if (options.extraFileExtensions) {
+    parserOptions.extraFileExtensions = options.extraFileExtensions;
+  }
+
+  if (typeof options.filePath === 'string') {
+    parserOptions.filePath = options.filePath;
+
+    const tsx = options.filePath.endsWith('.tsx');
+    if (tsx || options.filePath.endsWith('.ts')) {
+      parserOptions.jsx = tsx;
+    }
+  }
+
+  const { ast, services } = parseAndGenerateServices(code, parserOptions);
   ast.sourceType = options.sourceType;
 
   traverser.traverse(ast, {
-    enter: (node: any) => {
+    enter(node: any) {
       switch (node.type) {
         // Function#body cannot be null in ESTree spec.
         case 'FunctionExpression':
           if (!node.body) {
-            node.type = `TSEmptyBody${
-              node.type
-            }` as typescriptESTree.AST_NODE_TYPES;
+            node.type = `TSEmptyBody${node.type}` as AST_NODE_TYPES;
           }
           break;
         // no default

--- a/packages/parser/tests/lib/comments.ts
+++ b/packages/parser/tests/lib/comments.ts
@@ -15,8 +15,10 @@ describe('Comments', () => {
   testFiles.forEach(filename => {
     const code = fs.readFileSync(filename, 'utf8');
     const config: ParserOptions = {
-      jsx: true,
-      sourceType: 'module'
+      sourceType: 'module',
+      ecmaFeatures: {
+        jsx: true
+      }
     };
     it(
       testUtils.formatSnapshotName(filename, FIXTURES_DIR),

--- a/packages/parser/tests/lib/jsx.ts
+++ b/packages/parser/tests/lib/jsx.ts
@@ -28,7 +28,9 @@ describe('JSX', () => {
       const code = fs.readFileSync(filename, 'utf8');
       const config = {
         useJSXTextNode,
-        jsx: true
+        ecmaFeatures: {
+          jsx: true
+        }
       };
       it(
         testUtils.formatSnapshotName(filename, fixturesDir),

--- a/packages/parser/tests/lib/parser.ts
+++ b/packages/parser/tests/lib/parser.ts
@@ -1,5 +1,6 @@
 import * as typescriptESTree from '@typescript-eslint/typescript-estree';
 import { parse, parseForESLint, Syntax } from '../../src/parser';
+import * as scope from '../../src/analyze-scope';
 
 describe('parser', () => {
   it('parse() should return just the AST from parseForESLint()', () => {
@@ -15,10 +16,21 @@ describe('parser', () => {
   it('parseForESLint() should set the sourceType to script, if an invalid one is provided', () => {
     const code = 'const valid = true;';
     const spy = jest.spyOn(typescriptESTree, 'parseAndGenerateServices');
+    const spyScope = jest.spyOn(scope, 'analyzeScope');
     parseForESLint(code, { sourceType: 'foo' as any });
     expect(spy).toHaveBeenCalledWith(code, {
-      sourceType: 'script',
+      comment: true,
+      errorOnTypeScriptSyntacticAndSemanticIssues: false,
+      errorOnUnknownASTType: false,
+      jsx: false,
+      loc: true,
+      range: true,
+      tokens: true,
       useJSXTextNode: true
+    });
+    expect(spyScope).toHaveBeenCalledWith(jasmine.any(Object), {
+      ecmaFeatures: {},
+      sourceType: 'script'
     });
   });
 

--- a/packages/parser/tests/lib/tsx.ts
+++ b/packages/parser/tests/lib/tsx.ts
@@ -17,7 +17,9 @@ describe('TSX', () => {
     const code = fs.readFileSync(filename, 'utf8');
     const config = {
       useJSXTextNode: true,
-      jsx: true
+      ecmaFeatures: {
+        jsx: true
+      }
     };
     it(
       testUtils.formatSnapshotName(filename, FIXTURES_DIR, '.tsx'),
@@ -53,7 +55,9 @@ describe('TSX', () => {
       const config = {
         parser: '@typescript-eslint/parser',
         parserOptions: {
-          jsx: true
+          ecmaFeatures: {
+            jsx: true
+          }
         }
       };
       const messages = linter.verify(code, config);
@@ -85,7 +89,9 @@ describe('TSX', () => {
       const config = {
         parser: '@typescript-eslint/parser',
         parserOptions: {
-          jsx: true
+          ecmaFeatures: {
+            jsx: true
+          }
         }
       };
       const messages = linter.verify(code, config, { filename: 'test.ts' });
@@ -117,7 +123,9 @@ describe('TSX', () => {
       const config = {
         parser: '@typescript-eslint/parser',
         parserOptions: {
-          jsx: false
+          ecmaFeatures: {
+            jsx: false
+          }
         }
       };
       const messages = linter.verify(code, config, { filename: 'test.tsx' });

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -350,10 +350,7 @@ function generateAST<T extends ParserOptions = ParserOptions>(
 // Public
 //------------------------------------------------------------------------------
 
-export { AST_NODE_TYPES } from './ast-node-types';
-export { version };
-
-const version = packageJSON.version;
+export const version: string = packageJSON.version;
 
 export function parse<T extends ParserOptions = ParserOptions>(
   code: string,
@@ -378,3 +375,6 @@ export function parseAndGenerateServices(code: string, options: ParserOptions) {
     }
   };
 }
+
+export { AST_NODE_TYPES } from './ast-node-types';
+export { ParserOptions };


### PR DESCRIPTION
This PR contains changes from https://github.com/eslint/typescript-eslint-parser/pull/595 and adds validation for options passed to parser


fixes: https://github.com/eslint/typescript-eslint-parser/issues/594
fixes: https://github.com/typescript-eslint/typescript-eslint/issues/24