### PR TITLE
docs(eslint-plugin): [no-extraneous-class] fix option keys

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-extraneous-class.md
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-class.md
@@ -50,9 +50,9 @@ const StaticOnly = {
 
 This rule accepts a single object option.
 
-- `constructorOnly: true` will silence warnings about classes containing only a constructor.
+- `allowConstructorOnly: true` will silence warnings about classes containing only a constructor.
 - `allowEmpty: true` will silence warnings about empty classes.
-- `staticOnly: true` will silence warnings about classes containing only static members.
+- `allowStaticOnly: true` will silence warnings about classes containing only static members.
 
 ## When Not To Use It
 


### PR DESCRIPTION
Docs for `no-extraneous-class` list the following options:

- `constructorOnly`
- `allowEmpty`
- `staticOnly`

However in the rule source, these options are actually named:

- `allowContructorOnly`
- `allowEmpty`
- `allowStaticOnly`

This PR updates the docs to match the rule schema.