### PR TITLE
Fixer for typedef rule with variable declarations turned on

### DIFF
--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -604,5 +604,30 @@ ruleTester.run('typedef', rule, {
         },
       ],
     },
+    {
+      code: `
+      class Foo {
+        foo: 'bar'
+      }
+      const a = new Foo()
+      `,
+      output: `
+      class Foo {
+        foo: 'bar'
+      }
+      const a: Foo = new Foo()
+      `,
+      errors: [
+        {
+          data: { name: 'a' },
+          messageId: 'expectedTypedefNamed',
+        },
+      ],
+      options: [
+        {
+          variableDeclaration: true,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Fixes variable declarations missing type annotations when using

```json
"@typescript-eslint/typedef": ["error", {
  "variableDeclaration": true
}]
```