### PR TITLE
fix(typescript-estree): fix range of assignment in parameter

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1318,6 +1318,12 @@ export default function convert(config: ConvertConfig): ESTreeNode | null {
           left: parameter,
           right: convertChild(node.initializer)
         });
+
+        if (node.modifiers) {
+          // AssignmentPattern should not contain modifiers in range
+          result.range[0] = parameter.range[0];
+          result.loc = getLocFor(result.range[0], result.range[1], ast);
+        }
       } else {
         parameter = result = convert({
           node: node.name,

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -161,7 +161,7 @@ export function hasModifier(
  * @param node TypeScript AST node
  * @returns returns last modifier if present or null
  */
-export function getLastModifier(node: ts.Node): ts.Node | null {
+export function getLastModifier(node: ts.Node): ts.Modifier | null {
   return (
     (!!node.modifiers &&
       !!node.modifiers.length &&

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -342,15 +342,6 @@ tester.addFixturePatternConfig('typescript/basics', {
     'abstract-class-with-optional-method', // babel parse errors
     'declare-class-with-optional-method', // babel parse errors
     /**
-     * Was expected to be fixed by PR into Babel: https://github.com/babel/babel/pull/9284
-     * But not fixed in Babel 7.3
-     * TODO: Investigate differences
-     */
-    'class-with-private-parameter-properties',
-    'class-with-protected-parameter-properties',
-    'class-with-public-parameter-properties',
-    'class-with-readonly-parameter-properties',
-    /**
      * Was expected to be fixed by PR into Babel: https://github.com/babel/babel/pull/9302
      * But not fixed in Babel 7.3
      * TODO: Investigate differences

--- a/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
@@ -21291,12 +21291,12 @@ Object {
                         "line": 4,
                       },
                       "start": Object {
-                        "column": 14,
+                        "column": 22,
                         "line": 4,
                       },
                     },
                     "range": Array [
-                      116,
+                      124,
                       140,
                     ],
                     "right": Object {
@@ -21397,12 +21397,12 @@ Object {
                         "line": 5,
                       },
                       "start": Object {
-                        "column": 14,
+                        "column": 31,
                         "line": 5,
                       },
                     },
                     "range": Array [
-                      156,
+                      173,
                       197,
                     ],
                     "right": Object {
@@ -24408,12 +24408,12 @@ Object {
                         "line": 4,
                       },
                       "start": Object {
-                        "column": 14,
+                        "column": 24,
                         "line": 4,
                       },
                     },
                     "range": Array [
-                      120,
+                      130,
                       146,
                     ],
                     "right": Object {
@@ -24514,12 +24514,12 @@ Object {
                         "line": 5,
                       },
                       "start": Object {
-                        "column": 14,
+                        "column": 33,
                         "line": 5,
                       },
                     },
                     "range": Array [
-                      162,
+                      181,
                       205,
                     ],
                     "right": Object {
@@ -25533,12 +25533,12 @@ Object {
                         "line": 4,
                       },
                       "start": Object {
-                        "column": 14,
+                        "column": 21,
                         "line": 4,
                       },
                     },
                     "range": Array [
-                      114,
+                      121,
                       137,
                     ],
                     "right": Object {
@@ -25639,12 +25639,12 @@ Object {
                         "line": 5,
                       },
                       "start": Object {
-                        "column": 14,
+                        "column": 30,
                         "line": 5,
                       },
                     },
                     "range": Array [
-                      153,
+                      169,
                       193,
                     ],
                     "right": Object {
@@ -26586,12 +26586,12 @@ Object {
                         "line": 3,
                       },
                       "start": Object {
-                        "column": 14,
+                        "column": 23,
                         "line": 3,
                       },
                     },
                     "range": Array [
-                      68,
+                      77,
                       103,
                     ],
                     "right": Object {


### PR DESCRIPTION
This PR fixes issues with modifiers range beeing included into `AssignmentPattern` in parameter property
modifiers in this case are attached to `TSParameterProperty`

https://github.com/typescript-eslint/typescript-eslint/pull/114#discussion_r249599511