### PR TITLE
fix(eslint-plugin): [no-inferrable-types] ignore optional properties

### DIFF
--- a/packages/eslint-plugin/src/rules/no-inferrable-types.ts
+++ b/packages/eslint-plugin/src/rules/no-inferrable-types.ts
@@ -250,7 +250,7 @@ export default util.createRule<Options, MessageIds>({
       // Essentially a readonly property without a type
       // will result in its value being the type, leading to
       // compile errors if the type is stripped.
-      if (ignoreProperties || node.readonly) {
+      if (ignoreProperties || node.readonly || node.optional) {
         return;
       }
       reportInferrableType(node, node.typeAnnotation, node.value);

--- a/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts
@@ -123,6 +123,15 @@ ruleTester.run('no-inferrable-types', rule, {
         "class Foo { a: number = 5; b: boolean = true; c: string = 'foo'; }",
       options: [{ ignoreProperties: true }],
     },
+    {
+      code: `
+class Foo {
+  a?: number = 5;
+  b?: boolean = true;
+  c?: string = 'foo';
+}
+      `,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
Fixes #902 

> Technically in this case, it is actually a bug in no-inferrable-types.
> foo?: string = 'str' is not inferrable, as the property is optional.

