### PR TITLE
fix(eslint-plugin): fix wrong URL

### DIFF
--- a/packages/eslint-plugin/lib/util.js
+++ b/packages/eslint-plugin/lib/util.js
@@ -5,7 +5,7 @@ const version = require('../package.json').version;
 exports.tslintRule = name => `\`${name}\` from TSLint`;
 
 exports.metaDocsUrl = name =>
-  `https://github.com/typescript-eslint/typescript-eslint/blob/${version}/packages/eslint-plugin/docs/rules/${name}.md`;
+  `https://github.com/typescript-eslint/typescript-eslint/blob/v${version}/packages/eslint-plugin/docs/rules/${name}.md`;
 
 /**
  * Check if the context file name is *.ts or *.tsx


### PR DESCRIPTION
I have found the `metaDocsUrl` is wrong while creating an online playground. This PR fixes it.