### PR TITLE
fix(eslint-plugin): no-type-alias: fix typeof alias erroring

### DIFF
--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -108,6 +108,7 @@ export default util.createRule<Options, MessageIds>({
       AST_NODE_TYPES.TSArrayType,
       AST_NODE_TYPES.TSTypeReference,
       AST_NODE_TYPES.TSLiteralType,
+      AST_NODE_TYPES.TSTypeQuery,
     ];
 
     type CompositionType = TSESTree.TSUnionType | TSESTree.TSIntersectionType;

--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -364,6 +364,14 @@ type Foo<T> = {
         },
       ],
     },
+    {
+      code: 'type Foo = typeof bar;',
+      options: [{ allowAliases: 'always' }],
+    },
+    {
+      code: 'type Foo = typeof bar | typeof baz;',
+      options: [{ allowAliases: 'in-unions' }],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
I was running into an issue with the rule crashing on code like

```
type Foo =
  | typeof Bar
  | typeof Baz;
```
I thought it was because of the `|` being first, but when I added that test it passed. Seems like it's actually because the `TSTypeQuery` node type is never handled. I'm not sure if this is the right fix, though.

Also kind of relates to #270. Potential crash isn't caught in compile because of non-null assertion on line 216 in rules/no-type-alias.ts, but that seems like a bigger change.