### PR TITLE
fix(typescript-estree): disable watching by default

### DIFF
--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -70,7 +70,7 @@ function resetExtra(): void {
     jsx: false,
     loc: false,
     log: console.log, // eslint-disable-line no-console
-    noWatch: false,
+    noWatch: true,
     preserveNodeMaps: undefined,
     projects: [],
     range: false,

--- a/packages/typescript-estree/tests/lib/persistentParse.ts
+++ b/packages/typescript-estree/tests/lib/persistentParse.ts
@@ -57,6 +57,7 @@ function parseFile(filename: 'foo' | 'bar', tmpDir: string): void {
     project: './tsconfig.json',
     tsconfigRootDir: tmpDir,
     filePath: path.join(tmpDir, `${filename}.ts`),
+    noWatch: false,
   });
 }
 


### PR DESCRIPTION
Admitting defeat, in a way.
Across the many OS's, environments, and IDE plugins, it's clear the watching solution doesn't work well enough to be on by default.

We'll have to either harden the watching code, or find a better solution that doesn't involve watching.

Closes #1095