### PR TITLE
fix(eslint-plugin): [no-unnecessary-cond] fix naked type param

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -110,8 +110,16 @@ export default createRule<Options, MessageId>({
     function checkNode(node: TSESTree.Node): void {
       const type = getNodeType(node);
 
-      // Conditional is always necessary if it involves `any` or `unknown`
-      if (isTypeFlagSet(type, TypeFlags.Any | TypeFlags.Unknown)) {
+      // Conditional is always necessary if it involves:
+      //    `any` or `unknown` or a naked type parameter
+      if (
+        unionTypeParts(type).some(part =>
+          isTypeFlagSet(
+            part,
+            TypeFlags.Any | TypeFlags.Unknown | ts.TypeFlags.TypeParameter,
+          ),
+        )
+      ) {
         return;
       }
       if (isTypeFlagSet(type, TypeFlags.Never)) {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -72,6 +72,16 @@ const t1 = (b1 && b2) ? 'yes' : 'no'`,
 function test<T extends string>(t: T) {
   return t ? 'yes' : 'no'
 }`,
+    `
+// Naked type param
+function test<T>(t: T) {
+  return t ? 'yes' : 'no'
+}`,
+    `
+// Naked type param in union
+function test<T>(t: T | []) {
+  return t ? 'yes' : 'no'
+}`,
 
     // Boolean expressions
     `


### PR DESCRIPTION
Discovered that conditions involving a naked type param were being incorrectly considered "unnecessary":

```ts
function test<T>(t: T) {
  // raised an error here
  return t ? 'yes' : 'no'
}
```