### PR TITLE
fix(eslint-plugin): fix incorrect rule name

### DIFF
--- a/packages/eslint-plugin/src/rules/camelcase.ts
+++ b/packages/eslint-plugin/src/rules/camelcase.ts
@@ -6,7 +6,7 @@ type Options = util.InferOptionsTypeFromRule<typeof baseRule>;
 type MessageIds = util.InferMessageIdsTypeFromRule<typeof baseRule>;
 
 export default util.createRule<Options, MessageIds>({
-  name: 'ban-types',
+  name: 'camelcase',
   meta: {
     type: 'suggestion',
     docs: {

--- a/packages/eslint-plugin/src/rules/no-object-literal-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-object-literal-type-assertion.ts
@@ -9,7 +9,7 @@ type Options = [
 type MessageIds = 'unexpectedTypeAssertion';
 
 export default util.createRule<Options, MessageIds>({
-  name: 'no-object-literal-type-assertions',
+  name: 'no-object-literal-type-assertion',
   meta: {
     type: 'problem',
     docs: {


### PR DESCRIPTION
It causes incorrect document address in VS Code