### PR TITLE
docs(eslint-plugin): [no-explicit-any] correct docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-explicit-any.md
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.md
@@ -5,7 +5,7 @@ When `any` is used, all compiler type checks around that value are ignored.
 
 ## Rule Details
 
-This rule goes doesn't allow `any` types to be defined.
+This rule doesn't allow `any` types to be defined.
 It aims to keep TypeScript maximally useful.
 TypeScript has a compiler flag for `--noImplicitAny` that will prevent
 an `any` type from being implied by the compiler, but doesn't prevent


### PR DESCRIPTION
Remove stray word from doc

on-behalf-of: @wmde <software@wikimedia.de>