### PR TITLE
fix(eslint-plugin): [indent] handle empty generic declarations

### DIFF
--- a/packages/eslint-plugin/src/rules/indent.ts
+++ b/packages/eslint-plugin/src/rules/indent.ts
@@ -442,6 +442,10 @@ export default util.createRule<Options, MessageIds>({
       },
 
       TSTypeParameterDeclaration(node: TSESTree.TSTypeParameterDeclaration) {
+        if (!node.params.length) {
+          return;
+        }
+
         const [name, ...attributes] = node.params;
 
         // JSX is about the closest we can get because the angle brackets

--- a/packages/eslint-plugin/tests/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin/tests/rules/indent/indent.test.ts
@@ -770,6 +770,11 @@ const div: JQuery<HTMLElement> = $('<div>')
     },
     // https://github.com/typescript-eslint/typescript-eslint/issues/441
     `const;`,
+
+    // https://github.com/typescript-eslint/typescript-eslint/issues/1115
+    {
+      code: `const foo = function<> (): void {}`,
+    },
   ],
   invalid: [
     ...individualNodeTests.invalid,


### PR DESCRIPTION
Fixes #1115 