### PR TITLE
fix(typescript-estree): jsx comment parsing

### DIFF
--- a/packages/parser/tests/lib/__snapshots__/comments.ts.snap
+++ b/packages/parser/tests/lib/__snapshots__/comments.ts.snap
@@ -7282,6 +7282,796 @@ Object {
 }
 `;
 
+exports[`Comments fixtures/jsx-tag-comment-after-prop.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 10,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 6,
+                "line": 1,
+              },
+            },
+            "name": "pure",
+            "range": Array [
+              6,
+              10,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "async": false,
+            "body": Object {
+              "body": Array [
+                Object {
+                  "argument": Object {
+                    "children": Array [],
+                    "closingElement": null,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 8,
+                        "line": 8,
+                      },
+                      "start": Object {
+                        "column": 6,
+                        "line": 3,
+                      },
+                    },
+                    "openingElement": Object {
+                      "attributes": Array [
+                        Object {
+                          "loc": Object {
+                            "end": Object {
+                              "column": 17,
+                              "line": 5,
+                            },
+                            "start": Object {
+                              "column": 8,
+                              "line": 5,
+                            },
+                          },
+                          "name": Object {
+                            "loc": Object {
+                              "end": Object {
+                                "column": 11,
+                                "line": 5,
+                              },
+                              "start": Object {
+                                "column": 8,
+                                "line": 5,
+                              },
+                            },
+                            "name": "foo",
+                            "range": Array [
+                              66,
+                              69,
+                            ],
+                            "type": "JSXIdentifier",
+                          },
+                          "range": Array [
+                            66,
+                            75,
+                          ],
+                          "type": "JSXAttribute",
+                          "value": Object {
+                            "expression": Object {
+                              "loc": Object {
+                                "end": Object {
+                                  "column": 16,
+                                  "line": 5,
+                                },
+                                "start": Object {
+                                  "column": 13,
+                                  "line": 5,
+                                },
+                              },
+                              "range": Array [
+                                71,
+                                74,
+                              ],
+                              "raw": "123",
+                              "type": "Literal",
+                              "value": 123,
+                            },
+                            "loc": Object {
+                              "end": Object {
+                                "column": 17,
+                                "line": 5,
+                              },
+                              "start": Object {
+                                "column": 12,
+                                "line": 5,
+                              },
+                            },
+                            "range": Array [
+                              70,
+                              75,
+                            ],
+                            "type": "JSXExpressionContainer",
+                          },
+                        },
+                        Object {
+                          "loc": Object {
+                            "end": Object {
+                              "column": 18,
+                              "line": 7,
+                            },
+                            "start": Object {
+                              "column": 8,
+                              "line": 7,
+                            },
+                          },
+                          "name": Object {
+                            "loc": Object {
+                              "end": Object {
+                                "column": 11,
+                                "line": 7,
+                              },
+                              "start": Object {
+                                "column": 8,
+                                "line": 7,
+                              },
+                            },
+                            "name": "bar",
+                            "range": Array [
+                              99,
+                              102,
+                            ],
+                            "type": "JSXIdentifier",
+                          },
+                          "range": Array [
+                            99,
+                            109,
+                          ],
+                          "type": "JSXAttribute",
+                          "value": Object {
+                            "loc": Object {
+                              "end": Object {
+                                "column": 18,
+                                "line": 7,
+                              },
+                              "start": Object {
+                                "column": 12,
+                                "line": 7,
+                              },
+                            },
+                            "range": Array [
+                              103,
+                              109,
+                            ],
+                            "raw": "\\"woof\\"",
+                            "type": "Literal",
+                            "value": "woof",
+                          },
+                        },
+                      ],
+                      "loc": Object {
+                        "end": Object {
+                          "column": 8,
+                          "line": 8,
+                        },
+                        "start": Object {
+                          "column": 6,
+                          "line": 3,
+                        },
+                      },
+                      "name": Object {
+                        "loc": Object {
+                          "end": Object {
+                            "column": 10,
+                            "line": 3,
+                          },
+                          "start": Object {
+                            "column": 7,
+                            "line": 3,
+                          },
+                        },
+                        "name": "Foo",
+                        "range": Array [
+                          39,
+                          42,
+                        ],
+                        "type": "JSXIdentifier",
+                      },
+                      "range": Array [
+                        38,
+                        118,
+                      ],
+                      "selfClosing": true,
+                      "type": "JSXOpeningElement",
+                    },
+                    "range": Array [
+                      38,
+                      118,
+                    ],
+                    "type": "JSXElement",
+                  },
+                  "loc": Object {
+                    "end": Object {
+                      "column": 4,
+                      "line": 9,
+                    },
+                    "start": Object {
+                      "column": 2,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    23,
+                    123,
+                  ],
+                  "type": "ReturnStatement",
+                },
+              ],
+              "loc": Object {
+                "end": Object {
+                  "column": 1,
+                  "line": 10,
+                },
+                "start": Object {
+                  "column": 19,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                19,
+                125,
+              ],
+              "type": "BlockStatement",
+            },
+            "expression": false,
+            "generator": false,
+            "id": null,
+            "loc": Object {
+              "end": Object {
+                "column": 1,
+                "line": 10,
+              },
+              "start": Object {
+                "column": 13,
+                "line": 1,
+              },
+            },
+            "params": Array [],
+            "range": Array [
+              13,
+              125,
+            ],
+            "type": "ArrowFunctionExpression",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 1,
+              "line": 10,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            6,
+            125,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "const",
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        125,
+      ],
+      "type": "VariableDeclaration",
+    },
+  ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        51,
+        57,
+      ],
+      "type": "Line",
+      "value": " one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        84,
+        90,
+      ],
+      "type": "Line",
+      "value": " two",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 12,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    127,
+  ],
+  "sourceType": "module",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        5,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        6,
+        10,
+      ],
+      "type": "Identifier",
+      "value": "pure",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        11,
+        12,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        13,
+        14,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        14,
+        15,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        16,
+        18,
+      ],
+      "type": "Punctuator",
+      "value": "=>",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        19,
+        20,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        23,
+        29,
+      ],
+      "type": "Keyword",
+      "value": "return",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        30,
+        31,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        38,
+        39,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        39,
+        42,
+      ],
+      "type": "JSXIdentifier",
+      "value": "Foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        66,
+        69,
+      ],
+      "type": "JSXIdentifier",
+      "value": "foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        69,
+        70,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        70,
+        71,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        71,
+        74,
+      ],
+      "type": "Numeric",
+      "value": "123",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        74,
+        75,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        99,
+        102,
+      ],
+      "type": "JSXIdentifier",
+      "value": "bar",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        102,
+        103,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        103,
+        109,
+      ],
+      "type": "JSXText",
+      "value": "\\"woof\\"",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        116,
+        117,
+      ],
+      "type": "Punctuator",
+      "value": "/",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        117,
+        118,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        121,
+        122,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        122,
+        123,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        124,
+        125,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`Comments fixtures/jsx-tag-comments.src 1`] = `
 Object {
   "body": Array [

--- a/packages/shared-fixtures/fixtures/comments/jsx-tag-comment-after-prop.src.js
+++ b/packages/shared-fixtures/fixtures/comments/jsx-tag-comment-after-prop.src.js
@@ -1,0 +1,11 @@
+const pure = () => {
+  return (
+      <Foo
+        // one
+        foo={123}
+        // two
+        bar="woof"
+      />
+  );
+}
+

--- a/packages/typescript-estree/src/convert-comments.ts
+++ b/packages/typescript-estree/src/convert-comments.ts
@@ -147,7 +147,9 @@ export function convertComments(
         // Rescan after a JSX expression
         if (
           container.parent &&
-          container.parent.kind === ts.SyntaxKind.JsxExpression
+          container.parent.kind === ts.SyntaxKind.JsxExpression &&
+          container.parent.parent &&
+          container.parent.parent.kind === ts.SyntaxKind.JsxElement
         ) {
           kind = triviaScanner.reScanJsxToken();
           continue;

--- a/packages/typescript-estree/tests/lib/__snapshots__/comments.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/comments.ts.snap
@@ -7282,6 +7282,796 @@ Object {
 }
 `;
 
+exports[`Comments fixtures/jsx-tag-comment-after-prop.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 10,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 6,
+                "line": 1,
+              },
+            },
+            "name": "pure",
+            "range": Array [
+              6,
+              10,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "async": false,
+            "body": Object {
+              "body": Array [
+                Object {
+                  "argument": Object {
+                    "children": Array [],
+                    "closingElement": null,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 8,
+                        "line": 8,
+                      },
+                      "start": Object {
+                        "column": 6,
+                        "line": 3,
+                      },
+                    },
+                    "openingElement": Object {
+                      "attributes": Array [
+                        Object {
+                          "loc": Object {
+                            "end": Object {
+                              "column": 17,
+                              "line": 5,
+                            },
+                            "start": Object {
+                              "column": 8,
+                              "line": 5,
+                            },
+                          },
+                          "name": Object {
+                            "loc": Object {
+                              "end": Object {
+                                "column": 11,
+                                "line": 5,
+                              },
+                              "start": Object {
+                                "column": 8,
+                                "line": 5,
+                              },
+                            },
+                            "name": "foo",
+                            "range": Array [
+                              66,
+                              69,
+                            ],
+                            "type": "JSXIdentifier",
+                          },
+                          "range": Array [
+                            66,
+                            75,
+                          ],
+                          "type": "JSXAttribute",
+                          "value": Object {
+                            "expression": Object {
+                              "loc": Object {
+                                "end": Object {
+                                  "column": 16,
+                                  "line": 5,
+                                },
+                                "start": Object {
+                                  "column": 13,
+                                  "line": 5,
+                                },
+                              },
+                              "range": Array [
+                                71,
+                                74,
+                              ],
+                              "raw": "123",
+                              "type": "Literal",
+                              "value": 123,
+                            },
+                            "loc": Object {
+                              "end": Object {
+                                "column": 17,
+                                "line": 5,
+                              },
+                              "start": Object {
+                                "column": 12,
+                                "line": 5,
+                              },
+                            },
+                            "range": Array [
+                              70,
+                              75,
+                            ],
+                            "type": "JSXExpressionContainer",
+                          },
+                        },
+                        Object {
+                          "loc": Object {
+                            "end": Object {
+                              "column": 18,
+                              "line": 7,
+                            },
+                            "start": Object {
+                              "column": 8,
+                              "line": 7,
+                            },
+                          },
+                          "name": Object {
+                            "loc": Object {
+                              "end": Object {
+                                "column": 11,
+                                "line": 7,
+                              },
+                              "start": Object {
+                                "column": 8,
+                                "line": 7,
+                              },
+                            },
+                            "name": "bar",
+                            "range": Array [
+                              99,
+                              102,
+                            ],
+                            "type": "JSXIdentifier",
+                          },
+                          "range": Array [
+                            99,
+                            109,
+                          ],
+                          "type": "JSXAttribute",
+                          "value": Object {
+                            "loc": Object {
+                              "end": Object {
+                                "column": 18,
+                                "line": 7,
+                              },
+                              "start": Object {
+                                "column": 12,
+                                "line": 7,
+                              },
+                            },
+                            "range": Array [
+                              103,
+                              109,
+                            ],
+                            "raw": "\\"woof\\"",
+                            "type": "Literal",
+                            "value": "woof",
+                          },
+                        },
+                      ],
+                      "loc": Object {
+                        "end": Object {
+                          "column": 8,
+                          "line": 8,
+                        },
+                        "start": Object {
+                          "column": 6,
+                          "line": 3,
+                        },
+                      },
+                      "name": Object {
+                        "loc": Object {
+                          "end": Object {
+                            "column": 10,
+                            "line": 3,
+                          },
+                          "start": Object {
+                            "column": 7,
+                            "line": 3,
+                          },
+                        },
+                        "name": "Foo",
+                        "range": Array [
+                          39,
+                          42,
+                        ],
+                        "type": "JSXIdentifier",
+                      },
+                      "range": Array [
+                        38,
+                        118,
+                      ],
+                      "selfClosing": true,
+                      "type": "JSXOpeningElement",
+                    },
+                    "range": Array [
+                      38,
+                      118,
+                    ],
+                    "type": "JSXElement",
+                  },
+                  "loc": Object {
+                    "end": Object {
+                      "column": 4,
+                      "line": 9,
+                    },
+                    "start": Object {
+                      "column": 2,
+                      "line": 2,
+                    },
+                  },
+                  "range": Array [
+                    23,
+                    123,
+                  ],
+                  "type": "ReturnStatement",
+                },
+              ],
+              "loc": Object {
+                "end": Object {
+                  "column": 1,
+                  "line": 10,
+                },
+                "start": Object {
+                  "column": 19,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                19,
+                125,
+              ],
+              "type": "BlockStatement",
+            },
+            "expression": false,
+            "generator": false,
+            "id": null,
+            "loc": Object {
+              "end": Object {
+                "column": 1,
+                "line": 10,
+              },
+              "start": Object {
+                "column": 13,
+                "line": 1,
+              },
+            },
+            "params": Array [],
+            "range": Array [
+              13,
+              125,
+            ],
+            "type": "ArrowFunctionExpression",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 1,
+              "line": 10,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            6,
+            125,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "const",
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        125,
+      ],
+      "type": "VariableDeclaration",
+    },
+  ],
+  "comments": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        51,
+        57,
+      ],
+      "type": "Line",
+      "value": " one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        84,
+        90,
+      ],
+      "type": "Line",
+      "value": " two",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 12,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    127,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        5,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        6,
+        10,
+      ],
+      "type": "Identifier",
+      "value": "pure",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        11,
+        12,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        13,
+        14,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        14,
+        15,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        16,
+        18,
+      ],
+      "type": "Punctuator",
+      "value": "=>",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        19,
+        20,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        23,
+        29,
+      ],
+      "type": "Keyword",
+      "value": "return",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        30,
+        31,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        38,
+        39,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        39,
+        42,
+      ],
+      "type": "JSXIdentifier",
+      "value": "Foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        66,
+        69,
+      ],
+      "type": "JSXIdentifier",
+      "value": "foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        69,
+        70,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        70,
+        71,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        71,
+        74,
+      ],
+      "type": "Numeric",
+      "value": "123",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        74,
+        75,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        99,
+        102,
+      ],
+      "type": "JSXIdentifier",
+      "value": "bar",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        102,
+        103,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        103,
+        109,
+      ],
+      "type": "JSXText",
+      "value": "\\"woof\\"",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        116,
+        117,
+      ],
+      "type": "Punctuator",
+      "value": "/",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        117,
+        118,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        121,
+        122,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        122,
+        123,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        124,
+        125,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`Comments fixtures/jsx-tag-comments.src 1`] = `
 Object {
   "body": Array [

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
@@ -18,6 +18,8 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" e
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-generic-with-comment-in-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-tag-comment-after-prop.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-tag-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-text-with-multiline-non-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;


### PR DESCRIPTION
Fixes #643
Fixes #648
Fixes #703

The problem is that with the fix performed in https://github.com/typescript-eslint/typescript-eslint/pull/607, when you have something like this:

```
const pure = () => {
  return (
      <Foo
        // one
        foo={123}
        // two
        bar="woof"
      />
  );
}
```

We currently perform `reScanJsxToken()` on the closing brace for the `foo` attribute value.

This results in a `SyntaxKind.JsxText` token like this:
```
"}\n        // two\n        bar="woof"\n      />\n  );\n}\n"
```

So the `// two` never gets correctly identified. If we hadn't performed the `reScanJsxToken()` on the `}` closing brace for the JSX expression, the `// two` would have been tokenized correctly.

I have fixed this by changing the rescan call added in the PR referenced earlier to only apply if the JSX expression is inside a JSX element (which addresses the case it was added to fix to begin with).

Honestly, this feels like a bit of a band-aid solution. Admittedly, I don't have a lot of experience with the typescript scanner but I feel as though this is the best solution without reworking the method a bit. Looking at some of the tokens we end up with after rescanning sometimes, there seems to be some sacrifices made in order to keep this as simple as possible and just locate the comments (which is a totally fair and valid design decision).

I feel like a better way to make these rescan decisions would be to move forward to the next meaningful token before making the decision to rescan. Like, if we move forward past the `}` in this example:

```
const fifth = <div>{}http://example.com</div>;
```

And then look at the AST for the next token (`http` which ends up as `SyntaxKind.Identifier` without rescanning), the AST will tell us that we're on a JSXText node. So if we know the proceeding token was a closing brace for a JSXExpression, we can check the AST to see if we're on a JSXText node before making the decision to rescan. Even if the next token is a whitespace or a new line, the AST we have will already know that's a JSXText node.

I think this is a better approach than basing it on the type of parent for the JSXExpression (the change I made to fix the issue in this PR), since the issue is that we don't want the jsx text nodes to get tokenized incorrectly (which is what resulted in the text after `http:` getting incorrectly picked up as a comment). We could also probably benefit from this approach for the `>` token logic too.

If you want, I can update this PR and use the technique described above instead of the current fix I have applied.

Anyways, I have no experience working with the TS scanner output so I could be way off in my conclusions here, but the fact that we end up with tokens identified as `JsxText` that look like `}http://example.com` (notice the `}` included) also indicates that we're a little off in the approach here (although one can argue that for the sake of extracting the comments it's irrelevant).

