### PR TITLE
fix(eslint-plugin): Replace deprecated rule (no-triple-slash-reference) in recommended

### DIFF
--- a/packages/eslint-plugin/src/configs/recommended.json
+++ b/packages/eslint-plugin/src/configs/recommended.json
@@ -24,7 +24,7 @@
     "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/no-object-literal-type-assertion": "error",
     "@typescript-eslint/no-parameter-properties": "error",
-    "@typescript-eslint/no-triple-slash-reference": "error",
+    "@typescript-eslint/triple-slash-reference": "error",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "warn",
     "no-use-before-define": "off",


### PR DESCRIPTION
In eslint-plugin:recommended, the rule `no-triple-slash-reference` is deprecated.
So I think it should be replaced with `triple-slash-reference`.