### PR TITLE
docs(eslint-plugin): rewrite member-ordering docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/member-ordering.md
+++ b/packages/eslint-plugin/docs/rules/member-ordering.md
@@ -5,591 +5,638 @@ expressions easier to read, navigate and edit.
 
 ## Rule Details
 
-This rule aims to standardise the way interfaces, type literals, classes and class expressions are structured.
+This rule aims to standardize the way class declarations, class expressions, interfaces and type literals are structured.
+
+It allows to group members by their type (e.g. `public-static-field`, `protected-static-field`, `private-static-field`, `public-instance-field`, ...). By default, their order is the same inside `classes`, `classExpressions`, `interfaces` and `typeLiterals` (note: not all member types apply to `interfaces` and `typeLiterals`). It is possible to define the order for any of those individually or to change the default order for all of them by setting the `default` option.
 
 ## Options
 
-This rule, in its default state, does not require any argument, in which case the following order is enforced:
+```ts
+{
+  default?: Array<MemberType> | never
+  classes?: Array<MemberType> | never
+  classExpressions?: Array<MemberType> | never
 
-- `public-static-field`
-- `protected-static-field`
-- `private-static-field`
-- `public-instance-field`
-- `protected-instance-field`
-- `private-instance-field`
-- `public-field` (ignores scope)
-- `protected-field` (ignores scope)
-- `private-field` (ignores scope)
-- `static-field` (ignores accessibility)
-- `instance-field` (ignores accessibility)
-- `field` (ignores scope and/or accessibility)
-- `constructor` (ignores scope and/or accessibility)
-- `public-static-method`
-- `protected-static-method`
-- `private-static-method`
-- `public-instance-method`
-- `protected-instance-method`
-- `private-instance-method`
-- `public-method` (ignores scope)
-- `protected-method` (ignores scope)
-- `private-method` (ignores scope)
-- `static-method` (ignores accessibility)
-- `instance-method` (ignores accessibility)
-- `method` (ignores scope and/or accessibility)
+  interfaces?: ['field' | 'method' | 'constructor'] | never
+  typeLiterals?: ['field' | 'method' | 'constructor'] | never
+}
+```
 
-The rule can also take one or more of the following options:
+See below for the possible definitions of `MemberType`.
 
-- `default`, use this to change the default order (used when no specific configuration has been provided).
-- `classes`, use this to change the order in classes.
-- `classExpressions`, use this to change the order in class expressions.
-- `interfaces`, use this to change the order in interfaces.
-- `typeLiterals`, use this to change the order in type literals.
+### Member types (granular form)
 
-### default
+There are multiple ways to specify the member types. The most explicit and granular form is the following:
 
-Disable using `never` or use one of the following values to specify an order:
+```json5
+[
+  // Fields
+  'public-static-field',
+  'protected-static-field',
+  'private-static-field',
+  'public-instance-field',
+  'protected-instance-field',
+  'private-instance-field',
 
-- Fields:  
-  `public-static-field`  
-  `protected-static-field`  
-  `private-static-field`  
-  `public-instance-field`  
-  `protected-instance-field`  
-  `private-instance-field`  
-  `public-field` (= public-_-field)  
-  `protected-field` (= protected-_-field)  
-  `private-field` (= private-_-field)  
-  `static-field` (= _-static-field)  
-  `instance-field` (= \*-instance-field)  
-  `field` (= all)
+  // Constructors
+  'public-constructor',
+  'protected-constructor',
+  'private-constructor',
 
-- Constructors:  
-  `public-constructor`  
-  `protected-constructor`  
-  `private-constructor`  
-  `constructor` (= \*-constructor)
+  // Methods
+  'public-static-method',
+  'protected-static-method',
+  'private-static-method',
+  'public-instance-method',
+  'protected-instance-method',
+  'private-instance-method',
+]
+```
 
-- Methods:
-  `public-static-method`  
-  `protected-static-method`  
-  `private-static-method`  
-  `public-instance-method`  
-  `protected-instance-method`  
-  `private-instance-method`  
-  `public-method` (= public-_-method)  
-  `protected-method` (= protected-_-method)  
-  `private-method` (= private-_-method)  
-  `static-method` (= _-static-method)  
-  `instance-method` (= \*-instance-method)  
-  `method` (= all)
+Note: If you only specify some of the possible types, the non-specified ones can have any particular order. This means that they can be placed before, within or after the specified types and the linter won't complain about it.
 
-Examples of **incorrect** code for the `{ "default": [...] }` option:
+### Member group types (with accessibility, ignoring scope)
+
+It is also possible to group member types by their accessibility (`static`, `instance`), ignoring their scope.
+
+```json5
+[
+  // Fields
+  'public-field', // = ['public-static-field', 'public-instance-field'])
+  'protected-field', // = ['protected-static-field', 'protected-instance-field'])
+  'private-field', // = ['private-static-field', 'private-instance-field'])
+
+  // Constructors
+  // Only the accessibility of constructors is configurable. See below.
+
+  // Methods
+  'public-method', // = ['public-static-method', 'public-instance-method'])
+  'protected-method', // = ['protected-static-method', 'protected-instance-method'])
+  'private-method', // = ['private-static-method', 'private-instance-method'])
+]
+```
+
+### Member group types (with scope, ignoring accessibility)
+
+Another option is to group the member types by their scope (`public`, `protected`, `private`), ignoring their accessibility.
+
+```json5
+[
+  // Fields
+  'static-field', // = ['public-static-field', 'protected-static-field', 'private-static-field'])
+  'instance-field', // = ['public-instance-field', 'protected-instance-field', 'private-instance-field'])
+
+  // Constructors
+  'constructor', // = ['public-constructor', 'protected-constructor', 'private-constructor'])
+
+  // Methods
+  'static-method', // = ['public-static-method', 'protected-static-method', 'private-static-method'])
+  'instance-method', // = ['public-instance-method', 'protected-instance-method', 'private-instance-method']
+]
+```
+
+### Member group types (with scope and accessibility)
+
+The third grouping option is to ignore both scope and accessibility.
+
+```json5
+[
+  // Fields
+  'field', // = ['public-static-field', 'protected-static-field', 'private-static-field', 'public-instance-field', 'protected-instance-field', 'private-instance-field'])
+
+  // Constructors
+  // Only the accessibility of constructors is configurable. See above.
+
+  // Methods
+  'method', // = ['public-static-method', 'protected-static-method', 'private-static-method', 'public-instance-method', 'protected-instance-method', 'private-instance-method'])
+]
+```
+
+### Default configuration
+
+The default configuration looks as follows:
+
+```json
+{
+  "default": [
+    "public-static-field",
+    "protected-static-field",
+    "private-static-field",
+
+    "public-instance-field",
+    "protected-instance-field",
+    "private-instance-field",
+
+    "public-field",
+    "protected-field",
+    "private-field",
+
+    "static-field",
+    "instance-field",
+
+    "field",
+
+    "constructor",
+
+    "public-static-method",
+    "protected-static-method",
+    "private-static-method",
+
+    "public-instance-method",
+    "protected-instance-method",
+    "private-instance-method",
+
+    "public-method",
+    "protected-method",
+    "private-method",
+
+    "static-method",
+    "instance-method",
+
+    "method"
+  ]
+}
+```
+
+Note: The default configuration contains member group types which contain other member types (see above). This is intentional to provide better error messages.
+
+## Examples
+
+### Custom `default` configuration
+
+Note: The `default` options are overwritten in these examples.
+
+#### Configuration: `{ "default": ["method", "constructor", "field"] }`
+
+##### Incorrect examples
 
 ```ts
-// { "default": ["method", "constructor", "field"] }
-
 interface Foo {
-  // -> field
-  B: string;
+  B: string; // -> field
 
-  // -> constructor
-  new ();
+  new (); // -> constructor
 
-  // -> method
-  A(): void;
+  A(): void; // -> method
 }
+```
 
+Note: Wrong order.
+
+```ts
 type Foo = {
-  // -> field
-  B: string;
+  B: string; // -> field
 
   // no constructor
 
-  // -> method
-  A(): void;
-};
-
-class Foo {
-  // -> * field
-  private C: string;
-  public D: string;
-  protected static E: string;
-
-  // -> constructor
-  constructor() {}
-
-  // -> * method
-  public static A(): void {}
-  public B(): void {}
-}
-
-const Foo = class {
-  // -> * field
-  private C: string;
-  public D: string;
-
-  // -> constructor
-  constructor() {}
-
-  // -> * method
-  public static A(): void {}
-  public B(): void {}
-
-  // * field
-  protected static E: string;
-};
-
-// { "default": ["public-instance-method", "public-static-field"] }
-
-// does not apply for interfaces/type literals (accessibility and scope are not part of interfaces/type literals)
-
-class Foo {
-  // private instance field
-  private C: string;
-
-  // public instance field
-  public D: string;
-
-  // -> public static field
-  public static E: string;
-
-  // constructor
-  constructor() {}
-
-  // public static method
-  public static A(): void {}
-
-  // -> public instance method
-  public B(): void {}
-}
-
-const Foo = class {
-  // private instance field
-  private C: string;
-
-  // -> public static field
-  public static E: string;
-
-  // public instance field
-  public D: string;
-
-  // constructor
-  constructor() {}
-
-  // public static method
-  public static A(): void {}
-
-  // -> public instance method
-  public B(): void {}
+  A(): void; // -> method
 };
 ```
 
-Examples of **correct** code for the `{ "default": [...] }` option:
+Note: Not all specified member types have to exist.
 
 ```ts
-// { "default": ["method", "constructor", "field"] }
+class Foo {
+  private C: string; // -> field
+  public D: string; // -> field
+  protected static E: string; // -> field
 
+  constructor() {} // -> constructor
+
+  public static A(): void {} // -> method
+  public B(): void {} // -> method
+}
+```
+
+Note: Accessibility or scope are ignored with this ignored.
+
+```ts
+const Foo = class {
+  private C: string; // -> field
+  public D: string; // -> field
+
+  constructor() {} // -> constructor
+
+  public static A(): void {} // -> method
+  public B(): void {} // -> method
+
+  protected static E: string; // -> field
+};
+```
+
+Note: Not all members have to be grouped to find rule violations.
+
+##### Correct examples
+
+```ts
 interface Foo {
-    // -> method
-    A() : void;
+  A(): void; // -> method
 
-    // -> constructor
-    new();
+  new (); // -> constructor
 
-    // -> field
-    B: string;
-}
-
-type Foo = {
-    // -> method
-    A() : void;
-
-    // -> field
-    B: string;
-}
-
-class Foo {
-    // -> * method
-    public static A(): void {}
-    public B(): void {}
-
-    // -> constructor
-    constructor() {}
-
-    // -> * field
-    private C: string
-    public D: string
-    protected static E: string
-}
-
-const Foo = class {
-    // -> * method
-    public static A(): void {}
-    public B(): void {}
-
-    // -> constructor
-    constructor() {}
-
-    // -> * field
-    private C: string
-    public D: string
-    protected static E: string
-}
-
-// { "default": ["public-instance-method", "public-static-field"] }
-
-// does not apply for interfaces/type literals (accessibility and scope are not part of interfaces/type literals)
-
-class Foo {
-    // -> public instance method
-    public B(): void {}
-
-    // private instance field
-    private C: string
-
-    // public instance field
-    public D: string
-
-    // -> public static field
-    public static E: string
-
-    // constructor
-    constructor() {}
-
-    // public static method
-    public static A(): void {}
-}
-
-const Foo = class {
-    // -> public instance method
-    public B(): void {}
-
-    // private instance field
-    private C: string
-
-    // public instance field
-    public D: string
-
-    // constructor
-    constructor() {}
-
-    // public static method
-    public static A(): void {}
-
-    // -> protected static field
-    protected static: string
-}
-
-// { "default": ["public-static-field", "static-field", "instance-field"] }
-
-// does not apply for interfaces/type literals (accessibility and scope are not part of interfaces/type literals)
-
-class Foo {
-    // -> public static field
-    public static A: string;
-
-    // -> * static field
-    private static B: string;
-    protected statis C:string;
-    private static D: string;
-
-    // -> * instance field
-    private E: string;
-}
-
-const foo = class {
-    // * method
-    public T(): void {}
-
-    // -> public static field
-    public static A: string;
-
-    // constructor
-    constructor(){}
-
-    // -> * static field
-    private static B: string;
-    protected statis C:string;
-    private static D: string;
-
-    // -> * instance field
-    private E: string;
+  B: string; // -> field
 }
 ```
-
-### classes
-
-Disable using `never` or use one of the valid values (see default) to specify an order.
-
-Examples of **incorrect** code for the `{ "classes": [...] }` option:
 
 ```ts
-// { "classes": ["method", "constructor", "field"] }
+type Foo = {
+  A(): void; // -> method
 
-// does not apply for interfaces/type literals/class expressions.
+  // no constructor
 
+  B: string; // -> field
+};
+```
+
+```ts
 class Foo {
-  // -> field
-  private C: string;
-  public D: string;
-  protected static E: string;
+  public static A(): void {} // -> method
+  public B(): void {} // -> method
 
-  // -> constructor
-  constructor() {}
+  constructor() {} // -> constructor
 
-  // -> method
-  public static A(): void {}
-  public B(): void {}
-}
-
-// { "classes": ["public-instance-method", "public-static-field"] }
-
-// does not apply for interfaces/type literals/class expressions.
-
-class Foo {
-  // private instance field
-  private C: string;
-
-  // public instance field
-  public D: string;
-
-  // -> public static field
-  public static E: string;
-
-  // constructor
-  constructor() {}
-
-  // public static method
-  public static A(): void {}
-
-  // -> public instance method
-  public B(): void {}
+  private C: string; // -> field
+  public D: string; // -> field
+  protected static E: string; // -> field
 }
 ```
+
+```ts
+const Foo = class {
+  public static A(): void {} // -> method
+  public B(): void {} // -> method
+
+  constructor() {} // -> constructor
+
+  private C: string; // -> field
+  public D: string; // -> field
+  protected static E: string; // -> field
+};
+```
+
+#### Configuration: `{ "default": ["public-instance-method", "public-static-field"] }`
+
+Note: This configuration does not apply to interfaces/type literals as accessibility and scope are not part of interfaces/type literals.
+
+##### Incorrect examples
+
+```ts
+class Foo {
+  private C: string; // (irrelevant)
+
+  public D: string; // (irrelevant)
+
+  public static E: string; // -> public static field
+
+  constructor() {} // (irrelevant)
+
+  public static A(): void {} // (irrelevant)
+
+  public B(): void {} // -> public instance method
+}
+```
+
+Note: Public instance methods should come first before public static fields. Everything else can be placed anywhere.
+
+```ts
+const Foo = class {
+  private C: string; // (irrelevant)
+
+  public static E: string; // -> public static field
+
+  public D: string; // (irrelevant)
+
+  constructor() {} // (irrelevant)
+
+  public static A(): void {} // (irrelevant)
+
+  public B(): void {} // -> public instance method
+};
+```
+
+Note: Public instance methods should come first before public static fields. Everything else can be placed anywhere.
+
+##### Correct examples
+
+```ts
+class Foo {
+  public B(): void {} // -> public instance method
+
+  private C: string; // (irrelevant)
+
+  public D: string; // (irrelevant)
+
+  public static E: string; // -> public static field
+
+  constructor() {} // (irrelevant)
+
+  public static A(): void {} // (irrelevant)
+}
+```
+
+```ts
+const Foo = class {
+  public B(): void {} // -> public instance method
+
+  private C: string; // (irrelevant)
+
+  public D: string; // (irrelevant)
+
+  constructor() {} // (irrelevant)
+
+  public static A(): void {} // (irrelevant)
+
+  public static E: string; // -> public static field
+};
+```
+
+#### Configuration: `{ "default": ["public-static-field", "static-field", "instance-field"] }`
+
+Note: This configuration does not apply to interfaces/type literals as accessibility and scope are not part of interfaces/type literals.
+
+##### Incorrect examples
+
+```ts
+class Foo {
+  private E: string; // -> instance field
+
+  private static B: string; // -> static field
+  protected static C: string; // -> static field
+  private static D: string; // -> static field
+
+  public static A: string; // -> public static field
+}
+```
+
+Note: Public static fields should come first, followed by static fields and instance fields.
+
+```ts
+const foo = class {
+  public T(): void {} // (irrelevant)
+
+  private static B: string; // -> static field
+
+  constructor() {} // (irrelevant)
+
+  private E: string; // -> instance field
+
+  protected static C: string; // -> static field
+  private static D: string; // -> static field
+
+  public static A: string; // -> public static field
+};
+```
+
+Issue: Public static fields should come first, followed by static fields and instance fields.
+
+##### Correct examples
+
+```ts
+class Foo {
+  public static A: string; // -> public static field
+
+  private static B: string; // -> static field
+  protected static C: string; // -> static field
+  private static D: string; // -> static field
+
+  private E: string; // -> instance field
+}
+```
+
+```ts
+const foo = class {
+  public static A: string; // -> public static field
+
+  constructor() {} // -> constructor
+
+  private static B: string; // -> static field
+  protected static C: string; // -> static field
+  private static D: string; // -> static field
+
+  private E: string; // -> instance field
+
+  public T(): void {} // -> method
+};
+```
+
+### Custom `classes` configuration
+
+Note: If this is not set, the `default` will automatically be applied to classes as well. If a `classes` configuration is provided, only this configuration will be used for `classes` (i.e. nothing will be merged with `default`).
+
+Note: The configuration for `classes` does not apply to class expressions (use `classExpressions` for them).
+
+#### Configuration: `{ "classes": ["method", "constructor", "field"] }`
+
+##### Incorrect example
+
+```ts
+class Foo {
+  private C: string; // -> field
+  public D: string; // -> field
+  protected static E: string; // -> field
+
+  constructor() {} // -> constructor
+
+  public static A(): void {} // -> method
+  public B(): void {} // -> method
+}
+```
+
+##### Correct example
+
+```ts
+class Foo {
+  public static A(): void {} // -> method
+  public B(): void {} // -> method
+
+  constructor() {} // -> constructor
+
+  private C: string; // -> field
+  public D: string; // -> field
+  protected static E: string; // -> field
+}
+```
+
+#### Configuration: `{ "classes": ["public-instance-method", "public-static-field"] }`
+
+##### Incorrect example
+
+```ts
+class Foo {
+  private C: string; // (irrelevant)
+
+  public D: string; // (irrelevant)
+
+  public static E: string; // -> public static field
+
+  constructor() {} // (irrelevant)
+
+  public static A(): void {} // (irrelevant)
+
+  public B(): void {} // -> public instance method
+}
+```
+
+##### Correct example
 
 Examples of **correct** code for `{ "classes": [...] }` option:
 
 ```ts
-// { "classes": ["method", "constructor", "field"] }
-
-// does not apply for interfaces/type literals/class expressions.
-
 class Foo {
-  // -> * method
-  public static A(): void {}
-  public B(): void {}
+  private C: string; // (irrelevant)
 
-  // -> constructor
-  constructor() {}
+  public D: string; // (irrelevant)
 
-  // -> * field
-  private C: string;
-  public D: string;
-  protected static E: string;
-}
+  public static E: string; // -> public static field
 
-// { "classes": ["public-instance-method", "public-static-field"] }
+  constructor() {} // (irrelevant)
 
-// does not apply for interfaces/type literals/class expressions.
+  public static A(): void {} // (irrelevant)
 
-class Foo {
-  // private instance field
-  private C: string;
-
-  // public instance field
-  public D: string;
-
-  // -> public static field
-  public static E: string;
-
-  // constructor
-  constructor() {}
-
-  // public static method
-  public static A(): void {}
-
-  // -> public instance method
-  public B(): void {}
+  public B(): void {} // -> public instance method
 }
 ```
 
-### classExpressions
+### Custom `classExpressions` configuration
 
-Disable using `never` or use one of the valid values (see default) to specify an order.
+Note: If this is not set, the `default` will automatically be applied to classes expressions as well. If a `classExpressions` configuration is provided, only this configuration will be used for `classExpressions` (i.e. nothing will be merged with `default`).
 
-Examples of **incorrect** code for the `{ "classExpressions": [...] }` option:
+Note: The configuration for `classExpressions` does not apply to classes (use `classes` for them).
+
+#### Configuration: `{ "classExpressions": ["method", "constructor", "field"] }`
+
+##### Incorrect example
 
 ```ts
-// { "classExpressions": ["method", "constructor", "field"] }
-
-// does not apply for interfaces/type literals/class expressions.
-
 const foo = class {
-  // -> field
-  private C: string;
-  public D: string;
-  protected static E: string;
+  private C: string; // -> field
+  public D: string; // -> field
+  protected static E: string; // -> field
 
-  // -> constructor
-  constructor() {}
+  constructor() {} // -> constructor
 
-  // -> method
-  public static A(): void {}
-  public B(): void {}
-};
-
-// { "classExpressions": ["public-instance-method", "public-static-field"] }
-
-// does not apply for interfaces/type literals/class expressions.
-
-const foo = class {
-  // private instance field
-  private C: string;
-
-  // public instance field
-  public D: string;
-
-  // -> public static field
-  public static E: string;
-
-  // constructor
-  constructor() {}
-
-  // public static method
-  public static A(): void {}
-
-  // -> public instance method
-  public B(): void {}
+  public static A(): void {} // -> method
+  public B(): void {} // -> method
 };
 ```
 
-Examples of **correct** code for `{ "classExpressions": [...] }` option:
+##### Correct example
 
 ```ts
-// { "classExpressions": ["method", "constructor", "field"] }
-
-// does not apply for interfaces/type literals/class expressions.
-
 const foo = class {
-  // -> * method
-  public static A(): void {}
-  public B(): void {}
+  public static A(): void {} // -> method
+  public B(): void {} // -> method
 
-  // -> constructor
-  constructor() {}
+  constructor() {} // -> constructor
 
-  // -> * field
-  private C: string;
-  public D: string;
-  protected static E: string;
-};
-
-// { "classExpressions": ["public-instance-method", "public-static-field"] }
-
-// does not apply for interfaces/type literals/class expressions.
-
-const foo = class {
-  // private instance field
-  private C: string;
-
-  // public instance field
-  public D: string;
-
-  // -> public static field
-  public static E: string;
-
-  // constructor
-  constructor() {}
-
-  // public static method
-  public static A(): void {}
-
-  // -> public instance method
-  public B(): void {}
+  private C: string; // -> field
+  public D: string; // -> field
+  protected static E: string; // -> field
 };
 ```
 
-### interfaces
+#### Configuration: `{ "classExpressions": ["public-instance-method", "public-static-field"] }`
 
-Disable using `never` or use one of the following values to specify an order:  
-`field`  
-`constructor`  
-`method`
-
-Examples of **incorrect** code for the `{ "interfaces": [...] }` option:
+##### Incorrect example
 
 ```ts
-// { "interfaces": ["method", "constructor", "field"] }
+const foo = class {
+  private C: string; // (irrelevant)
 
-// does not apply for classes/class expressions/type literals
+  public D: string; // (irrelevant)
 
+  public static E: string; // -> public static field
+
+  constructor() {} // (irrelevant)
+
+  public static A(): void {} // (irrelevant)
+
+  public B(): void {} // -> public instance method
+};
+```
+
+##### Correct example
+
+```ts
+const foo = class {
+  private C: string; // (irrelevant)
+
+  public D: string; // (irrelevant)
+
+  public B(): void {} // -> public instance method
+
+  public static E: string; // -> public static field
+
+  constructor() {} // (irrelevant)
+
+  public static A(): void {} // (irrelevant)
+};
+```
+
+### Custom `interfaces` configuration
+
+Note: If this is not set, the `default` will automatically be applied to classes expressions as well. If a `interfaces` configuration is provided, only this configuration will be used for `interfaces` (i.e. nothing will be merged with `default`).
+
+Note: The configuration for `interfaces` only allows a limited set of member types: `field`, `constructor` and `method`.
+
+Note: The configuration for `interfaces` does not apply to type literals (use `typeLiterals` for them).
+
+#### Configuration: `{ "interfaces": ["method", "constructor", "field"] }`
+
+##### Incorrect example
+
+```ts
 interface Foo {
-  // -> field
-  B: string;
+  B: string; // -> field
 
-  // -> constructor
-  new ();
+  new (); // -> constructor
 
-  // -> method
-  A(): void;
+  A(): void; // -> method
 }
 ```
 
-Examples of **correct** code for the `{ "interfaces": [...] }` option:
+##### Correct example
 
 ```ts
-// { "interfaces": ["method", "constructor", "field"] }
-
-// does not apply for classes/class expressions/type literals
-
 interface Foo {
-  // -> method
-  A(): void;
+  A(): void; // -> method
 
-  // -> constructor
-  new ();
+  new (); // -> constructor
 
-  // -> field
-  B: string;
+  B: string; // -> field
 }
 ```
 
-### typeLiterals
+### Custom `typeLiterals` configuration
 
-Disable using `never` or use one of the valid values (see interfaces) to specify an order.
+Note: If this is not set, the `default` will automatically be applied to classes expressions as well. If a `typeLiterals` configuration is provided, only this configuration will be used for `typeLiterals` (i.e. nothing will be merged with `default`).
 
-Examples of **incorrect** code for the `{ "typeLiterals": [...] }` option:
+Note: The configuration for `typeLiterals` only allows a limited set of member types: `field`, `constructor` and `method`.
+
+Note: The configuration for `typeLiterals` does not apply to type literals (use `interfaces` for them).
+
+#### Configuration: `{ "typeLiterals": ["method", "constructor", "field"] }`
+
+##### Incorrect example
 
 ```ts
-// { "typeLiterals": ["method", "constructor", "field"] }
-
-// does not apply for classes/class expressions/interfaces
-
 type Foo = {
-  // -> field
-  B: string;
+  B: string; // -> field
 
-  // -> method
-  A(): void;
+  A(): void; // -> method
+
+  new (); // -> constructor
 };
 ```
 
-Examples of **correct** code for the `{ "typeLiterals": [...] }` option:
+##### Correct example
 
 ```ts
-// { "typeLiterals": ["method", "constructor", "field"] }
-
-// does not apply for classes/class expressions/interfaces
-
 type Foo = {
-  // -> method
-  A(): void;
+  A(): void; // -> method
 
-  // -> constructor
-  new ();
+  new (); // -> constructor
 
-  // -> field
-  B: string;
+  B: string; // -> field
 };
 ```
 

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -13,23 +13,26 @@ type Options = [
   }
 ];
 
-const schemaOptions = ['field', 'method', 'constructor'].reduce<string[]>(
-  (options, type) => {
-    options.push(type);
+const allMemberTypes = ['field', 'method', 'constructor'].reduce<string[]>(
+  (all, type) => {
+    all.push(type);
 
     ['public', 'protected', 'private'].forEach(accessibility => {
-      options.push(`${accessibility}-${type}`);
+      all.push(`${accessibility}-${type}`); // e.g. `public-field`
+
       if (type !== 'constructor') {
+        // There is no `static-constructor` or `instance-constructor
         ['static', 'instance'].forEach(scope => {
-          if (options.indexOf(`${scope}-${type}`) === -1) {
-            options.push(`${scope}-${type}`);
+          if (all.indexOf(`${scope}-${type}`) === -1) {
+            all.push(`${scope}-${type}`);
           }
-          options.push(`${accessibility}-${scope}-${type}`);
+
+          all.push(`${accessibility}-${scope}-${type}`);
         });
       }
     });
 
-    return options;
+    return all;
   },
   [],
 );
@@ -60,7 +63,7 @@ export default util.createRule<Options, MessageIds>({
               {
                 type: 'array',
                 items: {
-                  enum: schemaOptions,
+                  enum: allMemberTypes,
                 },
               },
             ],
@@ -73,7 +76,7 @@ export default util.createRule<Options, MessageIds>({
               {
                 type: 'array',
                 items: {
-                  enum: schemaOptions,
+                  enum: allMemberTypes,
                 },
               },
             ],
@@ -86,7 +89,7 @@ export default util.createRule<Options, MessageIds>({
               {
                 type: 'array',
                 items: {
-                  enum: schemaOptions,
+                  enum: allMemberTypes,
                 },
               },
             ],
@@ -230,12 +233,14 @@ export default util.createRule<Options, MessageIds>({
      * - If there is no order for accessibility-scope-type, then strip out the accessibility.
      * - If there is no order for scope-type, then strip out the scope.
      * - If there is no order for type, then return -1
-     * @param names the valid names to be validated.
+     * @param memberTypes the valid names to be validated.
      * @param order the current order to be validated.
+     *
+     * @return Index of the matching member type in the order configuration.
      */
-    function getRankOrder(names: string[], order: string[]): number {
+    function getRankOrder(memberTypes: string[], order: string[]): number {
       let rank = -1;
-      const stack = names.slice();
+      const stack = memberTypes.slice(); // Get a copy of the member types
 
       while (stack.length > 0 && rank === -1) {
         rank = order.indexOf(stack.shift()!);
@@ -248,7 +253,7 @@ export default util.createRule<Options, MessageIds>({
      * Gets the rank of the node given the order.
      * @param node the node to be evaluated.
      * @param order the current order to be validated.
-     * @param supportsModifiers a flag indicating whether the type supports modifiers or not.
+     * @param supportsModifiers a flag indicating whether the type supports modifiers (scope or accessibility) or not.
      */
     function getRank(
       node: TSESTree.ClassElement | TSESTree.TypeElement,
@@ -267,19 +272,21 @@ export default util.createRule<Options, MessageIds>({
           ? node.accessibility
           : 'public';
 
-      const names = [];
+      const memberTypes = [];
 
       if (supportsModifiers) {
         if (type !== 'constructor') {
-          names.push(`${accessibility}-${scope}-${type}`);
-          names.push(`${scope}-${type}`);
+          // Constructors have no scope
+          memberTypes.push(`${accessibility}-${scope}-${type}`);
+          memberTypes.push(`${scope}-${type}`);
         }
-        names.push(`${accessibility}-${type}`);
+
+        memberTypes.push(`${accessibility}-${type}`);
       }
 
-      names.push(type);
+      memberTypes.push(type);
 
-      return getRankOrder(names, order);
+      return getRankOrder(memberTypes, order);
     }
 
     /**
@@ -318,12 +325,13 @@ export default util.createRule<Options, MessageIds>({
     }
 
     /**
-     * Validates each member rank.
-     * @param members the members to be validated.
-     * @param order the current order to be validated.
-     * @param supportsModifiers a flag indicating whether the type supports modifiers or not.
+     * Validates if all members are correctly sorted.
+     *
+     * @param members Members to be validated.
+     * @param order Current order to be validated.
+     * @param supportsModifiers A flag indicating whether the type supports modifiers (scope or accessibility) or not.
      */
-    function validateMembers(
+    function validateMembersOrder(
       members: (TSESTree.ClassElement | TSESTree.TypeElement)[],
       order: OrderConfig,
       supportsModifiers: boolean,
@@ -331,6 +339,7 @@ export default util.createRule<Options, MessageIds>({
       if (members && order !== 'never') {
         const previousRanks: number[] = [];
 
+        // Find first member which isn't correctly sorted
         members.forEach(member => {
           const rank = getRank(member, order, supportsModifiers);
 
@@ -354,28 +363,28 @@ export default util.createRule<Options, MessageIds>({
 
     return {
       ClassDeclaration(node) {
-        validateMembers(
+        validateMembersOrder(
           node.body.body,
           options.classes || options.default!,
           true,
         );
       },
       ClassExpression(node) {
-        validateMembers(
+        validateMembersOrder(
           node.body.body,
           options.classExpressions || options.default!,
           true,
         );
       },
       TSInterfaceDeclaration(node) {
-        validateMembers(
+        validateMembersOrder(
           node.body.body,
           options.interfaces || options.default!,
           false,
         );
       },
       TSTypeLiteral(node) {
-        validateMembers(
+        validateMembersOrder(
           node.members,
           options.typeLiterals || options.default!,
           false,


### PR DESCRIPTION
Part of the [PR to enforce an alphabetic order for members](https://github.com/typescript-eslint/typescript-eslint/pull/2639) is to rewrite the existing docs to better document the current behavior of `member-ordering`. As this touches almost any line in the rule documentation, I thought it makes sense to open a separate PR for that.

In this PR, I've reworked the entire rule documentation to make it (hopefully) more clear how this rule works. The examples are mostly taken from the current rule documentation - some with little adaptations.
Besides that, I've changed a few names and added some comments in the rule implementation to make it more understandable (basically the points I didn't understand immediately while trying to understand the current implementation to better describe the rule).