### PR TITLE
feat(eslint-plugin): add `allowedPrefixes` prop to `interface-name-prefix`

### DIFF
--- a/packages/eslint-plugin/docs/rules/interface-name-prefix.md
+++ b/packages/eslint-plugin/docs/rules/interface-name-prefix.md
@@ -11,18 +11,21 @@ This rule enforces whether or not the `I` prefix is required for interface names
 The `_` prefix is sometimes used to designate a private declaration, so the rule also supports a private interface
 that might be named `_IAnimal` instead of `IAnimal`.
 
+Finally, there are a few rare names that look like an `I` prefix, such as Identity and Access Management, more commonly refereed to as "IAM".
+For these rare names, the rule can be provided an array of names to allow, via the `allowedPrefixes` option.
+
 ## Options
 
 This rule has an object option:
 
-- `{ "prefixWithI": "never" }`: (default) disallows all interfaces being prefixed with `"I"` or `"_I"`
+- `{ "prefixWithI": "never", "allowedPrefixes": [] }`: (default) disallows all interfaces being prefixed with `"I"` or `"_I"`
 - `{ "prefixWithI": "always" }`: requires all interfaces be prefixed with `"I"` (but does not allow `"_I"`)
 - `{ "prefixWithI": "always", "allowUnderscorePrefix": true }`: requires all interfaces be prefixed with
   either `"I"` or `"_I"`
 
 For backwards compatibility, this rule supports a string option instead:
 
-- `"never"`: Equivalent to `{ "prefixWithI": "never" }`
+- `"never"`: Equivalent to `{ "prefixWithI": "never", "allowedPrefixes": [] }`
 - `"always"`: Equivalent to `{ "prefixWithI": "always" }`
 
 ## Examples
@@ -55,6 +58,34 @@ interface Animal {
 }
 
 interface Iguana {
+  name: string;
+}
+```
+
+### never and allowing names
+
+**Configuration:** `{ "prefixWithI": "never", "allowedPrefixes": ["IAM"] }`
+
+The following patterns are considered warnings:
+
+```ts
+interface IAnimal {
+  name: string;
+}
+
+interface IPMUser {
+  name: string;
+}
+```
+
+The following patterns are not warnings:
+
+```ts
+interface Animal {
+  name: string;
+}
+
+interface IAMUser {
   name: string;
 }
 ```

--- a/packages/eslint-plugin/tests/rules/interface-name-prefix.test.ts
+++ b/packages/eslint-plugin/tests/rules/interface-name-prefix.test.ts
@@ -1,26 +1,41 @@
-import assert from 'assert';
 import rule, { parseOptions } from '../../src/rules/interface-name-prefix';
 import { RuleTester } from '../RuleTester';
 
 describe('interface-name-prefix', () => {
   it('parseOptions', () => {
-    assert.deepEqual(parseOptions(['never']), { prefixWithI: 'never' });
-    assert.deepEqual(parseOptions(['always']), {
-      prefixWithI: 'always',
-      allowUnderscorePrefix: false,
-    });
-    assert.deepEqual(parseOptions([{}]), { prefixWithI: 'never' });
-    assert.deepEqual(parseOptions([{ prefixWithI: 'never' }]), {
+    expect(parseOptions(['never'])).toStrictEqual({
       prefixWithI: 'never',
+      allowedPrefixes: [],
     });
-    assert.deepEqual(parseOptions([{ prefixWithI: 'always' }]), {
+    expect(parseOptions(['always'])).toStrictEqual({
       prefixWithI: 'always',
       allowUnderscorePrefix: false,
     });
-    assert.deepEqual(
+    expect(parseOptions([{}])).toStrictEqual({
+      prefixWithI: 'never',
+      allowedPrefixes: [],
+    });
+    expect(parseOptions([{ prefixWithI: 'never' }])).toStrictEqual({
+      prefixWithI: 'never',
+      allowedPrefixes: [],
+    });
+    expect(parseOptions([{ allowedPrefixes: ['IAM'] }])).toStrictEqual({
+      prefixWithI: 'never',
+      allowedPrefixes: ['IAM'],
+    });
+    expect(
+      parseOptions([{ prefixWithI: 'never', allowedPrefixes: [] }]),
+    ).toStrictEqual({
+      prefixWithI: 'never',
+      allowedPrefixes: [],
+    });
+    expect(parseOptions([{ prefixWithI: 'always' }])).toStrictEqual({
+      prefixWithI: 'always',
+      allowUnderscorePrefix: false,
+    });
+    expect(
       parseOptions([{ prefixWithI: 'always', allowUnderscorePrefix: true }]),
-      { prefixWithI: 'always', allowUnderscorePrefix: true },
-    );
+    ).toStrictEqual({ prefixWithI: 'always', allowUnderscorePrefix: true });
   });
 });
 
@@ -83,6 +98,14 @@ interface I18n {
             `,
       options: ['never'],
     },
+    {
+      code: `
+interface IAMUser {
+    name: string;
+}
+            `,
+      options: [{ allowedPrefixes: ['IAM'] }],
+    },
   ],
   invalid: [
     {
@@ -91,6 +114,21 @@ interface IAnimal {
     name: string;
 }
             `,
+      errors: [
+        {
+          messageId: 'noPrefix',
+          line: 2,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `
+interface IAMUser {
+    name: string;
+}
+            `,
+      options: [{ allowedPrefixes: ['IPM'] }],
       errors: [
         {
           messageId: 'noPrefix',


### PR DESCRIPTION
I hit this when working on my Terraform generator/parser/importer, where I have interfaces called `IAM`.

I've added `IAM` as the default value, but can remove that - it's the only real exception I could think of that made sense, but there could be more.

Also happy to not make it an option and just hardcode it instead 🤷‍♂ 