### PR TITLE
Align testrunner type to eslint

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -23,7 +23,7 @@ interface InvalidTestCase<
   TMessageIds extends string,
   TOptions extends Readonly<any[]>
 > extends ValidTestCase<TOptions> {
-  errors: number | Array<TestCaseError<TMessageIds> | string>;
+  errors: number | TestCaseError<TMessageIds>[] | string[];
   output?: string | null;
 }
 

--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -32,7 +32,7 @@ type TestCaseError<TMessageIds extends string> = (
       messageId: TMessageIds;
     }
   | {
-      message?: string | RegExp;
+      message: string | RegExp;
     }) & {
   data?: Record<string, any>;
   type?: AST_NODE_TYPES | AST_TOKEN_TYPES;

--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -27,8 +27,11 @@ interface InvalidTestCase<
   output?: string | null;
 }
 
-interface TestCaseError<TMessageIds extends string> {
+type TestCaseError<TMessageIds extends string> = ({
   messageId: TMessageIds;
+} | {
+  message?: string | RegExp;
+}) & {
   data?: Record<string, any>;
   type?: AST_NODE_TYPES | AST_TOKEN_TYPES;
   line?: number;

--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -27,18 +27,20 @@ interface InvalidTestCase<
   output?: string | null;
 }
 
-type TestCaseError<TMessageIds extends string> = ({
-  messageId: TMessageIds;
-} | {
-  message?: string | RegExp;
-}) & {
+type TestCaseError<TMessageIds extends string> = (
+  | {
+      messageId: TMessageIds;
+    }
+  | {
+      message?: string | RegExp;
+    }) & {
   data?: Record<string, any>;
   type?: AST_NODE_TYPES | AST_TOKEN_TYPES;
   line?: number;
   column?: number;
   endLine?: number;
   endColumn?: number;
-}
+};
 
 interface RunTests<
   TMessageIds extends string,

--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -23,7 +23,7 @@ interface InvalidTestCase<
   TMessageIds extends string,
   TOptions extends Readonly<any[]>
 > extends ValidTestCase<TOptions> {
-  errors: TestCaseError<TMessageIds>[];
+  errors: number | Array<TestCaseError<TMessageIds> | string>;
   output?: string | null;
 }
 

--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -23,7 +23,7 @@ interface InvalidTestCase<
   TMessageIds extends string,
   TOptions extends Readonly<any[]>
 > extends ValidTestCase<TOptions> {
-  errors: number | TestCaseError<TMessageIds>[] | string[];
+  errors: TestCaseError<TMessageIds>[];
   output?: string | null;
 }
 


### PR DESCRIPTION
1. Align to https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/eslint/index.d.ts#L565
2. Allow more accurate test when error message has placeholder such as
```
Expected message '${name}' to have a comment.
```