### PR TITLE
test(typescript-estree): reenable alignment tests

### DIFF
--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -123,18 +123,7 @@ const jsxFilesWithKnownIssues = jsxKnownIssues.map(f => f.replace('jsx/', ''));
  */
 jsxFilesWithKnownIssues.push('invalid-no-tag-name');
 
-tester.addFixturePatternConfig('javascript/basics', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'delete-expression',
-    'new-with-member-expression',
-    'update-expression',
-  ],
-});
+tester.addFixturePatternConfig('javascript/basics');
 
 tester.addFixturePatternConfig('comments', {
   ignore: [
@@ -144,18 +133,6 @@ tester.addFixturePatternConfig('comments', {
      */
     'no-comment-template', // Purely AST diffs
     'template-string-block', // Purely AST diffs
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'block-trailing-comment',
-    'jsx-with-greather-than',
-    'jsx-with-operators',
-    'surrounding-call-comments',
-    'switch-fallthrough-comment-in-function',
-    'switch-fallthrough-comment',
-    'switch-no-default-comment-in-nested-functions',
   ],
 });
 
@@ -163,31 +140,13 @@ tester.addFixturePatternConfig('javascript/templateStrings', {
   ignore: ['**/*'],
 });
 
-tester.addFixturePatternConfig('javascript/arrayLiteral', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'array-literal-in-lhs',
-  ],
-});
+tester.addFixturePatternConfig('javascript/arrayLiteral');
 
 tester.addFixturePatternConfig('javascript/simple-literals');
 
 tester.addFixturePatternConfig('javascript/directives');
 
-tester.addFixturePatternConfig('javascript/experimentalObjectRestSpread', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'property-spread',
-  ],
-});
+tester.addFixturePatternConfig('javascript/experimentalObjectRestSpread');
 
 tester.addFixturePatternConfig('javascript/arrowFunctions', {
   ignore: [
@@ -218,13 +177,6 @@ tester.addFixturePatternConfig('javascript/arrowFunctions', {
     'error-strict-param-names',
     'error-strict-param-no-paren-arguments',
     'error-strict-param-no-paren-eval',
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'as-param-with-params',
-    'as-param',
   ],
 });
 tester.addFixturePatternConfig('javascript/function', {
@@ -241,18 +193,7 @@ tester.addFixturePatternConfig('javascript/bigIntLiterals');
 tester.addFixturePatternConfig('javascript/binaryLiterals');
 tester.addFixturePatternConfig('javascript/blockBindings');
 
-tester.addFixturePatternConfig('javascript/callExpression', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'call-expression-with-array',
-    'call-expression-with-object',
-    'mixed-expression',
-  ],
-});
+tester.addFixturePatternConfig('javascript/callExpression');
 
 tester.addFixturePatternConfig('javascript/classes', {
   ignore: [
@@ -271,18 +212,7 @@ tester.addFixturePatternConfig('javascript/commaOperator');
 
 tester.addFixturePatternConfig('javascript/defaultParams');
 
-tester.addFixturePatternConfig('javascript/destructuring', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'array-member',
-    'call-expression-destruction-array',
-    'call-expression-destruction-object',
-  ],
-});
+tester.addFixturePatternConfig('javascript/destructuring');
 tester.addFixturePatternConfig('javascript/destructuring-and-arrowFunctions');
 tester.addFixturePatternConfig('javascript/destructuring-and-blockBindings');
 tester.addFixturePatternConfig('javascript/destructuring-and-defaultParams');
@@ -290,29 +220,11 @@ tester.addFixturePatternConfig('javascript/destructuring-and-forOf');
 tester.addFixturePatternConfig('javascript/destructuring-and-spread');
 
 tester.addFixturePatternConfig('javascript/experimentalAsyncIteration');
-tester.addFixturePatternConfig('javascript/experimentalDynamicImport', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'dynamic-import',
-  ],
-});
+tester.addFixturePatternConfig('javascript/experimentalDynamicImport');
 tester.addFixturePatternConfig('javascript/exponentiationOperators');
 tester.addFixturePatternConfig('javascript/experimentalOptionalCatchBinding');
 
-tester.addFixturePatternConfig('javascript/for', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'for-with-function',
-  ],
-});
+tester.addFixturePatternConfig('javascript/for');
 tester.addFixturePatternConfig('javascript/forIn', {
   ignore: [
     /**
@@ -330,74 +242,23 @@ tester.addFixturePatternConfig('javascript/forIn', {
      * SyntaxError: Invalid left-hand side in for-loop
      */
     'for-in-with-bare-assigment',
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'for-in-with-const',
-    'for-in-with-var',
   ],
 });
 
-tester.addFixturePatternConfig('javascript/forOf', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'for-of-array',
-    'for-of-object',
-    'for-of-with-var-and-braces',
-    'for-of-with-var-and-no-braces',
-    'invalid-for-of-with-const-and-no-braces',
-    'invalid-for-of-with-let-and-no-braces',
-  ],
-});
-tester.addFixturePatternConfig('javascript/generators', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'async-generator-method',
-    'yield-without-value-in-call',
-  ],
-});
+tester.addFixturePatternConfig('javascript/forOf');
+tester.addFixturePatternConfig('javascript/generators');
 tester.addFixturePatternConfig('javascript/globalReturn');
 tester.addFixturePatternConfig('javascript/hexLiterals');
-tester.addFixturePatternConfig('javascript/importMeta', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'simple-import-meta',
-  ],
-});
+tester.addFixturePatternConfig('javascript/importMeta');
 tester.addFixturePatternConfig('javascript/labels');
 
 tester.addFixturePatternConfig('javascript/modules', {
-  ignore: [
-    /**
-     * Expected babel parse errors - ts-estree is not currently throwing
-     */
-    'invalid-export-named-default', // babel parse errors
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'error-strict',
-  ],
   ignoreSourceType: [
     'error-function',
-    // 'error-strict',
+    'error-strict',
     'error-delete',
     'invalid-await',
+    'invalid-export-named-default',
     // babel does not recognise these as modules
     'export-named-as-default',
     'export-named-as-specifier',
@@ -410,16 +271,7 @@ tester.addFixturePatternConfig('javascript/modules', {
 
 tester.addFixturePatternConfig('javascript/newTarget');
 
-tester.addFixturePatternConfig('javascript/objectLiteral', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'object-literal-in-lhs',
-  ],
-});
+tester.addFixturePatternConfig('javascript/objectLiteral');
 tester.addFixturePatternConfig('javascript/objectLiteralComputedProperties');
 
 tester.addFixturePatternConfig('javascript/objectLiteralDuplicateProperties', {
@@ -456,18 +308,7 @@ tester.addFixturePatternConfig('javascript/regex');
 tester.addFixturePatternConfig('javascript/regexUFlag');
 tester.addFixturePatternConfig('javascript/regexYFlag');
 tester.addFixturePatternConfig('javascript/restParams');
-tester.addFixturePatternConfig('javascript/spread', {
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'multi-function-call',
-    'not-final-param',
-    'simple-function-call',
-  ],
-});
+tester.addFixturePatternConfig('javascript/spread');
 tester.addFixturePatternConfig('javascript/unicodeCodePointEscapes');
 
 /* ================================================== */
@@ -485,14 +326,6 @@ tester.addFixturePatternConfig('jsx-useJSXTextNode');
 
 tester.addFixturePatternConfig('tsx', {
   fileType: 'tsx',
-  ignore: [
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // optional chaining
-    'react-typed-props',
-  ],
 });
 
 /* ================================================== */
@@ -559,65 +392,36 @@ tester.addFixturePatternConfig('typescript/basics', {
      * [BABEL ERRORED, BUT TS-ESTREE DID NOT]
      */
     'const-assertions',
-    'readonly-arrays',
-    'readonly-tuples',
     /**
      * [TS-ESTREE ERRORED, BUT BABEL DID NOT]
      * SyntaxError: 'abstract' modifier can only appear on a class, method, or property declaration.
      */
     'abstract-class-with-abstract-constructor',
+    // babel hard fails on computed string enum members, but TS doesn't
+    'export-named-enum-computed-string',
     /**
-     * TS 3.7: optional chaining
-     * babel: sets optional property as true/undefined
-     * ts-estree: sets optional property as true/false
+     * TS 3.7: type assertion function
+     * there is difference in range between babel and ts-estree
+     * TODO: validate this
      */
-    'arrow-function-with-optional-parameter',
-    'optional-chain',
-    'optional-chain-with-parens',
-    'optional-chain-call',
-    'optional-chain-call-with-parens',
-    'optional-chain-element-access',
-    'optional-chain-element-access-with-parens',
-    'async-function-expression',
-    'class-with-accessibility-modifiers',
-    'class-with-mixin',
-    'global-this',
-    'never-type-param',
-    'non-null-assertion-operator',
-    'type-parameters-comments',
-    /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
-     */
-    // type assertion function
-    'type-assertion-in-function',
     'type-assertion-in-arrow-function',
+    'type-assertion-in-function',
     'type-assertion-in-interface',
     'type-assertion-in-method',
-    'type-guard-in-arrow-function',
-    'type-guard-in-function',
-    'type-guard-in-interface',
-    'type-guard-in-method',
     'type-assertion-with-guard-in-arrow-function',
     'type-assertion-with-guard-in-function',
     'type-assertion-with-guard-in-interface',
     'type-assertion-with-guard-in-method',
+    'type-guard-in-arrow-function',
+    'type-guard-in-function',
+    'type-guard-in-interface',
+    /**
+     * TS 3.7 feature changes
+     * TODO: remove me when babel adds support
+     */
     // declare class properties
-    'abstract-class-with-abstract-properties',
-    'abstract-class-with-abstract-readonly-property',
     'abstract-class-with-declare-properties',
     'class-with-declare-properties',
-    'class-with-definite-assignment',
-    'class-with-optional-computed-property',
-    'class-with-optional-properties',
-    'class-with-optional-property-undefined',
-    'class-with-property-function',
-    'class-with-property-values',
-    'class-with-readonly-property',
-    'object-with-escaped-properties',
-    'type-reference-comments',
-    // babel hard fails on computed string enum members, but TS doesn't
-    'export-named-enum-computed-string',
   ],
   ignoreSourceType: [
     /**
@@ -632,40 +436,12 @@ tester.addFixturePatternConfig('typescript/basics', {
 
 tester.addFixturePatternConfig('typescript/decorators/accessor-decorators', {
   fileType: 'ts',
-  ignore: [
-    /**
-     * TS 3.7: optional chaining
-     * babel: sets optional property as true/undefined
-     * ts-estree: sets optional property as true/false
-     */
-    'accessor-decorator-factory-instance-member',
-    'accessor-decorator-factory-static-member',
-    'accessor-decorator-instance-member',
-    'accessor-decorator-static-member',
-  ],
 });
 tester.addFixturePatternConfig('typescript/decorators/class-decorators', {
   fileType: 'ts',
-  ignore: [
-    /**
-     * TS 3.7: optional chaining
-     * babel: sets optional property as true/undefined
-     * ts-estree: sets optional property as true/false
-     */
-    'class-decorator-factory',
-  ],
 });
 tester.addFixturePatternConfig('typescript/decorators/method-decorators', {
   fileType: 'ts',
-  ignore: [
-    /**
-     * TS 3.7: optional chaining
-     * babel: sets optional property as true/undefined
-     * ts-estree: sets optional property as true/false
-     */
-    'method-decorator-factory-instance-member',
-    'method-decorator-factory-static-member',
-  ],
 });
 tester.addFixturePatternConfig('typescript/decorators/parameter-decorators', {
   fileType: 'ts',
@@ -676,35 +452,10 @@ tester.addFixturePatternConfig('typescript/decorators/parameter-decorators', {
      */
     'parameter-array-pattern-decorator',
     'parameter-rest-element-decorator',
-    /**
-     * TS 3.7: optional chaining
-     * babel: sets optional property as true/undefined
-     * ts-estree: sets optional property as true/false
-     */
-    'parameter-decorator-constructor',
-    'parameter-decorator-decorator-instance-member',
-    'parameter-decorator-decorator-static-member',
-    'parameter-object-pattern-decorator',
   ],
 });
 tester.addFixturePatternConfig('typescript/decorators/property-decorators', {
   fileType: 'ts',
-  ignore: [
-    /**
-     * TS 3.7: optional chaining
-     * babel: sets optional property as true/undefined
-     * ts-estree: sets optional property as true/false
-     */
-    'property-decorator-factory-instance-member',
-    'property-decorator-factory-static-member',
-    /**
-     * TS 3.7: declare class properties
-     * babel: sets declare property as true/undefined
-     * ts-estree: sets declare property as true/false
-     */
-    'property-decorator-instance-member',
-    'property-decorator-static-member',
-  ],
 });
 
 tester.addFixturePatternConfig('typescript/expressions', {
@@ -714,11 +465,6 @@ tester.addFixturePatternConfig('typescript/expressions', {
      * there is difference in range between babel and ts-estree
      */
     'tagged-template-expression-type-arguments',
-    /**
-     * babel: sets optional property as true/undefined
-     * ts-estree: sets optional property as true/false
-     */
-    'call-expression-type-arguments',
   ],
 });
 
@@ -749,14 +495,6 @@ tester.addFixturePatternConfig('typescript/errorRecovery', {
 
 tester.addFixturePatternConfig('typescript/types', {
   fileType: 'ts',
-  ignore: [
-    /**
-     * TS 3.7: optional chaining
-     * babel: sets optional property as true/undefined
-     * ts-estree: sets optional property as true/false
-     */
-    'this-type-expanded',
-  ],
 });
 
 tester.addFixturePatternConfig('typescript/declare', {

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -240,6 +240,7 @@ tester.addFixturePatternConfig('javascript/forIn', {
     /**
      * [BABEL ERRORED, BUT TS-ESTREE DID NOT]
      * SyntaxError: Invalid left-hand side in for-loop
+     * TODO: Error 2405: `The left-hand side of a 'for...in' statement must be of type 'string' or 'any'."`
      */
     'for-in-with-bare-assigment',
   ],
@@ -400,9 +401,9 @@ tester.addFixturePatternConfig('typescript/basics', {
     // babel hard fails on computed string enum members, but TS doesn't
     'export-named-enum-computed-string',
     /**
-     * TS 3.7: type assertion function
-     * there is difference in range between babel and ts-estree
-     * TODO: validate this
+     * Babel: TSTypePredicate includes `:` statement in range
+     * ts-estree: TSTypePredicate does not include `:` statement in range
+     * TODO: report this to babel
      */
     'type-assertion-in-arrow-function',
     'type-assertion-in-function',
@@ -416,10 +417,10 @@ tester.addFixturePatternConfig('typescript/basics', {
     'type-guard-in-function',
     'type-guard-in-interface',
     /**
-     * TS 3.7 feature changes
-     * TODO: remove me when babel adds support
+     * TS 3.7: declare class properties
+     * Babel: declare is not allowed with accessibility modifiers
+     * TODO: report this to babel
      */
-    // declare class properties
     'abstract-class-with-declare-properties',
     'class-with-declare-properties',
   ],

--- a/packages/typescript-estree/tests/ast-alignment/utils.ts
+++ b/packages/typescript-estree/tests/ast-alignment/utils.ts
@@ -234,14 +234,22 @@ export function preprocessBabylonAST(ast: any): any {
           };
         }
       },
-      /**
-       * Babel: ClassProperty + abstract: true
-       * ts-estree: TSAbstractClassProperty
-       */
       ClassProperty(node: any) {
+        /**
+         * Babel: ClassProperty + abstract: true
+         * ts-estree: TSAbstractClassProperty
+         */
         if (node.abstract) {
           node.type = 'TSAbstractClassProperty';
           delete node.abstract;
+        }
+        /**
+         * TS 3.7: declare class properties
+         * babel: sets declare property as true/undefined
+         * ts-estree: sets declare property as true/false
+         */
+        if (!node.declare) {
+          node.declare = false;
         }
       },
       TSExpressionWithTypeArguments(node: any, parent: any) {
@@ -270,6 +278,36 @@ export function preprocessBabylonAST(ast: any): any {
         ) {
           node.range[0] = node.typeParameters.range[0];
           node.loc.start = Object.assign({}, node.typeParameters.loc.start);
+        }
+      },
+      /**
+       * TS 3.7: optional chaining
+       * babel: sets optional property as true/undefined
+       * ts-estree: sets optional property as true/false
+       */
+      MemberExpression(node: any) {
+        if (!node.optional) {
+          node.optional = false;
+        }
+      },
+      CallExpression(node: any) {
+        if (!node.optional) {
+          node.optional = false;
+        }
+      },
+      OptionalCallExpression(node: any) {
+        if (!node.optional) {
+          node.optional = false;
+        }
+      },
+      /**
+       * TS 3.7: type assertion function
+       * babel: sets asserts property as true/undefined
+       * ts-estree: sets asserts property as true/false
+       */
+      TSTypePredicate(node: any) {
+        if (!node.asserts) {
+          node.asserts = false;
         }
       },
     },

--- a/packages/typescript-estree/tests/ast-alignment/utils.ts
+++ b/packages/typescript-estree/tests/ast-alignment/utils.ts
@@ -128,25 +128,6 @@ export function preprocessBabylonAST(ast: any): any {
     ],
     {
       /**
-       * Not yet supported in Babel https://github.com/babel/babel/issues/9228
-       */
-      StringLiteral(node: any) {
-        node.type = 'Literal';
-      },
-      /**
-       * Not yet supported in Babel https://github.com/babel/babel/issues/9228
-       */
-      NumericLiteral(node: any) {
-        node.type = 'Literal';
-      },
-      /**
-       * Not yet supported in Babel https://github.com/babel/babel/issues/9228
-       */
-      BooleanLiteral(node: any) {
-        node.type = 'Literal';
-        node.raw = String(node.value);
-      },
-      /**
        * Awaiting feedback on Babel issue https://github.com/babel/babel/issues/9231
        */
       TSCallSignatureDeclaration(node: any) {


### PR DESCRIPTION
This PR enables alignment tests that between babel and ts-estree