### PR TITLE
feat(ts-estree): add preserveNodeMaps option

### DIFF
--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -66,7 +66,19 @@ Parses the given string of code with the options provided and returns an ESTree-
    * When value is `false`, no logging will occur.
    * When value is not provided, `console.log()` will be used.
    */
-  loggerFn: undefined
+  loggerFn: undefined,
+
+  /**
+   * Allows the user to control whether or not two-way AST node maps are preserved
+   * during the AST conversion process.
+   *
+   * By default: the AST node maps are NOT preserved, unless `project` has been specified,
+   * in which case the maps are made available on the returned `parserServices`.
+   *
+   * NOTE: If `preserveNodeMaps` is explicitly set by the user, it will be respected,
+   * regardless of whether or not `project` is in use.
+   */
+  preserveNodeMaps: undefined
 }
 ```
 

--- a/packages/typescript-estree/src/ast-converter.ts
+++ b/packages/typescript-estree/src/ast-converter.ts
@@ -7,7 +7,7 @@ import { Extra } from './parser-options';
 export default function astConverter(
   ast: ts.SourceFile,
   extra: Extra,
-  shouldProvideParserServices: boolean,
+  shouldPreserveNodeMaps: boolean,
 ) {
   /**
    * The TypeScript compiler produced fundamental parse errors when parsing the
@@ -23,7 +23,7 @@ export default function astConverter(
   const instance = new Converter(ast, {
     errorOnUnknownASTType: extra.errorOnUnknownASTType || false,
     useJSXTextNode: extra.useJSXTextNode || false,
-    shouldProvideParserServices,
+    shouldPreserveNodeMaps,
   });
 
   const estree = instance.convertProgram();
@@ -42,9 +42,7 @@ export default function astConverter(
     estree.comments = convertComments(ast, extra.code);
   }
 
-  const astMaps = shouldProvideParserServices
-    ? instance.getASTMaps()
-    : undefined;
+  const astMaps = shouldPreserveNodeMaps ? instance.getASTMaps() : undefined;
 
   return { estree, astMaps };
 }

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -26,7 +26,7 @@ const SyntaxKind = ts.SyntaxKind;
 interface ConverterOptions {
   errorOnUnknownASTType: boolean;
   useJSXTextNode: boolean;
-  shouldProvideParserServices: boolean;
+  shouldPreserveNodeMaps: boolean;
 }
 
 /**
@@ -168,7 +168,7 @@ export class Converter {
     node: ts.Node,
     result: TSESTree.BaseNode | null,
   ) {
-    if (result && this.options.shouldProvideParserServices) {
+    if (result && this.options.shouldPreserveNodeMaps) {
       if (!this.tsNodeToESTreeNodeMap.has(node)) {
         this.tsNodeToESTreeNodeMap.set(node, result);
       }
@@ -217,7 +217,7 @@ export class Converter {
       result.loc = getLocFor(result.range[0], result.range[1], this.ast);
     }
 
-    if (result && this.options.shouldProvideParserServices) {
+    if (result && this.options.shouldPreserveNodeMaps) {
       this.esTreeNodeToTSNodeMap.set(result, node);
     }
     return result as T;

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -18,6 +18,7 @@ export interface Extra {
   projects: string[];
   tsconfigRootDir: string;
   extraFileExtensions: string[];
+  preserveNodeMaps?: boolean;
 }
 
 export interface ParserOptions {
@@ -34,6 +35,7 @@ export interface ParserOptions {
   filePath?: string;
   tsconfigRootDir?: string;
   extraFileExtensions?: string[];
+  preserveNodeMaps?: boolean;
 }
 
 export interface ParserWeakMap<TKey, TValueBase> {

--- a/packages/typescript-estree/tests/lib/convert.ts
+++ b/packages/typescript-estree/tests/lib/convert.ts
@@ -18,7 +18,7 @@ describe('convert', () => {
     const instance = new Converter(ast, {
       errorOnUnknownASTType: false,
       useJSXTextNode: false,
-      shouldProvideParserServices: false,
+      shouldPreserveNodeMaps: false,
     });
     expect(instance.convertProgram()).toMatchSnapshot();
   });
@@ -29,7 +29,7 @@ describe('convert', () => {
     const instance = new Converter(ast, {
       errorOnUnknownASTType: false,
       useJSXTextNode: false,
-      shouldProvideParserServices: false,
+      shouldPreserveNodeMaps: false,
     });
     expect((instance as any).deeplyCopy(ast.statements[0])).toMatchSnapshot();
   });
@@ -40,7 +40,7 @@ describe('convert', () => {
     const instance = new Converter(ast, {
       errorOnUnknownASTType: false,
       useJSXTextNode: false,
-      shouldProvideParserServices: false,
+      shouldPreserveNodeMaps: false,
     });
     expect((instance as any).deeplyCopy(ast.statements[0])).toMatchSnapshot();
   });
@@ -51,7 +51,7 @@ describe('convert', () => {
     const instance = new Converter(ast, {
       errorOnUnknownASTType: false,
       useJSXTextNode: false,
-      shouldProvideParserServices: false,
+      shouldPreserveNodeMaps: false,
     });
     expect(
       (instance as any).deeplyCopy((ast.statements[0] as any).expression),
@@ -64,7 +64,7 @@ describe('convert', () => {
     const instance = new Converter(ast, {
       errorOnUnknownASTType: false,
       useJSXTextNode: false,
-      shouldProvideParserServices: false,
+      shouldPreserveNodeMaps: false,
     });
     expect((instance as any).deeplyCopy(ast)).toMatchSnapshot();
   });
@@ -75,7 +75,7 @@ describe('convert', () => {
     const instance = new Converter(ast, {
       errorOnUnknownASTType: true,
       useJSXTextNode: false,
-      shouldProvideParserServices: false,
+      shouldPreserveNodeMaps: false,
     });
     expect(() => instance.convertProgram()).toThrow(
       'Unknown AST_NODE_TYPE: "TSJSDocNullableType"',
@@ -93,7 +93,7 @@ describe('convert', () => {
     const instance = new Converter(ast, {
       errorOnUnknownASTType: false,
       useJSXTextNode: false,
-      shouldProvideParserServices: true,
+      shouldPreserveNodeMaps: true,
     });
     instance.convertProgram();
     const maps = instance.getASTMaps();
@@ -127,7 +127,7 @@ describe('convert', () => {
     const instance = new Converter(ast, {
       errorOnUnknownASTType: false,
       useJSXTextNode: false,
-      shouldProvideParserServices: true,
+      shouldPreserveNodeMaps: true,
     });
     instance.convertProgram();
     const maps = instance.getASTMaps();
@@ -160,7 +160,7 @@ describe('convert', () => {
     const instance = new Converter(ast, {
       errorOnUnknownASTType: false,
       useJSXTextNode: false,
-      shouldProvideParserServices: true,
+      shouldPreserveNodeMaps: true,
     });
     const program = instance.convertProgram();
     const maps = instance.getASTMaps();

--- a/packages/typescript-estree/tests/lib/parse.ts
+++ b/packages/typescript-estree/tests/lib/parse.ts
@@ -88,6 +88,7 @@ describe('parse()', () => {
           tokens: expect.any(Array),
           tsconfigRootDir: expect.any(String),
           useJSXTextNode: false,
+          preserveNodeMaps: false,
         },
         false,
       );
@@ -124,6 +125,106 @@ describe('parse()', () => {
       expect(() => {
         parser.parseAndGenerateServices(code, options);
       }).toThrow('Decorators are not valid here.');
+    });
+  });
+
+  describe('preserveNodeMaps', () => {
+    const code = 'var a = true';
+    const baseConfig: ParserOptions = {
+      comment: true,
+      tokens: true,
+      range: true,
+      loc: true,
+    };
+
+    it('should not impact the use of parse()', () => {
+      const resultWithNoOptionSet = parser.parse(code, baseConfig);
+      const resultWithOptionSetToTrue = parser.parse(code, {
+        ...baseConfig,
+        preserveNodeMaps: true,
+      });
+      const resultWithOptionSetToFalse = parser.parse(code, {
+        ...baseConfig,
+        preserveNodeMaps: false,
+      });
+      const resultWithOptionSetExplicitlyToUndefined = parser.parse(code, {
+        ...baseConfig,
+        preserveNodeMaps: undefined,
+      });
+
+      expect(resultWithNoOptionSet).toMatchObject(resultWithOptionSetToTrue);
+      expect(resultWithNoOptionSet).toMatchObject(resultWithOptionSetToFalse);
+      expect(resultWithNoOptionSet).toMatchObject(
+        resultWithOptionSetExplicitlyToUndefined,
+      );
+    });
+
+    it('should not preserve node maps by default for parseAndGenerateServices(), unless `project` is set', () => {
+      const noOptionSet = parser.parseAndGenerateServices(code, baseConfig);
+
+      expect(noOptionSet.services.esTreeNodeToTSNodeMap).toBeUndefined();
+      expect(noOptionSet.services.tsNodeToESTreeNodeMap).toBeUndefined();
+
+      const withProjectNoOptionSet = parser.parseAndGenerateServices(code, {
+        ...baseConfig,
+        project: './tsconfig.json',
+      });
+
+      expect(withProjectNoOptionSet.services.esTreeNodeToTSNodeMap).toEqual(
+        expect.any(WeakMap),
+      );
+      expect(withProjectNoOptionSet.services.tsNodeToESTreeNodeMap).toEqual(
+        expect.any(WeakMap),
+      );
+    });
+
+    it('should preserve node maps for parseAndGenerateServices() when option is `true`, regardless of `project` config', () => {
+      const optionSetToTrue = parser.parseAndGenerateServices(code, {
+        ...baseConfig,
+        preserveNodeMaps: true,
+      });
+
+      expect(optionSetToTrue.services.esTreeNodeToTSNodeMap).toEqual(
+        expect.any(WeakMap),
+      );
+      expect(optionSetToTrue.services.tsNodeToESTreeNodeMap).toEqual(
+        expect.any(WeakMap),
+      );
+
+      const withProjectOptionSetToTrue = parser.parseAndGenerateServices(code, {
+        ...baseConfig,
+        preserveNodeMaps: true,
+        project: './tsconfig.json',
+      });
+
+      expect(withProjectOptionSetToTrue.services.esTreeNodeToTSNodeMap).toEqual(
+        expect.any(WeakMap),
+      );
+      expect(withProjectOptionSetToTrue.services.tsNodeToESTreeNodeMap).toEqual(
+        expect.any(WeakMap),
+      );
+    });
+
+    it('should not preserve node maps for parseAndGenerateServices() when option is `false`, regardless of `project` config', () => {
+      const optionSetToFalse = parser.parseAndGenerateServices(code, {
+        ...baseConfig,
+        preserveNodeMaps: false,
+      });
+
+      expect(optionSetToFalse.services.esTreeNodeToTSNodeMap).toBeUndefined();
+      expect(optionSetToFalse.services.tsNodeToESTreeNodeMap).toBeUndefined();
+
+      const withProjectOptionSetToFalse = parser.parseAndGenerateServices(
+        code,
+        { ...baseConfig, preserveNodeMaps: false, project: './tsconfig.json' },
+      );
+
+      expect(
+        withProjectOptionSetToFalse.services.esTreeNodeToTSNodeMap,
+      ).toBeUndefined();
+      expect(
+        withProjectOptionSetToFalse.services.tsNodeToESTreeNodeMap,
+      ).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
I have been working on converting some user-land custom TSLint rules to ESLint and this feature has come from that work.

- In many cases, I am discovering migrating custom TSLint rules to ESLint is _far_ easier if you first migrate the "infrastructure" over (all the rule and RuleTester config), but keep the rule logic largely the same. (With the idea that you can truly migrate the implementation at some point later).

- Naturally, this is only possible if you have access to the two-way AST node maps that _may_ be preserved during conversion.

- Preserving the AST node maps is currently only possible if using the `project` option. This is a good start, but as we know the `project` feature is expensive because of its requirement to create full TypeScript Programs.

- If a custom TSLint rule only requires _syntactic_ information, it is completely unnecessary to create a full Program.

This PR introduces a new option for `typescript-estree` which allows for the user to explicitly control whether or not AST node maps are preserved during conversion.

There will be follow up PRs where I add utilities I have created for ESLint rules which meet the above criteria (e.g.`getNodeMaps()`), but I wanted to add the flag itself in a dedicated PR.

(NOTE: for backwards compatibility the existing behaviour around `project` causing node maps to be preserved has been maintained here)