### PR TITLE
docs(eslint-plugin): ROADMAP note some jsdoc rules

### DIFF
--- a/packages/eslint-plugin/ROADMAP.md
+++ b/packages/eslint-plugin/ROADMAP.md
@@ -142,7 +142,7 @@
 | [`class-name`]                      | ✅  | [`@typescript-eslint/class-name-casing`]                                            |
 | [`comment-format`]                  | 🌟  | [`capitalized-comments`][capitalized-comments] & [`spaced-comment`][spaced-comment] |
 | [`comment-type`]                    | 🛑  | N/A                                                                                 |
-| [`completed-docs`]                  | 🔌  | [`eslint-plugin-jsdoc`][plugin:jsdoc]                                               |
+| [`completed-docs`]                  | 🔌  | [`jsdoc/require-jsdoc`]                                                             |
 | [`encoding`]                        | 🛑  | N/A                                                                                 |
 | [`file-header`]                     | 🔌  | [`eslint-plugin-header`][plugin:header] or [`-file-header`][plugin:file-header]     |
 | [`file-name-casing`]                | 🔌  | [`unicorn/filename-case`]                                                           |
@@ -160,7 +160,7 @@
 | [`no-consecutive-blank-lines`]      | 🌟  | [`no-multiple-empty-lines`][no-multiple-empty-lines]                                |
 | [`no-irregular-whitespace`]         | 🌟  | [`no-irregular-whitespace`][no-irregular-whitespace] with `skipStrings: false`      |
 | [`no-parameter-properties`]         | ✅  | [`@typescript-eslint/no-parameter-properties`]                                      |
-| [`no-redundant-jsdoc`]              | 🛑  | N/A ([open issue](https://github.com/gajus/eslint-plugin-jsdoc/issues/134))         |
+| [`no-redundant-jsdoc`]              | 🔌  | [`jsdoc/no-types`]                                                                  |
 | [`no-reference-import`]             | 🛑  | N/A                                                                                 |
 | [`no-trailing-whitespace`]          | 🌟  | [`no-trailing-spaces`][no-trailing-spaces]                                          |
 | [`no-unnecessary-callback-wrapper`] | 🛑  | N/A and this might be unsafe (i.e. with `forEach`)                                  |
@@ -664,11 +664,16 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 [`security/detect-non-literal-require`]: https://github.com/nodesecurity/eslint-plugin-security#detect-non-literal-require
 [`security/detect-possible-timing-attacks`]: https://github.com/nodesecurity/eslint-plugin-security#detect-possible-timing-attacks
 
+<!-- eslint-plugin-jsdoc -->
+
+[plugin:jsdoc]: https://github.com/gajus/eslint-plugin-jsdoc
+[`jsdoc/require-jsdoc`]: https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-jsdoc
+[`jsdoc/no-types`]: https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-no-types
+
 <!-- Miscellaneous plugins -->
 
 [`prefer-arrow/prefer-arrow-functions`]: https://github.com/TristonJ/eslint-plugin-prefer-arrow
 [plugin:promise]: https://github.com/xjamundx/eslint-plugin-promise
-[plugin:jsdoc]: https://github.com/gajus/eslint-plugin-jsdoc
 [plugin:header]: https://github.com/Stuk/eslint-plugin-header
 [plugin:file-header]: https://github.com/Sekhmet/eslint-plugin-file-header
 [plugin:compat]: https://github.com/amilajack/eslint-plugin-compat


### PR DESCRIPTION
The functionality of `no-redundant-jsdoc` from TSLint was already introduced in `jsdoc/no-types` rule. I updated the ROADMAP accordingly.