### PR TITLE
feat(eslint-plugin): [prefer-null-coal] opt for suggestion fixer

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
@@ -46,13 +46,15 @@ type Options = [
   {
     ignoreConditionalTests?: boolean;
     ignoreMixedLogicalExpressions?: boolean;
+    forceSuggestionFixer?: boolean;
   },
 ];
 
 const defaultOptions = [
   {
     ignoreConditionalTests: true,
-    ignoreMixedLogicalExpressions: true;
+    ignoreMixedLogicalExpressions: true,
+    forceSuggestionFixer: false,
   },
 ];
 ```
@@ -129,7 +131,13 @@ a ?? (b && c) ?? d;
 a ?? (b && c && d);
 ```
 
-**_NOTE:_** Errors for this specific case will be presented as suggestions, instead of fixes. This is because it is not always safe to automatically convert `||` to `??` within a mixed logical expression, as we cannot tell the intended precedence of the operator. Note that by design, `??` requires parentheses when used with `&&` or `||` in the same expression.
+**_NOTE:_** Errors for this specific case will be presented as suggestions (see below), instead of fixes. This is because it is not always safe to automatically convert `||` to `??` within a mixed logical expression, as we cannot tell the intended precedence of the operator. Note that by design, `??` requires parentheses when used with `&&` or `||` in the same expression.
+
+### forceSuggestionFixer
+
+Setting this option to `true` will cause the rule to use ESLint's "suggested fix" mode for all fixes. _This option is provided as to aid in transitioning your codebase onto this rule_.
+
+Suggestion fixes cannot be automatically applied via the `--fix` CLI command, but can be _manually_ chosen to be applied one at a time via an IDE or similar. This makes it safe to run autofixers on an existing codebase without worrying about potential runtime behaviour changes from this rule's fixer.
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -435,5 +435,33 @@ if (function werid() { return x ?? 'foo' }) {}
         },
       ],
     })),
+
+    // testing the suggestion fixer option
+    {
+      code: `
+declare const x: string | null;
+x || 'foo';
+      `.trimRight(),
+      output: null,
+      options: [{ forceSuggestionFixer: true }],
+      errors: [
+        {
+          messageId: 'preferNullish',
+          line: 3,
+          column: 3,
+          endLine: 3,
+          endColumn: 5,
+          suggestions: [
+            {
+              messageId: 'preferNullish',
+              output: `
+declare const x: string | null;
+x ?? 'foo';
+              `.trimRight(),
+            },
+          ],
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Fixes #1265

Adding an option to force the rule to only use suggestions.
This should help with users migrating existing codebases.