### PR TITLE
fix(eslint-plugin): [no-type-alias] Fix parenthesized type handling

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -8,6 +8,10 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-type-alias', rule, {
   valid: [
     {
+      code: "type A = 'a' & ('b' | 'c');",
+      options: [{ allowAliases: 'always' }],
+    },
+    {
       code: "type Foo = 'a';",
       options: [{ allowAliases: 'always' }],
     },


### PR DESCRIPTION
Fixes #575

It was going to be annoying to insert `if`s all over the place so I refactored the logic to make it cleaner.