### PR TITLE
fix(eslint-plugin): don’t mark `declare class` as unused

### DIFF
--- a/packages/eslint-plugin/lib/rules/no-unused-vars.js
+++ b/packages/eslint-plugin/lib/rules/no-unused-vars.js
@@ -92,6 +92,12 @@ module.exports = Object.assign({}, baseRule, {
       },
       '*[declare=true] Identifier'(node) {
         context.markVariableAsUsed(node.name);
+        const scope = context.getScope();
+        const { variableScope } = scope;
+        if (variableScope !== scope) {
+          const superVar = variableScope.set.get(node.name);
+          if (superVar) superVar.eslintUsed = true;
+        }
       }
     });
   }

--- a/packages/eslint-plugin/tests/lib/rules/no-unused-vars.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-unused-vars.js
@@ -542,6 +542,13 @@ declare var Foo: {
     foo(): string
 }
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/106
+    `
+declare class Foo {
+    constructor(value?: any): Object;
+    foo(): string;
+}
+    `,
     `
 import foo from 'foo';
 export interface Bar extends foo.i18n {}


### PR DESCRIPTION
Fixes #106.