### PR TITLE
chore(typescript-estree): fix package name in warning message

### DIFF
--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -364,7 +364,7 @@ function warnAboutTSVersion(): void {
     const border = '=============';
     const versionWarning = [
       border,
-      'WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.',
+      'WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.',
       'You may find that it works just fine, or you may not.',
       `SUPPORTED TYPESCRIPT VERSIONS: ${SUPPORTED_TYPESCRIPT_VERSIONS}`,
       `YOUR TYPESCRIPT VERSION: ${ACTIVE_TYPESCRIPT_VERSION}`,

--- a/packages/typescript-estree/tests/lib/warn-on-unsupported-ts.ts
+++ b/packages/typescript-estree/tests/lib/warn-on-unsupported-ts.ts
@@ -15,7 +15,7 @@ describe('Warn on unsupported TypeScript version', () => {
     parser.parse('');
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining(
-        'WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree',
+        'WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree',
       ),
     );
   });


### PR DESCRIPTION
Not sure if this is fine. I got this warning and ran `npm ls typescript-estree` in my project but that didn't return any results. Turns out that it was missing the scope of the package.