### PR TITLE
feat(eslint-plugin-tslint): add fixer for config rule

### DIFF
--- a/packages/eslint-plugin-tslint/src/rules/config.ts
+++ b/packages/eslint-plugin-tslint/src/rules/config.ts
@@ -67,6 +67,7 @@ export default createRule<Options, MessageIds>({
       category: 'TSLint' as any, // eslint-disable-line @typescript-eslint/no-explicit-any
       recommended: false,
     },
+    fixable: 'code',
     type: 'problem',
     messages: {
       failure: '{{message}} (tslint:{{ruleName}})',
@@ -164,6 +165,23 @@ export default createRule<Options, MessageIds>({
               line: end.line + 1,
               column: end.character,
             },
+          },
+          fix: fixer => {
+            const replacements = failure.getFix();
+
+            return Array.isArray(replacements)
+              ? replacements.map(replacement =>
+                  fixer.replaceTextRange(
+                    [replacement.start, replacement.end],
+                    replacement.text,
+                  ),
+                )
+              : replacements !== undefined
+              ? fixer.replaceTextRange(
+                  [replacements.start, replacements.end],
+                  replacements.text,
+                )
+              : [];
           },
         });
       });

--- a/packages/eslint-plugin-tslint/tests/fixture-project/4.ts
+++ b/packages/eslint-plugin-tslint/tests/fixture-project/4.ts
@@ -1,1 +1,1 @@
-var foo = true // semicolon
+var foo = true; // semicolon

--- a/packages/eslint-plugin-tslint/tests/fixture-project/4.ts
+++ b/packages/eslint-plugin-tslint/tests/fixture-project/4.ts
@@ -1,1 +1,1 @@
-var foo = true; // semicolon
+var foo = true // semicolon

--- a/packages/eslint-plugin-tslint/tests/index.spec.ts
+++ b/packages/eslint-plugin-tslint/tests/index.spec.ts
@@ -86,7 +86,7 @@ ruleTester.run('tslint/config', rule, {
     {
       code: 'var foo = true // semicolon',
       options: tslintRulesConfig,
-      output: 'var foo = true // semicolon',
+      output: 'var foo = true; // semicolon',
       filename: './tests/fixture-project/4.ts',
       errors: [
         {

--- a/tests/integration/fixtures/typescript-and-tslint-plugins-together/test.js.snap
+++ b/tests/integration/fixtures/typescript-and-tslint-plugins-together/test.js.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "errorCount": 1,
     "filePath": "/usr/linked/index.ts",
-    "fixableErrorCount": 0,
+    "fixableErrorCount": 1,
     "fixableWarningCount": 0,
     "messages": Array [
       Object {

--- a/tests/integration/fixtures/typescript-and-tslint-plugins-together/test.js.snap
+++ b/tests/integration/fixtures/typescript-and-tslint-plugins-together/test.js.snap
@@ -22,6 +22,13 @@ Array [
         "column": 20,
         "endColumn": 20,
         "endLine": 1,
+        "fix": Object {
+          "range": Array [
+            19,
+            19,
+          ],
+          "text": ";",
+        },
         "line": 1,
         "message": "Missing semicolon (tslint:semicolon)",
         "messageId": "failure",


### PR DESCRIPTION
Fixes: https://github.com/typescript-eslint/typescript-eslint/issues/1340

Add a fixer for the tslint config rule.

This was easier than expected - maybe I'm missing something? I'm not convinced this is tested enough, please give me any suggestions you have. I could maybe add an additional test for the `prefer-const` rule, which has a tslint fixer.