### PR TITLE
docs: financial contributors and TSLint migration updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 <p align="center">Monorepo for all the tooling which enables ESLint to support TypeScript</p>
 
 <p align="center">
-    <a href="https://dev.azure.com/typescript-eslint/TypeScript%20ESLint/_build/latest?definitionId=1&branchName=master"><a href="https://opencollective.com/typescript-eslint" alt="Financial Contributors on Open Collective"><img src="https://opencollective.com/typescript-eslint/all/badge.svg?label=financial+contributors" /></a> <img src="https://img.shields.io/azure-devops/build/typescript-eslint/TypeScript%20ESLint/1/master.svg?label=%F0%9F%9A%80%20Azure%20Pipelines&style=flat-square" alt="Azure Pipelines"/></a>
+    <a href="https://dev.azure.com/typescript-eslint/TypeScript%20ESLint/_build/latest?definitionId=1&branchName=master"><img src="https://img.shields.io/azure-devops/build/typescript-eslint/TypeScript%20ESLint/1/master.svg?label=%F0%9F%9A%80%20Azure%20Pipelines&style=flat-square" alt="Azure Pipelines"/></a>
+    <a href="https://opencollective.com/typescript-eslint" alt="Financial Contributors on Open Collective"><img src="https://opencollective.com/typescript-eslint/all/badge.svg?label=financial+contributors&style=flat-square" /></a>
     <a href="https://github.com/typescript-eslint/typescript-eslint/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/typescript-estree.svg?style=flat-square" alt="GitHub license" /></a>
     <a href="https://www.npmjs.com/package/@typescript-eslint/typescript-estree"><img src="https://img.shields.io/npm/dm/@typescript-eslint/typescript-estree.svg?style=flat-square" alt="NPM Downloads" /></a>
     <a href="https://codecov.io/gh/typescript-eslint/typescript-eslint"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/typescript-eslint/typescript-eslint.svg?style=flat-square"></a>
@@ -59,6 +60,14 @@ One advantage is there is no tooling required to reconcile differences between A
 Palantir, the backers behind TSLint announced earlier this year that **they would be deprecating TSLint in favor of supporting `typescript-eslint`** in order to benefit the community. You can read more about that here: https://medium.com/palantir/tslint-in-2019-1a144c2317a9
 
 The TypeScript Team themselves also announced their plans to move the TypeScript codebase from TSLint to `typescript-eslint`, and they have been big supporters of this project. More details at https://github.com/microsoft/TypeScript/issues/30553
+
+### Migrating from TSLint to ESLint
+
+If you are looking for help in migrating from TSLint to ESLint, you can check out this project: https://github.com/typescript-eslint/tslint-to-eslint-config
+
+You can look at [`the plugin ROADMAP.md`](./packages/eslint-plugin/ROADMAP.md) for an up to date overview of how TSLint rules compare to the ones in this package.
+
+There is also the ultimate fallback option of using both linters together for a while during your transition if you absolutely have to by using TSLint _within_ ESLint. For this option, check out [`@typescript-eslint/eslint-plugin-tslint`](./packages/eslint-plugin-tslint/).
 
 <br>
 
@@ -161,6 +170,8 @@ See an issue? Report it in as much detail as possible, ideally with a clear and 
 
 If you have the time and the inclination, you can even take it a step further and submit a PR to improve the project.
 
+There are also financial ways to contribute, please see [Financial Contributors](#Financial-Contributors) for more details.
+
 All positive contributions are welcome here!
 
 <br>
@@ -217,24 +228,39 @@ If you use a non-supported version of TypeScript, the parser will log a warning 
 
 <br>
 
-## Contributors
+## License
 
-### Code Contributors
+TypeScript ESLint inherits from the the original TypeScript ESLint Parser license, as the majority of the work began there. It is licensed under a permissive BSD 2-clause license.
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+<br>
+
+## Code Contributors
+
+This project exists thanks to every one of the awesome people who contribute code and documentation:
+
+<br>
+
 <a href="https://github.com/typescript-eslint/typescript-eslint/graphs/contributors"><img src="https://opencollective.com/typescript-eslint/contributors.svg?width=890&button=false" /></a>
 
-### Financial Contributors
+<br>
 
-Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/typescript-eslint/contribute)]
+🙏 An extra special thanks goes out to the wonderful people listed in [`CONTRIBUTORS.md`](./CONTRIBUTORS.md)
 
-#### Individuals
+<br>
+
+## Financial Contributors
+
+In addition to submitting code and documentation updates, you can help us sustain our community by becoming a financial contributor [[Click here to contribute - every little helps!](https://opencollective.com/typescript-eslint/contribute)]
+
+<br>
+
+### Individuals
 
 <a href="https://opencollective.com/typescript-eslint"><img src="https://opencollective.com/typescript-eslint/individuals.svg?width=890"></a>
 
-#### Organizations
+### Organizations
 
-Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/typescript-eslint/contribute)]
+Support this project with your organization. Your logo will show up here with a link to your website. [[Click here to contribute - every little helps!](https://opencollective.com/typescript-eslint/contribute)]
 
 <a href="https://opencollective.com/typescript-eslint/organization/0/website"><img src="https://opencollective.com/typescript-eslint/organization/0/avatar.svg"></a>
 <a href="https://opencollective.com/typescript-eslint/organization/1/website"><img src="https://opencollective.com/typescript-eslint/organization/1/avatar.svg"></a>
@@ -246,16 +272,6 @@ Support this project with your organization. Your logo will show up here with a 
 <a href="https://opencollective.com/typescript-eslint/organization/7/website"><img src="https://opencollective.com/typescript-eslint/organization/7/avatar.svg"></a>
 <a href="https://opencollective.com/typescript-eslint/organization/8/website"><img src="https://opencollective.com/typescript-eslint/organization/8/avatar.svg"></a>
 <a href="https://opencollective.com/typescript-eslint/organization/9/website"><img src="https://opencollective.com/typescript-eslint/organization/9/avatar.svg"></a>
-
-## License
-
-TypeScript ESLint inherits from the the original TypeScript ESLint Parser license, as the majority of the work began there. It is licensed under a permissive BSD 2-clause license.
-
-<br>
-
-## Contributors
-
-Thanks goes to the wonderful people listed in [`CONTRIBUTORS.md`](./CONTRIBUTORS.md).
 
 <br>
 

--- a/package.json
+++ b/package.json
@@ -68,15 +68,13 @@
     "jest": "^24.9.0",
     "lerna": "^3.16.4",
     "lint-staged": "^9.2.5",
+    "opencollective-postinstall": "^2.0.2",
     "prettier": "^1.18.2",
     "rimraf": "^3.0.0",
     "ts-jest": "^24.0.0",
     "ts-node": "^8.3.0",
     "tslint": "^5.19.0",
     "typescript": ">=3.2.1 <3.7.0"
-  },
-  "dependencies": {
-    "opencollective-postinstall": "^2.0.2"
   },
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
I don't think we'd want to go the route of adding the opencollective messaging as a postinstall of the actual npm packages we publish, but I think having it as the postinstall for the _repo_ is ok for now.