### PR TITLE
fix(typescript-estree): better handle canonical paths

### DIFF
--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -38,7 +38,7 @@ const folderWatchCallbackTrackingMap = new Map<
 /**
  * Stores the list of known files for each program
  */
-const programFileListCache = new Map<CanonicalPath, Set<string>>();
+const programFileListCache = new Map<CanonicalPath, Set<CanonicalPath>>();
 
 /**
  * Caches the last modified time of the tsconfig files
@@ -152,7 +152,9 @@ function getProgramsForProjects(
     let updatedProgram: ts.Program | null = null;
     if (!fileList) {
       updatedProgram = existingWatch.getProgram().getProgram();
-      fileList = new Set(updatedProgram.getRootFileNames());
+      fileList = new Set(
+        updatedProgram.getRootFileNames().map(f => getCanonicalFileName(f)),
+      );
       programFileListCache.set(tsconfigPath, fileList);
     }
 

--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -18,10 +18,29 @@ const DEFAULT_COMPILER_OPTIONS: ts.CompilerOptions = {
   // extendedDiagnostics: true,
 };
 
-function getTsconfigPath(tsconfigPath: string, extra: Extra): string {
-  return path.isAbsolute(tsconfigPath)
-    ? tsconfigPath
-    : path.join(extra.tsconfigRootDir || process.cwd(), tsconfigPath);
+// This narrows the type so we can be sure we're passing canonical names in the correct places
+type CanonicalPath = string & { __brand: unknown };
+const getCanonicalFileName = ts.sys.useCaseSensitiveFileNames
+  ? (path: string): CanonicalPath => path as CanonicalPath
+  : (path: string): CanonicalPath => path.toLowerCase() as CanonicalPath;
+
+function getTsconfigPath(tsconfigPath: string, extra: Extra): CanonicalPath {
+  return getCanonicalFileName(
+    path.isAbsolute(tsconfigPath)
+      ? tsconfigPath
+      : path.join(extra.tsconfigRootDir || process.cwd(), tsconfigPath),
+  );
 }
 
-export { ASTAndProgram, DEFAULT_COMPILER_OPTIONS, getTsconfigPath };
+function canonicalDirname(p: CanonicalPath): CanonicalPath {
+  return path.dirname(p) as CanonicalPath;
+}
+
+export {
+  ASTAndProgram,
+  canonicalDirname,
+  CanonicalPath,
+  DEFAULT_COMPILER_OPTIONS,
+  getCanonicalFileName,
+  getTsconfigPath,
+};

--- a/packages/typescript-estree/tests/lib/semanticInfo.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo.ts
@@ -254,7 +254,10 @@ describe('semanticInfo', () => {
     badConfig.project = '.';
     expect(() =>
       parseCodeAndGenerateServices(readFileSync(fileName, 'utf8'), badConfig),
-    ).toThrow(/File .+semanticInfo' not found/);
+    ).toThrow(
+      // case insensitive because unix based systems are case insensitive
+      /File .+semanticInfo' not found/i,
+    );
   });
 
   it('malformed project file', () => {


### PR DESCRIPTION
Whilst investigating #1110, I found that there are some cases where typescript will give us their "canonical path" instead of the actual path.

This is a problem on unix because the canonical path is all lower case, which means we can fail to fire directory updates, because the watcher path doesn't match.

This PR adds a pseudo-nominal type (waiting for the day typescript adds it for real) which ensures (at typecheck time) that the canonical path passed in where required.