### PR TITLE
docs(eslint-plugin): no-var-requires: Add example for ES6 modules

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-var-requires.md
+++ b/packages/eslint-plugin/docs/rules/no-var-requires.md
@@ -17,6 +17,7 @@ Examples of **correct** code for this rule:
 ```ts
 import foo = require('foo');
 require('foo');
+import foo from 'foo';
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
Fixes #899 

Adds an example to the documentation for replacing `require` with ES6 modules. Since this isn't going to work on everyone's system, I'm happy to also add a comment on this line stating the restrictions if the maintainers of this think it would be appropriate.