### PR TITLE
feat: Support eslint@6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,8 +62,6 @@ jobs:
           node_version: 10.x
         node_8_x:
           node_version: 8.x
-        node_6_x:
-          node_version: 6.x
     steps:
       - task: NodeTool@0
         inputs:

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "all-contributors-cli": "^6.0.0",
     "babel-code-frame": "^6.26.0",
     "cz-conventional-changelog": "2.1.0",
-    "eslint": "^5.12.1",
+    "eslint": "^6.0.0",
     "eslint-plugin-eslint-plugin": "^2.0.1",
     "eslint-plugin-jest": "^22.2.2",
     "glob": "7.1.2",

--- a/packages/eslint-plugin-tslint/package.json
+++ b/packages/eslint-plugin-tslint/package.json
@@ -35,7 +35,7 @@
     "lodash.memoize": "^4.1.2"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0",
+    "eslint": "^5.0.0 || ^6.0.0",
     "tslint": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/eslint-plugin-tslint/tests/index.spec.ts
+++ b/packages/eslint-plugin-tslint/tests/index.spec.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import * as parser from '@typescript-eslint/parser';
 import { readFileSync } from 'fs';
 import rule, { Options } from '../src/rules/config';
 
@@ -13,7 +14,7 @@ const ruleTester = new TSESLint.RuleTester({
      */
     project: './tests/tsconfig.json',
   },
-  parser: '@typescript-eslint/parser',
+  parser: require.resolve('@typescript-eslint/parser'),
 });
 
 /**
@@ -146,6 +147,7 @@ describe('tslint/error', () => {
   function testOutput(code: string, config: TSESLint.Linter.Config): void {
     const linter = new TSESLint.Linter();
     linter.defineRule('tslint/config', rule);
+    linter.defineParser('@typescript-eslint/parser', parser);
 
     expect(() => linter.verify(code, config)).toThrow(
       `You must provide a value for the "parserOptions.project" property for @typescript-eslint/parser`,
@@ -176,6 +178,7 @@ describe('tslint/error', () => {
     const linter = new TSESLint.Linter();
     jest.spyOn(console, 'warn').mockImplementation();
     linter.defineRule('tslint/config', rule);
+    linter.defineParser('@typescript-eslint/parser', parser);
     expect(() =>
       linter.verify('foo;', {
         parserOptions: {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -54,6 +54,6 @@
   },
   "peerDependencies": {
     "@typescript-eslint/parser": "^1.9.0",
-    "eslint": "^5.0.0"
+    "eslint": "^5.0.0 || ^6.0.0"
   }
 }

--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -72,7 +72,8 @@ function typeNeedsParentheses(node: TSESTree.Node): boolean {
   }
 }
 
-type Options = ['array' | 'generic' | 'array-simple'];
+export type OptionString = 'array' | 'generic' | 'array-simple';
+type Options = [OptionString];
 type MessageIds =
   | 'errorStringGeneric'
   | 'errorStringGenericSimple'

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
@@ -8,7 +8,6 @@ import {
   AST_TOKEN_TYPES,
   TSESLint,
 } from '@typescript-eslint/experimental-utils';
-import { createGlobalLinebreakMatcher } from 'eslint/lib/util/ast-utils';
 import {
   isOpeningParenToken,
   isClosingParenToken,
@@ -25,6 +24,10 @@ import { TokenOrComment } from './BinarySearchTree';
 import { OffsetStorage } from './OffsetStorage';
 import { TokenInfo } from './TokenInfo';
 import { createRule, ExcludeKeys, RequireKeys } from '../../util';
+
+function createGlobalLinebreakMatcher() {
+  return /\r\n|[\r\n\u2028\u2029]/gu;
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/packages/eslint-plugin/tests/RuleTester.ts
+++ b/packages/eslint-plugin/tests/RuleTester.ts
@@ -8,13 +8,13 @@ const parser = '@typescript-eslint/parser';
 // but that's not as clean to type as this is
 type RuleTesterConfig = Omit<TSESLint.RuleTesterConfig, 'parser'> & {
   parser: typeof parser;
-}
+};
 class RuleTester extends TSESLint.RuleTester {
   constructor(options: RuleTesterConfig) {
     super({
       ...options,
       parser: require.resolve(options.parser),
-    })
+    });
   }
 
   run<TMessageIds extends string, TOptions extends Readonly<any[]>>(
@@ -29,12 +29,12 @@ class RuleTester extends TSESLint.RuleTester {
           throw new Error(errorMessage);
         }
       }
-    })
+    });
     tests.invalid.forEach(test => {
       if (test.parser === parser) {
         throw new Error(errorMessage);
       }
-    })
+    });
 
     super.run(name, rule, tests);
   }

--- a/packages/eslint-plugin/tests/RuleTester.ts
+++ b/packages/eslint-plugin/tests/RuleTester.ts
@@ -3,13 +3,13 @@ import * as path from 'path';
 
 const parser = '@typescript-eslint/parser';
 
-// re-export the RuleTester from here to make it easier to do the tests
-// as of eslint 6 you have to provide an absolute path to the parser
-// but that's not as clean to type as this is
 type RuleTesterConfig = Omit<TSESLint.RuleTesterConfig, 'parser'> & {
   parser: typeof parser;
 };
 class RuleTester extends TSESLint.RuleTester {
+  // as of eslint 6 you have to provide an absolute path to the parser
+  // but that's not as clean to type, this saves us trying to manually enforce
+  // that contributors require.resolve everything
   constructor(options: RuleTesterConfig) {
     super({
       ...options,
@@ -17,6 +17,9 @@ class RuleTester extends TSESLint.RuleTester {
     });
   }
 
+  // as of eslint 6 you have to provide an absolute path to the parser
+  // If you don't do that at the test level, the test will fail somewhat cryptically...
+  // This is a lot more explicit
   run<TMessageIds extends string, TOptions extends Readonly<any[]>>(
     name: string,
     rule: TSESLint.RuleModule<TMessageIds, TOptions>,

--- a/packages/eslint-plugin/tests/RuleTester.ts
+++ b/packages/eslint-plugin/tests/RuleTester.ts
@@ -1,8 +1,44 @@
 import { TSESLint, ESLintUtils } from '@typescript-eslint/experimental-utils';
 import * as path from 'path';
 
+const parser = '@typescript-eslint/parser';
+
 // re-export the RuleTester from here to make it easier to do the tests
-const RuleTester = TSESLint.RuleTester;
+// as of eslint 6 you have to provide an absolute path to the parser
+// but that's not as clean to type as this is
+type RuleTesterConfig = Omit<TSESLint.RuleTesterConfig, 'parser'> & {
+  parser: typeof parser;
+}
+class RuleTester extends TSESLint.RuleTester {
+  constructor(options: RuleTesterConfig) {
+    super({
+      ...options,
+      parser: require.resolve(options.parser),
+    })
+  }
+
+  run<TMessageIds extends string, TOptions extends Readonly<any[]>>(
+    name: string,
+    rule: TSESLint.RuleModule<TMessageIds, TOptions>,
+    tests: TSESLint.RunTests<TMessageIds, TOptions>,
+  ): void {
+    const errorMessage = `Do not set the parser at the test level unless you want to use a parser other than ${parser}`;
+    tests.valid.forEach(test => {
+      if (typeof test !== 'string') {
+        if (test.parser === parser) {
+          throw new Error(errorMessage);
+        }
+      }
+    })
+    tests.invalid.forEach(test => {
+      if (test.parser === parser) {
+        throw new Error(errorMessage);
+      }
+    })
+
+    super.run(name, rule, tests);
+  }
+}
 
 function getFixturesRootDir() {
   return path.join(process.cwd(), 'tests/fixtures/');

--- a/packages/eslint-plugin/tests/eslint-rules/no-redeclare.test.ts
+++ b/packages/eslint-plugin/tests/eslint-rules/no-redeclare.test.ts
@@ -1,5 +1,8 @@
 import rule from 'eslint/lib/rules/no-redeclare';
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+import {
+  AST_NODE_TYPES,
+  AST_TOKEN_TYPES,
+} from '@typescript-eslint/experimental-utils';
 import { RuleTester } from '../RuleTester';
 
 const ruleTester = new RuleTester({
@@ -19,7 +22,6 @@ ruleTester.run('no-redeclare', rule, {
         ecmaVersion: 6,
       },
     },
-    'var Object = 0;',
     { code: 'var Object = 0;', options: [{ builtinGlobals: false }] },
     {
       code: 'var Object = 0;',
@@ -31,7 +33,11 @@ ruleTester.run('no-redeclare', rule, {
       options: [{ builtinGlobals: true }],
       parserOptions: { ecmaFeatures: { globalReturn: true } },
     },
-    { code: 'var top = 0;', env: { browser: true } },
+    {
+      code: 'var top = 0;',
+      env: { browser: true },
+      options: [{ builtinGlobals: false }],
+    },
     { code: 'var top = 0;', options: [{ builtinGlobals: true }] },
     {
       code: 'var top = 0;',
@@ -84,85 +90,115 @@ class D<T> {}
       parserOptions: { ecmaVersion: 6 },
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
       code: 'switch(foo) { case a: var b = 3;\ncase b: var b = 4}',
       errors: [
         {
-          message: "'b' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'b',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
       code: 'var a = 3; var a = 10;',
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
       code: 'var a = {}; var a = [];',
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
       code: 'var a; function a() {}',
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
       code: 'function a() {} function a() {}',
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
       code: 'var a = function() { }; var a = function() { }',
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
       code: 'var a = function() { }; var a = new Date();',
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
       code: 'var a = 3; var a = 10; var a = 15;',
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
@@ -170,9 +206,12 @@ class D<T> {}
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
@@ -180,9 +219,12 @@ class D<T> {}
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
@@ -190,9 +232,12 @@ class D<T> {}
       options: [{ builtinGlobals: true }],
       errors: [
         {
-          message: "'Object' is already defined.",
+          messageId: 'redeclaredAsBuiltin',
+          data: {
+            id: 'Object',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
@@ -200,9 +245,12 @@ class D<T> {}
       options: [{ builtinGlobals: true }],
       errors: [
         {
-          message: "'top' is already defined.",
+          messageId: 'redeclaredAsBuiltin',
+          data: {
+            id: 'top',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
       env: { browser: true },
     },
@@ -212,13 +260,19 @@ class D<T> {}
       parserOptions: { ecmaVersion: 6 },
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
         {
-          message: "'Object' is already defined.",
+          messageId: 'redeclaredAsBuiltin',
+          data: {
+            id: 'Object',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
@@ -227,9 +281,12 @@ class D<T> {}
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
@@ -238,9 +295,12 @@ class D<T> {}
       parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } },
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
     {
@@ -249,9 +309,12 @@ class D<T> {}
       parserOptions: { ecmaVersion: 6 },
       errors: [
         {
-          message: "'a' is already defined.",
+          messageId: 'redeclared',
+          data: {
+            id: 'a',
+          },
           type: AST_NODE_TYPES.Identifier,
-        } as any,
+        },
       ],
     },
 
@@ -261,9 +324,12 @@ class D<T> {}
       options: [{ builtinGlobals: true }],
       errors: [
         {
-          message: "'b' is already defined.",
-          type: AST_NODE_TYPES.Identifier,
-        } as any,
+          messageId: 'redeclaredBySyntax',
+          data: {
+            id: 'b',
+          },
+          type: AST_TOKEN_TYPES.Block,
+        },
       ],
     },
   ],

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -1,5 +1,6 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import rule from '../../src/rules/array-type';
+import * as parser from '@typescript-eslint/parser';
+import rule, { OptionString } from '../../src/rules/array-type';
 import { RuleTester } from '../RuleTester';
 
 const ruleTester = new RuleTester({
@@ -886,25 +887,32 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
 // eslint rule tester is not working with multi-pass
 // https://github.com/eslint/eslint/issues/11187
 describe('array-type (nested)', () => {
-  describe('should deeply fix correctly', () => {
-    function testOutput(option: string, code: string, output: string): void {
-      it(code, () => {
-        const linter = new TSESLint.Linter();
+  const linter = new TSESLint.Linter();
+  linter.defineRule('array-type', rule);
+  linter.defineParser('@typescript-eslint/parser', parser);
 
-        linter.defineRule('array-type', Object.assign({}, rule) as any);
+  describe('should deeply fix correctly', () => {
+    function testOutput(
+      option: OptionString,
+      code: string,
+      output: string,
+    ): void {
+      it(code, () => {
         const result = linter.verifyAndFix(
           code,
           {
             rules: {
-              'array-type': [2, option],
+              'array-type': ['error', option],
             },
             parser: '@typescript-eslint/parser',
           },
           {
             fix: true,
-          },
+          }
         );
 
+        expect(result.messages).toHaveLength(0);
+        expect(result.fixed).toBeTruthy();
         expect(result.output).toBe(output);
       });
     }

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -908,7 +908,7 @@ describe('array-type (nested)', () => {
           },
           {
             fix: true,
-          }
+          },
         );
 
         expect(result.messages).toHaveLength(0);

--- a/packages/eslint-plugin/tests/rules/ban-ts-ignore.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-ts-ignore.test.ts
@@ -52,7 +52,6 @@ if (false) {
   console.log("hello");
 }
             `,
-      parser: '@typescript-eslint/parser',
       errors: [
         {
           messageId: 'tsIgnoreComment',

--- a/packages/eslint-plugin/tests/rules/no-triple-slash-reference.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-triple-slash-reference.test.ts
@@ -33,7 +33,6 @@ let a
 /// <reference path="Animal" />
 let a
             `,
-      parser: '@typescript-eslint/parser',
       errors: [
         {
           messageId: 'noTripleSlashReference',

--- a/packages/eslint-plugin/tests/rules/no-use-before-define.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-use-before-define.test.ts
@@ -213,7 +213,6 @@ export namespace Third {
 }
             `,
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      parser: '@typescript-eslint/parser',
     },
     // https://github.com/eslint/typescript-eslint-parser/issues/550
     `
@@ -398,7 +397,7 @@ a();
     function a() {}
 }
             `,
-      parser: 'espree',
+      parser: require.resolve('espree'),
       errors: [
         {
           messageId: 'noUseBeforeDefine',

--- a/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
@@ -1032,7 +1032,6 @@ type Bar = Record<keyof Foo, string>
           },
         },
       ],
-      parser: '@typescript-eslint/parser',
     },
     'let resolver: (() => PromiseLike<T>) | PromiseLike<T>;',
   ],
@@ -4432,7 +4431,6 @@ type Bar = Record<keyof Foo, string>
           },
         },
       ],
-      parser: '@typescript-eslint/parser',
     },
   ],
   invalid: [

--- a/packages/eslint-plugin/typings/eslint-ast-util.d.ts
+++ b/packages/eslint-plugin/typings/eslint-ast-util.d.ts
@@ -1,3 +1,0 @@
-declare module 'eslint/lib/util/ast-utils' {
-  export function createGlobalLinebreakMatcher(): RegExp;
-}

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -212,7 +212,7 @@ declare module 'eslint/lib/rules/no-redeclare' {
   import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 
   const rule: TSESLint.RuleModule<
-    never,
+    'redeclared' | 'redeclaredAsBuiltin' | 'redeclaredBySyntax',
     [
       {
         builtinGlobals?: boolean;

--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -46,12 +46,8 @@ interface RunTests<
   invalid: InvalidTestCase<TMessageIds, TOptions>[];
 }
 interface RuleTesterConfig {
-  parser?:
-    | '@typescript-eslint/parser'
-    | 'espree'
-    | 'babel-eslint'
-    | 'esprima'
-    | string;
+  // should be require.resolve(parserPackageName)
+  parser: string;
   parserOptions?: ParserOptions;
 }
 declare interface RuleTester {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0"
+    "eslint": "^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "@types/eslint-visitor-keys": "^1.0.0",

--- a/packages/typescript-estree/tests/ast-alignment/utils.ts
+++ b/packages/typescript-estree/tests/ast-alignment/utils.ts
@@ -40,7 +40,7 @@ export function omitDeep(
     }
 
     for (const prop in node) {
-      if (node.hasOwnProperty(prop)) {
+      if (Object.prototype.hasOwnProperty.call(node, prop)) {
         if (shouldOmit(prop, node[prop])) {
           delete node[prop];
           continue;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,7 +1344,7 @@ agentkeepalive@^3.4.1:
   dependencies:
     humanize-ms "^1.2.1"
 
-ajv@^6.5.5, ajv@^6.9.1:
+ajv@^6.10.0, ajv@^6.5.5, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
@@ -2678,13 +2678,13 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@^5.12.1:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
-  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+eslint@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.0.0.tgz#9223f19223de73b4ed730e11bff44a376b65844d"
+  integrity sha512-SrrIfcd4tOgsspOKTSwamuTOAMZOUigHQhVMrzNjz4/B9Za6SHQDIocMIyIDfwDgx6MhS15nS6HC8kumCV2qBQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.9.1"
+    ajv "^6.10.0"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
@@ -2692,18 +2692,19 @@ eslint@^5.12.1:
     eslint-scope "^4.0.3"
     eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^5.0.1"
+    espree "^6.0.0"
     esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
+    glob-parent "^3.1.0"
     globals "^11.7.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     inquirer "^6.2.2"
-    js-yaml "^3.13.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.11"
@@ -2711,7 +2712,6 @@ eslint@^5.12.1:
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.2"
     progress "^2.0.0"
     regexpp "^2.0.1"
     semver "^5.5.1"
@@ -2720,10 +2720,10 @@ eslint@^5.12.1:
     table "^5.2.3"
     text-table "^0.2.0"
 
-espree@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
-  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+espree@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.0.0.tgz#716fc1f5a245ef5b9a7fdb1d7b0d3f02322e75f6"
+  integrity sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==
   dependencies:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"
@@ -7154,6 +7154,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@*:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 "typescript@>=3.2.1 <3.6.0":
   version "3.5.1"


### PR DESCRIPTION
There was some weirdness around now requiring absolute paths for parser in test, but otherwise seemed to "just work"

BREAKING: dropped support for node 6

Fixes #644
Fixes #564