### PR TITLE
fix(typescript-estree): fix `async` identifier token typed as `Keyword`

### DIFF
--- a/packages/parser/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/parser/tests/lib/__snapshots__/typescript.ts.snap
@@ -18534,6 +18534,614 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/basics/keyword-variables.src 1`] = `
+Object {
+  "$id": 11,
+  "block": Object {
+    "range": Array [
+      0,
+      154,
+    ],
+    "type": "Program",
+  },
+  "childScopes": Array [
+    Object {
+      "$id": 10,
+      "block": Object {
+        "range": Array [
+          0,
+          154,
+        ],
+        "type": "Program",
+      },
+      "childScopes": Array [],
+      "functionExpressionScope": false,
+      "isStrict": true,
+      "references": Array [
+        Object {
+          "$id": 5,
+          "from": Object {
+            "$ref": 10,
+          },
+          "identifier": Object {
+            "name": "get",
+            "range": Array [
+              6,
+              9,
+            ],
+            "type": "Identifier",
+          },
+          "kind": "w",
+          "resolved": Object {
+            "$ref": 0,
+          },
+          "writeExpr": Object {
+            "range": Array [
+              12,
+              13,
+            ],
+            "type": "Literal",
+          },
+        },
+        Object {
+          "$id": 6,
+          "from": Object {
+            "$ref": 10,
+          },
+          "identifier": Object {
+            "name": "set",
+            "range": Array [
+              21,
+              24,
+            ],
+            "type": "Identifier",
+          },
+          "kind": "w",
+          "resolved": Object {
+            "$ref": 1,
+          },
+          "writeExpr": Object {
+            "range": Array [
+              27,
+              28,
+            ],
+            "type": "Literal",
+          },
+        },
+        Object {
+          "$id": 7,
+          "from": Object {
+            "$ref": 10,
+          },
+          "identifier": Object {
+            "name": "module",
+            "range": Array [
+              36,
+              42,
+            ],
+            "type": "Identifier",
+          },
+          "kind": "w",
+          "resolved": Object {
+            "$ref": 2,
+          },
+          "writeExpr": Object {
+            "range": Array [
+              45,
+              46,
+            ],
+            "type": "Literal",
+          },
+        },
+        Object {
+          "$id": 8,
+          "from": Object {
+            "$ref": 10,
+          },
+          "identifier": Object {
+            "name": "type",
+            "range": Array [
+              54,
+              58,
+            ],
+            "type": "Identifier",
+          },
+          "kind": "w",
+          "resolved": Object {
+            "$ref": 3,
+          },
+          "writeExpr": Object {
+            "range": Array [
+              61,
+              62,
+            ],
+            "type": "Literal",
+          },
+        },
+        Object {
+          "$id": 9,
+          "from": Object {
+            "$ref": 10,
+          },
+          "identifier": Object {
+            "name": "async",
+            "range": Array [
+              70,
+              75,
+            ],
+            "type": "Identifier",
+          },
+          "kind": "w",
+          "resolved": Object {
+            "$ref": 4,
+          },
+          "writeExpr": Object {
+            "range": Array [
+              78,
+              79,
+            ],
+            "type": "Literal",
+          },
+        },
+      ],
+      "throughReferences": Array [],
+      "type": "module",
+      "upperScope": Object {
+        "$ref": 11,
+      },
+      "variableMap": Object {
+        "async": Object {
+          "$ref": 4,
+        },
+        "get": Object {
+          "$ref": 0,
+        },
+        "module": Object {
+          "$ref": 2,
+        },
+        "set": Object {
+          "$ref": 1,
+        },
+        "type": Object {
+          "$ref": 3,
+        },
+      },
+      "variableScope": Object {
+        "$ref": 10,
+      },
+      "variables": Array [
+        Object {
+          "$id": 0,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "get",
+                "range": Array [
+                  6,
+                  9,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  6,
+                  13,
+                ],
+                "type": "VariableDeclarator",
+              },
+              "parent": Object {
+                "range": Array [
+                  0,
+                  14,
+                ],
+                "type": "VariableDeclaration",
+              },
+              "type": "Variable",
+            },
+            Object {
+              "name": Object {
+                "name": "get",
+                "range": Array [
+                  93,
+                  96,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  93,
+                  96,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  82,
+                  153,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "get",
+              "range": Array [
+                6,
+                9,
+              ],
+              "type": "Identifier",
+            },
+            Object {
+              "name": "get",
+              "range": Array [
+                93,
+                96,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "get",
+          "references": Array [
+            Object {
+              "$ref": 5,
+            },
+          ],
+          "scope": Object {
+            "$ref": 10,
+          },
+        },
+        Object {
+          "$id": 1,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "set",
+                "range": Array [
+                  21,
+                  24,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  21,
+                  28,
+                ],
+                "type": "VariableDeclarator",
+              },
+              "parent": Object {
+                "range": Array [
+                  15,
+                  29,
+                ],
+                "type": "VariableDeclaration",
+              },
+              "type": "Variable",
+            },
+            Object {
+              "name": Object {
+                "name": "set",
+                "range": Array [
+                  100,
+                  103,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  100,
+                  103,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  82,
+                  153,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "set",
+              "range": Array [
+                21,
+                24,
+              ],
+              "type": "Identifier",
+            },
+            Object {
+              "name": "set",
+              "range": Array [
+                100,
+                103,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "set",
+          "references": Array [
+            Object {
+              "$ref": 6,
+            },
+          ],
+          "scope": Object {
+            "$ref": 10,
+          },
+        },
+        Object {
+          "$id": 2,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "module",
+                "range": Array [
+                  36,
+                  42,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  36,
+                  46,
+                ],
+                "type": "VariableDeclarator",
+              },
+              "parent": Object {
+                "range": Array [
+                  30,
+                  47,
+                ],
+                "type": "VariableDeclaration",
+              },
+              "type": "Variable",
+            },
+            Object {
+              "name": Object {
+                "name": "module",
+                "range": Array [
+                  107,
+                  113,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  107,
+                  113,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  82,
+                  153,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "module",
+              "range": Array [
+                36,
+                42,
+              ],
+              "type": "Identifier",
+            },
+            Object {
+              "name": "module",
+              "range": Array [
+                107,
+                113,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "module",
+          "references": Array [
+            Object {
+              "$ref": 7,
+            },
+          ],
+          "scope": Object {
+            "$ref": 10,
+          },
+        },
+        Object {
+          "$id": 3,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "type",
+                "range": Array [
+                  54,
+                  58,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  54,
+                  62,
+                ],
+                "type": "VariableDeclarator",
+              },
+              "parent": Object {
+                "range": Array [
+                  48,
+                  63,
+                ],
+                "type": "VariableDeclaration",
+              },
+              "type": "Variable",
+            },
+            Object {
+              "name": Object {
+                "name": "type",
+                "range": Array [
+                  117,
+                  121,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  117,
+                  121,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  82,
+                  153,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "type",
+              "range": Array [
+                54,
+                58,
+              ],
+              "type": "Identifier",
+            },
+            Object {
+              "name": "type",
+              "range": Array [
+                117,
+                121,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "type",
+          "references": Array [
+            Object {
+              "$ref": 8,
+            },
+          ],
+          "scope": Object {
+            "$ref": 10,
+          },
+        },
+        Object {
+          "$id": 4,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "async",
+                "range": Array [
+                  70,
+                  75,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  70,
+                  79,
+                ],
+                "type": "VariableDeclarator",
+              },
+              "parent": Object {
+                "range": Array [
+                  64,
+                  80,
+                ],
+                "type": "VariableDeclaration",
+              },
+              "type": "Variable",
+            },
+            Object {
+              "name": Object {
+                "name": "async",
+                "range": Array [
+                  125,
+                  130,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  125,
+                  130,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  82,
+                  153,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "async",
+              "range": Array [
+                70,
+                75,
+              ],
+              "type": "Identifier",
+            },
+            Object {
+              "name": "async",
+              "range": Array [
+                125,
+                130,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "async",
+          "references": Array [
+            Object {
+              "$ref": 9,
+            },
+          ],
+          "scope": Object {
+            "$ref": 10,
+          },
+        },
+      ],
+    },
+  ],
+  "functionExpressionScope": false,
+  "isStrict": false,
+  "references": Array [],
+  "throughReferences": Array [],
+  "type": "global",
+  "upperScope": null,
+  "variableMap": Object {},
+  "variableScope": Object {
+    "$ref": 11,
+  },
+  "variables": Array [],
+}
+`;
+
 exports[`typescript fixtures/basics/nested-type-arguments.src 1`] = `
 Object {
   "$id": 2,

--- a/packages/shared-fixtures/fixtures/typescript/basics/keyword-variables.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/keyword-variables.src.ts
@@ -1,0 +1,13 @@
+const get = 1;
+const set = 1;
+const module = 1;
+const type = 1;
+const async = 1;
+
+import {
+  get,
+  set,
+  module,
+  type,
+  async,
+} from 'fake-module';

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -455,6 +455,7 @@ export function getTokenType(token: any): AST_TOKEN_TYPES {
       case SyntaxKind.SetKeyword:
       case SyntaxKind.TypeKeyword:
       case SyntaxKind.ModuleKeyword:
+      case SyntaxKind.AsyncKeyword:
         return AST_TOKEN_TYPES.Identifier;
 
       default:
@@ -550,17 +551,17 @@ export function convertToken(
   ast: ts.SourceFile,
 ): TSESTree.Token {
   const start =
-      token.kind === SyntaxKind.JsxText
-        ? token.getFullStart()
-        : token.getStart(ast),
-    end = token.getEnd(),
-    value = ast.text.slice(start, end),
-    newToken: TSESTree.Token = {
-      type: getTokenType(token),
-      value,
-      range: [start, end],
-      loc: getLocFor(start, end, ast),
-    };
+    token.kind === SyntaxKind.JsxText
+      ? token.getFullStart()
+      : token.getStart(ast);
+  const end = token.getEnd();
+  const value = ast.text.slice(start, end);
+  const newToken: TSESTree.Token = {
+    type: getTokenType(token),
+    value,
+    range: [start, end],
+    loc: getLocFor(start, end, ast),
+  };
 
   if (newToken.type === 'RegularExpression') {
     newToken.regex = {

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
@@ -1883,6 +1883,8 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" e
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/keyof-operator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/keyword-variables.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/nested-type-arguments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/never-type-param.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;

--- a/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
@@ -58608,6 +58608,1442 @@ Object {
 }
 `;
 
+exports[`typescript fixtures/basics/keyword-variables.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 6,
+                "line": 1,
+              },
+            },
+            "name": "get",
+            "range": Array [
+              6,
+              9,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 13,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 12,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              12,
+              13,
+            ],
+            "raw": "1",
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 13,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            6,
+            13,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "const",
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        14,
+      ],
+      "type": "VariableDeclaration",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 6,
+                "line": 2,
+              },
+            },
+            "name": "set",
+            "range": Array [
+              21,
+              24,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 13,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 12,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              27,
+              28,
+            ],
+            "raw": "1",
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 13,
+              "line": 2,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 2,
+            },
+          },
+          "range": Array [
+            21,
+            28,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "const",
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        15,
+        29,
+      ],
+      "type": "VariableDeclaration",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 12,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 6,
+                "line": 3,
+              },
+            },
+            "name": "module",
+            "range": Array [
+              36,
+              42,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 16,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 15,
+                "line": 3,
+              },
+            },
+            "range": Array [
+              45,
+              46,
+            ],
+            "raw": "1",
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 16,
+              "line": 3,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 3,
+            },
+          },
+          "range": Array [
+            36,
+            46,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "const",
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        30,
+        47,
+      ],
+      "type": "VariableDeclaration",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 10,
+                "line": 4,
+              },
+              "start": Object {
+                "column": 6,
+                "line": 4,
+              },
+            },
+            "name": "type",
+            "range": Array [
+              54,
+              58,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 14,
+                "line": 4,
+              },
+              "start": Object {
+                "column": 13,
+                "line": 4,
+              },
+            },
+            "range": Array [
+              61,
+              62,
+            ],
+            "raw": "1",
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 14,
+              "line": 4,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 4,
+            },
+          },
+          "range": Array [
+            54,
+            62,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "const",
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        48,
+        63,
+      ],
+      "type": "VariableDeclaration",
+    },
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 11,
+                "line": 5,
+              },
+              "start": Object {
+                "column": 6,
+                "line": 5,
+              },
+            },
+            "name": "async",
+            "range": Array [
+              70,
+              75,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 5,
+              },
+              "start": Object {
+                "column": 14,
+                "line": 5,
+              },
+            },
+            "range": Array [
+              78,
+              79,
+            ],
+            "raw": "1",
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 15,
+              "line": 5,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 5,
+            },
+          },
+          "range": Array [
+            70,
+            79,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "const",
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        64,
+        80,
+      ],
+      "type": "VariableDeclaration",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 13,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        82,
+        153,
+      ],
+      "source": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 20,
+            "line": 13,
+          },
+          "start": Object {
+            "column": 7,
+            "line": 13,
+          },
+        },
+        "range": Array [
+          139,
+          152,
+        ],
+        "raw": "'fake-module'",
+        "type": "Literal",
+        "value": "fake-module",
+      },
+      "specifiers": Array [
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 8,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 8,
+              },
+            },
+            "name": "get",
+            "range": Array [
+              93,
+              96,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 5,
+              "line": 8,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 8,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 8,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 8,
+              },
+            },
+            "name": "get",
+            "range": Array [
+              93,
+              96,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            93,
+            96,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 9,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 9,
+              },
+            },
+            "name": "set",
+            "range": Array [
+              100,
+              103,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 5,
+              "line": 9,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 9,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 9,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 9,
+              },
+            },
+            "name": "set",
+            "range": Array [
+              100,
+              103,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            100,
+            103,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 10,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 10,
+              },
+            },
+            "name": "module",
+            "range": Array [
+              107,
+              113,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 8,
+              "line": 10,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 10,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 10,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 10,
+              },
+            },
+            "name": "module",
+            "range": Array [
+              107,
+              113,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            107,
+            113,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 6,
+                "line": 11,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 11,
+              },
+            },
+            "name": "type",
+            "range": Array [
+              117,
+              121,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 6,
+              "line": 11,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 11,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 6,
+                "line": 11,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 11,
+              },
+            },
+            "name": "type",
+            "range": Array [
+              117,
+              121,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            117,
+            121,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 12,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 12,
+              },
+            },
+            "name": "async",
+            "range": Array [
+              125,
+              130,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 7,
+              "line": 12,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 12,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 12,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 12,
+              },
+            },
+            "name": "async",
+            "range": Array [
+              125,
+              130,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            125,
+            130,
+          ],
+          "type": "ImportSpecifier",
+        },
+      ],
+      "type": "ImportDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 14,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    154,
+  ],
+  "sourceType": "module",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        5,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        6,
+        9,
+      ],
+      "type": "Identifier",
+      "value": "get",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        10,
+        11,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        12,
+        13,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        13,
+        14,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        15,
+        20,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        21,
+        24,
+      ],
+      "type": "Identifier",
+      "value": "set",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        25,
+        26,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        27,
+        28,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        28,
+        29,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        30,
+        35,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        36,
+        42,
+      ],
+      "type": "Identifier",
+      "value": "module",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        43,
+        44,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        45,
+        46,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        46,
+        47,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        48,
+        53,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        54,
+        58,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        59,
+        60,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        61,
+        62,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        62,
+        63,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        64,
+        69,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        70,
+        75,
+      ],
+      "type": "Identifier",
+      "value": "async",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        76,
+        77,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        78,
+        79,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        79,
+        80,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        82,
+        88,
+      ],
+      "type": "Keyword",
+      "value": "import",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        89,
+        90,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        93,
+        96,
+      ],
+      "type": "Identifier",
+      "value": "get",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        96,
+        97,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        100,
+        103,
+      ],
+      "type": "Identifier",
+      "value": "set",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        103,
+        104,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        107,
+        113,
+      ],
+      "type": "Identifier",
+      "value": "module",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        113,
+        114,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 11,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 11,
+        },
+      },
+      "range": Array [
+        117,
+        121,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 11,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 11,
+        },
+      },
+      "range": Array [
+        121,
+        122,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        125,
+        130,
+      ],
+      "type": "Identifier",
+      "value": "async",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        130,
+        131,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 13,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 13,
+        },
+      },
+      "range": Array [
+        132,
+        133,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 13,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 13,
+        },
+      },
+      "range": Array [
+        134,
+        138,
+      ],
+      "type": "Identifier",
+      "value": "from",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 13,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 13,
+        },
+      },
+      "range": Array [
+        139,
+        152,
+      ],
+      "type": "String",
+      "value": "'fake-module'",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 13,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 13,
+        },
+      },
+      "range": Array [
+        152,
+        153,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`typescript fixtures/basics/nested-type-arguments.src 1`] = `
 Object {
   "body": Array [


### PR DESCRIPTION
Fixes #678

The `async` keyword wasn't correctly handled in the parser with respect to variable names, so the token it created was typed as `Keyword` instead of `Identifier`