### PR TITLE
feat(eslint-plugin): [no-floating-promises] by default

### DIFF
--- a/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.json
+++ b/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.json
@@ -3,6 +3,7 @@
   "rules": {
     "@typescript-eslint/await-thenable": "error",
     "@typescript-eslint/no-for-in-array": "error",
+    "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-misused-promises": "error",
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/prefer-includes": "error",


### PR DESCRIPTION
It seems to make sense if things like `no-misused-promises` and `await-thenable` are enabled by default, no-floating-promises should also be.