### PR TITLE
fix(eslint-plugin): [typedef] handle AssignmentPattern inside TSParameterProperty

### DIFF
--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -79,6 +79,15 @@ export default util.createRule<[Options], MessageIds>({
             break;
           case AST_NODE_TYPES.TSParameterProperty:
             annotationNode = param.parameter;
+
+            // Check TS parameter property with default value like `constructor(private param: string = 'something') {}`
+            if (
+              annotationNode &&
+              annotationNode.type === AST_NODE_TYPES.AssignmentPattern
+            ) {
+              annotationNode = annotationNode.left;
+            }
+
             break;
           default:
             annotationNode = param;

--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -119,6 +119,9 @@ ruleTester.run('typedef', rule, {
     `class Test {
       constructor(param: string = 'something') {}
     }`,
+    `class Test {
+      constructor(private param: string = 'something') {}
+    }`,
     // Method parameters
     `class Test {
       public method(x: number): number { return x; }
@@ -426,6 +429,17 @@ ruleTester.run('typedef', rule, {
     {
       code: `class Test {
         constructor(param = 'something') {}
+      }`,
+      errors: [
+        {
+          column: 21,
+          messageId: 'expectedTypedef',
+        },
+      ],
+    },
+    {
+      code: `class Test {
+        constructor(private param = 'something') {}
       }`,
       errors: [
         {

--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -109,6 +109,16 @@ ruleTester.run('typedef', rule, {
     `function receivesString({ a }: { a: string }): void { }`,
     `function receivesStrings({ a, b }: { [i: string ]: string }): void { }`,
     `function receivesNumber(a: number = 123): void { }`,
+    // Constructor parameters
+    `class Test {
+      constructor() {}
+    }`,
+    `class Test {
+      constructor(param: string) {}
+    }`,
+    `class Test {
+      constructor(param: string = 'something') {}
+    }`,
     // Method parameters
     `class Test {
       public method(x: number): number { return x; }
@@ -397,6 +407,29 @@ ruleTester.run('typedef', rule, {
       errors: [
         {
           column: 26,
+          messageId: 'expectedTypedef',
+        },
+      ],
+    },
+    // Constructor parameters
+    {
+      code: `class Test {
+        constructor(param) {}
+      }`,
+      errors: [
+        {
+          column: 21,
+          messageId: 'expectedTypedefNamed',
+        },
+      ],
+    },
+    {
+      code: `class Test {
+        constructor(param = 'something') {}
+      }`,
+      errors: [
+        {
+          column: 21,
           messageId: 'expectedTypedef',
         },
       ],


### PR DESCRIPTION
#### What is the purpose of this pull request?

This is a potential fix for #921.

#### What changes did you make? (Give an overview)

The node with the `TSParameterProperty` type can contains the node with the `AssignmentPattern` type. In this case, we should check type annotations for the node with `AssignmentPattern`  type.

```ts
class Something {
    // Works fine without `= {}`
    constructor(private readonly _options: Options = {}) {
        //         ^                 ^ AssignmentPattern
        //         | TSParameterProperty
        //                                               
    }
}
```