### PR TITLE
chore: add vscode shared config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,5 @@ typings/
 .next
 
 .DS_Store
-.vscode
 .idea
 dist

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+      "esbenp.prettier-vscode",
+      "dbaeumer.vscode-eslint",
+      "editorconfig.editorconfig"
+  ],
+  "unwantedRecommendations": ["hookyqr.beautify", "dbaeumer.jshint"]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "type": "node",
+          "request": "launch",
+          "name": "Mocha Current Plugin File",
+          "cwd": "${workspaceFolder}/packages/eslint-plugin/",
+          "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+          "args": [
+              "--colors",
+              "${workspaceFolder}/packages/eslint-plugin/tests/lib/rules/${fileBasename}"
+          ],
+          "console": "integratedTerminal",
+          "internalConsoleOptions": "neverOpen"
+      }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       {
           "type": "node",
           "request": "launch",
-          "name": "Mocha Current Plugin File",
+          "name": "Jest Test Current eslint-plugin Rule",
           "cwd": "${workspaceFolder}/packages/eslint-plugin/",
           "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
           "args": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+
+{
+  // An array of language ids which should be validated by ESLint
+  "eslint.validate": [
+      "javascript",
+      "javascriptreact",
+      {
+          "language": "typescript",
+          "autoFix": true
+      },
+      {
+          "language": "typescriptreact",
+          "autoFix": true
+      }
+  ],
+
+  // When enabled, will trim trailing whitespace when saving a file.
+  "files.trimTrailingWhitespace": true,
+
+  // typescript auto-format settings
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "javascript.preferences.importModuleSpecifier": "auto",
+  "typescript.preferences.importModuleSpecifier": "auto",
+  "javascript.preferences.quoteStyle": "single",
+  "typescript.preferences.quoteStyle": "single"
+}


### PR DESCRIPTION
- add a launch config for debugging the plugin: runs the test for the currently opened file.
- add shared config to make sure everyone's eslint plugin works correctly, and to correctly setup the typescript env
- add extension config to help tell users about what extensions work well with this codebase:
  - recommend plugins:
    - eslint
    - editorconfig
    - prettier
  - advise against:
    - beautify
    - jshint