### PR TITLE
docs(eslint-plugin): clarify config for no-use-before-define

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-use-before-define.md
+++ b/packages/eslint-plugin/docs/rules/no-use-before-define.md
@@ -67,7 +67,7 @@ let myVar: StringOrNumber;
 
 ```json
 {
-  "no-use-before-define": ["error", { "functions": true, "classes": true }]
+  "@typescript-eslint/no-use-before-define": ["error", { "functions": true, "classes": true }]
 }
 ```
 


### PR DESCRIPTION
Clearing one of misunderstandings, because documentation is copied from original ESLint rule. 
related to #559