### PR TITLE
fix(typescript-estree): correct semver check range

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,13 +73,13 @@
     "ts-jest": "^24.0.0",
     "ts-node": "^8.3.0",
     "tslint": "^5.19.0",
-    "typescript": ">=3.2.1 <3.8.0 >3.7.0-dev.0"
+    "typescript": ">=3.2.1 <3.8.0 || >3.7.0-dev.0"
   },
   "collective": {
     "type": "opencollective",
     "url": "https://opencollective.com/typescript-eslint"
   },
   "resolutions": {
-    "typescript": "^3.7.0-beta"
+    "typescript": "^3.7.0-dev.20191018"
   }
 }

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -16,7 +16,7 @@ import { TSESTree } from './ts-estree';
  * This needs to be kept in sync with the top-level README.md in the
  * typescript-eslint monorepo
  */
-const SUPPORTED_TYPESCRIPT_VERSIONS = '>=3.2.1 <3.8.0 >3.7.0-dev.0';
+const SUPPORTED_TYPESCRIPT_VERSIONS = '>=3.2.1 <3.8.0 || >3.7.0-dev.0';
 const ACTIVE_TYPESCRIPT_VERSION = ts.version;
 const isRunningSupportedTypeScriptVersion = semver.satisfies(
   ACTIVE_TYPESCRIPT_VERSION,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7715,10 +7715,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*, "typescript@>=3.2.1 <3.8.0 >3.7.0-dev.0", typescript@^3.7.0-beta:
-  version "3.7.0-dev.20191015"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.0-dev.20191015.tgz#283a99aeb09c91963aa16adcf5cb2fccbea9bdc4"
-  integrity sha512-Cpfj1n4pEUVKL+jtS0mkZodJffyMmf3Wk/UjyZMGX4fsjK5KBPJf3NUlyXij8I8p1E2CAomdS5NPFrAR+z8pKw==
+typescript@*, "typescript@>=3.2.1 <3.8.0 || >3.7.0-dev.0", typescript@^3.7.0-dev.20191018:
+  version "3.7.0-dev.20191018"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.0-dev.20191018.tgz#6b98a655b124ca697364e2d7977c469a2bfede3d"
+  integrity sha512-Z8KpsytbY5lBMp5cc08VFoO8CgHC6IcbgyiA5vjh7fitkoG0qcem9C354YuiWV4O2+i2gdC7vF8tNUYqO/vUkQ==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
It wasn't matching 3.6.4 as valid because I missed the pipe.