### PR TITLE
docs(eslint-plugin): fix metadata for prefer-function-type

### DIFF
--- a/packages/eslint-plugin/lib/rules/prefer-function-type.js
+++ b/packages/eslint-plugin/lib/rules/prefer-function-type.js
@@ -24,7 +24,7 @@ module.exports = {
         'Use function types instead of interfaces with call signatures',
       category: 'TypeScript',
       recommended: false,
-      extraDescription: [util.tslintRule('prefer-function-type')],
+      extraDescription: [util.tslintRule('callable-types')],
       url: util.metaDocsUrl('prefer-function-type')
     },
     fixable: 'code',


### PR DESCRIPTION
Got confused by the rule name change and forgot to leave this part unchanged.