### PR TITLE
docs: fix typo in getting started doc

### DIFF
--- a/docs/getting-started/linting/README.md
+++ b/docs/getting-started/linting/README.md
@@ -139,7 +139,7 @@ There are many plugins, each covering a different slice of the JS development wo
 
 - Jest testing: [`eslint-plugin-jest`](https://www.npmjs.com/package/eslint-plugin-jest)
 - ESLint comment restrictions: [`eslint-plugin-eslint-comments`](https://www.npmjs.com/package/eslint-plugin-eslint-comments)
-- Import/export conventions : [`eslint-plugin-eslint-comments`](https://www.npmjs.com/package/eslint-plugin-import)
+- Import/export conventions : [`eslint-plugin-import`](https://www.npmjs.com/package/eslint-plugin-import)
 - React best practices: [`eslint-plugin-react`](https://www.npmjs.com/package/eslint-plugin-react) and [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks)
 - NodeJS best practices: [`eslint-plugin-node`](https://www.npmjs.com/package/eslint-plugin-node)
 


### PR DESCRIPTION
The link is to `eslint-plugin-import` but the text on the link is `eslint-plugin-eslint-comments`.