### PR TITLE
fix(typescript-estree): add ExportDefaultDeclaration to union DeclarationStatement

### DIFF
--- a/packages/typescript-estree/src/ts-estree/ts-estree.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-estree.ts
@@ -254,6 +254,7 @@ export type ClassElement =
 export type DeclarationStatement =
   | ClassDeclaration
   | ClassExpression
+  | ExportDefaultDeclaration
   | ExportAllDeclaration
   | ExportNamedDeclaration
   | FunctionDeclaration


### PR DESCRIPTION
I have this example:

https://astexplorer.net/#/gist/2c50aae34bea149fc9863a2dd0e7a6f5/69d563ee31f1bc01d3cf71c005bb92dd24c3910e

Notice how
```
export default class Foo {}
```

Is transformed to:

```
{
      "type": "ExportDefaultDeclaration",
      "declaration": {
        "type": "ClassDeclaration",
        "id": {
          "type": "Identifier",
          "name": "Foo",
          "range": [
            580,
            583
          ],
          "loc": {
            "start": {
              "line": 30,
              "column": 21
            },
            "end": {
              "line": 30,
              "column": 24
            }
          }
        },
        "body": {
          "type": "ClassBody",
          "body": [],
          "range": [
            584,
            586
          ],
          "loc": {
            "start": {
              "line": 30,
              "column": 25
            },
            "end": {
              "line": 30,
              "column": 27
            }
          }
        },
        "superClass": null,
        "range": [
          574,
          586
        ],
        "loc": {
          "start": {
            "line": 30,
            "column": 15
          },
          "end": {
            "line": 30,
            "column": 27
          }
        }
      },
      "range": [
        559,
        586
      ],
      "loc": {
        "start": {
          "line": 30,
          "column": 0
        },
        "end": {
          "line": 30,
          "column": 27
        }
      }
    }
```

according to Program.body which is a Statement[]

and `Statement` containing `DeclarationStatement`

I conclude that `DeclarationStatement` is missing `ExportDefaultDeclaration`