### PR TITLE
fix(utils): add ES2019 as valid `ecmaVersion`

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/ParserOptions.ts
+++ b/packages/experimental-utils/src/ts-eslint/ParserOptions.ts
@@ -4,7 +4,7 @@ export interface ParserOptions {
   range?: boolean;
   tokens?: boolean;
   sourceType?: 'script' | 'module';
-  ecmaVersion?: 3 | 5 | 6 | 7 | 8 | 9 | 2015 | 2016 | 2017 | 2018;
+  ecmaVersion?: 3 | 5 | 6 | 7 | 8 | 9 | 10 | 2015 | 2016 | 2017 | 2018 | 2019;
   ecmaFeatures?: {
     globalReturn?: boolean;
     jsx?: boolean;


### PR DESCRIPTION
See https://eslint.org/docs/user-guide/configuring#specifying-parser-options