### PR TITLE
fix(experimental-utils): make arguments to ruletester be readonly

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -22,7 +22,7 @@ interface InvalidTestCase<
   TMessageIds extends string,
   TOptions extends Readonly<any[]>
 > extends ValidTestCase<TOptions> {
-  errors: TestCaseError<TMessageIds>[];
+  errors: ReadonlyArray<TestCaseError<TMessageIds>>;
   output?: string | null;
 }
 
@@ -39,8 +39,8 @@ interface RunTests<
   TOptions extends Readonly<any[]>
 > {
   // RuleTester.run also accepts strings for valid cases
-  valid: (ValidTestCase<TOptions> | string)[];
-  invalid: InvalidTestCase<TMessageIds, TOptions>[];
+  valid: ReadonlyArray<(ValidTestCase<TOptions> | string)>;
+  invalid: ReadonlyArray<InvalidTestCase<TMessageIds, TOptions>>;
 }
 
 interface RunTests<
@@ -48,8 +48,8 @@ interface RunTests<
   TOptions extends Readonly<any[]>
 > {
   // RuleTester.run also accepts strings for valid cases
-  valid: (ValidTestCase<TOptions> | string)[];
-  invalid: InvalidTestCase<TMessageIds, TOptions>[];
+  valid: ReadonlyArray<(ValidTestCase<TOptions> | string)>;
+  invalid: ReadonlyArray<InvalidTestCase<TMessageIds, TOptions>>;
 }
 interface RuleTesterConfig {
   parser: '@typescript-eslint/parser';


### PR DESCRIPTION
This allows users to do `as const` in their test and avoid type widening issues for message ids and options

Avoids e.g.
![image](https://user-images.githubusercontent.com/1404810/57587727-c910fd00-7509-11e9-81cb-76af1222ae13.png)

While I can repeat `as const` on every instance, just doing `as const` on the entire object passed to the rule tester is cleaner 🙂 

Went for `ReadonlyArray<T>` over `readonly T[]` to keep the required TS version unchanged