### PR TITLE
test(eslint-plugin): [promise-function-async] Add regression tests for invalid async modifiers

### DIFF
--- a/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
+++ b/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
@@ -44,6 +44,29 @@ class Test {
   }
 }
     `,
+    `
+class InvalidAsyncModifiers {
+  public constructor() {
+    return new Promise<void>();
+  }
+  public get asyncGetter() {
+    return new Promise<void>();
+  }
+  public set asyncGetter(p: Promise<void>) {
+    return p;
+  }
+}
+    `,
+    `
+const invalidAsyncModifiers = {
+  get asyncGetter() {
+    return new Promise<void>();
+  },
+  set asyncGetter(p: Promise<void>) {
+    return p;
+  }
+}
+    `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/227
     `export function valid(n: number) { return n; }`,
     `export default function invalid(n: number) { return n; }`,


### PR DESCRIPTION
It seems like the rule is already smart enough to not check special methods (`get`, `set`, and `constructor` kinds), so i just added regression tests for them. As these kinds of methods cannot be marked `async`, the rule shouldn't check them in the first place.

refs #553 