### PR TITLE
docs: fix typo in documentation for explicit-function-return-type

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -142,9 +142,9 @@ let objectPropCast = <ObjectType>{
 declare functionWithArg(arg: () => number);
 functionWithArg(() => 1);
 
-declare functionWithObjectArg(arg: { meth: () => number });
+declare functionWithObjectArg(arg: { method: () => number });
 functionWithObjectArg({
-  meth() {
+  method() {
     return 1;
   },
 });


### PR DESCRIPTION
Resolves #769.