### PR TITLE
chore(eslint-plugin): add tsutils as dependency

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@typescript-eslint/parser": "1.1.1",
-    "requireindex": "^1.2.0"
+    "requireindex": "^1.2.0",
+    "tsutils": "^3.7.0"
   },
   "devDependencies": {
     "eslint": "^5.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7025,6 +7025,13 @@ tsutils@^2.27.2:
   dependencies:
     tslib "^1.8.1"
 
+tsutils@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.7.0.tgz#f97bdd2f109070bd1865467183e015b25734b477"
+  integrity sha512-n+e+3q7Jx2kfZw7tjfI9axEIWBY0sFMOlC+1K70X0SeXpO/UYSB+PN+E9tIJNqViB7oiXQdqD7dNchnvoneZew==
+  dependencies:
+    tslib "^1.8.1"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"


### PR DESCRIPTION
Managed to forget to add `tsutils` as a true dependency to `eslint-plugin` in #157.