### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] false positive for null assign to undefined

### DIFF
--- a/packages/eslint-plugin/src/util/types.ts
+++ b/packages/eslint-plugin/src/util/types.ts
@@ -1,5 +1,4 @@
 import {
-  isTypeFlagSet,
   isTypeReference,
   isUnionOrIntersectionType,
   unionTypeParts,
@@ -115,18 +114,24 @@ export function getConstrainedTypeAtLocation(
  * Checks if the given type is (or accepts) nullable
  * @param isReceiver true if the type is a receiving type (i.e. the type of a called function's parameter)
  */
-export function isNullableType(type: ts.Type, isReceiver?: boolean): boolean {
-  let flags: ts.TypeFlags = 0;
-  for (const t of unionTypeParts(type)) {
-    flags |= t.flags;
+export function isNullableType(
+  type: ts.Type,
+  {
+    isReceiver = false,
+    allowUndefined = true,
+  }: { isReceiver?: boolean; allowUndefined?: boolean } = {},
+): boolean {
+  const flags = getTypeFlags(type);
+
+  if (isReceiver && flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
+    return true;
   }
 
-  flags =
-    isReceiver && flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)
-      ? -1
-      : flags;
-
-  return (flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) !== 0;
+  if (allowUndefined) {
+    return (flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) !== 0;
+  } else {
+    return (flags & ts.TypeFlags.Null) !== 0;
+  }
 }
 
 /**
@@ -137,4 +142,33 @@ export function getDeclaration(
   node: ts.Expression,
 ): ts.Declaration {
   return checker.getSymbolAtLocation(node)!.declarations![0];
+}
+
+/**
+ * Gets all of the type flags in a type, iterating through unions automatically
+ */
+export function getTypeFlags(type: ts.Type): ts.TypeFlags {
+  let flags: ts.TypeFlags = 0;
+  for (const t of unionTypeParts(type)) {
+    flags |= t.flags;
+  }
+  return flags;
+}
+
+/**
+ * Checks if the given type is (or accepts) the given flags
+ * @param isReceiver true if the type is a receiving type (i.e. the type of a called function's parameter)
+ */
+export function isTypeFlagSet(
+  type: ts.Type,
+  flagsToCheck: ts.TypeFlags,
+  isReceiver?: boolean,
+): boolean {
+  const flags = getTypeFlags(type);
+
+  if (isReceiver && flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
+    return true;
+  }
+
+  return (flags & flagsToCheck) !== 0;
 }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import rule from '../../src/rules/no-unnecessary-type-assertion';
 import { RuleTester } from '../RuleTester';
 
-const rootDir = path.join(process.cwd(), 'tests/fixtures');
+const rootDir = path.resolve(__dirname, '../fixtures/');
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2015,
@@ -87,6 +87,13 @@ const x: number | null = null;
 class Foo {
   prop: number = x!;
 }
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/529
+    `
+declare function foo(str?: string): void;
+declare const str: string | null;
+
+foo(str!);
     `,
   ],
 


### PR DESCRIPTION
Fixes #529

Strict mode doesn't let you assign a null to an undefined.
This fixes the check to make sure the two types share a nullable type.