### PR TITLE
feat(eslint-plugin): add no-forgotten-func-call

### DIFF
--- a/packages/eslint-plugin/src/configs/all.json
+++ b/packages/eslint-plugin/src/configs/all.json
@@ -34,6 +34,7 @@
     "@typescript-eslint/no-extra-parens": "error",
     "@typescript-eslint/no-extraneous-class": "error",
     "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-forgotten-func-call": "error",
     "@typescript-eslint/no-for-in-array": "error",
     "@typescript-eslint/no-inferrable-types": "error",
     "no-magic-numbers": "off",

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -24,6 +24,7 @@ import noExplicitAny from './no-explicit-any';
 import noExtraParens from './no-extra-parens';
 import noExtraneousClass from './no-extraneous-class';
 import noFloatingPromises from './no-floating-promises';
+import noForgottenFuncCall from './no-forgotten-func-call';
 import noForInArray from './no-for-in-array';
 import noInferrableTypes from './no-inferrable-types';
 import noMagicNumbers from './no-magic-numbers';
@@ -90,6 +91,7 @@ export default {
   'no-extra-parens': noExtraParens,
   'no-extraneous-class': noExtraneousClass,
   'no-floating-promises': noFloatingPromises,
+  'no-forgotten-func-call': noForgottenFuncCall,
   'no-for-in-array': noForInArray,
   'no-inferrable-types': noInferrableTypes,
   'no-magic-numbers': noMagicNumbers,

--- a/packages/eslint-plugin/src/rules/no-forgotten-func-call.ts
+++ b/packages/eslint-plugin/src/rules/no-forgotten-func-call.ts
@@ -1,0 +1,141 @@
+import {
+  TSESTree,
+  AST_NODE_TYPES,
+} from '@typescript-eslint/experimental-utils';
+import { isFunctionTypeNode } from 'tsutils';
+import {
+  createRule,
+  getParserServices,
+  getConstrainedTypeAtLocation,
+} from '../util';
+import ts from 'typescript';
+
+type ExpressionWithTest =
+  | TSESTree.ConditionalExpression
+  | TSESTree.DoWhileStatement
+  | TSESTree.ForStatement
+  | TSESTree.IfStatement
+  | TSESTree.WhileStatement;
+
+// No options yet
+export type Options = [
+  {
+    allowAssignmentToAny?: boolean;
+  },
+];
+
+export type MessageId = 'callExpected';
+
+export default createRule<Options, MessageId>({
+  name: 'no-forgotten-func-call',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Finds functions that are not called',
+      category: 'Best Practices', // TODO
+      recommended: false,
+      requiresTypeChecking: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowAssignmentToAny: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      callExpected: 'Unexpected function, call expected.',
+    },
+  },
+  defaultOptions: [
+    {
+      allowAssignmentToAny: true,
+    },
+  ],
+  create(context, [{ allowAssignmentToAny }]) {
+    const service = getParserServices(context);
+    const checker = service.program.getTypeChecker();
+
+    function getTypeNode(node: TSESTree.Node): ts.TypeNode | undefined {
+      const tsNode = service.esTreeNodeToTSNodeMap.get(node);
+      const type = getConstrainedTypeAtLocation(checker, tsNode);
+      return checker.typeToTypeNode(type);
+    }
+
+    function isFunctionIdentifier(node: TSESTree.Node): boolean {
+      const typeNode = getTypeNode(node);
+      return typeNode !== undefined ? isFunctionTypeNode(typeNode) : false;
+    }
+
+    function isAnyIdentifier(node: TSESTree.Node): boolean {
+      const typeNode = getTypeNode(node);
+      // Assume `any` if we can’t find a type
+      return (
+        typeNode === undefined || typeNode.kind === ts.SyntaxKind.AnyKeyword
+      );
+    }
+
+    /**
+     * Checks if a conditional node is necessary:
+     * if the type of the node is always true or always false, it's not necessary.
+     */
+    function checkNode(node: TSESTree.Node): void {
+      if (isFunctionIdentifier(node)) {
+        context.report({ node, messageId: 'callExpected' });
+      }
+    }
+
+    /**
+     * Checks that a testable expression does not contain an uncalled function,
+     * reports otherwise. Filters all LogicalExpressions to prevent some
+     * duplicate reports.
+     */
+    function checkTestExpression(node: ExpressionWithTest): void {
+      if (
+        node.test !== null &&
+        node.test.type !== AST_NODE_TYPES.LogicalExpression
+      ) {
+        checkNode(node.test);
+      }
+    }
+
+    /**
+     * Checks that a logical expression does not contain uncalled functions,
+     * reports otherwise.
+     */
+    function checkLogicalExpression(node: TSESTree.LogicalExpression): void {
+      checkNode(node.left);
+      checkNode(node.right);
+    }
+
+    /**
+     * Checks that the right side of an assignment expression is not an
+     * uncalled functions, reports otherwise.
+     */
+    function checkAssignmentExpression(
+      node: TSESTree.AssignmentExpression,
+    ): void {
+      if (isFunctionIdentifier(node.left)) {
+        return;
+      }
+      if (allowAssignmentToAny && isAnyIdentifier(node.left)) {
+        return;
+      }
+      checkNode(node.right);
+    }
+
+    return {
+      ConditionalExpression: checkTestExpression,
+      DoWhileStatement: checkTestExpression,
+      ForStatement: checkTestExpression,
+      IfStatement: checkTestExpression,
+      WhileStatement: checkTestExpression,
+      LogicalExpression: checkLogicalExpression,
+      AssignmentExpression: checkAssignmentExpression,
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/rules/no-forgotten-func-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-forgotten-func-call.test.ts
@@ -50,6 +50,8 @@ if (d.e()) {}
 if (d.f) {}
 const h = {}
 h.i = () => {}
+declare const j: () => {} | undefined
+if (j && j()) {}
   `,
   ],
   invalid: [
@@ -87,6 +89,14 @@ f.g = () => {}
 `,
       options: [{ allowAssignmentToAny: false }],
       errors: [ruleError(3, 7, 'callExpected')],
+    },
+    {
+      code: `
+declare const f: () => {} | undefined
+if (f && f()) {}
+`,
+      options: [{ allowCheckAndCallExpressions: false }],
+      errors: [ruleError(3, 5, 'callExpected')],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-forgotten-func-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-forgotten-func-call.test.ts
@@ -1,0 +1,92 @@
+import path from 'path';
+import rule, { MessageId } from '../../src/rules/no-forgotten-func-call';
+import { RuleTester } from '../RuleTester';
+import { TestCaseError } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
+
+const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    tsconfigRootDir: rootPath,
+    project: './tsconfig.json',
+  },
+});
+
+const ruleError = (
+  line: number,
+  column: number,
+  messageId: MessageId,
+): TestCaseError<MessageId> => ({
+  messageId,
+  line,
+  column,
+});
+
+ruleTester.run('no-forgotten-func-call', rule, {
+  valid: [
+    `
+const a = () => false
+if (a()) {}
+function b() { return false }
+if (b()) {}
+let c = () => "c"
+c = () => "d"
+class D {
+  d() { return true }
+  e = () => { return true }
+  get f() { return true }
+  g() {
+    if (this.d()) {}
+    if (this.e()) {}
+    if (this.f) {}
+  }
+}
+const d = new D()
+if (d) {}
+if (d.d()) {}
+if (d.d !== undefined) {}
+if (d.e()) {}
+if (d.f) {}
+const h = {}
+h.i = () => {}
+  `,
+  ],
+  invalid: [
+    {
+      code: `
+const a = () => false
+if (a) {}
+function b() { return false }
+if (b) {}
+class D {
+  d() { return true }
+  e = () => { return true }
+  g() {
+    if (this.d) {}
+    if (this.e) {}
+  }
+}
+const d = new D()
+if (d.d) {}
+if (d.e) {}
+`,
+      errors: [
+        ruleError(3, 5, 'callExpected'),
+        ruleError(5, 5, 'callExpected'),
+        ruleError(10, 9, 'callExpected'),
+        ruleError(11, 9, 'callExpected'),
+        ruleError(15, 5, 'callExpected'),
+        ruleError(16, 5, 'callExpected'),
+      ],
+    },
+    {
+      code: `
+const f = {}
+f.g = () => {}
+`,
+      options: [{ allowAssignmentToAny: false }],
+      errors: [ruleError(3, 7, 'callExpected')],
+    },
+  ],
+});


### PR DESCRIPTION
This somewhat of a variant on the `no-unnecessary-condition` rule, which, for the code base I tried it on triggers way too many false positives.

It’s specifically intended to catch cases where there is something like:
```
if (this.isWorking) {
    // …
}
```
where `isWorking` is actually a method, not a property.

As a bonus, it also checks assignments where the function call might have been forgotten.

I’d love to get feedback on what’s there so far, and wether this rule is worth pursuing. 

TODO:
- [ ] Refine to reduce false positives
- [ ] Docs