### PR TITLE
chore: Add repository.directory to all package.json

### DIFF
--- a/packages/eslint-plugin-tslint/package.json
+++ b/packages/eslint-plugin-tslint/package.json
@@ -13,7 +13,11 @@
   "engines": {
     "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
   },
-  "repository": "typescript-eslint/typescript-eslint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint.git",
+    "directory": "packages/eslint-plugin-tslint"
+  },
   "bugs": {
     "url": "https://github.com/typescript-eslint/typescript-eslint/issues"
   },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -18,7 +18,11 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "typescript-eslint/typescript-eslint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint.git",
+    "directory": "packages/eslint-plugin"
+  },
   "bugs": {
     "url": "https://github.com/typescript-eslint/typescript-eslint/issues"
   },

--- a/packages/experimental-utils/package.json
+++ b/packages/experimental-utils/package.json
@@ -16,7 +16,11 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "typescript-eslint/typescript-eslint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint.git",
+    "directory": "packages/experimental-utils"
+  },
   "bugs": {
     "url": "https://github.com/typescript-eslint/typescript-eslint/issues"
   },

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -11,7 +11,11 @@
   "engines": {
     "node": "^6.14.0 || ^8.10.0 || >=9.10.0"
   },
-  "repository": "typescript-eslint/typescript-eslint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint.git",
+    "directory": "packages/parser"
+  },
   "bugs": {
     "url": "https://github.com/typescript-eslint/typescript-eslint/issues"
   },

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -12,7 +12,11 @@
   "engines": {
     "node": ">=6.14.0"
   },
-  "repository": "typescript-eslint/typescript-eslint",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint.git",
+    "directory": "packages/typescript-estree"
+  },
   "bugs": {
     "url": "https://github.com/typescript-eslint/typescript-eslint/issues"
   },


### PR DESCRIPTION
Documentation: https://docs.npmjs.com/files/package.json#repository.

Hopefully this will fix the broken links in
https://www.npmjs.com/package/@typescript-eslint/eslint-plugin#supported-rules.