### PR TITLE
fix(eslint-plugin): fix no-extraneous-class for class without name

### DIFF
--- a/packages/eslint-plugin/lib/rules/no-extraneous-class.js
+++ b/packages/eslint-plugin/lib/rules/no-extraneous-class.js
@@ -68,7 +68,10 @@ module.exports = {
 
         if (node.body.length === 0) {
           if (allowEmpty) return;
-          context.report({ node: id, messageId: 'empty' });
+          context.report({
+            node: id || node.parent,
+            messageId: 'empty'
+          });
           return;
         }
 
@@ -97,14 +100,17 @@ module.exports = {
         if (onlyConstructor) {
           if (!allowConstructorOnly) {
             context.report({
-              node: id,
+              node: id || node.parent,
               messageId: 'onlyConstructor'
             });
           }
           return;
         }
         if (onlyStatic && !allowStaticOnly) {
-          context.report({ node: id, messageId: 'onlyStatic' });
+          context.report({
+            node: id || node.parent,
+            messageId: 'onlyStatic'
+          });
         }
       }
     };

--- a/packages/eslint-plugin/tests/lib/rules/no-extraneous-class.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-extraneous-class.js
@@ -70,7 +70,9 @@ export class Bar {
 }
 `.trim(),
       options: [{ allowStaticOnly: true }]
-    }
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/170
+    'export default class { hello() { return "I am foo!"; } }'
   ],
 
   invalid: [
@@ -117,9 +119,13 @@ export class AClass {
         }
     }
 }
-
 `.trim(),
       errors: [onlyStatic, empty]
+    },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/170
+      code: 'export default class { static hello() {} }',
+      errors: [{ messageId: 'onlyStatic', type: 'ClassDeclaration' }]
     }
   ]
 });


### PR DESCRIPTION
This PR fixes crash of `no-extraneous-class` rule with classes without name.

fixes: #170