### PR TITLE
fix(typescript-estree): handle running out of fs watchers

### DIFF
--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -144,6 +144,11 @@ I work closely with the TypeScript Team and we are gradually aliging the AST of 
 - `npm run unit-tests` - run only unit tests
 - `npm run ast-alignment-tests` - run only Babylon AST alignment tests
 
+## Debugging
+
+If you encounter a bug with the parser that you want to investigate, you can turn on the debug logging via setting the environment variable: `DEBUG=typescript-eslint:*`.
+I.e. in this repo you can run: `DEBUG=typescript-eslint:* yarn lint`.
+
 ## License
 
 TypeScript ESTree inherits from the the original TypeScript ESLint Parser license, as the majority of the work began there. It is licensed under a permissive BSD 2-clause license.

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "chokidar": "^3.0.2",
+    "debug": "^4.1.1",
     "glob": "^7.1.4",
     "is-glob": "^4.0.1",
     "lodash.unescape": "4.0.1",
@@ -50,6 +51,7 @@
     "@babel/parser": "7.5.5",
     "@babel/types": "^7.3.2",
     "@types/babel-code-frame": "^6.20.1",
+    "@types/debug": "^4.1.5",
     "@types/glob": "^7.1.1",
     "@types/is-glob": "^4.0.1",
     "@types/lodash.isplainobject": "^4.0.4",

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -16,7 +16,7 @@ import {
   defaultCompilerOptions,
 } from './tsconfig-parser';
 
-const log = debug(`typescript-eslint:typescript-estree:parser`);
+const log = debug('typescript-eslint:typescript-estree:parser');
 
 /**
  * This needs to be kept in sync with the top-level README.md in the

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import path from 'path';
 import semver from 'semver';
 import * as ts from 'typescript'; // leave this as * as ts so people using util package don't need syntheticDefaultImports
@@ -14,6 +15,8 @@ import {
   createProgram,
   defaultCompilerOptions,
 } from './tsconfig-parser';
+
+const log = debug(`typescript-eslint:typescript-estree:parser`);
 
 /**
  * This needs to be kept in sync with the top-level README.md in the
@@ -39,6 +42,17 @@ let warnedAboutTSVersion = false;
  */
 function getFileName({ jsx }: { jsx?: boolean }): string {
   return jsx ? 'estree.tsx' : 'estree.ts';
+}
+
+function enforceString(code: unknown): string {
+  /**
+   * Ensure the source code is a string
+   */
+  if (typeof code !== 'string') {
+    return String(code);
+  }
+
+  return code;
 }
 
 /**
@@ -82,6 +96,8 @@ function getASTFromProject(
   options: TSESTreeOptions,
   createDefaultProgram: boolean,
 ): ASTAndProgram | undefined {
+  log('Attempting to get AST from project(s) for: %s', options.filePath);
+
   const filePath = options.filePath || getFileName(options);
   const astAndProgram = firstDefined(
     calculateProjectParserOptions(code, filePath, extra),
@@ -139,6 +155,11 @@ function getASTAndDefaultProject(
   code: string,
   options: TSESTreeOptions,
 ): ASTAndProgram | undefined {
+  log(
+    'Attempting to get AST from the default project(s): %s',
+    options.filePath,
+  );
+
   const fileName = options.filePath || getFileName(options);
   const program = createProgram(code, fileName, extra);
   const ast = program && program.getSourceFile(fileName);
@@ -150,6 +171,8 @@ function getASTAndDefaultProject(
  * @returns Returns a new source file and program corresponding to the linted code
  */
 function createNewProgram(code: string): ASTAndProgram {
+  log('Getting AST without type information');
+
   const FILENAME = getFileName(extra);
 
   const compilerHost: ts.CompilerHost = {
@@ -226,6 +249,9 @@ function getProgramAndAST(
 }
 
 function applyParserOptionsToExtra(options: TSESTreeOptions): void {
+  /**
+   * Turn on/off filesystem watchers
+   */
   extra.noWatch = typeof options.noWatch === 'boolean' && options.noWatch;
 
   /**
@@ -378,6 +404,7 @@ export function parse<T extends TSESTreeOptions = TSESTreeOptions>(
    * Reset the parse configuration
    */
   resetExtra();
+
   /**
    * Ensure users do not attempt to use parse() when they need parseAndGenerateServices()
    */
@@ -386,24 +413,25 @@ export function parse<T extends TSESTreeOptions = TSESTreeOptions>(
       `"errorOnTypeScriptSyntacticAndSemanticIssues" is only supported for parseAndGenerateServices()`,
     );
   }
+
   /**
    * Ensure the source code is a string, and store a reference to it
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (typeof code !== 'string' && !((code as any) instanceof String)) {
-    code = String(code);
-  }
+  code = enforceString(code);
   extra.code = code;
+
   /**
    * Apply the given parser options
    */
   if (typeof options !== 'undefined') {
     applyParserOptionsToExtra(options);
   }
+
   /**
    * Warn if the user is using an unsupported version of TypeScript
    */
   warnAboutTSVersion();
+
   /**
    * Create a ts.SourceFile directly, no ts.Program is needed for a simple
    * parse
@@ -414,6 +442,7 @@ export function parse<T extends TSESTreeOptions = TSESTreeOptions>(
     ts.ScriptTarget.Latest,
     /* setParentNodes */ true,
   );
+
   /**
    * Convert the TypeScript AST to an ESTree-compatible one
    */
@@ -428,14 +457,13 @@ export function parseAndGenerateServices<
    * Reset the parse configuration
    */
   resetExtra();
+
   /**
    * Ensure the source code is a string, and store a reference to it
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (typeof code !== 'string' && !((code as any) instanceof String)) {
-    code = String(code);
-  }
+  code = enforceString(code);
   extra.code = code;
+
   /**
    * Apply the given parser options
    */
@@ -449,10 +477,12 @@ export function parseAndGenerateServices<
       extra.errorOnTypeScriptSyntacticAndSemanticIssues = true;
     }
   }
+
   /**
    * Warn if the user is using an unsupported version of TypeScript
    */
   warnAboutTSVersion();
+
   /**
    * Generate a full ts.Program in order to be able to provide parser
    * services, such as type-checking
@@ -465,6 +495,7 @@ export function parseAndGenerateServices<
     shouldProvideParserServices,
     extra.createDefaultProgram,
   )!;
+
   /**
    * Determine whether or not two-way maps of converted AST nodes should be preserved
    * during the conversion process
@@ -473,11 +504,13 @@ export function parseAndGenerateServices<
     extra.preserveNodeMaps !== undefined
       ? extra.preserveNodeMaps
       : shouldProvideParserServices;
+
   /**
    * Convert the TypeScript AST to an ESTree-compatible one, and optionally preserve
    * mappings between converted and original AST nodes
    */
   const { estree, astMaps } = astConverter(ast, extra, shouldPreserveNodeMaps);
+
   /**
    * Even if TypeScript parsed the source code ok, and we had no problems converting the AST,
    * there may be other syntactic or semantic issues in the code that we can optionally report on.
@@ -488,6 +521,7 @@ export function parseAndGenerateServices<
       throw convertError(error);
     }
   }
+
   /**
    * Return the converted AST and additional parser services
    */

--- a/packages/typescript-estree/src/tsconfig-parser.ts
+++ b/packages/typescript-estree/src/tsconfig-parser.ts
@@ -5,7 +5,7 @@ import * as ts from 'typescript'; // leave this as * as ts so people using util 
 import { Extra } from './parser-options';
 import { WatchCompilerHostOfConfigFile } from './WatchCompilerHostOfConfigFile';
 
-const log = debug(`typescript-eslint:typescript-estree:tsconfig-parser`);
+const log = debug('typescript-eslint:typescript-estree:tsconfig-parser');
 
 /**
  * Default compiler options for program generation from single root file

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,6 +1329,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/debug@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
+  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -7758,9 +7763,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@*, "typescript@>=3.2.1 <3.8.0 >3.7.0-dev.0", typescript@^3.7.0-beta:
-  version "3.7.0-dev.20191006"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.0-dev.20191006.tgz#b455c0bdbc29625b6f95886e17c85ded1271f588"
-  integrity sha512-0uxLQ41QwguSZdMlQ5GUXljS42Ti1+AFJ1EnTsQOSX4Z0eG2bwxHDJItIRDGV6yZGBMXJ6HGapxv2qxSeW5svA==
+  version "3.7.0-dev.20191015"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.0-dev.20191015.tgz#283a99aeb09c91963aa16adcf5cb2fccbea9bdc4"
+  integrity sha512-Cpfj1n4pEUVKL+jtS0mkZodJffyMmf3Wk/UjyZMGX4fsjK5KBPJf3NUlyXij8I8p1E2CAomdS5NPFrAR+z8pKw==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
Fixes #1080

I followed typescript's lead here, and fall back to polling if `chokidar` throws an error when attempting to use fs watchers.

I also added support for reusing watchers, to attempt to conserve resources, and reduce the total number of watchers that we setup.

I also decided it was time to setup some logging to help with debugging.
The logging can be shown via `DEBUG=typescript-eslint:* yarn lint`