### PR TITLE
chore: Change config default for eslint-plugin-typescript issue to use correct prefix

### DIFF
--- a/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.md
+++ b/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.md
@@ -36,7 +36,7 @@ The more irrelevant code/config you give, the harder it is for us to investigate
 ```JSON
 {
   "rules": {
-    "typescript/<rule>": ["<setting>"]
+    "@typescript-eslint/<rule>": ["<setting>"]
   }
 }
 ```


### PR DESCRIPTION
Minor, but caught my eye as I submitted an issue