### PR TITLE
fix(typescript-estree): correct persisted parse for windows

### DIFF
--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -32,7 +32,7 @@ const correctPathCasing = useCaseSensitiveFileNames
 
 function getCanonicalFileName(filePath: string): CanonicalPath {
   let normalized = path.normalize(filePath);
-  if (normalized.endsWith('/')) {
+  if (normalized.endsWith(path.sep)) {
     normalized = normalized.substr(0, normalized.length - 1);
   }
   return correctPathCasing(normalized) as CanonicalPath;


### PR DESCRIPTION
Windows and Linux/Mac uses different path separator.

currently some of tests do not pass on windows machines because of that

this is used by persisted parse and may be related to #1394