### PR TITLE
fix(typescript-estree): fix optional computed member with identifier

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -949,7 +949,11 @@ export class Converter {
           result.definite = true;
         }
 
-        if (result.key.type === AST_NODE_TYPES.Literal && node.questionToken) {
+        if (
+          (result.key.type === AST_NODE_TYPES.Literal ||
+            result.key.type === AST_NODE_TYPES.Identifier) &&
+          node.questionToken
+        ) {
           result.optional = true;
         }
         return result;


### PR DESCRIPTION
This PR marks computed members with identifiers as names as optional.

Before
```
const bar = 'bar';
class Foo {
 [bar]?;
}
```
is represented as 
```
const bar = 'bar';
class Foo {
 [bar];
}
```