### PR TITLE
chore(parser): add `types` field to `package.json`

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "An ESLint custom parser which leverages TypeScript ESTree",
   "main": "dist/parser.js",
+  "types": "dist/parser.d.ts",
   "files": [
     "dist",
     "README.md",


### PR DESCRIPTION
I was wondering why WebStorm was completely ignoring my import:

```
import { parse } from '@typescript-eslint/parser';
```

Turns out it doesn't use `.d.ts` files for packages if they're not included via `types`/`typings`.
`eslint-plugin` also doesn't have this property, but there's not really a reason to import that.

It'd be great if this could be backported to v1, as `eslint-plugin-jest` is still supporting Node 6.
It's not a showstopper by any means, but would be very much appreciated :)