### PR TITLE
Cache ts.program between linted files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,8 @@
     "sourceType": "module",
     "ecmaFeatures": {
       "jsx": false
-    }
+    },
+    "project": "./tsconfig.base.json"
   },
   "overrides": [
     {

--- a/packages/typescript-estree/src/tsconfig-parser.ts
+++ b/packages/typescript-estree/src/tsconfig-parser.ts
@@ -15,28 +15,6 @@ const defaultCompilerOptions: ts.CompilerOptions = {
 };
 
 /**
- * Maps tsconfig paths to their corresponding file contents and resulting watches
- */
-const knownWatchProgramMap = new Map<
-  string,
-  ts.WatchOfConfigFile<ts.SemanticDiagnosticsBuilderProgram>
->();
-
-/**
- * Maps file paths to their set of corresponding watch callbacks
- * There may be more than one per file if a file is shared between projects
- */
-const watchCallbackTrackingMap = new Map<string, ts.FileWatcherCallback>();
-
-/**
- * Holds information about the file currently being linted
- */
-const currentLintOperationState = {
-  code: '',
-  filePath: '',
-};
-
-/**
  * Appropriately report issues found when reading a config file
  * @param diagnostic The diagnostic raised when creating a program
  */
@@ -46,7 +24,11 @@ function diagnosticReporter(diagnostic: ts.Diagnostic): void {
   );
 }
 
-const noopFileWatcher = { close: () => {} };
+function getTsconfigPath(tsconfigPath: string, extra: Extra): string {
+  return path.isAbsolute(tsconfigPath)
+    ? tsconfigPath
+    : path.join(extra.tsconfigRootDir || process.cwd(), tsconfigPath);
+}
 
 /**
  * Calculate project environments using options provided by consumer and paths from config
@@ -56,123 +38,47 @@ const noopFileWatcher = { close: () => {} };
  * @param extra.project Provided tsconfig paths
  * @returns The programs corresponding to the supplied tsconfig paths
  */
-export function calculateProjectParserOptions(
-  code: string,
-  filePath: string,
-  extra: Extra,
-): ts.Program[] {
-  const results = [];
-  const tsconfigRootDir = extra.tsconfigRootDir;
+const cache: Map<string, ts.Program> = new Map();
+export function calculateProjectParserOptions(extra: Extra): ts.Program[] {
+  const results: ts.Program[] = [];
 
-  // preserve reference to code and file being linted
-  currentLintOperationState.code = code;
-  currentLintOperationState.filePath = filePath;
-
-  // Update file version if necessary
-  // TODO: only update when necessary, currently marks as changed on every lint
-  const watchCallback = watchCallbackTrackingMap.get(filePath);
-  if (typeof watchCallback !== 'undefined') {
-    watchCallback(filePath, ts.FileWatcherEventKind.Changed);
-  }
-
-  for (let tsconfigPath of extra.projects) {
-    // if absolute paths aren't provided, make relative to tsconfigRootDir
-    if (!path.isAbsolute(tsconfigPath)) {
-      tsconfigPath = path.join(tsconfigRootDir, tsconfigPath);
-    }
-
-    const existingWatch = knownWatchProgramMap.get(tsconfigPath);
-
-    if (typeof existingWatch !== 'undefined') {
-      // get new program (updated if necessary)
-      results.push(existingWatch.getProgram().getProgram());
-      continue;
-    }
-
-    // create compiler host
-    const watchCompilerHost = ts.createWatchCompilerHost(
-      tsconfigPath,
-      /*optionsToExtend*/ { allowNonTsExtensions: true } as ts.CompilerOptions,
-      ts.sys,
-      ts.createSemanticDiagnosticsBuilderProgram,
-      diagnosticReporter,
-      /*reportWatchStatus*/ () => {},
-    );
-
-    // ensure readFile reads the code being linted instead of the copy on disk
-    const oldReadFile = watchCompilerHost.readFile;
-    watchCompilerHost.readFile = (filePath, encoding) =>
-      path.normalize(filePath) ===
-      path.normalize(currentLintOperationState.filePath)
-        ? currentLintOperationState.code
-        : oldReadFile(filePath, encoding);
-
-    // ensure process reports error on failure instead of exiting process immediately
-    watchCompilerHost.onUnRecoverableConfigFileDiagnostic = diagnosticReporter;
-
-    // ensure process doesn't emit programs
-    watchCompilerHost.afterProgramCreate = program => {
-      // report error if there are any errors in the config file
-      const configFileDiagnostics = program
-        .getConfigFileParsingDiagnostics()
-        .filter(
-          diag =>
-            diag.category === ts.DiagnosticCategory.Error &&
-            diag.code !== 18003,
-        );
-      if (configFileDiagnostics.length > 0) {
-        diagnosticReporter(configFileDiagnostics[0]);
+  extra.projects
+    .map(project => getTsconfigPath(project, extra))
+    .forEach(tsconfigPath => {
+      if (cache.has(tsconfigPath)) {
+        results.push(cache.get(tsconfigPath) as ts.Program);
+        return;
       }
-    };
 
-    // register callbacks to trigger program updates without using fileWatchers
-    watchCompilerHost.watchFile = (fileName, callback) => {
-      const normalizedFileName = path.normalize(fileName);
-      watchCallbackTrackingMap.set(normalizedFileName, callback);
-      return {
-        close: () => {
-          watchCallbackTrackingMap.delete(normalizedFileName);
-        },
+      const config = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+      if (config.error !== undefined) {
+        diagnosticReporter(config.error);
+      }
+      const parseConfigHost: ts.ParseConfigHost = {
+        fileExists: ts.sys.fileExists,
+        readDirectory: ts.sys.readDirectory,
+        readFile: ts.sys.readFile,
+        useCaseSensitiveFileNames: true,
       };
-    };
+      const parsed = ts.parseJsonConfigFileContent(
+        config.config,
+        parseConfigHost,
+        extra.tsconfigRootDir || path.dirname(tsconfigPath),
+        { noEmit: true },
+      );
+      if (parsed.errors !== undefined && parsed.errors.length > 0) {
+        diagnosticReporter(parsed.errors[0]);
+      }
+      const host = ts.createCompilerHost(
+        { ...defaultCompilerOptions, ...parsed.options },
+        true,
+      );
+      const program = ts.createProgram(parsed.fileNames, parsed.options, host);
 
-    // ensure fileWatchers aren't created for directories
-    watchCompilerHost.watchDirectory = () => noopFileWatcher;
+      cache.set(tsconfigPath, program);
 
-    // allow files with custom extensions to be included in program (uses internal ts api)
-    const oldOnDirectoryStructureHostCreate = (watchCompilerHost as any)
-      .onCachedDirectoryStructureHostCreate;
-    (watchCompilerHost as any).onCachedDirectoryStructureHostCreate = (
-      host: any,
-    ) => {
-      const oldReadDirectory = host.readDirectory;
-      host.readDirectory = (
-        path: string,
-        extensions?: ReadonlyArray<string>,
-        exclude?: ReadonlyArray<string>,
-        include?: ReadonlyArray<string>,
-        depth?: number,
-      ) =>
-        oldReadDirectory(
-          path,
-          !extensions
-            ? undefined
-            : extensions.concat(extra.extraFileExtensions),
-          exclude,
-          include,
-          depth,
-        );
-      oldOnDirectoryStructureHostCreate(host);
-    };
-
-    // create program
-    const programWatch = ts.createWatchProgram(watchCompilerHost);
-    const program = programWatch.getProgram().getProgram();
-
-    // cache watch program and return current program
-    knownWatchProgramMap.set(tsconfigPath, programWatch);
-    results.push(program);
-  }
+      results.push(program);
+    });
 
   return results;
 }
@@ -190,12 +96,7 @@ export function createProgram(code: string, filePath: string, extra: Extra) {
     return undefined;
   }
 
-  let tsconfigPath = extra.projects[0];
-
-  // if absolute paths aren't provided, make relative to tsconfigRootDir
-  if (!path.isAbsolute(tsconfigPath)) {
-    tsconfigPath = path.join(extra.tsconfigRootDir, tsconfigPath);
-  }
+  const tsconfigPath = getTsconfigPath(extra.projects[0], extra);
 
   const commandLine = ts.getParsedCommandLineOfConfigFile(
     tsconfigPath,

--- a/packages/typescript-estree/tests/lib/semanticInfo.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo.ts
@@ -48,6 +48,21 @@ describe('semanticInfo', () => {
     );
   });
 
+  it(`should cache the created ts.program`, () => {
+    const filename = testFiles[0];
+    const code = readFileSync(filename, 'utf8');
+    const options = createOptions(filename);
+    const optionsProjectString = {
+      ...options,
+      project: './tsconfig.json',
+    };
+    expect(
+      parseAndGenerateServices(code, optionsProjectString).services.program,
+    ).toBe(
+      parseAndGenerateServices(code, optionsProjectString).services.program,
+    );
+  });
+
   it(`should handle "project": "./tsconfig.json" and "project": ["./tsconfig.json"] the same`, () => {
     const filename = testFiles[0];
     const code = readFileSync(filename, 'utf8');
@@ -62,6 +77,38 @@ describe('semanticInfo', () => {
     };
     expect(parseAndGenerateServices(code, optionsProjectString)).toEqual(
       parseAndGenerateServices(code, optionsProjectArray),
+    );
+  });
+
+  it(`should resolve absolute and relative tsconfig paths the same`, () => {
+    const filename = testFiles[0];
+    const code = readFileSync(filename, 'utf8');
+    const options = createOptions(filename);
+    const optionsAbsolutePath = {
+      ...options,
+      project: `${__dirname}/../fixtures/semanticInfo/tsconfig.json`,
+    };
+    const optionsRelativePath = {
+      ...options,
+      project: `./tsconfig.json`,
+    };
+    const absolutePathResult = parseAndGenerateServices(
+      code,
+      optionsAbsolutePath,
+    );
+    const relativePathResult = parseAndGenerateServices(
+      code,
+      optionsRelativePath,
+    );
+    if (absolutePathResult.services.program === undefined) {
+      throw new Error('Unable to create ts.program for absolute tsconfig');
+    } else if (relativePathResult.services.program === undefined) {
+      throw new Error('Unable to create ts.program for relative tsconfig');
+    }
+    expect(
+      absolutePathResult.services.program.getResolvedProjectReferences(),
+    ).toEqual(
+      relativePathResult.services.program.getResolvedProjectReferences(),
     );
   });
 
@@ -190,7 +237,7 @@ describe('semanticInfo', () => {
     badConfig.project = './tsconfigs.json';
     expect(() =>
       parseCodeAndGenerateServices(readFileSync(fileName, 'utf8'), badConfig),
-    ).toThrow(/File .+tsconfigs\.json' not found/);
+    ).toThrow(/The specified path does not exist: .+tsconfigs\.json'/);
   });
 
   it('fail to read project file', () => {
@@ -199,7 +246,7 @@ describe('semanticInfo', () => {
     badConfig.project = '.';
     expect(() =>
       parseCodeAndGenerateServices(readFileSync(fileName, 'utf8'), badConfig),
-    ).toThrow(/File .+semanticInfo' not found/);
+    ).toThrow(/The specified path does not exist: .+semanticInfo'/);
   });
 
   it('malformed project file', () => {


### PR DESCRIPTION
## Background
This improves the performance issues outlined in #243.

## Approach
Rather than creating a watch program and having it parse each file as we lint it, instead we create a `ts.program` for each project and cache them.

When attempting to parse a file, we go through each created program and attempt to parse the given filename with it.

## Results
These are on my machine (2018 MBP w/ i7, 16GB RAM)
This repo w/o project
master: 3.40s
new: 3.24s

This repo w/ project
master: 13.34s
new: 5.68s

Single file in this repo w/ project
master: 10.83s
new: 4.92s

The repo originally mentioned in #243 w/ project
master: 50.72s
new: 9.94s

## Limitations
If a file that's being linted isn't included in the given tsconfig, performance remains poor, as we fall back to the current behaviour of parsing that file in isolation; https://github.com/eslint/eslint/issues/11222 might be able to help with this once it's shipped. This seems very much like an edge case though.