### PR TITLE
chore: add check for dirty workspace post-install

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "lint-fix": "eslint . --ext .js,.ts --fix",
     "pre-commit": "yarn lint-staged",
     "pre-push": "yarn format-check",
-    "postinstall": "lerna bootstrap && yarn build && lerna link",
+    "postinstall": "lerna bootstrap && yarn build && lerna link && npm run check-clean-workspace-after-install",
+    "check-clean-workspace-after-install": "git diff --quiet --exit-code",
     "test": "lerna run test --parallel",
     "typecheck": "lerna run typecheck"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7155,6 +7155,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@*:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+
 "typescript@>=3.2.1 <3.6.0":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"


### PR DESCRIPTION
It turns out installing with `yarn --frozen-lockfile` is not enough to catch all lockfile mutations because some of them can occur in child packages via lerna bootstrap.

This happened in https://github.com/typescript-eslint/typescript-eslint/pull/712 and it therefore broke master when it got merged because it breaks the release process (both canary and latest).

Added a git diff based validation to ensure CI fails if lock file updates are missed in future.

**This initial commit should fail**, will add the fix once we have verified it does.