### PR TITLE
chore: eliminate spurious Prettier warnings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 * text=auto
 *.js eol=lf
+*.json eol=lf
+*.md eol=lf
 *.ts eol=lf
 *.tsx eol=lf
 *.yml eol=lf


### PR DESCRIPTION
The Git commit hook always fails on Windows because the EOL character is not what Prettier expects it to be.