### PR TITLE
 fix(ts-estree): fix issue with nested jsx tag names

### DIFF
--- a/packages/parser/tests/lib/__snapshots__/jsx.ts.snap
+++ b/packages/parser/tests/lib/__snapshots__/jsx.ts.snap
@@ -9526,7 +9526,6 @@ Object {
                     },
                   },
                   "object": Object {
-                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 41,
@@ -9548,11 +9547,12 @@ Object {
                           "line": 2,
                         },
                       },
+                      "name": "this",
                       "range": Array [
                         45,
                         49,
                       ],
-                      "type": "ThisExpression",
+                      "type": "JSXIdentifier",
                     },
                     "property": Object {
                       "loc": Object {
@@ -9570,13 +9570,13 @@ Object {
                         50,
                         55,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "range": Array [
                       45,
                       55,
                     ],
-                    "type": "MemberExpression",
+                    "type": "JSXMemberExpression",
                   },
                   "property": Object {
                     "loc": Object {
@@ -9677,7 +9677,6 @@ Object {
                     },
                   },
                   "object": Object {
-                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 13,
@@ -9699,11 +9698,12 @@ Object {
                           "line": 2,
                         },
                       },
+                      "name": "this",
                       "range": Array [
                         17,
                         21,
                       ],
-                      "type": "ThisExpression",
+                      "type": "JSXIdentifier",
                     },
                     "property": Object {
                       "loc": Object {
@@ -9721,13 +9721,13 @@ Object {
                         22,
                         27,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "range": Array [
                       17,
                       27,
                     ],
-                    "type": "MemberExpression",
+                    "type": "JSXMemberExpression",
                   },
                   "property": Object {
                     "loc": Object {
@@ -9846,7 +9846,6 @@ Object {
                 },
               },
               "object": Object {
-                "computed": false,
                 "loc": Object {
                   "end": Object {
                     "column": 9,
@@ -9858,7 +9857,6 @@ Object {
                   },
                 },
                 "object": Object {
-                  "computed": false,
                   "loc": Object {
                     "end": Object {
                       "column": 7,
@@ -9870,7 +9868,6 @@ Object {
                     },
                   },
                   "object": Object {
-                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 5,
@@ -9897,7 +9894,7 @@ Object {
                         74,
                         75,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "property": Object {
                       "loc": Object {
@@ -9915,13 +9912,13 @@ Object {
                         76,
                         77,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "range": Array [
                       74,
                       77,
                     ],
-                    "type": "MemberExpression",
+                    "type": "JSXMemberExpression",
                   },
                   "property": Object {
                     "loc": Object {
@@ -9939,13 +9936,13 @@ Object {
                       78,
                       79,
                     ],
-                    "type": "Identifier",
+                    "type": "JSXIdentifier",
                   },
                   "range": Array [
                     74,
                     79,
                   ],
-                  "type": "MemberExpression",
+                  "type": "JSXMemberExpression",
                 },
                 "property": Object {
                   "loc": Object {
@@ -9963,13 +9960,13 @@ Object {
                     80,
                     81,
                   ],
-                  "type": "Identifier",
+                  "type": "JSXIdentifier",
                 },
                 "range": Array [
                   74,
                   81,
                 ],
-                "type": "MemberExpression",
+                "type": "JSXMemberExpression",
               },
               "property": Object {
                 "loc": Object {
@@ -10070,7 +10067,6 @@ Object {
                 },
               },
               "object": Object {
-                "computed": false,
                 "loc": Object {
                   "end": Object {
                     "column": 8,
@@ -10082,7 +10078,6 @@ Object {
                   },
                 },
                 "object": Object {
-                  "computed": false,
                   "loc": Object {
                     "end": Object {
                       "column": 6,
@@ -10094,7 +10089,6 @@ Object {
                     },
                   },
                   "object": Object {
-                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 4,
@@ -10121,7 +10115,7 @@ Object {
                         1,
                         2,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "property": Object {
                       "loc": Object {
@@ -10139,13 +10133,13 @@ Object {
                         3,
                         4,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "range": Array [
                       1,
                       4,
                     ],
-                    "type": "MemberExpression",
+                    "type": "JSXMemberExpression",
                   },
                   "property": Object {
                     "loc": Object {
@@ -10163,13 +10157,13 @@ Object {
                       5,
                       6,
                     ],
-                    "type": "Identifier",
+                    "type": "JSXIdentifier",
                   },
                   "range": Array [
                     1,
                     6,
                   ],
-                  "type": "MemberExpression",
+                  "type": "JSXMemberExpression",
                 },
                 "property": Object {
                   "loc": Object {
@@ -10187,13 +10181,13 @@ Object {
                     7,
                     8,
                   ],
-                  "type": "Identifier",
+                  "type": "JSXIdentifier",
                 },
                 "range": Array [
                   1,
                   8,
                 ],
-                "type": "MemberExpression",
+                "type": "JSXMemberExpression",
               },
               "property": Object {
                 "loc": Object {

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -9,7 +9,6 @@ import ts from 'typescript';
 import * as es from './typedefs';
 import {
   canContainDirective,
-  convertToken,
   createError,
   findNextToken,
   fixExports,
@@ -25,7 +24,6 @@ import {
   isComma,
   isComputedProperty,
   isESTreeClassMember,
-  isJSXToken,
   isOptional,
   unescapeStringLiteralText
 } from './node-utils';
@@ -369,50 +367,47 @@ export class Converter {
 
   /**
    * Converts a TypeScript JSX node.tagName into an ESTree node.name
-   * @param tagName the tagName object from a JSX ts.Node
+   * @param node the tagName object from a JSX ts.Node
    * @param parent
    * @returns the converted ESTree name object
    */
-  private convertTypeScriptJSXTagNameToESTreeName(
-    tagName: ts.JsxTagNameExpression,
+  protected convertJSXTagName(
+    node: ts.JsxTagNameExpression,
     parent: ts.Node
   ): es.JSXMemberExpression | es.JSXIdentifier {
-    // TODO: remove convertToken call
-    const tagNameToken = convertToken(tagName, this.ast);
-
-    if (tagName.kind === SyntaxKind.PropertyAccessExpression) {
-      const isNestedMemberExpression =
-        tagName.expression.kind === SyntaxKind.PropertyAccessExpression;
-
-      // Convert TSNode left and right objects into ESTreeNode object
-      // and property objects
-      const object = this.convertChild(tagName.expression, parent);
-      const property = this.convertChild(tagName.name, parent);
-
-      // Assign the appropriate types
-      object.type = isNestedMemberExpression
-        ? AST_NODE_TYPES.JSXMemberExpression
-        : AST_NODE_TYPES.JSXIdentifier;
-      property.type = AST_NODE_TYPES.JSXIdentifier;
-      if ((tagName as any).expression.kind === SyntaxKind.ThisKeyword) {
-        object.name = 'this';
-      }
-
-      return this.createNode<es.JSXMemberExpression>(tagName, {
-        type: AST_NODE_TYPES.JSXMemberExpression,
-        range: tagNameToken.range,
-        loc: tagNameToken.loc,
-        object: object,
-        property: property
-      });
-    } else {
-      return this.createNode<es.JSXIdentifier>(tagName, {
-        type: AST_NODE_TYPES.JSXIdentifier,
-        range: tagNameToken.range,
-        loc: tagNameToken.loc,
-        name: tagNameToken.value
-      });
+    let result: es.JSXMemberExpression | es.JSXIdentifier;
+    switch (node.kind) {
+      case SyntaxKind.PropertyAccessExpression:
+        result = this.createNode<es.JSXMemberExpression>(node, {
+          type: AST_NODE_TYPES.JSXMemberExpression,
+          object: this.convertJSXTagName(node.expression, parent),
+          property: this.convertJSXTagName(
+            node.name,
+            parent
+          ) as es.JSXIdentifier
+        });
+        break;
+      case SyntaxKind.ThisKeyword:
+        result = this.createNode<es.JSXIdentifier>(node, {
+          type: AST_NODE_TYPES.JSXIdentifier,
+          name: 'this'
+        });
+        break;
+      case SyntaxKind.Identifier:
+      default:
+        result = this.createNode<es.JSXIdentifier>(node, {
+          type: AST_NODE_TYPES.JSXIdentifier,
+          name: node.text
+        });
+        break;
     }
+
+    if (result && this.options.shouldProvideParserServices) {
+      this.tsNodeToESTreeNodeMap.set(node, result);
+      this.esTreeNodeToTSNodeMap.set(result, node);
+    }
+
+    return result;
   }
 
   /**
@@ -1617,36 +1612,12 @@ export class Converter {
       }
 
       case SyntaxKind.PropertyAccessExpression:
-        if (isJSXToken(parent)) {
-          const jsxMemberExpression = this.createNode<es.MemberExpression>(
-            node,
-            {
-              type: AST_NODE_TYPES.MemberExpression,
-              object: this.convertChild(node.expression),
-              property: this.convertChild(node.name)
-            }
-          );
-          // TODO: refactor this
-          const isNestedMemberExpression =
-            node.expression.kind === SyntaxKind.PropertyAccessExpression;
-          if (node.expression.kind === SyntaxKind.ThisKeyword) {
-            (jsxMemberExpression.object as any).name = 'this';
-          }
-
-          (jsxMemberExpression.object as any).type = isNestedMemberExpression
-            ? AST_NODE_TYPES.MemberExpression
-            : AST_NODE_TYPES.JSXIdentifier;
-          (jsxMemberExpression as any).property.type =
-            AST_NODE_TYPES.JSXIdentifier;
-          return jsxMemberExpression;
-        } else {
-          return this.createNode<es.MemberExpression>(node, {
-            type: AST_NODE_TYPES.MemberExpression,
-            object: this.convertChild(node.expression),
-            property: this.convertChild(node.name),
-            computed: false
-          });
-        }
+        return this.createNode<es.MemberExpression>(node, {
+          type: AST_NODE_TYPES.MemberExpression,
+          object: this.convertChild(node.expression),
+          property: this.convertChild(node.name),
+          computed: false
+        });
 
       case SyntaxKind.ElementAccessExpression:
         return this.createNode<es.MemberExpression>(node, {
@@ -1844,10 +1815,7 @@ export class Converter {
               ? this.convertTypeArgumentsToTypeParameters(node.typeArguments)
               : undefined,
             selfClosing: true,
-            name: this.convertTypeScriptJSXTagNameToESTreeName(
-              node.tagName,
-              node
-            ),
+            name: this.convertJSXTagName(node.tagName, node),
             attributes: node.attributes.properties.map(el =>
               this.convertChild(el)
             ),
@@ -1865,10 +1833,7 @@ export class Converter {
             ? this.convertTypeArgumentsToTypeParameters(node.typeArguments)
             : undefined,
           selfClosing: false,
-          name: this.convertTypeScriptJSXTagNameToESTreeName(
-            node.tagName,
-            node
-          ),
+          name: this.convertJSXTagName(node.tagName, node),
           attributes: node.attributes.properties.map(el =>
             this.convertChild(el)
           )
@@ -1877,7 +1842,7 @@ export class Converter {
       case SyntaxKind.JsxClosingElement:
         return this.createNode<es.JSXClosingElement>(node, {
           type: AST_NODE_TYPES.JSXClosingElement,
-          name: this.convertTypeScriptJSXTagNameToESTreeName(node.tagName, node)
+          name: this.convertJSXTagName(node.tagName, node)
         });
 
       case SyntaxKind.JsxOpeningFragment:

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -371,7 +371,7 @@ export class Converter {
    * @param parent
    * @returns the converted ESTree name object
    */
-  protected convertJSXTagName(
+  private convertJSXTagName(
     node: ts.JsxTagNameExpression,
     parent: ts.Node
   ): es.JSXMemberExpression | es.JSXIdentifier {

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -284,12 +284,7 @@ tester.addFixturePatternConfig('javascript/unicodeCodePointEscapes');
 /* ================================================== */
 
 tester.addFixturePatternConfig('jsx', {
-  ignore: jsxFilesWithKnownIssues.concat([
-    /**
-     * ts-estree: nested jsx tag names are not correctly converted
-     */
-    'tag-names-with-multi-dots-multi'
-  ])
+  ignore: jsxFilesWithKnownIssues
 });
 tester.addFixturePatternConfig('jsx-useJSXTextNode');
 

--- a/packages/typescript-estree/tests/lib/__snapshots__/convert.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/convert.ts.snap
@@ -1,0 +1,519 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`convert deeplyCopy should convert node correctly 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 8,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 5,
+            "line": 1,
+          },
+        },
+        "name": "foo",
+        "range": Array [
+          5,
+          8,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 35,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        35,
+      ],
+      "type": "TSTypeAliasDeclaration",
+      "typeAnnotation": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 35,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 11,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          11,
+          35,
+        ],
+        "transformFlags": undefined,
+        "type": "TSJSDocNullableType",
+        "typeAnnotation": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 35,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 11,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            11,
+            35,
+          ],
+          "type": "TSTypeAnnotation",
+          "typeAnnotation": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 35,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 12,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              12,
+              35,
+            ],
+            "type": "TSUnionType",
+            "types": Array [
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 12,
+                    "line": 1,
+                  },
+                },
+                "range": Array [
+                  12,
+                  18,
+                ],
+                "type": "TSTypeReference",
+                "typeName": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 15,
+                      "line": 1,
+                    },
+                    "start": Object {
+                      "column": 12,
+                      "line": 1,
+                    },
+                  },
+                  "name": "foo",
+                  "range": Array [
+                    12,
+                    15,
+                  ],
+                  "type": "Identifier",
+                },
+                "typeParameters": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 18,
+                      "line": 1,
+                    },
+                    "start": Object {
+                      "column": 15,
+                      "line": 1,
+                    },
+                  },
+                  "params": Array [
+                    Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 17,
+                          "line": 1,
+                        },
+                        "start": Object {
+                          "column": 16,
+                          "line": 1,
+                        },
+                      },
+                      "range": Array [
+                        16,
+                        17,
+                      ],
+                      "type": "TSTypeReference",
+                      "typeName": Object {
+                        "loc": Object {
+                          "end": Object {
+                            "column": 17,
+                            "line": 1,
+                          },
+                          "start": Object {
+                            "column": 16,
+                            "line": 1,
+                          },
+                        },
+                        "name": "T",
+                        "range": Array [
+                          16,
+                          17,
+                        ],
+                        "type": "Identifier",
+                      },
+                      "typeParameters": undefined,
+                    },
+                  ],
+                  "range": Array [
+                    15,
+                    18,
+                  ],
+                  "type": "TSTypeParameterInstantiation",
+                },
+              },
+              Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 35,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 21,
+                    "line": 1,
+                  },
+                },
+                "range": Array [
+                  21,
+                  35,
+                ],
+                "transformFlags": undefined,
+                "type": "TSJSDocNullableType",
+                "typeAnnotation": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 35,
+                      "line": 1,
+                    },
+                    "start": Object {
+                      "column": 21,
+                      "line": 1,
+                    },
+                  },
+                  "range": Array [
+                    21,
+                    35,
+                  ],
+                  "type": "TSTypeAnnotation",
+                  "typeAnnotation": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 35,
+                        "line": 1,
+                      },
+                      "start": Object {
+                        "column": 22,
+                        "line": 1,
+                      },
+                    },
+                    "range": Array [
+                      22,
+                      35,
+                    ],
+                    "transformFlags": undefined,
+                    "type": "TSJSDocNullableType",
+                    "typeAnnotation": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 34,
+                          "line": 1,
+                        },
+                        "start": Object {
+                          "column": 21,
+                          "line": 1,
+                        },
+                      },
+                      "range": Array [
+                        21,
+                        34,
+                      ],
+                      "type": "TSTypeAnnotation",
+                      "typeAnnotation": Object {
+                        "loc": Object {
+                          "end": Object {
+                            "column": 34,
+                            "line": 1,
+                          },
+                          "start": Object {
+                            "column": 22,
+                            "line": 1,
+                          },
+                        },
+                        "range": Array [
+                          22,
+                          34,
+                        ],
+                        "type": "TSParenthesizedType",
+                        "typeAnnotation": Object {
+                          "loc": Object {
+                            "end": Object {
+                              "column": 33,
+                              "line": 1,
+                            },
+                            "start": Object {
+                              "column": 23,
+                              "line": 1,
+                            },
+                          },
+                          "params": Array [],
+                          "range": Array [
+                            23,
+                            33,
+                          ],
+                          "returnType": Object {
+                            "loc": Object {
+                              "end": Object {
+                                "column": 33,
+                                "line": 1,
+                              },
+                              "start": Object {
+                                "column": 26,
+                                "line": 1,
+                              },
+                            },
+                            "range": Array [
+                              26,
+                              33,
+                            ],
+                            "type": "TSTypeAnnotation",
+                            "typeAnnotation": Object {
+                              "loc": Object {
+                                "end": Object {
+                                  "column": 33,
+                                  "line": 1,
+                                },
+                                "start": Object {
+                                  "column": 29,
+                                  "line": 1,
+                                },
+                              },
+                              "range": Array [
+                                29,
+                                33,
+                              ],
+                              "type": "TSVoidKeyword",
+                            },
+                          },
+                          "type": "TSFunctionType",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 35,
+      "line": 1,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    35,
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`convert deeplyCopy should convert node with decorators correctly 1`] = `
+Object {
+  "decorators": Array [
+    Object {
+      "expression": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 5,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 1,
+            "line": 1,
+          },
+        },
+        "name": "test",
+        "range": Array [
+          1,
+          5,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        5,
+      ],
+      "type": "Decorator",
+    },
+  ],
+  "heritageClauses": undefined,
+  "loc": Object {
+    "end": Object {
+      "column": 18,
+      "line": 1,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "members": Array [],
+  "modifiers": undefined,
+  "name": Object {
+    "loc": Object {
+      "end": Object {
+        "column": 15,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 12,
+        "line": 1,
+      },
+    },
+    "name": "foo",
+    "range": Array [
+      12,
+      15,
+    ],
+    "type": "Identifier",
+  },
+  "range": Array [
+    0,
+    18,
+  ],
+  "transformFlags": undefined,
+  "type": "TSClassDeclaration",
+  "typeParameters": null,
+}
+`;
+
+exports[`convert deeplyCopy should convert node with type parameters correctly 1`] = `
+Object {
+  "heritageClauses": undefined,
+  "loc": Object {
+    "end": Object {
+      "column": 15,
+      "line": 1,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "members": Array [],
+  "name": Object {
+    "loc": Object {
+      "end": Object {
+        "column": 9,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 6,
+        "line": 1,
+      },
+    },
+    "name": "foo",
+    "range": Array [
+      6,
+      9,
+    ],
+    "type": "Identifier",
+  },
+  "range": Array [
+    0,
+    15,
+  ],
+  "transformFlags": undefined,
+  "type": "TSClassDeclaration",
+  "typeParameters": Object {
+    "loc": Object {
+      "end": Object {
+        "column": 12,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 9,
+        "line": 1,
+      },
+    },
+    "params": Array [
+      Object {
+        "constraint": undefined,
+        "default": undefined,
+        "loc": Object {
+          "end": Object {
+            "column": 11,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 1,
+          },
+        },
+        "name": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 11,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 10,
+              "line": 1,
+            },
+          },
+          "name": "T",
+          "range": Array [
+            10,
+            11,
+          ],
+          "type": "Identifier",
+        },
+        "range": Array [
+          10,
+          11,
+        ],
+        "type": "TSTypeParameter",
+      },
+    ],
+    "range": Array [
+      9,
+      12,
+    ],
+    "type": "TSTypeParameterDeclaration",
+  },
+}
+`;

--- a/packages/typescript-estree/tests/lib/__snapshots__/jsx.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/jsx.ts.snap
@@ -9486,7 +9486,6 @@ Object {
                     },
                   },
                   "object": Object {
-                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 41,
@@ -9508,11 +9507,12 @@ Object {
                           "line": 2,
                         },
                       },
+                      "name": "this",
                       "range": Array [
                         45,
                         49,
                       ],
-                      "type": "ThisExpression",
+                      "type": "JSXIdentifier",
                     },
                     "property": Object {
                       "loc": Object {
@@ -9530,13 +9530,13 @@ Object {
                         50,
                         55,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "range": Array [
                       45,
                       55,
                     ],
-                    "type": "MemberExpression",
+                    "type": "JSXMemberExpression",
                   },
                   "property": Object {
                     "loc": Object {
@@ -9637,7 +9637,6 @@ Object {
                     },
                   },
                   "object": Object {
-                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 13,
@@ -9659,11 +9658,12 @@ Object {
                           "line": 2,
                         },
                       },
+                      "name": "this",
                       "range": Array [
                         17,
                         21,
                       ],
-                      "type": "ThisExpression",
+                      "type": "JSXIdentifier",
                     },
                     "property": Object {
                       "loc": Object {
@@ -9681,13 +9681,13 @@ Object {
                         22,
                         27,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "range": Array [
                       17,
                       27,
                     ],
-                    "type": "MemberExpression",
+                    "type": "JSXMemberExpression",
                   },
                   "property": Object {
                     "loc": Object {
@@ -9806,7 +9806,6 @@ Object {
                 },
               },
               "object": Object {
-                "computed": false,
                 "loc": Object {
                   "end": Object {
                     "column": 9,
@@ -9818,7 +9817,6 @@ Object {
                   },
                 },
                 "object": Object {
-                  "computed": false,
                   "loc": Object {
                     "end": Object {
                       "column": 7,
@@ -9830,7 +9828,6 @@ Object {
                     },
                   },
                   "object": Object {
-                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 5,
@@ -9857,7 +9854,7 @@ Object {
                         74,
                         75,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "property": Object {
                       "loc": Object {
@@ -9875,13 +9872,13 @@ Object {
                         76,
                         77,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "range": Array [
                       74,
                       77,
                     ],
-                    "type": "MemberExpression",
+                    "type": "JSXMemberExpression",
                   },
                   "property": Object {
                     "loc": Object {
@@ -9899,13 +9896,13 @@ Object {
                       78,
                       79,
                     ],
-                    "type": "Identifier",
+                    "type": "JSXIdentifier",
                   },
                   "range": Array [
                     74,
                     79,
                   ],
-                  "type": "MemberExpression",
+                  "type": "JSXMemberExpression",
                 },
                 "property": Object {
                   "loc": Object {
@@ -9923,13 +9920,13 @@ Object {
                     80,
                     81,
                   ],
-                  "type": "Identifier",
+                  "type": "JSXIdentifier",
                 },
                 "range": Array [
                   74,
                   81,
                 ],
-                "type": "MemberExpression",
+                "type": "JSXMemberExpression",
               },
               "property": Object {
                 "loc": Object {
@@ -10030,7 +10027,6 @@ Object {
                 },
               },
               "object": Object {
-                "computed": false,
                 "loc": Object {
                   "end": Object {
                     "column": 8,
@@ -10042,7 +10038,6 @@ Object {
                   },
                 },
                 "object": Object {
-                  "computed": false,
                   "loc": Object {
                     "end": Object {
                       "column": 6,
@@ -10054,7 +10049,6 @@ Object {
                     },
                   },
                   "object": Object {
-                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 4,
@@ -10081,7 +10075,7 @@ Object {
                         1,
                         2,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "property": Object {
                       "loc": Object {
@@ -10099,13 +10093,13 @@ Object {
                         3,
                         4,
                       ],
-                      "type": "Identifier",
+                      "type": "JSXIdentifier",
                     },
                     "range": Array [
                       1,
                       4,
                     ],
-                    "type": "MemberExpression",
+                    "type": "JSXMemberExpression",
                   },
                   "property": Object {
                     "loc": Object {
@@ -10123,13 +10117,13 @@ Object {
                       5,
                       6,
                     ],
-                    "type": "Identifier",
+                    "type": "JSXIdentifier",
                   },
                   "range": Array [
                     1,
                     6,
                   ],
-                  "type": "MemberExpression",
+                  "type": "JSXMemberExpression",
                 },
                 "property": Object {
                   "loc": Object {
@@ -10147,13 +10141,13 @@ Object {
                     7,
                     8,
                   ],
-                  "type": "Identifier",
+                  "type": "JSXIdentifier",
                 },
                 "range": Array [
                   1,
                   8,
                 ],
-                "type": "MemberExpression",
+                "type": "JSXMemberExpression",
               },
               "property": Object {
                 "loc": Object {

--- a/packages/typescript-estree/tests/lib/convert.ts
+++ b/packages/typescript-estree/tests/lib/convert.ts
@@ -1,0 +1,128 @@
+import { Converter } from '../../src/convert';
+import ts from 'typescript';
+
+describe('convert', () => {
+  function convertCode(code: string): ts.SourceFile {
+    return ts.createSourceFile(
+      'text.ts',
+      code,
+      ts.ScriptTarget.ESNext,
+      true,
+      ts.ScriptKind.TSX
+    );
+  }
+
+  it('deeplyCopy should convert node correctly', () => {
+    const ast = convertCode('type foo = ?foo<T> | ?(() => void)?');
+
+    const instance = new Converter(ast, {
+      errorOnUnknownASTType: false,
+      useJSXTextNode: false,
+      shouldProvideParserServices: false
+    });
+    expect(instance.convertProgram()).toMatchSnapshot();
+  });
+
+  it('deeplyCopy should convert node with decorators correctly', () => {
+    const ast = convertCode('@test class foo {}');
+
+    const instance = new Converter(ast, {
+      errorOnUnknownASTType: false,
+      useJSXTextNode: false,
+      shouldProvideParserServices: false
+    });
+    expect((instance as any).deeplyCopy(ast.statements[0])).toMatchSnapshot();
+  });
+
+  it('deeplyCopy should convert node with type parameters correctly', () => {
+    const ast = convertCode('class foo<T> {}');
+
+    const instance = new Converter(ast, {
+      errorOnUnknownASTType: false,
+      useJSXTextNode: false,
+      shouldProvideParserServices: false
+    });
+    expect((instance as any).deeplyCopy(ast.statements[0])).toMatchSnapshot();
+  });
+
+  it('deeplyCopy should fail on unknown node', () => {
+    const ast = convertCode('type foo = ?foo<T> | ?(() => void)?');
+
+    const instance = new Converter(ast, {
+      errorOnUnknownASTType: true,
+      useJSXTextNode: false,
+      shouldProvideParserServices: false
+    });
+    expect(() => instance.convertProgram()).toThrow(
+      'Unknown AST_NODE_TYPE: "TSJSDocNullableType"'
+    );
+  });
+
+  it('nodeMaps should contain basic nodes', () => {
+    const ast = convertCode(`
+      'test';
+      2;
+      class foo {};
+      type bar = {};
+    `);
+
+    const instance = new Converter(ast, {
+      errorOnUnknownASTType: false,
+      useJSXTextNode: false,
+      shouldProvideParserServices: true
+    });
+    instance.convertProgram();
+    const maps = instance.getASTMaps();
+
+    function checkMaps(child: any) {
+      child.forEachChild((node: any) => {
+        if (
+          node.kind !== ts.SyntaxKind.EndOfFileToken &&
+          node.kind !== ts.SyntaxKind.JsxAttributes &&
+          node.kind !== ts.SyntaxKind.VariableDeclaration
+        ) {
+          expect(node).toBe(
+            maps.esTreeNodeToTSNodeMap.get(maps.tsNodeToESTreeNodeMap.get(node))
+          );
+        }
+        checkMaps(node);
+      });
+    }
+
+    expect(ast).toBe(
+      maps.esTreeNodeToTSNodeMap.get(maps.tsNodeToESTreeNodeMap.get(ast))
+    );
+    checkMaps(ast);
+  });
+
+  it('nodeMaps should contain jsx nodes', () => {
+    const ast = convertCode(`<a.b.c.d.e></a.b.c.d.e>`);
+
+    const instance = new Converter(ast, {
+      errorOnUnknownASTType: false,
+      useJSXTextNode: false,
+      shouldProvideParserServices: true
+    });
+    instance.convertProgram();
+    const maps = instance.getASTMaps();
+
+    function checkMaps(child: any) {
+      child.forEachChild((node: any) => {
+        if (
+          node.kind !== ts.SyntaxKind.EndOfFileToken &&
+          node.kind !== ts.SyntaxKind.JsxAttributes
+        ) {
+          expect(node).toBe(
+            maps.esTreeNodeToTSNodeMap.get(maps.tsNodeToESTreeNodeMap.get(node))
+          );
+        }
+        checkMaps(node);
+      });
+    }
+
+    expect(ast).toBe(
+      maps.esTreeNodeToTSNodeMap.get(maps.tsNodeToESTreeNodeMap.get(ast))
+    );
+    checkMaps(ast);
+  });
+});


### PR DESCRIPTION
Changes:
- fix issue with nested jsx tag names `<a.b.c.d.e.f.g>`
- simplify conversion and determining if node is jsx tag name
- make sure that jsx tag names are added to `tsNodeToESTreeNodeMap` and `esTreeNodeToTSNodeMap`