### PR TITLE
fix(typescript-estree): only call watch callback on new files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,8 @@
     "sourceType": "module",
     "ecmaFeatures": {
       "jsx": false
-    }
+    },
+    "project": "./tsconfig.base.json"
   },
   "overrides": [
     {

--- a/packages/typescript-estree/src/tsconfig-parser.ts
+++ b/packages/typescript-estree/src/tsconfig-parser.ts
@@ -28,6 +28,8 @@ const knownWatchProgramMap = new Map<
  */
 const watchCallbackTrackingMap = new Map<string, ts.FileWatcherCallback>();
 
+const parsedFilesSeen = new Set<string>();
+
 /**
  * Holds information about the file currently being linted
  */
@@ -71,7 +73,7 @@ export function calculateProjectParserOptions(
   // Update file version if necessary
   // TODO: only update when necessary, currently marks as changed on every lint
   const watchCallback = watchCallbackTrackingMap.get(filePath);
-  if (typeof watchCallback !== 'undefined') {
+  if (parsedFilesSeen.has(filePath) && typeof watchCallback !== 'undefined') {
     watchCallback(filePath, ts.FileWatcherEventKind.Changed);
   }
 
@@ -174,6 +176,7 @@ export function calculateProjectParserOptions(
     results.push(program);
   }
 
+  parsedFilesSeen.add(filePath);
   return results;
 }
 


### PR DESCRIPTION
Addressing #243 

Currently we are creating a new `ts.Program` for every subsequent file linted after the first in a given run with the `project` object given.

Here we cut down the number of times this happens by ensuring we only tell the TS API that a file has changed when we lint a file for a second time (thereby implying a `--fix` mode or "watch" mode).