### PR TITLE
feat(eslint-plugin): [explicit-function-return-type] add handling for usage as arguments

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -138,6 +138,9 @@ let objectPropAs = {
 let objectPropCast = <ObjectType>{
   foo: () => 1,
 };
+
+declare functionWithArg(arg: () => number);
+functionWithArg(() => 1);
 ```
 
 ### allowHigherOrderFunctions

--- a/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
+++ b/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
@@ -188,6 +188,21 @@ export default util.createRule<Options, MessageIds>({
     }
 
     /**
+     * Checks if a node belongs to:
+     * `foo(() => 1)`
+     */
+    function isFunctionArgument(
+      parent: TSESTree.Node,
+      child: TSESTree.Node,
+    ): boolean {
+      return (
+        parent.type === AST_NODE_TYPES.CallExpression &&
+        // make sure this isn't an IIFE
+        parent.callee !== child
+      );
+    }
+
+    /**
      * Checks if a function declaration/expression has a return type.
      */
     function checkFunctionReturnType(
@@ -232,7 +247,8 @@ export default util.createRule<Options, MessageIds>({
             isTypeCast(node.parent) ||
             isVariableDeclaratorWithTypeAnnotation(node.parent) ||
             isClassPropertyWithTypeAnnotation(node.parent) ||
-            isPropertyOfObjectWithType(node.parent)
+            isPropertyOfObjectWithType(node.parent) ||
+            isFunctionArgument(node.parent, node)
           ) {
             return;
           }

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -245,6 +245,42 @@ function FunctionDeclaration() {
             `,
       options: [{ allowHigherOrderFunctions: true }],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/679
+    {
+      filename: 'test.ts',
+      code: `
+declare function foo(arg: () => void): void
+foo(() => 1)
+foo(() => {})
+foo(() => null)
+foo(() => true)
+foo(() => '')
+      `,
+      options: [
+        {
+          allowTypedFunctionExpressions: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+class Accumulator {
+  private count: number = 0;
+
+  public accumulate(fn: () => number): void {
+    this.count += fn();
+  }
+}
+
+new Accumulator().accumulate(() => 1);
+      `,
+      options: [
+        {
+          allowTypedFunctionExpressions: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -547,6 +583,89 @@ function FunctionDeclaration() {
           messageId: 'missingReturnType',
           line: 2,
           column: 22,
+        },
+      ],
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/679
+    {
+      filename: 'test.ts',
+      code: `
+declare function foo(arg: () => void): void
+foo(() => 1)
+foo(() => {})
+foo(() => null)
+foo(() => true)
+foo(() => '')
+      `,
+      options: [
+        {
+          allowTypedFunctionExpressions: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+        },
+        {
+          messageId: 'missingReturnType',
+          line: 4,
+        },
+        {
+          messageId: 'missingReturnType',
+          line: 5,
+        },
+        {
+          messageId: 'missingReturnType',
+          line: 6,
+        },
+        {
+          messageId: 'missingReturnType',
+          line: 7,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+class Accumulator {
+  private count: number = 0;
+
+  public accumulate(fn: () => number): void {
+    this.count += fn();
+  }
+}
+
+new Accumulator().accumulate(() => 1);
+      `,
+      options: [
+        {
+          allowTypedFunctionExpressions: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 10,
+          column: 30,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+(() => true)()
+      `,
+      options: [
+        {
+          allowTypedFunctionExpressions: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          column: 2,
         },
       ],
     },


### PR DESCRIPTION
Fixes #679 

This wasn't ever added to the implementation for some reason.