### PR TITLE
fix(eslint-plugin): no-unused-vars: mark declared statements as used

### DIFF
--- a/packages/eslint-plugin/lib/rules/no-unused-vars.js
+++ b/packages/eslint-plugin/lib/rules/no-unused-vars.js
@@ -62,6 +62,9 @@ module.exports = Object.assign({}, baseRule, {
       },
       'TSEnumMember Identifier'(node) {
         context.markVariableAsUsed(node.name);
+      },
+      '*[declare=true] Identifier'(node) {
+        context.markVariableAsUsed(node.name);
       }
     });
   }

--- a/packages/eslint-plugin/tests/lib/rules/no-unused-vars.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-unused-vars.js
@@ -525,6 +525,22 @@ import * as fastify from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 const server: fastify.FastifyInstance<Server, IncomingMessage, ServerResponse> = fastify({})
 server.get('/ping')
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/61
+    `declare function foo();`,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/61
+    `
+declare namespace Foo {
+    function bar(line: string, index: number | null, tabSize: number): number;
+    var baz: string;
+}
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/61
+    `
+declare var Foo: {
+    new (value?: any): Object,
+    foo(): string
+}
     `
   ],
 


### PR DESCRIPTION
This PR adds logic to mark all declared Identifiers used for `no-unused-vars`

fixes: #61