### PR TITLE
feat(eslint-plugin): [explicit-function-return-type] add option allowZeroOrSingleReturnStatement

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -198,6 +198,45 @@ function fn() {
 }
 ```
 
+### allowZeroOrSingleReturnStatement
+
+This option allows you to avoid writing verbose return types only if there is zero or single non-`undefined` return statement.
+
+Examples of **incorrect** code for this rule with `{ allowZeroOrSingleReturnStatement: true }`:
+
+```ts
+// Missing a return type because there is more than one non-undefined return statements
+function fn(a: boolean) {
+  if (a) return 1;
+  return Math.random();
+}
+```
+
+Examples of **correct** code for this rule with `{ allowZeroOrSingleReturnStatement: true }`:
+
+```ts
+// Do not have to specify `void` return type because there is zero return statements
+function fn() {}
+```
+
+```ts
+// Do not have to specify `number | undefined` because `undefined` does not change the primary return type
+function fn(a: boolean, b: boolean, c: boolean) {
+  if (a) return;
+  if (b) return undefined;
+  if (c) return void 0;
+  return Math.random();
+}
+```
+
+```ts
+// Need to specify the return type because there are more than one return types.
+function fn(a: boolean): number | 'invalid' {
+  if (a) return 'invalid';
+  return Math.random();
+}
+```
+
 ## When Not To Use It
 
 If you don't wish to prevent calling code from using function return values in unexpected ways, then

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -334,6 +334,25 @@ new Foo(1, () => {});
         },
       ],
     },
+    {
+      filename: 'test.ts',
+      code: `
+function f() { return true }
+const g = function() { return true }
+const h = () => true
+function r(a, b, c) {
+  if (a) return
+  else { return undefined }
+  for (;;) { return void(0) }
+  return true
+}
+      `,
+      options: [
+        {
+          allowZeroOrSingleReturnStatement: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -977,6 +996,66 @@ const func = (value: number) => ({ type: "X", value } as const);
           endLine: 2,
           column: 14,
           endColumn: 32,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+function f() { return true }
+const g = function() { return true }
+const h = () => true
+function r(a, b, c) {
+  if (a) return
+  else { return undefined }
+  for (;;) { return void(0) }
+  return true
+}
+function s(a) {
+  if (a) return 1
+  return true
+}
+      `,
+      options: [
+        {
+          allowZeroOrSingleReturnStatement: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          endLine: 2,
+          column: 1,
+          endColumn: 13,
+        },
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 11,
+          endColumn: 21,
+        },
+        {
+          messageId: 'missingReturnType',
+          line: 4,
+          endLine: 4,
+          column: 11,
+          endColumn: 16,
+        },
+        {
+          messageId: 'missingReturnType',
+          line: 5,
+          endLine: 5,
+          column: 1,
+          endColumn: 20,
+        },
+        {
+          messageId: 'missingReturnType',
+          line: 11,
+          endLine: 11,
+          column: 1,
+          endColumn: 14,
         },
       ],
     },


### PR DESCRIPTION
I would like to add a new option to an existing rule `explicit-function-return-type`.

Writing return types for every single function could be verbose and cumbersome. Therefore I would like to relax `explicit-function-return-type` rule only if a function contains zero or single non-`undefined` return statement.

The option title is `allowZeroOrSingleReturnStatement`.