### PR TITLE
test: use codecov bash uploader instead of js uploader

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
         displayName: 'Run integrations tests'
 
       - script: |
-          npx codecov -t $(CODECOV_TOKEN)
+          bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)
         displayName: 'Publish code coverage report'
 
   - job: unit_tests_on_other_node_versions


### PR DESCRIPTION
The js uploader keeps on timing out which causes coverage to not report, causing PR status to get stuck in pending.

The bash reporter has a retry mechanism, so it is supposed to be be more resilient.