### PR TITLE
fix(typescript-estree): correct ClassDeclarationBase type

### DIFF
--- a/packages/eslint-plugin/src/rules/indent.ts
+++ b/packages/eslint-plugin/src/rules/indent.ts
@@ -344,7 +344,7 @@ export default util.createRule<Options, MessageIds>({
         ]({
           type: AST_NODE_TYPES.ClassDeclaration,
           body: node.body as any,
-          id: undefined,
+          id: null,
           // TODO: This is invalid, there can be more than one extends in interface
           superClass: node.extends![0].expression as any,
 

--- a/packages/typescript-estree/src/ts-estree/ts-estree.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-estree.ts
@@ -454,9 +454,9 @@ interface BinaryExpressionBase extends BaseNode {
 interface ClassDeclarationBase extends BaseNode {
   typeParameters?: TSTypeParameterDeclaration;
   superTypeParameters?: TSTypeParameterInstantiation;
-  id?: Identifier;
+  id: Identifier | null;
   body: ClassBody;
-  superClass?: LeftHandSideExpression;
+  superClass: LeftHandSideExpression | null;
   implements?: ExpressionWithTypeArguments[];
   abstract?: boolean;
   declare?: boolean;


### PR DESCRIPTION
According to [the spec](https://github.com/estree/estree/blob/master/es2015.md#classes), `ClassDeclarationBase.id` and `ClassDeclarationBase.superClass` are always present and nullable