### PR TITLE
fix(eslint-plugin): fix an indentation following generic type annotation (#119)

### DIFF
--- a/packages/eslint-plugin/src/rules/indent.ts
+++ b/packages/eslint-plugin/src/rules/indent.ts
@@ -73,6 +73,7 @@ const KNOWN_NODES = new Set([
   AST_NODE_TYPES.TSTypeLiteral,
   AST_NODE_TYPES.TSTypeOperator,
   AST_NODE_TYPES.TSTypeParameter,
+  AST_NODE_TYPES.TSTypeParameterInstantiation,
   AST_NODE_TYPES.TSTypeParameterDeclaration,
   AST_NODE_TYPES.TSTypeReference,
   AST_NODE_TYPES.TSUnionType,

--- a/packages/eslint-plugin/tests/rules/indent.test.ts
+++ b/packages/eslint-plugin/tests/rules/indent.test.ts
@@ -742,6 +742,17 @@ const foo : Foo = {
             `,
       options: [4, { VariableDeclarator: { const: 3 } }],
     },
+    {
+      code: `
+const div: JQuery<HTMLElement> = $('<div>')
+        .addClass('some-class')
+        .appendTo($('body')),
+      button: JQuery<HTMLElement> = $('<button>')
+        .text('Cancel')
+        .appendTo(div);
+      `,
+      options: [2, { VariableDeclarator: { const: 3 } }],
+    },
   ],
   invalid: [
     ...individualNodeTests.invalid,


### PR DESCRIPTION
I got lucky finding this fix while reading through the AST. I would appreciate some explanations from someone who knows better :)