### PR TITLE
fix(experimental-utils): remove Rule.meta.extraDescription

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -19,10 +19,6 @@ interface RuleMetaDataDocs {
    */
   description: string;
   /**
-   * Extra information linking the rule to a tslint rule
-   */
-  extraDescription?: string[];
-  /**
    * The recommendation level for the rule.
    * Used by the build tools to generate the recommended config.
    * Set to false to not include it as a recommendation


### PR DESCRIPTION
`Rule.meta.extraDescription` is [not documented](https://eslint.org/docs/developer-guide/working-with-rules#rule-basics) and never used, so it might be confusing for consumers of `experimental-utils` package