### PR TITLE
fix(eslint-plugin): crash in no-unnecessary-type-arguments

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
@@ -110,6 +110,10 @@ function getTypeParametersFromType(
 
   const sym = getAliasedSymbol(symAtLocation, checker);
 
+  if (!sym.declarations) {
+    return undefined;
+  }
+
   return findFirstResult(sym.declarations, decl =>
     tsutils.isClassLikeDeclaration(decl) ||
     ts.isTypeAliasDeclaration(decl) ||

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
@@ -6,6 +6,7 @@ const rootDir = path.join(process.cwd(), 'tests/fixtures');
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2015,
+    sourceType: 'module',
     tsconfigRootDir: rootDir,
     project: './tsconfig.json',
   },
@@ -74,6 +75,9 @@ ruleTester.run('no-unnecessary-type-arguments', rule, {
       class Foo<T = number> extends Bar<string> {}`,
     `interface Bar<T = number> {}
       class Foo<T = number> implements Bar<string> {}`,
+    `import { F } from './missing';
+      function bar<T = F>() {}
+      bar<F<number>>()`,
   ],
   invalid: [
     {
@@ -176,6 +180,21 @@ ruleTester.run('no-unnecessary-type-arguments', rule, {
       ],
       output: `class Bar<T = string> {}
         class Foo<T = number> extends Bar {}`,
+    },
+    {
+      code: `import { F } from './missing';
+        function bar<T = F<string>>() {}
+        bar<F<string>>()`,
+      errors: [
+        {
+          line: 3,
+          column: 13,
+          messageId: 'unnecessaryTypeParameter',
+        },
+      ],
+      output: `import { F } from './missing';
+        function bar<T = F<string>>() {}
+        bar()`,
     },
   ],
 });


### PR DESCRIPTION
This PR contains fix for regression introduced in #1381

fixes #1400