### PR TITLE
fix(eslint-plugin): [require-await] crash when await is used outside of async

### DIFF
--- a/packages/eslint-plugin/src/rules/require-await.ts
+++ b/packages/eslint-plugin/src/rules/require-await.ts
@@ -146,9 +146,13 @@ export default util.createRule<Options, MessageIds>({
         scopeInfo.returnsPromise = isThenableType(expression);
       },
 
-      AwaitExpression: rules.AwaitExpression as TSESLint.RuleFunction<
-        TSESTree.Node
-      >,
+      AwaitExpression(node): void {
+        if (!scopeInfo) {
+          return;
+        }
+
+        rules.AwaitExpression(node);
+      },
       ForOfStatement: rules.ForOfStatement as TSESLint.RuleFunction<
         TSESTree.Node
       >,

--- a/packages/eslint-plugin/tests/rules/require-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-await.test.ts
@@ -128,6 +128,9 @@ ruleTester.run('require-await', rule, {
         return Promise.resolve(x);
       }`,
     },
+    {
+      code: `declare let Foo = (await import ('foo')).Foo;`,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
Fixes #1077 