### PR TITLE
fix(eslint-plugin): [pfa] Allow async getter/setter in classes

### DIFF
--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -105,7 +105,8 @@ export default util.createRule<Options, MessageIds>({
 
       if (
         node.parent &&
-        node.parent.type === 'Property' &&
+        (node.parent.type === 'Property' ||
+          node.parent.type === 'MethodDefinition') &&
         (node.parent.kind === 'get' || node.parent.kind === 'set')
       ) {
         return;

--- a/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
+++ b/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
@@ -54,6 +54,12 @@ class InvalidAsyncModifiers {
   public set asyncGetter(p: Promise<void>) {
     return p;
   }
+  public get asyncGetterFunc() {
+    return async () => new Promise<void>();
+  }
+  public set asyncGetterFunc(p: () => Promise<void>) {
+    return p;
+  }
 }
     `,
     `


### PR DESCRIPTION
In #820, support was added for getters/setters that return async functions, e.g.

```ts
const someObject = {
  get asyncGetterFunc() {
    return async () => new Promise<void>();
  },
  set asyncGetterFunc(p: () => Promise<void>) {
    return p;
  }
}
```

Unfortunately, the previous fix only handles getters/setters on objects (the implementation specifically checks for `node.parent.type === 'Property'`).

As it turns out, getter/setters on classes have `node.parent.type === 'MethodDeclaration'`, so the following code still generates warnings:

```ts
class SomeClass = {
  get asyncGetterFunc() {
    return async () => new Promise<void>();
  },
  set asyncGetterFunc(p: () => Promise<void>) {
    return p;
  }
}
```

This PR addresses the class getter/setter case, by checking if `node.parent.type === 'Property' || node.parent.type === 'MethodDefinition'`.