### PR TITLE
docs(eslint-plugin): fix examples of default-param-last rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/default-param-last.md
+++ b/packages/eslint-plugin/docs/rules/default-param-last.md
@@ -10,7 +10,6 @@ Examples of **incorrect** code for this rule:
 /* eslint @typescript-eslint/default-param-last: ["error"] */
 
 function f(a = 0, b: number) {}
-function f(a: number, b = 0, c?: number) {}
 function f(a: number, b = 0, c: number) {}
 function f(a: number, b?: number, c: number) {}
 ```
@@ -24,6 +23,7 @@ function f(a = 0) {}
 function f(a: number, b = 0) {}
 function f(a: number, b?: number) {}
 function f(a: number, b?: number, c = 0) {}
+function f(a: number, b = 0, c?: number) {}
 ```
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/default-param-last.md)</sup>


### PR DESCRIPTION
ref: #1407 #1418 

The following code is a correct example.

``` typescript
function f(a: number, b = 0, c?: number) {}
```

