### PR TITLE
fix(eslint-plugin): [strict-bool-expr] allow nullish coalescing

### DIFF
--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -150,7 +150,7 @@ export default util.createRule<Options, 'strictBooleanExpression'>({
       ForStatement: assertTestExpressionContainsBoolean,
       IfStatement: assertTestExpressionContainsBoolean,
       WhileStatement: assertTestExpressionContainsBoolean,
-      LogicalExpression: assertLocalExpressionContainsBoolean,
+      'LogicalExpression[operator!="??"]': assertLocalExpressionContainsBoolean,
       'UnaryExpression[operator="!"]': assertUnaryExpressionContainsBoolean,
     };
   },

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -159,11 +159,11 @@ ruleTester.run('strict-boolean-expressions', rule, {
     {
       options: [{ ignoreRhs: true }],
       code: `
-const obj = {};
-const bool = false;
-const boolOrObj = bool || obj;
-const boolAndObj = bool && obj;
-`,
+        const obj = {};
+        const bool = false;
+        const boolOrObj = bool || obj;
+        const boolAndObj = bool && obj;
+      `,
     },
     {
       options: [{ allowNullable: true }],
@@ -174,6 +174,10 @@ const boolAndObj = bool && obj;
         const f4 = (x?: false) => x ? 1 : 0;
       `,
     },
+    `
+      declare const x: string | null;
+      y = x ?? 'foo';
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
This rule shouldn't actually touch them, but it never checked the operator, so it does right now..