### PR TITLE
test(eslint-plugin): add test case for eslint arrow-parens

### DIFF
--- a/packages/eslint-plugin/tests/lib/eslint-rules/arrow-parens.js
+++ b/packages/eslint-plugin/tests/lib/eslint-rules/arrow-parens.js
@@ -21,23 +21,23 @@ ruleTester.run('arrow-parens', rule, {
     'const foo = function <T>(t: T) {};',
     {
       code: 'const foo = t => {};',
-      options: ["as-needed"]
+      options: ['as-needed']
     },
     {
       code: 'const foo = <T>(t) => {};',
-      options: ["as-needed"]
+      options: ['as-needed']
     },
     {
       code: 'const foo = (t: T) => {};',
-      options: ["as-needed"]
+      options: ['as-needed']
     },
     {
       code: 'const foo = <T>(t: T) => {};',
-      options: ["as-needed"]
+      options: ['as-needed']
     },
     {
       code: 'const foo = <T>(t: T) => ({});',
-      options: ["as-needed", { requireForBlockBody: true }]
+      options: ['as-needed', { requireForBlockBody: true }]
     }
   ],
   invalid: []

--- a/packages/eslint-plugin/tests/lib/eslint-rules/arrow-parens.js
+++ b/packages/eslint-plugin/tests/lib/eslint-rules/arrow-parens.js
@@ -1,0 +1,44 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('eslint/lib/rules/arrow-parens'),
+  RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser'
+});
+
+ruleTester.run('arrow-parens', rule, {
+  valid: [
+    // https://github.com/typescript-eslint/typescript-eslint/issues/14
+    'const foo = (t) => {};',
+    'const foo = <T>(t) => {};',
+    'const foo = <T>(t: T) => {};',
+    'const foo = <T>((t: T) => {});',
+    'const foo = function <T>(t: T) {};',
+    {
+      code: 'const foo = t => {};',
+      options: ["as-needed"]
+    },
+    {
+      code: 'const foo = <T>(t) => {};',
+      options: ["as-needed"]
+    },
+    {
+      code: 'const foo = (t: T) => {};',
+      options: ["as-needed"]
+    },
+    {
+      code: 'const foo = <T>(t: T) => {};',
+      options: ["as-needed"]
+    },
+    {
+      code: 'const foo = <T>(t: T) => ({});',
+      options: ["as-needed", { requireForBlockBody: true }]
+    }
+  ],
+  invalid: []
+});


### PR DESCRIPTION
Regression test for eslint `arrow-parens` rule.

fixes: #14