### PR TITLE
fix(typescript-estree): ImportDeclaration.specifier to Literal

### DIFF
--- a/packages/eslint-plugin/src/rules/triple-slash-reference.ts
+++ b/packages/eslint-plugin/src/rules/triple-slash-reference.ts
@@ -73,8 +73,7 @@ export default util.createRule<Options, MessageIds>({
     return {
       ImportDeclaration(node): void {
         if (programNode) {
-          const source = node.source as TSESTree.Literal;
-          hasMatchingReference(source);
+          hasMatchingReference(node.source);
         }
       },
       TSImportEqualsDeclaration(node): void {

--- a/packages/typescript-estree/src/ts-estree/ts-estree.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-estree.ts
@@ -732,7 +732,7 @@ export interface Import extends BaseNode {
 
 export interface ImportDeclaration extends BaseNode {
   type: AST_NODE_TYPES.ImportDeclaration;
-  source: Expression;
+  source: Literal;
   specifiers: ImportClause[];
 }
 


### PR DESCRIPTION
According to [the spec](https://github.com/estree/estree/blob/master/es2015.md#importdeclaration), `ImportDeclaration.source` should have type `Literal`