### PR TITLE
fix(eslint-plugin): Fix `allowExpressions` false positives in explicit-function-return-type and incorrect documentation

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -62,9 +62,11 @@ class Test {
 The rule accepts an options object with the following properties:
 
 - `allowExpressions` if true, only functions which are part of a declaration will be checked
+- `allowTypedFunctionExpressions` if true, type annotations are also allowed on the variable
+  of a function expression rather than on the function directly.
 
-By default, `allowExpressions: false` is used, meaning all declarations and
-expressions _must_ have a return type.
+By default, `allowExpressions: false` and `allowTypedFunctionExpressions: false` are used,
+meaning all declarations and expressions _must_ have a return type.
 
 ### allowExpressions
 

--- a/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
+++ b/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
@@ -39,7 +39,7 @@ export default util.createRule<Options, MessageIds>({
   },
   defaultOptions: [
     {
-      allowExpressions: true,
+      allowExpressions: false,
       allowTypedFunctionExpressions: false,
     },
   ],
@@ -89,6 +89,16 @@ export default util.createRule<Options, MessageIds>({
         | TSESTree.FunctionExpression,
     ): void {
       if (
+        options.allowExpressions &&
+        node.type !== AST_NODE_TYPES.FunctionDeclaration &&
+        node.parent &&
+        node.parent.type !== AST_NODE_TYPES.VariableDeclarator &&
+        node.parent.type !== AST_NODE_TYPES.MethodDefinition
+      ) {
+        return;
+      }
+
+      if (
         !node.returnType &&
         node.parent &&
         !isConstructor(node.parent) &&
@@ -112,16 +122,6 @@ export default util.createRule<Options, MessageIds>({
         | TSESTree.FunctionDeclaration
         | TSESTree.FunctionExpression,
     ): void {
-      if (
-        options.allowExpressions &&
-        node.type !== AST_NODE_TYPES.ArrowFunctionExpression &&
-        node.parent &&
-        node.parent.type !== AST_NODE_TYPES.VariableDeclarator &&
-        node.parent.type !== AST_NODE_TYPES.MethodDefinition
-      ) {
-        return;
-      }
-
       if (
         options.allowTypedFunctionExpressions &&
         node.parent &&

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -54,6 +54,7 @@ function test() {
             `,
     },
     {
+      filename: 'test.ts',
       code: `fn(() => {});`,
       options: [
         {
@@ -62,6 +63,7 @@ function test() {
       ],
     },
     {
+      filename: 'test.ts',
       code: `fn(function() {});`,
       options: [
         {
@@ -70,6 +72,7 @@ function test() {
       ],
     },
     {
+      filename: 'test.ts',
       code: `[function() {}, () => {}]`,
       options: [
         {
@@ -78,6 +81,7 @@ function test() {
       ],
     },
     {
+      filename: 'test.ts',
       code: `(function() {});`,
       options: [
         {
@@ -86,6 +90,7 @@ function test() {
       ],
     },
     {
+      filename: 'test.ts',
       code: `(() => {})();`,
       options: [
         {
@@ -190,6 +195,20 @@ class Test {
           messageId: 'missingReturnType',
           line: 11,
           column: 11,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `function test() {
+        return;
+      }`,
+      options: [{ allowExpressions: true }],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 1,
+          column: 1,
         },
       ],
     },


### PR DESCRIPTION
Fixes #387 

Also add documentation for the `allowTypedFunctionExpressions` which I forgot in my previous PR on this rule.