### PR TITLE
fix(eslint-plugin): [no-var-requires] error if parent is CallExpression

### DIFF
--- a/packages/eslint-plugin/src/rules/no-var-requires.ts
+++ b/packages/eslint-plugin/src/rules/no-var-requires.ts
@@ -27,7 +27,8 @@ export default util.createRule<Options, MessageIds>({
           node.callee.type === AST_NODE_TYPES.Identifier &&
           node.callee.name === 'require' &&
           node.parent &&
-          node.parent.type === AST_NODE_TYPES.VariableDeclarator
+          (node.parent.type === AST_NODE_TYPES.VariableDeclarator ||
+            node.parent.type === AST_NODE_TYPES.CallExpression)
         ) {
           context.report({
             node,

--- a/packages/eslint-plugin/tests/rules/no-var-requires.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-var-requires.test.ts
@@ -38,5 +38,15 @@ ruleTester.run('no-var-requires', rule, {
         },
       ],
     },
+    {
+      code: "let foo = trick(require('foo'))",
+      errors: [
+        {
+          messageId: 'noVarReqs',
+          line: 1,
+          column: 17,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Throwing error if the parent is CallExpression in no-var-requires plugin

Closes: #665