### PR TITLE
fix(utils): RuleTester should not require a parser

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -46,7 +46,12 @@ interface RunTests<
   invalid: InvalidTestCase<TMessageIds, TOptions>[];
 }
 interface RuleTesterConfig {
-  parser: '@typescript-eslint/parser';
+  parser?:
+    | '@typescript-eslint/parser'
+    | 'espree'
+    | 'babel-eslint'
+    | 'esprima'
+    | string;
   parserOptions?: ParserOptions;
 }
 declare interface RuleTester {


### PR DESCRIPTION
As briefly discussed in #425.

Background is that I want to use these utils for authoring eslint rules, but I want the tests to run using the default parser as the rules do not need type info