### PR TITLE
fix(typescript-estree): check TTY before version mismatch warning

### DIFF
--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -224,7 +224,11 @@ function applyParserOptionsToExtra(options: TSESTreeOptions): void {
 }
 
 function warnAboutTSVersion(): void {
-  if (!isRunningSupportedTypeScriptVersion && !warnedAboutTSVersion) {
+  if (
+    !isRunningSupportedTypeScriptVersion &&
+    !warnedAboutTSVersion &&
+    process.stdout.isTTY
+  ) {
     const border = '=============';
     const versionWarning = [
       border,

--- a/packages/typescript-estree/tests/lib/warn-on-unsupported-ts.ts
+++ b/packages/typescript-estree/tests/lib/warn-on-unsupported-ts.ts
@@ -3,20 +3,34 @@ import * as parser from '../../src/parser';
 
 jest.mock('semver');
 
+const resetIsTTY = process.stdout.isTTY;
+
 describe('Warn on unsupported TypeScript version', () => {
   afterEach(() => {
     jest.resetModules();
     jest.resetAllMocks();
+    process.stdout.isTTY = resetIsTTY;
   });
 
   it('should warn the user if they are using an unsupported TypeScript version', () => {
     (semver.satisfies as jest.Mock).mockReturnValue(false);
     jest.spyOn(console, 'log').mockImplementation();
+    process.stdout.isTTY = true;
+
     parser.parse('');
     expect(console.log).toHaveBeenCalledWith(
       expect.stringContaining(
         'WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree',
       ),
     );
+  });
+
+  it('should not warn the user when the user is running on a non TTY process', () => {
+    (semver.satisfies as jest.Mock).mockReturnValue(false);
+    jest.spyOn(console, 'log').mockImplementation();
+    process.stdout.isTTY = false;
+
+    parser.parse('');
+    expect(console.log).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Currently the Warning regarding the versions mismatch breaks other tools, like ALE for vim.
Since some tools depend on the output to the stdout to be a well formatted json.

This fixes the issue by allowing tools to use the parser without getting the warning, but still displaying the warning if the user triggers the command from the terminal. 

Fixes #1060 