### PR TITLE
fix(typescript-estree): correct type of `ArrayPattern.elements`

### DIFF
--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
@@ -578,7 +578,7 @@ export default createRule<Options, MessageIds>({
      * @param offset The amount that the elements should be offset
      */
     function addElementListIndent(
-      elements: TSESTree.Node[],
+      elements: (TSESTree.Node | null)[],
       startToken: TSESTree.Token,
       endToken: TSESTree.Token,
       offset: number | string,
@@ -606,7 +606,8 @@ export default createRule<Options, MessageIds>({
       offsets.setDesiredOffset(endToken, startToken, 0);
 
       // If the preference is "first" but there is no first element (e.g. sparse arrays w/ empty first slot), fall back to 1 level.
-      if (offset === 'first' && elements.length && !elements[0]) {
+      const firstElement = elements[0];
+      if (offset === 'first' && elements.length && !firstElement) {
         return;
       }
       elements.forEach((element, index) => {
@@ -628,7 +629,7 @@ export default createRule<Options, MessageIds>({
           tokenInfo.isFirstTokenOfLine(getFirstToken(element))
         ) {
           offsets.matchOffsetOf(
-            getFirstToken(elements[0]),
+            getFirstToken(firstElement!),
             getFirstToken(element),
           );
         } else {
@@ -640,6 +641,7 @@ export default createRule<Options, MessageIds>({
 
           if (
             previousElement &&
+            previousElementLastToken &&
             previousElementLastToken.loc.end.line -
               countTrailingLinebreaks(previousElementLastToken.value) >
               startToken.loc.end.line
@@ -854,7 +856,7 @@ export default createRule<Options, MessageIds>({
       ) {
         const openingBracket = sourceCode.getFirstToken(node)!;
         const closingBracket = sourceCode.getTokenAfter(
-          node.elements[node.elements.length - 1] || openingBracket,
+          node.elements[node.elements.length - 1] ?? openingBracket,
           isClosingBracketToken,
         )!;
 

--- a/packages/typescript-estree/src/ts-estree/ts-estree.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-estree.ts
@@ -681,7 +681,7 @@ export interface ArrayExpression extends BaseNode {
 
 export interface ArrayPattern extends BaseNode {
   type: AST_NODE_TYPES.ArrayPattern;
-  elements: DestructuringPattern[];
+  elements: (DestructuringPattern | null)[];
   typeAnnotation?: TSTypeAnnotation;
   optional?: boolean;
   decorators?: Decorator[];


### PR DESCRIPTION
#1450 pointed out that the type is incorrect. The parser assigns `null` if the element in the pattern is empty, but the types were non-nullable.