### PR TITLE
test(plugin-tslint): missing test cases for eslint-plugin-tslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,7 +54,10 @@
       }
     },
     {
-      "files": ["packages/eslint-plugin/test/**/*.ts"],
+      "files": [
+        "packages/eslint-plugin/test/**/*.ts",
+        "packages/eslint-plugin-tslint/tests/**/*.spec.ts"
+      ],
       "rules": {
         "eslint-plugin/no-identical-tests": "error"
       }

--- a/packages/eslint-plugin-tslint/src/custom-linter.ts
+++ b/packages/eslint-plugin-tslint/src/custom-linter.ts
@@ -13,7 +13,6 @@ export class CustomLinter extends TSLintLinter {
   }
 
   getSourceFile(fileName: string) {
-    const result = this.program.getSourceFile(fileName);
-    return result;
+    return this.program.getSourceFile(fileName);
   }
 }

--- a/packages/eslint-plugin-tslint/src/index.ts
+++ b/packages/eslint-plugin-tslint/src/index.ts
@@ -83,7 +83,7 @@ export const rules = {
         },
       ],
     },
-    create: function(context: Rule.RuleContext) {
+    create(context: Rule.RuleContext) {
       const fileName = context.getFilename();
       const sourceCode = context.getSourceCode().text;
       const parserServices: ParserServices | undefined = context.parserServices;

--- a/packages/eslint-plugin-tslint/tests/index.spec.ts
+++ b/packages/eslint-plugin-tslint/tests/index.spec.ts
@@ -155,4 +155,28 @@ describe('tslint/error', () => {
       },
     });
   });
+
+  it('should not crash if there is no tslint rules specified', () => {
+    const linter = new Linter();
+    jest.spyOn(console, 'warn').mockImplementation();
+    linter.defineRule('tslint/config', rules.config);
+    expect(() =>
+      linter.verify('foo;', {
+        parserOptions: {
+          project: `${__dirname}/test-project/tsconfig.json`,
+        },
+        rules: {
+          'tslint/config': [2, {}],
+        },
+        parser: '@typescript-eslint/parser',
+      }),
+    ).not.toThrow();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'No valid rules have been specified for TypeScript files',
+      ),
+    );
+    jest.resetAllMocks();
+  });
 });

--- a/packages/eslint-plugin-tslint/tests/index.spec.ts
+++ b/packages/eslint-plugin-tslint/tests/index.spec.ts
@@ -1,5 +1,5 @@
-import { rules } from '../src/index';
-import { RuleTester } from 'eslint';
+import { rules } from '../src';
+import { Linter, RuleTester } from 'eslint';
 import { readFileSync } from 'fs';
 
 const ruleTester = new RuleTester({
@@ -124,4 +124,35 @@ ruleTester.run('tslint/config', rules.config, {
       ],
     },
   ],
+});
+
+describe('tslint/error', () => {
+  function testOutput(code: string, config: Linter.Config): void {
+    const linter = new Linter();
+    linter.defineRule('tslint/config', rules.config);
+
+    expect(() => linter.verify(code, config)).toThrow(
+      `You must provide a value for the "parserOptions.project" property for @typescript-eslint/parser`,
+    );
+  }
+
+  it('should error on missing project', () => {
+    testOutput('foo;', {
+      rules: {
+        'tslint/config': [2, tslintRulesConfig],
+      },
+      parser: '@typescript-eslint/parser',
+    });
+  });
+
+  it('should error on default parser', () => {
+    testOutput('foo;', {
+      parserOptions: {
+        project: `${__dirname}/test-project/tsconfig.json`,
+      },
+      rules: {
+        'tslint/config': [2, tslintRulesConfig],
+      },
+    });
+  });
 });


### PR DESCRIPTION
This PR adds missing regression tests for eslint-plugin-tslint and enables linting of tests files in plugin