### PR TITLE
fix(eslint-plugin): peerDep should specify semver major range

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -53,7 +53,7 @@
     "marked": "^0.6.2"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "1.9.0",
+    "@typescript-eslint/parser": "^1.9.0",
     "eslint": "^5.0.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/typescript-eslint/typescript-eslint/issues/601

Needed because of https://github.com/lerna/lerna/pull/1187