### PR TITLE
docs(eslint-plugin): document mixed codebase usage for efrt/ema

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -78,6 +78,28 @@ const defaults = {
 };
 ```
 
+### Configuring in a mixed JS/TS codebase
+
+If you are working on a codebase within which you lint non-TypeScript code (i.e. `.js`/`.jsx`), you should ensure that you should use [ESLint `overrides`](https://eslint.org/docs/user-guide/configuring#disabling-rules-only-for-a-group-of-files) to only enable the rule on `.ts`/`.tsx` files. If you don't, then you will get unfixable lint errors reported within `.js`/`.jsx` files.
+
+```jsonc
+{
+  "rules": {
+    // disable the rule for all files
+    "@typescript-eslint/explicit-function-return-type": "off"
+  },
+  "overrides": [
+    {
+      // enable the rule specifically for TypeScript files
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": ["error"]
+      }
+    }
+  ]
+}
+```
+
 ### allowExpressions
 
 Examples of **incorrect** code for this rule with `{ allowExpressions: true }`:

--- a/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
+++ b/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
@@ -18,7 +18,7 @@ type AccessibilityLevel =
   | 'no-public' // don't require public
   | 'off'; // don't check
 
-interface Config {
+type Options = {
   accessibility?: AccessibilityLevel;
   overrides?: {
     accessors?: AccessibilityLevel;
@@ -28,13 +28,35 @@ interface Config {
     parameterProperties?: AccessibilityLevel;
   };
 }
+
+const defaultOptions: Options = {
+  accessibility: 'explicit',
+};
 ```
 
-Default config:
+### Configuring in a mixed JS/TS codebase
 
-```JSON
-{ "accessibility": "explicit" }
+If you are working on a codebase within which you lint non-TypeScript code (i.e. `.js`/`.jsx`), you should ensure that you should use [ESLint `overrides`](https://eslint.org/docs/user-guide/configuring#disabling-rules-only-for-a-group-of-files) to only enable the rule on `.ts`/`.tsx` files. If you don't, then you will get unfixable lint errors reported within `.js`/`.jsx` files.
+
+```jsonc
+{
+  "rules": {
+    // disable the rule for all files
+    "@typescript-eslint/explicit-member-accessibility": "off"
+  },
+  "overrides": [
+    {
+      // enable the rule specifically for TypeScript files
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "@typescript-eslint/explicit-member-accessibility": ["error"]
+      }
+    }
+  ]
+}
 ```
+
+### `accessibility`
 
 This rule in it's default state requires no configuration and will enforce that every class member has an accessibility modifier. If you would like to allow for some implicit public members then you have the following options:
 A possible configuration could be:


### PR DESCRIPTION
As per #906 - add a section to the readme for these two rules as they both will not work on JS code.