### PR TITLE
fix(eslint-plugin): [unbound-method] Allow typeof expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -119,6 +119,9 @@ function isSafeUse(node: TSESTree.Node): boolean {
     case AST_NODE_TYPES.TaggedTemplateExpression:
       return parent.tag === node;
 
+    case AST_NODE_TYPES.UnaryExpression:
+      return parent.operator === 'typeof';
+
     case AST_NODE_TYPES.TSNonNullExpression:
     case AST_NODE_TYPES.TSAsExpression:
     case AST_NODE_TYPES.TSTypeAssertion:

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -97,6 +97,12 @@ instane.boundStatic && 0;
 
 ContainsMethods.boundStatic ? 1 : 0;
 ContainsMethods.unboundStatic ? 1 : 0;
+
+typeof instance.bound === 'function';
+typeof instance.unbound === 'function';
+
+typeof ContainsMethods.boundStatic === 'function';
+typeof ContainsMethods.unboundStatic === 'function';
     `,
     `interface RecordA {
   readonly type: "A"


### PR DESCRIPTION
Fixes #692 

> **Disclaimer:**
I hope this is not frowned upon, but this PR relates to an issue labelled `good first issue`, despite the fact that I'm *not* a first-time contributor.

> I was in two minds about potentially taking away this opportunity for a new contributor to get involved with a nice easy PR, but on the other hand, this issue is currently triggering a warning in one of my projects and I just wanted it resolved.

> Apologies if this is considered bad form.

This PR allows for the case where the parent node of the unbound method is a unary `typeof` expression, and does not trigger an error.