### PR TITLE
feat(eslint-plugin): [strict-boolean-expressions] add ignoreRhs option

### DIFF
--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
@@ -52,6 +52,12 @@ while (typeof str !== 'undefined') {
 }
 ```
 
+## Options
+
+Options may be provided as an object with:
+
+- `ignoreRhs` to skip the check on the right hand side of expressions like `a && b` or `a || b` - allows these operators to be used for their short-circuiting behavior. (`false` by default).
+
 ## Related To
 
 - TSLint: [strict-boolean-expressions](https://palantir.github.io/tslint/rules/strict-boolean-expressions)

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -13,7 +13,13 @@ type ExpressionWithTest =
   | TSESTree.IfStatement
   | TSESTree.WhileStatement;
 
-export default util.createRule({
+type Options = [
+  {
+    ignoreRhs?: boolean;
+  }
+];
+
+export default util.createRule<Options, 'strictBooleanExpression'>({
   name: 'strict-boolean-expressions',
   meta: {
     type: 'suggestion',
@@ -22,13 +28,27 @@ export default util.createRule({
       category: 'Best Practices',
       recommended: false,
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignoreRhs: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     messages: {
       strictBooleanExpression: 'Unexpected non-boolean in conditional.',
     },
   },
-  defaultOptions: [],
-  create(context) {
+  defaultOptions: [
+    {
+      ignoreRhs: false,
+    },
+  ],
+  create(context, [{ ignoreRhs }]) {
     const service = util.getParserServices(context);
     const checker = service.program.getTypeChecker();
 
@@ -65,7 +85,10 @@ export default util.createRule({
     function assertLocalExpressionContainsBoolean(
       node: TSESTree.LogicalExpression,
     ): void {
-      if (!isBooleanType(node.left) || !isBooleanType(node.right)) {
+      if (
+        !isBooleanType(node.left) ||
+        (!ignoreRhs && !isBooleanType(node.right))
+      ) {
         reportNode(node);
       }
     }

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -156,6 +156,15 @@ ruleTester.run('strict-boolean-expressions', rule, {
     `
       function foo<T extends boolean>(arg: T) { return !arg; }
     `,
+    {
+      options: [{ ignoreRhs: true }],
+      code: `
+const obj = {};
+const bool = false;
+const boolOrObj = bool || obj;
+const boolAndObj = bool && obj;
+`,
+    },
   ],
 
   invalid: [
@@ -902,6 +911,27 @@ ruleTester.run('strict-boolean-expressions', rule, {
           column: 58,
         },
       ],
+    },
+    {
+      options: [{ ignoreRhs: true }],
+      errors: [
+        {
+          messageId: 'strictBooleanExpression',
+          line: 4,
+          column: 19,
+        },
+        {
+          messageId: 'strictBooleanExpression',
+          line: 5,
+          column: 20,
+        },
+      ],
+      code: `
+const obj = {};
+const bool = false;
+const objOrBool = obj || bool;
+const objAndBool = obj && bool;
+`,
     },
   ],
 });


### PR DESCRIPTION
Adds an ignoreRhs option, to match the equivalent option in the tslint version of this rule.

This is a particularly good option to have for react code where [stuff like this is idiomatic](https://reactjs.org/docs/conditional-rendering.html#inline-if-with-logical--operator):

```tsx
function MyComponent() {
    const shouldRenderFoo: boolean = /*...*/;
    return (<div>
          {shouldRenderFoo && <span>Foo</span>}
          <span>Bar</span>
    </div>);
}
```

Fixes #691