### PR TITLE
fix(eslint-plugin): out-of-bounds access in member-ordering rule

### DIFF
--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -182,6 +182,9 @@ export default util.createRule<Options, MessageIds>({
       node: TSESTree.ClassElement | TSESTree.TypeElement,
     ): string | null {
       // TODO: add missing TSCallSignatureDeclaration
+      // TODO: add missing TSIndexSignature
+      // TODO: add missing TSAbstractClassProperty
+      // TODO: add missing TSAbstractMethodDefinition
       switch (node.type) {
         case AST_NODE_TYPES.MethodDefinition:
           return node.kind;
@@ -258,7 +261,7 @@ export default util.createRule<Options, MessageIds>({
       const type = getNodeType(node);
       if (type === null) {
         // shouldn't happen but just in case, put it on the end
-        return Number.MAX_SAFE_INTEGER;
+        return order.length - 1;
       }
 
       const scope = 'static' in node && node.static ? 'static' : 'instance';

--- a/packages/eslint-plugin/tests/rules/member-ordering.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering.test.ts
@@ -1211,6 +1211,12 @@ type Foo = {
             `,
       options: [{ default: ['method', 'constructor', 'field'] }],
     },
+    `
+abstract class Foo {
+    B: string;
+    abstract A: () => {}
+}
+    `,
   ],
   invalid: [
     {
@@ -3306,6 +3312,25 @@ type Foo = {
             rank: 'field',
           },
           line: 5,
+          column: 5,
+        },
+      ],
+    },
+    {
+      code: `
+abstract class Foo {
+    abstract A: () => {}
+    B: string;
+}
+          `,
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            name: 'B',
+            rank: 'method',
+          },
+          line: 4,
           column: 5,
         },
       ],


### PR DESCRIPTION
Fixes Cannot read property 'replace' of undefined error when
unknown node types are used in the source code.
Also adds TODO comments for missing node types.

---

**Some background information:**

There are several node types that are not implemented yet, like:

- TSCallSignatureDeclaration
- TSIndexSignature
- TSAbstractClassProperty
- TSAbstractMethodDefinition
- ...?

In that case, the current implementation returns `Number.MAX_SAFE_INTEGER` to increase the order ranking. In `getLowestRank`, however, this number is used as index for `order` which will obviously fail in some cases.

In my case, the `rank` in `getLowestRank` was an array that looked like this `[ 3, 3, 16, 9007199254740991 ]`. This threw:

```
TypeError: Cannot read property 'replace' of undefined
    at getLowestRank (/Users/jhnns/dev/some-project/node_modules/@typescript-eslint/eslint-plugin/dist/rules/member-ordering.js:272:34)
    at members.forEach.member (/Users/jhnns/dev/some-project/node_modules/@typescript-eslint/eslint-plugin/dist/rules/member-ordering.js:292:43)
    at Array.forEach (<anonymous>)
    at validateMembers (/Users/jhnns/dev/some-project/node_modules/@typescript-eslint/eslint-plugin/dist/rules/member-ordering.js:283:25)
    at ClassDeclaration (/Users/jhnns/dev/some-project/node_modules/@typescript-eslint/eslint-plugin/dist/rules/member-ordering.js:305:17)
    at listeners.(anonymous function).forEach.listener (/Users/jhnns/dev/some-project/node_modules/eslint/lib/util/safe-emitter.js:45:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/jhnns/dev/some-project/node_modules/eslint/lib/util/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/Users/jhnns/dev/some-project/node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (/Users/jhnns/dev/some-project/node_modules/eslint/lib/util/node-event-generator.js:280:22)
```

Fixes #307