### PR TITLE
chore: simplify git hooks

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,8 +1,7 @@
 {
   "hooks": {
-    "pre-commit": [
-        "yarn test && lint-staged"
-    ],
+    "pre-commit": "yarn pre-commit",
+    "pre-push": "yarn pre-push",
     "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
   }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
         displayName: 'Typecheck all packages'
 
       - script: |
-          yarn check-format
+          yarn format-check
         displayName: 'Check code formatting'
 
       - script: |

--- a/package.json
+++ b/package.json
@@ -17,19 +17,21 @@
     "url": "https://github.com/typescript-eslint/typescript-eslint/issues"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap && yarn build && lerna link",
-    "test": "lerna run test --parallel",
     "build": "lerna run build",
     "clean": "lerna clean && lerna run clean",
-    "typecheck": "lerna run typecheck",
-    "lint": "eslint . --ext .js,.ts",
-    "lint-fix": "eslint . --ext .js,.ts --fix",
     "cz": "git-cz",
-    "check-format": "prettier --list-different \"./**/*.{ts,js,json,md}\"",
+    "generate-contributors": "yarn ts-node ./tools/generate-contributors.ts && yarn all-contributors generate",
     "format": "prettier --write \"./**/*.{ts,js,json,md}\"",
+    "format-check": "prettier --list-different \"./**/*.{ts,js,json,md}\"",
     "integration-tests": "docker-compose -f tests/integration/docker-compose.yml up",
     "kill-integration-test-containers": "docker-compose -f tests/integration/docker-compose.yml down -v --rmi local",
-    "generate-contributors": "yarn ts-node ./tools/generate-contributors.ts && yarn all-contributors generate"
+    "lint": "eslint . --ext .js,.ts",
+    "lint-fix": "eslint . --ext .js,.ts --fix",
+    "pre-commit": "yarn lint-staged",
+    "pre-push": "yarn lint && yarn typecheck && yarn format-check",
+    "postinstall": "lerna bootstrap && yarn build && lerna link",
+    "test": "lerna run test --parallel",
+    "typecheck": "lerna run typecheck"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Closes #259 

We have too many tests to run at commit time now.
I would also say that there are too many to run at push time, as well.
Our CI will run all of the tests (incl integration tests), so there's no need to force contributors to wait through a full test cycle every commit/push.

- change pre-commit hook to only run prettier.
    - commit hooks are used regularly, so we want it to be as lightweight as possible.
- add pre-push hook which runs lint + typecheck + format.
    - these are all much heavier (total i find takes ~30-40s), but I think it's good to try and block pushes because of these - some of the most common errors I see are lint problems or unformatted files.

---

My question (for @JamesHenry, who I think added it?), is do we need commitizen? It's just admins that can push to master, otherwise all branch commits are hidden behind a squashed PR message (which is enforced via one of the PR status checks)  - so enforcing a commit message style on the client seems unnecessary?