### PR TITLE
fix(eslint-plugin): member-naming

### DIFF
--- a/packages/eslint-plugin/docs/rules/member-naming.md
+++ b/packages/eslint-plugin/docs/rules/member-naming.md
@@ -4,7 +4,9 @@ It can be helpful to enforce naming conventions for `private` (and sometimes `pr
 
 ## Rule Details
 
-This rule allows you to enforce conventions for class property names by their visibility. By default, it enforces nothing.
+This rule allows you to enforce conventions for class property and method names by their visibility. By default, it enforces nothing.
+
+> Note: constructors are explicitly ignored regardless of the the regular expression options provided
 
 ## Options
 

--- a/packages/eslint-plugin/src/rules/member-naming.ts
+++ b/packages/eslint-plugin/src/rules/member-naming.ts
@@ -75,6 +75,9 @@ export default util.createRule<Options, MessageIds>({
       const accessibility: Modifiers = node.accessibility || 'public';
       const convention = conventions[accessibility];
 
+      const method = node as TSESTree.MethodDefinition;
+      if (method.kind === 'constructor') return;
+
       if (!convention || convention.test(name)) return;
 
       context.report({

--- a/packages/eslint-plugin/tests/rules/member-naming.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-naming.test.ts
@@ -12,6 +12,14 @@ ruleTester.run('member-naming', rule, {
       options: [{ public: '^_' }],
     },
     {
+      code: `class Class { private constructor(); _fooBar() {} }`,
+      options: [{ private: '^_' }],
+    },
+    {
+      code: `class Class { constructor() {}; _fooBar() {} }`,
+      options: [{ public: '^_' }],
+    },
+    {
       code: `class Class { public _fooBar() {} }`,
       options: [{ public: '^_' }],
     },


### PR DESCRIPTION
updating rule prevent applying naming conventtions to constructor methods, fixes #359