### PR TITLE
fix(eslint-plugin): Remove `no-dupe-class-members` from eslint-recommended

### DIFF
--- a/packages/eslint-plugin/src/configs/eslint-recommended.ts
+++ b/packages/eslint-plugin/src/configs/eslint-recommended.ts
@@ -32,6 +32,8 @@ export default {
         'no-this-before-super': 'off',
         // This is checked by Typescript using the option `strictNullChecks`.
         'no-undef': 'off',
+        // This is already checked by Typescript.
+        'no-dupe-class-members': 'off',
         /**
          * 2. Enable more ideomatic code
          */
@@ -41,8 +43,6 @@ export default {
         // The spread operator/rest parameters should be prefered in Typescript.
         'prefer-rest-params': 'error',
         'prefer-spread': 'error',
-        // This is already checked by Typescript.
-        'no-dupe-class-members': 'error',
       },
     },
   ],


### PR DESCRIPTION
This disables the `no-dupe-class-members` rule in `eslint-recommended`. The rule is already checked by Typescript.

Since the rules are less strict, this shouldn't be a breaking change. However, I'm unsure whether this counts as a patch or a feature release.