### PR TITLE
fix: in eslint 6 `traverser.js` now lives in `lib/shared`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "all-contributors-cli": "^6.0.0",
     "babel-code-frame": "^6.26.0",
     "cz-conventional-changelog": "2.1.0",
-    "eslint": "^5.12.1",
+    "eslint": "^6.0.0-rc.0",
     "eslint-plugin-eslint-plugin": "^2.0.1",
     "eslint-plugin-jest": "^22.2.2",
     "glob": "7.1.2",

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -5,7 +5,7 @@ import {
   ParserServices,
 } from '@typescript-eslint/typescript-estree';
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import traverser from 'eslint/lib/util/traverser';
+import traverser from 'eslint/lib/shared/traverser';
 import { analyzeScope } from './analyze-scope';
 import { visitorKeys } from './visitor-keys';
 

--- a/packages/parser/typings/eslint.d.ts
+++ b/packages/parser/typings/eslint.d.ts
@@ -1,4 +1,4 @@
-declare module 'eslint/lib/util/traverser' {
+declare module 'eslint/lib/shared/traverser' {
   import { TSESTree } from '@typescript-eslint/experimental-utils';
   const traverser: {
     traverse(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,7 +1344,7 @@ agentkeepalive@^3.4.1:
   dependencies:
     humanize-ms "^1.2.1"
 
-ajv@^6.5.5, ajv@^6.9.1:
+ajv@^6.10.0, ajv@^6.5.5, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
@@ -2678,13 +2678,13 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@^5.12.1:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
-  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+eslint@^6.0.0-rc.0:
+  version "6.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.0.0-rc.0.tgz#9e792a4174527e5a09c5ead9baf256842752cb98"
+  integrity sha512-l+h6fxr/OMkTOz2cORKFnjBcdk2uY63RKnFANoc4MjI5ZpiVCI0OeH26gOcRvyQtrzmdmiKvlLeNN2LHAIsNuA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.9.1"
+    ajv "^6.10.0"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
@@ -2692,18 +2692,19 @@ eslint@^5.12.1:
     eslint-scope "^4.0.3"
     eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^5.0.1"
+    espree "^6.0.0-alpha.0"
     esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
+    glob-parent "^3.1.0"
     globals "^11.7.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     inquirer "^6.2.2"
-    js-yaml "^3.13.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.11"
@@ -2711,7 +2712,6 @@ eslint@^5.12.1:
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.2"
     progress "^2.0.0"
     regexpp "^2.0.1"
     semver "^5.5.1"
@@ -2720,10 +2720,10 @@ eslint@^5.12.1:
     table "^5.2.3"
     text-table "^0.2.0"
 
-espree@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
-  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+espree@^6.0.0-alpha.0:
+  version "6.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.0.0-alpha.0.tgz#4db6aa458d63896575d48cb3498aedfc7d45f2a8"
+  integrity sha512-Y5iDF27FSV+Lbi9WGWm3hz3Zsfh7a24xRAkNwDGoLWJe82NoxtL30hqCY2EEZ5FGvsc0IAj9V3QlwNjjj7RlTg==
   dependencies:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"


### PR DESCRIPTION
Attempts to fix #563 
Parser imports an internal eslint file `lib/utils/traverser.js` whi is moved in eslint v6 into `lib/shared/traverser.js`,

