### PR TITLE
fix(eslint-plugin): naming-convention null pattern

### DIFF
--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -688,7 +688,9 @@ function getIdentifiersFromPattern(
 
     case AST_NODE_TYPES.ArrayPattern:
       pattern.elements.forEach(element => {
-        getIdentifiersFromPattern(element, identifiers);
+        if (element !== null) {
+          getIdentifiersFromPattern(element, identifiers);
+        }
       });
       break;
 

--- a/packages/eslint-plugin/tests/rules/naming-convention.test.ts
+++ b/packages/eslint-plugin/tests/rules/naming-convention.test.ts
@@ -684,6 +684,18 @@ ruleTester.run('naming-convention', rule, {
         },
       ],
     },
+    {
+      code: `
+        const match = 'test'.match(/test/);
+        const [, key, value] = match;
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['camelCase'],
+        },
+      ],
+    },
   ],
   invalid: [
     ...createInvalidTestCases(cases),


### PR DESCRIPTION
I just switched over to the new `naming-convention` rule (which is pretty awesome), I was getting an exception `TypeError: Cannot read property 'type' of null`, here is a quick repo:

```ts
const match = 'test'.match(/test/);
const [, key, value] = match;
```

With the minimum configuration of
```js
{
  selector: 'default',
  format: ['camelCase'],
}
```

This is the case because the `AST_NODE_TYPES.ArrayPattern` was returning an array of elements in which the first element is `null`, then, when we recursively step back into `getIdentifiersFromPattern`, we're immediately evaluating `null.type`. 

The solution I'm proposing is just filtering out those `null` elements in the loop prior to recursion. I added a regression test as well.

Thank you!