### PR TITLE
chore(parser): mark TS as optional peer dependency

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -51,5 +51,10 @@
     "@types/glob": "^7.1.1",
     "@typescript-eslint/shared-fixtures": "2.11.0",
     "glob": "*"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
Since `@typescript-eslint/typescript-estree` has an [optional peer dependency](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/typescript-estree/package.json#L70) on TS, `@typescript-eslint/parser` should too.