### PR TITLE
docs(eslint-plugin): no-type-alias: Fix Typo

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-type-alias.md
+++ b/packages/eslint-plugin/docs/rules/no-type-alias.md
@@ -247,7 +247,7 @@ type Foo = (name: string, age: number) => string | Person;
 type Foo = (name: string, age: number) => string & Person;
 ```
 
-### allowsLiterals
+### allowLiterals
 
 This applies to literal types (`type Foo = { ... }`).
 


### PR DESCRIPTION
allowsLiterals -> allowLiterals