### PR TITLE
docs(eslint-plugin): [no-unnec-type-arg] correct doc title

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
@@ -1,4 +1,4 @@
-# Enforces that types will not to be used (no-unnecessary-type-arguments)
+# Enforces that types will not be used unnecessary (no-unnecessary-type-arguments)
 
 Warns if an explicitly specified type argument is the default for that type parameter.
 

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
@@ -1,4 +1,4 @@
-# Enforces that types will not be used unnecessary (no-unnecessary-type-arguments)
+# Enforces that type arguments will not be used if not required (no-unnecessary-type-arguments)
 
 Warns if an explicitly specified type argument is the default for that type parameter.
 


### PR DESCRIPTION
It's still somewhat ambiguous given it's actually for generics only, but now it's grammatically correct 🤷‍♂ 