### PR TITLE
feat(typescript-estree): tighten prop name and destructure types

### DIFF
--- a/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
+++ b/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
@@ -55,13 +55,13 @@ export default util.createRule({
         case AST_NODE_TYPES.FunctionDeclaration:
           return member.id && member.id.name;
         case AST_NODE_TYPES.TSMethodSignature:
-          return util.getNameFromPropertyName(member.key);
+          return util.getNameFromMember(member, sourceCode);
         case AST_NODE_TYPES.TSCallSignatureDeclaration:
           return 'call';
         case AST_NODE_TYPES.TSConstructSignatureDeclaration:
           return 'new';
         case AST_NODE_TYPES.MethodDefinition:
-          return util.getNameFromClassMember(member, sourceCode);
+          return util.getNameFromMember(member, sourceCode);
       }
 
       return null;

--- a/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
+++ b/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
@@ -125,10 +125,7 @@ export default util.createRule<Options, MessageIds>({
           break;
       }
 
-      const methodName = util.getNameFromClassMember(
-        methodDefinition,
-        sourceCode,
-      );
+      const methodName = util.getNameFromMember(methodDefinition, sourceCode);
 
       if (check === 'off' || ignoredMethodNames.has(methodName)) {
         return;
@@ -163,7 +160,7 @@ export default util.createRule<Options, MessageIds>({
     ): void {
       const nodeType = 'class property';
 
-      const propertyName = util.getNameFromPropertyName(classProperty.key);
+      const propertyName = util.getNameFromMember(classProperty, sourceCode);
       if (
         propCheck === 'no-public' &&
         classProperty.accessibility === 'public'

--- a/packages/eslint-plugin/src/rules/member-naming.ts
+++ b/packages/eslint-plugin/src/rules/member-naming.ts
@@ -99,7 +99,7 @@ export default util.createRule<Options, MessageIds>({
 
       validate(
         node.key,
-        util.getNameFromClassMember(node, sourceCode),
+        util.getNameFromMember(node, sourceCode),
         node.accessibility,
       );
     }

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -231,12 +231,12 @@ export default util.createRule<Options, MessageIds>({
         case AST_NODE_TYPES.TSMethodSignature:
         case AST_NODE_TYPES.TSAbstractClassProperty:
         case AST_NODE_TYPES.ClassProperty:
-          return util.getNameFromPropertyName(node.key);
+          return util.getNameFromMember(node, sourceCode);
         case AST_NODE_TYPES.TSAbstractMethodDefinition:
         case AST_NODE_TYPES.MethodDefinition:
           return node.kind === 'constructor'
             ? 'constructor'
-            : util.getNameFromClassMember(node, sourceCode);
+            : util.getNameFromMember(node, sourceCode);
         case AST_NODE_TYPES.TSConstructSignatureDeclaration:
           return 'new';
         case AST_NODE_TYPES.TSIndexSignature:

--- a/packages/typescript-estree/src/ts-estree/ts-estree.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-estree.ts
@@ -345,7 +345,6 @@ export type Modifier =
 export type ObjectLiteralElementLike =
   | MethodDefinition
   | Property
-  | RestElement
   | SpreadElement
   | TSAbstractMethodDefinition;
 export type Parameter =
@@ -355,6 +354,13 @@ export type Parameter =
   | ObjectPattern
   | Identifier
   | TSParameterProperty;
+export type DestructuringPattern =
+  | Identifier
+  | ObjectPattern
+  | ArrayPattern
+  | RestElement
+  | AssignmentPattern
+  | MemberExpression;
 export type PrimaryExpression =
   | ArrayExpression
   | ArrayPattern
@@ -374,7 +380,7 @@ export type PrimaryExpression =
   | TemplateLiteral
   | ThisExpression
   | TSNullKeyword;
-export type PropertyName = Identifier | Literal;
+export type PropertyName = Expression;
 export type Statement =
   | BlockStatement
   | BreakStatement
@@ -509,7 +515,7 @@ interface LiteralBase extends BaseNode {
 }
 
 interface MethodDefinitionBase extends BaseNode {
-  key: Expression;
+  key: PropertyName;
   value: FunctionExpression | TSEmptyBodyFunctionExpression;
   computed: boolean;
   static: boolean;
@@ -542,7 +548,7 @@ export interface ArrayExpression extends BaseNode {
 
 export interface ArrayPattern extends BaseNode {
   type: AST_NODE_TYPES.ArrayPattern;
-  elements: Expression[];
+  elements: DestructuringPattern[];
   typeAnnotation?: TSTypeAnnotation;
   optional?: boolean;
   decorators?: Decorator[];
@@ -897,7 +903,7 @@ export interface ObjectExpression extends BaseNode {
 
 export interface ObjectPattern extends BaseNode {
   type: AST_NODE_TYPES.ObjectPattern;
-  properties: ObjectLiteralElementLike[];
+  properties: (Property | RestElement)[];
   typeAnnotation?: TSTypeAnnotation;
   optional?: boolean;
   decorators?: Decorator[];
@@ -923,7 +929,7 @@ export interface Property extends BaseNode {
 
 export interface RestElement extends BaseNode {
   type: AST_NODE_TYPES.RestElement;
-  argument: BindingName | Expression | PropertyName;
+  argument: DestructuringPattern;
   typeAnnotation?: TSTypeAnnotation;
   optional?: boolean;
   value?: AssignmentPattern;


### PR DESCRIPTION
Whilst working on #1318, I noticed that the types for both property names and destructuring were wrong.

property names assumed that only `Identifier | Literal` were valid, when in fact any expression is valid, if and only if the name is computed: `{ [1 + 2]: 1 }`.

Part of me thinks we should probably split the types to make this nicer (I've raised #1345)

The destructuring types were also inconsistent, so I corrected them.
