### PR TITLE
fix(eslint-plugin): fix false positive from adjacent-overload-signatures

### DIFF
--- a/packages/eslint-plugin/lib/rules/adjacent-overload-signatures.js
+++ b/packages/eslint-plugin/lib/rules/adjacent-overload-signatures.js
@@ -94,20 +94,17 @@ module.exports = {
       const members = node.body || node.members;
 
       if (members) {
-        let name;
-        let method;
-        let index;
         let lastMethod;
         const seenMethods = [];
 
         members.forEach(member => {
-          name = getMemberName(member);
-          method = {
+          const name = getMemberName(member);
+          const method = {
             name,
             static: member.static
           };
 
-          index = seenMethods.findIndex(seenMethod =>
+          const index = seenMethods.findIndex(seenMethod =>
             isSameMethod(method, seenMethod)
           );
           if (index > -1 && !isSameMethod(method, lastMethod)) {

--- a/packages/eslint-plugin/lib/rules/adjacent-overload-signatures.js
+++ b/packages/eslint-plugin/lib/rules/adjacent-overload-signatures.js
@@ -84,27 +84,29 @@ module.exports = {
 
       if (members) {
         let name;
+        let nameWithStatic;
         let index;
         let lastName;
         const seen = [];
 
         members.forEach(member => {
           name = getMemberName(member);
+          nameWithStatic = (member.static ? 'static ' : '') + name;
 
-          index = seen.indexOf(name);
-          if (index > -1 && lastName !== name) {
+          index = seen.indexOf(nameWithStatic);
+          if (index > -1 && lastName !== nameWithStatic) {
             context.report({
               node: member,
               messageId: 'adjacentSignature',
               data: {
-                name
+                name: nameWithStatic
               }
             });
           } else if (name && index === -1) {
-            seen.push(name);
+            seen.push(nameWithStatic);
           }
 
-          lastName = name;
+          lastName = nameWithStatic;
         });
       }
     }

--- a/packages/eslint-plugin/tests/lib/rules/adjacent-overload-signatures.js
+++ b/packages/eslint-plugin/tests/lib/rules/adjacent-overload-signatures.js
@@ -213,6 +213,23 @@ class Foo {
     baz(): void {}
 }
         `,
+    `
+class Foo {
+    name: string;
+    static foo(s: string): void;
+    static foo(n: number): void;
+    static foo(sn: string | number): void {}
+    bar(): void {}
+    baz(): void {}
+}
+        `,
+    `
+class Test {
+  static test() {}
+  untest() {}
+  test() {}
+}
+        `,
     // examples from https://github.com/nzakas/eslint-plugin-typescript/issues/138
     'export default function<T>(foo : T) {}',
     'export default function named<T>(foo : T) {}'
@@ -785,6 +802,26 @@ class Foo {
         {
           messageId: 'adjacentSignature',
           data: { name: 'foo' },
+          line: 5,
+          column: 5
+        }
+      ]
+    },
+    {
+      code: `
+class Foo {
+    static foo(s: string): void;
+    name: string;
+    static foo(n: number): void;
+    static foo(sn: string | number): void {}
+    bar(): void {}
+    baz(): void {}
+}
+            `,
+      errors: [
+        {
+          messageId: 'adjacentSignature',
+          data: { name: 'static foo' },
           line: 5,
           column: 5
         }


### PR DESCRIPTION
`adjacent-overload-signatures` rule won't distinguish between static and instance methods, despite they're different. So when they have the same name, they'll be treated as the same thing, which can cause a false positive result.

Fix https://github.com/typescript-eslint/typescript-eslint/issues/169