### PR TITLE
chore: disable automated canary during 2.x prerelease

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,28 +77,28 @@ jobs:
           yarn test
         displayName: 'Run unit tests'
 
-  - job: publish_canary_version
-    displayName: Publish the latest code as a canary version
-    dependsOn:
-    - primary_code_validation_and_tests
-    - unit_tests_on_other_node_versions
-    condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'), ne(variables['Build.Reason'], 'PullRequest'))
-    pool:
-      vmImage: 'Ubuntu-16.04'
-    steps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: 11
-        displayName: 'Install Node.js 11'
+  # - job: publish_canary_version
+  #   displayName: Publish the latest code as a canary version
+  #   dependsOn:
+  #   - primary_code_validation_and_tests
+  #   - unit_tests_on_other_node_versions
+  #   condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'), ne(variables['Build.Reason'], 'PullRequest'))
+  #   pool:
+  #     vmImage: 'Ubuntu-16.04'
+  #   steps:
+  #     - task: NodeTool@0
+  #       inputs:
+  #         versionSpec: 11
+  #       displayName: 'Install Node.js 11'
 
-      - script: |
-          # This also runs a build as part of the postinstall
-          # bootstrap
-          yarn --ignore-engines --frozen-lockfile
+  #     - script: |
+  #         # This also runs a build as part of the postinstall
+  #         # bootstrap
+  #         yarn --ignore-engines --frozen-lockfile
 
-      - script: |
-          npm config set //registry.npmjs.org/:_authToken=$(NPM_TOKEN)
+  #     - script: |
+  #         npm config set //registry.npmjs.org/:_authToken=$(NPM_TOKEN)
 
-      - script: |
-          npx lerna publish --canary --exact --force-publish --yes
-        displayName: 'Publish all packages to npm'
+  #     - script: |
+  #         npx lerna publish --canary --exact --force-publish --yes
+  #       displayName: 'Publish all packages to npm'


### PR DESCRIPTION
The automated canary is not picking up on the 2.x and so is publishing 1.x versions on merge to master. Disabling for now until 2.x hits stable