### PR TITLE
docs(eslint-plugin): fix errors in explicit-member-accessibility examples

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
+++ b/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
@@ -79,7 +79,7 @@ The following patterns are considered correct with the default options `{ access
 
 ```ts
 class Animal {
-  public constructor(public breed, animalName) {
+  public constructor(public breed, name) {
     // Parameter property and constructor
     this.animalName = name;
   }
@@ -102,7 +102,7 @@ The following patterns are considered incorrect with the accessibility set to **
 
 ```ts
 class Animal {
-  public constructor(public breed, animalName) {
+  public constructor(public breed, name) {
     // Parameter property and constructor
     this.animalName = name;
   }
@@ -125,7 +125,7 @@ The following patterns are considered correct with the accessibility set to **no
 
 ```ts
 class Animal {
-  constructor(protected breed, animalName) {
+  constructor(protected breed, name) {
     // Parameter property and constructor
     this.name = name;
   }


### PR DESCRIPTION
Hi,

I found some nitpicks in code examples in the `explicit-member-accessibility` rule document, so I opened this PR to fix them.

If I was doing something wrong, please close this PR.

