### PR TITLE
docs(prefer-readonly): add rule name to title

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-readonly.md
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly.md
@@ -1,4 +1,4 @@
-# require never-modified private members be marked as `readonly`
+# require never-modified private members be marked as `readonly` (prefer-readonly)
 
 This rule enforces that private members are marked as `readonly` if they're never modified outside of the constructor.
 


### PR DESCRIPTION
The "(prefer-readonly)" part wasn't in the title.