### PR TITLE
fix(eslint-plugin): [no-type-alias] handle constructor aliases

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-type-alias.md
+++ b/packages/eslint-plugin/docs/rules/no-type-alias.md
@@ -84,6 +84,7 @@ or more of the following you may pass an object with the options set as follows:
 
 - `allowAliases` set to `"always"` will allow you to do aliasing (Defaults to `"never"`).
 - `allowCallbacks` set to `"always"` will allow you to use type aliases with callbacks (Defaults to `"never"`)
+- `allowConstructors` set to `"always"` will allow you to use type aliases with constructors (Defaults to `"never"`)
 - `allowLiterals` set to `"always"` will allow you to use type aliases with literal objects (Defaults to `"never"`)
 - `allowMappedTypes` set to `"always"` will allow you to use type aliases as mapping tools (Defaults to `"never"`)
 - `allowTupleTypes` set to `"always"` will allow you to use type aliases with tuples (Defaults to `"never"`)
@@ -246,6 +247,20 @@ class Person {}
 type Foo = (name: string, age: number) => string | Person;
 
 type Foo = (name: string, age: number) => string & Person;
+```
+
+### allowConstructors
+
+This applies to constructor types.
+
+The setting accepts the following values:
+
+- `"always"` or `"never"` to active or deactivate the feature.
+
+Examples of **correct** code for the `{ "allowConstructors": "always" }` option:
+
+```ts
+type Foo = new () => void;
 ```
 
 ### allowLiterals

--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -22,6 +22,7 @@ type Options = [
   {
     allowAliases?: Values;
     allowCallbacks?: 'always' | 'never';
+    allowConstructors?: 'always' | 'never';
     allowLiterals?: Values;
     allowMappedTypes?: Values;
     allowTupleTypes?: Values;
@@ -62,6 +63,9 @@ export default util.createRule<Options, MessageIds>({
           allowCallbacks: {
             enum: ['always', 'never'],
           },
+          allowConstructors: {
+            enum: ['always', 'never'],
+          },
           allowLiterals: {
             enum: enumValues,
           },
@@ -80,6 +84,7 @@ export default util.createRule<Options, MessageIds>({
     {
       allowAliases: 'never',
       allowCallbacks: 'never',
+      allowConstructors: 'never',
       allowLiterals: 'never',
       allowMappedTypes: 'never',
       allowTupleTypes: 'never',
@@ -91,6 +96,7 @@ export default util.createRule<Options, MessageIds>({
       {
         allowAliases,
         allowCallbacks,
+        allowConstructors,
         allowLiterals,
         allowMappedTypes,
         allowTupleTypes,
@@ -219,6 +225,15 @@ export default util.createRule<Options, MessageIds>({
         // callback
         if (allowCallbacks === 'never') {
           reportError(type.node, type.compositionType, isTopLevel, 'Callbacks');
+        }
+      } else if (type.node.type === AST_NODE_TYPES.TSConstructorType) {
+        if (allowConstructors === 'never') {
+          reportError(
+            type.node,
+            type.compositionType,
+            isTopLevel,
+            'Constructors',
+          );
         }
       } else if (type.node.type === AST_NODE_TYPES.TSTypeLiteral) {
         // literal object type

--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -439,6 +439,10 @@ type Foo<T> = {
         'type Foo = [string] & [number, number] | keyof [number, number, number];',
       options: [{ allowTupleTypes: 'in-unions-and-intersections' }],
     },
+    {
+      code: 'type Foo = new (bar: number) => string | null;',
+      options: [{ allowConstructors: 'always' }],
+    },
   ],
   invalid: [
     {
@@ -3173,6 +3177,20 @@ type Foo<T> = {
       errors: [
         {
           messageId: 'noTypeAlias',
+        },
+      ],
+    },
+    {
+      code: 'type Foo = new (bar: number) => string | null;',
+      options: [{ allowConstructors: 'never' }],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'constructors',
+            line: 1,
+            column: 12,
+          },
         },
       ],
     },


### PR DESCRIPTION
Fixes #1191 