### PR TITLE
fix(typescript-estree): normalize paths to fix cache miss on windows

### DIFF
--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -21,8 +21,10 @@ const DEFAULT_COMPILER_OPTIONS: ts.CompilerOptions = {
 // This narrows the type so we can be sure we're passing canonical names in the correct places
 type CanonicalPath = string & { __brand: unknown };
 const getCanonicalFileName = ts.sys.useCaseSensitiveFileNames
-  ? (path: string): CanonicalPath => path as CanonicalPath
-  : (path: string): CanonicalPath => path.toLowerCase() as CanonicalPath;
+  ? (filePath: string): CanonicalPath =>
+      path.normalize(filePath) as CanonicalPath
+  : (filePath: string): CanonicalPath =>
+      path.normalize(filePath).toLowerCase() as CanonicalPath;
 
 function getTsconfigPath(tsconfigPath: string, extra: Extra): CanonicalPath {
   return getCanonicalFileName(


### PR DESCRIPTION
Fixes #1126

Windows paths can come in with forward or back slashes.
Need to normalize the paths so they have the same slashes.

NGL switching from mac to windows to do this was so painful.