### PR TITLE
fix(eslint-plugin): [@typescript-eslint/typedef] support default value for parameter

### DIFF
--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -76,7 +76,7 @@ export default util.createRule<[Options], MessageIds>({
             annotationNode = param.left;
             break;
           case AST_NODE_TYPES.TSParameterProperty:
-            annotationNode = undefined;
+            annotationNode = param.parameter;
             break;
           default:
             annotationNode = param;

--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -69,10 +69,21 @@ export default util.createRule<[Options], MessageIds>({
 
     function checkParameters(params: TSESTree.Parameter[]) {
       for (const param of params) {
-        if (
-          param.type !== AST_NODE_TYPES.TSParameterProperty &&
-          !param.typeAnnotation
-        ) {
+        let annotationNode: TSESTree.Node | undefined;
+
+        switch (param.type) {
+          case AST_NODE_TYPES.AssignmentPattern:
+            annotationNode = param.left;
+            break;
+          case AST_NODE_TYPES.TSParameterProperty:
+            annotationNode = undefined;
+            break;
+          default:
+            annotationNode = param;
+            break;
+        }
+
+        if (annotationNode !== undefined && !annotationNode.typeAnnotation) {
           report(param, getNodeName(param));
         }
       }

--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -381,6 +381,17 @@ ruleTester.run('typedef', rule, {
         },
       ],
     },
+    {
+      code: `class Test {
+        public constructor(public x) { }
+      }`,
+      errors: [
+        {
+          column: 28,
+          messageId: 'expectedTypedef',
+        },
+      ],
+    },
     // Property declarations
     {
       code: `type Test = {

--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -101,7 +101,7 @@ ruleTester.run('typedef', rule, {
         },
       ],
     },
-    // Parameters
+    // Function parameters
     `function receivesNumber(a: number): void { }`,
     `function receivesStrings(a: string, b: string): void { }`,
     `function receivesNumber([a]: [number]): void { }`,
@@ -109,6 +109,13 @@ ruleTester.run('typedef', rule, {
     `function receivesString({ a }: { a: string }): void { }`,
     `function receivesStrings({ a, b }: { [i: string ]: string }): void { }`,
     `function receivesNumber(a: number = 123): void { }`,
+    // Method parameters
+    `class Test {
+      public method(x: number): number { return x; }
+    }`,
+    `class Test {
+      public method(x: number = 123): number { return x; }
+    }`,
     // Property declarations
     `type Test = {
        member: number;
@@ -292,7 +299,7 @@ ruleTester.run('typedef', rule, {
         },
       ],
     },
-    // Parameters
+    // Function parameters
     {
       code: `function receivesNumber(a): void { }`,
       errors: [
@@ -347,6 +354,29 @@ ruleTester.run('typedef', rule, {
       errors: [
         {
           column: 26,
+          messageId: 'expectedTypedef',
+        },
+      ],
+    },
+    // Method parameters
+    {
+      code: `class Test {
+        public method(x): number { return x; }
+      }`,
+      errors: [
+        {
+          column: 23,
+          messageId: 'expectedTypedefNamed',
+        },
+      ],
+    },
+    {
+      code: `class Test {
+        public method(x = 123): number { return x; }
+      }`,
+      errors: [
+        {
+          column: 23,
           messageId: 'expectedTypedef',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -108,6 +108,7 @@ ruleTester.run('typedef', rule, {
     `function receivesNumbers([a, b]: number[]): void { }`,
     `function receivesString({ a }: { a: string }): void { }`,
     `function receivesStrings({ a, b }: { [i: string ]: string }): void { }`,
+    `function receivesNumber(a: number = 123): void { }`,
     // Property declarations
     `type Test = {
        member: number;


### PR DESCRIPTION
Fixes https://github.com/typescript-eslint/typescript-eslint/issues/784