### PR TITLE
fix(typescript-estree): make FunctionDeclaration.body non-null

### DIFF
--- a/packages/typescript-estree/src/ts-estree/ts-estree.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-estree.ts
@@ -718,6 +718,7 @@ export interface ForStatement extends BaseNode {
 
 export interface FunctionDeclaration extends FunctionDeclarationBase {
   type: AST_NODE_TYPES.FunctionDeclaration;
+  body: BlockStatement;
 }
 
 export interface FunctionExpression extends FunctionDeclarationBase {


### PR DESCRIPTION
This is half of #734:

> I didn't realise it, but in #156, it added handling to convert function declarations with no body into TSFunctionDeclaration (https://github.com/typescript-eslint/typescript-eslint/pull/156/files#diff-68b2b0b0d2d0ff1846b1114472008332R674)
>
> So it looks like there's no case now that a FunctionDeclaration can have no body?