### PR TITLE
Update version range in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The `canary` (latest master) version is:
 
 We will always endeavor to support the latest stable version of TypeScript. Sometimes, but not always, changes in TypeScript will not require breaking changes in this project, and so we are able to support more than one version of TypeScript.
 
-**The version range of TypeScript currently supported by this parser is `>=3.2.1 <3.4.0`.**
+**The version range of TypeScript currently supported by this parser is `>=3.2.1 <3.5.0`.**
 
 This is reflected in the `devDependency` requirement within the package.json file, and it is what the tests will be run against. We have an open `peerDependency` requirement in order to allow for experimentation on newer/beta versions of TypeScript.
 


### PR DESCRIPTION
In #399 Typescript 3.4 was supported, but a reference to the compatible
versions the `README.md` was missed in the update.

This commit updates that referance to match the versions in
`package.json`.