### PR TITLE
fix(eslint-plugin): [class-name-casing] allow unicode letters

### DIFF
--- a/packages/eslint-plugin/src/rules/class-name-casing.ts
+++ b/packages/eslint-plugin/src/rules/class-name-casing.ts
@@ -38,16 +38,28 @@ export default util.createRule<Options, MessageIds>({
   },
   defaultOptions: [{ allowUnderscorePrefix: false }],
   create(context, [options]) {
+    const UNDERSCORE = '_';
+
+    /**
+     * Determine if the string is Upper cased
+     * @param str
+     */
+    function isUpperCase(str: string): boolean {
+      return str === str.toUpperCase();
+    }
+
     /**
      * Determine if the identifier name is PascalCased
      * @param name The identifier name
      */
     function isPascalCase(name: string): boolean {
-      if (options.allowUnderscorePrefix) {
-        return /^_?[A-Z][0-9A-Za-z]*$/.test(name);
-      } else {
-        return /^[A-Z][0-9A-Za-z]*$/.test(name);
-      }
+      const startIndex =
+        options.allowUnderscorePrefix && name.startsWith(UNDERSCORE) ? 1 : 0;
+
+      return (
+        isUpperCase(name.charAt(startIndex)) &&
+        !name.includes(UNDERSCORE, startIndex)
+      );
     }
 
     /**

--- a/packages/eslint-plugin/tests/rules/class-name-casing.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-name-casing.test.ts
@@ -18,11 +18,22 @@ ruleTester.run('class-name-casing', rule, {
       code: 'class _NameWithUnderscore {}',
       options: [{ allowUnderscorePrefix: true }],
     },
+    {
+      code: 'class Foo {}',
+      options: [{ allowUnderscorePrefix: true }],
+    },
+    {
+      code: 'class _ÈFoo {}',
+      options: [{ allowUnderscorePrefix: true }],
+    },
     'var Foo = class {};',
     'interface SomeInterface {}',
     'class ClassNameWithDigit2 {}',
     'abstract class ClassNameWithDigit2 {}',
     'var ba_zz = class Foo {};',
+    'class ClassNameWithUnicodeÈ {}',
+    'class ÈClassNameWithUnicode {}',
+    'class ClassNameWithæUnicode {}',
   ],
 
   invalid: [
@@ -149,6 +160,20 @@ ruleTester.run('class-name-casing', rule, {
           },
           line: 1,
           column: 15,
+        },
+      ],
+    },
+    {
+      code: `class æInvalidClassNameWithUnicode {}`,
+      errors: [
+        {
+          messageId: 'notPascalCased',
+          data: {
+            friendlyName: 'Class',
+            name: 'æInvalidClassNameWithUnicode',
+          },
+          line: 1,
+          column: 7,
         },
       ],
     },


### PR DESCRIPTION
Fixes #1039 