### PR TITLE
feat: add new package for strictly typing configuration files

### DIFF
--- a/.eslintrc-example-test-temp.ts
+++ b/.eslintrc-example-test-temp.ts
@@ -1,7 +1,66 @@
-// @ts-check
-const { typedConfig } = require('@typescript-eslint/typed-config');
+/**
+ * TEST FILE TODO DELETE THIS BEFORE FINAL COMMIT
+ */
 
-module.exports = typedConfig({
+import {
+  typedConfig,
+  ESLintConfig as ESLintConfigBase,
+} from './packages/typed-config/dist/index';
+
+declare global {
+  namespace ESLintConfig {
+    interface Rules {
+      myRule?:
+        | ESLintConfigBase.RuleLevelAndNoOptions
+        | [ESLintConfigBase.RuleLevel, { test: string }];
+    }
+  }
+}
+
+// eslint-plugin-eslint-comments
+// some hand-crafted types for the smallest plugin we have installed
+declare global {
+  namespace ESLintConfig {
+    interface Rules {
+      'eslint-comments/disable-enable-pair'?:
+        | ESLintConfigBase.RuleLevelAndNoOptions
+        | [
+            ESLintConfigBase.RuleLevel,
+            {
+              allowWholeFile?: boolean;
+            },
+          ];
+      'eslint-comments/no-aggregating-enable'?: ESLintConfigBase.RuleLevelAndNoOptions;
+      'eslint-comments/no-duplicate-disable'?: ESLintConfigBase.RuleLevelAndNoOptions;
+      'eslint-comments/no-restricted-disable'?:
+        | ESLintConfigBase.RuleLevelAndNoOptions
+        | [ESLintConfigBase.RuleLevel, ...string[]];
+      'eslint-comments/no-unlimited-disable'?: ESLintConfigBase.RuleLevelAndNoOptions;
+      'eslint-comments/no-unused-disable'?: ESLintConfigBase.RuleLevelAndNoOptions;
+      'eslint-comments/no-unused-enable'?: ESLintConfigBase.RuleLevelAndNoOptions;
+      'eslint-comments/no-use'?:
+        | ESLintConfigBase.RuleLevelAndNoOptions
+        | [
+            ESLintConfigBase.RuleLevel,
+            {
+              allow?: (
+                | 'eslint'
+                | 'eslint-disable'
+                | 'eslint-disable-line'
+                | 'eslint-disable-next-line'
+                | 'eslint-enable'
+                | 'eslint-env'
+                | 'exported'
+                | 'global'
+                | 'globals'
+              )[];
+            },
+          ];
+    }
+  }
+}
+
+export = typedConfig({
   root: true,
   plugins: [
     'eslint-plugin',
@@ -9,6 +68,7 @@ module.exports = typedConfig({
     'jest',
     'import',
     'eslint-comments',
+    1, // expected error: Type 'number' is not assignable to type 'string'.
   ],
   env: {
     es6: true,
@@ -19,8 +79,15 @@ module.exports = typedConfig({
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    1, // expected error: Type 'number' is not assignable to type 'string'.
   ],
   rules: {
+    myRule: [
+      // expected error: Type 'string[]' is missing the following properties from type '[RuleLevel, { test: string; }]': 0, 1
+      'error',
+      'foo',
+    ],
+
     //
     // our plugin :D
     //

--- a/packages/typed-config/LICENSE
+++ b/packages/typed-config/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 TypeScript ESLint and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/typed-config/README.md
+++ b/packages/typed-config/README.md
@@ -1,0 +1,41 @@
+<h1 align="center">Typed ESLint Config</h1>
+
+<p align="center">A utility function which provides types for `.eslintrc` files.</p>
+
+<p align="center">
+    <a href="https://dev.azure.com/typescript-eslint/TypeScript%20ESLint/_build/latest?definitionId=1&branchName=master"><img src="https://img.shields.io/azure-devops/build/typescript-eslint/TypeScript%20ESLint/1/master.svg?label=%F0%9F%9A%80%20Azure%20Pipelines&style=flat-square" alt="Azure Pipelines"/></a>
+    <a href="https://github.com/typescript-eslint/typed-config/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/typed-config.svg?style=flat-square" alt="GitHub license" /></a>
+    <a href="https://www.npmjs.com/package/@typescript-eslint/typed-config"><img src="https://img.shields.io/npm/v/@typescript-eslint/typed-config.svg?style=flat-square" alt="NPM Version" /></a>
+    <a href="https://www.npmjs.com/package/@typescript-eslint/typed-config"><img src="https://img.shields.io/npm/dm/@typescript-eslint/typed-config.svg?style=flat-square" alt="NPM Downloads" /></a>
+    <a href="http://commitizen.github.io/cz-cli/"><img src="https://img.shields.io/badge/commitizen-friendly-brightgreen.svg?style=flat-square" alt="Commitizen friendly" /></a>
+</p>
+
+<br>
+
+## About
+
+## Installation
+
+```sh
+npm install @typescript-eslint/typed-config --save-dev
+```
+
+## Usage
+
+Create a `.eslintrc.js` configuration file, and use the function:
+
+```js
+const typedConfig = require('@typescript-eslint/typed-config');
+
+module.exports = typedConfig({});
+```
+
+## Supported TypeScript Version
+
+Please see https://github.com/typescript-eslint/typescript-eslint for the supported TypeScript version.
+
+**Please ensure that you are using a supported version before submitting any issues/bug reports.**
+
+## Reporting Issues
+
+Please use the @typescript-eslint/typed-config issue template when creating your issue and fill out the information requested as best you can. This will really help us when looking into your issue.

--- a/packages/typed-config/jest.config.js
+++ b/packages/typed-config/jest.config.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  testRegex: './tests/(lib/.*\\.(jsx?|tsx?)|ast-alignment/spec\\.ts)$',
+  collectCoverage: false,
+  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  coverageReporters: ['text-summary', 'lcov'],
+};

--- a/packages/typed-config/package.json
+++ b/packages/typed-config/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@typescript-eslint/typed-config",
+  "version": "2.10.0",
+  "description": "A utility function which provides types for `.eslintrc` files.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint.git",
+    "directory": "packages/typed-config"
+  },
+  "bugs": {
+    "url": "https://github.com/typescript-eslint/typescript-eslint/issues"
+  },
+  "license": "MIT",
+  "keywords": [
+    "typescript",
+    "eslint"
+  ],
+  "scripts": {
+    "build": "tsc -b tsconfig.build.json",
+    "clean": "tsc -b tsconfig.build.json --clean",
+    "format": "prettier --write \"./**/*.{ts,js,json,md}\" --ignore-path ../../.prettierignore",
+    "lint": "eslint . --ext .js,.ts --ignore-path='../../.eslintignore'",
+    "test": "jest --coverage",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/typed-config/src/index.ts
+++ b/packages/typed-config/src/index.ts
@@ -1,0 +1,317 @@
+declare global {
+  // a namespace makes it easy to group all of the types together
+  // so that they don't pollute the global namespace
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace ESLintConfig {
+    export type RuleLevel = 0 | 1 | 2 | 'off' | 'warn' | 'error';
+    export type RuleLevelAndNoOptions = RuleLevel | [RuleLevel];
+    export type RuleLevelAndUnknownOptions =
+      | RuleLevelAndNoOptions
+      | [RuleLevel, ...unknown[]];
+
+    interface Config {
+      /**
+       * An environment defines global variables that are predefined.
+       *
+       * https://eslint.org/docs/user-guide/configuring#specifying-environments
+       */
+      env?: Env;
+
+      /**
+       * If you want to extend a specific configuration file, you can use the extends property and specify the path to
+       * the file.
+       *
+       * Accepts any valid node require compatible string.
+       * Also accepts the package name, excluding `eslint-config-`, eg:
+       * - `eslint-config-prettier` can be specified as `prettier`
+       *
+       * https://eslint.org/docs/user-guide/configuring#extending-configuration-files
+       */
+      extends?: string[];
+
+      /**
+       * The no-undef rule will warn on variables that are accessed but not defined within the same file. If you are
+       * using global variables inside of a file then it's worthwhile to define those globals so that ESLint will
+       * not warn about their usage.
+       *
+       * Set each global variable name equal to true to allow the variable to be overwritten or false to disallow overwriting.
+       *
+       * https://eslint.org/docs/user-guide/configuring#specifying-globals
+       */
+      globals?: Globals;
+
+      /**
+       * Tell ESLint to ignore specific files and directories.
+       *
+       * Each value must use the same pattern as the `.eslintignore` file.
+       */
+      ignorePatterns?: string[];
+
+      /**
+       * Prevent comments from changing config or rules
+       */
+      noInlineConfig?: boolean;
+
+      /**
+       * The parser to use to parse files.
+       *
+       * By default, ESLint uses Espree as its parser. However, if you use a language that Espree doesn't support
+       * (such as typescript), or if you use "bleeding-edge" JS features that Espree doesn't support, you can specify
+       * a parser that can parse the files correctly.
+       *
+       * Accepts any valid node require compatible string.
+       *
+       * https://eslint.org/docs/user-guide/configuring#specifying-parser
+       */
+      parser?:
+        | string
+        // these won't appear in the types, nor will they be auto-suggested, but it's good to provide some examples
+        | '@typescript-eslint/parser'
+        | 'babel-eslint'
+        | 'vue-eslint-parser';
+
+      /**
+       * The configuration options that will be passed to the parser.
+       *
+       * https://eslint.org/docs/user-guide/configuring#specifying-parser-options
+       */
+      parserOptions?: ParserOptions;
+
+      /**
+       * ESLint supports the use of third-party plugins. Before using the plugin, you have to install it using npm.
+       *
+       * Accepts any valid node requrie compatible string.
+       * Also accepts the package name, excluding `eslint-plugin-`, eg:
+       * - `eslint-plugin-react` can be specified as `react`
+       * - `@typescript-eslint/eslint-plugin` can be specified as `@typescript-eslint`
+       * - `@typescript-eslint/eslint-plugin-tslint` can be speficied as `@typescript-eslint/tslint`
+       *
+       * https://eslint.org/docs/user-guide/configuring#configuring-plugins
+       */
+      plugins?: string | string[];
+
+      /**
+       * The processor to use pre-process files.
+       *
+       * Processors can extract JavaScript code from another kind of files, so that ESLint can lint the JavaScript.
+       *
+       * Accepts any valid node require compatible string.
+       *
+       * https://eslint.org/docs/user-guide/configuring#specifying-processor
+       */
+      processor?: string;
+
+      /**
+       * By default, ESLint will look for configuration files in all parent folders up to the root directory.
+       * This can be useful if you want all of your projects to follow a certain convention, but can sometimes lead to
+       * unexpected results.
+       *
+       * To limit ESLint to a specific project, set this to `true` in a configuration in the root of your project.
+       */
+      root?: boolean;
+
+      /**
+       * Configuration for individual ESLint rules.
+       *
+       * https://eslint.org/docs/user-guide/configuring#configuring-rules
+       */
+      rules?: Rules;
+
+      /**
+       * Some plugins use shared settings amongst their rules.
+       * Settings placed here are passed to every single rule that gets executed.
+       * Refer to the documentation for each plugin you are using to determine if shared settings are required.
+       */
+      settings?: Settings;
+    }
+    interface ConfigWithOverrides extends Config {
+      /**
+       * Allows to override configuration for specific files and folders, specified by glob patterns.
+       *
+       * https://eslint.org/docs/user-guide/configuring#configuration-based-on-glob-patterns
+       */
+      overrides?: ({
+        /**
+         * Glob pattern for files to apply 'overrides' configuration, relative to the directory of the config file
+         */
+        files: string[];
+        /**
+         * If a file matches any of the 'excludedFiles' glob patterns, the 'overrides' configuration won’t apply
+         */
+        excludedFiles?: string | string[];
+      } & Config)[];
+    }
+
+    interface Env {
+      [k: string]: boolean | undefined; // need the | undefined so that 3rd parties can specify optional props
+
+      /**
+       * defines require() and define() as global variables as per the amd spec
+       */
+      amd?: boolean;
+      /**
+       * AppleScript global variables
+       */
+      applescript?: boolean;
+      /**
+       * Atom test helper globals
+       */
+      atomtest?: boolean;
+      /**
+       * browser global variables
+       */
+      browser?: boolean;
+      /**
+       * CommonJS global variables and CommonJS scoping (use this for browser-only code that uses Browserify/WebPack)
+       */
+      commonjs?: boolean;
+      /**
+       * Globals common to both Node and Browser
+       */
+      'shared-node-browser'?: boolean;
+      /**
+       * Ember test helper globals
+       */
+      embertest?: boolean;
+      /**
+       * enable all ECMAScript 6 features except for modules
+       */
+      es6?: boolean;
+      /**
+       * GreaseMonkey globals
+       */
+      greasemonkey?: boolean;
+      /**
+       * adds all of the Jasmine testing global variables for version 1.3 and 2.0
+       */
+      jasmine?: boolean;
+      /**
+       * Jest global variables
+       */
+      jest?: boolean;
+      /**
+       * jQuery global variables
+       */
+      jquery?: boolean;
+      /**
+       * Meteor global variables
+       */
+      meteor?: boolean;
+      /**
+       * adds all of the Mocha test global variables
+       */
+      mocha?: boolean;
+      /**
+       * MongoDB global variables
+       */
+      mongo?: boolean;
+      /**
+       * Java 8 Nashorn global variables
+       */
+      nashorn?: boolean;
+      /**
+       * Node.js global variables and Node.js scoping
+       */
+      node?: boolean;
+      /**
+       * PhantomJS global variables
+       */
+      phantomjs?: boolean;
+      /**
+       * Prototype.js global variables
+       */
+      prototypejs?: boolean;
+      /**
+       * Protractor global variables
+       */
+      protractor?: boolean;
+      /**
+       * QUnit global variables
+       */
+      qunit?: boolean;
+      /**
+       * Service Worker global variables
+       */
+      serviceworker?: boolean;
+      /**
+       * ShellJS global variables
+       */
+      shelljs?: boolean;
+      /**
+       * WebExtensions globals
+       */
+      webextensions?: boolean;
+      /**
+       * web workers global variables
+       */
+      worker?: boolean;
+    }
+
+    type GlobalsLevel = 'readonly' | 'writable' | 'off' | boolean;
+    interface Globals {
+      [name: string]: GlobalsLevel | undefined; // need the | undefined so that 3rd parties can specify optional props
+    }
+
+    interface ParserOptions {
+      /**
+       * The version of ECMAScript syntax you want to use
+       */
+      ecmaVersion?:
+        | 3
+        | 5
+        | 6
+        | 2015 // same as 6
+        | 7
+        | 2016 // same as 7
+        | 8
+        | 2017 // same as 8
+        | 9
+        | 2018 // same as 9
+        | 10
+        | 2019 // same as 10
+        | 11
+        | 2020; // same as 11
+
+      /**
+       * Set to "script" (default) or "module" if your code is in ECMAScript modules.
+       */
+      sourceType?: 'script' | 'module';
+
+      /**
+       * An object indicating which additional language features you'd like to use.
+       */
+      ecmaFeatures?: {
+        /**
+         * Allow return statements in the global scope.
+         */
+        globalReturn?: boolean;
+        /**
+         * Enable global strict mode (if ecmaVersion is 5 or greater).
+         */
+        impliedStrict?: boolean;
+        /**
+         * Enable JSX.
+         */
+        jsx?: boolean;
+      };
+
+      [name: string]: unknown;
+    }
+
+    interface Rules {
+      [name: string]: RuleLevel | RuleLevelAndUnknownOptions;
+    }
+
+    interface Settings {
+      [name: string]: unknown;
+    }
+  }
+}
+
+function typedConfig(
+  config: ESLintConfig.ConfigWithOverrides,
+): ESLintConfig.ConfigWithOverrides {
+  return config;
+}
+
+export { typedConfig, ESLintConfig };

--- a/packages/typed-config/tsconfig.build.json
+++ b/packages/typed-config/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/packages/typed-config/tsconfig.json
+++ b/packages/typed-config/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "composite": false,
+    "rootDir": "."
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
Following on from https://github.com/eslint/rfcs/pull/50, as it doesn't look like that idea is going to get in by itself, and the proposed alternative (new config file) would probably take quite a while.

cc interested parties - @G-Rath @mysticatea @kaicataldo 

---

Playing with providing a framework to create a strictly typed config file.
The function is just an identity function, but via `// @ts-check`, typescript will consume the declared types for it, and strictly type the config object.

Plugin authors will be able to use declaration merging in order to augment our types, and provide strict types for their rules (see `.eslintrc-example-test-temp.ts` for a working example).

I.e. an eslint plugin can provide types themselves, within their package, or users can provide types for them via DefinitelyTyped.

If people like this idea, we can also add in tooling to this package to help plugin maintainers automatically generate types based on their json schemas (see https://github.com/bradzacher/eslint-config-brad/tree/master/src/types which is generated by https://github.com/bradzacher/eslint-config-brad/blob/master/scripts/generateTypes.ts)