### PR TITLE
fix(typescript-estree): correct parenthesized optional chain AST

### DIFF
--- a/packages/parser/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/parser/tests/lib/__snapshots__/typescript.ts.snap
@@ -22242,31 +22242,31 @@ Object {
 
 exports[`typescript fixtures/basics/optional-chain-call.src 1`] = `
 Object {
-  "$id": 22,
+  "$id": 23,
   "block": Object {
     "range": Array [
       0,
-      181,
+      194,
     ],
     "type": "Program",
   },
   "childScopes": Array [
     Object {
-      "$id": 21,
+      "$id": 22,
       "block": Object {
         "range": Array [
           0,
-          181,
+          194,
         ],
         "type": "Program",
       },
       "childScopes": Array [
         Object {
-          "$id": 20,
+          "$id": 21,
           "block": Object {
             "range": Array [
               0,
-              180,
+              193,
             ],
             "type": "FunctionDeclaration",
           },
@@ -22277,7 +22277,7 @@ Object {
             Object {
               "$id": 3,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "one",
@@ -22296,7 +22296,7 @@ Object {
             Object {
               "$id": 4,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "fn",
@@ -22313,7 +22313,7 @@ Object {
             Object {
               "$id": 5,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "one",
@@ -22332,7 +22332,7 @@ Object {
             Object {
               "$id": 6,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "two",
@@ -22349,7 +22349,7 @@ Object {
             Object {
               "$id": 7,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "fn",
@@ -22366,7 +22366,7 @@ Object {
             Object {
               "$id": 8,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "one",
@@ -22385,7 +22385,7 @@ Object {
             Object {
               "$id": 9,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "fn",
@@ -22402,7 +22402,7 @@ Object {
             Object {
               "$id": 10,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "one",
@@ -22421,7 +22421,7 @@ Object {
             Object {
               "$id": 11,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "three",
@@ -22438,7 +22438,7 @@ Object {
             Object {
               "$id": 12,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "fn",
@@ -22455,7 +22455,7 @@ Object {
             Object {
               "$id": 13,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "one",
@@ -22474,7 +22474,7 @@ Object {
             Object {
               "$id": 14,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "three",
@@ -22491,7 +22491,7 @@ Object {
             Object {
               "$id": 15,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "fn",
@@ -22508,7 +22508,7 @@ Object {
             Object {
               "$id": 16,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "one",
@@ -22527,7 +22527,7 @@ Object {
             Object {
               "$id": 17,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "one",
@@ -22546,13 +22546,13 @@ Object {
             Object {
               "$id": 18,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "one",
                 "range": Array [
+                  163,
                   166,
-                  169,
                 ],
                 "type": "Identifier",
               },
@@ -22565,13 +22565,32 @@ Object {
             Object {
               "$id": 19,
               "from": Object {
-                "$ref": 20,
+                "$ref": 21,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  179,
+                  182,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 20,
+              "from": Object {
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "two",
                 "range": Array [
-                  174,
-                  177,
+                  187,
+                  190,
                 ],
                 "type": "Identifier",
               },
@@ -22606,12 +22625,12 @@ Object {
               "$ref": 15,
             },
             Object {
-              "$ref": 19,
+              "$ref": 20,
             },
           ],
           "type": "function",
           "upperScope": Object {
-            "$ref": 21,
+            "$ref": 22,
           },
           "variableMap": Object {
             "arguments": Object {
@@ -22622,7 +22641,7 @@ Object {
             },
           },
           "variableScope": Object {
-            "$ref": 20,
+            "$ref": 21,
           },
           "variables": Array [
             Object {
@@ -22633,7 +22652,7 @@ Object {
               "name": "arguments",
               "references": Array [],
               "scope": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
             },
             Object {
@@ -22651,7 +22670,7 @@ Object {
                   "node": Object {
                     "range": Array [
                       0,
-                      180,
+                      193,
                     ],
                     "type": "FunctionDeclaration",
                   },
@@ -22696,9 +22715,12 @@ Object {
                 Object {
                   "$ref": 18,
                 },
+                Object {
+                  "$ref": 19,
+                },
               ],
               "scope": Object {
-                "$ref": 20,
+                "$ref": 21,
               },
             },
           ],
@@ -22733,12 +22755,12 @@ Object {
           "$ref": 15,
         },
         Object {
-          "$ref": 19,
+          "$ref": 20,
         },
       ],
       "type": "module",
       "upperScope": Object {
-        "$ref": 22,
+        "$ref": 23,
       },
       "variableMap": Object {
         "processOptionalCall": Object {
@@ -22746,7 +22768,7 @@ Object {
         },
       },
       "variableScope": Object {
-        "$ref": 21,
+        "$ref": 22,
       },
       "variables": Array [
         Object {
@@ -22764,7 +22786,7 @@ Object {
               "node": Object {
                 "range": Array [
                   0,
-                  180,
+                  193,
                 ],
                 "type": "FunctionDeclaration",
               },
@@ -22786,7 +22808,7 @@ Object {
           "name": "processOptionalCall",
           "references": Array [],
           "scope": Object {
-            "$ref": 21,
+            "$ref": 22,
           },
         },
       ],
@@ -22821,14 +22843,552 @@ Object {
       "$ref": 15,
     },
     Object {
-      "$ref": 19,
+      "$ref": 20,
     },
   ],
   "type": "global",
   "upperScope": null,
   "variableMap": Object {},
   "variableScope": Object {
-    "$ref": 22,
+    "$ref": 23,
+  },
+  "variables": Array [],
+}
+`;
+
+exports[`typescript fixtures/basics/optional-chain-call-with-parens.src 1`] = `
+Object {
+  "$id": 20,
+  "block": Object {
+    "range": Array [
+      0,
+      218,
+    ],
+    "type": "Program",
+  },
+  "childScopes": Array [
+    Object {
+      "$id": 19,
+      "block": Object {
+        "range": Array [
+          0,
+          218,
+        ],
+        "type": "Program",
+      },
+      "childScopes": Array [
+        Object {
+          "$id": 18,
+          "block": Object {
+            "range": Array [
+              0,
+              217,
+            ],
+            "type": "FunctionDeclaration",
+          },
+          "childScopes": Array [],
+          "functionExpressionScope": false,
+          "isStrict": true,
+          "references": Array [
+            Object {
+              "$id": 3,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  51,
+                  54,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 4,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "fn",
+                "range": Array [
+                  56,
+                  58,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 5,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  66,
+                  69,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 6,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "two",
+                "range": Array [
+                  71,
+                  74,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 7,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  85,
+                  88,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 8,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "fn",
+                "range": Array [
+                  94,
+                  96,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 9,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  104,
+                  107,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 10,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "three",
+                "range": Array [
+                  113,
+                  118,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 11,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  129,
+                  132,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 12,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "three",
+                "range": Array [
+                  138,
+                  143,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 13,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "fn",
+                "range": Array [
+                  145,
+                  147,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 14,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  156,
+                  159,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 15,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  169,
+                  172,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 16,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  184,
+                  187,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 17,
+              "from": Object {
+                "$ref": 18,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  202,
+                  205,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+          ],
+          "throughReferences": Array [
+            Object {
+              "$ref": 4,
+            },
+            Object {
+              "$ref": 6,
+            },
+            Object {
+              "$ref": 8,
+            },
+            Object {
+              "$ref": 10,
+            },
+            Object {
+              "$ref": 12,
+            },
+            Object {
+              "$ref": 13,
+            },
+          ],
+          "type": "function",
+          "upperScope": Object {
+            "$ref": 19,
+          },
+          "variableMap": Object {
+            "arguments": Object {
+              "$ref": 1,
+            },
+            "one": Object {
+              "$ref": 2,
+            },
+          },
+          "variableScope": Object {
+            "$ref": 18,
+          },
+          "variables": Array [
+            Object {
+              "$id": 1,
+              "defs": Array [],
+              "eslintUsed": undefined,
+              "identifiers": Array [],
+              "name": "arguments",
+              "references": Array [],
+              "scope": Object {
+                "$ref": 18,
+              },
+            },
+            Object {
+              "$id": 2,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "one",
+                    "range": Array [
+                      35,
+                      44,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      0,
+                      217,
+                    ],
+                    "type": "FunctionDeclaration",
+                  },
+                  "parent": null,
+                  "type": "Parameter",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "one",
+                  "range": Array [
+                    35,
+                    44,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "one",
+              "references": Array [
+                Object {
+                  "$ref": 3,
+                },
+                Object {
+                  "$ref": 5,
+                },
+                Object {
+                  "$ref": 7,
+                },
+                Object {
+                  "$ref": 9,
+                },
+                Object {
+                  "$ref": 11,
+                },
+                Object {
+                  "$ref": 14,
+                },
+                Object {
+                  "$ref": 15,
+                },
+                Object {
+                  "$ref": 16,
+                },
+                Object {
+                  "$ref": 17,
+                },
+              ],
+              "scope": Object {
+                "$ref": 18,
+              },
+            },
+          ],
+        },
+      ],
+      "functionExpressionScope": false,
+      "isStrict": true,
+      "references": Array [],
+      "throughReferences": Array [
+        Object {
+          "$ref": 4,
+        },
+        Object {
+          "$ref": 6,
+        },
+        Object {
+          "$ref": 8,
+        },
+        Object {
+          "$ref": 10,
+        },
+        Object {
+          "$ref": 12,
+        },
+        Object {
+          "$ref": 13,
+        },
+      ],
+      "type": "module",
+      "upperScope": Object {
+        "$ref": 20,
+      },
+      "variableMap": Object {
+        "processOptionalCallParens": Object {
+          "$ref": 0,
+        },
+      },
+      "variableScope": Object {
+        "$ref": 19,
+      },
+      "variables": Array [
+        Object {
+          "$id": 0,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "processOptionalCallParens",
+                "range": Array [
+                  9,
+                  34,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  0,
+                  217,
+                ],
+                "type": "FunctionDeclaration",
+              },
+              "parent": null,
+              "type": "FunctionName",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "processOptionalCallParens",
+              "range": Array [
+                9,
+                34,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "processOptionalCallParens",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 19,
+          },
+        },
+      ],
+    },
+  ],
+  "functionExpressionScope": false,
+  "isStrict": false,
+  "references": Array [],
+  "throughReferences": Array [
+    Object {
+      "$ref": 4,
+    },
+    Object {
+      "$ref": 6,
+    },
+    Object {
+      "$ref": 8,
+    },
+    Object {
+      "$ref": 10,
+    },
+    Object {
+      "$ref": 12,
+    },
+    Object {
+      "$ref": 13,
+    },
+  ],
+  "type": "global",
+  "upperScope": null,
+  "variableMap": Object {},
+  "variableScope": Object {
+    "$ref": 20,
   },
   "variables": Array [],
 }
@@ -23142,6 +23702,843 @@ Object {
   "variableMap": Object {},
   "variableScope": Object {
     "$ref": 11,
+  },
+  "variables": Array [],
+}
+`;
+
+exports[`typescript fixtures/basics/optional-chain-element-access-with-parens.src 1`] = `
+Object {
+  "$id": 11,
+  "block": Object {
+    "range": Array [
+      0,
+      168,
+    ],
+    "type": "Program",
+  },
+  "childScopes": Array [
+    Object {
+      "$id": 10,
+      "block": Object {
+        "range": Array [
+          0,
+          168,
+        ],
+        "type": "Program",
+      },
+      "childScopes": Array [
+        Object {
+          "$id": 9,
+          "block": Object {
+            "range": Array [
+              0,
+              167,
+            ],
+            "type": "FunctionDeclaration",
+          },
+          "childScopes": Array [],
+          "functionExpressionScope": false,
+          "isStrict": true,
+          "references": Array [
+            Object {
+              "$id": 3,
+              "from": Object {
+                "$ref": 9,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  54,
+                  57,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 4,
+              "from": Object {
+                "$ref": 9,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  68,
+                  71,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 5,
+              "from": Object {
+                "$ref": 9,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  85,
+                  88,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 6,
+              "from": Object {
+                "$ref": 9,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  102,
+                  105,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 7,
+              "from": Object {
+                "$ref": 9,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  122,
+                  125,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 8,
+              "from": Object {
+                "$ref": 9,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  144,
+                  147,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+          ],
+          "throughReferences": Array [],
+          "type": "function",
+          "upperScope": Object {
+            "$ref": 10,
+          },
+          "variableMap": Object {
+            "arguments": Object {
+              "$ref": 1,
+            },
+            "one": Object {
+              "$ref": 2,
+            },
+          },
+          "variableScope": Object {
+            "$ref": 9,
+          },
+          "variables": Array [
+            Object {
+              "$id": 1,
+              "defs": Array [],
+              "eslintUsed": undefined,
+              "identifiers": Array [],
+              "name": "arguments",
+              "references": Array [],
+              "scope": Object {
+                "$ref": 9,
+              },
+            },
+            Object {
+              "$id": 2,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "one",
+                    "range": Array [
+                      38,
+                      47,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      0,
+                      167,
+                    ],
+                    "type": "FunctionDeclaration",
+                  },
+                  "parent": null,
+                  "type": "Parameter",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "one",
+                  "range": Array [
+                    38,
+                    47,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "one",
+              "references": Array [
+                Object {
+                  "$ref": 3,
+                },
+                Object {
+                  "$ref": 4,
+                },
+                Object {
+                  "$ref": 5,
+                },
+                Object {
+                  "$ref": 6,
+                },
+                Object {
+                  "$ref": 7,
+                },
+                Object {
+                  "$ref": 8,
+                },
+              ],
+              "scope": Object {
+                "$ref": 9,
+              },
+            },
+          ],
+        },
+      ],
+      "functionExpressionScope": false,
+      "isStrict": true,
+      "references": Array [],
+      "throughReferences": Array [],
+      "type": "module",
+      "upperScope": Object {
+        "$ref": 11,
+      },
+      "variableMap": Object {
+        "processOptionalElementParens": Object {
+          "$ref": 0,
+        },
+      },
+      "variableScope": Object {
+        "$ref": 10,
+      },
+      "variables": Array [
+        Object {
+          "$id": 0,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "processOptionalElementParens",
+                "range": Array [
+                  9,
+                  37,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  0,
+                  167,
+                ],
+                "type": "FunctionDeclaration",
+              },
+              "parent": null,
+              "type": "FunctionName",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "processOptionalElementParens",
+              "range": Array [
+                9,
+                37,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "processOptionalElementParens",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 10,
+          },
+        },
+      ],
+    },
+  ],
+  "functionExpressionScope": false,
+  "isStrict": false,
+  "references": Array [],
+  "throughReferences": Array [],
+  "type": "global",
+  "upperScope": null,
+  "variableMap": Object {},
+  "variableScope": Object {
+    "$ref": 11,
+  },
+  "variables": Array [],
+}
+`;
+
+exports[`typescript fixtures/basics/optional-chain-with-parens.src 1`] = `
+Object {
+  "$id": 19,
+  "block": Object {
+    "range": Array [
+      0,
+      182,
+    ],
+    "type": "Program",
+  },
+  "childScopes": Array [
+    Object {
+      "$id": 18,
+      "block": Object {
+        "range": Array [
+          0,
+          182,
+        ],
+        "type": "Program",
+      },
+      "childScopes": Array [
+        Object {
+          "$id": 17,
+          "block": Object {
+            "range": Array [
+              0,
+              181,
+            ],
+            "type": "FunctionDeclaration",
+          },
+          "childScopes": Array [],
+          "functionExpressionScope": false,
+          "isStrict": true,
+          "references": Array [
+            Object {
+              "$id": 3,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  47,
+                  50,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 4,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "two",
+                "range": Array [
+                  52,
+                  55,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 5,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  61,
+                  64,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 6,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "two",
+                "range": Array [
+                  66,
+                  69,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 7,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  81,
+                  84,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 8,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "three",
+                "range": Array [
+                  90,
+                  95,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 9,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  101,
+                  104,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 10,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "three",
+                "range": Array [
+                  110,
+                  115,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 11,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  126,
+                  129,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 12,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "three",
+                "range": Array [
+                  135,
+                  140,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 13,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "four",
+                "range": Array [
+                  142,
+                  146,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 14,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "one",
+                "range": Array [
+                  152,
+                  155,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": Object {
+                "$ref": 2,
+              },
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 15,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "three",
+                "range": Array [
+                  161,
+                  166,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+            Object {
+              "$id": 16,
+              "from": Object {
+                "$ref": 17,
+              },
+              "identifier": Object {
+                "name": "four",
+                "range": Array [
+                  168,
+                  172,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "r",
+              "resolved": null,
+              "writeExpr": undefined,
+            },
+          ],
+          "throughReferences": Array [
+            Object {
+              "$ref": 4,
+            },
+            Object {
+              "$ref": 6,
+            },
+            Object {
+              "$ref": 8,
+            },
+            Object {
+              "$ref": 10,
+            },
+            Object {
+              "$ref": 12,
+            },
+            Object {
+              "$ref": 13,
+            },
+            Object {
+              "$ref": 15,
+            },
+            Object {
+              "$ref": 16,
+            },
+          ],
+          "type": "function",
+          "upperScope": Object {
+            "$ref": 18,
+          },
+          "variableMap": Object {
+            "arguments": Object {
+              "$ref": 1,
+            },
+            "one": Object {
+              "$ref": 2,
+            },
+          },
+          "variableScope": Object {
+            "$ref": 17,
+          },
+          "variables": Array [
+            Object {
+              "$id": 1,
+              "defs": Array [],
+              "eslintUsed": undefined,
+              "identifiers": Array [],
+              "name": "arguments",
+              "references": Array [],
+              "scope": Object {
+                "$ref": 17,
+              },
+            },
+            Object {
+              "$id": 2,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "one",
+                    "range": Array [
+                      31,
+                      40,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      0,
+                      181,
+                    ],
+                    "type": "FunctionDeclaration",
+                  },
+                  "parent": null,
+                  "type": "Parameter",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "one",
+                  "range": Array [
+                    31,
+                    40,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "one",
+              "references": Array [
+                Object {
+                  "$ref": 3,
+                },
+                Object {
+                  "$ref": 5,
+                },
+                Object {
+                  "$ref": 7,
+                },
+                Object {
+                  "$ref": 9,
+                },
+                Object {
+                  "$ref": 11,
+                },
+                Object {
+                  "$ref": 14,
+                },
+              ],
+              "scope": Object {
+                "$ref": 17,
+              },
+            },
+          ],
+        },
+      ],
+      "functionExpressionScope": false,
+      "isStrict": true,
+      "references": Array [],
+      "throughReferences": Array [
+        Object {
+          "$ref": 4,
+        },
+        Object {
+          "$ref": 6,
+        },
+        Object {
+          "$ref": 8,
+        },
+        Object {
+          "$ref": 10,
+        },
+        Object {
+          "$ref": 12,
+        },
+        Object {
+          "$ref": 13,
+        },
+        Object {
+          "$ref": 15,
+        },
+        Object {
+          "$ref": 16,
+        },
+      ],
+      "type": "module",
+      "upperScope": Object {
+        "$ref": 19,
+      },
+      "variableMap": Object {
+        "processOptionalParens": Object {
+          "$ref": 0,
+        },
+      },
+      "variableScope": Object {
+        "$ref": 18,
+      },
+      "variables": Array [
+        Object {
+          "$id": 0,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "processOptionalParens",
+                "range": Array [
+                  9,
+                  30,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  0,
+                  181,
+                ],
+                "type": "FunctionDeclaration",
+              },
+              "parent": null,
+              "type": "FunctionName",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "processOptionalParens",
+              "range": Array [
+                9,
+                30,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "processOptionalParens",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 18,
+          },
+        },
+      ],
+    },
+  ],
+  "functionExpressionScope": false,
+  "isStrict": false,
+  "references": Array [],
+  "throughReferences": Array [
+    Object {
+      "$ref": 4,
+    },
+    Object {
+      "$ref": 6,
+    },
+    Object {
+      "$ref": 8,
+    },
+    Object {
+      "$ref": 10,
+    },
+    Object {
+      "$ref": 12,
+    },
+    Object {
+      "$ref": 13,
+    },
+    Object {
+      "$ref": 15,
+    },
+    Object {
+      "$ref": 16,
+    },
+  ],
+  "type": "global",
+  "upperScope": null,
+  "variableMap": Object {},
+  "variableScope": Object {
+    "$ref": 19,
   },
   "variables": Array [],
 }

--- a/packages/shared-fixtures/fixtures/typescript/basics/optional-chain-call-with-parens.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/optional-chain-call-with-parens.src.ts
@@ -1,0 +1,13 @@
+function processOptionalCallParens(one?: any) {
+  (one?.fn());
+  (one?.two).fn();
+  (one.two?.fn());
+  (one.two?.three).fn();
+  (one.two?.three?.fn());
+
+  (one?.());
+  (one?.())();
+  (one?.())?.();
+
+  (one?.()).two;
+}

--- a/packages/shared-fixtures/fixtures/typescript/basics/optional-chain-call.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/optional-chain-call.src.ts
@@ -6,6 +6,7 @@ function processOptionalCall(one?: any) {
   one.two?.three?.fn();
 
   one?.();
+  one?.()();
   one?.()?.();
 
   one?.().two;

--- a/packages/shared-fixtures/fixtures/typescript/basics/optional-chain-element-access-with-parens.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/optional-chain-element-access-with-parens.src.ts
@@ -1,0 +1,8 @@
+function processOptionalElementParens(one?: any) {
+  (one?.[2]);
+  (one?.[2])[3];
+  (one[2]?.[3]);
+  (one[2]?.[3])[4];
+  (one[2]?.[3]?.[4]);
+  (one[2]?.[3]?.[4])[5];
+}

--- a/packages/shared-fixtures/fixtures/typescript/basics/optional-chain-with-parens.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/optional-chain-with-parens.src.ts
@@ -1,0 +1,8 @@
+function processOptionalParens(one?: any) {
+  (one?.two);
+  (one?.two).three;
+  (one.two?.three);
+  (one.two?.three).four;
+  (one.two?.three?.four);
+  (one.two?.three?.four).five;
+}

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1690,16 +1690,19 @@ export class Converter {
       }
 
       case SyntaxKind.PropertyAccessExpression: {
-        const isLocallyOptional = node.questionDotToken !== undefined;
         const object = this.convertChild(node.expression);
         const property = this.convertChild(node.name);
         const computed = false;
-        if (
-          isLocallyOptional ||
-          // the optional expression should propogate up the member expression tree
-          object.type === AST_NODE_TYPES.OptionalMemberExpression ||
-          object.type === AST_NODE_TYPES.OptionalCallExpression
-        ) {
+
+        const isLocallyOptional = node.questionDotToken !== undefined;
+        // the optional expression should propogate up the member expression tree
+        const isChildOptional =
+          (object.type === AST_NODE_TYPES.OptionalMemberExpression ||
+            object.type === AST_NODE_TYPES.OptionalCallExpression) &&
+          // (x?.y).z is semantically different, and as such .z is no longer optional
+          node.expression.kind !== ts.SyntaxKind.ParenthesizedExpression;
+
+        if (isLocallyOptional || isChildOptional) {
           return this.createNode<TSESTree.OptionalMemberExpression>(node, {
             type: AST_NODE_TYPES.OptionalMemberExpression,
             object,
@@ -1719,16 +1722,19 @@ export class Converter {
       }
 
       case SyntaxKind.ElementAccessExpression: {
-        const isLocallyOptional = node.questionDotToken !== undefined;
         const object = this.convertChild(node.expression);
         const property = this.convertChild(node.argumentExpression);
         const computed = true;
-        if (
-          isLocallyOptional ||
-          // the optional expression should propogate up the member expression tree
-          object.type === AST_NODE_TYPES.OptionalMemberExpression ||
-          object.type === AST_NODE_TYPES.OptionalCallExpression
-        ) {
+
+        const isLocallyOptional = node.questionDotToken !== undefined;
+        // the optional expression should propogate up the member expression tree
+        const isChildOptional =
+          (object.type === AST_NODE_TYPES.OptionalMemberExpression ||
+            object.type === AST_NODE_TYPES.OptionalCallExpression) &&
+          // (x?.y).z is semantically different, and as such .z is no longer optional
+          node.expression.kind !== ts.SyntaxKind.ParenthesizedExpression;
+
+        if (isLocallyOptional || isChildOptional) {
           return this.createNode<TSESTree.OptionalMemberExpression>(node, {
             type: AST_NODE_TYPES.OptionalMemberExpression,
             object,
@@ -1748,16 +1754,19 @@ export class Converter {
       }
 
       case SyntaxKind.CallExpression: {
-        const isLocallyOptional = node.questionDotToken !== undefined;
         const callee = this.convertChild(node.expression);
         const args = node.arguments.map(el => this.convertChild(el));
         let result;
-        if (
-          isLocallyOptional ||
-          // the optional expression should propogate up the member expression tree
-          callee.type === AST_NODE_TYPES.OptionalMemberExpression ||
-          callee.type === AST_NODE_TYPES.OptionalCallExpression
-        ) {
+
+        const isLocallyOptional = node.questionDotToken !== undefined;
+        // the optional expression should propogate up the member expression tree
+        const isChildOptional =
+          (callee.type === AST_NODE_TYPES.OptionalMemberExpression ||
+            callee.type === AST_NODE_TYPES.OptionalCallExpression) &&
+          // (x?.y).z() is semantically different, and as such .z() is no longer optional
+          node.expression.kind !== ts.SyntaxKind.ParenthesizedExpression;
+
+        if (isLocallyOptional || isChildOptional) {
           result = this.createNode<TSESTree.OptionalCallExpression>(node, {
             type: AST_NODE_TYPES.OptionalCallExpression,
             callee,

--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -20,7 +20,10 @@ const DEFAULT_COMPILER_OPTIONS: ts.CompilerOptions = {
 
 // This narrows the type so we can be sure we're passing canonical names in the correct places
 type CanonicalPath = string & { __brand: unknown };
-const getCanonicalFileName = ts.sys.useCaseSensitiveFileNames
+// typescript doesn't provide a ts.sys implementation for browser environments
+const useCaseSensitiveFileNames =
+  ts.sys !== undefined ? ts.sys.useCaseSensitiveFileNames : true;
+const getCanonicalFileName = useCaseSensitiveFileNames
   ? (filePath: string): CanonicalPath =>
       path.normalize(filePath) as CanonicalPath
   : (filePath: string): CanonicalPath =>

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -16,11 +16,18 @@ import { TSESTree } from './ts-estree';
  * This needs to be kept in sync with the top-level README.md in the
  * typescript-eslint monorepo
  */
-const SUPPORTED_TYPESCRIPT_VERSIONS = '>=3.2.1 <3.8.0 || >3.7.0-dev.0';
+const SUPPORTED_TYPESCRIPT_VERSIONS = '>=3.2.1 <3.8.0';
+/*
+ * The semver package will ignore prerelease ranges, and we don't want to explicitly document every one
+ * List them all separately here, so we can automatically create the full string
+ */
+const SUPPORTED_PRERELEASE_RANGES = ['>3.7.0-dev.0', '3.7.1-rc'];
 const ACTIVE_TYPESCRIPT_VERSION = ts.version;
 const isRunningSupportedTypeScriptVersion = semver.satisfies(
   ACTIVE_TYPESCRIPT_VERSION,
-  SUPPORTED_TYPESCRIPT_VERSIONS,
+  [SUPPORTED_TYPESCRIPT_VERSIONS]
+    .concat(SUPPORTED_PRERELEASE_RANGES)
+    .join(' || '),
 );
 
 let extra: Extra;
@@ -224,22 +231,21 @@ function applyParserOptionsToExtra(options: TSESTreeOptions): void {
 }
 
 function warnAboutTSVersion(): void {
-  if (
-    !isRunningSupportedTypeScriptVersion &&
-    !warnedAboutTSVersion &&
-    process.stdout.isTTY
-  ) {
-    const border = '=============';
-    const versionWarning = [
-      border,
-      'WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.',
-      'You may find that it works just fine, or you may not.',
-      `SUPPORTED TYPESCRIPT VERSIONS: ${SUPPORTED_TYPESCRIPT_VERSIONS}`,
-      `YOUR TYPESCRIPT VERSION: ${ACTIVE_TYPESCRIPT_VERSION}`,
-      'Please only submit bug reports when using the officially supported version.',
-      border,
-    ];
-    extra.log(versionWarning.join('\n\n'));
+  if (!isRunningSupportedTypeScriptVersion && !warnedAboutTSVersion) {
+    const isTTY = typeof process === undefined ? false : process.stdout.isTTY;
+    if (isTTY) {
+      const border = '=============';
+      const versionWarning = [
+        border,
+        'WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.',
+        'You may find that it works just fine, or you may not.',
+        `SUPPORTED TYPESCRIPT VERSIONS: ${SUPPORTED_TYPESCRIPT_VERSIONS}`,
+        `YOUR TYPESCRIPT VERSION: ${ACTIVE_TYPESCRIPT_VERSION}`,
+        'Please only submit bug reports when using the officially supported version.',
+        border,
+      ];
+      extra.log(versionWarning.join('\n\n'));
+    }
     warnedAboutTSVersion = true;
   }
 }

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -583,8 +583,11 @@ tester.addFixturePatternConfig('typescript/basics', {
      */
     // optional chaining
     'optional-chain',
+    'optional-chain-with-parens',
     'optional-chain-call',
+    'optional-chain-call-with-parens',
     'optional-chain-element-access',
+    'optional-chain-element-access-with-parens',
     'async-function-expression',
     'class-with-accessibility-modifiers',
     'class-with-mixin',

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.ts.snap
@@ -1918,7 +1918,13 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" e
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-call.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-call-with-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-element-access.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-element-access-with-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-with-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/parenthesized-use-strict.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 

--- a/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
@@ -71072,7 +71072,7 @@ Object {
               },
               "loc": Object {
                 "end": Object {
-                  "column": 13,
+                  "column": 11,
                   "line": 9,
                 },
                 "start": Object {
@@ -71080,16 +71080,16 @@ Object {
                   "line": 9,
                 },
               },
-              "optional": true,
+              "optional": false,
               "range": Array [
                 150,
-                161,
+                159,
               ],
               "type": "OptionalCallExpression",
             },
             "loc": Object {
               "end": Object {
-                "column": 14,
+                "column": 12,
                 "line": 9,
               },
               "start": Object {
@@ -71099,7 +71099,80 @@ Object {
             },
             "range": Array [
               150,
-              162,
+              160,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "arguments": Array [],
+              "callee": Object {
+                "arguments": Array [],
+                "callee": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 5,
+                      "line": 10,
+                    },
+                    "start": Object {
+                      "column": 2,
+                      "line": 10,
+                    },
+                  },
+                  "name": "one",
+                  "range": Array [
+                    163,
+                    166,
+                  ],
+                  "type": "Identifier",
+                },
+                "loc": Object {
+                  "end": Object {
+                    "column": 9,
+                    "line": 10,
+                  },
+                  "start": Object {
+                    "column": 2,
+                    "line": 10,
+                  },
+                },
+                "optional": true,
+                "range": Array [
+                  163,
+                  170,
+                ],
+                "type": "OptionalCallExpression",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 13,
+                  "line": 10,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 10,
+                },
+              },
+              "optional": true,
+              "range": Array [
+                163,
+                174,
+              ],
+              "type": "OptionalCallExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 14,
+                "line": 10,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 10,
+              },
+            },
+            "range": Array [
+              163,
+              175,
             ],
             "type": "ExpressionStatement",
           },
@@ -71109,11 +71182,11 @@ Object {
               "loc": Object {
                 "end": Object {
                   "column": 13,
-                  "line": 11,
+                  "line": 12,
                 },
                 "start": Object {
                   "column": 2,
-                  "line": 11,
+                  "line": 12,
                 },
               },
               "object": Object {
@@ -71122,34 +71195,34 @@ Object {
                   "loc": Object {
                     "end": Object {
                       "column": 5,
-                      "line": 11,
+                      "line": 12,
                     },
                     "start": Object {
                       "column": 2,
-                      "line": 11,
+                      "line": 12,
                     },
                   },
                   "name": "one",
                   "range": Array [
-                    166,
-                    169,
+                    179,
+                    182,
                   ],
                   "type": "Identifier",
                 },
                 "loc": Object {
                   "end": Object {
                     "column": 9,
-                    "line": 11,
+                    "line": 12,
                   },
                   "start": Object {
                     "column": 2,
-                    "line": 11,
+                    "line": 12,
                   },
                 },
                 "optional": true,
                 "range": Array [
-                  166,
-                  173,
+                  179,
+                  186,
                 ],
                 "type": "OptionalCallExpression",
               },
@@ -71158,39 +71231,39 @@ Object {
                 "loc": Object {
                   "end": Object {
                     "column": 13,
-                    "line": 11,
+                    "line": 12,
                   },
                   "start": Object {
                     "column": 10,
-                    "line": 11,
+                    "line": 12,
                   },
                 },
                 "name": "two",
                 "range": Array [
-                  174,
-                  177,
+                  187,
+                  190,
                 ],
                 "type": "Identifier",
               },
               "range": Array [
-                166,
-                177,
+                179,
+                190,
               ],
               "type": "OptionalMemberExpression",
             },
             "loc": Object {
               "end": Object {
                 "column": 14,
-                "line": 11,
+                "line": 12,
               },
               "start": Object {
                 "column": 2,
-                "line": 11,
+                "line": 12,
               },
             },
             "range": Array [
-              166,
-              178,
+              179,
+              191,
             ],
             "type": "ExpressionStatement",
           },
@@ -71198,7 +71271,7 @@ Object {
         "loc": Object {
           "end": Object {
             "column": 1,
-            "line": 12,
+            "line": 13,
           },
           "start": Object {
             "column": 40,
@@ -71207,7 +71280,7 @@ Object {
         },
         "range": Array [
           40,
-          180,
+          193,
         ],
         "type": "BlockStatement",
       },
@@ -71234,7 +71307,7 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 12,
+          "line": 13,
         },
         "start": Object {
           "column": 0,
@@ -71298,7 +71371,7 @@ Object {
       ],
       "range": Array [
         0,
-        180,
+        193,
       ],
       "type": "FunctionDeclaration",
     },
@@ -71306,7 +71379,7 @@ Object {
   "loc": Object {
     "end": Object {
       "column": 0,
-      "line": 13,
+      "line": 14,
     },
     "start": Object {
       "column": 0,
@@ -71315,7 +71388,7 @@ Object {
   },
   "range": Array [
     0,
-    181,
+    194,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -72402,7 +72475,7 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 11,
+          "column": 10,
           "line": 9,
         },
         "start": Object {
@@ -72412,10 +72485,28 @@ Object {
       },
       "range": Array [
         157,
+        158,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        158,
         159,
       ],
       "type": "Punctuator",
-      "value": "?.",
+      "value": ")",
     },
     Object {
       "loc": Object {
@@ -72433,6 +72524,2749 @@ Object {
         160,
       ],
       "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        163,
+        166,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        166,
+        168,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        168,
+        169,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        169,
+        170,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        170,
+        172,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        172,
+        173,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        173,
+        174,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        174,
+        175,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        179,
+        182,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        182,
+        184,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        184,
+        185,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        185,
+        186,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        186,
+        187,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        187,
+        190,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        190,
+        191,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 13,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 13,
+        },
+      },
+      "range": Array [
+        192,
+        193,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
+exports[`typescript fixtures/basics/optional-chain-call-with-parens.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "async": false,
+      "body": Object {
+        "body": Array [
+          Object {
+            "expression": Object {
+              "arguments": Array [],
+              "callee": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 10,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 2,
+                  },
+                },
+                "object": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 6,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 2,
+                    },
+                  },
+                  "name": "one",
+                  "range": Array [
+                    51,
+                    54,
+                  ],
+                  "type": "Identifier",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 10,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 8,
+                      "line": 2,
+                    },
+                  },
+                  "name": "fn",
+                  "range": Array [
+                    56,
+                    58,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  51,
+                  58,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 12,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 2,
+                },
+              },
+              "optional": false,
+              "range": Array [
+                51,
+                60,
+              ],
+              "type": "OptionalCallExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 14,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              50,
+              62,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "arguments": Array [],
+              "callee": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 2,
+                    "line": 3,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 11,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 3,
+                    },
+                  },
+                  "object": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 6,
+                        "line": 3,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 3,
+                      },
+                    },
+                    "name": "one",
+                    "range": Array [
+                      66,
+                      69,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "optional": true,
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 11,
+                        "line": 3,
+                      },
+                      "start": Object {
+                        "column": 8,
+                        "line": 3,
+                      },
+                    },
+                    "name": "two",
+                    "range": Array [
+                      71,
+                      74,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    66,
+                    74,
+                  ],
+                  "type": "OptionalMemberExpression",
+                },
+                "optional": false,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 15,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "column": 13,
+                      "line": 3,
+                    },
+                  },
+                  "name": "fn",
+                  "range": Array [
+                    76,
+                    78,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  65,
+                  78,
+                ],
+                "type": "MemberExpression",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 17,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 3,
+                },
+              },
+              "optional": false,
+              "range": Array [
+                65,
+                80,
+              ],
+              "type": "CallExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 18,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 3,
+              },
+            },
+            "range": Array [
+              65,
+              81,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "arguments": Array [],
+              "callee": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 4,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 10,
+                      "line": 4,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 4,
+                    },
+                  },
+                  "object": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 6,
+                        "line": 4,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 4,
+                      },
+                    },
+                    "name": "one",
+                    "range": Array [
+                      85,
+                      88,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "optional": false,
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 10,
+                        "line": 4,
+                      },
+                      "start": Object {
+                        "column": 7,
+                        "line": 4,
+                      },
+                    },
+                    "name": "two",
+                    "range": Array [
+                      89,
+                      92,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    85,
+                    92,
+                  ],
+                  "type": "MemberExpression",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 14,
+                      "line": 4,
+                    },
+                    "start": Object {
+                      "column": 12,
+                      "line": 4,
+                    },
+                  },
+                  "name": "fn",
+                  "range": Array [
+                    94,
+                    96,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  85,
+                  96,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 4,
+                },
+              },
+              "optional": false,
+              "range": Array [
+                85,
+                98,
+              ],
+              "type": "OptionalCallExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 18,
+                "line": 4,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 4,
+              },
+            },
+            "range": Array [
+              84,
+              100,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "arguments": Array [],
+              "callee": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 21,
+                    "line": 5,
+                  },
+                  "start": Object {
+                    "column": 2,
+                    "line": 5,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 17,
+                      "line": 5,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 5,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 10,
+                        "line": 5,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 5,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 6,
+                          "line": 5,
+                        },
+                        "start": Object {
+                          "column": 3,
+                          "line": 5,
+                        },
+                      },
+                      "name": "one",
+                      "range": Array [
+                        104,
+                        107,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "optional": false,
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 10,
+                          "line": 5,
+                        },
+                        "start": Object {
+                          "column": 7,
+                          "line": 5,
+                        },
+                      },
+                      "name": "two",
+                      "range": Array [
+                        108,
+                        111,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      104,
+                      111,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "optional": true,
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 17,
+                        "line": 5,
+                      },
+                      "start": Object {
+                        "column": 12,
+                        "line": 5,
+                      },
+                    },
+                    "name": "three",
+                    "range": Array [
+                      113,
+                      118,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    104,
+                    118,
+                  ],
+                  "type": "OptionalMemberExpression",
+                },
+                "optional": false,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 21,
+                      "line": 5,
+                    },
+                    "start": Object {
+                      "column": 19,
+                      "line": 5,
+                    },
+                  },
+                  "name": "fn",
+                  "range": Array [
+                    120,
+                    122,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  103,
+                  122,
+                ],
+                "type": "MemberExpression",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 23,
+                  "line": 5,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 5,
+                },
+              },
+              "optional": false,
+              "range": Array [
+                103,
+                124,
+              ],
+              "type": "CallExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 24,
+                "line": 5,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 5,
+              },
+            },
+            "range": Array [
+              103,
+              125,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "arguments": Array [],
+              "callee": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 21,
+                    "line": 6,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 6,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 17,
+                      "line": 6,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 6,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 10,
+                        "line": 6,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 6,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 6,
+                          "line": 6,
+                        },
+                        "start": Object {
+                          "column": 3,
+                          "line": 6,
+                        },
+                      },
+                      "name": "one",
+                      "range": Array [
+                        129,
+                        132,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "optional": false,
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 10,
+                          "line": 6,
+                        },
+                        "start": Object {
+                          "column": 7,
+                          "line": 6,
+                        },
+                      },
+                      "name": "two",
+                      "range": Array [
+                        133,
+                        136,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      129,
+                      136,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "optional": true,
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 17,
+                        "line": 6,
+                      },
+                      "start": Object {
+                        "column": 12,
+                        "line": 6,
+                      },
+                    },
+                    "name": "three",
+                    "range": Array [
+                      138,
+                      143,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    129,
+                    143,
+                  ],
+                  "type": "OptionalMemberExpression",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 21,
+                      "line": 6,
+                    },
+                    "start": Object {
+                      "column": 19,
+                      "line": 6,
+                    },
+                  },
+                  "name": "fn",
+                  "range": Array [
+                    145,
+                    147,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  129,
+                  147,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 23,
+                  "line": 6,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 6,
+                },
+              },
+              "optional": false,
+              "range": Array [
+                129,
+                149,
+              ],
+              "type": "OptionalCallExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 25,
+                "line": 6,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 6,
+              },
+            },
+            "range": Array [
+              128,
+              151,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "arguments": Array [],
+              "callee": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 6,
+                    "line": 8,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 8,
+                  },
+                },
+                "name": "one",
+                "range": Array [
+                  156,
+                  159,
+                ],
+                "type": "Identifier",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 10,
+                  "line": 8,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 8,
+                },
+              },
+              "optional": true,
+              "range": Array [
+                156,
+                163,
+              ],
+              "type": "OptionalCallExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 12,
+                "line": 8,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 8,
+              },
+            },
+            "range": Array [
+              155,
+              165,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "arguments": Array [],
+              "callee": Object {
+                "arguments": Array [],
+                "callee": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 6,
+                      "line": 9,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 9,
+                    },
+                  },
+                  "name": "one",
+                  "range": Array [
+                    169,
+                    172,
+                  ],
+                  "type": "Identifier",
+                },
+                "loc": Object {
+                  "end": Object {
+                    "column": 10,
+                    "line": 9,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 9,
+                  },
+                },
+                "optional": true,
+                "range": Array [
+                  169,
+                  176,
+                ],
+                "type": "OptionalCallExpression",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 13,
+                  "line": 9,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 9,
+                },
+              },
+              "optional": false,
+              "range": Array [
+                168,
+                179,
+              ],
+              "type": "CallExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 14,
+                "line": 9,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 9,
+              },
+            },
+            "range": Array [
+              168,
+              180,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "arguments": Array [],
+              "callee": Object {
+                "arguments": Array [],
+                "callee": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 6,
+                      "line": 10,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 10,
+                    },
+                  },
+                  "name": "one",
+                  "range": Array [
+                    184,
+                    187,
+                  ],
+                  "type": "Identifier",
+                },
+                "loc": Object {
+                  "end": Object {
+                    "column": 10,
+                    "line": 10,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 10,
+                  },
+                },
+                "optional": true,
+                "range": Array [
+                  184,
+                  191,
+                ],
+                "type": "OptionalCallExpression",
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 15,
+                  "line": 10,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 10,
+                },
+              },
+              "optional": true,
+              "range": Array [
+                183,
+                196,
+              ],
+              "type": "OptionalCallExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 16,
+                "line": 10,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 10,
+              },
+            },
+            "range": Array [
+              183,
+              197,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": false,
+              "loc": Object {
+                "end": Object {
+                  "column": 15,
+                  "line": 12,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 12,
+                },
+              },
+              "object": Object {
+                "arguments": Array [],
+                "callee": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 6,
+                      "line": 12,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 12,
+                    },
+                  },
+                  "name": "one",
+                  "range": Array [
+                    202,
+                    205,
+                  ],
+                  "type": "Identifier",
+                },
+                "loc": Object {
+                  "end": Object {
+                    "column": 10,
+                    "line": 12,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 12,
+                  },
+                },
+                "optional": true,
+                "range": Array [
+                  202,
+                  209,
+                ],
+                "type": "OptionalCallExpression",
+              },
+              "optional": false,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 12,
+                  },
+                  "start": Object {
+                    "column": 12,
+                    "line": 12,
+                  },
+                },
+                "name": "two",
+                "range": Array [
+                  211,
+                  214,
+                ],
+                "type": "Identifier",
+              },
+              "range": Array [
+                201,
+                214,
+              ],
+              "type": "MemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 16,
+                "line": 12,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 12,
+              },
+            },
+            "range": Array [
+              201,
+              215,
+            ],
+            "type": "ExpressionStatement",
+          },
+        ],
+        "loc": Object {
+          "end": Object {
+            "column": 1,
+            "line": 13,
+          },
+          "start": Object {
+            "column": 46,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          46,
+          217,
+        ],
+        "type": "BlockStatement",
+      },
+      "expression": false,
+      "generator": false,
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 34,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 9,
+            "line": 1,
+          },
+        },
+        "name": "processOptionalCallParens",
+        "range": Array [
+          9,
+          34,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 13,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "params": Array [
+        Object {
+          "loc": Object {
+            "end": Object {
+              "column": 44,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 35,
+              "line": 1,
+            },
+          },
+          "name": "one",
+          "optional": true,
+          "range": Array [
+            35,
+            44,
+          ],
+          "type": "Identifier",
+          "typeAnnotation": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 44,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 39,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              39,
+              44,
+            ],
+            "type": "TSTypeAnnotation",
+            "typeAnnotation": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 44,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 41,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                41,
+                44,
+              ],
+              "type": "TSAnyKeyword",
+            },
+          },
+        },
+      ],
+      "range": Array [
+        0,
+        217,
+      ],
+      "type": "FunctionDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 14,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    218,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        8,
+      ],
+      "type": "Keyword",
+      "value": "function",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 34,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        34,
+      ],
+      "type": "Identifier",
+      "value": "processOptionalCallParens",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 35,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        34,
+        35,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 38,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        35,
+        38,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 39,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        38,
+        39,
+      ],
+      "type": "Punctuator",
+      "value": "?",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 40,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        39,
+        40,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 44,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        41,
+        44,
+      ],
+      "type": "Identifier",
+      "value": "any",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 45,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        44,
+        45,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 47,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        46,
+        47,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        50,
+        51,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        51,
+        54,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        54,
+        56,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        56,
+        58,
+      ],
+      "type": "Identifier",
+      "value": "fn",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        58,
+        59,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        59,
+        60,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        60,
+        61,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        61,
+        62,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        65,
+        66,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        66,
+        69,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        69,
+        71,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        71,
+        74,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        74,
+        75,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        75,
+        76,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        76,
+        78,
+      ],
+      "type": "Identifier",
+      "value": "fn",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        78,
+        79,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        79,
+        80,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        80,
+        81,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        84,
+        85,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        85,
+        88,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        88,
+        89,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        89,
+        92,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        92,
+        94,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        94,
+        96,
+      ],
+      "type": "Identifier",
+      "value": "fn",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        96,
+        97,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        97,
+        98,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        98,
+        99,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        99,
+        100,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        103,
+        104,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        104,
+        107,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        107,
+        108,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        108,
+        111,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        111,
+        113,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        113,
+        118,
+      ],
+      "type": "Identifier",
+      "value": "three",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        118,
+        119,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        119,
+        120,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        120,
+        122,
+      ],
+      "type": "Identifier",
+      "value": "fn",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 21,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        122,
+        123,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        123,
+        124,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 24,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        124,
+        125,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        128,
+        129,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        129,
+        132,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        132,
+        133,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        133,
+        136,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        136,
+        138,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        138,
+        143,
+      ],
+      "type": "Identifier",
+      "value": "three",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        143,
+        145,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        145,
+        147,
+      ],
+      "type": "Identifier",
+      "value": "fn",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 21,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        147,
+        148,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        148,
+        149,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 24,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        149,
+        150,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 24,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        150,
+        151,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        155,
+        156,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        156,
+        159,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        159,
+        161,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        161,
+        162,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        162,
+        163,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        163,
+        164,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        164,
+        165,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        168,
+        169,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        169,
+        172,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        172,
+        174,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        174,
+        175,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        175,
+        176,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        176,
+        177,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        177,
+        178,
+      ],
+      "type": "Punctuator",
       "value": "(",
     },
     Object {
@@ -72447,8 +75281,8 @@ Object {
         },
       },
       "range": Array [
-        160,
-        161,
+        178,
+        179,
       ],
       "type": "Punctuator",
       "value": ")",
@@ -72465,8 +75299,8 @@ Object {
         },
       },
       "range": Array [
-        161,
-        162,
+        179,
+        180,
       ],
       "type": "Punctuator",
       "value": ";",
@@ -72474,53 +75308,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 5,
-          "line": 11,
+          "column": 3,
+          "line": 10,
         },
         "start": Object {
           "column": 2,
-          "line": 11,
+          "line": 10,
         },
       },
       "range": Array [
-        166,
-        169,
-      ],
-      "type": "Identifier",
-      "value": "one",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 7,
-          "line": 11,
-        },
-        "start": Object {
-          "column": 5,
-          "line": 11,
-        },
-      },
-      "range": Array [
-        169,
-        171,
-      ],
-      "type": "Punctuator",
-      "value": "?.",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 8,
-          "line": 11,
-        },
-        "start": Object {
-          "column": 7,
-          "line": 11,
-        },
-      },
-      "range": Array [
-        171,
-        172,
+        183,
+        184,
       ],
       "type": "Punctuator",
       "value": "(",
@@ -72528,17 +75326,71 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 9,
-          "line": 11,
+          "column": 6,
+          "line": 10,
         },
         "start": Object {
-          "column": 8,
-          "line": 11,
+          "column": 3,
+          "line": 10,
         },
       },
       "range": Array [
-        172,
-        173,
+        184,
+        187,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        187,
+        189,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        189,
+        190,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        190,
+        191,
       ],
       "type": "Punctuator",
       "value": ")",
@@ -72546,17 +75398,215 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 10,
-          "line": 11,
+          "column": 11,
+          "line": 10,
         },
         "start": Object {
-          "column": 9,
-          "line": 11,
+          "column": 10,
+          "line": 10,
         },
       },
       "range": Array [
-        173,
-        174,
+        191,
+        192,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        192,
+        194,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        194,
+        195,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        195,
+        196,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        196,
+        197,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        201,
+        202,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        202,
+        205,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        205,
+        207,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        207,
+        208,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        208,
+        209,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        209,
+        210,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        210,
+        211,
       ],
       "type": "Punctuator",
       "value": ".",
@@ -72564,17 +75614,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 13,
-          "line": 11,
+          "column": 15,
+          "line": 12,
         },
         "start": Object {
-          "column": 10,
-          "line": 11,
+          "column": 12,
+          "line": 12,
         },
       },
       "range": Array [
-        174,
-        177,
+        211,
+        214,
       ],
       "type": "Identifier",
       "value": "two",
@@ -72582,17 +75632,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 14,
-          "line": 11,
+          "column": 16,
+          "line": 12,
         },
         "start": Object {
-          "column": 13,
-          "line": 11,
+          "column": 15,
+          "line": 12,
         },
       },
       "range": Array [
-        177,
-        178,
+        214,
+        215,
       ],
       "type": "Punctuator",
       "value": ";",
@@ -72601,16 +75651,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 12,
+          "line": 13,
         },
         "start": Object {
           "column": 0,
-          "line": 12,
+          "line": 13,
         },
       },
       "range": Array [
-        179,
-        180,
+        216,
+        217,
       ],
       "type": "Punctuator",
       "value": "}",
@@ -74676,6 +77726,4543 @@ Object {
       "range": Array [
         140,
         141,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
+exports[`typescript fixtures/basics/optional-chain-element-access-with-parens.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "async": false,
+      "body": Object {
+        "body": Array [
+          Object {
+            "expression": Object {
+              "computed": true,
+              "loc": Object {
+                "end": Object {
+                  "column": 11,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 2,
+                },
+              },
+              "object": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 6,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 2,
+                  },
+                },
+                "name": "one",
+                "range": Array [
+                  54,
+                  57,
+                ],
+                "type": "Identifier",
+              },
+              "optional": true,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 10,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 9,
+                    "line": 2,
+                  },
+                },
+                "range": Array [
+                  60,
+                  61,
+                ],
+                "raw": "2",
+                "type": "Literal",
+                "value": 2,
+              },
+              "range": Array [
+                54,
+                62,
+              ],
+              "type": "OptionalMemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 13,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              53,
+              64,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": true,
+              "loc": Object {
+                "end": Object {
+                  "column": 15,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 3,
+                },
+              },
+              "object": Object {
+                "computed": true,
+                "loc": Object {
+                  "end": Object {
+                    "column": 11,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 3,
+                  },
+                },
+                "object": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 6,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 3,
+                    },
+                  },
+                  "name": "one",
+                  "range": Array [
+                    68,
+                    71,
+                  ],
+                  "type": "Identifier",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 10,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "column": 9,
+                      "line": 3,
+                    },
+                  },
+                  "range": Array [
+                    74,
+                    75,
+                  ],
+                  "raw": "2",
+                  "type": "Literal",
+                  "value": 2,
+                },
+                "range": Array [
+                  68,
+                  76,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "optional": false,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 13,
+                    "line": 3,
+                  },
+                },
+                "range": Array [
+                  78,
+                  79,
+                ],
+                "raw": "3",
+                "type": "Literal",
+                "value": 3,
+              },
+              "range": Array [
+                67,
+                80,
+              ],
+              "type": "MemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 16,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 3,
+              },
+            },
+            "range": Array [
+              67,
+              81,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": true,
+              "loc": Object {
+                "end": Object {
+                  "column": 14,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 4,
+                },
+              },
+              "object": Object {
+                "computed": true,
+                "loc": Object {
+                  "end": Object {
+                    "column": 9,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 4,
+                  },
+                },
+                "object": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 6,
+                      "line": 4,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 4,
+                    },
+                  },
+                  "name": "one",
+                  "range": Array [
+                    85,
+                    88,
+                  ],
+                  "type": "Identifier",
+                },
+                "optional": false,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 8,
+                      "line": 4,
+                    },
+                    "start": Object {
+                      "column": 7,
+                      "line": 4,
+                    },
+                  },
+                  "range": Array [
+                    89,
+                    90,
+                  ],
+                  "raw": "2",
+                  "type": "Literal",
+                  "value": 2,
+                },
+                "range": Array [
+                  85,
+                  91,
+                ],
+                "type": "MemberExpression",
+              },
+              "optional": true,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 13,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 12,
+                    "line": 4,
+                  },
+                },
+                "range": Array [
+                  94,
+                  95,
+                ],
+                "raw": "3",
+                "type": "Literal",
+                "value": 3,
+              },
+              "range": Array [
+                85,
+                96,
+              ],
+              "type": "OptionalMemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 16,
+                "line": 4,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 4,
+              },
+            },
+            "range": Array [
+              84,
+              98,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": true,
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 5,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 5,
+                },
+              },
+              "object": Object {
+                "computed": true,
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 5,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 5,
+                  },
+                },
+                "object": Object {
+                  "computed": true,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 9,
+                      "line": 5,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 5,
+                    },
+                  },
+                  "object": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 6,
+                        "line": 5,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 5,
+                      },
+                    },
+                    "name": "one",
+                    "range": Array [
+                      102,
+                      105,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "optional": false,
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 8,
+                        "line": 5,
+                      },
+                      "start": Object {
+                        "column": 7,
+                        "line": 5,
+                      },
+                    },
+                    "range": Array [
+                      106,
+                      107,
+                    ],
+                    "raw": "2",
+                    "type": "Literal",
+                    "value": 2,
+                  },
+                  "range": Array [
+                    102,
+                    108,
+                  ],
+                  "type": "MemberExpression",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 13,
+                      "line": 5,
+                    },
+                    "start": Object {
+                      "column": 12,
+                      "line": 5,
+                    },
+                  },
+                  "range": Array [
+                    111,
+                    112,
+                  ],
+                  "raw": "3",
+                  "type": "Literal",
+                  "value": 3,
+                },
+                "range": Array [
+                  102,
+                  113,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "optional": false,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 5,
+                  },
+                  "start": Object {
+                    "column": 16,
+                    "line": 5,
+                  },
+                },
+                "range": Array [
+                  115,
+                  116,
+                ],
+                "raw": "4",
+                "type": "Literal",
+                "value": 4,
+              },
+              "range": Array [
+                101,
+                117,
+              ],
+              "type": "MemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 19,
+                "line": 5,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 5,
+              },
+            },
+            "range": Array [
+              101,
+              118,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": true,
+              "loc": Object {
+                "end": Object {
+                  "column": 19,
+                  "line": 6,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 6,
+                },
+              },
+              "object": Object {
+                "computed": true,
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 6,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 6,
+                  },
+                },
+                "object": Object {
+                  "computed": true,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 9,
+                      "line": 6,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 6,
+                    },
+                  },
+                  "object": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 6,
+                        "line": 6,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 6,
+                      },
+                    },
+                    "name": "one",
+                    "range": Array [
+                      122,
+                      125,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "optional": false,
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 8,
+                        "line": 6,
+                      },
+                      "start": Object {
+                        "column": 7,
+                        "line": 6,
+                      },
+                    },
+                    "range": Array [
+                      126,
+                      127,
+                    ],
+                    "raw": "2",
+                    "type": "Literal",
+                    "value": 2,
+                  },
+                  "range": Array [
+                    122,
+                    128,
+                  ],
+                  "type": "MemberExpression",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 13,
+                      "line": 6,
+                    },
+                    "start": Object {
+                      "column": 12,
+                      "line": 6,
+                    },
+                  },
+                  "range": Array [
+                    131,
+                    132,
+                  ],
+                  "raw": "3",
+                  "type": "Literal",
+                  "value": 3,
+                },
+                "range": Array [
+                  122,
+                  133,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "optional": true,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 6,
+                  },
+                  "start": Object {
+                    "column": 17,
+                    "line": 6,
+                  },
+                },
+                "range": Array [
+                  136,
+                  137,
+                ],
+                "raw": "4",
+                "type": "Literal",
+                "value": 4,
+              },
+              "range": Array [
+                122,
+                138,
+              ],
+              "type": "OptionalMemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 21,
+                "line": 6,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 6,
+              },
+            },
+            "range": Array [
+              121,
+              140,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": true,
+              "loc": Object {
+                "end": Object {
+                  "column": 23,
+                  "line": 7,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 7,
+                },
+              },
+              "object": Object {
+                "computed": true,
+                "loc": Object {
+                  "end": Object {
+                    "column": 19,
+                    "line": 7,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 7,
+                  },
+                },
+                "object": Object {
+                  "computed": true,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 14,
+                      "line": 7,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 7,
+                    },
+                  },
+                  "object": Object {
+                    "computed": true,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 9,
+                        "line": 7,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 7,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 6,
+                          "line": 7,
+                        },
+                        "start": Object {
+                          "column": 3,
+                          "line": 7,
+                        },
+                      },
+                      "name": "one",
+                      "range": Array [
+                        144,
+                        147,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "optional": false,
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 8,
+                          "line": 7,
+                        },
+                        "start": Object {
+                          "column": 7,
+                          "line": 7,
+                        },
+                      },
+                      "range": Array [
+                        148,
+                        149,
+                      ],
+                      "raw": "2",
+                      "type": "Literal",
+                      "value": 2,
+                    },
+                    "range": Array [
+                      144,
+                      150,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "optional": true,
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 13,
+                        "line": 7,
+                      },
+                      "start": Object {
+                        "column": 12,
+                        "line": 7,
+                      },
+                    },
+                    "range": Array [
+                      153,
+                      154,
+                    ],
+                    "raw": "3",
+                    "type": "Literal",
+                    "value": 3,
+                  },
+                  "range": Array [
+                    144,
+                    155,
+                  ],
+                  "type": "OptionalMemberExpression",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 18,
+                      "line": 7,
+                    },
+                    "start": Object {
+                      "column": 17,
+                      "line": 7,
+                    },
+                  },
+                  "range": Array [
+                    158,
+                    159,
+                  ],
+                  "raw": "4",
+                  "type": "Literal",
+                  "value": 4,
+                },
+                "range": Array [
+                  144,
+                  160,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "optional": false,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 22,
+                    "line": 7,
+                  },
+                  "start": Object {
+                    "column": 21,
+                    "line": 7,
+                  },
+                },
+                "range": Array [
+                  162,
+                  163,
+                ],
+                "raw": "5",
+                "type": "Literal",
+                "value": 5,
+              },
+              "range": Array [
+                143,
+                164,
+              ],
+              "type": "MemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 24,
+                "line": 7,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 7,
+              },
+            },
+            "range": Array [
+              143,
+              165,
+            ],
+            "type": "ExpressionStatement",
+          },
+        ],
+        "loc": Object {
+          "end": Object {
+            "column": 1,
+            "line": 8,
+          },
+          "start": Object {
+            "column": 49,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          49,
+          167,
+        ],
+        "type": "BlockStatement",
+      },
+      "expression": false,
+      "generator": false,
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 37,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 9,
+            "line": 1,
+          },
+        },
+        "name": "processOptionalElementParens",
+        "range": Array [
+          9,
+          37,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "params": Array [
+        Object {
+          "loc": Object {
+            "end": Object {
+              "column": 47,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 38,
+              "line": 1,
+            },
+          },
+          "name": "one",
+          "optional": true,
+          "range": Array [
+            38,
+            47,
+          ],
+          "type": "Identifier",
+          "typeAnnotation": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 47,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 42,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              42,
+              47,
+            ],
+            "type": "TSTypeAnnotation",
+            "typeAnnotation": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 47,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 44,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                44,
+                47,
+              ],
+              "type": "TSAnyKeyword",
+            },
+          },
+        },
+      ],
+      "range": Array [
+        0,
+        167,
+      ],
+      "type": "FunctionDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 9,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    168,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        8,
+      ],
+      "type": "Keyword",
+      "value": "function",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 37,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        37,
+      ],
+      "type": "Identifier",
+      "value": "processOptionalElementParens",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 38,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        37,
+        38,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 41,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        38,
+        41,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 42,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        41,
+        42,
+      ],
+      "type": "Punctuator",
+      "value": "?",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 43,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        42,
+        43,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 47,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        44,
+        47,
+      ],
+      "type": "Identifier",
+      "value": "any",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 48,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        47,
+        48,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 50,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        49,
+        50,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        53,
+        54,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        54,
+        57,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        57,
+        59,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        59,
+        60,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        60,
+        61,
+      ],
+      "type": "Numeric",
+      "value": "2",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        61,
+        62,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        62,
+        63,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        63,
+        64,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        67,
+        68,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        68,
+        71,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        71,
+        73,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        73,
+        74,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        74,
+        75,
+      ],
+      "type": "Numeric",
+      "value": "2",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        75,
+        76,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        76,
+        77,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        77,
+        78,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        78,
+        79,
+      ],
+      "type": "Numeric",
+      "value": "3",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        79,
+        80,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        80,
+        81,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        84,
+        85,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        85,
+        88,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        88,
+        89,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        89,
+        90,
+      ],
+      "type": "Numeric",
+      "value": "2",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        90,
+        91,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        91,
+        93,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        93,
+        94,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        94,
+        95,
+      ],
+      "type": "Numeric",
+      "value": "3",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        95,
+        96,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        96,
+        97,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        97,
+        98,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        101,
+        102,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        102,
+        105,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        105,
+        106,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        106,
+        107,
+      ],
+      "type": "Numeric",
+      "value": "2",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        107,
+        108,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        108,
+        110,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        110,
+        111,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        111,
+        112,
+      ],
+      "type": "Numeric",
+      "value": "3",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        112,
+        113,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        113,
+        114,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        114,
+        115,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        115,
+        116,
+      ],
+      "type": "Numeric",
+      "value": "4",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        116,
+        117,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        117,
+        118,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        121,
+        122,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        122,
+        125,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        125,
+        126,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        126,
+        127,
+      ],
+      "type": "Numeric",
+      "value": "2",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        127,
+        128,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        128,
+        130,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        130,
+        131,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        131,
+        132,
+      ],
+      "type": "Numeric",
+      "value": "3",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        132,
+        133,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        133,
+        135,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        135,
+        136,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        136,
+        137,
+      ],
+      "type": "Numeric",
+      "value": "4",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        137,
+        138,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        138,
+        139,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        139,
+        140,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        143,
+        144,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        144,
+        147,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        147,
+        148,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        148,
+        149,
+      ],
+      "type": "Numeric",
+      "value": "2",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        149,
+        150,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        150,
+        152,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        152,
+        153,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        153,
+        154,
+      ],
+      "type": "Numeric",
+      "value": "3",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        154,
+        155,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        155,
+        157,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        157,
+        158,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        158,
+        159,
+      ],
+      "type": "Numeric",
+      "value": "4",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        159,
+        160,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        160,
+        161,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        161,
+        162,
+      ],
+      "type": "Punctuator",
+      "value": "[",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 21,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        162,
+        163,
+      ],
+      "type": "Numeric",
+      "value": "5",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        163,
+        164,
+      ],
+      "type": "Punctuator",
+      "value": "]",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 24,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        164,
+        165,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        166,
+        167,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
+exports[`typescript fixtures/basics/optional-chain-with-parens.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "async": false,
+      "body": Object {
+        "body": Array [
+          Object {
+            "expression": Object {
+              "computed": false,
+              "loc": Object {
+                "end": Object {
+                  "column": 11,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 2,
+                },
+              },
+              "object": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 6,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 2,
+                  },
+                },
+                "name": "one",
+                "range": Array [
+                  47,
+                  50,
+                ],
+                "type": "Identifier",
+              },
+              "optional": true,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 11,
+                    "line": 2,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 2,
+                  },
+                },
+                "name": "two",
+                "range": Array [
+                  52,
+                  55,
+                ],
+                "type": "Identifier",
+              },
+              "range": Array [
+                47,
+                55,
+              ],
+              "type": "OptionalMemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 13,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 2,
+              },
+            },
+            "range": Array [
+              46,
+              57,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": false,
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 3,
+                },
+              },
+              "object": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 11,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 3,
+                  },
+                },
+                "object": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 6,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 3,
+                    },
+                  },
+                  "name": "one",
+                  "range": Array [
+                    61,
+                    64,
+                  ],
+                  "type": "Identifier",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 11,
+                      "line": 3,
+                    },
+                    "start": Object {
+                      "column": 8,
+                      "line": 3,
+                    },
+                  },
+                  "name": "two",
+                  "range": Array [
+                    66,
+                    69,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  61,
+                  69,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "optional": false,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 13,
+                    "line": 3,
+                  },
+                },
+                "name": "three",
+                "range": Array [
+                  71,
+                  76,
+                ],
+                "type": "Identifier",
+              },
+              "range": Array [
+                60,
+                76,
+              ],
+              "type": "MemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 19,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 3,
+              },
+            },
+            "range": Array [
+              60,
+              77,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": false,
+              "loc": Object {
+                "end": Object {
+                  "column": 17,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 4,
+                },
+              },
+              "object": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 10,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 4,
+                  },
+                },
+                "object": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 6,
+                      "line": 4,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 4,
+                    },
+                  },
+                  "name": "one",
+                  "range": Array [
+                    81,
+                    84,
+                  ],
+                  "type": "Identifier",
+                },
+                "optional": false,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 10,
+                      "line": 4,
+                    },
+                    "start": Object {
+                      "column": 7,
+                      "line": 4,
+                    },
+                  },
+                  "name": "two",
+                  "range": Array [
+                    85,
+                    88,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  81,
+                  88,
+                ],
+                "type": "MemberExpression",
+              },
+              "optional": true,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 12,
+                    "line": 4,
+                  },
+                },
+                "name": "three",
+                "range": Array [
+                  90,
+                  95,
+                ],
+                "type": "Identifier",
+              },
+              "range": Array [
+                81,
+                95,
+              ],
+              "type": "OptionalMemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 19,
+                "line": 4,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 4,
+              },
+            },
+            "range": Array [
+              80,
+              97,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": false,
+              "loc": Object {
+                "end": Object {
+                  "column": 23,
+                  "line": 5,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 5,
+                },
+              },
+              "object": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 5,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 5,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 10,
+                      "line": 5,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 5,
+                    },
+                  },
+                  "object": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 6,
+                        "line": 5,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 5,
+                      },
+                    },
+                    "name": "one",
+                    "range": Array [
+                      101,
+                      104,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "optional": false,
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 10,
+                        "line": 5,
+                      },
+                      "start": Object {
+                        "column": 7,
+                        "line": 5,
+                      },
+                    },
+                    "name": "two",
+                    "range": Array [
+                      105,
+                      108,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    101,
+                    108,
+                  ],
+                  "type": "MemberExpression",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 17,
+                      "line": 5,
+                    },
+                    "start": Object {
+                      "column": 12,
+                      "line": 5,
+                    },
+                  },
+                  "name": "three",
+                  "range": Array [
+                    110,
+                    115,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  101,
+                  115,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "optional": false,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 5,
+                  },
+                  "start": Object {
+                    "column": 19,
+                    "line": 5,
+                  },
+                },
+                "name": "four",
+                "range": Array [
+                  117,
+                  121,
+                ],
+                "type": "Identifier",
+              },
+              "range": Array [
+                100,
+                121,
+              ],
+              "type": "MemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 24,
+                "line": 5,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 5,
+              },
+            },
+            "range": Array [
+              100,
+              122,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": false,
+              "loc": Object {
+                "end": Object {
+                  "column": 23,
+                  "line": 6,
+                },
+                "start": Object {
+                  "column": 3,
+                  "line": 6,
+                },
+              },
+              "object": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 6,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 6,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 10,
+                      "line": 6,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 6,
+                    },
+                  },
+                  "object": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 6,
+                        "line": 6,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 6,
+                      },
+                    },
+                    "name": "one",
+                    "range": Array [
+                      126,
+                      129,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "optional": false,
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 10,
+                        "line": 6,
+                      },
+                      "start": Object {
+                        "column": 7,
+                        "line": 6,
+                      },
+                    },
+                    "name": "two",
+                    "range": Array [
+                      130,
+                      133,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    126,
+                    133,
+                  ],
+                  "type": "MemberExpression",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 17,
+                      "line": 6,
+                    },
+                    "start": Object {
+                      "column": 12,
+                      "line": 6,
+                    },
+                  },
+                  "name": "three",
+                  "range": Array [
+                    135,
+                    140,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  126,
+                  140,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "optional": true,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 6,
+                  },
+                  "start": Object {
+                    "column": 19,
+                    "line": 6,
+                  },
+                },
+                "name": "four",
+                "range": Array [
+                  142,
+                  146,
+                ],
+                "type": "Identifier",
+              },
+              "range": Array [
+                126,
+                146,
+              ],
+              "type": "OptionalMemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 25,
+                "line": 6,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 6,
+              },
+            },
+            "range": Array [
+              125,
+              148,
+            ],
+            "type": "ExpressionStatement",
+          },
+          Object {
+            "expression": Object {
+              "computed": false,
+              "loc": Object {
+                "end": Object {
+                  "column": 29,
+                  "line": 7,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 7,
+                },
+              },
+              "object": Object {
+                "computed": false,
+                "loc": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 7,
+                  },
+                  "start": Object {
+                    "column": 3,
+                    "line": 7,
+                  },
+                },
+                "object": Object {
+                  "computed": false,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 17,
+                      "line": 7,
+                    },
+                    "start": Object {
+                      "column": 3,
+                      "line": 7,
+                    },
+                  },
+                  "object": Object {
+                    "computed": false,
+                    "loc": Object {
+                      "end": Object {
+                        "column": 10,
+                        "line": 7,
+                      },
+                      "start": Object {
+                        "column": 3,
+                        "line": 7,
+                      },
+                    },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 6,
+                          "line": 7,
+                        },
+                        "start": Object {
+                          "column": 3,
+                          "line": 7,
+                        },
+                      },
+                      "name": "one",
+                      "range": Array [
+                        152,
+                        155,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "optional": false,
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 10,
+                          "line": 7,
+                        },
+                        "start": Object {
+                          "column": 7,
+                          "line": 7,
+                        },
+                      },
+                      "name": "two",
+                      "range": Array [
+                        156,
+                        159,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "range": Array [
+                      152,
+                      159,
+                    ],
+                    "type": "MemberExpression",
+                  },
+                  "optional": true,
+                  "property": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 17,
+                        "line": 7,
+                      },
+                      "start": Object {
+                        "column": 12,
+                        "line": 7,
+                      },
+                    },
+                    "name": "three",
+                    "range": Array [
+                      161,
+                      166,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "range": Array [
+                    152,
+                    166,
+                  ],
+                  "type": "OptionalMemberExpression",
+                },
+                "optional": true,
+                "property": Object {
+                  "loc": Object {
+                    "end": Object {
+                      "column": 23,
+                      "line": 7,
+                    },
+                    "start": Object {
+                      "column": 19,
+                      "line": 7,
+                    },
+                  },
+                  "name": "four",
+                  "range": Array [
+                    168,
+                    172,
+                  ],
+                  "type": "Identifier",
+                },
+                "range": Array [
+                  152,
+                  172,
+                ],
+                "type": "OptionalMemberExpression",
+              },
+              "optional": false,
+              "property": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 29,
+                    "line": 7,
+                  },
+                  "start": Object {
+                    "column": 25,
+                    "line": 7,
+                  },
+                },
+                "name": "five",
+                "range": Array [
+                  174,
+                  178,
+                ],
+                "type": "Identifier",
+              },
+              "range": Array [
+                151,
+                178,
+              ],
+              "type": "MemberExpression",
+            },
+            "loc": Object {
+              "end": Object {
+                "column": 30,
+                "line": 7,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 7,
+              },
+            },
+            "range": Array [
+              151,
+              179,
+            ],
+            "type": "ExpressionStatement",
+          },
+        ],
+        "loc": Object {
+          "end": Object {
+            "column": 1,
+            "line": 8,
+          },
+          "start": Object {
+            "column": 42,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          42,
+          181,
+        ],
+        "type": "BlockStatement",
+      },
+      "expression": false,
+      "generator": false,
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 30,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 9,
+            "line": 1,
+          },
+        },
+        "name": "processOptionalParens",
+        "range": Array [
+          9,
+          30,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "params": Array [
+        Object {
+          "loc": Object {
+            "end": Object {
+              "column": 40,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 31,
+              "line": 1,
+            },
+          },
+          "name": "one",
+          "optional": true,
+          "range": Array [
+            31,
+            40,
+          ],
+          "type": "Identifier",
+          "typeAnnotation": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 40,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 35,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              35,
+              40,
+            ],
+            "type": "TSTypeAnnotation",
+            "typeAnnotation": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 40,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 37,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                37,
+                40,
+              ],
+              "type": "TSAnyKeyword",
+            },
+          },
+        },
+      ],
+      "range": Array [
+        0,
+        181,
+      ],
+      "type": "FunctionDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 9,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    182,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        8,
+      ],
+      "type": "Keyword",
+      "value": "function",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 30,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        30,
+      ],
+      "type": "Identifier",
+      "value": "processOptionalParens",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 31,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        30,
+        31,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 34,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        31,
+        34,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 35,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        34,
+        35,
+      ],
+      "type": "Punctuator",
+      "value": "?",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 36,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        35,
+        36,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 40,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        37,
+        40,
+      ],
+      "type": "Identifier",
+      "value": "any",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 41,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        40,
+        41,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 43,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        42,
+        43,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        46,
+        47,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        47,
+        50,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        50,
+        52,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        52,
+        55,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        55,
+        56,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        56,
+        57,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        60,
+        61,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        61,
+        64,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        64,
+        66,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        66,
+        69,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        69,
+        70,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        70,
+        71,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        71,
+        76,
+      ],
+      "type": "Identifier",
+      "value": "three",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        76,
+        77,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        80,
+        81,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        81,
+        84,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        84,
+        85,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        85,
+        88,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        88,
+        90,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        90,
+        95,
+      ],
+      "type": "Identifier",
+      "value": "three",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        95,
+        96,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        96,
+        97,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        100,
+        101,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        101,
+        104,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        104,
+        105,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        105,
+        108,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        108,
+        110,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        110,
+        115,
+      ],
+      "type": "Identifier",
+      "value": "three",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        115,
+        116,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        116,
+        117,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        117,
+        121,
+      ],
+      "type": "Identifier",
+      "value": "four",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 24,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        121,
+        122,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        125,
+        126,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        126,
+        129,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        129,
+        130,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        130,
+        133,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        133,
+        135,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        135,
+        140,
+      ],
+      "type": "Identifier",
+      "value": "three",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        140,
+        142,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        142,
+        146,
+      ],
+      "type": "Identifier",
+      "value": "four",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 24,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        146,
+        147,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 6,
+        },
+        "start": Object {
+          "column": 24,
+          "line": 6,
+        },
+      },
+      "range": Array [
+        147,
+        148,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        151,
+        152,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 3,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        152,
+        155,
+      ],
+      "type": "Identifier",
+      "value": "one",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        155,
+        156,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        156,
+        159,
+      ],
+      "type": "Identifier",
+      "value": "two",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        159,
+        161,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        161,
+        166,
+      ],
+      "type": "Identifier",
+      "value": "three",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        166,
+        168,
+      ],
+      "type": "Punctuator",
+      "value": "?.",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        168,
+        172,
+      ],
+      "type": "Identifier",
+      "value": "four",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 24,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        172,
+        173,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 24,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        173,
+        174,
+      ],
+      "type": "Punctuator",
+      "value": ".",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 29,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 25,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        174,
+        178,
+      ],
+      "type": "Identifier",
+      "value": "five",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 30,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 29,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        178,
+        179,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        180,
+        181,
       ],
       "type": "Punctuator",
       "value": "}",


### PR DESCRIPTION
Fixes #1139

Also fixes the package not working in the browser (`ts.sys === undefined` in the browser).

The snapshots are getting pretty ugly now.
I think we need a new system for them (#1142).

I tested this via a local build of ASTExplorer.
Sidebar - we should really maintain our own version of it (#1143).