### PR TITLE
fix: 🐛 When using always have a different error message

### DIFF
--- a/packages/eslint-plugin/src/rules/interface-name-prefix.ts
+++ b/packages/eslint-plugin/src/rules/interface-name-prefix.ts
@@ -1,7 +1,7 @@
 import * as util from '../util';
 
 type Options = ['never' | 'always'];
-type MessageIds = 'noPrefix';
+type MessageIds = 'noPrefix' | 'alwaysPrefix';
 
 export default util.createRule<Options, MessageIds>({
   name: 'interface-name-prefix',
@@ -15,6 +15,7 @@ export default util.createRule<Options, MessageIds>({
     },
     messages: {
       noPrefix: 'Interface name must not be prefixed with "I".',
+      alwaysPrefix: 'Interface name must be prefixed with "I".',
     },
     schema: [
       {
@@ -51,7 +52,7 @@ export default util.createRule<Options, MessageIds>({
           if (!isPrefixedWithI(node.id.name)) {
             context.report({
               node: node.id,
-              messageId: 'noPrefix',
+              messageId: 'alwaysPrefix',
             });
           }
         }

--- a/packages/eslint-plugin/tests/rules/interface-name-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/interface-name-prefix.test.ts
@@ -77,7 +77,7 @@ interface Animal {
       options: ['always'],
       errors: [
         {
-          messageId: 'noPrefix',
+          messageId: 'alwaysPrefix',
           line: 2,
           column: 11,
         },
@@ -92,7 +92,7 @@ interface Iguana {
       options: ['always'],
       errors: [
         {
-          messageId: 'noPrefix',
+          messageId: 'alwaysPrefix',
           line: 2,
           column: 11,
         },


### PR DESCRIPTION
interface-name-prefix currenlty provides 'Interface name must not be
prefixed with "I".' but when in always mode it should give an error
message that matches the intent, added 'Interface name must be prefixed
with "I".' for when "always" is enabled