### PR TITLE
feat: support mixed JS/TS codebases by default

### DIFF
--- a/packages/eslint-plugin/src/configs/recommended.json
+++ b/packages/eslint-plugin/src/configs/recommended.json
@@ -8,7 +8,6 @@
     "@typescript-eslint/camelcase": "error",
     "@typescript-eslint/class-name-casing": "error",
     "@typescript-eslint/consistent-type-assertions": "error",
-    "@typescript-eslint/explicit-function-return-type": "warn",
     "@typescript-eslint/interface-name-prefix": "error",
     "@typescript-eslint/member-delimiter-style": "error",
     "no-array-constructor": "off",
@@ -34,5 +33,13 @@
     "prefer-const": "error",
     "prefer-rest-params": "error",
     "prefer-spread": "error"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "warn"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
The recommended config should not lint for [`explicit-function-return-type`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md) in JS files.