### PR TITLE
chore: migrate lodash from function packages

### DIFF
--- a/packages/eslint-plugin-tslint/package.json
+++ b/packages/eslint-plugin-tslint/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@typescript-eslint/experimental-utils": "2.15.0",
-    "lodash.memoize": "^4.1.2"
+    "lodash": "^4.17.15"
   },
   "peerDependencies": {
     "eslint": "^5.0.0 || ^6.0.0",
@@ -40,7 +40,7 @@
     "typescript": "*"
   },
   "devDependencies": {
-    "@types/lodash.memoize": "^4.1.4",
+    "@types/lodash": "^4.14.149",
     "@typescript-eslint/parser": "2.15.0"
   }
 }

--- a/packages/eslint-plugin-tslint/src/rules/config.ts
+++ b/packages/eslint-plugin-tslint/src/rules/config.ts
@@ -2,7 +2,7 @@ import {
   ESLintUtils,
   ParserServices,
 } from '@typescript-eslint/experimental-utils';
-import memoize from 'lodash.memoize';
+import memoize from 'lodash/memoize';
 import { Configuration, RuleSeverity } from 'tslint';
 import { CustomLinter } from '../custom-linter';
 

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -43,7 +43,7 @@
     "eslint-visitor-keys": "^1.1.0",
     "glob": "^7.1.6",
     "is-glob": "^4.0.1",
-    "lodash.unescape": "4.0.1",
+    "lodash": "^4.17.15",
     "semver": "^6.3.0",
     "tsutils": "^3.17.1"
   },
@@ -55,7 +55,7 @@
     "@types/debug": "^4.1.5",
     "@types/glob": "^7.1.1",
     "@types/is-glob": "^4.0.1",
-    "@types/lodash.unescape": "^4.0.4",
+    "@types/lodash": "^4.14.149",
     "@types/semver": "^6.2.0",
     "@types/tmp": "^0.1.0",
     "@typescript-eslint/shared-fixtures": "2.15.0",

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -1,4 +1,4 @@
-import unescape from 'lodash.unescape';
+import unescape from 'lodash/unescape';
 import * as ts from 'typescript';
 import { AST_NODE_TYPES, AST_TOKEN_TYPES, TSESTree } from './ts-estree';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,24 +1376,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
-"@types/lodash.memoize@^4.1.4":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz#3221f981790a415cab1a239f25c17efd8b604c23"
-  integrity sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.unescape@^4.0.4":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.unescape/-/lodash.unescape-4.0.6.tgz#cca470b1ab7736a81ea91bd071b2ed4f21ed4520"
-  integrity sha512-9JwlwdieWYlLqr1s/X8M1/Heo9qaFb2lHj6ETFlwJQrU9QyMvKngMnYzz0OYE4qx+VFdZgVP9I7AnBdju8/x0g==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.141"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.141.tgz#d81f4d0c562abe28713406b571ffb27692a82ae6"
-  integrity sha512-v5NYIi9qEbFEUpCyikmnOYe4YlP8BMUdTcNCAquAKzu+FA7rZ1onj9x80mbnDdOW/K5bFf3Tv5kJplP33+gAbQ==
+"@types/lodash@^4.14.149":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
 "@types/marked@^0.7.1":
   version "0.7.1"
@@ -5473,7 +5459,7 @@ lodash.map@^4.5.1:
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
 
-lodash.memoize@4.x, lodash.memoize@^4.1.2:
+lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
@@ -5502,11 +5488,6 @@ lodash.templatesettings@^4.0.0:
   integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
     lodash._reinterpolate "^3.0.0"
-
-lodash.unescape@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
-  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
 lodash.uniq@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
This PR migrates our usages of `lodash.*` standalone per method packages to single module.

Why?
Other projects started moving out of `standalone per method packages` in favor of single module (eg. babel)

> However, use of these packages is discouraged and they will be removed in v5.
https://lodash.com/per-method-packages

fixes #1399