### PR TITLE
fix(eslint-plugin): improve detection of used vars in heritage

### DIFF
--- a/packages/eslint-plugin/lib/rules/no-unused-vars.js
+++ b/packages/eslint-plugin/lib/rules/no-unused-vars.js
@@ -75,12 +75,12 @@ module.exports = Object.assign({}, baseRule, {
       },
       TSInterfaceHeritage(node) {
         if (node.expression) {
-          markHeritageAsUsed(node.expression)
+          markHeritageAsUsed(node.expression);
         }
       },
       TSClassImplements(node) {
         if (node.expression) {
-          markHeritageAsUsed(node.expression)
+          markHeritageAsUsed(node.expression);
         }
       },
       'TSParameterProperty Identifier'(node) {

--- a/packages/eslint-plugin/lib/rules/no-unused-vars.js
+++ b/packages/eslint-plugin/lib/rules/no-unused-vars.js
@@ -45,6 +45,25 @@ module.exports = Object.assign({}, baseRule, {
       }
     }
 
+    /**
+     * Mark heritage clause as used
+     * @param node The node currently being traversed
+     * @returns {void}
+     */
+    function markHeritageAsUsed(node) {
+      switch (node.type) {
+        case 'Identifier':
+          context.markVariableAsUsed(node.name);
+          break;
+        case 'MemberExpression':
+          markHeritageAsUsed(node.object);
+          break;
+        case 'CallExpression':
+          markHeritageAsUsed(node.callee);
+          break;
+      }
+    }
+
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
@@ -54,8 +73,15 @@ module.exports = Object.assign({}, baseRule, {
       'TSTypeReference Identifier'(node) {
         context.markVariableAsUsed(node.name);
       },
-      'TSClassImplements Identifier'(node) {
-        context.markVariableAsUsed(node.name);
+      TSInterfaceHeritage(node) {
+        if (node.expression) {
+          markHeritageAsUsed(node.expression)
+        }
+      },
+      TSClassImplements(node) {
+        if (node.expression) {
+          markHeritageAsUsed(node.expression)
+        }
       },
       'TSParameterProperty Identifier'(node) {
         // just assume parameter properties are used

--- a/packages/eslint-plugin/tests/lib/rules/no-unused-vars.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-unused-vars.js
@@ -541,6 +541,15 @@ declare var Foo: {
     new (value?: any): Object,
     foo(): string
 }
+    `,
+    `
+import foo from 'foo';
+export interface Bar extends foo.i18n {}
+    `,
+    `
+import foo from 'foo';
+import bar from 'foo';
+export interface Bar extends foo.i18n<bar> {}
     `
   ],
 
@@ -761,6 +770,62 @@ enum FormFieldIds {
           message: "'FormFieldIds' is defined but never used.",
           line: 2,
           column: 6
+        }
+      ]
+    },
+    {
+      code: `
+import test from 'test';
+import baz from 'baz';
+export interface Bar extends baz.test {}
+    `,
+      errors: [
+        {
+          message: "'test' is defined but never used.",
+          line: 2,
+          column: 8
+        }
+      ]
+    },
+    {
+      code: `
+import test from 'test';
+import baz from 'baz';
+export interface Bar extends baz().test {}
+    `,
+      errors: [
+        {
+          message: "'test' is defined but never used.",
+          line: 2,
+          column: 8
+        }
+      ]
+    },
+    {
+      code: `
+import test from 'test';
+import baz from 'baz';
+export class Bar implements baz.test {}
+    `,
+      errors: [
+        {
+          message: "'test' is defined but never used.",
+          line: 2,
+          column: 8
+        }
+      ]
+    },
+    {
+      code: `
+import test from 'test';
+import baz from 'baz';
+export class Bar implements baz().test {}
+    `,
+      errors: [
+        {
+          message: "'test' is defined but never used.",
+          line: 2,
+          column: 8
         }
       ]
     }


### PR DESCRIPTION
This PR fixes issue with heritage clause in classes and interfaces, it also reduces possible false possitives from class heritage when used as MemberExpression 

fixes: #45