### PR TITLE
docs: fix typo in no-misused-promises related links

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-misused-promises.md
+++ b/packages/eslint-plugin/docs/rules/no-misused-promises.md
@@ -112,7 +112,7 @@ misuses of them outside of what the Typescript compiler will check.
 
 ## Related to
 
-- [`no-floating-promises`]('./no-floating-promises.md')
+- [`no-floating-promises`](./no-floating-promises.md)
 
 ## Further Reading
 


### PR DESCRIPTION
the link was quoted, which does not work