### PR TITLE
test(ts-estree): upgrade babel to 7.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@babel/code-frame": "7.0.0",
-    "@babel/parser": "7.3.0",
+    "@babel/parser": "7.3.2",
     "@commitlint/cli": "^7.1.2",
     "@commitlint/config-conventional": "^7.1.2",
     "@commitlint/travis-cli": "^7.1.2",

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -164,7 +164,20 @@ tester.addFixturePatternConfig('javascript/arrowFunctions', {
      * with the same name, for example.
      */
     'error-dup-params', // babel parse errors
-    'error-strict-dup-params' // babel parse errors
+    'error-strict-dup-params', // babel parse errors
+    /**
+     * typescript reports TS1100 and babel errors on this
+     * TS1100: "Invalid use of '{0}' in strict mode."
+     * TODO: do we want TS1100 error code?
+     */
+    'error-strict-eval', // babel parse errors
+    'error-strict-default-param-eval',
+    'error-strict-eval-return',
+    'error-strict-param-arguments',
+    'error-strict-param-eval',
+    'error-strict-param-names',
+    'error-strict-param-no-paren-arguments',
+    'error-strict-param-no-paren-eval'
   ]
 });
 tester.addFixturePatternConfig('javascript/function', {
@@ -236,7 +249,12 @@ tester.addFixturePatternConfig('javascript/modules', {
      */
     'invalid-export-named-default' // babel parse errors
   ],
-  ignoreSourceType: ['error-function', 'error-strict', 'error-delete']
+  ignoreSourceType: [
+    'error-function',
+    'error-strict',
+    'error-delete',
+    'invalid-await'
+  ]
 });
 
 tester.addFixturePatternConfig('javascript/newTarget');
@@ -364,14 +382,8 @@ tester.addFixturePatternConfig('typescript/basics', {
      */
     'type-assertion-arrow-function',
     /**
-     * PR for range of declare keyword has been merged into Babel: https://github.com/babel/babel/pull/9406
-     * TODO: remove me in next babel > 7.3.1
-     */
-    'export-declare-const-named-enum',
-    'export-declare-named-enum',
-    /**
      * Babel does not include optional keyword into range parameter in arrow function
-     * TODO: report it to babel
+     * https://github.com/babel/babel/issues/9461
      */
     'arrow-function-with-optional-parameter'
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.0.tgz#930251fe6714df47ce540a919ccdf6dcfb652b61"
-  integrity sha512-8M30TzMpLHGmuthHZStm4F+az5wxyYeh8U+LWK7+b2qnlQ0anXBmOQ1I8DCMV1K981wPY3C3kWZ4SA1lR3Y3xQ==
+"@babel/parser@7.3.2":
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.2.tgz#95cdeddfc3992a6ca2a1315191c1679ca32c55cd"
+  integrity sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==
 
 "@commitlint/cli@^7.1.2", "@commitlint/cli@^7.3.2":
   version "7.3.2"


### PR DESCRIPTION
babel 7.3.2 got released yesterday, and this pr upgrades changes in alignment tests.

babel reports now error on invalid usage of identifiers/keywords in strict mode, 
typescript has `TS1100: "Invalid use of '{0}' in strict mode."`, but i'm unsure if we want to error on this code.