### PR TITLE
feat: suggestion types, suggestions for no-explicit-any

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^12.12.7",
     "all-contributors-cli": "^6.11.0",
     "cz-conventional-changelog": "^3.0.2",
-    "eslint": "^6.6.0",
+    "eslint": "^6.7.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-eslint-plugin": "^2.1.0",
     "eslint-plugin-import": "^2.18.2",

--- a/packages/eslint-plugin/tests/rules/no-explicit-any.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-explicit-any.test.ts
@@ -3,6 +3,7 @@ import { RuleTester } from '../RuleTester';
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 
 type InvalidTestCase = TSESLint.InvalidTestCase<MessageIds, Options>;
+type SuggestionOutput = TSESLint.SuggestionOutput<MessageIds>;
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
@@ -306,11 +307,31 @@ type obj = {
           messageId: 'unexpectedAny',
           line: 1,
           column: 31,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: 'function generic(param: Array<unknown>): Array<any> {}',
+            },
+            {
+              messageId: 'suggestNever',
+              output: 'function generic(param: Array<never>): Array<any> {}',
+            },
+          ],
         },
         {
           messageId: 'unexpectedAny',
           line: 1,
           column: 44,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: 'function generic(param: Array<any>): Array<unknown> {}',
+            },
+            {
+              messageId: 'suggestNever',
+              output: 'function generic(param: Array<any>): Array<never> {}',
+            },
+          ],
         },
       ],
     },
@@ -705,11 +726,31 @@ type obj = {
           messageId: 'unexpectedAny',
           line: 1,
           column: 15,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: `class Foo<t = unknown> extends Bar<any> {}`,
+            },
+            {
+              messageId: 'suggestNever',
+              output: `class Foo<t = never> extends Bar<any> {}`,
+            },
+          ],
         },
         {
           messageId: 'unexpectedAny',
           line: 1,
           column: 32,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: `class Foo<t = any> extends Bar<unknown> {}`,
+            },
+            {
+              messageId: 'suggestNever',
+              output: `class Foo<t = any> extends Bar<never> {}`,
+            },
+          ],
         },
       ],
     },
@@ -720,11 +761,31 @@ type obj = {
           messageId: 'unexpectedAny',
           line: 1,
           column: 24,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: `abstract class Foo<t = unknown> extends Bar<any> {}`,
+            },
+            {
+              messageId: 'suggestNever',
+              output: `abstract class Foo<t = never> extends Bar<any> {}`,
+            },
+          ],
         },
         {
           messageId: 'unexpectedAny',
           line: 1,
           column: 41,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: `abstract class Foo<t = any> extends Bar<unknown> {}`,
+            },
+            {
+              messageId: 'suggestNever',
+              output: `abstract class Foo<t = any> extends Bar<never> {}`,
+            },
+          ],
         },
       ],
     },
@@ -735,16 +796,46 @@ type obj = {
           messageId: 'unexpectedAny',
           line: 1,
           column: 24,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: `abstract class Foo<t = unknown> implements Bar<any>, Baz<any> {}`,
+            },
+            {
+              messageId: 'suggestNever',
+              output: `abstract class Foo<t = never> implements Bar<any>, Baz<any> {}`,
+            },
+          ],
         },
         {
           messageId: 'unexpectedAny',
           line: 1,
           column: 44,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: `abstract class Foo<t = any> implements Bar<unknown>, Baz<any> {}`,
+            },
+            {
+              messageId: 'suggestNever',
+              output: `abstract class Foo<t = any> implements Bar<never>, Baz<any> {}`,
+            },
+          ],
         },
         {
           messageId: 'unexpectedAny',
           line: 1,
           column: 54,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: `abstract class Foo<t = any> implements Bar<any>, Baz<unknown> {}`,
+            },
+            {
+              messageId: 'suggestNever',
+              output: `abstract class Foo<t = any> implements Bar<any>, Baz<never> {}`,
+            },
+          ],
         },
       ],
     },
@@ -771,19 +862,51 @@ type obj = {
     {
       // https://github.com/typescript-eslint/typescript-eslint/issues/64
       code: `
-        function test<T extends Partial<any>>() {}
-        const test = <T extends Partial<any>>() => {};
-      `,
+function test<T extends Partial<any>>() {}
+const test = <T extends Partial<any>>() => {};
+      `.trimRight(),
       errors: [
         {
           messageId: 'unexpectedAny',
           line: 2,
-          column: 41,
+          column: 33,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: `
+function test<T extends Partial<unknown>>() {}
+const test = <T extends Partial<any>>() => {};
+              `.trimRight(),
+            },
+            {
+              messageId: 'suggestNever',
+              output: `
+function test<T extends Partial<never>>() {}
+const test = <T extends Partial<any>>() => {};
+              `.trimRight(),
+            },
+          ],
         },
         {
           messageId: 'unexpectedAny',
           line: 3,
-          column: 41,
+          column: 33,
+          suggestions: [
+            {
+              messageId: 'suggestUnknown',
+              output: `
+function test<T extends Partial<any>>() {}
+const test = <T extends Partial<unknown>>() => {};
+              `.trimRight(),
+            },
+            {
+              messageId: 'suggestNever',
+              output: `
+function test<T extends Partial<any>>() {}
+const test = <T extends Partial<never>>() => {};
+              `.trimRight(),
+            },
+          ],
         },
       ],
     },
@@ -869,7 +992,23 @@ type obj = {
       ],
     },
   ] as InvalidTestCase[]).reduce<InvalidTestCase[]>((acc, testCase) => {
-    acc.push(testCase);
+    const suggestions = (code: string): SuggestionOutput[] => [
+      {
+        messageId: 'suggestUnknown',
+        output: code.replace(/any/, 'unknown'),
+      },
+      {
+        messageId: 'suggestNever',
+        output: code.replace(/any/, 'never'),
+      },
+    ];
+    acc.push({
+      ...testCase,
+      errors: testCase.errors.map(e => ({
+        ...e,
+        suggestions: e.suggestions ?? suggestions(testCase.code),
+      })),
+    });
     const options = testCase.options || [];
     const code = `// fixToUnknown: true\n${testCase.code}`;
     acc.push({
@@ -881,7 +1020,17 @@ type obj = {
           return err;
         }
 
-        return { ...err, line: err.line + 1 };
+        return {
+          ...err,
+          line: err.line + 1,
+          suggestions:
+            err.suggestions?.map(
+              (s): SuggestionOutput => ({
+                ...s,
+                output: `// fixToUnknown: true\n${s.output}`,
+              }),
+            ) ?? suggestions(code),
+        };
       }),
     });
 

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -105,6 +105,9 @@ interface RuleFixer {
 type ReportFixFunction = (
   fixer: RuleFixer,
 ) => null | RuleFix | RuleFix[] | IterableIterator<RuleFix>;
+type ReportSuggestionArray<TMessageIds extends string> = ReportDescriptorBase<
+  TMessageIds
+>[];
 
 interface ReportDescriptorBase<TMessageIds extends string> {
   /**
@@ -119,7 +122,19 @@ interface ReportDescriptorBase<TMessageIds extends string> {
    * The messageId which is being reported.
    */
   messageId: TMessageIds;
+  // we disallow this because it's much better to use messageIds for reusable errors that are easily testable
+  // message?: string;
+  // suggestions instead have this property that works the same, but again it's much better to use messageIds
+  // desc?: string;
 }
+interface ReportDescriptorWithSuggestion<TMessageIds extends string>
+  extends ReportDescriptorBase<TMessageIds> {
+  /**
+   * 6.7's Suggestions API
+   */
+  suggest?: ReportSuggestionArray<TMessageIds> | null;
+}
+
 interface ReportDescriptorNodeOptionalLoc {
   /**
    * The Node or AST Token which the report is being attached to
@@ -136,9 +151,9 @@ interface ReportDescriptorLocOnly {
    */
   loc: TSESTree.SourceLocation | TSESTree.LineAndColumnData;
 }
-type ReportDescriptor<TMessageIds extends string> = ReportDescriptorBase<
-  TMessageIds
-> &
+type ReportDescriptor<
+  TMessageIds extends string
+> = ReportDescriptorWithSuggestion<TMessageIds> &
   (ReportDescriptorNodeOptionalLoc | ReportDescriptorLocOnly);
 
 interface RuleContext<
@@ -416,6 +431,7 @@ interface RuleModule<
 export {
   ReportDescriptor,
   ReportFixFunction,
+  ReportSuggestionArray,
   RuleContext,
   RuleFix,
   RuleFixer,

--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -19,6 +19,16 @@ interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   };
 }
 
+interface SuggestionOutput<TMessageIds extends string> {
+  messageId: TMessageIds;
+  data?: Record<string, unknown>;
+  /**
+   * NOTE: Suggestions will be applied as a stand-alone change, without triggering multipass fixes.
+   * Each individual error has its own suggestion, so you have to show the correct, _isolated_ output for each suggestion.
+   */
+  output: string;
+}
+
 interface InvalidTestCase<
   TMessageIds extends string,
   TOptions extends Readonly<unknown[]>
@@ -35,6 +45,7 @@ interface TestCaseError<TMessageIds extends string> {
   column?: number;
   endLine?: number;
   endColumn?: number;
+  suggestions?: SuggestionOutput<TMessageIds>[];
 }
 
 interface RunTests<
@@ -79,6 +90,7 @@ class RuleTester extends (ESLintRuleTester as {
 
 export {
   InvalidTestCase,
+  SuggestionOutput,
   RuleTester,
   RuleTesterConfig,
   RunTests,

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -14,5 +14,5 @@ These tests are setup to run within docker containers to ensure that each test i
 1. Copy+paste the `test.sh` from an existing fixture, and adjust the `eslint` command as required.
 1. Add a new entry to `docker-compose.yml` by copy+pasting an existing section, and changing the name to match your new folder.
 1. Add a new entry to `run-all-tests.sh` by copy+pasting an existing command, and changing the name to match your new folder.
-1. Run your integration test by running the single command you copied in .
+1. Run your integration test by running the single command you copied in the previous step.
    - If your test finishes successfully, a `test.js.snap` will be created.

--- a/tests/integration/fixtures/markdown/test.js.snap
+++ b/tests/integration/fixtures/markdown/test.js.snap
@@ -29,6 +29,30 @@ Array [
         "nodeType": "TSAnyKeyword",
         "ruleId": "@typescript-eslint/no-explicit-any",
         "severity": 2,
+        "suggestions": Array [
+          Object {
+            "desc": "Use \`unknown\` instead, this will force you to explicitly, and safely assert the type is correct.",
+            "fix": Object {
+              "range": Array [
+                51,
+                54,
+              ],
+              "text": "unknown",
+            },
+            "messageId": "suggestUnknown",
+          },
+          Object {
+            "desc": "Use \`never\` instead, this is useful when instantiating generic type parameters that you don't need to know the type of.",
+            "fix": Object {
+              "range": Array [
+                51,
+                54,
+              ],
+              "text": "never",
+            },
+            "messageId": "suggestNever",
+          },
+        ],
       },
       Object {
         "column": 3,
@@ -62,6 +86,30 @@ Array [
         "nodeType": "TSAnyKeyword",
         "ruleId": "@typescript-eslint/no-explicit-any",
         "severity": 2,
+        "suggestions": Array [
+          Object {
+            "desc": "Use \`unknown\` instead, this will force you to explicitly, and safely assert the type is correct.",
+            "fix": Object {
+              "range": Array [
+                16,
+                19,
+              ],
+              "text": "unknown",
+            },
+            "messageId": "suggestUnknown",
+          },
+          Object {
+            "desc": "Use \`never\` instead, this is useful when instantiating generic type parameters that you don't need to know the type of.",
+            "fix": Object {
+              "range": Array [
+                16,
+                19,
+              ],
+              "text": "never",
+            },
+            "messageId": "suggestNever",
+          },
+        ],
       },
       Object {
         "column": 3,
@@ -84,6 +132,30 @@ Array [
         "nodeType": "TSAnyKeyword",
         "ruleId": "@typescript-eslint/no-explicit-any",
         "severity": 2,
+        "suggestions": Array [
+          Object {
+            "desc": "Use \`unknown\` instead, this will force you to explicitly, and safely assert the type is correct.",
+            "fix": Object {
+              "range": Array [
+                16,
+                19,
+              ],
+              "text": "unknown",
+            },
+            "messageId": "suggestUnknown",
+          },
+          Object {
+            "desc": "Use \`never\` instead, this is useful when instantiating generic type parameters that you don't need to know the type of.",
+            "fix": Object {
+              "range": Array [
+                16,
+                19,
+              ],
+              "text": "never",
+            },
+            "messageId": "suggestNever",
+          },
+        ],
       },
       Object {
         "column": 3,
@@ -106,6 +178,30 @@ Array [
         "nodeType": "TSAnyKeyword",
         "ruleId": "@typescript-eslint/no-explicit-any",
         "severity": 2,
+        "suggestions": Array [
+          Object {
+            "desc": "Use \`unknown\` instead, this will force you to explicitly, and safely assert the type is correct.",
+            "fix": Object {
+              "range": Array [
+                16,
+                19,
+              ],
+              "text": "unknown",
+            },
+            "messageId": "suggestUnknown",
+          },
+          Object {
+            "desc": "Use \`never\` instead, this is useful when instantiating generic type parameters that you don't need to know the type of.",
+            "fix": Object {
+              "range": Array [
+                16,
+                19,
+              ],
+              "text": "never",
+            },
+            "messageId": "suggestNever",
+          },
+        ],
       },
       Object {
         "column": 3,

--- a/tests/integration/fixtures/vue-jsx/test.js.snap
+++ b/tests/integration/fixtures/vue-jsx/test.js.snap
@@ -18,6 +18,30 @@ Array [
         "nodeType": "TSAnyKeyword",
         "ruleId": "@typescript-eslint/no-explicit-any",
         "severity": 2,
+        "suggestions": Array [
+          Object {
+            "desc": "Use \`unknown\` instead, this will force you to explicitly, and safely assert the type is correct.",
+            "fix": Object {
+              "range": Array [
+                390,
+                393,
+              ],
+              "text": "unknown",
+            },
+            "messageId": "suggestUnknown",
+          },
+          Object {
+            "desc": "Use \`never\` instead, this is useful when instantiating generic type parameters that you don't need to know the type of.",
+            "fix": Object {
+              "range": Array [
+                390,
+                393,
+              ],
+              "text": "never",
+            },
+            "messageId": "suggestNever",
+          },
+        ],
       },
     ],
     "source": "<script lang=\\"tsx\\">

--- a/tests/integration/fixtures/vue-sfc/test.js.snap
+++ b/tests/integration/fixtures/vue-sfc/test.js.snap
@@ -18,6 +18,30 @@ Array [
         "nodeType": "TSAnyKeyword",
         "ruleId": "@typescript-eslint/no-explicit-any",
         "severity": 2,
+        "suggestions": Array [
+          Object {
+            "desc": "Use \`unknown\` instead, this will force you to explicitly, and safely assert the type is correct.",
+            "fix": Object {
+              "range": Array [
+                708,
+                711,
+              ],
+              "text": "unknown",
+            },
+            "messageId": "suggestUnknown",
+          },
+          Object {
+            "desc": "Use \`never\` instead, this is useful when instantiating generic type parameters that you don't need to know the type of.",
+            "fix": Object {
+              "range": Array [
+                708,
+                711,
+              ],
+              "text": "never",
+            },
+            "messageId": "suggestNever",
+          },
+        ],
       },
     ],
     "source": "<!-- Hello.vue -->

--- a/yarn.lock
+++ b/yarn.lock
@@ -3029,10 +3029,10 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.6.0.tgz#4a01a2fb48d32aacef5530ee9c5a78f11a8afd04"
-  integrity sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==
+eslint@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.7.0.tgz#766162e383b236e61d873697f82c3a3e41392020"
+  integrity sha512-dQpj+PaHKHfXHQ2Imcw5d853PTvkUGbHk/MR68KQUl98EgKDCdh4vLRH1ZxhqeQjQFJeg8fgN0UwmNhN3l8dDQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"
@@ -3049,7 +3049,7 @@ eslint@^6.6.0:
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
-    globals "^11.7.0"
+    globals "^12.1.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
@@ -3062,7 +3062,7 @@ eslint@^6.6.0:
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    optionator "^0.8.2"
+    optionator "^0.8.3"
     progress "^2.0.0"
     regexpp "^2.0.1"
     semver "^6.1.2"
@@ -3290,7 +3290,7 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -3730,10 +3730,17 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
-globals@^11.1.0, globals@^11.7.0:
+globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^12.1.0:
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-12.3.0.tgz#1e564ee5c4dded2ab098b0f88f24702a3c56be13"
+  integrity sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==
+  dependencies:
+    type-fest "^0.8.1"
 
 globby@^10.0.1:
   version "10.0.1"
@@ -5952,7 +5959,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1, optionator@^0.8.2:
+optionator@^0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
@@ -5963,6 +5970,18 @@ optionator@^0.8.1, optionator@^0.8.2:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+optionator@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.6"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    word-wrap "~1.2.3"
 
 os-homedir@^1.0.0:
   version "1.0.2"
@@ -7751,6 +7770,11 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
+type-fest@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -7981,7 +8005,7 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
-word-wrap@^1.0.3:
+word-wrap@^1.0.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==


### PR DESCRIPTION
Fixes #1249

I wanted to add an example usage at the same time.
`no-explicit-any` seemed like a good candidate because it's not possible to explicitly fix to this.
Suggestions are the perfect use case for it!