### PR TITLE
docs(eslint-plugin): removed counts from ROADMAP

### DIFF
--- a/packages/eslint-plugin/ROADMAP.md
+++ b/packages/eslint-plugin/ROADMAP.md
@@ -1,15 +1,10 @@
 ﻿# Roadmap
 
-<!--
-  When updating these totals, please make sure to subtract 1 from the total
-  count retrived via Ctrl/Cmd+F since this key shouldn’t count in the results.
--->
-
-✅ (30) = done<br>
-🌟 (79) = in ESLint core<br>
-🔌 (33) = in another plugin<br>
-🌓 (16) = implementations differ or ESLint version is missing functionality<br>
-🛑 (68) = unimplemented<br>
+✅ = done<br>
+🌟 = in ESLint core<br>
+🔌 = in another plugin<br>
+🌓 = implementations differ or ESLint version is missing functionality<br>
+🛑 = unimplemented<br>
 
 ## TSLint rules
 


### PR DESCRIPTION
As discussed, they are too awkward to manually maintain when multiple plugin PRs are open at the same time.

We can revisit and look at a way to autogenerate.