### PR TITLE
fix(typescript-estree): fix synthetic default import

### DIFF
--- a/packages/typescript-estree/src/visitor-keys.ts
+++ b/packages/typescript-estree/src/visitor-keys.ts
@@ -1,4 +1,4 @@
-import eslintVisitorKeys from 'eslint-visitor-keys';
+import * as eslintVisitorKeys from 'eslint-visitor-keys';
 
 export const visitorKeys = eslintVisitorKeys.unionWith({
   // Additional estree nodes.


### PR DESCRIPTION
The generated `.d.ts` file would be something like
```
import * as eslintVisitorKeys from 'eslint-visitor-keys';
```
Which require the user to turn on `allowSyntheticDefaultImports` in tsconfig

otherwise they will see
```
node_modules/@typescript-eslint/typescript-estree/dist/visitor-keys.d.ts:1:8 - error TS1192: Module '"//tools/eslint/eslint-plugin-ts/node_modules/@types/eslint-visitor-keys/index"' has no default export.

1 import eslintVisitorKeys from 'eslint-visitor-keys';
         ~~~~~~~~~~~~~~~~~


Found 1 error.
```