### PR TITLE
fix(eslint-plugin): fix crash in rule indent for eslint 5.12.1

### DIFF
--- a/packages/eslint-plugin/lib/rules/indent.js
+++ b/packages/eslint-plugin/lib/rules/indent.js
@@ -101,7 +101,8 @@ module.exports = Object.assign({}, baseRule, {
       url: util.metaDocsUrl('indent')
     },
     fixable: 'whitespace',
-    schema: baseRule.meta.schema
+    schema: baseRule.meta.schema,
+    messages: baseRule.meta.messages
   },
 
   create(context) {

--- a/packages/eslint-plugin/lib/rules/no-unused-vars.js
+++ b/packages/eslint-plugin/lib/rules/no-unused-vars.js
@@ -21,7 +21,8 @@ module.exports = Object.assign({}, baseRule, {
       url: util.metaDocsUrl('no-unused-vars'),
       recommended: 'warn'
     },
-    schema: baseRule.meta.schema
+    schema: baseRule.meta.schema,
+    messages: baseRule.meta.messages
   },
 
   create(context) {


### PR DESCRIPTION
This PR fixes crash of indent rule when used with eslint 5.12.11 and makes sure that `no-unused-vars` has messages copied from parent rule (not used yet)

this is related to https://github.com/eslint/eslint/pull/10773

fixes: #80
fixes: #96