### PR TITLE
fix: Correct `@types/json-schema` dependency

### DIFF
--- a/packages/eslint-plugin-tslint/package.json
+++ b/packages/eslint-plugin-tslint/package.json
@@ -39,7 +39,6 @@
     "tslint": "^5.0.0"
   },
   "devDependencies": {
-    "@types/json-schema": "^7.0.3",
     "@types/lodash.memoize": "^4.1.4",
     "@typescript-eslint/parser": "1.11.0"
   }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -48,6 +48,7 @@
     "tsutils": "^3.7.0"
   },
   "devDependencies": {
+    "@types/json-schema": "^7.0.3",
     "@types/marked": "^0.6.5",
     "chalk": "^2.4.2",
     "marked": "^0.6.2"

--- a/packages/experimental-utils/package.json
+++ b/packages/experimental-utils/package.json
@@ -36,6 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@types/json-schema": "^7.0.3",
     "@typescript-eslint/typescript-estree": "1.11.0",
     "eslint-scope": "^4.0.0"
   },


### PR DESCRIPTION
As per https://github.com/typescript-eslint/typescript-eslint/issues/36#issuecomment-508748273

The dependencies weren't declare correctly.