### PR TITLE
fix(typescript-estree): fix `is` identifier token typed as `Keyword`

### DIFF
--- a/packages/parser/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/parser/tests/lib/__snapshots__/typescript.ts.snap
@@ -18536,21 +18536,21 @@ Object {
 
 exports[`typescript fixtures/basics/keyword-variables.src 1`] = `
 Object {
-  "$id": 11,
+  "$id": 13,
   "block": Object {
     "range": Array [
       0,
-      154,
+      174,
     ],
     "type": "Program",
   },
   "childScopes": Array [
     Object {
-      "$id": 10,
+      "$id": 12,
       "block": Object {
         "range": Array [
           0,
-          154,
+          174,
         ],
         "type": "Program",
       },
@@ -18559,9 +18559,9 @@ Object {
       "isStrict": true,
       "references": Array [
         Object {
-          "$id": 5,
+          "$id": 6,
           "from": Object {
-            "$ref": 10,
+            "$ref": 12,
           },
           "identifier": Object {
             "name": "get",
@@ -18584,9 +18584,9 @@ Object {
           },
         },
         Object {
-          "$id": 6,
+          "$id": 7,
           "from": Object {
-            "$ref": 10,
+            "$ref": 12,
           },
           "identifier": Object {
             "name": "set",
@@ -18609,9 +18609,9 @@ Object {
           },
         },
         Object {
-          "$id": 7,
+          "$id": 8,
           "from": Object {
-            "$ref": 10,
+            "$ref": 12,
           },
           "identifier": Object {
             "name": "module",
@@ -18634,9 +18634,9 @@ Object {
           },
         },
         Object {
-          "$id": 8,
+          "$id": 9,
           "from": Object {
-            "$ref": 10,
+            "$ref": 12,
           },
           "identifier": Object {
             "name": "type",
@@ -18659,9 +18659,9 @@ Object {
           },
         },
         Object {
-          "$id": 9,
+          "$id": 10,
           "from": Object {
-            "$ref": 10,
+            "$ref": 12,
           },
           "identifier": Object {
             "name": "async",
@@ -18683,11 +18683,36 @@ Object {
             "type": "Literal",
           },
         },
+        Object {
+          "$id": 11,
+          "from": Object {
+            "$ref": 12,
+          },
+          "identifier": Object {
+            "name": "is",
+            "range": Array [
+              87,
+              89,
+            ],
+            "type": "Identifier",
+          },
+          "kind": "w",
+          "resolved": Object {
+            "$ref": 5,
+          },
+          "writeExpr": Object {
+            "range": Array [
+              92,
+              93,
+            ],
+            "type": "Literal",
+          },
+        },
       ],
       "throughReferences": Array [],
       "type": "module",
       "upperScope": Object {
-        "$ref": 11,
+        "$ref": 13,
       },
       "variableMap": Object {
         "async": Object {
@@ -18695,6 +18720,9 @@ Object {
         },
         "get": Object {
           "$ref": 0,
+        },
+        "is": Object {
+          "$ref": 5,
         },
         "module": Object {
           "$ref": 2,
@@ -18707,7 +18735,7 @@ Object {
         },
       },
       "variableScope": Object {
-        "$ref": 10,
+        "$ref": 12,
       },
       "variables": Array [
         Object {
@@ -18742,22 +18770,22 @@ Object {
               "name": Object {
                 "name": "get",
                 "range": Array [
-                  93,
-                  96,
+                  107,
+                  110,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  93,
-                  96,
+                  107,
+                  110,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  82,
-                  153,
+                  96,
+                  173,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -18777,8 +18805,8 @@ Object {
             Object {
               "name": "get",
               "range": Array [
-                93,
-                96,
+                107,
+                110,
               ],
               "type": "Identifier",
             },
@@ -18786,11 +18814,11 @@ Object {
           "name": "get",
           "references": Array [
             Object {
-              "$ref": 5,
+              "$ref": 6,
             },
           ],
           "scope": Object {
-            "$ref": 10,
+            "$ref": 12,
           },
         },
         Object {
@@ -18825,22 +18853,22 @@ Object {
               "name": Object {
                 "name": "set",
                 "range": Array [
-                  100,
-                  103,
+                  114,
+                  117,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  100,
-                  103,
+                  114,
+                  117,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  82,
-                  153,
+                  96,
+                  173,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -18860,8 +18888,8 @@ Object {
             Object {
               "name": "set",
               "range": Array [
-                100,
-                103,
+                114,
+                117,
               ],
               "type": "Identifier",
             },
@@ -18869,11 +18897,11 @@ Object {
           "name": "set",
           "references": Array [
             Object {
-              "$ref": 6,
+              "$ref": 7,
             },
           ],
           "scope": Object {
-            "$ref": 10,
+            "$ref": 12,
           },
         },
         Object {
@@ -18908,22 +18936,22 @@ Object {
               "name": Object {
                 "name": "module",
                 "range": Array [
-                  107,
-                  113,
+                  121,
+                  127,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  107,
-                  113,
+                  121,
+                  127,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  82,
-                  153,
+                  96,
+                  173,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -18943,8 +18971,8 @@ Object {
             Object {
               "name": "module",
               "range": Array [
-                107,
-                113,
+                121,
+                127,
               ],
               "type": "Identifier",
             },
@@ -18952,11 +18980,11 @@ Object {
           "name": "module",
           "references": Array [
             Object {
-              "$ref": 7,
+              "$ref": 8,
             },
           ],
           "scope": Object {
-            "$ref": 10,
+            "$ref": 12,
           },
         },
         Object {
@@ -18991,22 +19019,22 @@ Object {
               "name": Object {
                 "name": "type",
                 "range": Array [
-                  117,
-                  121,
+                  131,
+                  135,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  117,
-                  121,
+                  131,
+                  135,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  82,
-                  153,
+                  96,
+                  173,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -19026,8 +19054,8 @@ Object {
             Object {
               "name": "type",
               "range": Array [
-                117,
-                121,
+                131,
+                135,
               ],
               "type": "Identifier",
             },
@@ -19035,11 +19063,11 @@ Object {
           "name": "type",
           "references": Array [
             Object {
-              "$ref": 8,
+              "$ref": 9,
             },
           ],
           "scope": Object {
-            "$ref": 10,
+            "$ref": 12,
           },
         },
         Object {
@@ -19074,22 +19102,22 @@ Object {
               "name": Object {
                 "name": "async",
                 "range": Array [
-                  125,
-                  130,
+                  139,
+                  144,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  125,
-                  130,
+                  139,
+                  144,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  82,
-                  153,
+                  96,
+                  173,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -19109,8 +19137,8 @@ Object {
             Object {
               "name": "async",
               "range": Array [
-                125,
-                130,
+                139,
+                144,
               ],
               "type": "Identifier",
             },
@@ -19118,11 +19146,94 @@ Object {
           "name": "async",
           "references": Array [
             Object {
-              "$ref": 9,
+              "$ref": 10,
             },
           ],
           "scope": Object {
-            "$ref": 10,
+            "$ref": 12,
+          },
+        },
+        Object {
+          "$id": 5,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "is",
+                "range": Array [
+                  87,
+                  89,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  87,
+                  93,
+                ],
+                "type": "VariableDeclarator",
+              },
+              "parent": Object {
+                "range": Array [
+                  81,
+                  94,
+                ],
+                "type": "VariableDeclaration",
+              },
+              "type": "Variable",
+            },
+            Object {
+              "name": Object {
+                "name": "is",
+                "range": Array [
+                  148,
+                  150,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  148,
+                  150,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  96,
+                  173,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "is",
+              "range": Array [
+                87,
+                89,
+              ],
+              "type": "Identifier",
+            },
+            Object {
+              "name": "is",
+              "range": Array [
+                148,
+                150,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "is",
+          "references": Array [
+            Object {
+              "$ref": 11,
+            },
+          ],
+          "scope": Object {
+            "$ref": 12,
           },
         },
       ],
@@ -19136,7 +19247,7 @@ Object {
   "upperScope": null,
   "variableMap": Object {},
   "variableScope": Object {
-    "$ref": 11,
+    "$ref": 13,
   },
   "variables": Array [],
 }

--- a/packages/shared-fixtures/fixtures/typescript/basics/keyword-variables.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/keyword-variables.src.ts
@@ -3,6 +3,7 @@ const set = 1;
 const module = 1;
 const type = 1;
 const async = 1;
+const is = 1;
 
 import {
   get,
@@ -10,4 +11,5 @@ import {
   module,
   type,
   async,
+  is,
 } from 'fake-module';

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -456,6 +456,7 @@ export function getTokenType(token: any): AST_TOKEN_TYPES {
       case SyntaxKind.TypeKeyword:
       case SyntaxKind.ModuleKeyword:
       case SyntaxKind.AsyncKeyword:
+      case SyntaxKind.IsKeyword:
         return AST_TOKEN_TYPES.Identifier;
 
       default:

--- a/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
@@ -58982,34 +58982,108 @@ Object {
       "type": "VariableDeclaration",
     },
     Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 6,
+              },
+              "start": Object {
+                "column": 6,
+                "line": 6,
+              },
+            },
+            "name": "is",
+            "range": Array [
+              87,
+              89,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 12,
+                "line": 6,
+              },
+              "start": Object {
+                "column": 11,
+                "line": 6,
+              },
+            },
+            "range": Array [
+              92,
+              93,
+            ],
+            "raw": "1",
+            "type": "Literal",
+            "value": 1,
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 12,
+              "line": 6,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 6,
+            },
+          },
+          "range": Array [
+            87,
+            93,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "const",
       "loc": Object {
         "end": Object {
-          "column": 21,
-          "line": 13,
+          "column": 13,
+          "line": 6,
         },
         "start": Object {
           "column": 0,
-          "line": 7,
+          "line": 6,
         },
       },
       "range": Array [
-        82,
-        153,
+        81,
+        94,
+      ],
+      "type": "VariableDeclaration",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 15,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        96,
+        173,
       ],
       "source": Object {
         "loc": Object {
           "end": Object {
             "column": 20,
-            "line": 13,
+            "line": 15,
           },
           "start": Object {
             "column": 7,
-            "line": 13,
+            "line": 15,
           },
         },
         "range": Array [
-          139,
-          152,
+          159,
+          172,
         ],
         "raw": "'fake-module'",
         "type": "Literal",
@@ -59021,51 +59095,51 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 5,
-                "line": 8,
+                "line": 9,
               },
               "start": Object {
                 "column": 2,
-                "line": 8,
+                "line": 9,
               },
             },
             "name": "get",
             "range": Array [
-              93,
-              96,
+              107,
+              110,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 5,
-              "line": 8,
+              "line": 9,
             },
             "start": Object {
               "column": 2,
-              "line": 8,
+              "line": 9,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 5,
-                "line": 8,
+                "line": 9,
               },
               "start": Object {
                 "column": 2,
-                "line": 8,
+                "line": 9,
               },
             },
             "name": "get",
             "range": Array [
-              93,
-              96,
+              107,
+              110,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            93,
-            96,
+            107,
+            110,
           ],
           "type": "ImportSpecifier",
         },
@@ -59074,51 +59148,51 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 5,
-                "line": 9,
+                "line": 10,
               },
               "start": Object {
                 "column": 2,
-                "line": 9,
+                "line": 10,
               },
             },
             "name": "set",
             "range": Array [
-              100,
-              103,
+              114,
+              117,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 5,
-              "line": 9,
+              "line": 10,
             },
             "start": Object {
               "column": 2,
-              "line": 9,
+              "line": 10,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 5,
-                "line": 9,
+                "line": 10,
               },
               "start": Object {
                 "column": 2,
-                "line": 9,
+                "line": 10,
               },
             },
             "name": "set",
             "range": Array [
-              100,
-              103,
+              114,
+              117,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            100,
-            103,
+            114,
+            117,
           ],
           "type": "ImportSpecifier",
         },
@@ -59127,51 +59201,51 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 8,
-                "line": 10,
+                "line": 11,
               },
               "start": Object {
                 "column": 2,
-                "line": 10,
+                "line": 11,
               },
             },
             "name": "module",
             "range": Array [
-              107,
-              113,
+              121,
+              127,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 8,
-              "line": 10,
+              "line": 11,
             },
             "start": Object {
               "column": 2,
-              "line": 10,
+              "line": 11,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 8,
-                "line": 10,
+                "line": 11,
               },
               "start": Object {
                 "column": 2,
-                "line": 10,
+                "line": 11,
               },
             },
             "name": "module",
             "range": Array [
-              107,
-              113,
+              121,
+              127,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            107,
-            113,
+            121,
+            127,
           ],
           "type": "ImportSpecifier",
         },
@@ -59180,51 +59254,51 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 6,
-                "line": 11,
+                "line": 12,
               },
               "start": Object {
                 "column": 2,
-                "line": 11,
+                "line": 12,
               },
             },
             "name": "type",
             "range": Array [
-              117,
-              121,
+              131,
+              135,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 6,
-              "line": 11,
+              "line": 12,
             },
             "start": Object {
               "column": 2,
-              "line": 11,
+              "line": 12,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 6,
-                "line": 11,
+                "line": 12,
               },
               "start": Object {
                 "column": 2,
-                "line": 11,
+                "line": 12,
               },
             },
             "name": "type",
             "range": Array [
-              117,
-              121,
+              131,
+              135,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            117,
-            121,
+            131,
+            135,
           ],
           "type": "ImportSpecifier",
         },
@@ -59233,51 +59307,104 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 7,
-                "line": 12,
+                "line": 13,
               },
               "start": Object {
                 "column": 2,
-                "line": 12,
+                "line": 13,
               },
             },
             "name": "async",
             "range": Array [
-              125,
-              130,
+              139,
+              144,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 7,
-              "line": 12,
+              "line": 13,
             },
             "start": Object {
               "column": 2,
-              "line": 12,
+              "line": 13,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 7,
-                "line": 12,
+                "line": 13,
               },
               "start": Object {
                 "column": 2,
-                "line": 12,
+                "line": 13,
               },
             },
             "name": "async",
             "range": Array [
-              125,
-              130,
+              139,
+              144,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            125,
-            130,
+            139,
+            144,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 4,
+                "line": 14,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 14,
+              },
+            },
+            "name": "is",
+            "range": Array [
+              148,
+              150,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 4,
+              "line": 14,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 14,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 4,
+                "line": 14,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 14,
+              },
+            },
+            "name": "is",
+            "range": Array [
+              148,
+              150,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            148,
+            150,
           ],
           "type": "ImportSpecifier",
         },
@@ -59288,7 +59415,7 @@ Object {
   "loc": Object {
     "end": Object {
       "column": 0,
-      "line": 14,
+      "line": 16,
     },
     "start": Object {
       "column": 0,
@@ -59297,7 +59424,7 @@ Object {
   },
   "range": Array [
     0,
-    154,
+    174,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -59754,17 +59881,107 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 6,
-          "line": 7,
+          "column": 5,
+          "line": 6,
         },
         "start": Object {
           "column": 0,
-          "line": 7,
+          "line": 6,
         },
       },
       "range": Array [
-        82,
-        88,
+        81,
+        86,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        87,
+        89,
+      ],
+      "type": "Identifier",
+      "value": "is",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        90,
+        91,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        92,
+        93,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        93,
+        94,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        96,
+        102,
       ],
       "type": "Keyword",
       "value": "import",
@@ -59773,16 +59990,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 8,
-          "line": 7,
+          "line": 8,
         },
         "start": Object {
           "column": 7,
-          "line": 7,
+          "line": 8,
         },
       },
       "range": Array [
-        89,
-        90,
+        103,
+        104,
       ],
       "type": "Punctuator",
       "value": "{",
@@ -59791,16 +60008,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 5,
-          "line": 8,
+          "line": 9,
         },
         "start": Object {
           "column": 2,
-          "line": 8,
+          "line": 9,
         },
       },
       "range": Array [
-        93,
-        96,
+        107,
+        110,
       ],
       "type": "Identifier",
       "value": "get",
@@ -59809,16 +60026,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 8,
+          "line": 9,
         },
         "start": Object {
           "column": 5,
-          "line": 8,
+          "line": 9,
         },
       },
       "range": Array [
-        96,
-        97,
+        110,
+        111,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -59827,16 +60044,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 5,
-          "line": 9,
+          "line": 10,
         },
         "start": Object {
           "column": 2,
-          "line": 9,
+          "line": 10,
         },
       },
       "range": Array [
-        100,
-        103,
+        114,
+        117,
       ],
       "type": "Identifier",
       "value": "set",
@@ -59845,16 +60062,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 9,
+          "line": 10,
         },
         "start": Object {
           "column": 5,
-          "line": 9,
+          "line": 10,
         },
       },
       "range": Array [
-        103,
-        104,
+        117,
+        118,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -59863,16 +60080,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 8,
-          "line": 10,
+          "line": 11,
         },
         "start": Object {
           "column": 2,
-          "line": 10,
+          "line": 11,
         },
       },
       "range": Array [
-        107,
-        113,
+        121,
+        127,
       ],
       "type": "Identifier",
       "value": "module",
@@ -59881,16 +60098,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 9,
-          "line": 10,
+          "line": 11,
         },
         "start": Object {
           "column": 8,
-          "line": 10,
+          "line": 11,
         },
       },
       "range": Array [
-        113,
-        114,
+        127,
+        128,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -59899,16 +60116,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 11,
+          "line": 12,
         },
         "start": Object {
           "column": 2,
-          "line": 11,
+          "line": 12,
         },
       },
       "range": Array [
-        117,
-        121,
+        131,
+        135,
       ],
       "type": "Identifier",
       "value": "type",
@@ -59917,16 +60134,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 7,
-          "line": 11,
+          "line": 12,
         },
         "start": Object {
           "column": 6,
-          "line": 11,
+          "line": 12,
         },
       },
       "range": Array [
-        121,
-        122,
+        135,
+        136,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -59935,16 +60152,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 7,
-          "line": 12,
+          "line": 13,
         },
         "start": Object {
           "column": 2,
-          "line": 12,
+          "line": 13,
         },
       },
       "range": Array [
-        125,
-        130,
+        139,
+        144,
       ],
       "type": "Identifier",
       "value": "async",
@@ -59953,16 +60170,52 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 8,
-          "line": 12,
+          "line": 13,
         },
         "start": Object {
           "column": 7,
-          "line": 12,
+          "line": 13,
         },
       },
       "range": Array [
-        130,
-        131,
+        144,
+        145,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 14,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 14,
+        },
+      },
+      "range": Array [
+        148,
+        150,
+      ],
+      "type": "Identifier",
+      "value": "is",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 14,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 14,
+        },
+      },
+      "range": Array [
+        150,
+        151,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -59971,16 +60224,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 13,
+          "line": 15,
         },
         "start": Object {
           "column": 0,
-          "line": 13,
+          "line": 15,
         },
       },
       "range": Array [
-        132,
-        133,
+        152,
+        153,
       ],
       "type": "Punctuator",
       "value": "}",
@@ -59989,16 +60242,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 13,
+          "line": 15,
         },
         "start": Object {
           "column": 2,
-          "line": 13,
+          "line": 15,
         },
       },
       "range": Array [
-        134,
-        138,
+        154,
+        158,
       ],
       "type": "Identifier",
       "value": "from",
@@ -60007,16 +60260,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 20,
-          "line": 13,
+          "line": 15,
         },
         "start": Object {
           "column": 7,
-          "line": 13,
+          "line": 15,
         },
       },
       "range": Array [
-        139,
-        152,
+        159,
+        172,
       ],
       "type": "String",
       "value": "'fake-module'",
@@ -60025,16 +60278,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 21,
-          "line": 13,
+          "line": 15,
         },
         "start": Object {
           "column": 20,
-          "line": 13,
+          "line": 15,
         },
       },
       "range": Array [
-        152,
-        153,
+        172,
+        173,
       ],
       "type": "Punctuator",
       "value": ";",


### PR DESCRIPTION
Fixes #749 

As in #681 (and quoting from that PR), the `is` keyword wasn't correctly handled in the parser with respect to variable names, so the token it created was typed as Keyword instead of Identifier.

I suppose there are other such keywords that are also valid identifiers, but I'm not sure where to find the complete list.