### PR TITLE
fix(eslint-plugin): Remove duplicated code

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -45,15 +45,6 @@ interface RunTests<
   valid: (ValidTestCase<TOptions> | string)[];
   invalid: InvalidTestCase<TMessageIds, TOptions>[];
 }
-
-interface RunTests<
-  TMessageIds extends string,
-  TOptions extends Readonly<any[]>
-> {
-  // RuleTester.run also accepts strings for valid cases
-  valid: (ValidTestCase<TOptions> | string)[];
-  invalid: InvalidTestCase<TMessageIds, TOptions>[];
-}
 interface RuleTesterConfig {
   parser: '@typescript-eslint/parser';
   parserOptions?: ParserOptions;


### PR DESCRIPTION
The definition of `RunTests` is duplicated...
Is there any reason for that?