### PR TITLE
docs(eslint-plugin): fix typo in typedef docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/typedef.md
+++ b/packages/eslint-plugin/docs/rules/typedef.md
@@ -44,7 +44,7 @@ For example, with the following configuration:
 ```json
 {
   "rules": {
-    "typedef": [
+    "@typescript-eslint/typedef": [
       "error",
       {
         "arrowParameter": false,


### PR DESCRIPTION
Updated rule name, typedef to @typescript-eslint/typedef