### PR TITLE
fix(utils): move `typescript` from peer dep to dev dep

### DIFF
--- a/packages/experimental-utils/package.json
+++ b/packages/experimental-utils/package.json
@@ -41,7 +41,9 @@
     "eslint-scope": "^4.0.0"
   },
   "peerDependencies": {
-    "eslint": "*",
+    "eslint": "*"
+  },
+  "devDependencies": {
     "typescript": "*"
   }
 }


### PR DESCRIPTION
Done in https://github.com/typescript-eslint/typescript-eslint/pull/535/files#diff-5c11193544492a7547f43d5531701d83 so hopefully fine on its own as well 🙂 

This makes sure we don't get a peer dep warning if an eslint plugin depends on the utils to author the rules but do not need TS when running