### PR TITLE
chore: add typescript as optionalDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ We will always endeavor to support the latest stable version of TypeScript. Some
 
 **The version range of TypeScript currently supported by this parser is `>=3.2.1 <3.7.0`.**
 
-This is reflected in the `devDependency` requirement within the package.json file, and it is what the tests will be run against. We have an open `peerDependency` requirement in order to allow for experimentation on newer/beta versions of TypeScript.
+This is reflected in the `devDependency` requirement within the package.json file, and it is what the tests will be run against. We have an open `optionalDependency` requirement in order to allow for experimentation on newer/beta versions of TypeScript.
 
 If you use a non-supported version of TypeScript, the parser will log a warning to the console. If you want to disable this warning, you can configure this in your `parserOptions`. See: [`@typescript-eslint/parser`](./packages/parser/) and [`@typescript-eslint/typescript-estree`](./packages/typescript-estree/).
 

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -16,6 +16,8 @@
 npm install @typescript-eslint/parser --save-dev
 ```
 
+Note: `@typescript-eslint/parser` assumes you have `typescript` already installed. Please read the documentation [here](https://github.com/typescript-eslint/typescript-eslint#supported-typescript-version) for more details.
+
 ## Usage
 
 In your ESLint configuration file, set the `parser` property:

--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -27,6 +27,8 @@ In fact, it is already used within these hyper-popular open-source projects to p
 npm install @typescript-eslint/typescript-estree --save-dev
 ```
 
+Note: `@typescript-eslint/typescript-estree` assumes you have `typescript` already installed. Please read the documentation [here](https://github.com/typescript-eslint/typescript-eslint#supported-typescript-version) for more details.
+
 ## API
 
 ### parse(code, options)

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -61,5 +61,8 @@
     "glob": "^7.1.4",
     "lodash.isplainobject": "4.0.6",
     "typescript": "*"
+  },
+  "optionalDependencies": {
+    "typescript": "*"
   }
 }


### PR DESCRIPTION
While debugging https://github.com/eslint/eslint/issues/12376, I was kindly directed by @JamesHenry to https://github.com/typescript-eslint/typescript-eslint/issues/828#issuecomment-519974952. Thought this could maybe made clearer with a README change and adding `typescript` as an optional dependency. Testing with npm<6.11, it seems the `optionalDependencies` key is ignored.

Happy to remove the optional dependency addition if the team feels just having the documentation is a better fix for now.