### PR TITLE
fix(typescript-estree): allow expressions in ExportDefaultDeclaration

### DIFF
--- a/packages/typescript-estree/src/ts-estree/ts-estree.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-estree.ts
@@ -659,7 +659,7 @@ export interface ExportAllDeclaration extends BaseNode {
 
 export interface ExportDefaultDeclaration extends BaseNode {
   type: AST_NODE_TYPES.ExportDefaultDeclaration;
-  declaration: ExportDeclaration;
+  declaration: ExportDeclaration | Expression;
 }
 
 export interface ExportNamedDeclaration extends BaseNode {


### PR DESCRIPTION
Currently `ExportDefaultDeclaration` is locked down to only `ExportDeclaration`, but expressions are also valid. For example:

```ts
export default new Foo();
export default 123;
export default bar;
```