### PR TITLE
test(eslint-plugin): add missing test cases for rules

### DIFF
--- a/packages/eslint-plugin/src/rules/class-name-casing.ts
+++ b/packages/eslint-plugin/src/rules/class-name-casing.ts
@@ -67,7 +67,13 @@ export default util.createRule<Options, MessageIds>({
      * @param decl The declaration
      * @param id The name of the declaration
      */
-    function report(decl: TSESTree.Node, id: TSESTree.Identifier): void {
+    function report(
+      decl:
+        | TSESTree.ClassDeclaration
+        | TSESTree.TSInterfaceDeclaration
+        | TSESTree.ClassExpression,
+      id: TSESTree.Identifier,
+    ): void {
       let friendlyName;
 
       switch (decl.type) {
@@ -78,8 +84,6 @@ export default util.createRule<Options, MessageIds>({
         case AST_NODE_TYPES.TSInterfaceDeclaration:
           friendlyName = 'Interface';
           break;
-        default:
-          friendlyName = decl.type;
       }
 
       context.report({

--- a/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
+++ b/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
@@ -183,7 +183,7 @@ export default util.createRule<Options, MessageIds>({
 
     /**
      * Checks that the parameter property has the desired accessibility modifiers set.
-     * @param {TSESTree.TSParameterProperty} node The node representing a Parameter Property
+     * @param node The node representing a Parameter Property
      */
     function checkParameterPropertyAccessibilityModifier(
       node: TSESTree.TSParameterProperty,

--- a/packages/eslint-plugin/src/rules/no-array-constructor.ts
+++ b/packages/eslint-plugin/src/rules/no-array-constructor.ts
@@ -15,7 +15,7 @@ export default util.createRule({
     },
     fixable: 'code',
     messages: {
-      useLiteral: 'The array literal notation [] is preferrable.',
+      useLiteral: 'The array literal notation [] is preferable.',
     },
     schema: [],
   },

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -49,33 +49,25 @@ export default util.createRule<Options, MessageIds>({
           return;
         }
 
-        if (!node.extends || node.extends.length === 0) {
+        const extend = node.extends;
+        if (!extend || extend.length === 0) {
           context.report({
             node: node.id,
             messageId: 'noEmpty',
           });
-        } else if (node.extends.length === 1) {
+        } else if (extend.length === 1) {
           // interface extends exactly 1 interface --> Report depending on rule setting
-          if (allowSingleExtends) {
-            return;
-          } else {
+          if (!allowSingleExtends) {
             context.report({
               node: node.id,
               messageId: 'noEmptyWithSuper',
-              fix(fixer) {
-                if (node.extends && node.extends.length) {
-                  return [
-                    fixer.replaceText(
-                      node,
-                      `type ${sourceCode.getText(
-                        node.id,
-                      )} = ${sourceCode.getText(node.extends[0])}`,
-                    ),
-                  ];
-                }
-
-                return null;
-              },
+              fix: fixer =>
+                fixer.replaceText(
+                  node,
+                  `type ${sourceCode.getText(node.id)} = ${sourceCode.getText(
+                    extend[0],
+                  )}`,
+                ),
             });
           }
         }

--- a/packages/eslint-plugin/src/rules/no-misused-new.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-new.ts
@@ -22,7 +22,7 @@ export default util.createRule({
   defaultOptions: [],
   create(context) {
     /**
-     * @param {ASTNode} node type to be inspected.
+     * @param node type to be inspected.
      * @returns name of simple type or null
      */
     function getTypeReferenceName(
@@ -48,8 +48,8 @@ export default util.createRule({
     }
 
     /**
-     * @param {ASTNode} parent parent node.
-     * @param {ASTNode} returnType type to be compared
+     * @param parent parent node.
+     * @param returnType type to be compared
      */
     function isMatchingParentType(
       parent: undefined | TSESTree.Node,

--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -218,8 +218,7 @@ export default util.createRule<Options, MessageIds>({
 
     /**
      * Validates the node looking for aliases, callbacks and literals.
-     * @param node the node to be validated.
-     * @param compositionType the type of composition this alias is part of (null if not
+     * @param type the type of composition this alias is part of (null if not
      *                                  part of a composition)
      * @param isTopLevel a flag indicating this is the top level node.
      */

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -245,7 +245,7 @@ export default util.createRule<Options, MessageIds>({
         node: TSESTree.TSTypeAssertion | TSESTree.TSAsExpression,
       ): void {
         if (
-          options?.typesToIgnore?.includes(
+          options.typesToIgnore?.includes(
             sourceCode.getText(node.typeAnnotation),
           )
         ) {

--- a/packages/eslint-plugin/tests/fixtures/class.ts
+++ b/packages/eslint-plugin/tests/fixtures/class.ts
@@ -1,0 +1,1 @@
+export class Error {}

--- a/packages/eslint-plugin/tests/fixtures/class.ts
+++ b/packages/eslint-plugin/tests/fixtures/class.ts
@@ -1,1 +1,2 @@
+// used be no-throw-literal test case to validate custom error
 export class Error {}

--- a/packages/eslint-plugin/tests/fixtures/class.ts
+++ b/packages/eslint-plugin/tests/fixtures/class.ts
@@ -1,2 +1,2 @@
-// used be no-throw-literal test case to validate custom error
+// used by no-throw-literal test case to validate custom error
 export class Error {}

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -313,6 +313,25 @@ ruleTester.run('array-type', rule, {
       ],
     },
     {
+      code: 'let a: Array<>[] = []',
+      output: 'let a: any[][] = []',
+      options: [{ default: 'array-simple' }],
+      errors: [
+        {
+          messageId: 'errorStringGenericSimple',
+          data: { type: 'T' },
+          line: 1,
+          column: 8,
+        },
+        {
+          messageId: 'errorStringArraySimple',
+          data: { type: 'any' },
+          line: 1,
+          column: 8,
+        },
+      ],
+    },
+    {
       code: `let x: Array<undefined> = [undefined] as undefined[];`,
       output: `let x: undefined[] = [undefined] as undefined[];`,
       options: [{ default: 'array-simple' }],

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -42,15 +42,15 @@ ruleTester.run('array-type', rule, {
       options: [{ default: 'generic' }],
     },
     {
-      code: `let fooVar: Array;`,
+      code: 'let fooVar: Array;',
       options: [{ default: 'generic' }],
     },
     {
-      code: `function foo (a: Array<Bar>): Array<Bar> {}`,
+      code: 'function foo (a: Array<Bar>): Array<Bar> {}',
       options: [{ default: 'generic' }],
     },
     {
-      code: `let yy: number[][] = [[4, 5], [6]];`,
+      code: 'let yy: number[][] = [[4, 5], [6]];',
       options: [{ default: 'array-simple' }],
     },
     {
@@ -66,15 +66,15 @@ ruleTester.run('array-type', rule, {
       options: [{ default: 'array-simple' }],
     },
     {
-      code: `let fooVar: Array<(c: number) => number>;`,
+      code: 'let fooVar: Array<(c: number) => number>;',
       options: [{ default: 'array-simple' }],
     },
     {
-      code: `type fooUnion = Array<string | number | boolean>;`,
+      code: 'type fooUnion = Array<string | number | boolean>;',
       options: [{ default: 'array-simple' }],
     },
     {
-      code: `type fooIntersection = Array<string & number>;`,
+      code: 'type fooIntersection = Array<string & number>;',
       options: [{ default: 'array-simple' }],
     },
     {
@@ -91,11 +91,11 @@ ruleTester.run('array-type', rule, {
       options: [{ default: 'array-simple' }],
     },
     {
-      code: `let yy: number[][] = [[4, 5], [6]];`,
+      code: 'let yy: number[][] = [[4, 5], [6]];',
       options: [{ default: 'array' }],
     },
     {
-      code: `let ya = [[1, "2"]] as[number, string][];`,
+      code: 'let ya = [[1, "2"]] as[number, string][];',
       options: [{ default: 'array' }],
     },
     {
@@ -111,15 +111,15 @@ ruleTester.run('array-type', rule, {
       options: [{ default: 'array' }],
     },
     {
-      code: `let barVar: ((c: number) => number)[];`,
+      code: 'let barVar: ((c: number) => number)[];',
       options: [{ default: 'array' }],
     },
     {
-      code: `type barUnion = (string|number|boolean)[];`,
+      code: 'type barUnion = (string|number|boolean)[];',
       options: [{ default: 'array' }],
     },
     {
-      code: `type barIntersection = (string & number)[];`,
+      code: 'type barIntersection = (string & number)[];',
       options: [{ default: 'array' }],
     },
     {
@@ -134,15 +134,15 @@ ruleTester.run('array-type', rule, {
       options: [{ default: 'array' }],
     },
     {
-      code: `let z: Array = [3, "4"];`,
+      code: 'let z: Array = [3, "4"];',
       options: [{ default: 'generic' }],
     },
     {
-      code: `let xx: Array<Array<number>> = [[1, 2], [3]];`,
+      code: 'let xx: Array<Array<number>> = [[1, 2], [3]];',
       options: [{ default: 'generic' }],
     },
     {
-      code: `type Arr<T> = Array<T>;`,
+      code: 'type Arr<T> = Array<T>;',
       options: [{ default: 'generic' }],
     },
     {
@@ -158,15 +158,15 @@ ruleTester.run('array-type', rule, {
       options: [{ default: 'generic' }],
     },
     {
-      code: `let fooVar: Array<(c: number) => number>;`,
+      code: 'let fooVar: Array<(c: number) => number>;',
       options: [{ default: 'generic' }],
     },
     {
-      code: `type fooUnion = Array<string|number|boolean>;`,
+      code: 'type fooUnion = Array<string|number|boolean>;',
       options: [{ default: 'generic' }],
     },
     {
-      code: `type fooIntersection = Array<string & number>;`,
+      code: 'type fooIntersection = Array<string & number>;',
       options: [{ default: 'generic' }],
     },
     {
@@ -189,15 +189,15 @@ ruleTester.run('array-type', rule, {
       options: [{ default: 'array', readonly: 'generic' }],
     },
     {
-      code: `let a: Array<string> = []`,
+      code: 'let a: Array<string> = []',
       options: [{ default: 'generic', readonly: 'array' }],
     },
     {
-      code: `let a: readonly number[] = []`,
+      code: 'let a: readonly number[] = []',
       options: [{ default: 'generic', readonly: 'array' }],
     },
     {
-      code: `let a: readonly Array<number>[] = [[]]`,
+      code: 'let a: readonly Array<number>[] = [[]]',
       options: [{ default: 'generic', readonly: 'array' }],
     },
   ],
@@ -332,8 +332,8 @@ ruleTester.run('array-type', rule, {
       ],
     },
     {
-      code: `let x: Array<undefined> = [undefined] as undefined[];`,
-      output: `let x: undefined[] = [undefined] as undefined[];`,
+      code: 'let x: Array<undefined> = [undefined] as undefined[];',
+      output: 'let x: undefined[] = [undefined] as undefined[];',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -345,8 +345,8 @@ ruleTester.run('array-type', rule, {
       ],
     },
     {
-      code: `let xx: Array<object> = [];`,
-      output: `let xx: object[] = [];`,
+      code: 'let xx: Array<object> = [];',
+      output: 'let xx: object[] = [];',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -358,8 +358,8 @@ ruleTester.run('array-type', rule, {
       ],
     },
     {
-      code: `let y: string[] = <Array<string>>["2"];`,
-      output: `let y: string[] = <string[]>["2"];`,
+      code: 'let y: string[] = <Array<string>>["2"];',
+      output: 'let y: string[] = <string[]>["2"];',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -371,8 +371,8 @@ ruleTester.run('array-type', rule, {
       ],
     },
     {
-      code: `let z: Array = [3, "4"];`,
-      output: `let z: any[] = [3, "4"];`,
+      code: 'let z: Array = [3, "4"];',
+      output: 'let z: any[] = [3, "4"];',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -384,8 +384,8 @@ ruleTester.run('array-type', rule, {
       ],
     },
     {
-      code: `let ya = [[1, "2"]] as[number, string][];`,
-      output: `let ya = [[1, "2"]] as Array<[number, string]>;`,
+      code: 'let ya = [[1, "2"]] as[number, string][];',
+      output: 'let ya = [[1, "2"]] as Array<[number, string]>;',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -397,8 +397,8 @@ ruleTester.run('array-type', rule, {
       ],
     },
     {
-      code: `type Arr<T> = Array<T>;`,
-      output: `type Arr<T> = T[];`,
+      code: 'type Arr<T> = Array<T>;',
+      output: 'type Arr<T> = T[];',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -465,8 +465,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let barVar: ((c: number) => number)[];`,
-      output: `let barVar: Array<(c: number) => number>;`,
+      code: 'let barVar: ((c: number) => number)[];',
+      output: 'let barVar: Array<(c: number) => number>;',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -478,8 +478,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `type barUnion = (string|number|boolean)[];`,
-      output: `type barUnion = Array<string|number|boolean>;`,
+      code: 'type barUnion = (string|number|boolean)[];',
+      output: 'type barUnion = Array<string|number|boolean>;',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -491,8 +491,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `type barIntersection = (string & number)[];`,
-      output: `type barIntersection = Array<string & number>;`,
+      code: 'type barIntersection = (string & number)[];',
+      output: 'type barIntersection = Array<string & number>;',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -504,8 +504,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let v: Array<fooName.BarType> = [{ bar: "bar" }];`,
-      output: `let v: fooName.BarType[] = [{ bar: "bar" }];`,
+      code: 'let v: Array<fooName.BarType> = [{ bar: "bar" }];',
+      output: 'let v: fooName.BarType[] = [{ bar: "bar" }];',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -517,8 +517,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let w: fooName.BazType<string>[] = [["baz"]];`,
-      output: `let w: Array<fooName.BazType<string>> = [["baz"]];`,
+      code: 'let w: fooName.BazType<string>[] = [["baz"]];',
+      output: 'let w: Array<fooName.BazType<string>> = [["baz"]];',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -530,8 +530,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let x: Array<undefined> = [undefined] as undefined[];`,
-      output: `let x: undefined[] = [undefined] as undefined[];`,
+      code: 'let x: Array<undefined> = [undefined] as undefined[];',
+      output: 'let x: undefined[] = [undefined] as undefined[];',
       options: [{ default: 'array' }],
       errors: [
         {
@@ -543,8 +543,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let y: string[] = <Array<string>>["2"];`,
-      output: `let y: string[] = <string[]>["2"];`,
+      code: 'let y: string[] = <Array<string>>["2"];',
+      output: 'let y: string[] = <string[]>["2"];',
       options: [{ default: 'array' }],
       errors: [
         {
@@ -556,8 +556,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let z: Array = [3, "4"];`,
-      output: `let z: any[] = [3, "4"];`,
+      code: 'let z: Array = [3, "4"];',
+      output: 'let z: any[] = [3, "4"];',
       options: [{ default: 'array' }],
       errors: [
         {
@@ -569,8 +569,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `type Arr<T> = Array<T>;`,
-      output: `type Arr<T> = T[];`,
+      code: 'type Arr<T> = Array<T>;',
+      output: 'type Arr<T> = T[];',
       options: [{ default: 'array' }],
       errors: [
         {
@@ -635,8 +635,8 @@ let yyyy: Arr<Arr<string>[][]> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let fooVar: Array<(c: number) => number>;`,
-      output: `let fooVar: ((c: number) => number)[];`,
+      code: 'let fooVar: Array<(c: number) => number>;',
+      output: 'let fooVar: ((c: number) => number)[];',
       options: [{ default: 'array' }],
       errors: [
         {
@@ -648,8 +648,8 @@ let yyyy: Arr<Arr<string>[][]> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `type fooUnion = Array<string|number|boolean>;`,
-      output: `type fooUnion = (string|number|boolean)[];`,
+      code: 'type fooUnion = Array<string|number|boolean>;',
+      output: 'type fooUnion = (string|number|boolean)[];',
       options: [{ default: 'array' }],
       errors: [
         {
@@ -661,8 +661,8 @@ let yyyy: Arr<Arr<string>[][]> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `type fooIntersection = Array<string & number>;`,
-      output: `type fooIntersection = (string & number)[];`,
+      code: 'type fooIntersection = Array<string & number>;',
+      output: 'type fooIntersection = (string & number)[];',
       options: [{ default: 'array' }],
       errors: [
         {
@@ -674,7 +674,7 @@ let yyyy: Arr<Arr<string>[][]> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let fooVar: Array[];`,
+      code: 'let fooVar: Array[];',
       options: [{ default: 'array' }],
       errors: [
         {
@@ -686,7 +686,7 @@ let yyyy: Arr<Arr<string>[][]> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let fooVar: Array[];`,
+      code: 'let fooVar: Array[];',
       options: [{ default: 'array-simple' }],
       errors: [
         {
@@ -698,8 +698,8 @@ let yyyy: Arr<Arr<string>[][]> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let x: Array<number> = [1] as number[];`,
-      output: `let x: Array<number> = [1] as Array<number>;`,
+      code: 'let x: Array<number> = [1] as number[];',
+      output: 'let x: Array<number> = [1] as Array<number>;',
       options: [{ default: 'generic' }],
       errors: [
         {
@@ -711,8 +711,8 @@ let yyyy: Arr<Arr<string>[][]> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let y: string[] = <Array<string>>["2"];`,
-      output: `let y: Array<string> = <Array<string>>["2"];`,
+      code: 'let y: string[] = <Array<string>>["2"];',
+      output: 'let y: Array<string> = <Array<string>>["2"];',
       options: [{ default: 'generic' }],
       errors: [
         {
@@ -724,8 +724,8 @@ let yyyy: Arr<Arr<string>[][]> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let ya = [[1, "2"]] as[number, string][];`,
-      output: `let ya = [[1, "2"]] as Array<[number, string]>;`,
+      code: 'let ya = [[1, "2"]] as[number, string][];',
+      output: 'let ya = [[1, "2"]] as Array<[number, string]>;',
       options: [{ default: 'generic' }],
       errors: [
         {
@@ -790,8 +790,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `let barVar: ((c: number) => number)[];`,
-      output: `let barVar: Array<(c: number) => number>;`,
+      code: 'let barVar: ((c: number) => number)[];',
+      output: 'let barVar: Array<(c: number) => number>;',
       options: [{ default: 'generic' }],
       errors: [
         {
@@ -803,8 +803,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `type barUnion = (string|number|boolean)[];`,
-      output: `type barUnion = Array<string|number|boolean>;`,
+      code: 'type barUnion = (string|number|boolean)[];',
+      output: 'type barUnion = Array<string|number|boolean>;',
       options: [{ default: 'generic' }],
       errors: [
         {
@@ -816,8 +816,8 @@ let yyyy: Arr<Array<Array<Arr<string>>>> = [[[["2"]]]];`,
       ],
     },
     {
-      code: `type barIntersection = (string & number)[];`,
-      output: `type barIntersection = Array<string & number>;`,
+      code: 'type barIntersection = (string & number)[];',
+      output: 'type barIntersection = Array<string & number>;',
       options: [{ default: 'generic' }],
       errors: [
         {
@@ -1020,104 +1020,104 @@ class Foo<T = Bar[][]> extends Bar<T, T[]> implements Baz<T[]> {
     );
     testOutput(
       'array-simple',
-      `let xx: Array<Array<number>> = [[1, 2], [3]];`,
-      `let xx: number[][] = [[1, 2], [3]];`,
+      'let xx: Array<Array<number>> = [[1, 2], [3]];',
+      'let xx: number[][] = [[1, 2], [3]];',
     );
     testOutput(
       'array',
-      `let xx: Array<Array<number>> = [[1, 2], [3]];`,
-      `let xx: number[][] = [[1, 2], [3]];`,
+      'let xx: Array<Array<number>> = [[1, 2], [3]];',
+      'let xx: number[][] = [[1, 2], [3]];',
     );
     testOutput(
       'generic',
-      `let yy: number[][] = [[4, 5], [6]];`,
-      `let yy: Array<Array<number>> = [[4, 5], [6]];`,
+      'let yy: number[][] = [[4, 5], [6]];',
+      'let yy: Array<Array<number>> = [[4, 5], [6]];',
     );
 
     // readonly
     testOutput(
       'generic',
-      `let x: readonly number[][]`,
-      `let x: ReadonlyArray<Array<number>>`,
+      'let x: readonly number[][]',
+      'let x: ReadonlyArray<Array<number>>',
     );
     testOutput(
       'generic',
-      `let x: readonly (readonly number[])[]`,
-      `let x: ReadonlyArray<ReadonlyArray<number>>`,
+      'let x: readonly (readonly number[])[]',
+      'let x: ReadonlyArray<ReadonlyArray<number>>',
     );
     testOutput(
       'array',
-      `let x: ReadonlyArray<Array<number>>`,
-      `let x: readonly number[][]`,
+      'let x: ReadonlyArray<Array<number>>',
+      'let x: readonly number[][]',
     );
     testOutput(
       'array',
-      `let x: ReadonlyArray<ReadonlyArray<number>>`,
-      `let x: readonly (readonly number[])[]`,
+      'let x: ReadonlyArray<ReadonlyArray<number>>',
+      'let x: readonly (readonly number[])[]',
     );
     testOutput(
       'array',
-      `let x: ReadonlyArray<readonly number[]>`,
-      `let x: readonly (readonly number[])[]`,
+      'let x: ReadonlyArray<readonly number[]>',
+      'let x: readonly (readonly number[])[]',
     );
     testOutput(
       'array',
-      `let x: ReadonlyArray<number>`,
-      `let x: ReadonlyArray<number>`,
-      'generic',
-    );
-    testOutput(
-      'array',
-      `let a: string[] = []`,
-      `let a: string[] = []`,
+      'let x: ReadonlyArray<number>',
+      'let x: ReadonlyArray<number>',
       'generic',
     );
     testOutput(
       'array',
-      `let a: readonly number[][] = []`,
-      `let a: ReadonlyArray<number[]> = []`,
+      'let a: string[] = []',
+      'let a: string[] = []',
+      'generic',
+    );
+    testOutput(
+      'array',
+      'let a: readonly number[][] = []',
+      'let a: ReadonlyArray<number[]> = []',
       'generic',
     );
     testOutput(
       'generic',
-      `let a: string[] = []`,
-      `let a: Array<string> = []`,
+      'let a: string[] = []',
+      'let a: Array<string> = []',
       'array',
     );
     testOutput(
       'generic',
-      `let a: readonly number[][] = []`,
-      `let a: readonly Array<number>[] = []`,
+      'let a: readonly number[][] = []',
+      'let a: readonly Array<number>[] = []',
       'array',
     );
     testOutput(
       'generic',
-      `type T = readonly(string)[]`,
-      `type T = ReadonlyArray<string>`,
+      'type T = readonly(string)[]',
+      'type T = ReadonlyArray<string>',
       'generic',
     );
     testOutput(
       'generic',
-      `let a: readonly(readonly string[])[] = []`,
-      `let a: ReadonlyArray<ReadonlyArray<string>> = []`,
+      'let a: readonly(readonly string[])[] = []',
+      'let a: ReadonlyArray<ReadonlyArray<string>> = []',
       'generic',
     );
     testOutput(
       'generic',
-      `type T = readonly(readonly string[])[]`,
-      `type T = ReadonlyArray<ReadonlyArray<string>>`,
+      'type T = readonly(readonly string[])[]',
+      'type T = ReadonlyArray<ReadonlyArray<string>>',
       'generic',
     );
     testOutput(
       'generic',
-      `type T = readonly (readonly string[])[]`,
-      `type T = ReadonlyArray<ReadonlyArray<string>>`,
+      'type T = readonly (readonly string[])[]',
+      'type T = ReadonlyArray<ReadonlyArray<string>>',
       'generic',
     );
     testOutput(
       'generic',
-      `type T = readonly    (readonly string[])[]`,
-      `type T = ReadonlyArray<ReadonlyArray<string>>`,
+      'type T = readonly    (readonly string[])[]',
+      'type T = ReadonlyArray<ReadonlyArray<string>>',
       'generic',
     );
   });

--- a/packages/eslint-plugin/tests/rules/class-name-casing.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-name-casing.test.ts
@@ -172,7 +172,7 @@ ruleTester.run('class-name-casing', rule, {
       ],
     },
     {
-      code: `class æInvalidClassNameWithUnicode {}`,
+      code: 'class æInvalidClassNameWithUnicode {}',
       errors: [
         {
           messageId: 'notPascalCased',

--- a/packages/eslint-plugin/tests/rules/class-name-casing.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-name-casing.test.ts
@@ -34,6 +34,14 @@ ruleTester.run('class-name-casing', rule, {
     'class ClassNameWithUnicodeÈ {}',
     'class ÈClassNameWithUnicode {}',
     'class ClassNameWithæUnicode {}',
+    // Following test cases are valid, but no one is going to write code like this
+    'var { bar } = class { static bar() { return 2 } }',
+    `var [ bar ] = class {
+      static [Symbol.iterator]() {
+        return { next: () => ({ value: 1, done: false}) }
+      }
+    }
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
@@ -300,12 +300,12 @@ class Test {
     },
     {
       filename: 'test.ts',
-      code: `class Test { x = 2 }`,
+      code: 'class Test { x = 2 }',
       options: [{ overrides: { properties: 'off' } }],
     },
     {
       filename: 'test.ts',
-      code: `class Test { private x = 2 }`,
+      code: 'class Test { private x = 2 }',
       options: [{ overrides: { properties: 'explicit' } }],
     },
     {
@@ -317,7 +317,7 @@ class Test {
       options: [{ overrides: { properties: 'no-public' } }],
     },
     {
-      code: `class Test { constructor(private { x }: any[]) { }}`,
+      code: 'class Test { constructor(private { x }: any[]) { }}',
       options: [{ accessibility: 'no-public' }],
     },
   ],
@@ -660,7 +660,7 @@ class Test {
     },
     {
       filename: 'test.ts',
-      code: `class Test { x = 2 }`,
+      code: 'class Test { x = 2 }',
       options: [
         {
           accessibility: 'off',
@@ -696,7 +696,7 @@ class Test {
       ],
     },
     {
-      code: `class Test { constructor(public ...x: any[]) { }}`,
+      code: 'class Test { constructor(public ...x: any[]) { }}',
       options: [{ accessibility: 'explicit' }],
       errors: [
         {

--- a/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
@@ -252,11 +252,7 @@ class Test {
   constructor(public foo: number){}
 }
       `,
-      options: [
-        {
-          accessibility: 'no-public',
-        },
-      ],
+      options: [{ accessibility: 'no-public' }],
     },
     {
       filename: 'test.ts',
@@ -267,11 +263,7 @@ class Test {
   }
 }
       `,
-      options: [
-        {
-          ignoredMethodNames: ['getX'],
-        },
-      ],
+      options: [{ ignoredMethodNames: ['getX'] }],
     },
     {
       filename: 'test.ts',
@@ -282,11 +274,7 @@ class Test {
   }
 }
       `,
-      options: [
-        {
-          ignoredMethodNames: ['getX'],
-        },
-      ],
+      options: [{ ignoredMethodNames: ['getX'] }],
     },
     {
       filename: 'test.ts',
@@ -297,11 +285,7 @@ class Test {
   }
 }
       `,
-      options: [
-        {
-          ignoredMethodNames: ['getX'],
-        },
-      ],
+      options: [{ ignoredMethodNames: ['getX'] }],
     },
     {
       filename: 'test.ts',
@@ -312,11 +296,29 @@ class Test {
   }
 }
       `,
-      options: [
-        {
-          ignoredMethodNames: ['getX'],
-        },
-      ],
+      options: [{ ignoredMethodNames: ['getX'] }],
+    },
+    {
+      filename: 'test.ts',
+      code: `class Test { x = 2 }`,
+      options: [{ overrides: { properties: 'off' } }],
+    },
+    {
+      filename: 'test.ts',
+      code: `class Test { private x = 2 }`,
+      options: [{ overrides: { properties: 'explicit' } }],
+    },
+    {
+      filename: 'test.ts',
+      code: `class Test {
+        x = 2
+        private x = 2
+      }`,
+      options: [{ overrides: { properties: 'no-public' } }],
+    },
+    {
+      code: `class Test { constructor(private { x }: any[]) { }}`,
+      options: [{ accessibility: 'no-public' }],
     },
   ],
   invalid: [
@@ -653,6 +655,54 @@ class Test {
           messageId: 'unwantedPublicAccessibility',
           line: 3,
           column: 15,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `class Test { x = 2 }`,
+      options: [
+        {
+          accessibility: 'off',
+          overrides: { properties: 'explicit' },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingAccessibility',
+          line: 1,
+          column: 14,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `class Test {
+        public x = 2
+        private x = 2
+      }`,
+      options: [
+        {
+          accessibility: 'off',
+          overrides: { properties: 'no-public' },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'unwantedPublicAccessibility',
+          line: 2,
+          column: 9,
+        },
+      ],
+    },
+    {
+      code: `class Test { constructor(public ...x: any[]) { }}`,
+      options: [{ accessibility: 'explicit' }],
+      errors: [
+        {
+          messageId: 'missingAccessibility',
+          line: 1,
+          column: 14,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-misused-new.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-new.test.ts
@@ -14,40 +14,22 @@ declare abstract class C {
     get new ();
     bar();
 }
-        `,
-    `
-class C {
-    constructor();
-}
-        `,
-    `
-class C {
-    constructor() {}
-}
-        `,
+    `,
+    `class C { constructor(); }`,
+    `const foo = class { constructor(); }`,
+    `const foo = class { new(): X }`,
     // OK if there's a body
-    `
-class C {
-    new() {}
-}
-        `,
+    `class C { new() {} }`,
+    `class C { constructor() {} }`,
+    `const foo = class { new() {} }`,
+    `const foo = class { constructor() {} }`,
     // OK if return type is not the interface.
-    `
-interface I {
-    new(): {};
-}
-        `,
+    `interface I { new(): {}; }`,
     // 'new' OK in type literal (we don't know the type name)
-    `
-type T = {
-    new(): T;
-}
-        `,
-    `
-export default class {
-    constructor();
-}
-        `,
+    `type T = { new(): T; }`,
+    `export default class { constructor(); }`,
+    `interface foo { new<T>(): bar<T>; }`,
+    `interface foo { new<T>(): 'x'; }`,
   ],
   invalid: [
     {
@@ -123,6 +105,20 @@ declare abstract class C {
       errors: [
         {
           messageId: 'errorMessageClass',
+          line: 3,
+          column: 5,
+        },
+      ],
+    },
+    {
+      code: `
+interface I {
+    constructor(): '';
+}
+`,
+      errors: [
+        {
+          messageId: 'errorMessageInterface',
           line: 3,
           column: 5,
         },

--- a/packages/eslint-plugin/tests/rules/no-misused-new.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-new.test.ts
@@ -15,21 +15,21 @@ declare abstract class C {
     bar();
 }
     `,
-    `class C { constructor(); }`,
-    `const foo = class { constructor(); }`,
-    `const foo = class { new(): X }`,
+    'class C { constructor(); }',
+    'const foo = class { constructor(); }',
+    'const foo = class { new(): X }',
     // OK if there's a body
-    `class C { new() {} }`,
-    `class C { constructor() {} }`,
-    `const foo = class { new() {} }`,
-    `const foo = class { constructor() {} }`,
+    'class C { new() {} }',
+    'class C { constructor() {} }',
+    'const foo = class { new() {} }',
+    'const foo = class { constructor() {} }',
     // OK if return type is not the interface.
-    `interface I { new(): {}; }`,
+    'interface I { new(): {}; }',
     // 'new' OK in type literal (we don't know the type name)
-    `type T = { new(): T; }`,
-    `export default class { constructor(); }`,
-    `interface foo { new<T>(): bar<T>; }`,
-    `interface foo { new<T>(): 'x'; }`,
+    'type T = { new(): T; }',
+    'export default class { constructor(); }',
+    'interface foo { new<T>(): bar<T>; }',
+    "interface foo { new<T>(): 'x'; }",
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-throw-literal.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-throw-literal.test.ts
@@ -13,9 +13,9 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-throw-literal', rule, {
   valid: [
-    `throw new Error();`,
-    `throw new Error('error');`,
-    `throw Error('error');`,
+    'throw new Error();',
+    "throw new Error('error');",
+    "throw Error('error');",
     `
 const e = new Error();
 throw e;
@@ -63,14 +63,14 @@ class CustomError1 extends Error {}
 class CustomError2 extends CustomError1 {}
 throw new CustomError();
     `,
-    `throw foo = new Error();`,
-    `throw 1, 2, new Error();`,
-    `throw 'literal' && new Error();`,
-    `throw new Error() || 'literal'`,
-    `throw foo ? new Error() : 'literal';`,
-    `throw foo ? 'literal' : new Error();`,
-    `function* foo() { let index = 0; throw yield index++; }`,
-    `async function foo() { throw await bar; }`,
+    'throw foo = new Error();',
+    'throw 1, 2, new Error();',
+    "throw 'literal' && new Error();",
+    "throw new Error() || 'literal'",
+    "throw foo ? new Error() : 'literal';",
+    "throw foo ? 'literal' : new Error();",
+    'function* foo() { let index = 0; throw yield index++; }',
+    'async function foo() { throw await bar; }',
     `
 import { Error } from './missing';
 throw Error;
@@ -78,7 +78,7 @@ throw Error;
   ],
   invalid: [
     {
-      code: `throw undefined;`,
+      code: 'throw undefined;',
       errors: [
         {
           messageId: 'undef',
@@ -86,7 +86,7 @@ throw Error;
       ],
     },
     {
-      code: `throw new String('');`,
+      code: "throw new String('');",
       errors: [
         {
           messageId: 'object',
@@ -94,7 +94,7 @@ throw Error;
       ],
     },
     {
-      code: `throw 'error';`,
+      code: "throw 'error';",
       errors: [
         {
           messageId: 'object',
@@ -102,7 +102,7 @@ throw Error;
       ],
     },
     {
-      code: `throw 0;`,
+      code: 'throw 0;',
       errors: [
         {
           messageId: 'object',
@@ -110,7 +110,7 @@ throw Error;
       ],
     },
     {
-      code: `throw false;`,
+      code: 'throw false;',
       errors: [
         {
           messageId: 'object',
@@ -118,7 +118,7 @@ throw Error;
       ],
     },
     {
-      code: `throw null;`,
+      code: 'throw null;',
       errors: [
         {
           messageId: 'object',
@@ -126,7 +126,7 @@ throw Error;
       ],
     },
     {
-      code: `throw {};`,
+      code: 'throw {};',
       errors: [
         {
           messageId: 'object',
@@ -134,7 +134,7 @@ throw Error;
       ],
     },
     {
-      code: `throw 'a' + 'b';`,
+      code: "throw 'a' + 'b';",
       errors: [
         {
           messageId: 'object',
@@ -153,7 +153,7 @@ throw a + 'b';
       ],
     },
     {
-      code: `throw foo = 'error';`,
+      code: "throw foo = 'error';",
       errors: [
         {
           messageId: 'object',
@@ -161,7 +161,7 @@ throw a + 'b';
       ],
     },
     {
-      code: `throw new Error(), 1, 2, 3;`,
+      code: 'throw new Error(), 1, 2, 3;',
       errors: [
         {
           messageId: 'object',
@@ -169,7 +169,7 @@ throw a + 'b';
       ],
     },
     {
-      code: `throw 'literal' && 'not an Error';`,
+      code: "throw 'literal' && 'not an Error';",
       errors: [
         {
           messageId: 'object',
@@ -177,7 +177,7 @@ throw a + 'b';
       ],
     },
     {
-      code: `throw foo ? 'not an Error' : 'literal';`,
+      code: "throw foo ? 'not an Error' : 'literal';",
       errors: [
         {
           messageId: 'object',

--- a/packages/eslint-plugin/tests/rules/no-throw-literal.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-throw-literal.test.ts
@@ -4,6 +4,7 @@ import { RuleTester, getFixturesRootDir } from '../RuleTester';
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2018,
+    sourceType: 'module',
     tsconfigRootDir: getFixturesRootDir(),
     project: './tsconfig.json',
   },
@@ -12,113 +13,68 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-throw-literal', rule, {
   valid: [
-    {
-      code: `throw new Error();`,
-    },
-    {
-      code: `throw new Error('error');`,
-    },
-    {
-      code: `throw Error('error');`,
-    },
-    {
-      code: `
+    `throw new Error();`,
+    `throw new Error('error');`,
+    `throw Error('error');`,
+    `
 const e = new Error();
 throw e;
-      `,
-    },
-    {
-      code: `
+    `,
+    `
 try {
   throw new Error();
 } catch (e) {
   throw e;
 }
-      `,
-    },
-    {
-      code: `
+    `,
+    `
 function foo() {
   return new Error();
 }
-
 throw foo();
-      `,
-    },
-    {
-      code: `
+    `,
+    `
 const foo = {
   bar: new Error()
 }
-
 throw foo.bar;
-      `,
-    },
-    {
-      code: `
+    `,
+    `
 const foo = {
   bar: new Error()
 }
 
 throw foo['bar'];
-      `,
-    },
-    {
-      code: `
+    `,
+    `
 const foo = {
   bar: new Error()
 }
 
 const bar = 'bar';
 throw foo[bar];
-      `,
-    },
-    {
-      code: `
+    `,
+    `
 class CustomError extends Error {};
 throw new CustomError();
-      `,
-    },
-    {
-      code: `
+    `,
+    `
 class CustomError1 extends Error {}
 class CustomError2 extends CustomError1 {}
 throw new CustomError();
-      `,
-    },
-    {
-      code: `throw foo = new Error();`,
-    },
-    {
-      code: `throw 1, 2, new Error();`,
-    },
-    {
-      code: `throw 'literal' && new Error();`,
-    },
-    {
-      code: `throw new Error() || 'literal'`,
-    },
-    {
-      code: `throw foo ? new Error() : 'literal';`,
-    },
-    {
-      code: `throw foo ? 'literal' : new Error();`,
-    },
-    {
-      code: `
-function* foo() {
-  let index = 0;
-  throw yield index++;
-}
-      `,
-    },
-    {
-      code: `
-async function foo() {
-  throw await bar;
-}
-      `,
-    },
+    `,
+    `throw foo = new Error();`,
+    `throw 1, 2, new Error();`,
+    `throw 'literal' && new Error();`,
+    `throw new Error() || 'literal'`,
+    `throw foo ? new Error() : 'literal';`,
+    `throw foo ? 'literal' : new Error();`,
+    `function* foo() { let index = 0; throw yield index++; }`,
+    `async function foo() { throw await bar; }`,
+    `
+import { Error } from './missing';
+throw Error;
+    `,
   ],
   invalid: [
     {
@@ -316,6 +272,19 @@ throw Error;
       errors: [
         {
           messageId: 'object',
+        },
+      ],
+    },
+    {
+      code: `
+import { Error } from './class';
+throw new Error();
+      `,
+      errors: [
+        {
+          messageId: 'object',
+          line: 3,
+          column: 7,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -3225,5 +3225,29 @@ type Foo<T> = {
         },
       ],
     },
+    {
+      // unique symbol is not allowed in this context
+      code: 'type Foo = keyof [string] | unique symbol;',
+      errors: [
+        {
+          messageId: 'noCompositionAlias',
+          data: {
+            compositionType: 'union',
+            typeName: 'Tuple Types',
+          },
+          line: 1,
+          column: 12,
+        },
+        {
+          messageId: 'noCompositionAlias',
+          data: {
+            compositionType: 'union',
+            typeName: 'Unhandled',
+          },
+          line: 1,
+          column: 29,
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -358,7 +358,8 @@ type Foo<T> = {
       options: [{ allowMappedTypes: 'in-intersections' }],
     },
     {
-      code: `export type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;`,
+      code:
+        'export type ClassValue = string | number | ClassDictionary | ClassArray | undefined | null | false;',
       options: [
         {
           allowAliases: 'in-unions-and-intersections',
@@ -2974,7 +2975,7 @@ type Foo<T> = {
     },
     {
       // https://github.com/typescript-eslint/typescript-eslint/issues/270
-      code: `export type ButtonProps = JSX.IntrinsicElements['button'];`,
+      code: "export type ButtonProps = JSX.IntrinsicElements['button'];",
       errors: [
         {
           messageId: 'noTypeAlias',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -30,6 +30,8 @@ const foo = ({ hello: "hello" }) as PossibleTuple;`,
     `
 type PossibleTuple = { 0: "hello", 5: "hello" };
 const foo = ({ 0: "hello", 5: "hello" }) as PossibleTuple;`,
+    `let bar: number | undefined = x;
+      let foo: number = bar!;`,
     {
       code: `
 type Foo = number;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -39,15 +39,15 @@ const foo = (3 + 5) as Foo;`,
       options: [{ typesToIgnore: ['Foo'] }],
     },
     {
-      code: `const foo = (3 + 5) as any;`,
+      code: 'const foo = (3 + 5) as any;',
       options: [{ typesToIgnore: ['any'] }],
     },
     {
-      code: `((Syntax as any).ArrayExpression = 'foo')`,
+      code: "((Syntax as any).ArrayExpression = 'foo')",
       options: [{ typesToIgnore: ['any'] }],
     },
     {
-      code: `const foo = (3 + 5) as string;`,
+      code: 'const foo = (3 + 5) as string;',
       options: [{ typesToIgnore: ['string'] }],
     },
     {

--- a/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
@@ -102,6 +102,12 @@ for(let x = 0; x < arr.length(); x++) {}
 for(let x = 0; x < arr.length; x+=11) {}
 `,
     `
+for(let x = arr.length; x > 1; x-=1) {}
+`,
+    `
+for(let x = 0; x < arr.length; x*=2) {}
+`,
+    `
 for(let x = 0; x < arr.length; x=x+11) {}
 `,
     `

--- a/packages/eslint-plugin/tests/rules/prefer-readonly.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly.test.ts
@@ -13,9 +13,9 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('prefer-readonly', rule, {
   valid: [
-    `function ignore() { }`,
-    `const ignore = function () { }`,
-    `const ignore = () => { }`,
+    'function ignore() { }',
+    'const ignore = function () { }',
+    'const ignore = () => { }',
     `const container = { member: true };
       container.member;`,
     `const container = { member: 1 };
@@ -30,7 +30,7 @@ ruleTester.run('prefer-readonly', rule, {
       --container.member;`,
     `const container = { member: 1 };
       container.member--;`,
-    `class TestEmpty { }`,
+    'class TestEmpty { }',
     `class TestReadonlyStatic {
       private static readonly correctlyReadonlyStatic = 7;
     }`,

--- a/packages/eslint-plugin/tests/rules/triple-slash-reference.test.ts
+++ b/packages/eslint-plugin/tests/rules/triple-slash-reference.test.ts
@@ -12,6 +12,28 @@ ruleTester.run('triple-slash-reference', rule, {
   valid: [
     {
       code: `
+      // <reference path="foo" />
+      // <reference types="bar" />
+      // <reference lib="baz" />
+      import * as foo from "foo"
+      import * as bar from "bar"
+      import * as baz from "baz"
+      `,
+      options: [{ path: 'never', types: 'never', lib: 'never' }],
+    },
+    {
+      code: `
+      // <reference path="foo" />
+      // <reference types="bar" />
+      // <reference lib="baz" />
+      import foo = require("foo")
+      import bar = require("bar")
+      import baz = require("baz")
+      `,
+      options: [{ path: 'never', types: 'never', lib: 'never' }],
+    },
+    {
+      code: `
       /// <reference path="foo" />
       /// <reference types="bar" />
       /// <reference lib="baz" />
@@ -23,26 +45,45 @@ ruleTester.run('triple-slash-reference', rule, {
     },
     {
       code: `
-      import * as foo from "foo"
+      /// <reference path="foo" />
+      /// <reference types="bar" />
+      /// <reference lib="baz" />
+      import foo = require("foo")
+      import bar = require("bar")
+      import baz = require("baz")
       `,
+      options: [{ path: 'always', types: 'always', lib: 'always' }],
+    },
+    {
+      code: `import * as foo from "foo"`,
       options: [{ path: 'never' }],
     },
     {
-      code: `
-      import * as foo from "foo"
-      `,
+      code: `import foo = require("foo");`,
+      options: [{ path: 'never' }],
+    },
+    {
+      code: `import * as foo from "foo"`,
       options: [{ types: 'never' }],
     },
     {
-      code: `
-      import * as foo from "foo"
-      `,
+      code: `import foo = require("foo");`,
+      options: [{ types: 'never' }],
+    },
+    {
+      code: `import * as foo from "foo"`,
       options: [{ lib: 'never' }],
     },
     {
-      code: `
-      import * as foo from "foo"
-      `,
+      code: `import foo = require("foo");`,
+      options: [{ lib: 'never' }],
+    },
+    {
+      code: `import * as foo from "foo"`,
+      options: [{ types: 'prefer-import' }],
+    },
+    {
+      code: `import foo = require("foo");`,
       options: [{ types: 'prefer-import' }],
     },
     {

--- a/packages/eslint-plugin/tests/rules/triple-slash-reference.test.ts
+++ b/packages/eslint-plugin/tests/rules/triple-slash-reference.test.ts
@@ -55,35 +55,35 @@ ruleTester.run('triple-slash-reference', rule, {
       options: [{ path: 'always', types: 'always', lib: 'always' }],
     },
     {
-      code: `import * as foo from "foo"`,
+      code: 'import * as foo from "foo"',
       options: [{ path: 'never' }],
     },
     {
-      code: `import foo = require("foo");`,
+      code: 'import foo = require("foo");',
       options: [{ path: 'never' }],
     },
     {
-      code: `import * as foo from "foo"`,
+      code: 'import * as foo from "foo"',
       options: [{ types: 'never' }],
     },
     {
-      code: `import foo = require("foo");`,
+      code: 'import foo = require("foo");',
       options: [{ types: 'never' }],
     },
     {
-      code: `import * as foo from "foo"`,
+      code: 'import * as foo from "foo"',
       options: [{ lib: 'never' }],
     },
     {
-      code: `import foo = require("foo");`,
+      code: 'import foo = require("foo");',
       options: [{ lib: 'never' }],
     },
     {
-      code: `import * as foo from "foo"`,
+      code: 'import * as foo from "foo"',
       options: [{ types: 'prefer-import' }],
     },
     {
-      code: `import foo = require("foo");`,
+      code: 'import foo = require("foo");',
       options: [{ types: 'prefer-import' }],
     },
     {
@@ -133,7 +133,7 @@ import foo = require("foo");
       ],
     },
     {
-      code: `/// <reference path="foo" />`,
+      code: '/// <reference path="foo" />',
       options: [{ path: 'never' }],
       errors: [
         {
@@ -144,7 +144,7 @@ import foo = require("foo");
       ],
     },
     {
-      code: `/// <reference types="foo" />`,
+      code: '/// <reference types="foo" />',
       options: [{ types: 'never' }],
       errors: [
         {
@@ -155,7 +155,7 @@ import foo = require("foo");
       ],
     },
     {
-      code: `/// <reference lib="foo" />`,
+      code: '/// <reference lib="foo" />',
       options: [{ lib: 'never' }],
       errors: [
         {


### PR DESCRIPTION
This PR adds some edge cases for uncovered syntax that is actually validated by rules.

each commit represents changes to tests for one rule
- there is few minor changes to code (redundant conditions)

i was unable to get coverage for all rules that i checked up to 100% (some of code paths can't be triggered)

affected tests for rules:
- array-type
- no-empty-interface
- prefer-for-of
- no-type-alias
- triple-slash-reference
- no-unnecessary-type-assertion
- class-name-casing
- no-misused-new
- no-throw-literal
- explicit-member-accessibility