### PR TITLE
fix(typescript-estree): parsing of deeply nested new files in new folder

### DIFF
--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -396,8 +396,7 @@ function maybeInvalidateProgram(
     if (folderWatchCallbacks) {
       folderWatchCallbacks.forEach(cb => {
         cb(currentDir, ts.FileWatcherEventKind.Changed);
-        // Temp: disable fix to validate test o
-        // cb(current!, ts.FileWatcherEventKind.Changed);
+        cb(current!, ts.FileWatcherEventKind.Changed);
       });
       hasCallback = true;
       break;

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -394,9 +394,10 @@ function maybeInvalidateProgram(
     current = next;
     const folderWatchCallbacks = folderWatchCallbackTrackingMap.get(current);
     if (folderWatchCallbacks) {
-      folderWatchCallbacks.forEach(cb =>
-        cb(currentDir, ts.FileWatcherEventKind.Changed),
-      );
+      folderWatchCallbacks.forEach(cb => {
+        cb(currentDir, ts.FileWatcherEventKind.Changed);
+        cb(current!, ts.FileWatcherEventKind.Changed);
+      });
       hasCallback = true;
       break;
     }

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -396,7 +396,8 @@ function maybeInvalidateProgram(
     if (folderWatchCallbacks) {
       folderWatchCallbacks.forEach(cb => {
         cb(currentDir, ts.FileWatcherEventKind.Changed);
-        cb(current!, ts.FileWatcherEventKind.Changed);
+        // Temp: disable fix to validate test o
+        // cb(current!, ts.FileWatcherEventKind.Changed);
       });
       hasCallback = true;
       break;

--- a/packages/typescript-estree/tests/lib/persistentParse.ts
+++ b/packages/typescript-estree/tests/lib/persistentParse.ts
@@ -241,16 +241,15 @@ describe('persistent parse', () => {
     baseTests(tsConfigExcludeBar, tsConfigIncludeAll);
   });
 
-  describe('ui/components/file', () => {
-    it(`failed`, () => {
+  describe('tsconfig with extends and nested folders', () => {
+    // https://github.com/typescript-eslint/typescript-eslint/issues/1394
+    it('parses both files successfully', () => {
       const tsConfigExcludeBar = {
-        include: ['src/'],
-        exclude: ['src/electron'],
+        include: ['src'],
       };
       const tsConfigIncludeAll = {
         extends: './tsconfig.extend.json',
-        include: ['./**/*', './.storybook/**/*'],
-        exclude: ['assets', 'build', 'build-resources', 'node_modules', 'tmp'],
+        include: ['./**/*'],
       };
 
       const PROJECT_DIR = setup(tsConfigIncludeAll, false);

--- a/packages/typescript-estree/tests/lib/persistentParse.ts
+++ b/packages/typescript-estree/tests/lib/persistentParse.ts
@@ -23,8 +23,14 @@ afterEach(() => {
 function writeTSConfig(dirName: string, config: Record<string, unknown>): void {
   fs.writeFileSync(path.join(dirName, 'tsconfig.json'), JSON.stringify(config));
 }
-function writeTSConfigExtend(dirName: string, config: Record<string, unknown>): void {
-  fs.writeFileSync(path.join(dirName, 'tsconfig.extend.json'), JSON.stringify(config));
+function writeTSConfigExtend(
+  dirName: string,
+  config: Record<string, unknown>,
+): void {
+  fs.writeFileSync(
+    path.join(dirName, 'tsconfig.extend.json'),
+    JSON.stringify(config),
+  );
 }
 function writeFile(dirName: string, file: keyof typeof CONTENTS): void {
   fs.writeFileSync(path.join(dirName, 'src', `${file}.ts`), CONTENTS[file]);
@@ -255,12 +261,16 @@ describe('persistent parse', () => {
       fs.mkdirSync(path.join(PROJECT_DIR, 'src', 'ui'));
       fs.mkdirSync(path.join(PROJECT_DIR, 'src', 'ui', 'components'));
 
-      const bazSlashBar = path.join( 'ui', 'components', 'file') as 'ui/components/file';
+      const bazSlashBar = path.join(
+        'ui',
+        'components',
+        'file',
+      ) as 'ui/components/file';
 
       // write a new file and attempt to parse it
       writeFile(PROJECT_DIR, bazSlashBar);
 
       expect(() => parseFile(bazSlashBar, PROJECT_DIR)).not.toThrow();
-    })
+    });
   });
 });


### PR DESCRIPTION
### Context:
Currently `**` is resolved only as directory, it means that for `./**/*` paths `/src/test.ts`, `/test.ts` is going to work but `/src/test/test.ts` will not.

This is edge case and happens when you setup includes with `**`.

### Config example:

```json5
// tsconfig.extend.json
{
  "include": ["src"],
}
```
```json5
// tsconfig.json
{
  "extends": "./tsconfig.extend.json",
  "include": ["./**/*"],
}
```

fixes #1394