### PR TITLE
fix(eslint-plugin): set default-param-last as an extension rule

### DIFF
--- a/packages/eslint-plugin/src/configs/all.json
+++ b/packages/eslint-plugin/src/configs/all.json
@@ -10,6 +10,7 @@
     "@typescript-eslint/brace-style": "error",
     "@typescript-eslint/consistent-type-assertions": "error",
     "@typescript-eslint/consistent-type-definitions": "error",
+    "default-param-last": "off",
     "@typescript-eslint/default-param-last": "error",
     "@typescript-eslint/explicit-function-return-type": "error",
     "@typescript-eslint/explicit-member-accessibility": "error",

--- a/packages/eslint-plugin/tools/generate-configs.ts
+++ b/packages/eslint-plugin/tools/generate-configs.ts
@@ -24,6 +24,7 @@ const DEFAULT_RULE_SETTING = 'warn';
 const BASE_RULES_TO_BE_OVERRIDDEN = new Set([
   'brace-style',
   'camelcase',
+  'default-param-last',
   'func-call-spacing',
   'indent',
   'no-array-constructor',


### PR DESCRIPTION
Forgot to list the rule as an extension rule