### PR TITLE
docs(eslint-plugin): typo in no-unnecessary-condition.md

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
@@ -59,6 +59,6 @@ The main downside to using this rule is the need for type information.
 
 ## Related To
 
-- ESLint: [no-constant-condition](https://eslint.org/docs/rules/no-constant-condition) - this rule is essentially a stronger versison
+- ESLint: [no-constant-condition](https://eslint.org/docs/rules/no-constant-condition) - this rule is essentially a stronger version.
 
 - [strict-boolean-expression](./strict-boolean-expressions.md) - a stricter alternative to this rule.


### PR DESCRIPTION
Just a typo in the docs.