### PR TITLE
docs(eslint-plugin): add docs on using Prettier with the plugin

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -82,7 +82,7 @@ Install [`eslint-config-prettier`](https://github.com/prettier/eslint-config-pre
 }
 ```
 
-*Note: Make sure you have `eslint-config-prettier@4.0.0` or newer.*
+**Note: Make sure you have `eslint-config-prettier@4.0.0` or newer.**
 
 ## Supported Rules
 


### PR DESCRIPTION
~BLOCKED on `eslint-config-prettier@4` being released.~