### PR TITLE
chore: Added an internal eslint plugin for repo-specific lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,11 @@
 {
   "root": true,
-  "plugins": ["eslint-plugin", "@typescript-eslint", "jest"],
+  "plugins": [
+    "eslint-plugin",
+    "@typescript-eslint",
+    "jest",
+    "@typescript-eslint/internal-repo-rules"
+  ],
   "env": {
     "es6": true,
     "node": true
@@ -9,10 +14,9 @@
   "rules": {
     "comma-dangle": ["error", "always-multiline"],
     "curly": ["error", "all"],
-    "no-dupe-class-members": "off",
-    "no-mixed-operators": "error",
     "no-console": "off",
     "no-dupe-class-members": "off",
+    "no-mixed-operators": "error",
     "no-undef": "off",
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/no-explicit-any": "off",
@@ -64,6 +68,12 @@
       ],
       "rules": {
         "eslint-plugin/no-identical-tests": "error"
+      }
+    },
+    {
+      "files": ["packages/eslint-plugin/src/rules/**/*.ts"],
+      "rules": {
+        "@typescript-eslint/internal-repo-rules/no-ts-estree-import": "error"
       }
     }
   ]

--- a/packages/eslint-plugin-internal-repo-rules/README.md
+++ b/packages/eslint-plugin-internal-repo-rules/README.md
@@ -1,0 +1,5 @@
+# eslint-plugin-internal-repo-rules
+
+This is just a collection of internal lint rules to help enforce some guidelines specific to this repositiory.
+
+These are not intended to be used externally.

--- a/packages/eslint-plugin-internal-repo-rules/jest.config.js
+++ b/packages/eslint-plugin-internal-repo-rules/jest.config.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  testRegex: './tests/.+\\.test\\.ts$',
+  collectCoverage: false,
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  coverageReporters: ['text-summary', 'lcov'],
+};

--- a/packages/eslint-plugin-internal-repo-rules/package.json
+++ b/packages/eslint-plugin-internal-repo-rules/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@typescript-eslint/eslint-plugin-internal-repo-rules",
+  "version": "1.8.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "jest --coverage",
+    "prebuild": "npm run clean",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rimraf dist/",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@typescript-eslint/experimental-utils": "1.8.0",
+    "requireindex": "^1.2.0"
+  }
+}

--- a/packages/eslint-plugin-internal-repo-rules/src/createRule.ts
+++ b/packages/eslint-plugin-internal-repo-rules/src/createRule.ts
@@ -1,0 +1,5 @@
+import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+
+const createRule = ESLintUtils.RuleCreator(() => '');
+
+export { createRule };

--- a/packages/eslint-plugin-internal-repo-rules/src/index.ts
+++ b/packages/eslint-plugin-internal-repo-rules/src/index.ts
@@ -1,0 +1,17 @@
+import requireIndex from 'requireindex';
+import path from 'path';
+
+const rules = requireIndex(path.join(__dirname, 'rules'));
+// eslint expects the rule to be on rules[name], not rules[name].default
+const rulesWithoutDefault = Object.keys(rules).reduce<Record<string, any>>(
+  (acc, ruleName) => {
+    acc[ruleName] = rules[ruleName].default;
+    return acc;
+  },
+  {},
+);
+
+// import all rules in lib/rules
+export = {
+  rules: rulesWithoutDefault,
+};

--- a/packages/eslint-plugin-internal-repo-rules/src/rules/no-ts-estree-import.ts
+++ b/packages/eslint-plugin-internal-repo-rules/src/rules/no-ts-estree-import.ts
@@ -1,0 +1,53 @@
+import { createRule } from '../createRule';
+import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+
+const TSESTREE_NAME = '@typescript-eslint/typescript-estree';
+const UTILS_NAME = '@typescript-eslint/experimental-utils';
+
+/*
+Typescript will not error if people use typescript-estree within eslint-plugin.
+This is because it's an indirect dependency.
+We don't want people to import it, instead we want them to import from the utils package.
+*/
+
+export default createRule({
+  name: 'no-ts-estree-import',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: `Enforces that eslint-plugin rules don't require anything from ${TSESTREE_NAME}`,
+      category: 'Possible Errors',
+      recommended: 'error',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      dontImportTSEStree: [
+        `Don't import from ${TSESTREE_NAME}. Everything you need should be available in ${UTILS_NAME}.`,
+        `${TSESTREE_NAME} is an indirect dependency of this package, and thus should not be used directly.`,
+      ].join('\n'),
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (
+          node.source.type === AST_NODE_TYPES.Literal &&
+          node.source.value === TSESTREE_NAME
+        ) {
+          context.report({
+            node,
+            messageId: 'dontImportTSEStree',
+            fix(fixer) {
+              return fixer.replaceTextRange(
+                [node.source.range[0] + 1, node.source.range[1] - 1],
+                UTILS_NAME,
+              );
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-internal-repo-rules/tests/RuleTester.ts
+++ b/packages/eslint-plugin-internal-repo-rules/tests/RuleTester.ts
@@ -1,0 +1,7 @@
+import { TSESLint, ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { RuleTester as ESLintRuleTester } from 'eslint';
+
+const RuleTester: TSESLint.RuleTester = ESLintRuleTester as any;
+const { batchedSingleLineTests } = ESLintUtils;
+
+export { RuleTester, batchedSingleLineTests };

--- a/packages/eslint-plugin-internal-repo-rules/tests/rules/no-ts-estree.test.ts
+++ b/packages/eslint-plugin-internal-repo-rules/tests/rules/no-ts-estree.test.ts
@@ -1,0 +1,43 @@
+import rule from '../../src/rules/no-ts-estree-import';
+import { RuleTester, batchedSingleLineTests } from '../RuleTester';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-ts-estree-import', rule, {
+  valid: [
+    'import { foo } from "@typescript-eslint/experimental-utils";',
+    'import foo from "@typescript-eslint/experimental-utils";',
+    'import * as foo from "@typescript-eslint/experimental-utils";',
+  ],
+  invalid: batchedSingleLineTests({
+    code: `
+import { foo } from "@typescript-eslint/typescript-estree";
+import foo from "@typescript-eslint/typescript-estree";
+import * as foo from "@typescript-eslint/typescript-estree";
+    `,
+    output: `
+import { foo } from "@typescript-eslint/experimental-utils";
+import foo from "@typescript-eslint/experimental-utils";
+import * as foo from "@typescript-eslint/experimental-utils";
+    `,
+    errors: [
+      {
+        messageId: 'dontImportTSEStree',
+        line: 2,
+      },
+      {
+        messageId: 'dontImportTSEStree',
+        line: 3,
+      },
+      {
+        messageId: 'dontImportTSEStree',
+        line: 4,
+      },
+    ],
+  }),
+});

--- a/packages/eslint-plugin-internal-repo-rules/tsconfig.build.json
+++ b/packages/eslint-plugin-internal-repo-rules/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    // specifically disable declarations for the plugin
+    "declaration": false,
+    "declarationMap": false,
+    "outDir": "./dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src", "typings"]
+}

--- a/packages/eslint-plugin-internal-repo-rules/tsconfig.json
+++ b/packages/eslint-plugin-internal-repo-rules/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src", "typings", "tests"]
+}

--- a/packages/eslint-plugin-internal-repo-rules/typings/requireindex.d.ts
+++ b/packages/eslint-plugin-internal-repo-rules/typings/requireindex.d.ts
@@ -1,0 +1,9 @@
+declare module 'requireindex' {
+  type RequireIndex = (
+    path: string,
+    basenames?: string[],
+  ) => Record<string, any>;
+
+  const fn: RequireIndex;
+  export = fn;
+}

--- a/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
+++ b/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/typescript-estree';
+import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createRule, getParserServices, getTypeName } from '../util';
 import { getStaticValue } from 'eslint-utils';
 

--- a/packages/experimental-utils/package.json
+++ b/packages/experimental-utils/package.json
@@ -22,7 +22,6 @@
   },
   "license": "MIT",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest --coverage",
     "prebuild": "npm run clean",

--- a/packages/experimental-utils/src/eslint-utils/batchedSingleLineTests.ts
+++ b/packages/experimental-utils/src/eslint-utils/batchedSingleLineTests.ts
@@ -36,24 +36,26 @@ function batchedSingleLineTests<
 ): (ValidTestCase<TOptions> | InvalidTestCase<TMessageIds, TOptions>)[] {
   // eslint counts lines from 1
   const lineOffset = options.code[0] === '\n' ? 2 : 1;
-  return options.code
-    .trim()
-    .split('\n')
-    .map((code, i) => {
-      const lineNum = i + lineOffset;
-      const errors =
-        'errors' in options
-          ? options.errors.filter(e => e.line === lineNum)
-          : [];
-      return {
-        ...options,
-        code,
-        errors: errors.map(e => ({
-          ...e,
-          line: 1,
-        })),
-      };
-    });
+  const splitCode = options.code.trim().split('\n');
+  const splitOutput =
+    'output' in options && options.output
+      ? options.output.trim().split('\n')
+      : [];
+
+  return splitCode.map((code, i) => {
+    const lineNum = i + lineOffset;
+    const errors =
+      'errors' in options ? options.errors.filter(e => e.line === lineNum) : [];
+    return {
+      ...options,
+      code,
+      output: splitOutput[i],
+      errors: errors.map(e => ({
+        ...e,
+        line: 1,
+      })),
+    };
+  });
 }
 
 export { batchedSingleLineTests };


### PR DESCRIPTION
there might be a number of additional rules we want to add to help with linting for code reviews..
I tried to use `import/no-extraneous-dependencies ` but it breaks too much because of things like `typescript`.

Definitely should look at using that rule instead when (if) we add ts back as a peer dep.

The reason we need this is to ensure the plugin uses the correct import. Esp currently open PRs, it's hard to ensure they use the correct import.
Because TS doesn't error here (because it's an indirect dependency), it's just easier if there's a rule to catch it...