### PR TITLE
 fix(eslint-plugin): [no-unnecessary-type-assertion] handle missing declarations

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -134,6 +134,11 @@ export default util.createRule<Options, MessageIds>({
      */
     function isPossiblyUsedBeforeAssigned(node: ts.Expression): boolean {
       const declaration = util.getDeclaration(checker, node);
+      if (!declaration) {
+        // don't know what the declaration is for some reason, so just assume the worst
+        return true;
+      }
+
       if (
         // non-strict mode doesn't care about used before assigned errors
         isStrictCompilerOptionEnabled(compilerOptions, 'strictNullChecks') &&

--- a/packages/eslint-plugin/src/util/types.ts
+++ b/packages/eslint-plugin/src/util/types.ts
@@ -1,5 +1,4 @@
 import {
-  isTypeFlagSet,
   isTypeReference,
   isUnionOrIntersectionType,
   unionTypeParts,
@@ -115,18 +114,24 @@ export function getConstrainedTypeAtLocation(
  * Checks if the given type is (or accepts) nullable
  * @param isReceiver true if the type is a receiving type (i.e. the type of a called function's parameter)
  */
-export function isNullableType(type: ts.Type, isReceiver?: boolean): boolean {
-  let flags: ts.TypeFlags = 0;
-  for (const t of unionTypeParts(type)) {
-    flags |= t.flags;
+export function isNullableType(
+  type: ts.Type,
+  {
+    isReceiver = false,
+    allowUndefined = true,
+  }: { isReceiver?: boolean; allowUndefined?: boolean } = {},
+): boolean {
+  const flags = getTypeFlags(type);
+
+  if (isReceiver && flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
+    return true;
   }
 
-  flags =
-    isReceiver && flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)
-      ? -1
-      : flags;
-
-  return (flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) !== 0;
+  if (allowUndefined) {
+    return (flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) !== 0;
+  } else {
+    return (flags & ts.TypeFlags.Null) !== 0;
+  }
 }
 
 /**
@@ -137,4 +142,33 @@ export function getDeclaration(
   node: ts.Expression,
 ): ts.Declaration {
   return checker.getSymbolAtLocation(node)!.declarations![0];
+}
+
+/**
+ * Gets all of the type flags in a type, iterating through unions automatically
+ */
+export function getTypeFlags(type: ts.Type): ts.TypeFlags {
+  let flags: ts.TypeFlags = 0;
+  for (const t of unionTypeParts(type)) {
+    flags |= t.flags;
+  }
+  return flags;
+}
+
+/**
+ * Checks if the given type is (or accepts) the given flags
+ * @param isReceiver true if the type is a receiving type (i.e. the type of a called function's parameter)
+ */
+export function isTypeFlagSet(
+  type: ts.Type,
+  flagsToCheck: ts.TypeFlags,
+  isReceiver?: boolean,
+): boolean {
+  const flags = getTypeFlags(type);
+
+  if (isReceiver && flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
+    return true;
+  }
+
+  return (flags & flagsToCheck) !== 0;
 }

--- a/packages/eslint-plugin/src/util/types.ts
+++ b/packages/eslint-plugin/src/util/types.ts
@@ -181,32 +181,3 @@ export function isTypeFlagSet(
 
   return (flags & flagsToCheck) !== 0;
 }
-
-/**
- * Gets all of the type flags in a type, iterating through unions automatically
- */
-export function getTypeFlags(type: ts.Type): ts.TypeFlags {
-  let flags: ts.TypeFlags = 0;
-  for (const t of unionTypeParts(type)) {
-    flags |= t.flags;
-  }
-  return flags;
-}
-
-/**
- * Checks if the given type is (or accepts) the given flags
- * @param isReceiver true if the type is a receiving type (i.e. the type of a called function's parameter)
- */
-export function isTypeFlagSet(
-  type: ts.Type,
-  flagsToCheck: ts.TypeFlags,
-  isReceiver?: boolean,
-): boolean {
-  const flags = getTypeFlags(type);
-
-  if (isReceiver && flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
-    return true;
-  }
-
-  return (flags & flagsToCheck) !== 0;
-}

--- a/packages/eslint-plugin/src/util/types.ts
+++ b/packages/eslint-plugin/src/util/types.ts
@@ -140,8 +140,17 @@ export function isNullableType(
 export function getDeclaration(
   checker: ts.TypeChecker,
   node: ts.Expression,
-): ts.Declaration {
-  return checker.getSymbolAtLocation(node)!.declarations![0];
+): ts.Declaration | null {
+  const symbol = checker.getSymbolAtLocation(node);
+  if (!symbol) {
+    return null;
+  }
+  const declarations = symbol.declarations;
+  if (!declarations) {
+    return null;
+  }
+
+  return declarations[0];
 }
 
 /**

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -95,6 +95,21 @@ declare const str: string | null;
 
 foo(str!);
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/532
+    `
+declare function a(a: string): any;
+declare const b: string | null;
+class Mx {
+  @a(b!)
+  private prop = 1;
+}
+    `,
+    `
+class Mx {
+  @a(b!)
+  private prop = 1;
+}
+    `,
   ],
 
   invalid: [
@@ -277,6 +292,31 @@ class Foo {
         {
           messageId: 'contextuallyUnnecessary',
           line: 4,
+        },
+      ],
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/532
+    {
+      code: `
+declare function a(a: string): any;
+const b = 'asdf';
+class Mx {
+  @a(b!)
+  private prop = 1;
+}
+      `,
+      output: `
+declare function a(a: string): any;
+const b = 'asdf';
+class Mx {
+  @a(b)
+  private prop = 1;
+}
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 5,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import rule from '../../src/rules/no-unnecessary-type-assertion';
 import { RuleTester } from '../RuleTester';
 
-const rootDir = path.join(process.cwd(), 'tests/fixtures');
+const rootDir = path.resolve(__dirname, '../fixtures/');
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2015,
@@ -87,6 +87,13 @@ const x: number | null = null;
 class Foo {
   prop: number = x!;
 }
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/529
+    `
+declare function foo(str?: string): void;
+declare const str: string | null;
+
+foo(str!);
     `,
   ],
 


### PR DESCRIPTION
Fixes #532

The example in the issue works fine as long as all the required declarations are attached.
If something is missing, then it breaks because the code was assuming valid typescript.