### PR TITLE
docs(eslint-plugin): [no-unnecessary-condition] tweak wording

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
@@ -59,6 +59,6 @@ The main downside to using this rule is the need for type information.
 
 ## Related To
 
-- ESLint: [no-constant-condition](https://eslint.org/docs/rules/no-constant-condition) - this rule is essentially a stronger version.
+- ESLint: [no-constant-condition](https://eslint.org/docs/rules/no-constant-condition) - `no-unnecessary-condition` is essentially a stronger version of `no-constant-condition`, but requires type information.
 
-- [strict-boolean-expression](./strict-boolean-expressions.md) - a stricter alternative to this rule.
+- [strict-boolean-expressions](./strict-boolean-expressions.md) - a more opinionated version of `no-unnecessary-condition`. `strict-boolean-expressions` enforces a specific code style, while `no-unnecessary-condition` is about correctness.

--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
@@ -63,4 +63,4 @@ Options may be provided as an object with:
 
 - TSLint: [strict-boolean-expressions](https://palantir.github.io/tslint/rules/strict-boolean-expressions)
 
-- [no-unnecessary-condition](./no-unnecessary-condition.md) - a looser alternative to this rule.
+- [no-unnecessary-condition](./no-unnecessary-condition.md) - essentially a less opinionated alternative to this rule. `strict-boolean-expressions` enforces a specific code style, while `no-unnecessary-condition` is about correctness.


### PR DESCRIPTION
Fixes #1016.

Removes "looser/stricter" wording in favor of "more opinionated, less opinionated" and clarifies in what way `no-unnecessary-condition` is less opinionated.