### PR TITLE
fix(eslint-plugin): support switch statement [unbound-method]

### DIFF
--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -97,6 +97,7 @@ function isSafeUse(node: TSESTree.Node): boolean {
     case AST_NODE_TYPES.IfStatement:
     case AST_NODE_TYPES.ForStatement:
     case AST_NODE_TYPES.MemberExpression:
+    case AST_NODE_TYPES.SwitchStatement:
     case AST_NODE_TYPES.UpdateExpression:
     case AST_NODE_TYPES.WhileStatement:
       return true;

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -98,6 +98,20 @@ instane.boundStatic && 0;
 ContainsMethods.boundStatic ? 1 : 0;
 ContainsMethods.unboundStatic ? 1 : 0;
 `,
+    `interface RecordA {
+  readonly type: "A"
+  readonly a: {}
+}
+interface RecordB {
+  readonly type: "B"
+  readonly b: {}
+}
+type AnyRecord = RecordA | RecordB
+
+function test(obj: AnyRecord) {
+  switch (obj.type) {
+  }
+}`,
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #451 

added given example as positive test and switch-statement to `isSafeUse`.