### PR TITLE
feat(eslint-plugin): sort members alphabetically

### DIFF
--- a/packages/eslint-plugin/docs/rules/member-ordering.md
+++ b/packages/eslint-plugin/docs/rules/member-ordering.md
@@ -7,40 +7,47 @@ A consistent ordering of fields, methods and constructors can make interfaces, t
 This rule aims to standardize the way class declarations, class expressions, interfaces and type literals are structured and ordered.
 
 ### Grouping and sorting member groups
+
 It allows to group members by their type (e.g. `public-static-field`, `protected-static-field`, `private-static-field`, `public-instance-field`, ...) and enforce a certain order for these groups. By default, their order is the same inside `classes`, `classExpressions`, `interfaces` and `typeLiterals` (note: not all member types apply to `interfaces` and `typeLiterals`). It is possible to define the order for any of those individually or to change the default order for all of them by setting the `default` option.
 
 ### Sorting members
-Besides grouping the members and sorting their groups, this rule also allows to sort the members themselves. You have 2 options: Sort all of them while ignoring their type or sort them inside of the member types (e.g. sort all fields in an interface alphabetically).
+
+Besides grouping the members and sorting their groups, this rule also allows to sort the members themselves (e.g. `a`, `b`, `c`, ...). You have 2 options: Sort all of them while ignoring their type or sort them while respecting their types (e.g. sort all fields in an interface alphabetically).
 
 ## Options
+
 These options allow to specify how to group the members and sort their groups.
 
+- Sort groups, don't enforce member order: Use `memberTypes`
+- Sort members, don't enforce group order: Use `order`
+- Sort members within groups: Use `memberTypes` and `order`
+
 ```ts
+type TypeOptions<T> =
+  | {
+    memberTypes: Array<T> | 'never',
+    order?: 'alphabetically' | 'as-written',
+  }
+  | {
+    order: 'alphabetically',
+  };
+
 {
-  default?: Array<MemberType> | 'never'
+  default?: TypeOptions<MemberTypes>,
 
-  classes?: Array<MemberType> | 'never'
-  classExpressions?: Array<MemberType> | 'never'
+  classes?: TypeOptions<MemberTypes>,
+  classExpressions?: TypeOptions<MemberTypes>,
 
-  interfaces?: ['signature' | 'field' | 'method' | 'constructor'] | 'never'
-  typeLiterals?: ['signature' | 'field' | 'method' | 'constructor'] | 'never'
-}
-```
-
-If you want to enforce an alphabetic order, you have to use this form
-```ts
-{
-  default?: Array<MemberType> | { memberTypes?: Array<MemberType> | 'never', order?: 'alphabetically' } | 'never'
-
-  classes?: Array<MemberType> | { memberTypes?: Array<MemberType> | 'never', order?: 'alphabetically' } | 'never'
-  classExpressions?: Array<MemberType> | { memberTypes?: Array<MemberType> | 'never', order?: 'alphabetically' } | 'never'
-
-  interfaces?: ['field' | 'method' | 'constructor'] | { memberTypes?: Array<MemberType> | 'never', order?: 'alphabetically' } | 'never'
-  typeLiterals?: ['field' | 'method' | 'constructor'] | { memberTypes?: Array<MemberType> | 'never', order?: 'alphabetically' } | 'never'
+  interfaces?: TypeOptions<'signature' | 'field' | 'method' | 'constructor'>,
+  typeLiterals?: TypeOptions<'signature' | 'field' | 'method' | 'constructor'>,
 }
 ```
 
 See below for the possible definitions of `MemberType`.
+
+### Deprecated syntax
+
+Note: There is a deprecated syntax to specify the member types as an array.
 
 ### Member types (granular form)
 
@@ -156,57 +163,63 @@ The third grouping option is to ignore both scope and accessibility.
 
 The default configuration looks as follows:
 
-```json
+```json5
 {
-  "default": [
-    "signature",
+  default: [
+    'signature',
 
-    "public-static-field",
-    "protected-static-field",
-    "private-static-field",
+    'public-static-field',
+    'protected-static-field',
+    'private-static-field',
 
-    "public-instance-field",
-    "protected-instance-field",
-    "private-instance-field",
+    'public-instance-field',
+    'protected-instance-field',
+    'private-instance-field',
 
-    "public-abstract-field",
-    "protected-abstract-field",
-    "private-abstract-field",
+    'public-abstract-field',
+    'protected-abstract-field',
+    'private-abstract-field',
 
-    "public-field",
-    "protected-field",
-    "private-field",
+    'public-field',
+    'protected-field',
+    'private-field',
 
-    "static-field",
-    "instance-field",
-    "abstract-field",
+    'static-field',
+    'instance-field',
+    'abstract-field',
 
-    "field",
+    'field',
 
-    "constructor",
+    // Constructors
+    'public-constructor',
+    'protected-constructor',
+    'private-constructor',
 
-    "public-static-method",
-    "protected-static-method",
-    "private-static-method",
+    'constructor',
 
-    "public-instance-method",
-    "protected-instance-method",
-    "private-instance-method",
+    // Methods
+    'public-static-method',
+    'protected-static-method',
+    'private-static-method',
 
-    "public-abstract-method",
-    "protected-abstract-method",
-    "private-abstract-method",
+    'public-instance-method',
+    'protected-instance-method',
+    'private-instance-method',
 
-    "public-method",
-    "protected-method",
-    "private-method",
+    'public-abstract-method',
+    'protected-abstract-method',
+    'private-abstract-method',
 
-    "static-method",
-    "instance-method",
-    "abstract-method",
+    'public-method',
+    'protected-method',
+    'private-method',
 
-    "method"
-  ]
+    'static-method',
+    'instance-method',
+    'abstract-method',
+
+    'method',
+  ],
 }
 ```
 
@@ -733,9 +746,11 @@ type Foo = {
 ```
 
 ### Sorting alphabetically within member groups
+
 It is possible to sort all members within a group alphabetically.
 
 #### Configuration: `{ default: { order: 'alphabetically' } }`
+
 This will apply the default order (see above) and enforce an alphabetic order within each group.
 
 ##### Incorrect examples
@@ -779,6 +794,7 @@ interface Foo {
 Note: Wrong alphabetic order (should be `a(): void` --> `b(): void` --> `c(): void`).
 
 ### Sorting alphabetically while ignoring member groups
+
 It is also possible to sort all members and ignore the member groups completely.
 
 #### Configuration: `{ default: { memberTypes: 'never', order: 'alphabetically' } }`

--- a/packages/eslint-plugin/docs/rules/member-ordering.md
+++ b/packages/eslint-plugin/docs/rules/member-ordering.md
@@ -1,16 +1,19 @@
 # Require a consistent member declaration order (`member-ordering`)
 
-A consistent ordering of fields, methods and constructors can make interfaces, type literals, classes and class
-expressions easier to read, navigate and edit.
+A consistent ordering of fields, methods and constructors can make interfaces, type literals, classes and class expressions easier to read, navigate and edit.
 
 ## Rule Details
 
-This rule aims to standardize the way class declarations, class expressions, interfaces and type literals are structured.
+This rule aims to standardize the way class declarations, class expressions, interfaces and type literals are structured and ordered.
 
-It allows to group members by their type (e.g. `public-static-field`, `protected-static-field`, `private-static-field`, `public-instance-field`, ...). By default, their order is the same inside `classes`, `classExpressions`, `interfaces` and `typeLiterals` (note: not all member types apply to `interfaces` and `typeLiterals`). It is possible to define the order for any of those individually or to change the default order for all of them by setting the `default` option.
+### Grouping and sorting member groups
+It allows to group members by their type (e.g. `public-static-field`, `protected-static-field`, `private-static-field`, `public-instance-field`, ...) and enforce a certain order for these groups. By default, their order is the same inside `classes`, `classExpressions`, `interfaces` and `typeLiterals` (note: not all member types apply to `interfaces` and `typeLiterals`). It is possible to define the order for any of those individually or to change the default order for all of them by setting the `default` option.
+
+### Sorting members
+Besides grouping the members and sorting their groups, this rule also allows to sort the members themselves. You have 2 options: Sort all of them while ignoring their type or sort them inside of the member types (e.g. sort all fields in an interface alphabetically).
 
 ## Options
-
+These options allow to specify how to group the members and sort their groups.
 ```ts
 {
   default?: Array<MemberType> | never
@@ -19,6 +22,18 @@ It allows to group members by their type (e.g. `public-static-field`, `protected
 
   interfaces?: ['signature' | 'field' | 'method' | 'constructor'] | never
   typeLiterals?: ['signature' | 'field' | 'method' | 'constructor'] | never
+}
+```
+
+If you want to enforce an alphabetic order, you have to use this form
+```ts
+{
+  default?: { memberTypes?: Array<MemberType>, order?: 'alphabetically' } | never
+  classes?: { memberTypes?: Array<MemberType>, order?: 'alphabetically' } | never
+  classExpressions?: { memberTypes?: Array<MemberType>, order?: 'alphabetically' } | never
+
+  interfaces?: { memberTypes?: Array<MemberType>, order?: 'alphabetically' } | never
+  typeLiterals?: { memberTypes?: Array<MemberType>, order?: 'alphabetically' } | never
 }
 ```
 
@@ -193,6 +208,8 @@ The default configuration looks as follows:
 ```
 
 Note: The default configuration contains member group types which contain other member types (see above). This is intentional to provide better error messages.
+
+Note: By default, the members are not sorted. If you want to sort them alphabetically, you have to provide a custom configuration.
 
 ## Examples
 

--- a/packages/eslint-plugin/docs/rules/member-ordering.md
+++ b/packages/eslint-plugin/docs/rules/member-ordering.md
@@ -14,26 +14,29 @@ Besides grouping the members and sorting their groups, this rule also allows to 
 
 ## Options
 These options allow to specify how to group the members and sort their groups.
+
 ```ts
 {
-  default?: Array<MemberType> | never
-  classes?: Array<MemberType> | never
-  classExpressions?: Array<MemberType> | never
+  default?: Array<MemberType> | 'never'
 
-  interfaces?: ['signature' | 'field' | 'method' | 'constructor'] | never
-  typeLiterals?: ['signature' | 'field' | 'method' | 'constructor'] | never
+  classes?: Array<MemberType> | 'never'
+  classExpressions?: Array<MemberType> | 'never'
+
+  interfaces?: ['signature' | 'field' | 'method' | 'constructor'] | 'never'
+  typeLiterals?: ['signature' | 'field' | 'method' | 'constructor'] | 'never'
 }
 ```
 
 If you want to enforce an alphabetic order, you have to use this form
 ```ts
 {
-  default?: { memberTypes?: Array<MemberType>, order?: 'alphabetically' } | never
-  classes?: { memberTypes?: Array<MemberType>, order?: 'alphabetically' } | never
-  classExpressions?: { memberTypes?: Array<MemberType>, order?: 'alphabetically' } | never
+  default?: Array<MemberType> | { memberTypes?: Array<MemberType> | 'never', order?: 'alphabetically' } | 'never'
 
-  interfaces?: { memberTypes?: Array<MemberType>, order?: 'alphabetically' } | never
-  typeLiterals?: { memberTypes?: Array<MemberType>, order?: 'alphabetically' } | never
+  classes?: Array<MemberType> | { memberTypes?: Array<MemberType> | 'never', order?: 'alphabetically' } | 'never'
+  classExpressions?: Array<MemberType> | { memberTypes?: Array<MemberType> | 'never', order?: 'alphabetically' } | 'never'
+
+  interfaces?: ['field' | 'method' | 'constructor'] | { memberTypes?: Array<MemberType> | 'never', order?: 'alphabetically' } | 'never'
+  typeLiterals?: ['field' | 'method' | 'constructor'] | { memberTypes?: Array<MemberType> | 'never', order?: 'alphabetically' } | 'never'
 }
 ```
 
@@ -728,6 +731,72 @@ type Foo = {
   B: string; // -> field
 };
 ```
+
+### Sorting alphabetically within member groups
+It is possible to sort all members within a group alphabetically.
+
+#### Configuration: `{ default: { order: 'alphabetically' } }`
+This will apply the default order (see above) and enforce an alphabetic order within each group.
+
+##### Incorrect examples
+
+```ts
+interface Foo {
+  a: x;
+  b: x;
+  c: x;
+
+  a(): void;
+  b(): void;
+  c(): void;
+
+  [a: string]: number;
+  (): Baz;
+
+  new (): Bar;
+}
+```
+
+Note: Wrong group order for `new () : Bar`.
+
+```ts
+interface Foo {
+  a: x;
+  b: x;
+  c: x;
+
+  new (): Bar;
+
+  c(): void;
+  b(): void;
+  a(): void;
+
+  [a: string]: number;
+  (): Baz;
+}
+```
+
+Note: Wrong alphabetic order (should be `a(): void` --> `b(): void` --> `c(): void`).
+
+### Sorting alphabetically while ignoring member groups
+It is also possible to sort all members and ignore the member groups completely.
+
+#### Configuration: `{ default: { memberTypes: 'never', order: 'alphabetically' } }`
+
+##### Incorrect example
+
+```ts
+interface Foo {
+  b(): void;
+  a: b;
+
+  [a: string]: number; // Order doesn't matter (no sortable identifier)
+  new (): Bar; // Order doesn't matter (no sortable identifier)
+  (): Baz; // Order doesn't matter (no sortable identifier)
+}
+```
+
+Note: Wrong alphabetic order `b(): void` should come after `a: b`.
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/docs/rules/member-ordering.md
+++ b/packages/eslint-plugin/docs/rules/member-ordering.md
@@ -166,8 +166,10 @@ The default configuration looks as follows:
 ```json5
 {
   default: [
+    // Index signature
     'signature',
 
+    // Fields
     'public-static-field',
     'protected-static-field',
     'private-static-field',
@@ -481,7 +483,7 @@ const foo = class {
 };
 ```
 
-Issue: Public static fields should come first, followed by static fields and instance fields.
+Note: Public static fields should come first, followed by static fields and instance fields.
 
 ##### Correct examples
 
@@ -575,21 +577,19 @@ class Foo {
 
 ##### Correct example
 
-Examples of **correct** code for `{ "classes": [...] }` option:
-
 ```ts
 class Foo {
   private C: string; // (irrelevant)
 
   public D: string; // (irrelevant)
 
-  public static E: string; // -> public static field
+  public B(): void {} // -> public instance method
 
   constructor() {} // (irrelevant)
 
   public static A(): void {} // (irrelevant)
 
-  public B(): void {} // -> public instance method
+  public static E: string; // -> public static field
 }
 ```
 
@@ -749,7 +749,7 @@ type Foo = {
 
 It is possible to sort all members within a group alphabetically.
 
-#### Configuration: `{ default: { order: 'alphabetically' } }`
+#### Configuration: `{ default: { memberTypes: <Default Order>, order: 'alphabetically' } }`
 
 This will apply the default order (see above) and enforce an alphabetic order within each group.
 
@@ -761,37 +761,35 @@ interface Foo {
   b: x;
   c: x;
 
+  new (): Bar;
+  (): Baz;
+
   a(): void;
   b(): void;
   c(): void;
 
+  // Wrong group order, should be placed before all field definitions
   [a: string]: number;
-  (): Baz;
-
-  new (): Bar;
 }
 ```
 
-Note: Wrong group order for `new () : Bar`.
-
 ```ts
 interface Foo {
+  [a: string]: number;
+
   a: x;
   b: x;
   c: x;
 
   new (): Bar;
+  (): Baz;
 
+  // Wrong alphabetic order within group
   c(): void;
   b(): void;
   a(): void;
-
-  [a: string]: number;
-  (): Baz;
 }
 ```
-
-Note: Wrong alphabetic order (should be `a(): void` --> `b(): void` --> `c(): void`).
 
 ### Sorting alphabetically while ignoring member groups
 

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -1,12 +1,20 @@
 import {
-  TSESTree,
   AST_NODE_TYPES,
+  TSESLint,
+  TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import * as util from '../util';
 
-type MessageIds = 'incorrectOrder';
-type OrderConfig = string[] | 'never';
-type Options = [
+export type MessageIds = 'incorrectGroupOrder' | 'incorrectOrder';
+
+interface SortedOrderConfig {
+  memberTypes?: string[] | 'never';
+  order: 'alphabetically';
+}
+
+type OrderConfig = string[] | SortedOrderConfig | 'never';
+
+export type Options = [
   {
     default?: OrderConfig;
     classes?: OrderConfig;
@@ -14,6 +22,54 @@ type Options = [
     interfaces?: OrderConfig;
     typeLiterals?: OrderConfig;
   },
+];
+
+const defaultOrder = [
+  'public-static-field',
+  'protected-static-field',
+  'private-static-field',
+
+  'public-instance-field',
+  'protected-instance-field',
+  'private-instance-field',
+
+  'public-abstract-field',
+  'protected-abstract-field',
+  'private-abstract-field',
+
+  'public-field',
+  'protected-field',
+  'private-field',
+
+  'static-field',
+  'instance-field',
+  'abstract-field',
+
+  'field',
+
+  'constructor',
+
+  'public-static-method',
+  'protected-static-method',
+  'private-static-method',
+
+  'public-instance-method',
+  'protected-instance-method',
+  'private-instance-method',
+
+  'public-abstract-method',
+  'protected-abstract-method',
+  'private-abstract-method',
+
+  'public-method',
+  'protected-method',
+  'private-method',
+
+  'static-method',
+  'instance-method',
+  'abstract-method',
+
+  'method',
 ];
 
 const allMemberTypes = ['field', 'method', 'constructor'].reduce<string[]>(
@@ -24,8 +80,8 @@ const allMemberTypes = ['field', 'method', 'constructor'].reduce<string[]>(
       all.push(`${accessibility}-${type}`); // e.g. `public-field`
 
       if (type !== 'constructor') {
-        // There is no `static-constructor` or `instance-constructor or `abstract-constructor`
-        ['static', 'instance', 'abstract'].forEach(scope => {
+        // There is no `static-constructor` or `instance-constructor
+        ['static', 'instance'].forEach(scope => {
           if (!all.includes(`${scope}-${type}`)) {
             all.push(`${scope}-${type}`);
           }
@@ -39,7 +95,233 @@ const allMemberTypes = ['field', 'method', 'constructor'].reduce<string[]>(
   },
   [],
 );
-allMemberTypes.unshift('signature');
+
+const neverConfig = {
+  type: 'string',
+  enum: ['never'],
+};
+
+const allMemberTypesArrayConfig = {
+  type: 'array',
+  items: {
+    enum: allMemberTypes,
+  },
+};
+
+const allMemberTypesDefaultConfig = {
+  type: 'string',
+  enum: ['never'],
+};
+
+const allMemberTypesObjectConfig = {
+  type: 'object',
+  properties: {
+    memberTypes: {
+      oneOf: [allMemberTypesDefaultConfig, allMemberTypesArrayConfig],
+    },
+    order: {
+      type: 'string',
+      enum: ['alphabetically'],
+    },
+  },
+  additionalProperties: false,
+};
+
+const functionExpressions = [
+  AST_NODE_TYPES.FunctionExpression,
+  AST_NODE_TYPES.ArrowFunctionExpression,
+];
+
+/**
+ * Gets the node type.
+ * @param node the node to be evaluated.
+ */
+function getNodeType(
+  node: TSESTree.ClassElement | TSESTree.TypeElement,
+): string | null {
+  // TODO: add missing TSCallSignatureDeclaration
+  switch (node.type) {
+    case AST_NODE_TYPES.TSAbstractMethodDefinition:
+    case AST_NODE_TYPES.MethodDefinition:
+      return node.kind;
+    case AST_NODE_TYPES.TSMethodSignature:
+      return 'method';
+    case AST_NODE_TYPES.TSConstructSignatureDeclaration:
+      return 'constructor';
+    case AST_NODE_TYPES.TSAbstractClassProperty:
+    case AST_NODE_TYPES.ClassProperty:
+      return node.value && functionExpressions.includes(node.value.type)
+        ? 'method'
+        : 'field';
+    case AST_NODE_TYPES.TSPropertySignature:
+      return 'field';
+    case AST_NODE_TYPES.TSIndexSignature:
+      return 'signature';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Gets the member name based on the member type.
+ *
+ * @param node the node to be evaluated.
+ * @param sourceCode
+ */
+function getMemberName(
+  node: TSESTree.ClassElement | TSESTree.TypeElement,
+  sourceCode: TSESLint.SourceCode,
+): string | null {
+  switch (node.type) {
+    case AST_NODE_TYPES.TSPropertySignature:
+    case AST_NODE_TYPES.TSMethodSignature:
+    case AST_NODE_TYPES.TSAbstractClassProperty:
+    case AST_NODE_TYPES.ClassProperty:
+      return util.getNameFromMember(node, sourceCode);
+    case AST_NODE_TYPES.TSAbstractMethodDefinition:
+    case AST_NODE_TYPES.MethodDefinition:
+      return node.kind === 'constructor'
+        ? 'constructor'
+            : util.getNameFromMember(node, sourceCode);
+    case AST_NODE_TYPES.TSConstructSignatureDeclaration:
+      return 'new';
+    case AST_NODE_TYPES.TSIndexSignature:
+      return util.getNameFromIndexSignature(node);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Gets the member identifier (null if there is no identifier).
+ *
+ * @param node the node to be evaluated.
+ * @param sourceCode
+ */
+function getIdentifier(
+  node: TSESTree.ClassElement | TSESTree.TypeElement,
+  sourceCode: TSESLint.SourceCode,
+): string | null {
+  switch (node.type) {
+    case AST_NODE_TYPES.TSPropertySignature:
+    case AST_NODE_TYPES.TSMethodSignature:
+    case AST_NODE_TYPES.ClassProperty:
+      return util.getNameFromPropertyName(node.key);
+    case AST_NODE_TYPES.MethodDefinition:
+      return util.getNameFromClassMember(node, sourceCode);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Gets the calculated rank using the provided method definition.
+ * The algorithm is as follows:
+ * - Get the rank based on the accessibility-scope-type name, e.g. public-instance-field
+ * - If there is no order for accessibility-scope-type, then strip out the accessibility.
+ * - If there is no order for scope-type, then strip out the scope.
+ * - If there is no order for type, then return -1
+ * @param memberGroups the valid names to be validated.
+ * @param orderConfig the current order to be validated.
+ *
+ * @return Index of the matching member type in the order configuration.
+ */
+function getRankOrder(memberGroups: string[], orderConfig: string[]): number {
+  let rank = -1;
+  const stack = memberGroups.slice(); // Get a copy of the member groups
+
+  while (stack.length > 0 && rank === -1) {
+    rank = orderConfig.indexOf(stack.shift()!);
+  }
+
+  return rank;
+}
+
+/**
+ * Gets the rank of the node given the order.
+ * @param node the node to be evaluated.
+ * @param orderConfig the current order to be validated.
+ * @param supportsModifiers a flag indicating whether the type supports modifiers (scope or accessibility) or not.
+ */
+function getRank(
+  node: TSESTree.ClassElement | TSESTree.TypeElement,
+  orderConfig: string[],
+  supportsModifiers: boolean,
+): number {
+  const type = getNodeType(node);
+
+  if (type === null) {
+    // shouldn't happen but just in case, put it on the end
+    return orderConfig.length - 1;
+  }
+
+      const abstract =
+        node.type === AST_NODE_TYPES.TSAbstractClassProperty ||
+        node.type === AST_NODE_TYPES.TSAbstractMethodDefinition;
+
+      const scope =
+        'static' in node && node.static
+          ? 'static'
+          : abstract
+          ? 'abstract'
+          : 'instance';
+  const accessibility =
+    'accessibility' in node && node.accessibility
+      ? node.accessibility
+      : 'public';
+
+  // Collect all existing member groups (e.g. 'public-instance-field', 'instance-field', 'public-field', 'constructor' etc.)
+  const memberGroups = [];
+
+  if (supportsModifiers) {
+    if (type !== 'constructor') {
+      // Constructors have no scope
+      memberGroups.push(`${accessibility}-${scope}-${type}`);
+      memberGroups.push(`${scope}-${type}`);
+    }
+
+    memberGroups.push(`${accessibility}-${type}`);
+  }
+
+  memberGroups.push(type);
+
+  return getRankOrder(memberGroups, orderConfig);
+}
+
+/**
+ * Gets the lowest possible rank higher than target.
+ * e.g. given the following order:
+ *   ...
+ *   public-static-method
+ *   protected-static-method
+ *   private-static-method
+ *   public-instance-method
+ *   protected-instance-method
+ *   private-instance-method
+ *   ...
+ * and considering that a public-instance-method has already been declared, so ranks contains
+ * public-instance-method, then the lowest possible rank for public-static-method is
+ * public-instance-method.
+ * @param ranks the existing ranks in the object.
+ * @param target the target rank.
+ * @param order the current order to be validated.
+ * @returns the name of the lowest possible rank without dashes (-).
+ */
+function getLowestRank(
+  ranks: number[],
+  target: number,
+  order: string[],
+): string {
+  let lowest = ranks[ranks.length - 1];
+
+  ranks.forEach(rank => {
+    if (rank > target) {
+      lowest = Math.min(lowest, rank);
+    }
+  });
+
+  return order[lowest].replace(/-/g, ' ');
+}
 
 export default util.createRule<Options, MessageIds>({
   name: 'member-ordering',
@@ -52,6 +334,8 @@ export default util.createRule<Options, MessageIds>({
     },
     messages: {
       incorrectOrder:
+        'Member "{{member}}" should be declared before member "{{beforeMember}}".',
+      incorrectGroupOrder:
         'Member {{name}} should be declared before all {{rank}} definitions.',
     },
     schema: [
@@ -60,67 +344,37 @@ export default util.createRule<Options, MessageIds>({
         properties: {
           default: {
             oneOf: [
-              {
-                enum: ['never'],
-              },
-              {
-                type: 'array',
-                items: {
-                  enum: allMemberTypes,
-                },
-              },
+              neverConfig,
+              allMemberTypesArrayConfig,
+              allMemberTypesObjectConfig,
             ],
           },
           classes: {
             oneOf: [
-              {
-                enum: ['never'],
-              },
-              {
-                type: 'array',
-                items: {
-                  enum: allMemberTypes,
-                },
-              },
+              neverConfig,
+              allMemberTypesArrayConfig,
+              allMemberTypesObjectConfig,
             ],
           },
           classExpressions: {
             oneOf: [
-              {
-                enum: ['never'],
-              },
-              {
-                type: 'array',
-                items: {
-                  enum: allMemberTypes,
-                },
-              },
+              neverConfig,
+              allMemberTypesArrayConfig,
+              allMemberTypesObjectConfig,
             ],
           },
           interfaces: {
             oneOf: [
-              {
-                enum: ['never'],
-              },
-              {
-                type: 'array',
-                items: {
-                  enum: ['signature', 'field', 'method', 'constructor'],
-                },
-              },
+              neverConfig,
+              allMemberTypesArrayConfig,
+              allMemberTypesObjectConfig,
             ],
           },
           typeLiterals: {
             oneOf: [
-              {
-                enum: ['never'],
-              },
-              {
-                type: 'array',
-                items: {
-                  enum: ['signature', 'field', 'method', 'constructor'],
-                },
-              },
+              neverConfig,
+              allMemberTypesArrayConfig,
+              allMemberTypesObjectConfig,
             ],
           },
         },
@@ -130,263 +384,132 @@ export default util.createRule<Options, MessageIds>({
   },
   defaultOptions: [
     {
-      default: [
-        'signature',
-
-        'public-static-field',
-        'protected-static-field',
-        'private-static-field',
-
-        'public-instance-field',
-        'protected-instance-field',
-        'private-instance-field',
-
-        'public-abstract-field',
-        'protected-abstract-field',
-        'private-abstract-field',
-
-        'public-field',
-        'protected-field',
-        'private-field',
-
-        'static-field',
-        'instance-field',
-        'abstract-field',
-
-        'field',
-
-        'constructor',
-
-        'public-static-method',
-        'protected-static-method',
-        'private-static-method',
-
-        'public-instance-method',
-        'protected-instance-method',
-        'private-instance-method',
-
-        'public-abstract-method',
-        'protected-abstract-method',
-        'private-abstract-method',
-
-        'public-method',
-        'protected-method',
-        'private-method',
-
-        'static-method',
-        'instance-method',
-        'abstract-method',
-
-        'method',
-      ],
+      default: defaultOrder,
     },
   ],
   create(context, [options]) {
-    const sourceCode = context.getSourceCode();
-
-    const functionExpressions = [
-      AST_NODE_TYPES.FunctionExpression,
-      AST_NODE_TYPES.ArrowFunctionExpression,
-    ];
-
-    /**
-     * Gets the node type.
-     * @param node the node to be evaluated.
-     */
-    function getNodeType(
-      node: TSESTree.ClassElement | TSESTree.TypeElement,
-    ): string | null {
-      // TODO: add missing TSCallSignatureDeclaration
-      switch (node.type) {
-        case AST_NODE_TYPES.TSAbstractMethodDefinition:
-        case AST_NODE_TYPES.MethodDefinition:
-          return node.kind;
-        case AST_NODE_TYPES.TSMethodSignature:
-          return 'method';
-        case AST_NODE_TYPES.TSConstructSignatureDeclaration:
-          return 'constructor';
-        case AST_NODE_TYPES.TSAbstractClassProperty:
-        case AST_NODE_TYPES.ClassProperty:
-          return node.value && functionExpressions.includes(node.value.type)
-            ? 'method'
-            : 'field';
-        case AST_NODE_TYPES.TSPropertySignature:
-          return 'field';
-        case AST_NODE_TYPES.TSIndexSignature:
-          return 'signature';
-        default:
-          return null;
-      }
-    }
-
-    /**
-     * Gets the member name based on the member type.
-     * @param node the node to be evaluated.
-     */
-    function getMemberName(
-      node: TSESTree.ClassElement | TSESTree.TypeElement,
-    ): string | null {
-      switch (node.type) {
-        case AST_NODE_TYPES.TSPropertySignature:
-        case AST_NODE_TYPES.TSMethodSignature:
-        case AST_NODE_TYPES.TSAbstractClassProperty:
-        case AST_NODE_TYPES.ClassProperty:
-          return util.getNameFromMember(node, sourceCode);
-        case AST_NODE_TYPES.TSAbstractMethodDefinition:
-        case AST_NODE_TYPES.MethodDefinition:
-          return node.kind === 'constructor'
-            ? 'constructor'
-            : util.getNameFromMember(node, sourceCode);
-        case AST_NODE_TYPES.TSConstructSignatureDeclaration:
-          return 'new';
-        case AST_NODE_TYPES.TSIndexSignature:
-          return util.getNameFromIndexSignature(node);
-        default:
-          return null;
-      }
-    }
-
-    /**
-     * Gets the calculated rank using the provided method definition.
-     * The algorithm is as follows:
-     * - Get the rank based on the accessibility-scope-type name, e.g. public-instance-field
-     * - If there is no order for accessibility-scope-type, then strip out the accessibility.
-     * - If there is no order for scope-type, then strip out the scope.
-     * - If there is no order for type, then return -1
-     * @param memberTypes the valid names to be validated.
-     * @param order the current order to be validated.
-     *
-     * @return Index of the matching member type in the order configuration.
-     */
-    function getRankOrder(memberTypes: string[], order: string[]): number {
-      let rank = -1;
-      const stack = memberTypes.slice(); // Get a copy of the member types
-
-      while (stack.length > 0 && rank === -1) {
-        rank = order.indexOf(stack.shift()!);
-      }
-
-      return rank;
-    }
-
-    /**
-     * Gets the rank of the node given the order.
-     * @param node the node to be evaluated.
-     * @param order the current order to be validated.
-     * @param supportsModifiers a flag indicating whether the type supports modifiers (scope or accessibility) or not.
-     */
-    function getRank(
-      node: TSESTree.ClassElement | TSESTree.TypeElement,
-      order: string[],
-      supportsModifiers: boolean,
-    ): number {
-      const type = getNodeType(node);
-      if (type === null) {
-        // shouldn't happen but just in case, put it on the end
-        return order.length - 1;
-      }
-
-      const abstract =
-        node.type === AST_NODE_TYPES.TSAbstractClassProperty ||
-        node.type === AST_NODE_TYPES.TSAbstractMethodDefinition;
-
-      const scope =
-        'static' in node && node.static
-          ? 'static'
-          : abstract
-          ? 'abstract'
-          : 'instance';
-      const accessibility =
-        'accessibility' in node && node.accessibility
-          ? node.accessibility
-          : 'public';
-
-      const memberTypes = [];
-
-      if (supportsModifiers) {
-        if (type !== 'constructor') {
-          // Constructors have no scope
-          memberTypes.push(`${accessibility}-${scope}-${type}`);
-          memberTypes.push(`${scope}-${type}`);
-        }
-
-        memberTypes.push(`${accessibility}-${type}`);
-      }
-
-      memberTypes.push(type);
-
-      return getRankOrder(memberTypes, order);
-    }
-
-    /**
-     * Gets the lowest possible rank higher than target.
-     * e.g. given the following order:
-     *   ...
-     *   public-static-method
-     *   protected-static-method
-     *   private-static-method
-     *   public-instance-method
-     *   protected-instance-method
-     *   private-instance-method
-     *   ...
-     * and considering that a public-instance-method has already been declared, so ranks contains
-     * public-instance-method, then the lowest possible rank for public-static-method is
-     * public-instance-method.
-     * @param ranks the existing ranks in the object.
-     * @param target the target rank.
-     * @param order the current order to be validated.
-     * @returns the name of the lowest possible rank without dashes (-).
-     */
-    function getLowestRank(
-      ranks: number[],
-      target: number,
-      order: string[],
-    ): string {
-      let lowest = ranks[ranks.length - 1];
-
-      ranks.forEach(rank => {
-        if (rank > target) {
-          lowest = Math.min(lowest, rank);
-        }
-      });
-
-      return order[lowest].replace(/-/g, ' ');
-    }
-
     /**
      * Validates if all members are correctly sorted.
      *
      * @param members Members to be validated.
-     * @param order Current order to be validated.
+     * @param orderConfig Order config to be validated.
      * @param supportsModifiers A flag indicating whether the type supports modifiers (scope or accessibility) or not.
      */
     function validateMembersOrder(
       members: (TSESTree.ClassElement | TSESTree.TypeElement)[],
-      order: OrderConfig,
+      orderConfig: OrderConfig,
       supportsModifiers: boolean,
     ): void {
-      if (members && order !== 'never') {
-        const previousRanks: number[] = [];
+      if (members.length > 0 && orderConfig !== 'never') {
+        if (Array.isArray(orderConfig)) {
+          // Sort member groups (= ignore alphabetic order)
+          const memberGroupsOrder = orderConfig;
 
-        // Find first member which isn't correctly sorted
-        members.forEach(member => {
-          const rank = getRank(member, order, supportsModifiers);
+          const previousRanks: number[] = [];
 
-          if (rank !== -1) {
-            if (rank < previousRanks[previousRanks.length - 1]) {
-              context.report({
-                node: member,
-                messageId: 'incorrectOrder',
-                data: {
-                  name: getMemberName(member),
-                  rank: getLowestRank(previousRanks, rank, order),
-                },
-              });
-            } else {
-              previousRanks.push(rank);
+          // Find first member which isn't correctly sorted
+          members.forEach(member => {
+            const rank = getRank(member, memberGroupsOrder, supportsModifiers);
+            const name = getMemberName(member, context.getSourceCode());
+
+            if (rank !== -1) {
+              // Make sure member types are correctly grouped
+              // Works for 1st item because x < undefined === false for any x (typeof string)
+              if (rank < previousRanks[previousRanks.length - 1]) {
+                context.report({
+                  node: member,
+                  messageId: 'incorrectGroupOrder',
+                  data: {
+                    name,
+                    rank: getLowestRank(previousRanks, rank, memberGroupsOrder),
+                  },
+                });
+              } else {
+                previousRanks.push(rank);
+              }
             }
-          }
-        });
+          });
+        } else if (orderConfig.memberTypes === 'never') {
+          // Sort members alphabetically + ignore groups
+
+          let previousName = '';
+
+          // console.log(members)
+
+          // Find first member which isn't correctly sorted
+          members.forEach(member => {
+            const name = getIdentifier(member, context.getSourceCode());
+
+            // Same member group --> Check alphabetic order
+            if (name) {
+              // Not all members have sortable identifiers
+              if (name < previousName) {
+                context.report({
+                  node: member,
+                  messageId: 'incorrectOrder',
+                  data: {
+                    member: name,
+                    beforeMember: previousName,
+                  },
+                });
+              }
+
+              previousName = name;
+            }
+          });
+        } else {
+          // Sort groups + sort alphabetically within each group
+          const memberGroupsOrder = orderConfig.memberTypes || defaultOrder;
+
+          const previousRanks: number[] = [];
+          let previousName = '';
+
+          // Find first member which isn't correctly sorted
+          members.forEach(member => {
+            const rank = getRank(member, memberGroupsOrder, supportsModifiers);
+            const name = getIdentifier(member, context.getSourceCode());
+
+            if (rank !== -1) {
+              // Make sure member types are correctly grouped
+              // Works for 1st item because x < undefined === false for any x (typeof string)
+              if (rank < previousRanks[previousRanks.length - 1]) {
+                context.report({
+                  node: member,
+                  messageId: 'incorrectGroupOrder',
+                  data: {
+                    name: getMemberName(member, context.getSourceCode()),
+                    rank: getLowestRank(previousRanks, rank, memberGroupsOrder),
+                  },
+                });
+              } else if (rank === previousRanks[previousRanks.length - 1]) {
+                // Same member group --> Check alphabetic order
+                if (name) {
+                  // Not all members have sortable identifiers
+                  if (previousName) {
+                    if (name < previousName) {
+                      context.report({
+                        node: member,
+                        messageId: 'incorrectOrder',
+                        data: {
+                          member: name,
+                          beforeMember: previousName,
+                        },
+                      });
+                    }
+
+                    previousName = name;
+                  }
+                }
+              } else {
+                previousRanks.push(rank);
+
+                if (name) {
+                  previousName = name;
+                }
+              }
+            }
+          });
+        }
       }
     }
 

--- a/packages/eslint-plugin/tests/rules/member-ordering.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering.test.ts
@@ -1,7 +1,11 @@
 // TODO - migrate this test to the rule
 /* eslint-disable @typescript-eslint/internal/plugin-test-formatting */
 
-import rule, { MessageIds, Options } from '../../src/rules/member-ordering';
+import rule, {
+  defaultOrder,
+  MessageIds,
+  Options,
+} from '../../src/rules/member-ordering';
 import { RuleTester } from '../RuleTester';
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 
@@ -1436,7 +1440,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'Z',
             rank: 'field',
@@ -1534,7 +1538,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'Z',
             rank: 'field',
@@ -1635,7 +1639,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'Z',
             rank: 'field',
@@ -1836,7 +1840,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'new',
             rank: 'field',
@@ -2026,7 +2030,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'Z',
             rank: 'field',
@@ -3342,7 +3346,6 @@ const foo = class {
         },
       ],
     },
-
     {
       code: `
 class Foo {
@@ -3373,7 +3376,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'Z',
             rank: 'public instance method',
@@ -3521,7 +3524,7 @@ abstract class Foo {
           `,
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'B',
             rank: 'public abstract field',
@@ -3542,7 +3545,7 @@ abstract class Foo {
       options: [{ default: ['method', 'constructor', 'field'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'C',
             rank: 'field',
@@ -3574,7 +3577,7 @@ class Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'D',
             rank: 'signature',
@@ -3590,13 +3593,12 @@ abstract class Foo {
     abstract B: string;
     abstract A(): void;
     public C(): {};
-
 }
           `,
       options: [{ default: ['method', 'constructor', 'field'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'A',
             rank: 'field',
@@ -3605,7 +3607,7 @@ abstract class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'C',
             rank: 'field',
@@ -3628,8 +3630,8 @@ const sortedWithoutGroupingDefaultOption: TSESLint.RunTests<
       code: `
 interface Foo {
   a : b;
+  [a: string] : number;
   b() : void;
-  [a: string] : number; // Will be ignored (no sortable identifier)
   new () : Bar; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
@@ -3664,8 +3666,8 @@ interface Foo {
       code: `
 type Foo = {
   a : b;
+  [a: string] : number;
   b() : void;
-  [a: string] : number; // Will be ignored (no sortable identifier)
   new () : Bar; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
@@ -3778,7 +3780,7 @@ const foo = class Foo {
 interface Foo {
   b() : void;
   a : b;
-  [a: string] : number; // Will be ignored (no sortable identifier)
+  [a: string] : number;
   new () : Bar; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
@@ -3829,7 +3831,7 @@ interface Foo {
 type Foo = {
   b() : void;
   a : b;
-  [a: string] : number; // Will be ignored (no sortable identifier)
+  [a: string] : number;
   new () : Bar; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
@@ -3991,10 +3993,10 @@ const sortedWithoutGroupingClassesOption: TSESLint.RunTests<
     {
       code: `
 interface Foo {
+  [a: string] : number;
   c : b;
   new () : Bar;
   b() : void;
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -4027,10 +4029,10 @@ interface Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
   c : b;
   new () : Bar;
   b() : void;
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -4200,10 +4202,10 @@ const sortedWithoutGroupingClassExpressionsOption: TSESLint.RunTests<
     {
       code: `
 interface Foo {
+  [a: string] : number;
   c : b;
   new () : Bar;
   b() : void;
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -4242,10 +4244,10 @@ interface Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
   c : b;
   new () : Bar;
   b() : void;
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -4437,9 +4439,9 @@ const sortedWithoutGroupingInterfacesOption: TSESLint.RunTests<
     {
       code: `
 interface Foo {
+  [a: string] : number;
   a : b;
   b() : void;
-  [a: string] : number; // Will be ignored (no sortable identifier)
   new () : Bar; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
@@ -4479,10 +4481,10 @@ interface Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
   c : b;
   new () : Bar;
   b() : void;
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -4612,7 +4614,7 @@ const foo = class Foo {
 interface Foo {
   b() : void;
   a : b;
-  [a: string] : number; // Will be ignored (no sortable identifier)
+  [a: string] : number;
   new () : Bar; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
@@ -4672,10 +4674,10 @@ const sortedWithoutGroupingTypeLiteralsOption: TSESLint.RunTests<
     {
       code: `
 interface Foo {
+  [a: string] : number;
   c : b;
   new () : Bar;
   b() : void;
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -4714,9 +4716,9 @@ interface Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
   a : b;
   b() : void;
-  [a: string] : number; // Will be ignored (no sortable identifier)
   new () : Bar; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
@@ -4847,7 +4849,7 @@ const foo = class Foo {
 type Foo = {
   b() : void;
   a : b;
-  [a: string] : number; // Will be ignored (no sortable identifier)
+  [a: string] : number;
   new () : Bar; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
@@ -4907,6 +4909,8 @@ const sortedWithGroupingDefaultOption: TSESLint.RunTests<
     {
       code: `
 interface Foo {
+  [a: string] : number;
+
   a : x;
   b : x;
   c : x;
@@ -4917,11 +4921,12 @@ interface Foo {
   b() : void;
   c() : void;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
     },
 
     // default option + interface + custom order + alphabetically
@@ -4938,7 +4943,7 @@ interface Foo {
   b : x;
   c : x;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
+  [a: string] : number;
   () : Baz; // Will be ignored (no sortable identifier)
 }
             `,
@@ -4956,6 +4961,8 @@ interface Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
+
   a : x;
   b : x;
   c : x;
@@ -4966,17 +4973,20 @@ type Foo = {
   b() : void;
   c() : void;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
     },
 
     // default option + type literal + custom order + alphabetically
     {
       code: `
 type Foo = {
+  [a: string] : number;
+
   new () : Bar;
 
   a() : void;
@@ -4987,7 +4997,6 @@ type Foo = {
   b : x;
   c : x;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 }
             `,
@@ -5016,7 +5025,9 @@ class Foo {
   constructor() {}
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
     },
 
     // default option + class + custom order + alphabetically
@@ -5059,7 +5070,9 @@ const foo = class Foo {
   constructor() {}
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
     },
 
     // default option + class expression + custom order + alphabetically
@@ -5092,6 +5105,8 @@ const foo = class Foo {
     {
       code: `
 interface Foo {
+  [a: string] : number;
+
   a : x;
   b : x;
   c : x;
@@ -5100,28 +5115,15 @@ interface Foo {
   b() : void;
   a() : void;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 
   new () : Bar;
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
       errors: [
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'b',
-            beforeMember: 'c',
-          },
-        },
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'a',
-            beforeMember: 'b',
-          },
-        },
         {
           messageId: 'incorrectGroupOrder',
           data: {
@@ -5136,6 +5138,8 @@ interface Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
+
   a : x;
   b : x;
   c : x;
@@ -5144,28 +5148,15 @@ type Foo = {
   b() : void;
   a() : void;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 
   new () : Bar;
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
       errors: [
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'b',
-            beforeMember: 'c',
-          },
-        },
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'a',
-            beforeMember: 'b',
-          },
-        },
         {
           messageId: 'incorrectGroupOrder',
           data: {
@@ -5189,27 +5180,15 @@ class Foo {
   public d: string = "";
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
       errors: [
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'b',
-            beforeMember: 'c',
-          },
-        },
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'a',
-            beforeMember: 'b',
-          },
-        },
         {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'd',
-            rank: 'constructor',
+            rank: 'public constructor',
           },
         },
       ],
@@ -5228,27 +5207,15 @@ const foo = class Foo {
   public d: string = "";
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
       errors: [
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'b',
-            beforeMember: 'c',
-          },
-        },
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'a',
-            beforeMember: 'b',
-          },
-        },
         {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'd',
-            rank: 'constructor',
+            rank: 'public constructor',
           },
         },
       ],
@@ -5265,6 +5232,8 @@ const sortedWithGroupingClassesOption: TSESLint.RunTests<
     {
       code: `
 interface Foo {
+  [a: string] : number;
+
   c : x;
   b : x;
   a : x;
@@ -5275,7 +5244,6 @@ interface Foo {
   b() : void;
   a() : void;
 
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -5286,6 +5254,8 @@ interface Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
+
   c : x;
   b : x;
   a : x;
@@ -5296,7 +5266,6 @@ type Foo = {
   b() : void;
   a() : void;
 
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -5318,7 +5287,9 @@ class Foo {
   constructor() {}
 }
             `,
-      options: [{ classes: { order: 'alphabetically' } }],
+      options: [
+        { classes: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
     },
 
     // classes option + class + custom order + alphabetically
@@ -5378,27 +5349,15 @@ class Foo {
   public d: string = "";
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
       errors: [
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'b',
-            beforeMember: 'c',
-          },
-        },
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'a',
-            beforeMember: 'b',
-          },
-        },
         {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'd',
-            rank: 'constructor',
+            rank: 'public constructor',
           },
         },
       ],
@@ -5415,6 +5374,8 @@ const sortedWithGroupingClassExpressionsOption: TSESLint.RunTests<
     {
       code: `
 interface Foo {
+  [a: string] : number;
+
   c : x;
   b : x;
   a : x;
@@ -5425,7 +5386,6 @@ interface Foo {
   b() : void;
   a() : void;
 
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -5436,6 +5396,8 @@ interface Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
+
   c : x;
   b : x;
   a : x;
@@ -5446,7 +5408,6 @@ type Foo = {
   b() : void;
   a() : void;
 
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -5486,7 +5447,14 @@ const foo = class Foo {
   constructor() {}
 }
             `,
-      options: [{ classExpressions: { order: 'alphabetically' } }],
+      options: [
+        {
+          classExpressions: {
+            memberTypes: defaultOrder,
+            order: 'alphabetically',
+          },
+        },
+      ],
     },
 
     // classExpressions option + class expression + custom order + alphabetically
@@ -5528,27 +5496,15 @@ const foo = class Foo {
   public d: string = "";
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
       errors: [
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'b',
-            beforeMember: 'c',
-          },
-        },
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'a',
-            beforeMember: 'b',
-          },
-        },
         {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'd',
-            rank: 'constructor',
+            rank: 'public constructor',
           },
         },
       ],
@@ -5565,21 +5521,29 @@ const sortedWithGroupingInterfacesOption: TSESLint.RunTests<
     {
       code: `
 interface Foo {
+  [a: string] : number;
+
   a : x;
   b : x;
   c : x;
-
-  new () : Bar;
 
   a() : void;
   b() : void;
   c() : void;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
+  new () : Bar;
+
   () : Baz; // Will be ignored (no sortable identifier)
 }
             `,
-      options: [{ interfaces: { order: 'alphabetically' } }],
+      options: [
+        {
+          interfaces: {
+            memberTypes: ['signature', 'field', 'method', 'constructor'],
+            order: 'alphabetically',
+          },
+        },
+      ],
     },
 
     // interfaces option + interface + custom order + alphabetically
@@ -5596,7 +5560,7 @@ interface Foo {
   b : x;
   c : x;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
+  [a: string] : number;
   () : Baz; // Will be ignored (no sortable identifier)
 }
             `,
@@ -5614,6 +5578,8 @@ interface Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
+
   c : x;
   b : x;
   a : x;
@@ -5624,7 +5590,6 @@ type Foo = {
   b() : void;
   a() : void;
 
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -5672,6 +5637,8 @@ const foo = class Foo {
     {
       code: `
 interface Foo {
+  [a: string] : number;
+
   a : x;
   b : x;
   c : x;
@@ -5680,28 +5647,15 @@ interface Foo {
   b() : void;
   a() : void;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 
   new () : Bar;
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
       errors: [
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'b',
-            beforeMember: 'c',
-          },
-        },
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'a',
-            beforeMember: 'b',
-          },
-        },
         {
           messageId: 'incorrectGroupOrder',
           data: {
@@ -5723,6 +5677,8 @@ const sortedWithGroupingTypeLiteralsOption: TSESLint.RunTests<
     {
       code: `
 interface Foo {
+  [a: string] : number;
+
   c : x;
   b : x;
   a : x;
@@ -5733,7 +5689,6 @@ interface Foo {
   b() : void;
   a() : void;
 
-  [a: string] : number;
   () : Baz;
 }
             `,
@@ -5744,21 +5699,29 @@ interface Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
+
   a : x;
   b : x;
   c : x;
-
-  new () : Bar;
 
   a() : void;
   b() : void;
   c() : void;
 
-  [a: string] : number;
+  new () : Bar;
+
   () : Baz;
 }
             `,
-      options: [{ typeLiterals: { order: 'alphabetically' } }],
+      options: [
+        {
+          typeLiterals: {
+            memberTypes: ['signature', 'field', 'method', 'constructor'],
+            order: 'alphabetically',
+          },
+        },
+      ],
     },
 
     // typeLiterals option + type literal + custom order + alphabetically
@@ -5775,7 +5738,7 @@ type Foo = {
   b : x;
   c : x;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
+  [a: string] : number;
   () : Baz; // Will be ignored (no sortable identifier)
 }
             `,
@@ -5830,6 +5793,8 @@ const foo = class Foo {
     {
       code: `
 type Foo = {
+  [a: string] : number;
+
   a : x;
   b : x;
   c : x;
@@ -5838,28 +5803,15 @@ type Foo = {
   b() : void;
   a() : void;
 
-  [a: string] : number; // Will be ignored (no sortable identifier)
   () : Baz; // Will be ignored (no sortable identifier)
 
   new () : Bar;
 }
             `,
-      options: [{ default: { order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
       errors: [
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'b',
-            beforeMember: 'c',
-          },
-        },
-        {
-          messageId: 'incorrectOrder',
-          data: {
-            member: 'a',
-            beforeMember: 'b',
-          },
-        },
         {
           messageId: 'incorrectGroupOrder',
           data: {

--- a/packages/eslint-plugin/tests/rules/member-ordering.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering.test.ts
@@ -1,14 +1,15 @@
 // TODO - migrate this test to the rule
 /* eslint-disable @typescript-eslint/internal/plugin-test-formatting */
 
-import rule from '../../src/rules/member-ordering';
+import rule, { MessageIds, Options } from '../../src/rules/member-ordering';
 import { RuleTester } from '../RuleTester';
+import { TSESLint } from '@typescript-eslint/experimental-utils';
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
 
-ruleTester.run('member-ordering', rule, {
+const grouped: TSESLint.RunTests<MessageIds, Options> = {
   valid: [
     `
 // no accessibility === public
@@ -1339,7 +1340,7 @@ interface Foo {
             `,
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'new',
             rank: 'method',
@@ -1372,7 +1373,7 @@ interface Foo {
       options: [{ default: ['signature', 'method', 'constructor', 'field'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'field',
@@ -1381,7 +1382,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'field',
@@ -1390,7 +1391,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'field',
@@ -1399,7 +1400,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'field',
@@ -1408,7 +1409,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'field',
@@ -1417,7 +1418,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'field',
@@ -1426,7 +1427,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'new',
             rank: 'field',
@@ -1470,7 +1471,7 @@ interface Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'field',
@@ -1479,7 +1480,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'field',
@@ -1488,7 +1489,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'field',
@@ -1497,7 +1498,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'field',
@@ -1506,7 +1507,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'field',
@@ -1515,7 +1516,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'field',
@@ -1524,7 +1525,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'new',
             rank: 'field',
@@ -1571,7 +1572,7 @@ interface Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'field',
@@ -1580,7 +1581,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'field',
@@ -1589,7 +1590,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'field',
@@ -1598,7 +1599,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'field',
@@ -1607,7 +1608,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'field',
@@ -1616,7 +1617,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'field',
@@ -1625,7 +1626,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'new',
             rank: 'field',
@@ -1671,7 +1672,7 @@ interface Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'B',
             rank: 'method',
@@ -1680,7 +1681,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'C',
             rank: 'method',
@@ -1689,7 +1690,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'D',
             rank: 'method',
@@ -1698,7 +1699,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'E',
             rank: 'method',
@@ -1707,7 +1708,7 @@ interface Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'F',
             rank: 'method',
@@ -1739,7 +1740,7 @@ type Foo = {
             `,
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'new',
             rank: 'method',
@@ -1772,7 +1773,7 @@ type Foo = {
       options: [{ default: ['method', 'constructor', 'signature', 'field'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'field',
@@ -1781,7 +1782,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'field',
@@ -1790,7 +1791,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'field',
@@ -1799,7 +1800,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'field',
@@ -1808,7 +1809,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'field',
@@ -1817,7 +1818,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'field',
@@ -1826,7 +1827,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'Z',
             rank: 'field',
@@ -1870,7 +1871,7 @@ type Foo = {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'signature',
@@ -1879,7 +1880,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'signature',
@@ -1888,7 +1889,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'signature',
@@ -1897,7 +1898,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'signature',
@@ -1906,7 +1907,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'signature',
@@ -1915,7 +1916,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'signature',
@@ -1924,7 +1925,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'new',
             rank: 'signature',
@@ -1962,7 +1963,7 @@ type Foo = {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'field',
@@ -1971,7 +1972,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'field',
@@ -1980,7 +1981,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'field',
@@ -1989,7 +1990,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'field',
@@ -1998,7 +1999,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'field',
@@ -2007,7 +2008,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'field',
@@ -2016,7 +2017,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'new',
             rank: 'field',
@@ -2062,7 +2063,7 @@ type Foo = {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'B',
             rank: 'method',
@@ -2071,7 +2072,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'C',
             rank: 'method',
@@ -2080,7 +2081,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'D',
             rank: 'method',
@@ -2089,7 +2090,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'E',
             rank: 'method',
@@ -2098,7 +2099,7 @@ type Foo = {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'F',
             rank: 'method',
@@ -2129,7 +2130,7 @@ class Foo {
             `,
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'public instance method',
@@ -2138,7 +2139,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'public instance method',
@@ -2147,7 +2148,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'public instance method',
@@ -2179,7 +2180,7 @@ class Foo {
       options: [{ default: ['field', 'constructor', 'method', 'signature'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'A',
             rank: 'constructor',
@@ -2188,7 +2189,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'B',
             rank: 'constructor',
@@ -2197,7 +2198,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'C',
             rank: 'constructor',
@@ -2206,7 +2207,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'D',
             rank: 'constructor',
@@ -2215,7 +2216,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'E',
             rank: 'constructor',
@@ -2224,7 +2225,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'F',
             rank: 'constructor',
@@ -2255,7 +2256,7 @@ class Foo {
       options: [{ default: ['field', 'method'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'A',
             rank: 'method',
@@ -2286,7 +2287,7 @@ class Foo {
       options: [{ default: ['method', 'field'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'field',
@@ -2317,7 +2318,7 @@ class Foo {
       options: [{ classes: ['method', 'constructor', 'field'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'field',
@@ -2326,7 +2327,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'field',
@@ -2335,7 +2336,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'field',
@@ -2344,7 +2345,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'field',
@@ -2353,7 +2354,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'constructor',
             rank: 'field',
@@ -2389,7 +2390,7 @@ class Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'field',
@@ -2398,7 +2399,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'field',
@@ -2407,7 +2408,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'field',
@@ -2416,7 +2417,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'field',
@@ -2425,7 +2426,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'field',
@@ -2434,7 +2435,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'field',
@@ -2443,7 +2444,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'constructor',
             rank: 'field',
@@ -2486,7 +2487,7 @@ class Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'A',
             rank: 'private field',
@@ -2495,7 +2496,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'F',
             rank: 'protected field',
@@ -2539,7 +2540,7 @@ class Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'public instance method',
@@ -2548,7 +2549,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'constructor',
             rank: 'public field',
@@ -2589,7 +2590,7 @@ class Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'constructor',
             rank: 'method',
@@ -2632,7 +2633,7 @@ class Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'private static method',
@@ -2641,7 +2642,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'private static method',
@@ -2676,7 +2677,7 @@ class Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'protected static field',
@@ -2712,7 +2713,7 @@ class Foo {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'protected static field',
@@ -2742,7 +2743,7 @@ const foo = class Foo {
             `,
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'public instance method',
@@ -2751,7 +2752,7 @@ const foo = class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'public instance method',
@@ -2760,7 +2761,7 @@ const foo = class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'public instance method',
@@ -2792,7 +2793,7 @@ const foo = class {
       options: [{ default: ['signature', 'field', 'constructor', 'method'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'A',
             rank: 'constructor',
@@ -2801,7 +2802,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'B',
             rank: 'constructor',
@@ -2810,7 +2811,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'C',
             rank: 'constructor',
@@ -2819,7 +2820,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'D',
             rank: 'constructor',
@@ -2828,7 +2829,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'E',
             rank: 'constructor',
@@ -2837,7 +2838,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'F',
             rank: 'constructor',
@@ -2869,7 +2870,7 @@ const foo = class {
       options: [{ default: ['field', 'method'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'A',
             rank: 'method',
@@ -2900,7 +2901,7 @@ const foo = class {
       options: [{ default: ['method', 'field'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'field',
@@ -2932,7 +2933,7 @@ const foo = class {
       options: [{ classExpressions: ['method', 'constructor', 'field'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'field',
@@ -2941,7 +2942,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'field',
@@ -2950,7 +2951,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'field',
@@ -2959,7 +2960,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'field',
@@ -2968,7 +2969,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'constructor',
             rank: 'field',
@@ -3004,7 +3005,7 @@ const foo = class {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'field',
@@ -3013,7 +3014,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'field',
@@ -3022,7 +3023,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'I',
             rank: 'field',
@@ -3031,7 +3032,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'field',
@@ -3040,7 +3041,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'field',
@@ -3049,7 +3050,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'field',
@@ -3058,7 +3059,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'constructor',
             rank: 'field',
@@ -3101,7 +3102,7 @@ const foo = class {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'A',
             rank: 'private field',
@@ -3110,7 +3111,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'F',
             rank: 'protected field',
@@ -3154,7 +3155,7 @@ const foo = class {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'public instance method',
@@ -3163,7 +3164,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'constructor',
             rank: 'public field',
@@ -3204,7 +3205,7 @@ const foo = class {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'constructor',
             rank: 'method',
@@ -3247,7 +3248,7 @@ const foo = class {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'G',
             rank: 'private static method',
@@ -3256,7 +3257,7 @@ const foo = class {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'H',
             rank: 'private static method',
@@ -3295,7 +3296,7 @@ const foo = class {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'L',
             rank: 'protected static field',
@@ -3331,7 +3332,7 @@ const foo = class {
       ],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'protected static field',
@@ -3354,7 +3355,7 @@ class Foo {
             `,
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'A',
             rank: 'public instance method',
@@ -3363,7 +3364,7 @@ class Foo {
           column: 5,
         },
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'constructor',
             rank: 'public instance method',
@@ -3395,7 +3396,7 @@ class Foo {
       options: [{ default: ['method', 'constructor', 'field', 'signature'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'constructor',
@@ -3418,7 +3419,7 @@ class Foo {
       options: [{ default: ['method', 'constructor', 'field'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'K',
             rank: 'constructor',
@@ -3438,7 +3439,7 @@ interface Foo {
             `,
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'A',
             rank: 'method',
@@ -3458,7 +3459,7 @@ type Foo = {
             `,
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'A',
             rank: 'method',
@@ -3479,7 +3480,7 @@ type Foo = {
       options: [{ default: ['method', 'constructor', 'field'] }],
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'J',
             rank: 'field',
@@ -3498,7 +3499,7 @@ abstract class Foo {
           `,
       errors: [
         {
-          messageId: 'incorrectOrder',
+          messageId: 'incorrectGroupOrder',
           data: {
             name: 'B',
             rank: 'public abstract method',
@@ -3614,5 +3615,2306 @@ abstract class Foo {
         },
       ],
     },
+  ],
+};
+
+const sortedWithoutGroupingDefaultOption: TSESLint.RunTests<
+  MessageIds,
+  Options
+> = {
+  valid: [
+    // default option + interface + multiple types
+    {
+      code: `
+interface Foo {
+  a : b;
+  b() : void;
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  new () : Bar; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + interface + lower/upper case
+    {
+      code: `
+interface Foo {
+  A : b;
+  a : b;
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + interface + numbers
+    {
+      code: `
+interface Foo {
+  a1 : b;
+  aa : b;
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + type literal + multiple types
+    {
+      code: `
+type Foo = {
+  a : b;
+  b() : void;
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  new () : Bar; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + type literal + lower/upper case
+    {
+      code: `
+type Foo = {
+  A : b;
+  a : b;
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + type literal + numbers
+    {
+      code: `
+type Foo = {
+  a1 : b;
+  aa : b;
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + class + multiple types
+    {
+      code: `
+class Foo {
+  public static a : string;
+  protected static b : string = "";
+  private static c : string = "";
+  constructor() {} // Will be ignored (no sortable identifier)
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + class + lower/upper case
+    {
+      code: `
+class Foo {
+  public static A : string;
+  public static a : string;
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + class + numbers
+    {
+      code: `
+class Foo {
+  public static a1 : string;
+  public static aa : string;
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + class expression + multiple types
+    {
+      code: `
+const foo = class Foo {
+  public static a : string;
+  protected static b : string = "";
+  private static c : string = "";
+  constructor() {} // Will be ignored (no sortable identifier)
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + class expression + lower/upper case
+    {
+      code: `
+const foo = class Foo {
+  public static A : string;
+  public static a : string;
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + class expression + numbers
+    {
+      code: `
+const foo = class Foo {
+  public static a1 : string;
+  public static aa : string;
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+  ],
+  invalid: [
+    // default option + interface + wrong order
+    {
+      code: `
+interface Foo {
+  b() : void;
+  a : b;
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  new () : Bar; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+          `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // default option + interface + wrong order (multiple)
+    {
+      code: `
+interface Foo {
+  c : string;
+  b : string;
+  a : string;
+}
+          `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // default option + type literal + wrong order
+    {
+      code: `
+type Foo = {
+  b() : void;
+  a : b;
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  new () : Bar; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+          `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // default option + type literal + wrong order (multiple)
+    {
+      code: `
+type Foo = {
+  c : string;
+  b : string;
+  a : string;
+}
+          `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // default option + class + wrong order
+    {
+      code: `
+class Foo {
+  protected static b : string = "";
+  public static a : string;
+  private static c : string = "";
+  constructor() {} // Will be ignored (no sortable identifier)
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+}
+          `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // default option + class + wrong order (multiple)
+    {
+      code: `
+class Foo {
+  public static c: string;
+  public static b: string;
+  public static a: string;
+}
+          `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // default option + class expression + wrong order
+    {
+      code: `
+const foo = class Foo {
+  protected static b : string = "";
+  public static a : string;
+  private static c : string = "";
+  constructor() {} // Will be ignored (no sortable identifier)
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+}
+          `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // default option + class expression + wrong order (multiple)
+    {
+      code: `
+const foo = class Foo {
+  public static c: string;
+  public static b: string;
+  public static a: string;
+}
+          `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const sortedWithoutGroupingClassesOption: TSESLint.RunTests<
+  MessageIds,
+  Options
+> = {
+  valid: [
+    // classes option + interface + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+interface Foo {
+  c : b;
+  new () : Bar;
+  b() : void;
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + interface + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+interface Foo {
+  a : b;
+  A : b;
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + interface + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+interface Foo {
+  aa : b;
+  a1 : b;
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + type literal + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+type Foo = {
+  c : b;
+  new () : Bar;
+  b() : void;
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + type literal + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+type Foo = {
+  a : b;
+  A : b;
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + type literal + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+type Foo = {
+  aa : b;
+  a1 : b;
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + class + multiple types
+    {
+      code: `
+class Foo {
+  public static a : string;
+  protected static b : string = "";
+  private static c : string = "";
+  constructor() {} // Will be ignored (no sortable identifier)
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + class + lower/upper case
+    {
+      code: `
+class Foo {
+  public static A : string;
+  public static a : string;
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + class + numbers
+    {
+      code: `
+class Foo {
+  public static a1 : string;
+  public static aa : string;
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + class expression + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+const foo = class Foo {
+  public static a : string;
+  protected static b : string = "";
+  private static c : string = "";
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+  constructor() {}
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + class expression + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+const foo = class Foo {
+  public static a : string;
+  public static A : string;
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // classes option + class expression + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+const foo = class Foo {
+  public static aa : string;
+  public static a1 : string;
+}
+            `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+  ],
+  invalid: [
+    // classes option + class + wrong order
+    {
+      code: `
+class Foo {
+  protected static b : string = "";
+  public static a : string;
+  private static c : string = "";
+  constructor() {} // Will be ignored (no sortable identifier)
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+}
+          `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // classes option + class + wrong order (multiple)
+    {
+      code: `
+class Foo {
+  public static c: string;
+  public static b: string;
+  public static a: string;
+}
+          `,
+      options: [{ classes: { memberTypes: 'never', order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const sortedWithoutGroupingClassExpressionsOption: TSESLint.RunTests<
+  MessageIds,
+  Options
+> = {
+  valid: [
+    // classExpressions option + interface + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+interface Foo {
+  c : b;
+  new () : Bar;
+  b() : void;
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + interface + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+interface Foo {
+  a : b;
+  A : b;
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + interface + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+interface Foo {
+  aa : b;
+  a1 : b;
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + type literal + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+type Foo = {
+  c : b;
+  new () : Bar;
+  b() : void;
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + type literal + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+type Foo = {
+  a : b;
+  A : b;
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + type literal + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+type Foo = {
+  aa : b;
+  a1 : b;
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + class + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+class Foo {
+  public static a : string;
+  protected static b : string = "";
+  private static c : string = "";
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+  constructor() {}
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + class + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+class Foo {
+  public static a : string;
+  public static A : string;
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + class + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+class Foo {
+  public static aa : string;
+  public static a1 : string;
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + class expression + multiple types
+    {
+      code: `
+const foo = class Foo {
+  public static a : string;
+  protected static b : string = "";
+  private static c : string = "";
+  constructor() {} // Will be ignored (no sortable identifier)
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + class expression + lower/upper case
+    {
+      code: `
+const foo = class Foo {
+  public static A : string;
+  public static a : string;
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // classExpressions option + class expression + numbers
+    {
+      code: `
+const foo = class Foo {
+  public static a1 : string;
+  public static aa : string;
+}
+            `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+  ],
+  invalid: [
+    // classExpressions option + class expression + wrong order
+    {
+      code: `
+const foo = class Foo {
+  protected static b : string = "";
+  public static a : string;
+  private static c : string = "";
+  constructor() {} // Will be ignored (no sortable identifier)
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+}
+          `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // classExpressions option + class expression + wrong order (multiple)
+    {
+      code: `
+const foo = class Foo {
+  public static c: string;
+  public static b: string;
+  public static a: string;
+}
+          `,
+      options: [
+        { classExpressions: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const sortedWithoutGroupingInterfacesOption: TSESLint.RunTests<
+  MessageIds,
+  Options
+> = {
+  valid: [
+    // interfaces option + interface + multiple types
+    {
+      code: `
+interface Foo {
+  a : b;
+  b() : void;
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  new () : Bar; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + interface + lower/upper case
+    {
+      code: `
+interface Foo {
+  A : b;
+  a : b;
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + interface + numbers
+    {
+      code: `
+interface Foo {
+  a1 : b;
+  aa : b;
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + type literal + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+type Foo = {
+  c : b;
+  new () : Bar;
+  b() : void;
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + type literal + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+type Foo = {
+  a : b;
+  A : b;
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + type literal + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+type Foo = {
+  aa : b;
+  a1 : b;
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + class + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+class Foo {
+  public static a : string;
+  protected static b : string = "";
+  private static c : string = "";
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+  constructor() {}
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + class + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+class Foo {
+  public static a : string;
+  public static A : string;
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + class + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+class Foo {
+  public static aa : string;
+  public static a1 : string;
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + class expression + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+const foo = class Foo {
+  public static a : string;
+  protected static b : string = "";
+  private static c : string = "";
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+  constructor() {}
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + class expression + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+const foo = class Foo {
+  public static a : string;
+  public static A : string;
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // interfaces option + class expression + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+const foo = class Foo {
+  public static aa : string;
+  public static a1 : string;
+}
+            `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+  ],
+  invalid: [
+    // interfaces option + interface + wrong order
+    {
+      code: `
+interface Foo {
+  b() : void;
+  a : b;
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  new () : Bar; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+          `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // interfaces option + interface + wrong order (multiple)
+    {
+      code: `
+interface Foo {
+  c : string;
+  b : string;
+  a : string;
+}
+          `,
+      options: [
+        { interfaces: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const sortedWithoutGroupingTypeLiteralsOption: TSESLint.RunTests<
+  MessageIds,
+  Options
+> = {
+  valid: [
+    // typeLiterals option + interface + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+interface Foo {
+  c : b;
+  new () : Bar;
+  b() : void;
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + interface + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+interface Foo {
+  a : b;
+  A : b;
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + interface + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+interface Foo {
+  aa : b;
+  a1 : b;
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + type literal + multiple types
+    {
+      code: `
+type Foo = {
+  a : b;
+  b() : void;
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  new () : Bar; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + type literal + lower/upper case
+    {
+      code: `
+type Foo = {
+  A : b;
+  a : b;
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + type literal + numbers
+    {
+      code: `
+type Foo = {
+  a1 : b;
+  aa : b;
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + class + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+class Foo {
+  public static a : string;
+  protected static b : string = "";
+  private static c : string = "";
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+  constructor() {}
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + class + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+class Foo {
+  public static a : string;
+  public static A : string;
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + class + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+class Foo {
+  public static aa : string;
+  public static a1 : string;
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + class expression + multiple types --> Only member group order is checked (default config)
+    {
+      code: `
+const foo = class Foo {
+  public static a : string;
+  protected static b : string = "";
+  private static c : string = "";
+  public d : string = "";
+  protected e : string = "";
+  private f : string = "";
+  constructor() {}
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + class expression + lower/upper case --> Only member group order is checked (default config)
+    {
+      code: `
+const foo = class Foo {
+  public static a : string;
+  public static A : string;
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+
+    // typeLiterals option + class expression + numbers --> Only member group order is checked (default config)
+    {
+      code: `
+const foo = class Foo {
+  public static aa : string;
+  public static a1 : string;
+}
+            `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+    },
+  ],
+  invalid: [
+    // typeLiterals option + type literal + wrong order
+    {
+      code: `
+type Foo = {
+  b() : void;
+  a : b;
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  new () : Bar; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+          `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+
+    // typeLiterals option + type literal + wrong order (multiple)
+    {
+      code: `
+type Foo = {
+  c : string;
+  b : string;
+  a : string;
+}
+          `,
+      options: [
+        { typeLiterals: { memberTypes: 'never', order: 'alphabetically' } },
+      ],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const sortedWithGroupingDefaultOption: TSESLint.RunTests<
+  MessageIds,
+  Options
+> = {
+  valid: [
+    // default option + interface + default order + alphabetically
+    {
+      code: `
+interface Foo {
+  a : x;
+  b : x;
+  c : x;
+
+  new () : Bar;
+
+  a() : void;
+  b() : void;
+  c() : void;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+    },
+
+    // default option + interface + custom order + alphabetically
+    {
+      code: `
+interface Foo {
+  new () : Bar;
+
+  a() : void;
+  b() : void;
+  c() : void;
+
+  a : x;
+  b : x;
+  c : x;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [
+        {
+          default: {
+            memberTypes: ['constructor', 'method', 'field'],
+            order: 'alphabetically',
+          },
+        },
+      ],
+    },
+
+    // default option + type literal + default order + alphabetically
+    {
+      code: `
+type Foo = {
+  a : x;
+  b : x;
+  c : x;
+
+  new () : Bar;
+
+  a() : void;
+  b() : void;
+  c() : void;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+    },
+
+    // default option + type literal + custom order + alphabetically
+    {
+      code: `
+type Foo = {
+  new () : Bar;
+
+  a() : void;
+  b() : void;
+  c() : void;
+
+  a : x;
+  b : x;
+  c : x;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [
+        {
+          default: {
+            memberTypes: ['constructor', 'method', 'field'],
+            order: 'alphabetically',
+          },
+        },
+      ],
+    },
+
+    // default option + class + default order + alphabetically
+    {
+      code: `
+class Foo {
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  constructor() {}
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+    },
+
+    // default option + class + custom order + alphabetically
+    {
+      code: `
+class Foo {
+  constructor() {}
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+}
+            `,
+      options: [
+        {
+          default: {
+            memberTypes: ['constructor', 'instance-field', 'static-field'],
+            order: 'alphabetically',
+          },
+        },
+      ],
+    },
+
+    // default option + class expression + default order + alphabetically
+    {
+      code: `
+const foo = class Foo {
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  constructor() {}
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+    },
+
+    // default option + class expression + custom order + alphabetically
+    {
+      code: `
+const foo = class Foo {
+  constructor() {}
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+}
+            `,
+      options: [
+        {
+          default: {
+            memberTypes: ['constructor', 'instance-field', 'static-field'],
+            order: 'alphabetically',
+          },
+        },
+      ],
+    },
+  ],
+  invalid: [
+    // default option + interface + wrong order within group and wrong group order + alphabetically
+    {
+      code: `
+interface Foo {
+  a : x;
+  b : x;
+  c : x;
+
+  c() : void;
+  b() : void;
+  a() : void;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+
+  new () : Bar;
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
+          messageId: 'incorrectGroupOrder',
+          data: {
+            name: 'new',
+            rank: 'method',
+          },
+        },
+      ],
+    },
+
+    // default option + type literal + wrong order within group and wrong group order + alphabetically
+    {
+      code: `
+type Foo = {
+  a : x;
+  b : x;
+  c : x;
+
+  c() : void;
+  b() : void;
+  a() : void;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+
+  new () : Bar;
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
+          messageId: 'incorrectGroupOrder',
+          data: {
+            name: 'new',
+            rank: 'method',
+          },
+        },
+      ],
+    },
+
+    // default option + class + wrong order within group and wrong group order + alphabetically
+    {
+      code: `
+class Foo {
+  public static c: string = "";
+  public static b: string = "";
+  public static a: string;
+
+  constructor() {}
+
+  public d: string = "";
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
+          messageId: 'incorrectGroupOrder',
+          data: {
+            name: 'd',
+            rank: 'constructor',
+          },
+        },
+      ],
+    },
+
+    // default option + class expression + wrong order within group and wrong group order + alphabetically
+    {
+      code: `
+const foo = class Foo {
+  public static c: string = "";
+  public static b: string = "";
+  public static a: string;
+
+  constructor() {}
+
+  public d: string = "";
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
+          messageId: 'incorrectGroupOrder',
+          data: {
+            name: 'd',
+            rank: 'constructor',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const sortedWithGroupingClassesOption: TSESLint.RunTests<
+  MessageIds,
+  Options
+> = {
+  valid: [
+    // classes option + interface + alphabetically --> Default order applies
+    {
+      code: `
+interface Foo {
+  c : x;
+  b : x;
+  a : x;
+
+  new () : Bar;
+
+  c() : void;
+  b() : void;
+  a() : void;
+
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [{ classes: { order: 'alphabetically' } }],
+    },
+
+    // classes option + type literal + alphabetically --> Default order applies
+    {
+      code: `
+type Foo = {
+  c : x;
+  b : x;
+  a : x;
+
+  new () : Bar;
+
+  c() : void;
+  b() : void;
+  a() : void;
+
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [{ classes: { order: 'alphabetically' } }],
+    },
+
+    // classes option + class + default order + alphabetically
+    {
+      code: `
+class Foo {
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  constructor() {}
+}
+            `,
+      options: [{ classes: { order: 'alphabetically' } }],
+    },
+
+    // classes option + class + custom order + alphabetically
+    {
+      code: `
+class Foo {
+  constructor() {}
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+}
+            `,
+      options: [
+        {
+          classes: {
+            memberTypes: ['constructor', 'instance-field', 'static-field'],
+            order: 'alphabetically',
+          },
+        },
+      ],
+    },
+
+    // classes option + class expression + alphabetically --> Default order applies
+    {
+      code: `
+const foo = class Foo {
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  constructor() {}
+}
+            `,
+      options: [{ classes: { order: 'alphabetically' } }],
+    },
+  ],
+  invalid: [
+    // default option + class + wrong order within group and wrong group order + alphabetically
+    {
+      code: `
+class Foo {
+  public static c: string = "";
+  public static b: string = "";
+  public static a: string;
+
+  constructor() {}
+
+  public d: string = "";
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
+          messageId: 'incorrectGroupOrder',
+          data: {
+            name: 'd',
+            rank: 'constructor',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const sortedWithGroupingClassExpressionsOption: TSESLint.RunTests<
+  MessageIds,
+  Options
+> = {
+  valid: [
+    // classExpressions option + interface + alphabetically --> Default order applies
+    {
+      code: `
+interface Foo {
+  c : x;
+  b : x;
+  a : x;
+
+  new () : Bar;
+
+  c() : void;
+  b() : void;
+  a() : void;
+
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [{ classExpressions: { order: 'alphabetically' } }],
+    },
+
+    // classExpressions option + type literal + alphabetically --> Default order applies
+    {
+      code: `
+type Foo = {
+  c : x;
+  b : x;
+  a : x;
+
+  new () : Bar;
+
+  c() : void;
+  b() : void;
+  a() : void;
+
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [{ classExpressions: { order: 'alphabetically' } }],
+    },
+
+    // classExpressions option + class + alphabetically --> Default order applies
+    {
+      code: `
+class Foo {
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  constructor() {}
+}
+            `,
+      options: [{ classExpressions: { order: 'alphabetically' } }],
+    },
+
+    // classExpressions option + class expression + default order + alphabetically
+    {
+      code: `
+const foo = class Foo {
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  constructor() {}
+}
+            `,
+      options: [{ classExpressions: { order: 'alphabetically' } }],
+    },
+
+    // classExpressions option + class expression + custom order + alphabetically
+    {
+      code: `
+const foo = class Foo {
+  constructor() {}
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+}
+            `,
+      options: [
+        {
+          classExpressions: {
+            memberTypes: ['constructor', 'instance-field', 'static-field'],
+            order: 'alphabetically',
+          },
+        },
+      ],
+    },
+  ],
+  invalid: [
+    // default option + class expression + wrong order within group and wrong group order + alphabetically
+    {
+      code: `
+const foo = class Foo {
+  public static c: string = "";
+  public static b: string = "";
+  public static a: string;
+
+  constructor() {}
+
+  public d: string = "";
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
+          messageId: 'incorrectGroupOrder',
+          data: {
+            name: 'd',
+            rank: 'constructor',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const sortedWithGroupingInterfacesOption: TSESLint.RunTests<
+  MessageIds,
+  Options
+> = {
+  valid: [
+    // interfaces option + interface + default order + alphabetically
+    {
+      code: `
+interface Foo {
+  a : x;
+  b : x;
+  c : x;
+
+  new () : Bar;
+
+  a() : void;
+  b() : void;
+  c() : void;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [{ interfaces: { order: 'alphabetically' } }],
+    },
+
+    // interfaces option + interface + custom order + alphabetically
+    {
+      code: `
+interface Foo {
+  new () : Bar;
+
+  a() : void;
+  b() : void;
+  c() : void;
+
+  a : x;
+  b : x;
+  c : x;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [
+        {
+          interfaces: {
+            memberTypes: ['constructor', 'method', 'field'],
+            order: 'alphabetically',
+          },
+        },
+      ],
+    },
+
+    // interfaces option + type literal + alphabetically --> Default order applies
+    {
+      code: `
+type Foo = {
+  c : x;
+  b : x;
+  a : x;
+
+  new () : Bar;
+
+  c() : void;
+  b() : void;
+  a() : void;
+
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [{ interfaces: { order: 'alphabetically' } }],
+    },
+
+    // interfaces option + class + alphabetically --> Default order applies
+    {
+      code: `
+class Foo {
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  constructor() {}
+}
+            `,
+      options: [{ interfaces: { order: 'alphabetically' } }],
+    },
+
+    // interfaces option + class expression + alphabetically --> Default order applies
+    {
+      code: `
+const foo = class Foo {
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  constructor() {}
+}
+            `,
+      options: [{ interfaces: { order: 'alphabetically' } }],
+    },
+  ],
+  invalid: [
+    // default option + interface + wrong order within group and wrong group order + alphabetically
+    {
+      code: `
+interface Foo {
+  a : x;
+  b : x;
+  c : x;
+
+  c() : void;
+  b() : void;
+  a() : void;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+
+  new () : Bar;
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
+          messageId: 'incorrectGroupOrder',
+          data: {
+            name: 'new',
+            rank: 'method',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const sortedWithGroupingTypeLiteralsOption: TSESLint.RunTests<
+  MessageIds,
+  Options
+> = {
+  valid: [
+    // typeLiterals option + interface + alphabetically --> Default order applies
+    {
+      code: `
+interface Foo {
+  c : x;
+  b : x;
+  a : x;
+
+  new () : Bar;
+
+  c() : void;
+  b() : void;
+  a() : void;
+
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [{ typeLiterals: { order: 'alphabetically' } }],
+    },
+
+    // typeLiterals option + type literal + default order + alphabetically
+    {
+      code: `
+type Foo = {
+  a : x;
+  b : x;
+  c : x;
+
+  new () : Bar;
+
+  a() : void;
+  b() : void;
+  c() : void;
+
+  [a: string] : number;
+  () : Baz;
+}
+            `,
+      options: [{ typeLiterals: { order: 'alphabetically' } }],
+    },
+
+    // typeLiterals option + type literal + custom order + alphabetically
+    {
+      code: `
+type Foo = {
+  new () : Bar;
+
+  a() : void;
+  b() : void;
+  c() : void;
+
+  a : x;
+  b : x;
+  c : x;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+}
+            `,
+      options: [
+        {
+          typeLiterals: {
+            memberTypes: ['constructor', 'method', 'field'],
+            order: 'alphabetically',
+          },
+        },
+      ],
+    },
+
+    // typeLiterals option + class + alphabetically --> Default order applies
+    {
+      code: `
+class Foo {
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  constructor() {}
+}
+            `,
+      options: [{ typeLiterals: { order: 'alphabetically' } }],
+    },
+
+    // typeLiterals option + class expression + alphabetically --> Default order applies
+    {
+      code: `
+const foo = class Foo {
+  public static a: string;
+  protected static b: string = "";
+  private static c: string = "";
+
+  public d: string = "";
+  protected e: string = "";
+  private f: string = "";
+
+  constructor() {}
+}
+            `,
+      options: [{ typeLiterals: { order: 'alphabetically' } }],
+    },
+  ],
+  invalid: [
+    // default option + type literal + wrong order within group and wrong group order + alphabetically
+    {
+      code: `
+type Foo = {
+  a : x;
+  b : x;
+  c : x;
+
+  c() : void;
+  b() : void;
+  a() : void;
+
+  [a: string] : number; // Will be ignored (no sortable identifier)
+  () : Baz; // Will be ignored (no sortable identifier)
+
+  new () : Bar;
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
+          messageId: 'incorrectGroupOrder',
+          data: {
+            name: 'new',
+            rank: 'method',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const sortedWithoutGrouping = {
+  valid: [
+    ...sortedWithoutGroupingDefaultOption.valid,
+    ...sortedWithoutGroupingClassesOption.valid,
+    ...sortedWithoutGroupingClassExpressionsOption.valid,
+    ...sortedWithoutGroupingInterfacesOption.valid,
+    ...sortedWithoutGroupingTypeLiteralsOption.valid,
+  ],
+  invalid: [
+    ...sortedWithoutGroupingDefaultOption.invalid,
+    ...sortedWithoutGroupingClassesOption.invalid,
+    ...sortedWithoutGroupingClassExpressionsOption.invalid,
+    ...sortedWithoutGroupingInterfacesOption.invalid,
+    ...sortedWithoutGroupingTypeLiteralsOption.invalid,
+  ],
+};
+
+const sortedWithGrouping = {
+  valid: [
+    ...sortedWithGroupingDefaultOption.valid,
+    ...sortedWithGroupingClassesOption.valid,
+    ...sortedWithGroupingClassExpressionsOption.valid,
+    ...sortedWithGroupingInterfacesOption.valid,
+    ...sortedWithGroupingTypeLiteralsOption.valid,
+  ],
+  invalid: [
+    ...sortedWithGroupingDefaultOption.invalid,
+    ...sortedWithGroupingClassesOption.invalid,
+    ...sortedWithGroupingClassExpressionsOption.invalid,
+    ...sortedWithGroupingInterfacesOption.invalid,
+    ...sortedWithGroupingTypeLiteralsOption.invalid,
+  ],
+};
+
+ruleTester.run('member-ordering', rule, {
+  valid: [
+    ...grouped.valid,
+    ...sortedWithoutGrouping.valid,
+    ...sortedWithGrouping.valid,
+  ],
+  invalid: [
+    ...grouped.invalid,
+    ...sortedWithoutGrouping.invalid,
+    ...sortedWithGrouping.invalid,
   ],
 });

--- a/packages/eslint-plugin/tests/rules/member-ordering.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering.test.ts
@@ -1,6 +1,3 @@
-// TODO - migrate this test to the rule
-/* eslint-disable @typescript-eslint/internal/plugin-test-formatting */
-
 import rule, {
   defaultOrder,
   MessageIds,
@@ -3629,14 +3626,14 @@ const sortedWithoutGroupingDefaultOption: TSESLint.RunTests<
     {
       code: `
 interface Foo {
-  a : b;
-  [a: string] : number;
-  b() : void;
-  new () : Bar; // Will be ignored (no sortable identifier)
-  () : Baz; // Will be ignored (no sortable identifier)
+  a(): Foo;
+  (): Foo;
+  b(): Foo;
 }
             `,
-      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+      options: [
+        { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
+      ],
     },
 
     // default option + interface + lower/upper case
@@ -3668,8 +3665,8 @@ type Foo = {
   a : b;
   [a: string] : number;
   b() : void;
-  new () : Bar; // Will be ignored (no sortable identifier)
-  () : Baz; // Will be ignored (no sortable identifier)
+  new () : Bar;
+  () : Baz;
 }
             `,
       options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
@@ -3704,7 +3701,7 @@ class Foo {
   public static a : string;
   protected static b : string = "";
   private static c : string = "";
-  constructor() {} // Will be ignored (no sortable identifier)
+  constructor() {}
   public d : string = "";
   protected e : string = "";
   private f : string = "";
@@ -3742,7 +3739,7 @@ const foo = class Foo {
   public static a : string;
   protected static b : string = "";
   private static c : string = "";
-  constructor() {} // Will be ignored (no sortable identifier)
+  constructor() {}
   public d : string = "";
   protected e : string = "";
   private f : string = "";
@@ -3781,8 +3778,8 @@ interface Foo {
   b() : void;
   a : b;
   [a: string] : number;
-  new () : Bar; // Will be ignored (no sortable identifier)
-  () : Baz; // Will be ignored (no sortable identifier)
+  new () : Bar;
+  () : Baz;
 }
           `,
       options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
@@ -3832,8 +3829,8 @@ type Foo = {
   b() : void;
   a : b;
   [a: string] : number;
-  new () : Bar; // Will be ignored (no sortable identifier)
-  () : Baz; // Will be ignored (no sortable identifier)
+  new () : Bar;
+  () : Baz;
 }
           `,
       options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
@@ -3883,7 +3880,7 @@ class Foo {
   protected static b : string = "";
   public static a : string;
   private static c : string = "";
-  constructor() {} // Will be ignored (no sortable identifier)
+  constructor() {}
   public d : string = "";
   protected e : string = "";
   private f : string = "";
@@ -3936,7 +3933,7 @@ const foo = class Foo {
   protected static b : string = "";
   public static a : string;
   private static c : string = "";
-  constructor() {} // Will be ignored (no sortable identifier)
+  constructor() {}
   public d : string = "";
   protected e : string = "";
   private f : string = "";
@@ -4068,7 +4065,7 @@ class Foo {
   public static a : string;
   protected static b : string = "";
   private static c : string = "";
-  constructor() {} // Will be ignored (no sortable identifier)
+  constructor() {}
   public d : string = "";
   protected e : string = "";
   private f : string = "";
@@ -4145,7 +4142,7 @@ class Foo {
   protected static b : string = "";
   public static a : string;
   private static c : string = "";
-  constructor() {} // Will be ignored (no sortable identifier)
+  constructor() {}
   public d : string = "";
   protected e : string = "";
   private f : string = "";
@@ -4333,7 +4330,7 @@ const foo = class Foo {
   public static a : string;
   protected static b : string = "";
   private static c : string = "";
-  constructor() {} // Will be ignored (no sortable identifier)
+  constructor() {}
   public d : string = "";
   protected e : string = "";
   private f : string = "";
@@ -4378,7 +4375,7 @@ const foo = class Foo {
   protected static b : string = "";
   public static a : string;
   private static c : string = "";
-  constructor() {} // Will be ignored (no sortable identifier)
+  constructor() {}
   public d : string = "";
   protected e : string = "";
   private f : string = "";
@@ -4442,8 +4439,8 @@ interface Foo {
   [a: string] : number;
   a : b;
   b() : void;
-  new () : Bar; // Will be ignored (no sortable identifier)
-  () : Baz; // Will be ignored (no sortable identifier)
+  new () : Bar;
+  () : Baz;
 }
             `,
       options: [
@@ -4615,8 +4612,8 @@ interface Foo {
   b() : void;
   a : b;
   [a: string] : number;
-  new () : Bar; // Will be ignored (no sortable identifier)
-  () : Baz; // Will be ignored (no sortable identifier)
+  new () : Bar;
+  () : Baz;
 }
           `,
       options: [
@@ -4719,8 +4716,8 @@ type Foo = {
   [a: string] : number;
   a : b;
   b() : void;
-  new () : Bar; // Will be ignored (no sortable identifier)
-  () : Baz; // Will be ignored (no sortable identifier)
+  new () : Bar;
+  () : Baz;
 }
             `,
       options: [
@@ -4850,8 +4847,8 @@ type Foo = {
   b() : void;
   a : b;
   [a: string] : number;
-  new () : Bar; // Will be ignored (no sortable identifier)
-  () : Baz; // Will be ignored (no sortable identifier)
+  new () : Bar;
+  () : Baz;
 }
           `,
       options: [
@@ -4921,7 +4918,7 @@ interface Foo {
   b() : void;
   c() : void;
 
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 }
             `,
       options: [
@@ -4944,7 +4941,7 @@ interface Foo {
   c : x;
 
   [a: string] : number;
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 }
             `,
       options: [
@@ -4973,7 +4970,7 @@ type Foo = {
   b() : void;
   c() : void;
 
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 }
             `,
       options: [
@@ -4997,7 +4994,7 @@ type Foo = {
   b : x;
   c : x;
 
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 }
             `,
       options: [
@@ -5115,7 +5112,7 @@ interface Foo {
   b() : void;
   a() : void;
 
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 
   new () : Bar;
 }
@@ -5148,7 +5145,7 @@ type Foo = {
   b() : void;
   a() : void;
 
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 
   new () : Bar;
 }
@@ -5533,7 +5530,7 @@ interface Foo {
 
   new () : Bar;
 
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 }
             `,
       options: [
@@ -5561,7 +5558,7 @@ interface Foo {
   c : x;
 
   [a: string] : number;
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 }
             `,
       options: [
@@ -5647,7 +5644,7 @@ interface Foo {
   b() : void;
   a() : void;
 
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 
   new () : Bar;
 }
@@ -5739,7 +5736,7 @@ type Foo = {
   c : x;
 
   [a: string] : number;
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 }
             `,
       options: [
@@ -5803,7 +5800,7 @@ type Foo = {
   b() : void;
   a() : void;
 
-  () : Baz; // Will be ignored (no sortable identifier)
+  () : Baz;
 
   new () : Bar;
 }

--- a/packages/typescript-estree/src/ts-estree/ts-estree.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-estree.ts
@@ -308,11 +308,9 @@ export type BindingPattern = ArrayPattern | ObjectPattern;
 export type BindingName = BindingPattern | Identifier;
 export type ClassElement =
   | ClassProperty
-  | FunctionExpression
   | MethodDefinition
   | TSAbstractClassProperty
   | TSAbstractMethodDefinition
-  | TSEmptyBodyFunctionExpression
   | TSIndexSignature;
 export type ClassProperty =
   | ClassPropertyComputedName


### PR DESCRIPTION
Hi,

this PR adds a new rule to sort members in `interface`s alphabetically. A use case for such a rule would be the following:

### Use case
Sorting things can have certain benefits, e.g. fewer merge conflicts or easier manual comparison of implementations.

Currently, in ESLint, multiple things can be sorted alphabetically:
- [sort-keys](https://eslint.org/docs/rules/sort-keys)
- [sort-vars](https://eslint.org/docs/rules/sort-vars)
- [sort-imports](https://eslint.org/docs/rules/sort-imports)

Additionally, it is possible to sort members using [member-ordering](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/member-ordering.md). Except if I didn't understand how to use the `member-ordering` rule correctly, currently, there is no option to sort members of interfaces alphabetically.

Let's say we have an interface which looks as follows:
```ts
interface Foo {
  B: string; // should come after `A`
  A: string;
  C: string;
}
```

The intended definition of this `interface` is:
```ts
interface Foo {
  A: string;
  B: string;
  C: string;
}
```

This PR adds a rule which detects these issues. This is probably something where we could also provide a fix. I just wanted to make sure this goes into the right direction before. Looks like there is an open issue to create a rule for this in TSLint: [Feature Request: alphabetize interface members/fields](https://github.com/palantir/tslint/issues/3482). Let me know what you think!