### PR TITLE
fix(eslint-plugin): prevent preferring includes inside includes

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-includes.ts
+++ b/packages/eslint-plugin/src/rules/prefer-includes.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/typescript-estree';
+import { TSESTree, AST_NODE_TYPES } from '@typescript-eslint/typescript-estree';
 import { getStaticValue } from 'eslint-utils';
 import { AST as RegExpAST, parseRegExpLiteral } from 'regexpp';
 import ts from 'typescript';
@@ -153,6 +153,21 @@ export default createRule({
           ) {
             return;
           }
+        }
+
+        // Check if `indexOf` is used as part of `includes` method declaration
+        let parent = node.parent;
+        while (parent) {
+          if (
+            (parent.type === AST_NODE_TYPES.MethodDefinition &&
+              parent.key.type === 'Identifier' &&
+              parent.key.name === 'includes') ||
+            // to handle a case where a class is declared inside `includes` method
+            parent.type === AST_NODE_TYPES.ClassDeclaration
+          ) {
+            return;
+          }
+          parent = parent.parent;
         }
 
         // Report it.

--- a/packages/eslint-plugin/tests/rules/prefer-includes.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-includes.test.ts
@@ -89,6 +89,31 @@ ruleTester.run('prefer-includes', rule, {
         something.test(a)
       }
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/471
+    `
+      class MyList<T> {
+        indexOf(value: T): number {
+          return -1;
+        }
+
+        includes(value: T): boolean {
+          return this.indexOf(value) !== -1
+        }
+      }
+    `,
+    `
+    class Wrapper {
+      includes(value: T): boolean {
+        class MyList<T> {
+          indexOf(value: T): number {
+            return -1;
+          }
+        }
+
+        return true;
+      }
+    }
+    `,
   ],
   invalid: [
     // positive


### PR DESCRIPTION
Fixes #471 