### PR TITLE
feat(eslint-plugin): add Airbnb compatibility ruleset

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -51,6 +51,7 @@
     "@types/marked": "^0.6.5",
     "@types/prettier": "^1.18.2",
     "chalk": "^2.4.2",
+    "eslint-config-airbnb-base": "^14.0.0",
     "marked": "^0.7.0",
     "prettier": "*",
     "typescript": "*"

--- a/packages/eslint-plugin/src/configs/airbnb.js
+++ b/packages/eslint-plugin/src/configs/airbnb.js
@@ -1,0 +1,92 @@
+/**
+ * This is a compatibility ruleset that converts rules from Airbnb
+ * which can be handled better by TypeScript.
+ */
+
+const {
+  rules: baseBestPracticesRules,
+} = require('eslint-config-airbnb-base/rules/best-practices');
+const {
+  rules: baseErrorsRules,
+} = require('eslint-config-airbnb-base/rules/errors');
+const { rules: baseES6Rules } = require('eslint-config-airbnb-base/rules/es6');
+const {
+  rules: baseStyleRules,
+} = require('eslint-config-airbnb-base/rules/style');
+const {
+  rules: baseVariablesRules,
+} = require('eslint-config-airbnb-base/rules/variables');
+
+module.exports = {
+  extends: [
+    // Disable checks overlapping with the ones built into TypeScript
+    'plugin:@typescript-eslint/eslint-recommended',
+
+    // Add support for resolving TS imports
+    'plugin:import/typescript',
+  ],
+
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        // Using a type system makes it safe enough to spread props
+        'react/jsx-props-no-spreading': 'off',
+      },
+    },
+  ],
+
+  rules: {
+    // Allow .tsx files to have JSX
+    'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.tsx'] }],
+
+    'brace-style': 'off',
+    '@typescript-eslint/brace-style': baseStyleRules['brace-style'],
+
+    camelcase: 'off',
+    '@typescript-eslint/camelcase': baseStyleRules.camelcase,
+
+    'func-call-spacing': 'off',
+    '@typescript-eslint/func-call-spacing': baseStyleRules['func-call-spacing'],
+
+    indent: 'off',
+    '@typescript-eslint/indent': baseStyleRules.indent,
+
+    'no-array-constructor': 'off',
+    '@typescript-eslint/no-array-constructor':
+      baseStyleRules['no-array-constructor'],
+
+    'no-empty-function': 'off',
+    '@typescript-eslint/no-empty-function':
+      baseBestPracticesRules['no-empty-function'],
+
+    'no-extra-parens': 'off',
+    '@typescript-eslint/no-extra-parens': baseErrorsRules['no-extra-parens'],
+
+    'no-magic-numbers': 'off',
+    '@typescript-eslint/no-magic-numbers':
+      baseBestPracticesRules['no-magic-numbers'],
+
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': baseVariablesRules['no-unused-vars'],
+
+    'no-use-before-define': 'off',
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      {
+        ...baseVariablesRules['no-use-before-define'][1],
+        typedefs: true,
+      },
+    ],
+
+    'no-useless-constructor': 'off',
+    '@typescript-eslint/no-useless-constructor':
+      baseES6Rules['no-useless-constructor'],
+
+    quotes: 'off',
+    '@typescript-eslint/quotes': baseStyleRules.quotes,
+
+    semi: 'off',
+    '@typescript-eslint/semi': baseStyleRules.semi,
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,6 +2327,11 @@ config-chain@^1.1.11:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
+confusing-browser-globals@^1.0.7:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
+  integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -2933,6 +2938,15 @@ escodegen@^1.9.1:
     optionator "^0.8.1"
   optionalDependencies:
     source-map "~0.6.1"
+
+eslint-config-airbnb-base@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz#8a7bcb9643d13c55df4dd7444f138bf4efa61e17"
+  integrity sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==
+  dependencies:
+    confusing-browser-globals "^1.0.7"
+    object.assign "^4.1.0"
+    object.entries "^1.1.0"
 
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
@@ -5847,7 +5861,7 @@ object-inspect@^1.6.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"
   integrity sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -5858,6 +5872,26 @@ object-visit@^1.0.0:
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.entries@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
+  integrity sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.12.0"
+    function-bind "^1.1.1"
+    has "^1.0.3"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -7715,7 +7749,12 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*, "typescript@>=3.2.1 <3.8.0 || >3.7.0-dev.0", typescript@^3.7.0-dev.20191018:
+typescript@*:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
+  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+
+"typescript@>=3.2.1 <3.8.0 || >3.7.0-dev.0":
   version "3.7.0-dev.20191018"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.0-dev.20191018.tgz#6b98a655b124ca697364e2d7977c469a2bfede3d"
   integrity sha512-Z8KpsytbY5lBMp5cc08VFoO8CgHC6IcbgyiA5vjh7fitkoG0qcem9C354YuiWV4O2+i2gdC7vF8tNUYqO/vUkQ==


### PR DESCRIPTION
I've tried [adding TypeScript compatibility for the Airbnb config](https://github.com/airbnb/javascript/pull/2122), but unfortunately, it was dismissed. Let's see how it goes the other way around, as a compatibility ruleset is already available for `eslint-recommended`.