### PR TITLE
Emit declarations for eslint-plugin

### DIFF
--- a/packages/eslint-plugin/tsconfig.build.json
+++ b/packages/eslint-plugin/tsconfig.build.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    // specifically disable declarations for the plugin
-    "declaration": true,
-    "declarationMap": true,
     "outDir": "./dist",
     "resolveJsonModule": true
   },

--- a/packages/eslint-plugin/tsconfig.build.json
+++ b/packages/eslint-plugin/tsconfig.build.json
@@ -2,8 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     // specifically disable declarations for the plugin
-    "declaration": false,
-    "declarationMap": false,
+    "declaration": true,
+    "declarationMap": true,
     "outDir": "./dist",
     "resolveJsonModule": true
   },


### PR DESCRIPTION
The `createRule` helper is extremely useful for writing rules in TypeScript. I would like to use that for my own ESLint rules. Exporting the types will help a lot.