### PR TITLE
docs(eslint-plugin): typo in space-before-function-paren docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/space-before-function-paren.md
+++ b/packages/eslint-plugin/docs/rules/space-before-function-paren.md
@@ -4,7 +4,7 @@ When formatting a function, whitespace is allowed between the function name or `
 
 <!-- prettier-ignore -->
 ```ts
-function withoutSpace (x) {
+function withoutSpace(x) {
   // ...
 }
 
@@ -12,7 +12,7 @@ function withSpace (x) {
   // ...
 }
 
-var anonymousWithoutSpace = function () {};
+var anonymousWithoutSpace = function() {};
 
 var anonymousWithSpace = function () {};
 ```


### PR DESCRIPTION
This lint is about the space after `function` but in the example both versions do have one.
The eslint page has it like this
```js
function withoutSpace(x) { // <-- NO space
    // ...
}

function withSpace (x) { // <-- space
    // ...
}

var anonymousWithoutSpace = function() {};

var anonymousWithSpace = function () {};
```