### PR TITLE
docs(eslint-plugin): correct `naming-convention` example

### DIFF
--- a/packages/eslint-plugin/docs/rules/naming-convention.md
+++ b/packages/eslint-plugin/docs/rules/naming-convention.md
@@ -250,7 +250,7 @@ Group Selectors are provided for convenience, and essentially bundle up sets of 
     "error",
     {
       "selector": "memberLike",
-      "modifier": ["private"],
+      "modifiers": ["private"],
       "format": ["camelCase"],
       "leadingUnderscore": "require"
     }


### PR DESCRIPTION
Fixes #1474