### PR TITLE
fix(experimental-utils): Avoid typescript import at runtime

### DIFF
--- a/packages/experimental-utils/src/index.ts
+++ b/packages/experimental-utils/src/index.ts
@@ -6,9 +6,15 @@ export { ESLintUtils, TSESLint, TSESLintScope };
 
 // for convenience's sake - export the types directly from here so consumers
 // don't need to reference/install both packages in their code
+
+// NOTE - this uses hard links inside ts-estree to avoid initing the entire package
+//        via its main file (which imports typescript at runtime).
+//        Not every eslint-plugin written in typescript requires typescript at runtime.
 export {
   AST_NODE_TYPES,
   AST_TOKEN_TYPES,
-  ParserServices,
   TSESTree,
-} from '@typescript-eslint/typescript-estree';
+} from '@typescript-eslint/typescript-estree/dist/ts-estree';
+export {
+  ParserServices,
+} from '@typescript-eslint/typescript-estree/dist/parser-options';


### PR DESCRIPTION
See: https://github.com/typescript-eslint/typescript-eslint/pull/425#issuecomment-498162293