### PR TITLE
fix(experimental-utils): add `endLine` and `endColumn`

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -32,6 +32,8 @@ interface TestCaseError<TMessageIds extends string> {
   type?: AST_NODE_TYPES | AST_TOKEN_TYPES;
   line?: number;
   column?: number;
+  endLine?: number;
+  endColumn?: number;
 }
 
 interface RunTests<


### PR DESCRIPTION
The `end{Line,Column}` are nice to verify ranges of error messages.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2194a1ac8b3e83a882b07257a8dfdc94b5fe2b72/types/eslint/index.d.ts#L565-L574
https://github.com/typescript-eslint/typescript-eslint/blob/89c87cc607172c5cd3f49a563ac283441632fbff/packages/experimental-utils/src/ts-eslint/Linter.ts#L95-L96

Couldn't find anywhere where its omission was discussed

---

Thanks so much for publishing these! Will be converting `eslint-plugin-jest` to use them.