### PR TITLE
test(ts-estree): add missing test cases for parser options

### DIFF
--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -107,7 +107,7 @@ function getASTAndDefaultProject(code: string, options: ParserOptions) {
 function createNewProgram(code: string) {
   const FILENAME = getFileName(extra);
 
-  const compilerHost = {
+  const compilerHost: ts.CompilerHost = {
     fileExists() {
       return true;
     },

--- a/packages/typescript-estree/tests/lib/__snapshots__/convert.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/convert.ts.snap
@@ -1,5 +1,179 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`convert deeplyCopy should convert array of nodes 1`] = `
+Object {
+  "amdDependencies": Array [],
+  "bindDiagnostics": Array [],
+  "bindSuggestionDiagnostics": undefined,
+  "checkJsDirective": undefined,
+  "endOfFileToken": Object {
+    "loc": Object {
+      "end": Object {
+        "column": 12,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 12,
+        "line": 1,
+      },
+    },
+    "range": Array [
+      12,
+      12,
+    ],
+    "type": "TSEndOfFileToken",
+  },
+  "externalModuleIndicator": undefined,
+  "fileName": "text.ts",
+  "hasNoDefaultLib": false,
+  "identifierCount": 2,
+  "identifiers": Map {
+    "foo" => "foo",
+    "T" => "T",
+  },
+  "isDeclarationFile": false,
+  "languageVariant": 1,
+  "languageVersion": 6,
+  "libReferenceDirectives": Array [],
+  "lineMap": Array [
+    null,
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 12,
+      "line": 1,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "nodeCount": 7,
+  "parseDiagnostics": Array [],
+  "pragmas": Map {},
+  "range": Array [
+    0,
+    12,
+  ],
+  "referencedFiles": Array [],
+  "scriptKind": 4,
+  "statements": Array [
+    Object {
+      "expression": Object {
+        "arguments": Array [],
+        "callee": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 7,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 1,
+            },
+          },
+          "name": "foo",
+          "range": Array [
+            4,
+            7,
+          ],
+          "type": "Identifier",
+        },
+        "loc": Object {
+          "end": Object {
+            "column": 12,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          0,
+          12,
+        ],
+        "type": "NewExpression",
+        "typeParameters": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 10,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 7,
+              "line": 1,
+            },
+          },
+          "params": Array [
+            Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 9,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                8,
+                9,
+              ],
+              "type": "TSTypeReference",
+              "typeName": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 9,
+                    "line": 1,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 1,
+                  },
+                },
+                "name": "T",
+                "range": Array [
+                  8,
+                  9,
+                ],
+                "type": "Identifier",
+              },
+              "typeParameters": undefined,
+            },
+          ],
+          "range": Array [
+            7,
+            10,
+          ],
+          "type": "TSTypeParameterInstantiation",
+        },
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        12,
+      ],
+      "type": "ExpressionStatement",
+    },
+  ],
+  "text": "new foo<T>()",
+  "transformFlags": undefined,
+  "type": "TSSourceFile",
+  "typeReferenceDirectives": Array [],
+}
+`;
+
 exports[`convert deeplyCopy should convert node correctly 1`] = `
 Object {
   "body": Array [
@@ -418,6 +592,101 @@ Object {
   "transformFlags": undefined,
   "type": "TSClassDeclaration",
   "typeParameters": null,
+}
+`;
+
+exports[`convert deeplyCopy should convert node with type arguments correctly 1`] = `
+Object {
+  "arguments": Array [],
+  "expression": Object {
+    "loc": Object {
+      "end": Object {
+        "column": 7,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 4,
+        "line": 1,
+      },
+    },
+    "name": "foo",
+    "range": Array [
+      4,
+      7,
+    ],
+    "type": "Identifier",
+  },
+  "loc": Object {
+    "end": Object {
+      "column": 12,
+      "line": 1,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    12,
+  ],
+  "transformFlags": undefined,
+  "type": "TSNewExpression",
+  "typeParameters": Object {
+    "loc": Object {
+      "end": Object {
+        "column": 10,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 7,
+        "line": 1,
+      },
+    },
+    "params": Array [
+      Object {
+        "loc": Object {
+          "end": Object {
+            "column": 9,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 8,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          8,
+          9,
+        ],
+        "type": "TSTypeReference",
+        "typeName": Object {
+          "loc": Object {
+            "end": Object {
+              "column": 9,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 8,
+              "line": 1,
+            },
+          },
+          "name": "T",
+          "range": Array [
+            8,
+            9,
+          ],
+          "type": "Identifier",
+        },
+        "typeParameters": undefined,
+      },
+    ],
+    "range": Array [
+      7,
+      10,
+    ],
+    "type": "TSTypeParameterInstantiation",
+  },
 }
 `;
 

--- a/packages/typescript-estree/tests/lib/convert.ts
+++ b/packages/typescript-estree/tests/lib/convert.ts
@@ -45,6 +45,30 @@ describe('convert', () => {
     expect((instance as any).deeplyCopy(ast.statements[0])).toMatchSnapshot();
   });
 
+  it('deeplyCopy should convert node with type arguments correctly', () => {
+    const ast = convertCode('new foo<T>()');
+
+    const instance = new Converter(ast, {
+      errorOnUnknownASTType: false,
+      useJSXTextNode: false,
+      shouldProvideParserServices: false
+    });
+    expect(
+      (instance as any).deeplyCopy((ast.statements[0] as any).expression)
+    ).toMatchSnapshot();
+  });
+
+  it('deeplyCopy should convert array of nodes', () => {
+    const ast = convertCode('new foo<T>()');
+
+    const instance = new Converter(ast, {
+      errorOnUnknownASTType: false,
+      useJSXTextNode: false,
+      shouldProvideParserServices: false
+    });
+    expect((instance as any).deeplyCopy(ast)).toMatchSnapshot();
+  });
+
   it('deeplyCopy should fail on unknown node', () => {
     const ast = convertCode('type foo = ?foo<T> | ?(() => void)?');
 

--- a/packages/typescript-estree/tests/lib/parse.ts
+++ b/packages/typescript-estree/tests/lib/parse.ts
@@ -104,4 +104,37 @@ describe('parse()', () => {
       );
     });
   });
+
+  describe('errorOnTypeScriptSyntacticAndSemanticIssues', () => {
+    const code = '@test const foo = 2';
+    const options: ParserOptions = {
+      comment: true,
+      tokens: true,
+      range: true,
+      loc: true,
+      errorOnTypeScriptSyntacticAndSemanticIssues: true
+    };
+
+    it('should throw on invalid option when used in parse', () => {
+      expect(() => {
+        parser.parse(code, options);
+      }).toThrow(
+        `"errorOnTypeScriptSyntacticAndSemanticIssues" is only supported for parseAndGenerateServices()`
+      );
+    });
+
+    it('should not throw when used in parseAndGenerateServices', () => {
+      expect(() => {
+        parser.parseAndGenerateServices(code, options);
+      }).not.toThrow(
+        `"errorOnTypeScriptSyntacticAndSemanticIssues" is only supported for parseAndGenerateServices()`
+      );
+    });
+
+    it('should error on invalid code', () => {
+      expect(() => {
+        parser.parseAndGenerateServices(code, options);
+      }).toThrow('Decorators are not valid here.');
+    });
+  });
 });


### PR DESCRIPTION
This PR adds missing test cases for converter and parse in ts-estree