### PR TITLE
fix(eslint-plugin): [prefer-optional-chain] handle more cases

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -334,9 +334,15 @@ function isValidChainTarget(
   ) {
     const isObjectValid =
       ALLOWED_MEMBER_OBJECT_TYPES.has(node.object.type) &&
+      // make sure to validate the expression is of our expected structure
       isValidChainTarget(node.object, true);
     const isPropertyValid = node.computed
-      ? ALLOWED_COMPUTED_PROP_TYPES.has(node.property.type)
+      ? ALLOWED_COMPUTED_PROP_TYPES.has(node.property.type) &&
+        // make sure to validate the member expression is of our expected structure
+        (node.property.type === AST_NODE_TYPES.MemberExpression ||
+        node.property.type === AST_NODE_TYPES.OptionalMemberExpression
+          ? isValidChainTarget(node.property, allowIdentifier)
+          : true)
       : ALLOWED_NON_COMPUTED_PROP_TYPES.has(node.property.type);
 
     return isObjectValid && isPropertyValid;

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -2,9 +2,15 @@ import {
   AST_NODE_TYPES,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
+import { isOpeningParenToken } from 'eslint-utils';
 import * as util from '../util';
 
-const WHITESPACE_REGEX = /\s/g;
+type ValidChainTarget =
+  | TSESTree.BinaryExpression
+  | TSESTree.CallExpression
+  | TSESTree.MemberExpression
+  | TSESTree.OptionalCallExpression
+  | TSESTree.OptionalMemberExpression;
 
 /*
 The AST is always constructed such the first element is always the deepest element.
@@ -70,19 +76,36 @@ export default util.createRule({
         let optionallyChainedCode = previousLeftText;
         let expressionCount = 1;
         while (current.type === AST_NODE_TYPES.LogicalExpression) {
-          if (!isValidChainTarget(current.right)) {
+          if (
+            !isValidChainTarget(
+              current.right,
+              // only allow identifiers for the first chain - foo && foo()
+              expressionCount === 1,
+            )
+          ) {
             break;
           }
 
           const leftText = previousLeftText;
           const rightText = getText(current.right);
-          if (!rightText.startsWith(leftText)) {
+          // can't just use startsWith because of cases like foo && fooBar.baz;
+          const matchRegex = new RegExp(
+            `^${
+              // escape regex characters
+              leftText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            }[^a-zA-Z0-9_]`,
+          );
+          if (
+            !matchRegex.test(rightText) &&
+            // handle redundant cases like foo.bar && foo.bar
+            leftText !== rightText
+          ) {
             break;
           }
-          expressionCount += 1;
 
           // omit weird doubled up expression that make no sense like foo.bar && foo.bar
           if (rightText !== leftText) {
+            expressionCount += 1;
             previousLeftText = rightText;
 
             /*
@@ -108,21 +131,37 @@ export default util.createRule({
             rightText === 'foo.bar.baz[buzz]'
             leftText === 'foo.bar.baz'
             diff === '[buzz]'
+
+            5)
+            rightText === 'foo.bar.baz?.buzz'
+            leftText === 'foo.bar.baz'
+            diff === '?.buzz'
             */
             const diff = rightText.replace(leftText, '');
-            const needsDot = diff.startsWith('(') || diff.startsWith('[');
-            optionallyChainedCode += `?${needsDot ? '.' : ''}${diff}`;
+            if (diff.startsWith('?')) {
+              // item was "pre optional chained"
+              optionallyChainedCode += diff;
+            } else {
+              const needsDot = diff.startsWith('(') || diff.startsWith('[');
+              optionallyChainedCode += `?${needsDot ? '.' : ''}${diff}`;
+            }
           }
 
-          /* istanbul ignore if: this shouldn't ever happen, but types */
-          if (!current.parent) {
-            break;
-          }
           previous = current;
-          current = current.parent;
+          current = util.nullThrows(
+            current.parent,
+            util.NullThrowsReasons.MissingParent,
+          );
         }
 
         if (expressionCount > 1) {
+          if (previous.right.type === AST_NODE_TYPES.BinaryExpression) {
+            // case like foo && foo.bar !== someValue
+            optionallyChainedCode += ` ${
+              previous.right.operator
+            } ${sourceCode.getText(previous.right.right)}`;
+          }
+
           context.report({
             node: previous,
             messageId: 'preferOptionalChain',
@@ -134,36 +173,169 @@ export default util.createRule({
       },
     };
 
-    function getText(
-      node:
-        | TSESTree.BinaryExpression
-        | TSESTree.CallExpression
-        | TSESTree.Identifier
-        | TSESTree.MemberExpression,
-    ): string {
-      const text = sourceCode.getText(
-        node.type === AST_NODE_TYPES.BinaryExpression ? node.left : node,
-      );
+    function getText(node: ValidChainTarget | TSESTree.Identifier): string {
+      if (node.type === AST_NODE_TYPES.BinaryExpression) {
+        return getText(
+          // isValidChainTarget ensures this is type safe
+          node.left as ValidChainTarget,
+        );
+      }
 
-      // Removes spaces from the source code for the given node
-      return text.replace(WHITESPACE_REGEX, '');
+      if (
+        node.type === AST_NODE_TYPES.CallExpression ||
+        node.type === AST_NODE_TYPES.OptionalCallExpression
+      ) {
+        const calleeText = getText(
+          // isValidChainTarget ensures this is type safe
+          node.callee as ValidChainTarget,
+        );
+
+        // ensure that the call arguments are left untouched, or else we can break cases that _need_ whitespace:
+        // - JSX: <Foo Needs Space Between Attrs />
+        // - Unary Operators: typeof foo, await bar, delete baz
+        const closingParenToken = util.nullThrows(
+          sourceCode.getLastToken(node),
+          util.NullThrowsReasons.MissingToken('closing parenthesis', node.type),
+        );
+        const openingParenToken = util.nullThrows(
+          sourceCode.getFirstTokenBetween(
+            node.callee,
+            closingParenToken,
+            isOpeningParenToken,
+          ),
+          util.NullThrowsReasons.MissingToken('opening parenthesis', node.type),
+        );
+
+        const argumentsText = sourceCode.text.substring(
+          openingParenToken.range[0],
+          closingParenToken.range[1],
+        );
+
+        return `${calleeText}${argumentsText}`;
+      }
+
+      if (node.type === AST_NODE_TYPES.Identifier) {
+        return node.name;
+      }
+
+      return getMemberExpressionText(node);
+    }
+
+    /**
+     * Gets a normalised representation of the given MemberExpression
+     */
+    function getMemberExpressionText(
+      node: TSESTree.MemberExpression | TSESTree.OptionalMemberExpression,
+    ): string {
+      let objectText: string;
+
+      // cases should match the list in ALLOWED_MEMBER_OBJECT_TYPES
+      switch (node.object.type) {
+        case AST_NODE_TYPES.CallExpression:
+        case AST_NODE_TYPES.OptionalCallExpression:
+        case AST_NODE_TYPES.Identifier:
+          objectText = getText(node.object);
+          break;
+
+        case AST_NODE_TYPES.MemberExpression:
+        case AST_NODE_TYPES.OptionalMemberExpression:
+          objectText = getMemberExpressionText(node.object);
+          break;
+
+        /* istanbul ignore next */
+        default:
+          throw new Error(`Unexpected member object type: ${node.object.type}`);
+      }
+
+      let propertyText: string;
+      if (node.computed) {
+        // cases should match the list in ALLOWED_COMPUTED_PROP_TYPES
+        switch (node.property.type) {
+          case AST_NODE_TYPES.Identifier:
+            propertyText = getText(node.property);
+            break;
+
+          case AST_NODE_TYPES.Literal:
+          case AST_NODE_TYPES.BigIntLiteral:
+          case AST_NODE_TYPES.TemplateLiteral:
+            propertyText = sourceCode.getText(node.property);
+            break;
+
+          case AST_NODE_TYPES.MemberExpression:
+          case AST_NODE_TYPES.OptionalMemberExpression:
+            propertyText = getMemberExpressionText(node.property);
+            break;
+
+          /* istanbul ignore next */
+          default:
+            throw new Error(
+              `Unexpected member property type: ${node.object.type}`,
+            );
+        }
+
+        return `${objectText}${node.optional ? '?.' : ''}[${propertyText}]`;
+      } else {
+        // cases should match the list in ALLOWED_NON_COMPUTED_PROP_TYPES
+        switch (node.property.type) {
+          case AST_NODE_TYPES.Identifier:
+            propertyText = getText(node.property);
+            break;
+
+          /* istanbul ignore next */
+          default:
+            throw new Error(
+              `Unexpected member property type: ${node.object.type}`,
+            );
+        }
+
+        return `${objectText}${node.optional ? '?.' : '.'}${propertyText}`;
+      }
     }
   },
 });
 
+const ALLOWED_MEMBER_OBJECT_TYPES: ReadonlySet<AST_NODE_TYPES> = new Set([
+  AST_NODE_TYPES.CallExpression,
+  AST_NODE_TYPES.Identifier,
+  AST_NODE_TYPES.MemberExpression,
+  AST_NODE_TYPES.OptionalCallExpression,
+  AST_NODE_TYPES.OptionalMemberExpression,
+]);
+const ALLOWED_COMPUTED_PROP_TYPES: ReadonlySet<AST_NODE_TYPES> = new Set([
+  AST_NODE_TYPES.BigIntLiteral,
+  AST_NODE_TYPES.Identifier,
+  AST_NODE_TYPES.Literal,
+  AST_NODE_TYPES.MemberExpression,
+  AST_NODE_TYPES.OptionalMemberExpression,
+  AST_NODE_TYPES.TemplateLiteral,
+]);
+const ALLOWED_NON_COMPUTED_PROP_TYPES: ReadonlySet<AST_NODE_TYPES> = new Set([
+  AST_NODE_TYPES.Identifier,
+]);
+
 function isValidChainTarget(
   node: TSESTree.Node,
-  allowIdentifier = false,
-): node is
-  | TSESTree.BinaryExpression
-  | TSESTree.CallExpression
-  | TSESTree.MemberExpression {
+  allowIdentifier: boolean,
+): node is ValidChainTarget | TSESTree.Identifier {
   if (
     node.type === AST_NODE_TYPES.MemberExpression ||
-    node.type === AST_NODE_TYPES.CallExpression
+    node.type === AST_NODE_TYPES.OptionalMemberExpression
   ) {
-    return true;
+    const isObjectValid = ALLOWED_MEMBER_OBJECT_TYPES.has(node.object.type);
+    const isPropertyValid = node.computed
+      ? ALLOWED_COMPUTED_PROP_TYPES.has(node.property.type)
+      : ALLOWED_NON_COMPUTED_PROP_TYPES.has(node.property.type);
+
+    return isObjectValid && isPropertyValid;
   }
+
+  if (
+    node.type === AST_NODE_TYPES.CallExpression ||
+    node.type === AST_NODE_TYPES.OptionalCallExpression
+  ) {
+    return isValidChainTarget(node.callee, allowIdentifier);
+  }
+
   if (allowIdentifier && node.type === AST_NODE_TYPES.Identifier) {
     return true;
   }

--- a/packages/eslint-plugin/src/util/index.ts
+++ b/packages/eslint-plugin/src/util/index.ts
@@ -4,6 +4,7 @@ export * from './astUtils';
 export * from './createRule';
 export * from './getParserServices';
 export * from './misc';
+export * from './nullThrows';
 export * from './types';
 
 // this is done for convenience - saves migrating all of the old rules

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -11,14 +11,14 @@ import {
 /**
  * Check if the context file name is *.d.ts or *.d.tsx
  */
-export function isDefinitionFile(fileName: string): boolean {
+function isDefinitionFile(fileName: string): boolean {
   return /\.d\.tsx?$/i.test(fileName || '');
 }
 
 /**
  * Upper cases the first character or the string
  */
-export function upperCaseFirst(str: string): string {
+function upperCaseFirst(str: string): string {
   return str[0].toUpperCase() + str.slice(1);
 }
 
@@ -31,7 +31,7 @@ type InferOptionsTypeFromRuleNever<T> = T extends TSESLint.RuleModule<
 /**
  * Uses type inference to fetch the TOptions type from the given RuleModule
  */
-export type InferOptionsTypeFromRule<T> = T extends TSESLint.RuleModule<
+type InferOptionsTypeFromRule<T> = T extends TSESLint.RuleModule<
   string,
   infer TOptions
 >
@@ -41,7 +41,7 @@ export type InferOptionsTypeFromRule<T> = T extends TSESLint.RuleModule<
 /**
  * Uses type inference to fetch the TMessageIds type from the given RuleModule
  */
-export type InferMessageIdsTypeFromRule<T> = T extends TSESLint.RuleModule<
+type InferMessageIdsTypeFromRule<T> = T extends TSESLint.RuleModule<
   infer TMessageIds,
   unknown[]
 >
@@ -51,9 +51,7 @@ export type InferMessageIdsTypeFromRule<T> = T extends TSESLint.RuleModule<
 /**
  * Gets a string name representation of the given PropertyName node
  */
-export function getNameFromPropertyName(
-  propertyName: TSESTree.PropertyName,
-): string {
+function getNameFromPropertyName(propertyName: TSESTree.PropertyName): string {
   if (propertyName.type === AST_NODE_TYPES.Identifier) {
     return propertyName.name;
   }
@@ -61,9 +59,9 @@ export function getNameFromPropertyName(
 }
 
 /** Return true if both parameters are equal. */
-export type Equal<T> = (a: T, b: T) => boolean;
+type Equal<T> = (a: T, b: T) => boolean;
 
-export function arraysAreEqual<T>(
+function arraysAreEqual<T>(
   a: T[] | undefined,
   b: T[] | undefined,
   eq: (a: T, b: T) => boolean,
@@ -78,7 +76,7 @@ export function arraysAreEqual<T>(
 }
 
 /** Returns the first non-`undefined` result. */
-export function findFirstResult<T, U>(
+function findFirstResult<T, U>(
   inputs: T[],
   getResult: (t: T) => U | undefined,
 ): U | undefined {
@@ -95,7 +93,7 @@ export function findFirstResult<T, U>(
  * Gets a string name representation of the name of the given MethodDefinition
  * or ClassProperty node, with handling for computed property names.
  */
-export function getNameFromClassMember(
+function getNameFromClassMember(
   methodDefinition:
     | TSESTree.MethodDefinition
     | TSESTree.ClassProperty
@@ -122,11 +120,25 @@ function keyCanBeReadAsPropertyName(
   );
 }
 
-export type ExcludeKeys<
+type ExcludeKeys<
   TObj extends Record<string, unknown>,
   TKeys extends keyof TObj
 > = { [k in Exclude<keyof TObj, TKeys>]: TObj[k] };
-export type RequireKeys<
+type RequireKeys<
   TObj extends Record<string, unknown>,
   TKeys extends keyof TObj
 > = ExcludeKeys<TObj, TKeys> & { [k in TKeys]-?: Exclude<TObj[k], undefined> };
+
+export {
+  arraysAreEqual,
+  Equal,
+  ExcludeKeys,
+  findFirstResult,
+  getNameFromClassMember,
+  getNameFromPropertyName,
+  InferMessageIdsTypeFromRule,
+  InferOptionsTypeFromRule,
+  isDefinitionFile,
+  RequireKeys,
+  upperCaseFirst,
+};

--- a/packages/eslint-plugin/src/util/nullThrows.ts
+++ b/packages/eslint-plugin/src/util/nullThrows.ts
@@ -1,0 +1,28 @@
+/**
+ * A set of common reasons for calling nullThrows
+ */
+const NullThrowsReasons = {
+  MissingParent: 'Expected node to have a parent.',
+  MissingToken: (token: string, thing: string) =>
+    `Expected to find a ${token} for the ${thing}.`,
+} as const;
+
+/**
+ * Assert that a value must not be null or undefined.
+ * This is a nice explicit alternative to the non-null assertion operator.
+ */
+function nullThrows<T>(value: T | null | undefined, message: string): T {
+  // this function is primarily used to keep types happy in a safe way
+  // i.e. is used when we expect that a value is never nullish
+  // this means that it's pretty much impossible to test the below if...
+
+  // so ignore it in coverage metrics.
+  /* istanbul ignore if */
+  if (value === null || value === undefined) {
+    throw new Error(`Non-null Assertion Failed: ${message}`);
+  }
+
+  return value;
+}
+
+export { nullThrows, NullThrowsReasons };

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain.test.ts
@@ -116,8 +116,6 @@ const baseCases = [
 
 ruleTester.run('prefer-optional-chain', rule, {
   valid: [
-    'x["y"] !== undefined && x["y"] !== null',
-    'result && this.options.shouldPreserveNodeMaps',
     'foo && bar',
     'foo && foo',
     'foo || bar',
@@ -126,8 +124,10 @@ ruleTester.run('prefer-optional-chain', rule, {
     'foo ?? foo.bar',
     "file !== 'index.ts' && file.endsWith('.ts')",
     'nextToken && sourceCode.isSpaceBetweenTokens(prevToken, nextToken)',
+    'result && this.options.shouldPreserveNodeMaps',
     'foo && fooBar.baz',
     'foo !== null && foo !== undefined',
+    'x["y"] !== undefined && x["y"] !== null',
     // currently do not handle complex computed properties
     'foo && foo[bar as string] && foo[bar as string].baz',
     'foo && foo[1 + 2] && foo[1 + 2].baz',

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain.test.ts
@@ -13,135 +13,92 @@ const ruleTester = new RuleTester({
 const baseCases = [
   // chained members
   {
-    code: `
-      foo && foo.bar
-    `,
-    output: `
-      foo?.bar
-    `,
+    code: 'foo && foo.bar',
+    output: 'foo?.bar',
   },
   {
-    code: `
-      foo && foo()
-    `,
-    output: `
-      foo?.()
-    `,
+    code: 'foo && foo()',
+    output: 'foo?.()',
   },
   {
-    code: `
-      foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz
-    `,
-    output: `
-      foo?.bar?.baz?.buzz
-    `,
+    code: 'foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz',
+    output: 'foo?.bar?.baz?.buzz',
   },
   {
     // case with a jump (i.e. a non-nullish prop)
-    code: `
-      foo && foo.bar && foo.bar.baz.buzz
-    `,
-    output: `
-      foo?.bar?.baz.buzz
-    `,
+    code: 'foo && foo.bar && foo.bar.baz.buzz',
+    output: 'foo?.bar?.baz.buzz',
   },
   {
     // case where for some reason there is a doubled up expression
-    code: `
-      foo && foo.bar && foo.bar.baz && foo.bar.baz && foo.bar.baz.buzz
-    `,
-    output: `
-      foo?.bar?.baz?.buzz
-    `,
+    code: 'foo && foo.bar && foo.bar.baz && foo.bar.baz && foo.bar.baz.buzz',
+    output: 'foo?.bar?.baz?.buzz',
   },
   // chained members with element access
   {
-    code: `
-      foo && foo[bar] && foo[bar].baz && foo[bar].baz.buzz
-    `,
-    output: `
-      foo?.[bar]?.baz?.buzz
-    `,
+    code: 'foo && foo[bar] && foo[bar].baz && foo[bar].baz.buzz',
+    output: 'foo?.[bar]?.baz?.buzz',
   },
   {
     // case with a jump (i.e. a non-nullish prop)
-    code: `
-      foo && foo[bar].baz && foo[bar].baz.buzz
-    `,
-    output: `
-      foo?.[bar].baz?.buzz
-    `,
+    code: 'foo && foo[bar].baz && foo[bar].baz.buzz',
+    output: 'foo?.[bar].baz?.buzz',
   },
   // chained calls
   {
-    code: `
-      foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz()
-    `,
-    output: `
-      foo?.bar?.baz?.buzz()
-    `,
+    code: 'foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz()',
+    output: 'foo?.bar?.baz?.buzz()',
   },
   {
-    code: `
-      foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz && foo.bar.baz.buzz()
-    `,
-    output: `
-      foo?.bar?.baz?.buzz?.()
-    `,
+    code:
+      'foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz && foo.bar.baz.buzz()',
+    output: 'foo?.bar?.baz?.buzz?.()',
   },
   {
     // case with a jump (i.e. a non-nullish prop)
-    code: `
-      foo && foo.bar && foo.bar.baz.buzz()
-    `,
-    output: `
-      foo?.bar?.baz.buzz()
-    `,
+    code: 'foo && foo.bar && foo.bar.baz.buzz()',
+    output: 'foo?.bar?.baz.buzz()',
   },
   {
     // case with a jump (i.e. a non-nullish prop)
-    code: `
-      foo && foo.bar && foo.bar.baz.buzz && foo.bar.baz.buzz()
-    `,
-    output: `
-      foo?.bar?.baz.buzz?.()
-    `,
+    code: 'foo && foo.bar && foo.bar.baz.buzz && foo.bar.baz.buzz()',
+    output: 'foo?.bar?.baz.buzz?.()',
   },
   {
     // case with a call expr inside the chain for some inefficient reason
-    code: `
-      foo && foo.bar() && foo.bar().baz && foo.bar().baz.buzz && foo.bar().baz.buzz()
-    `,
-    output: `
-      foo?.bar()?.baz?.buzz?.()
-    `,
+    code:
+      'foo && foo.bar() && foo.bar().baz && foo.bar().baz.buzz && foo.bar().baz.buzz()',
+    output: 'foo?.bar()?.baz?.buzz?.()',
   },
   // chained calls with element access
   {
-    code: `
-      foo && foo.bar && foo.bar.baz && foo.bar.baz[buzz]()
-    `,
-    output: `
-      foo?.bar?.baz?.[buzz]()
-    `,
+    code: 'foo && foo.bar && foo.bar.baz && foo.bar.baz[buzz]()',
+    output: 'foo?.bar?.baz?.[buzz]()',
   },
   {
-    code: `
-      foo && foo.bar && foo.bar.baz && foo.bar.baz[buzz] && foo.bar.baz[buzz]()
-    `,
-    output: `
-      foo?.bar?.baz?.[buzz]?.()
-    `,
+    code:
+      'foo && foo.bar && foo.bar.baz && foo.bar.baz[buzz] && foo.bar.baz[buzz]()',
+    output: 'foo?.bar?.baz?.[buzz]?.()',
   },
   // two-for-one
   {
-    code: `
-      foo && foo.bar && foo.bar.baz || baz && baz.bar && baz.bar.foo
-    `,
-    output: `
-      foo?.bar?.baz || baz?.bar?.foo
-    `,
+    code: 'foo && foo.bar && foo.bar.baz || baz && baz.bar && baz.bar.foo',
+    output: 'foo?.bar?.baz || baz?.bar?.foo',
     errors: 2,
+  },
+  // (partially) pre-optional chained
+  {
+    code:
+      'foo && foo?.bar && foo?.bar.baz && foo?.bar.baz[buzz] && foo?.bar.baz[buzz]()',
+    output: 'foo?.bar?.baz?.[buzz]?.()',
+  },
+  {
+    code: 'foo && foo?.bar.baz && foo?.bar.baz[buzz]',
+    output: 'foo?.bar.baz?.[buzz]',
+  },
+  {
+    code: 'foo && foo?.() && foo?.().bar',
+    output: 'foo?.()?.bar',
   },
 ].map(
   c =>
@@ -167,6 +124,11 @@ ruleTester.run('prefer-optional-chain', rule, {
     'foo ?? foo.bar',
     "file !== 'index.ts' && file.endsWith('.ts')",
     'nextToken && sourceCode.isSpaceBetweenTokens(prevToken, nextToken)',
+    'foo && fooBar.baz',
+    // currently do not handle complex computed properties
+    'foo && foo[bar as string] && foo[bar as string].baz',
+    'foo && foo[1 + 2] && foo[1 + 2].baz',
+    'foo && foo[typeof bar] && foo[typeof bar].baz',
   ],
   invalid: [
     ...baseCases,
@@ -193,28 +155,114 @@ ruleTester.run('prefer-optional-chain', rule, {
     // strict nullish equality checks x !== null && x.y !== null
     ...baseCases.map(c => ({
       ...c,
-      code: c.code.replace(/&&/g, ' !== null &&'),
+      code: c.code.replace(/&&/g, '!== null &&'),
     })),
     ...baseCases.map(c => ({
       ...c,
-      code: c.code.replace(/&&/g, ' != null &&'),
+      code: c.code.replace(/&&/g, '!= null &&'),
     })),
     ...baseCases.map(c => ({
       ...c,
-      code: c.code.replace(/&&/g, ' !== undefined &&'),
+      code: c.code.replace(/&&/g, '!== undefined &&'),
     })),
     ...baseCases.map(c => ({
       ...c,
-      code: c.code.replace(/&&/g, ' != undefined &&'),
+      code: c.code.replace(/&&/g, '!= undefined &&'),
     })),
     {
       // case with inconsistent checks
+      code:
+        'foo && foo.bar != null && foo.bar.baz !== undefined && foo.bar.baz.buzz',
+      output: 'foo?.bar?.baz?.buzz',
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+        },
+      ],
+    },
+    // ensure essential whitespace isn't removed
+    {
+      code: 'foo && foo.bar(baz => (<This Requires Spaces />));',
+      output: 'foo?.bar(baz => (<This Requires Spaces />));',
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+        },
+      ],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: 'foo && foo.bar(baz => typeof baz);',
+      output: 'foo?.bar(baz => typeof baz);',
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+        },
+      ],
+    },
+    {
+      code: 'foo && foo["some long string"] && foo["some long string"].baz',
+      output: 'foo?.["some long string"]?.baz',
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+        },
+      ],
+    },
+    // should preserve comments in a call expression
+    {
       code: `
-        foo && foo.bar != null && foo.bar.baz && foo.bar.baz.buzz !== undefined
+        foo && foo.bar(/* comment */a,
+          // comment2
+          b, );
       `,
       output: `
-        foo?.bar?.baz?.buzz
+        foo?.bar(/* comment */a,
+          // comment2
+          b, );
       `,
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+        },
+      ],
+    },
+    // ensure binary expressions that are the last expression do not get removed
+    {
+      code: 'foo && foo.bar != null',
+      output: 'foo?.bar != null',
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+        },
+      ],
+    },
+    {
+      code: 'foo && foo.bar != undefined',
+      output: 'foo?.bar != undefined',
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+        },
+      ],
+    },
+    {
+      code: 'foo && foo.bar != null && baz',
+      output: 'foo?.bar != null && baz',
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+        },
+      ],
+    },
+    // other weird cases
+    {
+      code: 'foo && foo?.()',
+      output: 'foo?.()',
       errors: [
         {
           messageId: 'preferOptionalChain',

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain.test.ts
@@ -116,6 +116,8 @@ const baseCases = [
 
 ruleTester.run('prefer-optional-chain', rule, {
   valid: [
+    'x["y"] !== undefined && x["y"] !== null',
+    'result && this.options.shouldPreserveNodeMaps',
     'foo && bar',
     'foo && foo',
     'foo || bar',
@@ -125,6 +127,7 @@ ruleTester.run('prefer-optional-chain', rule, {
     "file !== 'index.ts' && file.endsWith('.ts')",
     'nextToken && sourceCode.isSpaceBetweenTokens(prevToken, nextToken)',
     'foo && fooBar.baz',
+    'foo !== null && foo !== undefined',
     // currently do not handle complex computed properties
     'foo && foo[bar as string] && foo[bar as string].baz',
     'foo && foo[1 + 2] && foo[1 + 2].baz',
@@ -207,6 +210,24 @@ ruleTester.run('prefer-optional-chain', rule, {
     {
       code: 'foo && foo["some long string"] && foo["some long string"].baz',
       output: 'foo?.["some long string"]?.baz',
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+        },
+      ],
+    },
+    {
+      code: 'foo && foo[`some long string`] && foo[`some long string`].baz',
+      output: 'foo?.[`some long string`]?.baz',
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+        },
+      ],
+    },
+    {
+      code: "foo && foo['some long string'] && foo['some long string'].baz",
+      output: "foo?.['some long string']?.baz",
       errors: [
         {
           messageId: 'preferOptionalChain',


### PR DESCRIPTION
I imported my implementation to the fb codebase and ran it (because I figured this rule isn't actually TS specific), and I found a few cases that I missed in the original implementation.

To better handle the cases, I significantly reduced the "allowed" scope of the rule by only allowing certain AST structures (see the `isValidChainTarget` function).

## Changes:

### at detection time:
1) no longer false-positives on chains where the first variable name is a substring of the next in the chain:
    - `foo && fooBar.baz`
1) now can detect chains with some optionals already:
    - `foo && foo.bar?.baz`
1) no longer detcets arbitrarily "complex" computed cases, such as:
`foo && foo[bar as string] && foo[bar as string].baz`, or
`foo && foo[1 + 2] && foo[1 + 2].baz`.
    - I realised that in order to "normalise" the text for comparison, the rule needs to know how to normalise every allowed node.
    - There's probably a better algorithm than just comparing text directly that removes this limitation.

### at fix time:
1) no longer modifies call expression arguments (fixes a bug where required spaces in unary operators and JSX was stripped):
    - `foo && foo.map(bar => <Baz bar={bar} />)`
      - fix to `foo?.map(bar => <Baz bar={bar} />)`
    - `foo && foo.map(bar => typeof bar)`
      - fix to `foo?.map(bar => typeof bar)`
    - `foo && foo.bar(/* comment */a, )`
      - fix to `foo?.bar(/* comment */a, )`
1) No longer strips spaces from computed member expression literals:
    - `foo && foo['bar baz']`
      - fix to `foo?.['bar baz']`
1) No longer drops trailing binary expressions:
    - `foo != null && foo.bar != null`
      - fix to `foo?.bar != null`
    - `foo && foo.bar != null && baz`
      - fix to `foo?.bar != null && baz`
