### PR TITLE
test(ts-estree): add test for parsing nested jsx tag names

### DIFF
--- a/packages/parser/tests/lib/__snapshots__/jsx.ts.snap
+++ b/packages/parser/tests/lib/__snapshots__/jsx.ts.snap
@@ -9463,6 +9463,1722 @@ Object {
 }
 `;
 
+exports[`JSX useJSXTextNode: false fixtures/tag-names-with-multi-dots-multi.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "expression": Object {
+        "children": Array [
+          Object {
+            "loc": Object {
+              "end": Object {
+                "column": 2,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 13,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              13,
+              16,
+            ],
+            "raw": "
+  ",
+            "type": "Literal",
+            "value": "
+  ",
+          },
+          Object {
+            "children": Array [],
+            "closingElement": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 57,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 29,
+                  "line": 2,
+                },
+              },
+              "name": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 56,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 31,
+                    "line": 2,
+                  },
+                },
+                "object": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 49,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 31,
+                      "line": 2,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 41,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 31,
+                        "line": 2,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 35,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 31,
+                          "line": 2,
+                        },
+                      },
+                      "range": Array [
+                        45,
+                        49,
+                      ],
+                      "type": "ThisExpression",
+                    },
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 41,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 36,
+                          "line": 2,
+                        },
+                      },
+                      "name": "const",
+                      "range": Array [
+                        50,
+                        55,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      45,
+                      55,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 49,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 42,
+                        "line": 2,
+                      },
+                    },
+                    "name": "declare",
+                    "range": Array [
+                      56,
+                      63,
+                    ],
+                    "type": "JSXIdentifier",
+                  },
+                  "range": Array [
+                    45,
+                    63,
+                  ],
+                  "type": "JSXMemberExpression",
+                },
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 56,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 50,
+                      "line": 2,
+                    },
+                  },
+                  "name": "static",
+                  "range": Array [
+                    64,
+                    70,
+                  ],
+                  "type": "JSXIdentifier",
+                },
+                "range": Array [
+                  45,
+                  70,
+                ],
+                "type": "JSXMemberExpression",
+              },
+              "range": Array [
+                43,
+                71,
+              ],
+              "type": "JSXClosingElement",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 57,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 2,
+              },
+            },
+            "openingElement": Object {
+              "attributes": Array [],
+              "loc": Object {
+                "end": Object {
+                  "column": 29,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 2,
+                },
+              },
+              "name": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 28,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 2,
+                  },
+                },
+                "object": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 21,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 2,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 13,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 2,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 7,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 3,
+                          "line": 2,
+                        },
+                      },
+                      "range": Array [
+                        17,
+                        21,
+                      ],
+                      "type": "ThisExpression",
+                    },
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 13,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 8,
+                          "line": 2,
+                        },
+                      },
+                      "name": "const",
+                      "range": Array [
+                        22,
+                        27,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      17,
+                      27,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 21,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 14,
+                        "line": 2,
+                      },
+                    },
+                    "name": "declare",
+                    "range": Array [
+                      28,
+                      35,
+                    ],
+                    "type": "JSXIdentifier",
+                  },
+                  "range": Array [
+                    17,
+                    35,
+                  ],
+                  "type": "JSXMemberExpression",
+                },
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 28,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 22,
+                      "line": 2,
+                    },
+                  },
+                  "name": "static",
+                  "range": Array [
+                    36,
+                    42,
+                  ],
+                  "type": "JSXIdentifier",
+                },
+                "range": Array [
+                  17,
+                  42,
+                ],
+                "type": "JSXMemberExpression",
+              },
+              "range": Array [
+                16,
+                43,
+              ],
+              "selfClosing": false,
+              "type": "JSXOpeningElement",
+            },
+            "range": Array [
+              16,
+              71,
+            ],
+            "type": "JSXElement",
+          },
+          Object {
+            "loc": Object {
+              "end": Object {
+                "column": 0,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 57,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              71,
+              72,
+            ],
+            "raw": "
+",
+            "type": "Literal",
+            "value": "
+",
+          },
+        ],
+        "closingElement": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 14,
+              "line": 3,
+            },
+            "start": Object {
+              "column": 0,
+              "line": 3,
+            },
+          },
+          "name": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 13,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 3,
+              },
+            },
+            "object": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 11,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 3,
+                },
+              },
+              "object": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 9,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 2,
+                    "line": 3,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 7,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "column": 2,
+                      "line": 3,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 5,
+                        "line": 3,
+                      },
+                      "start": Object {
+                        "column": 2,
+                        "line": 3,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 3,
+                          "line": 3,
+                        },
+                        "start": Object {
+                          "column": 2,
+                          "line": 3,
+                        },
+                      },
+                      "name": "a",
+                      "range": Array [
+                        74,
+                        75,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 5,
+                          "line": 3,
+                        },
+                        "start": Object {
+                          "column": 4,
+                          "line": 3,
+                        },
+                      },
+                      "name": "b",
+                      "range": Array [
+                        76,
+                        77,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      74,
+                      77,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 7,
+                        "line": 3,
+                      },
+                      "start": Object {
+                        "column": 6,
+                        "line": 3,
+                      },
+                    },
+                    "name": "c",
+                    "range": Array [
+                      78,
+                      79,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    74,
+                    79,
+                  ],
+                  "type": "MemberExpression",
+                },
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 9,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "column": 8,
+                      "line": 3,
+                    },
+                  },
+                  "name": "d",
+                  "range": Array [
+                    80,
+                    81,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  74,
+                  81,
+                ],
+                "type": "MemberExpression",
+              },
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 11,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 10,
+                    "line": 3,
+                  },
+                },
+                "name": "e",
+                "range": Array [
+                  82,
+                  83,
+                ],
+                "type": "JSXIdentifier",
+              },
+              "range": Array [
+                74,
+                83,
+              ],
+              "type": "JSXMemberExpression",
+            },
+            "property": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 13,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 12,
+                  "line": 3,
+                },
+              },
+              "name": "f",
+              "range": Array [
+                84,
+                85,
+              ],
+              "type": "JSXIdentifier",
+            },
+            "range": Array [
+              74,
+              85,
+            ],
+            "type": "JSXMemberExpression",
+          },
+          "range": Array [
+            72,
+            86,
+          ],
+          "type": "JSXClosingElement",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 14,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "openingElement": Object {
+          "attributes": Array [],
+          "loc": Object {
+            "end": Object {
+              "column": 13,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "name": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 12,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 1,
+                "line": 1,
+              },
+            },
+            "object": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 10,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                },
+              },
+              "object": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 8,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 1,
+                    "line": 1,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 6,
+                      "line": 1,
+                    },
+                    "start": Object {
+                      "column": 1,
+                      "line": 1,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 4,
+                        "line": 1,
+                      },
+                      "start": Object {
+                        "column": 1,
+                        "line": 1,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 2,
+                          "line": 1,
+                        },
+                        "start": Object {
+                          "column": 1,
+                          "line": 1,
+                        },
+                      },
+                      "name": "a",
+                      "range": Array [
+                        1,
+                        2,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 4,
+                          "line": 1,
+                        },
+                        "start": Object {
+                          "column": 3,
+                          "line": 1,
+                        },
+                      },
+                      "name": "b",
+                      "range": Array [
+                        3,
+                        4,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      1,
+                      4,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 6,
+                        "line": 1,
+                      },
+                      "start": Object {
+                        "column": 5,
+                        "line": 1,
+                      },
+                    },
+                    "name": "c",
+                    "range": Array [
+                      5,
+                      6,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    1,
+                    6,
+                  ],
+                  "type": "MemberExpression",
+                },
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 8,
+                      "line": 1,
+                    },
+                    "start": Object {
+                      "column": 7,
+                      "line": 1,
+                    },
+                  },
+                  "name": "d",
+                  "range": Array [
+                    7,
+                    8,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  1,
+                  8,
+                ],
+                "type": "MemberExpression",
+              },
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 10,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 9,
+                    "line": 1,
+                  },
+                },
+                "name": "e",
+                "range": Array [
+                  9,
+                  10,
+                ],
+                "type": "JSXIdentifier",
+              },
+              "range": Array [
+                1,
+                10,
+              ],
+              "type": "JSXMemberExpression",
+            },
+            "property": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 12,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 11,
+                  "line": 1,
+                },
+              },
+              "name": "f",
+              "range": Array [
+                11,
+                12,
+              ],
+              "type": "JSXIdentifier",
+            },
+            "range": Array [
+              1,
+              12,
+            ],
+            "type": "JSXMemberExpression",
+          },
+          "range": Array [
+            0,
+            13,
+          ],
+          "selfClosing": false,
+          "type": "JSXOpeningElement",
+        },
+        "range": Array [
+          0,
+          86,
+        ],
+        "type": "JSXElement",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        87,
+      ],
+      "type": "ExpressionStatement",
+    },
+  ],
+  "comments": Array [],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 4,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    88,
+  ],
+  "sourceType": "module",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        1,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 2,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        1,
+        2,
+      ],
+      "type": "JSXIdentifier",
+      "value": "a",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        2,
+        3,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        3,
+        4,
+      ],
+      "type": "JSXIdentifier",
+      "value": "b",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        4,
+        5,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        6,
+      ],
+      "type": "JSXIdentifier",
+      "value": "c",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        6,
+        7,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        7,
+        8,
+      ],
+      "type": "JSXIdentifier",
+      "value": "d",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        8,
+        9,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        10,
+      ],
+      "type": "JSXIdentifier",
+      "value": "e",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        10,
+        11,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        11,
+        12,
+      ],
+      "type": "JSXIdentifier",
+      "value": "f",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        12,
+        13,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 2,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        13,
+        16,
+      ],
+      "type": "JSXText",
+      "value": "
+  ",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        16,
+        17,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        17,
+        21,
+      ],
+      "type": "Keyword",
+      "value": "this",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        21,
+        22,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        22,
+        27,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        27,
+        28,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        28,
+        35,
+      ],
+      "type": "Keyword",
+      "value": "declare",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        35,
+        36,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 28,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        36,
+        42,
+      ],
+      "type": "Keyword",
+      "value": "static",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 29,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 28,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        42,
+        43,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 30,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 29,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        43,
+        44,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 31,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        44,
+        45,
+      ],
+      "type": "Punctuator",
+      "value": "/",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 35,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 31,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        45,
+        49,
+      ],
+      "type": "Keyword",
+      "value": "this",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 36,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        49,
+        50,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 41,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 36,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        50,
+        55,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 42,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 41,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        55,
+        56,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 49,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 42,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        56,
+        63,
+      ],
+      "type": "Keyword",
+      "value": "declare",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 50,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 49,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        63,
+        64,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 56,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 50,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        64,
+        70,
+      ],
+      "type": "Keyword",
+      "value": "static",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 57,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 56,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        70,
+        71,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 0,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 57,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        71,
+        72,
+      ],
+      "type": "JSXText",
+      "value": "
+",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        72,
+        73,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 2,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        73,
+        74,
+      ],
+      "type": "Punctuator",
+      "value": "/",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        74,
+        75,
+      ],
+      "type": "JSXIdentifier",
+      "value": "a",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        75,
+        76,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        76,
+        77,
+      ],
+      "type": "JSXIdentifier",
+      "value": "b",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        77,
+        78,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        78,
+        79,
+      ],
+      "type": "JSXIdentifier",
+      "value": "c",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        79,
+        80,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        80,
+        81,
+      ],
+      "type": "JSXIdentifier",
+      "value": "d",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        81,
+        82,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        82,
+        83,
+      ],
+      "type": "JSXIdentifier",
+      "value": "e",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        83,
+        84,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        84,
+        85,
+      ],
+      "type": "JSXIdentifier",
+      "value": "f",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        85,
+        86,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        86,
+        87,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`JSX useJSXTextNode: false fixtures/test-content.src 1`] = `
 Object {
   "body": Array [

--- a/packages/shared-fixtures/fixtures/jsx/tag-names-with-multi-dots-multi.src.js
+++ b/packages/shared-fixtures/fixtures/jsx/tag-names-with-multi-dots-multi.src.js
@@ -1,0 +1,3 @@
+<a.b.c.d.e.f>
+  <this.const.declare.static></this.const.declare.static>
+</a.b.c.d.e.f>;

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -284,7 +284,12 @@ tester.addFixturePatternConfig('javascript/unicodeCodePointEscapes');
 /* ================================================== */
 
 tester.addFixturePatternConfig('jsx', {
-  ignore: jsxFilesWithKnownIssues
+  ignore: jsxFilesWithKnownIssues.concat([
+    /**
+     * ts-estree: nested jsx tag names are not correctly converted
+     */
+    'tag-names-with-multi-dots-multi'
+  ])
 });
 tester.addFixturePatternConfig('jsx-useJSXTextNode');
 

--- a/packages/typescript-estree/tests/lib/__snapshots__/jsx.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/jsx.ts.snap
@@ -9423,6 +9423,1721 @@ Object {
 }
 `;
 
+exports[`JSX useJSXTextNode: false fixtures/tag-names-with-multi-dots-multi.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "expression": Object {
+        "children": Array [
+          Object {
+            "loc": Object {
+              "end": Object {
+                "column": 2,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 13,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              13,
+              16,
+            ],
+            "raw": "
+  ",
+            "type": "Literal",
+            "value": "
+  ",
+          },
+          Object {
+            "children": Array [],
+            "closingElement": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 57,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 29,
+                  "line": 2,
+                },
+              },
+              "name": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 56,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 31,
+                    "line": 2,
+                  },
+                },
+                "object": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 49,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 31,
+                      "line": 2,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 41,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 31,
+                        "line": 2,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 35,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 31,
+                          "line": 2,
+                        },
+                      },
+                      "range": Array [
+                        45,
+                        49,
+                      ],
+                      "type": "ThisExpression",
+                    },
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 41,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 36,
+                          "line": 2,
+                        },
+                      },
+                      "name": "const",
+                      "range": Array [
+                        50,
+                        55,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      45,
+                      55,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 49,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 42,
+                        "line": 2,
+                      },
+                    },
+                    "name": "declare",
+                    "range": Array [
+                      56,
+                      63,
+                    ],
+                    "type": "JSXIdentifier",
+                  },
+                  "range": Array [
+                    45,
+                    63,
+                  ],
+                  "type": "JSXMemberExpression",
+                },
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 56,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 50,
+                      "line": 2,
+                    },
+                  },
+                  "name": "static",
+                  "range": Array [
+                    64,
+                    70,
+                  ],
+                  "type": "JSXIdentifier",
+                },
+                "range": Array [
+                  45,
+                  70,
+                ],
+                "type": "JSXMemberExpression",
+              },
+              "range": Array [
+                43,
+                71,
+              ],
+              "type": "JSXClosingElement",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 57,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 2,
+              },
+            },
+            "openingElement": Object {
+              "attributes": Array [],
+              "loc": Object {
+                "end": Object {
+                  "column": 29,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 2,
+                },
+              },
+              "name": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 28,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 2,
+                  },
+                },
+                "object": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 21,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 2,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 13,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 2,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 7,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 3,
+                          "line": 2,
+                        },
+                      },
+                      "range": Array [
+                        17,
+                        21,
+                      ],
+                      "type": "ThisExpression",
+                    },
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 13,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 8,
+                          "line": 2,
+                        },
+                      },
+                      "name": "const",
+                      "range": Array [
+                        22,
+                        27,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      17,
+                      27,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 21,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 14,
+                        "line": 2,
+                      },
+                    },
+                    "name": "declare",
+                    "range": Array [
+                      28,
+                      35,
+                    ],
+                    "type": "JSXIdentifier",
+                  },
+                  "range": Array [
+                    17,
+                    35,
+                  ],
+                  "type": "JSXMemberExpression",
+                },
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 28,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 22,
+                      "line": 2,
+                    },
+                  },
+                  "name": "static",
+                  "range": Array [
+                    36,
+                    42,
+                  ],
+                  "type": "JSXIdentifier",
+                },
+                "range": Array [
+                  17,
+                  42,
+                ],
+                "type": "JSXMemberExpression",
+              },
+              "range": Array [
+                16,
+                43,
+              ],
+              "selfClosing": false,
+              "type": "JSXOpeningElement",
+            },
+            "range": Array [
+              16,
+              71,
+            ],
+            "type": "JSXElement",
+          },
+          Object {
+            "loc": Object {
+              "end": Object {
+                "column": 0,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 57,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              71,
+              72,
+            ],
+            "raw": "
+",
+            "type": "Literal",
+            "value": "
+",
+          },
+        ],
+        "closingElement": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 14,
+              "line": 3,
+            },
+            "start": Object {
+              "column": 0,
+              "line": 3,
+            },
+          },
+          "name": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 13,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 3,
+              },
+            },
+            "object": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 11,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 3,
+                },
+              },
+              "object": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 9,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 2,
+                    "line": 3,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 7,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "column": 2,
+                      "line": 3,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 5,
+                        "line": 3,
+                      },
+                      "start": Object {
+                        "column": 2,
+                        "line": 3,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 3,
+                          "line": 3,
+                        },
+                        "start": Object {
+                          "column": 2,
+                          "line": 3,
+                        },
+                      },
+                      "name": "a",
+                      "range": Array [
+                        74,
+                        75,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 5,
+                          "line": 3,
+                        },
+                        "start": Object {
+                          "column": 4,
+                          "line": 3,
+                        },
+                      },
+                      "name": "b",
+                      "range": Array [
+                        76,
+                        77,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      74,
+                      77,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 7,
+                        "line": 3,
+                      },
+                      "start": Object {
+                        "column": 6,
+                        "line": 3,
+                      },
+                    },
+                    "name": "c",
+                    "range": Array [
+                      78,
+                      79,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    74,
+                    79,
+                  ],
+                  "type": "MemberExpression",
+                },
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 9,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "column": 8,
+                      "line": 3,
+                    },
+                  },
+                  "name": "d",
+                  "range": Array [
+                    80,
+                    81,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  74,
+                  81,
+                ],
+                "type": "MemberExpression",
+              },
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 11,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 10,
+                    "line": 3,
+                  },
+                },
+                "name": "e",
+                "range": Array [
+                  82,
+                  83,
+                ],
+                "type": "JSXIdentifier",
+              },
+              "range": Array [
+                74,
+                83,
+              ],
+              "type": "JSXMemberExpression",
+            },
+            "property": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 13,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 12,
+                  "line": 3,
+                },
+              },
+              "name": "f",
+              "range": Array [
+                84,
+                85,
+              ],
+              "type": "JSXIdentifier",
+            },
+            "range": Array [
+              74,
+              85,
+            ],
+            "type": "JSXMemberExpression",
+          },
+          "range": Array [
+            72,
+            86,
+          ],
+          "type": "JSXClosingElement",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 14,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "openingElement": Object {
+          "attributes": Array [],
+          "loc": Object {
+            "end": Object {
+              "column": 13,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "name": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 12,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 1,
+                "line": 1,
+              },
+            },
+            "object": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 10,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 1,
+                  "line": 1,
+                },
+              },
+              "object": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 8,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 1,
+                    "line": 1,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 6,
+                      "line": 1,
+                    },
+                    "start": Object {
+                      "column": 1,
+                      "line": 1,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 4,
+                        "line": 1,
+                      },
+                      "start": Object {
+                        "column": 1,
+                        "line": 1,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 2,
+                          "line": 1,
+                        },
+                        "start": Object {
+                          "column": 1,
+                          "line": 1,
+                        },
+                      },
+                      "name": "a",
+                      "range": Array [
+                        1,
+                        2,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 4,
+                          "line": 1,
+                        },
+                        "start": Object {
+                          "column": 3,
+                          "line": 1,
+                        },
+                      },
+                      "name": "b",
+                      "range": Array [
+                        3,
+                        4,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      1,
+                      4,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 6,
+                        "line": 1,
+                      },
+                      "start": Object {
+                        "column": 5,
+                        "line": 1,
+                      },
+                    },
+                    "name": "c",
+                    "range": Array [
+                      5,
+                      6,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    1,
+                    6,
+                  ],
+                  "type": "MemberExpression",
+                },
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 8,
+                      "line": 1,
+                    },
+                    "start": Object {
+                      "column": 7,
+                      "line": 1,
+                    },
+                  },
+                  "name": "d",
+                  "range": Array [
+                    7,
+                    8,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  1,
+                  8,
+                ],
+                "type": "MemberExpression",
+              },
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 10,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 9,
+                    "line": 1,
+                  },
+                },
+                "name": "e",
+                "range": Array [
+                  9,
+                  10,
+                ],
+                "type": "JSXIdentifier",
+              },
+              "range": Array [
+                1,
+                10,
+              ],
+              "type": "JSXMemberExpression",
+            },
+            "property": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 12,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 11,
+                  "line": 1,
+                },
+              },
+              "name": "f",
+              "range": Array [
+                11,
+                12,
+              ],
+              "type": "JSXIdentifier",
+            },
+            "range": Array [
+              1,
+              12,
+            ],
+            "type": "JSXMemberExpression",
+          },
+          "range": Array [
+            0,
+            13,
+          ],
+          "selfClosing": false,
+          "type": "JSXOpeningElement",
+        },
+        "range": Array [
+          0,
+          86,
+        ],
+        "type": "JSXElement",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        87,
+      ],
+      "type": "ExpressionStatement",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 4,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    88,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        1,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 2,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        1,
+        2,
+      ],
+      "type": "JSXIdentifier",
+      "value": "a",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        2,
+        3,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        3,
+        4,
+      ],
+      "type": "JSXIdentifier",
+      "value": "b",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        4,
+        5,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        6,
+      ],
+      "type": "JSXIdentifier",
+      "value": "c",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        6,
+        7,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        7,
+        8,
+      ],
+      "type": "JSXIdentifier",
+      "value": "d",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        8,
+        9,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        10,
+      ],
+      "type": "JSXIdentifier",
+      "value": "e",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        10,
+        11,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        11,
+        12,
+      ],
+      "type": "JSXIdentifier",
+      "value": "f",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        12,
+        13,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 2,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        13,
+        16,
+      ],
+      "type": "JSXText",
+      "value": "
+  ",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        16,
+        17,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        17,
+        21,
+      ],
+      "type": "Keyword",
+      "value": "this",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        21,
+        22,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        22,
+        27,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        27,
+        28,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        28,
+        35,
+      ],
+      "type": "Keyword",
+      "value": "declare",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        35,
+        36,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 28,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        36,
+        42,
+      ],
+      "type": "Keyword",
+      "value": "static",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 29,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 28,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        42,
+        43,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 30,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 29,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        43,
+        44,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 31,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        44,
+        45,
+      ],
+      "type": "Punctuator",
+      "value": "/",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 35,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 31,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        45,
+        49,
+      ],
+      "type": "Keyword",
+      "value": "this",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 36,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        49,
+        50,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 41,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 36,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        50,
+        55,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 42,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 41,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        55,
+        56,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 49,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 42,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        56,
+        63,
+      ],
+      "type": "Keyword",
+      "value": "declare",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 50,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 49,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        63,
+        64,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 56,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 50,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        64,
+        70,
+      ],
+      "type": "Keyword",
+      "value": "static",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 57,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 56,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        70,
+        71,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 0,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 57,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        71,
+        72,
+      ],
+      "type": "JSXText",
+      "value": "
+",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        72,
+        73,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 2,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        73,
+        74,
+      ],
+      "type": "Punctuator",
+      "value": "/",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        74,
+        75,
+      ],
+      "type": "JSXIdentifier",
+      "value": "a",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        75,
+        76,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        76,
+        77,
+      ],
+      "type": "JSXIdentifier",
+      "value": "b",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        77,
+        78,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        78,
+        79,
+      ],
+      "type": "JSXIdentifier",
+      "value": "c",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        79,
+        80,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        80,
+        81,
+      ],
+      "type": "JSXIdentifier",
+      "value": "d",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        81,
+        82,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        82,
+        83,
+      ],
+      "type": "JSXIdentifier",
+      "value": "e",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        83,
+        84,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        84,
+        85,
+      ],
+      "type": "JSXIdentifier",
+      "value": "f",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        85,
+        86,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        86,
+        87,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`JSX useJSXTextNode: false fixtures/test-content.src 1`] = `
 Object {
   "body": Array [

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
@@ -1798,6 +1798,15 @@ Object {
 }
 `;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/tag-names-with-multi-dots-multi.src 1`] = `
+Object {
+  "column": 7,
+  "index": 21,
+  "lineNumber": 2,
+  "message": "'>' expected.",
+}
+`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/test-content.src 1`] = `
 Object {
   "column": 5,


### PR DESCRIPTION
`<a.b.c.d.e.f>` is not correctly parsed, this is test scenario to be fixed

only first 3 namespaces are correctly converted due to https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/typescript-estree/src/convert.ts#L1597