### PR TITLE
docs(eslint-plugin): mention member-delimiter-style in semi

### DIFF
--- a/packages/eslint-plugin/docs/rules/semi.md
+++ b/packages/eslint-plugin/docs/rules/semi.md
@@ -1,12 +1,15 @@
 # require or disallow semicolons instead of ASI (semi)
 
-This rule enforces consistent use of semicolons.
+This rule enforces consistent use of semicolons after statements.
 
 ## Rule Details
 
 This rule extends the base [eslint/semi](https://eslint.org/docs/rules/semi) rule.
 It supports all options and features of the base rule.
 This version adds support for numerous typescript features.
+
+See also the [@typescript-eslint/member-delimiter-style](member-delimiter-style.md) rule,
+which by default requires members to be delimited by semicolons.
 
 ## How to use
 

--- a/packages/eslint-plugin/docs/rules/semi.md
+++ b/packages/eslint-plugin/docs/rules/semi.md
@@ -9,7 +9,7 @@ It supports all options and features of the base rule.
 This version adds support for numerous typescript features.
 
 See also the [@typescript-eslint/member-delimiter-style](member-delimiter-style.md) rule,
-which by default requires members to be delimited by semicolons.
+which allows you to specify the delimiter for `type` and `interface` members.
 
 ## How to use
 


### PR DESCRIPTION
Both are related to semicolons, so let’s help looking for member-delimiter-style by linking it here.

---

Follow-up for #714, where I misunderstood what the semi rule is for.