### PR TITLE
fix(eslint-plugin): [no-magic-numbers] add support for enums

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-magic-numbers.md
+++ b/packages/eslint-plugin/docs/rules/no-magic-numbers.md
@@ -41,4 +41,28 @@ Examples of **correct** code for the `{ "ignoreNumericLiteralTypes": true }` opt
 type SmallPrimes = 2 | 3 | 5 | 7 | 11;
 ```
 
+### ignoreEnums
+
+A boolean to specify if enums used in Typescript are considered okay. `false` by default.
+
+Examples of **incorrect** code for the `{ "ignoreEnum": false }` option:
+
+```ts
+/*eslint @typescript-eslint/no-magic-numbers: ["error", { "ignoreEnum": false }]*/
+
+enum foo = {
+    SECOND = 1000,
+}
+```
+
+Examples of **correct** code for the `{ "ignoreEnum": true }` option:
+
+```ts
+/*eslint @typescript-eslint/no-magic-numbers: ["error", { "ignoreEnum": true }]*/
+
+enum foo = {
+    SECOND = 1000,
+}
+```
+
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-magic-numbers.md)</sup>

--- a/packages/eslint-plugin/src/rules/no-magic-numbers.ts
+++ b/packages/eslint-plugin/src/rules/no-magic-numbers.ts
@@ -29,6 +29,9 @@ export default util.createRule<Options, MessageIds>({
           ignoreNumericLiteralTypes: {
             type: 'boolean',
           },
+          ignoreEnums: {
+            type: 'boolean',
+          },
         },
       },
     ],
@@ -41,6 +44,7 @@ export default util.createRule<Options, MessageIds>({
       enforceConst: false,
       detectObjects: false,
       ignoreNumericLiteralTypes: false,
+      ignoreEnums: false,
     },
   ],
   create(context, [options]) {
@@ -53,18 +57,6 @@ export default util.createRule<Options, MessageIds>({
      */
     function isNumber(node: TSESTree.Literal): boolean {
       return typeof node.value === 'number';
-    }
-
-    /**
-     * Checks if the node grandparent is a Typescript enum declaration
-     * @param node the node to be validated.
-     * @returns true if the node grandparent is a Typescript enum declaration
-     * @private
-     */
-    function isGrandparentTSEnumDeclaration(node: TSESTree.Node): boolean {
-      return node.parent && node.parent.parent
-        ? node.parent.parent.type === AST_NODE_TYPES.TSEnumDeclaration
-        : false;
     }
 
     /**
@@ -95,6 +87,19 @@ export default util.createRule<Options, MessageIds>({
       }
 
       return false;
+    }
+
+    /**
+     * Checks if the node parent is a Typescript enum member
+     * @param node the node to be validated.
+     * @returns true if the node parent is a Typescript enum member
+     * @private
+     */
+    function isParentTSEnumDeclaration(node: TSESTree.Node): boolean {
+      return (
+        typeof node.parent !== 'undefined' &&
+        node.parent.type === AST_NODE_TYPES.TSEnumMember
+      );
     }
 
     /**
@@ -146,7 +151,7 @@ export default util.createRule<Options, MessageIds>({
     return {
       Literal(node) {
         // Check if the node is a TypeScript enum declaration
-        if (isGrandparentTSEnumDeclaration(node)) {
+        if (options.ignoreEnums && isParentTSEnumDeclaration(node)) {
           return;
         }
 

--- a/packages/eslint-plugin/src/rules/no-magic-numbers.ts
+++ b/packages/eslint-plugin/src/rules/no-magic-numbers.ts
@@ -56,6 +56,18 @@ export default util.createRule<Options, MessageIds>({
     }
 
     /**
+     * Checks if the node grandparent is a Typescript enum declaration
+     * @param node the node to be validated.
+     * @returns true if the node grandparent is a Typescript enum declaration
+     * @private
+     */
+    function isGrandparentTSEnumDeclaration(node: TSESTree.Node): boolean {
+      return node.parent && node.parent.parent
+        ? node.parent.parent.type === AST_NODE_TYPES.TSEnumDeclaration
+        : false;
+    }
+
+    /**
      * Checks if the node grandparent is a Typescript type alias declaration
      * @param node the node to be validated.
      * @returns true if the node grandparent is a Typescript type alias declaration
@@ -133,7 +145,12 @@ export default util.createRule<Options, MessageIds>({
 
     return {
       Literal(node) {
-        // Check TypeScript specific nodes
+        // Check if the node is a TypeScript enum declaration
+        if (isGrandparentTSEnumDeclaration(node)) {
+          return;
+        }
+
+        // Check TypeScript specific nodes for Numeric Literal
         if (
           options.ignoreNumericLiteralTypes &&
           isNumber(node) &&

--- a/packages/eslint-plugin/tests/rules/no-magic-numbers.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-magic-numbers.test.ts
@@ -18,9 +18,6 @@ ruleTester.run('no-magic-numbers', rule, {
       code: 'type Foo = true;',
     },
     {
-      code: 'enum foo { SECOND = 1000 }',
-    },
-    {
       code: 'type Foo = 1;',
       options: [{ ignoreNumericLiteralTypes: true }],
     },
@@ -35,6 +32,14 @@ ruleTester.run('no-magic-numbers', rule, {
     {
       code: 'type Foo = 1 | -1;',
       options: [{ ignoreNumericLiteralTypes: true }],
+    },
+    {
+      code: 'enum foo { SECOND = 1000 }',
+      options: [{ ignoreEnums: true }],
+    },
+    {
+      code: 'enum foo { SECOND = 1000, NUM = "0123456789" }',
+      options: [{ ignoreEnums: true }],
     },
   ],
 
@@ -130,6 +135,34 @@ ruleTester.run('no-magic-numbers', rule, {
           },
           line: 1,
           column: 22,
+        },
+      ],
+    },
+    {
+      code: 'enum foo { SECOND = 1000 }',
+      options: [{ ignoreEnums: false }],
+      errors: [
+        {
+          messageId: 'noMagic',
+          data: {
+            raw: '1000',
+          },
+          line: 1,
+          column: 21,
+        },
+      ],
+    },
+    {
+      code: 'enum foo { SECOND = 1000, NUM = "0123456789" }',
+      options: [{ ignoreEnums: false }],
+      errors: [
+        {
+          messageId: 'noMagic',
+          data: {
+            raw: '1000',
+          },
+          line: 1,
+          column: 21,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-magic-numbers.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-magic-numbers.test.ts
@@ -18,6 +18,9 @@ ruleTester.run('no-magic-numbers', rule, {
       code: 'type Foo = true;',
     },
     {
+      code: 'enum foo { SECOND = 1000 }',
+    },
+    {
       code: 'type Foo = 1;',
       options: [{ ignoreNumericLiteralTypes: true }],
     },

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -180,6 +180,7 @@ declare module 'eslint/lib/rules/no-magic-numbers' {
         enforceConst?: boolean;
         detectObjects?: boolean;
         ignoreNumericLiteralTypes?: boolean;
+        ignoreEnums?: boolean;
       }
     ],
     {


### PR DESCRIPTION
Fixes #573.

Currently, the following code will fail to lint using the default no-magic-numbers configuration
```
enum foo {
  SECOND = 1000,
  NUM = '0123456789',
}
```

One could make the argument that perhaps we instead want to define it in some other way, perhaps using constants and referring to them such as:
```
const MS_SECONDS = 1000;
enum foo {
  SECOND = MS_SECONDS,
  NUM = '0123456789',
}
```
However, this will result in a compiler error `Computed values are not permitted in an enum with string valued members.ts(2553)`.

I made these changes to resolve that problem. I tried to follow the existing code pattern as much as possible, however, I am open to changes. I also assumed updating the documentation would be unnecessary for this fix, let me know if we would like a change there and I'll handle it.

Thanks for your time!