### PR TITLE
docs(typescript-eslint): correct version typo in documentation url

### DIFF
--- a/packages/eslint-plugin/src/util/createRule.ts
+++ b/packages/eslint-plugin/src/util/createRule.ts
@@ -48,7 +48,7 @@ export function createRule<
       ...meta,
       docs: {
         ...meta.docs,
-        url: `https://github.com/typescript-eslint/typescript-eslint/blob/${version}/packages/eslint-plugin/docs/rules/${name}.md`,
+        url: `https://github.com/typescript-eslint/typescript-eslint/blob/v${version}/packages/eslint-plugin/docs/rules/${name}.md`,
         extraDescription: meta.docs.tslintName
           ? [`\`${meta.docs.tslintName}\` from TSLint`]
           : undefined,


### PR DESCRIPTION
The docs URL was missing a "v" before the version number and I put it there. 
I think it got lost in [the previous PR](https://github.com/typescript-eslint/typescript-eslint/pull/71).