### PR TITLE
fix(typescript-estree): ensure parents are defined

### DIFF
--- a/packages/typescript-estree/src/tsconfig-parser.ts
+++ b/packages/typescript-estree/src/tsconfig-parser.ts
@@ -89,7 +89,10 @@ export function calculateProjectParserOptions(
 
     if (typeof existingWatch !== 'undefined') {
       // get new program (updated if necessary)
-      results.push(existingWatch.getProgram().getProgram());
+      const updatedProgram = existingWatch.getProgram().getProgram();
+      updatedProgram.getTypeChecker(); // sets parent pointers in source files
+      results.push(updatedProgram);
+
       continue;
     }
 


### PR DESCRIPTION
Fixes #498 

When getting the updated program from the TS watch program, it doesn't automatically set parent pointers in the contained source files (which we then traverse as ASTs). By getting the type checker, it triggers a side effect to set those parent pointers.