### PR TITLE
test(ts-estree): correct jsx for semantic-diagnostics tests

### DIFF
--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import jsxKnownIssues from '../../../shared-fixtures/jsx-known-issues';
+import { isJSXFileType } from '../../tools/test-utils';
 
 interface Fixture {
   filename: string;
@@ -61,7 +62,7 @@ class FixturesTester {
     const ignore = config.ignore || [];
     const fileType = config.fileType || 'js';
     const ignoreSourceType = config.ignoreSourceType || [];
-    const jsx = fileType === 'js' || fileType === 'jsx' || fileType === 'tsx';
+    const jsx = isJSXFileType(fileType);
 
     /**
      * The TypeScript compiler gives us the "externalModuleIndicator" to allow typescript-estree do dynamically detect the "sourceType".

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
@@ -8,77 +8,21 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" e
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsdoc-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-block-comment.src 1`] = `
-Object {
-  "column": 10,
-  "index": 84,
-  "lineNumber": 5,
-  "message": "Unterminated regular expression literal.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-block-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-comment-after-jsx.src 1`] = `
-Object {
-  "column": 14,
-  "index": 48,
-  "lineNumber": 3,
-  "message": "Type expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-comment-after-jsx.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-comment-after-self-closing-jsx.src 1`] = `
-Object {
-  "column": 13,
-  "index": 47,
-  "lineNumber": 3,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-comment-after-self-closing-jsx.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-tag-comments.src 1`] = `
-Object {
-  "column": 9,
-  "index": 113,
-  "lineNumber": 7,
-  "message": "Type expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-tag-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-text-with-multiline-non-comment.src 1`] = `
-Object {
-  "column": 5,
-  "index": 81,
-  "lineNumber": 7,
-  "message": "Type expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-text-with-multiline-non-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-text-with-url.src 1`] = `
-Object {
-  "column": 17,
-  "index": 17,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-text-with-url.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-with-greather-than.src 1`] = `
-Object {
-  "column": 0,
-  "index": 69,
-  "lineNumber": 4,
-  "message": "Expression expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-with-greather-than.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-with-operators.src 1`] = `
-Object {
-  "column": 0,
-  "index": 69,
-  "lineNumber": 4,
-  "message": "Expression expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-with-operators.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/line-comment-with-block-syntax.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
@@ -1330,120 +1274,71 @@ Object {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/attributes.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/attributes.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/element-keyword-name.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-conditional.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-invalid-js-identifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-tags.src 1`] = `
+Object {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "'{' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/empty-placeholder.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/escape-patterns.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-attribute.src 1`] = `
 Object {
   "column": 5,
   "index": 5,
   "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/element-keyword-name.src 1`] = `
-Object {
-  "column": 12,
-  "index": 18,
-  "lineNumber": 2,
-  "message": "'>' expected.",
-}
-`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-comment.src 1`] = `
-Object {
-  "column": 30,
-  "index": 30,
-  "lineNumber": 1,
-  "message": "Unterminated regular expression literal.",
-}
-`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-conditional.src 1`] = `
-Object {
-  "column": 3,
-  "index": 3,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-invalid-js-identifier.src 1`] = `
-Object {
-  "column": 9,
-  "index": 9,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-tags.src 1`] = `
-Object {
-  "column": 11,
-  "index": 11,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/empty-placeholder.src 1`] = `
-Object {
-  "column": 7,
-  "index": 7,
-  "lineNumber": 1,
-  "message": "Unterminated regular expression literal.",
-}
-`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/escape-patterns.src 1`] = `
-Object {
-  "column": 3,
-  "index": 3,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-attribute.src 1`] = `
-Object {
-  "column": 3,
-  "index": 3,
-  "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "'{' expected.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-attribute-missing-equals.src 1`] = `
 Object {
-  "column": 5,
-  "index": 5,
+  "column": 14,
+  "index": 14,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "Identifier expected.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-broken-tag.src 1`] = `
 Object {
-  "column": 3,
-  "index": 3,
+  "column": 12,
+  "index": 12,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "Unterminated string literal.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-computed-end-tag-name.src 1`] = `
 Object {
-  "column": 9,
-  "index": 9,
+  "column": 2,
+  "index": 2,
   "lineNumber": 1,
-  "message": "Type expected.",
+  "message": "Identifier expected.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-computed-string-end-tag-name.src 1`] = `
 Object {
-  "column": 11,
-  "index": 11,
+  "column": 2,
+  "index": 2,
   "lineNumber": 1,
-  "message": "Type expected.",
+  "message": "Identifier expected.",
 }
 `;
 
@@ -1452,23 +1347,23 @@ Object {
   "column": 9,
   "index": 9,
   "lineNumber": 1,
-  "message": "':' expected.",
+  "message": "'}' expected.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-leading-dot-tag-name.src 1`] = `
 Object {
-  "column": 1,
-  "index": 1,
+  "column": 0,
+  "index": 0,
   "lineNumber": 1,
-  "message": "Type expected.",
+  "message": "Expression expected.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-matching-placeholder-in-closing-tag.src 1`] = `
 Object {
-  "column": 5,
-  "index": 5,
+  "column": 27,
+  "index": 27,
   "lineNumber": 1,
   "message": "'>' expected.",
 }
@@ -1476,28 +1371,28 @@ Object {
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-mismatched-closing-tag.src 1`] = `
 Object {
-  "column": 4,
-  "index": 4,
+  "column": 3,
+  "index": 3,
   "lineNumber": 1,
-  "message": "Type expected.",
+  "message": "Expected corresponding JSX closing tag for 'a'.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-mismatched-closing-tags.src 1`] = `
 Object {
-  "column": 6,
-  "index": 6,
+  "column": 1,
+  "index": 1,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "JSX element 'a' has no corresponding closing tag.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-mismatched-dot-tag-name.src 1`] = `
 Object {
-  "column": 8,
-  "index": 8,
+  "column": 7,
+  "index": 7,
   "lineNumber": 1,
-  "message": "Type expected.",
+  "message": "Expected corresponding JSX closing tag for 'a.b.c'.",
 }
 `;
 
@@ -1506,34 +1401,34 @@ Object {
   "column": 2,
   "index": 2,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "Identifier expected.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-missing-closing-tag.src 1`] = `
 Object {
-  "column": 3,
-  "index": 3,
+  "column": 1,
+  "index": 1,
   "lineNumber": 1,
-  "message": "Expression expected.",
+  "message": "JSX element 'a' has no corresponding closing tag.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-missing-closing-tag-attribute-placeholder.src 1`] = `
 Object {
-  "column": 3,
-  "index": 3,
+  "column": 1,
+  "index": 1,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "JSX element 'a' has no corresponding closing tag.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-missing-namespace-name.src 1`] = `
 Object {
-  "column": 1,
-  "index": 1,
+  "column": 0,
+  "index": 0,
   "lineNumber": 1,
-  "message": "Type expected.",
+  "message": "Expression expected.",
 }
 `;
 
@@ -1542,16 +1437,16 @@ Object {
   "column": 2,
   "index": 2,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "Identifier expected.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-missing-spread-operator.src 1`] = `
 Object {
-  "column": 5,
-  "index": 5,
+  "column": 6,
+  "index": 6,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "'...' expected.",
 }
 `;
 
@@ -1560,7 +1455,7 @@ Object {
   "column": 4,
   "index": 4,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "Identifier expected.",
 }
 `;
 
@@ -1569,7 +1464,7 @@ Object {
   "column": 2,
   "index": 2,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "Identifier expected.",
 }
 `;
 
@@ -1578,43 +1473,43 @@ Object {
   "column": 36,
   "index": 36,
   "lineNumber": 1,
-  "message": "Expression expected.",
+  "message": "JSX expressions must have one parent element.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-no-common-parent-with-comment.src 1`] = `
 Object {
-  "column": 38,
-  "index": 38,
+  "column": 63,
+  "index": 63,
   "lineNumber": 1,
-  "message": "',' expected.",
+  "message": "JSX expressions must have one parent element.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-no-tag-name.src 1`] = `
 Object {
-  "column": 1,
-  "index": 1,
+  "column": 0,
+  "index": 0,
   "lineNumber": 1,
-  "message": "Type expected.",
+  "message": "Declaration or statement expected.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-placeholder-in-closing-tag.src 1`] = `
 Object {
-  "column": 12,
-  "index": 12,
+  "column": 16,
+  "index": 16,
   "lineNumber": 1,
-  "message": "Unterminated regular expression literal.",
+  "message": "'>' expected.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-shorthand-fragment-no-closing.src 1`] = `
 Object {
-  "column": 1,
-  "index": 1,
+  "column": 0,
+  "index": 0,
   "lineNumber": 1,
-  "message": "Type expected.",
+  "message": "JSX fragment has no corresponding closing tag.",
 }
 `;
 
@@ -1629,64 +1524,29 @@ Object {
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-unexpected-comma.src 1`] = `
 Object {
-  "column": 6,
-  "index": 6,
+  "column": 19,
+  "index": 19,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "Identifier expected.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/japanese-characters.src 1`] = `
-Object {
-  "column": 6,
-  "index": 6,
-  "lineNumber": 1,
-  "message": "Type expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/japanese-characters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/less-than-operator.src 1`] = `
-Object {
-  "column": 6,
-  "index": 6,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/less-than-operator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/member-expression.src 1`] = `
-Object {
-  "column": 6,
-  "index": 6,
-  "lineNumber": 1,
-  "message": "Type expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/member-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/member-expression-this.src 1`] = `
-Object {
-  "column": 5,
-  "index": 5,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/member-expression-this.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/multiple-blank-spaces.src 1`] = `
-Object {
-  "column": 8,
-  "index": 8,
-  "lineNumber": 1,
-  "message": "Type expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/multiple-blank-spaces.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/namespaced-attribute-and-value-inserted.src 1`] = `
 Object {
-  "column": 3,
-  "index": 3,
+  "column": 4,
+  "index": 4,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "Identifier expected.",
 }
 `;
 
@@ -1695,36 +1555,22 @@ Object {
   "column": 2,
   "index": 2,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "Identifier expected.",
 }
 `;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/newslines-and-entities.src 1`] = `
 Object {
-  "column": 4,
-  "index": 4,
+  "column": 8,
+  "index": 8,
   "lineNumber": 1,
-  "message": "'>' expected.",
+  "message": "Invalid character.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/self-closing-tag.src 1`] = `
-Object {
-  "column": 3,
-  "index": 3,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/self-closing-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/self-closing-tag-inside-tag.src 1`] = `
-Object {
-  "column": 9,
-  "index": 15,
-  "lineNumber": 2,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/self-closing-tag-inside-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/self-closing-tag-with-newline.src 1`] = `
 Object {
@@ -1735,140 +1581,35 @@ Object {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/shorthand-fragment.src 1`] = `
-Object {
-  "column": 1,
-  "index": 1,
-  "lineNumber": 1,
-  "message": "Type expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/shorthand-fragment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/shorthand-fragment-with-child.src 1`] = `
-Object {
-  "column": 1,
-  "index": 1,
-  "lineNumber": 1,
-  "message": "Type expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/shorthand-fragment-with-child.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/spread-child.src 1`] = `
-Object {
-  "column": 15,
-  "index": 15,
-  "lineNumber": 1,
-  "message": "Unterminated regular expression literal.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/spread-child.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/spread-operator-attribute-and-regular-attribute.src 1`] = `
-Object {
-  "column": 5,
-  "index": 5,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/spread-operator-attribute-and-regular-attribute.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/spread-operator-attributes.src 1`] = `
-Object {
-  "column": 5,
-  "index": 5,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/spread-operator-attributes.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/tag-names-with-dots.src 1`] = `
-Object {
-  "column": 6,
-  "index": 6,
-  "lineNumber": 1,
-  "message": "Type expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/tag-names-with-dots.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/tag-names-with-multi-dots.src 1`] = `
-Object {
-  "column": 8,
-  "index": 8,
-  "lineNumber": 1,
-  "message": "Type expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/tag-names-with-multi-dots.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/tag-names-with-multi-dots-multi.src 1`] = `
-Object {
-  "column": 7,
-  "index": 21,
-  "lineNumber": 2,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/tag-names-with-multi-dots-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/test-content.src 1`] = `
-Object {
-  "column": 5,
-  "index": 5,
-  "lineNumber": 1,
-  "message": "Expression expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/test-content.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/trailing-spread-operator-attribute.src 1`] = `
-Object {
-  "column": 5,
-  "index": 5,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/trailing-spread-operator-attribute.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/unknown-escape-pattern.src 1`] = `
-Object {
-  "column": 3,
-  "index": 3,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/unknown-escape-pattern.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx-useJSXTextNode/self-closing-tag-inside-tag.src 1`] = `
-Object {
-  "column": 9,
-  "index": 15,
-  "lineNumber": 2,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx-useJSXTextNode/self-closing-tag-inside-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx-useJSXTextNode/test-content.src 1`] = `
-Object {
-  "column": 5,
-  "index": 5,
-  "lineNumber": 1,
-  "message": "Expression expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx-useJSXTextNode/test-content.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/tsx/generic-jsx-element.src 1`] = `
-Object {
-  "column": 21,
-  "index": 21,
-  "lineNumber": 1,
-  "message": "'>' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/tsx/generic-jsx-element.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/tsx/react-typed-props.src 1`] = `
-Object {
-  "column": 12,
-  "index": 141,
-  "lineNumber": 9,
-  "message": "',' expected.",
-}
-`;
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/tsx/react-typed-props.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/babylon-convergence/type-parameter-whitespace-loc.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 

--- a/packages/typescript-estree/tests/lib/comments.ts
+++ b/packages/typescript-estree/tests/lib/comments.ts
@@ -11,7 +11,8 @@ import { extname } from 'path';
 import { ParserOptions } from '../../src/parser-options';
 import {
   createSnapshotTestBlock,
-  formatSnapshotName
+  formatSnapshotName,
+  isJSXFileType
 } from '../../tools/test-utils';
 
 //------------------------------------------------------------------------------
@@ -35,7 +36,7 @@ describe('Comments', () => {
       range: true,
       tokens: true,
       comment: true,
-      jsx: fileExtension === '.js'
+      jsx: isJSXFileType(fileExtension)
     };
     it(
       formatSnapshotName(filename, FIXTURES_DIR, fileExtension),

--- a/packages/typescript-estree/tests/lib/semantic-diagnostics-enabled.ts
+++ b/packages/typescript-estree/tests/lib/semantic-diagnostics-enabled.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'fs';
 import glob from 'glob';
 import * as parser from '../../src/parser';
 import { extname } from 'path';
-import { formatSnapshotName } from '../../tools/test-utils';
+import { formatSnapshotName, isJSXFileType } from '../../tools/test-utils';
 
 //------------------------------------------------------------------------------
 // Setup
@@ -30,12 +30,13 @@ describe('Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" 
   testFiles.forEach(filename => {
     const code = readFileSync(filename, 'utf8');
     const fileExtension = extname(filename);
-    const config = {
+    const config: parser.ParserOptions = {
       loc: true,
       range: true,
       tokens: true,
       errorOnUnknownASTType: true,
-      errorOnTypeScriptSyntacticAndSemanticIssues: true
+      errorOnTypeScriptSyntacticAndSemanticIssues: true,
+      jsx: isJSXFileType(fileExtension)
     };
     it(formatSnapshotName(filename, FIXTURES_DIR, fileExtension), () => {
       expect.assertions(1);

--- a/packages/typescript-estree/tests/lib/tsx.ts
+++ b/packages/typescript-estree/tests/lib/tsx.ts
@@ -10,7 +10,8 @@ import { extname } from 'path';
 import { ParserOptions } from '../../src/parser-options';
 import {
   createSnapshotTestBlock,
-  formatSnapshotName
+  formatSnapshotName,
+  isJSXFileType
 } from '../../tools/test-utils';
 
 //------------------------------------------------------------------------------
@@ -28,16 +29,17 @@ const testFiles = glob.sync(`${FIXTURES_DIR}/**/*.src.tsx`);
 describe('TSX', () => {
   testFiles.forEach(filename => {
     const code = readFileSync(filename, 'utf8');
+    const fileExtension = extname(filename);
     const config: ParserOptions = {
       loc: true,
       range: true,
       tokens: true,
       errorOnUnknownASTType: true,
       useJSXTextNode: true,
-      jsx: true
+      jsx: isJSXFileType(fileExtension)
     };
     it(
-      formatSnapshotName(filename, FIXTURES_DIR, extname(filename)),
+      formatSnapshotName(filename, FIXTURES_DIR, fileExtension),
       createSnapshotTestBlock(code, config)
     );
   });

--- a/packages/typescript-estree/tests/lib/typescript.ts
+++ b/packages/typescript-estree/tests/lib/typescript.ts
@@ -11,7 +11,8 @@ import { extname } from 'path';
 import { ParserOptions } from '../../src/parser-options';
 import {
   createSnapshotTestBlock,
-  formatSnapshotName
+  formatSnapshotName,
+  isJSXFileType
 } from '../../tools/test-utils';
 
 //------------------------------------------------------------------------------
@@ -29,14 +30,16 @@ const testFiles = glob.sync(`${FIXTURES_DIR}/**/*.src.ts`);
 describe('typescript', () => {
   testFiles.forEach(filename => {
     const code = readFileSync(filename, 'utf8');
+    const fileExtension = extname(filename);
     const config: ParserOptions = {
       loc: true,
       range: true,
       tokens: true,
-      errorOnUnknownASTType: true
+      errorOnUnknownASTType: true,
+      jsx: isJSXFileType(fileExtension)
     };
     it(
-      formatSnapshotName(filename, FIXTURES_DIR, extname(filename)),
+      formatSnapshotName(filename, FIXTURES_DIR, fileExtension),
       createSnapshotTestBlock(code, config)
     );
   });

--- a/packages/typescript-estree/tools/test-utils.ts
+++ b/packages/typescript-estree/tools/test-utils.ts
@@ -80,3 +80,14 @@ export function formatSnapshotName(
     .replace(fixturesDir + '/', '')
     .replace(fileExtension, '')}`;
 }
+
+/**
+ * Check if file extension is one used for jsx
+ * @param fileType
+ */
+export function isJSXFileType(fileType: string): boolean {
+  if (fileType.startsWith('.')) {
+    fileType = fileType.slice(1);
+  }
+  return fileType === 'js' || fileType === 'jsx' || fileType === 'tsx';
+}


### PR DESCRIPTION
files with js, jsx, tsx extensions should be parsed as "JSX" in semantic-diagnostics tests