### PR TITLE
feat(eslint-plugin)!: [promise-function-async] make allowAny default true

### DIFF
--- a/packages/eslint-plugin/docs/rules/promise-function-async.md
+++ b/packages/eslint-plugin/docs/rules/promise-function-async.md
@@ -36,7 +36,7 @@ async function functionDeturnsPromise() {
 
 Options may be provided as an object with:
 
-- `allowAny` to indicate that `any` or `unknown` shouldn't be considered Promises (`false` by default).
+- `allowAny` to indicate that `any` or `unknown` shouldn't be considered Promises (`true` by default).
 - `allowedPromiseNames` to indicate any extra names of classes or interfaces to be considered Promises when returned.
 
 In addition, each of the following properties may be provided, and default to `true`:
@@ -51,7 +51,6 @@ In addition, each of the following properties may be provided, and default to `t
   "@typescript-eslint/promise-function-async": [
     "error",
     {
-      "allowAny": true,
       "allowedPromiseNames": ["Thenable"],
       "checkArrowFunctions": true,
       "checkFunctionDeclarations": true,

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -58,7 +58,7 @@ export default util.createRule<Options, MessageIds>({
   },
   defaultOptions: [
     {
-      allowAny: false,
+      allowAny: true,
       allowedPromiseNames: [],
       checkArrowFunctions: true,
       checkFunctionDeclarations: true,

--- a/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
+++ b/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
@@ -102,6 +102,11 @@ function returnsAny(): any {
   return 0;
 }
       `,
+      options: [
+        {
+          allowAny: false,
+        },
+      ],
       errors: [
         {
           messageId,
@@ -114,6 +119,11 @@ function returnsUnknown(): unknown {
   return 0;
 }
       `,
+      options: [
+        {
+          allowAny: false,
+        },
+      ],
       errors: [
         {
           messageId,


### PR DESCRIPTION
BREAKING CHANGE: changing default rule config

Having functions that return `any` be considered async is weird. I left the option in just in case someone wants this functinoality.
https://github.com/typescript-eslint/typescript-eslint/issues/501#issuecomment-498160270