### PR TITLE
fix(typescript-estree): fix identifier tokens typed as `Keyword`

### DIFF
--- a/packages/parser/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/parser/tests/lib/__snapshots__/typescript.ts.snap
@@ -20267,31 +20267,31 @@ Object {
 
 exports[`typescript fixtures/basics/keyword-variables.src 1`] = `
 Object {
-  "$id": 23,
+  "$id": 108,
   "block": Object {
     "range": Array [
       0,
-      212,
+      1078,
     ],
     "type": "Program",
   },
   "childScopes": Array [
     Object {
-      "$id": 22,
+      "$id": 107,
       "block": Object {
         "range": Array [
           0,
-          212,
+          1078,
         ],
         "type": "Program",
       },
       "childScopes": Array [
         Object {
-          "$id": 21,
+          "$id": 94,
           "block": Object {
             "range": Array [
               0,
-              126,
+              613,
             ],
             "type": "BlockStatement",
           },
@@ -20300,176 +20300,776 @@ Object {
           "isStrict": true,
           "references": Array [
             Object {
-              "$id": 14,
+              "$id": 63,
               "from": Object {
-                "$ref": 21,
+                "$ref": 94,
               },
               "identifier": Object {
-                "name": "get",
+                "name": "abstract",
                 "range": Array [
                   10,
-                  13,
+                  18,
                 ],
                 "type": "Identifier",
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 7,
+                "$ref": 32,
               },
               "writeExpr": Object {
                 "range": Array [
-                  16,
-                  17,
+                  21,
+                  22,
                 ],
                 "type": "Literal",
               },
             },
             Object {
-              "$id": 15,
+              "$id": 64,
               "from": Object {
-                "$ref": 21,
+                "$ref": 94,
               },
               "identifier": Object {
-                "name": "set",
+                "name": "as",
                 "range": Array [
-                  27,
-                  30,
-                ],
-                "type": "Identifier",
-              },
-              "kind": "w",
-              "resolved": Object {
-                "$ref": 8,
-              },
-              "writeExpr": Object {
-                "range": Array [
-                  33,
+                  32,
                   34,
                 ],
-                "type": "Literal",
-              },
-            },
-            Object {
-              "$id": 16,
-              "from": Object {
-                "$ref": 21,
-              },
-              "identifier": Object {
-                "name": "module",
-                "range": Array [
-                  44,
-                  50,
-                ],
                 "type": "Identifier",
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 9,
+                "$ref": 33,
               },
               "writeExpr": Object {
                 "range": Array [
-                  53,
-                  54,
+                  37,
+                  38,
                 ],
                 "type": "Literal",
               },
             },
             Object {
-              "$id": 17,
+              "$id": 65,
               "from": Object {
-                "$ref": 21,
+                "$ref": 94,
               },
               "identifier": Object {
-                "name": "type",
+                "name": "asserts",
                 "range": Array [
-                  64,
-                  68,
+                  48,
+                  55,
                 ],
                 "type": "Identifier",
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 10,
+                "$ref": 34,
               },
               "writeExpr": Object {
                 "range": Array [
-                  71,
+                  58,
+                  59,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 66,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "any",
+                "range": Array [
+                  69,
                   72,
                 ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 35,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  75,
+                  76,
+                ],
                 "type": "Literal",
               },
             },
             Object {
-              "$id": 18,
+              "$id": 67,
               "from": Object {
-                "$ref": 21,
+                "$ref": 94,
               },
               "identifier": Object {
                 "name": "async",
                 "range": Array [
-                  82,
-                  87,
+                  86,
+                  91,
                 ],
                 "type": "Identifier",
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 11,
+                "$ref": 36,
               },
               "writeExpr": Object {
                 "range": Array [
-                  90,
-                  91,
+                  94,
+                  95,
                 ],
                 "type": "Literal",
               },
             },
             Object {
-              "$id": 19,
+              "$id": 68,
               "from": Object {
-                "$ref": 21,
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "await",
+                "range": Array [
+                  105,
+                  110,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 37,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  113,
+                  114,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 69,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "boolean",
+                "range": Array [
+                  124,
+                  131,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 38,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  134,
+                  135,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 70,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "constructor",
+                "range": Array [
+                  145,
+                  156,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 39,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  159,
+                  160,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 71,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "declare",
+                "range": Array [
+                  170,
+                  177,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 40,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  180,
+                  181,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 72,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "get",
+                "range": Array [
+                  191,
+                  194,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 41,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  197,
+                  198,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 73,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "infer",
+                "range": Array [
+                  208,
+                  213,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 42,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  216,
+                  217,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 74,
+              "from": Object {
+                "$ref": 94,
               },
               "identifier": Object {
                 "name": "is",
                 "range": Array [
-                  101,
-                  103,
+                  227,
+                  229,
                 ],
                 "type": "Identifier",
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 12,
+                "$ref": 43,
               },
               "writeExpr": Object {
                 "range": Array [
-                  106,
-                  107,
+                  232,
+                  233,
                 ],
                 "type": "Literal",
               },
             },
             Object {
-              "$id": 20,
+              "$id": 75,
               "from": Object {
-                "$ref": 21,
+                "$ref": 94,
               },
               "identifier": Object {
-                "name": "of",
+                "name": "keyof",
                 "range": Array [
-                  117,
-                  119,
+                  243,
+                  248,
                 ],
                 "type": "Identifier",
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 13,
+                "$ref": 44,
               },
               "writeExpr": Object {
                 "range": Array [
-                  122,
-                  123,
+                  251,
+                  252,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 76,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "module",
+                "range": Array [
+                  262,
+                  268,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 45,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  271,
+                  272,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 77,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "namespace",
+                "range": Array [
+                  282,
+                  291,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 46,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  294,
+                  295,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 78,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "never",
+                "range": Array [
+                  305,
+                  310,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 47,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  313,
+                  314,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 79,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "readonly",
+                "range": Array [
+                  324,
+                  332,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 48,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  335,
+                  336,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 80,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "require",
+                "range": Array [
+                  346,
+                  353,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 49,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  356,
+                  357,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 81,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "number",
+                "range": Array [
+                  367,
+                  373,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 50,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  376,
+                  377,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 82,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "object",
+                "range": Array [
+                  387,
+                  393,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 51,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  396,
+                  397,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 83,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "set",
+                "range": Array [
+                  407,
+                  410,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 52,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  413,
+                  414,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 84,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "string",
+                "range": Array [
+                  424,
+                  430,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 53,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  433,
+                  434,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 85,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "symbol",
+                "range": Array [
+                  444,
+                  450,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 54,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  453,
+                  454,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 86,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "type",
+                "range": Array [
+                  464,
+                  468,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 55,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  471,
+                  472,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 87,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "undefined",
+                "range": Array [
+                  482,
+                  491,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 56,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  494,
+                  495,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 88,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "unique",
+                "range": Array [
+                  505,
+                  511,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 57,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  514,
+                  515,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 89,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "unknown",
+                "range": Array [
+                  525,
+                  532,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 58,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  535,
+                  536,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 90,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "from",
+                "range": Array [
+                  546,
+                  550,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 59,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  553,
+                  554,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 91,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "global",
+                "range": Array [
+                  564,
+                  570,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 60,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  573,
+                  574,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 92,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "bigint",
+                "range": Array [
+                  584,
+                  590,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 61,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  593,
+                  594,
+                ],
+                "type": "Literal",
+              },
+            },
+            Object {
+              "$id": 93,
+              "from": Object {
+                "$ref": 94,
+              },
+              "identifier": Object {
+                "name": "of",
+                "range": Array [
+                  604,
+                  606,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 62,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  609,
+                  610,
                 ],
                 "type": "Literal",
               },
@@ -20478,58 +21078,130 @@ Object {
           "throughReferences": Array [],
           "type": "block",
           "upperScope": Object {
-            "$ref": 22,
+            "$ref": 107,
           },
           "variableMap": Object {
+            "abstract": Object {
+              "$ref": 32,
+            },
+            "any": Object {
+              "$ref": 35,
+            },
+            "as": Object {
+              "$ref": 33,
+            },
+            "asserts": Object {
+              "$ref": 34,
+            },
             "async": Object {
-              "$ref": 11,
+              "$ref": 36,
+            },
+            "await": Object {
+              "$ref": 37,
+            },
+            "bigint": Object {
+              "$ref": 61,
+            },
+            "boolean": Object {
+              "$ref": 38,
+            },
+            "constructor": Object {
+              "$ref": 39,
+            },
+            "declare": Object {
+              "$ref": 40,
+            },
+            "from": Object {
+              "$ref": 59,
             },
             "get": Object {
-              "$ref": 7,
+              "$ref": 41,
+            },
+            "global": Object {
+              "$ref": 60,
+            },
+            "infer": Object {
+              "$ref": 42,
             },
             "is": Object {
-              "$ref": 12,
+              "$ref": 43,
+            },
+            "keyof": Object {
+              "$ref": 44,
             },
             "module": Object {
-              "$ref": 9,
+              "$ref": 45,
+            },
+            "namespace": Object {
+              "$ref": 46,
+            },
+            "never": Object {
+              "$ref": 47,
+            },
+            "number": Object {
+              "$ref": 50,
+            },
+            "object": Object {
+              "$ref": 51,
             },
             "of": Object {
-              "$ref": 13,
+              "$ref": 62,
+            },
+            "readonly": Object {
+              "$ref": 48,
+            },
+            "require": Object {
+              "$ref": 49,
             },
             "set": Object {
-              "$ref": 8,
+              "$ref": 52,
+            },
+            "string": Object {
+              "$ref": 53,
+            },
+            "symbol": Object {
+              "$ref": 54,
             },
             "type": Object {
-              "$ref": 10,
+              "$ref": 55,
+            },
+            "undefined": Object {
+              "$ref": 56,
+            },
+            "unique": Object {
+              "$ref": 57,
+            },
+            "unknown": Object {
+              "$ref": 58,
             },
           },
           "variableScope": Object {
-            "$ref": 22,
+            "$ref": 107,
           },
           "variables": Array [
             Object {
-              "$id": 7,
+              "$id": 32,
               "defs": Array [
                 Object {
                   "name": Object {
-                    "name": "get",
+                    "name": "abstract",
                     "range": Array [
                       10,
-                      13,
+                      18,
                     ],
                     "type": "Identifier",
                   },
                   "node": Object {
                     "range": Array [
                       10,
-                      17,
+                      22,
                     ],
                     "type": "VariableDeclarator",
                   },
                   "parent": Object {
                     "range": Array [
                       4,
-                      18,
+                      23,
                     ],
                     "type": "VariableDeclaration",
                   },
@@ -20539,47 +21211,47 @@ Object {
               "eslintUsed": undefined,
               "identifiers": Array [
                 Object {
-                  "name": "get",
+                  "name": "abstract",
                   "range": Array [
                     10,
-                    13,
+                    18,
                   ],
                   "type": "Identifier",
                 },
               ],
-              "name": "get",
+              "name": "abstract",
               "references": Array [
                 Object {
-                  "$ref": 14,
+                  "$ref": 63,
                 },
               ],
               "scope": Object {
-                "$ref": 21,
+                "$ref": 94,
               },
             },
             Object {
-              "$id": 8,
+              "$id": 33,
               "defs": Array [
                 Object {
                   "name": Object {
-                    "name": "set",
+                    "name": "as",
                     "range": Array [
-                      27,
-                      30,
-                    ],
-                    "type": "Identifier",
-                  },
-                  "node": Object {
-                    "range": Array [
-                      27,
+                      32,
                       34,
                     ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      32,
+                      38,
+                    ],
                     "type": "VariableDeclarator",
                   },
                   "parent": Object {
                     "range": Array [
-                      21,
-                      35,
+                      26,
+                      39,
                     ],
                     "type": "VariableDeclaration",
                   },
@@ -20589,97 +21261,47 @@ Object {
               "eslintUsed": undefined,
               "identifiers": Array [
                 Object {
-                  "name": "set",
+                  "name": "as",
                   "range": Array [
-                    27,
-                    30,
+                    32,
+                    34,
                   ],
                   "type": "Identifier",
                 },
               ],
-              "name": "set",
+              "name": "as",
               "references": Array [
                 Object {
-                  "$ref": 15,
+                  "$ref": 64,
                 },
               ],
               "scope": Object {
-                "$ref": 21,
+                "$ref": 94,
               },
             },
             Object {
-              "$id": 9,
+              "$id": 34,
               "defs": Array [
                 Object {
                   "name": Object {
-                    "name": "module",
+                    "name": "asserts",
                     "range": Array [
-                      44,
-                      50,
-                    ],
-                    "type": "Identifier",
-                  },
-                  "node": Object {
-                    "range": Array [
-                      44,
-                      54,
-                    ],
-                    "type": "VariableDeclarator",
-                  },
-                  "parent": Object {
-                    "range": Array [
-                      38,
+                      48,
                       55,
                     ],
-                    "type": "VariableDeclaration",
-                  },
-                  "type": "Variable",
-                },
-              ],
-              "eslintUsed": undefined,
-              "identifiers": Array [
-                Object {
-                  "name": "module",
-                  "range": Array [
-                    44,
-                    50,
-                  ],
-                  "type": "Identifier",
-                },
-              ],
-              "name": "module",
-              "references": Array [
-                Object {
-                  "$ref": 16,
-                },
-              ],
-              "scope": Object {
-                "$ref": 21,
-              },
-            },
-            Object {
-              "$id": 10,
-              "defs": Array [
-                Object {
-                  "name": Object {
-                    "name": "type",
-                    "range": Array [
-                      64,
-                      68,
-                    ],
                     "type": "Identifier",
                   },
                   "node": Object {
                     "range": Array [
-                      64,
-                      72,
+                      48,
+                      59,
                     ],
                     "type": "VariableDeclarator",
                   },
                   "parent": Object {
                     "range": Array [
-                      58,
-                      73,
+                      42,
+                      60,
                     ],
                     "type": "VariableDeclaration",
                   },
@@ -20689,47 +21311,97 @@ Object {
               "eslintUsed": undefined,
               "identifiers": Array [
                 Object {
-                  "name": "type",
+                  "name": "asserts",
                   "range": Array [
-                    64,
-                    68,
+                    48,
+                    55,
                   ],
                   "type": "Identifier",
                 },
               ],
-              "name": "type",
+              "name": "asserts",
               "references": Array [
                 Object {
-                  "$ref": 17,
+                  "$ref": 65,
                 },
               ],
               "scope": Object {
-                "$ref": 21,
+                "$ref": 94,
               },
             },
             Object {
-              "$id": 11,
+              "$id": 35,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "any",
+                    "range": Array [
+                      69,
+                      72,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      69,
+                      76,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      63,
+                      77,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "any",
+                  "range": Array [
+                    69,
+                    72,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "any",
+              "references": Array [
+                Object {
+                  "$ref": 66,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 36,
               "defs": Array [
                 Object {
                   "name": Object {
                     "name": "async",
                     "range": Array [
-                      82,
-                      87,
+                      86,
+                      91,
                     ],
                     "type": "Identifier",
                   },
                   "node": Object {
                     "range": Array [
-                      82,
-                      91,
+                      86,
+                      95,
                     ],
                     "type": "VariableDeclarator",
                   },
                   "parent": Object {
                     "range": Array [
-                      76,
-                      92,
+                      80,
+                      96,
                     ],
                     "type": "VariableDeclaration",
                   },
@@ -20741,8 +21413,8 @@ Object {
                 Object {
                   "name": "async",
                   "range": Array [
-                    82,
-                    87,
+                    86,
+                    91,
                   ],
                   "type": "Identifier",
                 },
@@ -20750,36 +21422,336 @@ Object {
               "name": "async",
               "references": Array [
                 Object {
-                  "$ref": 18,
+                  "$ref": 67,
                 },
               ],
               "scope": Object {
-                "$ref": 21,
+                "$ref": 94,
               },
             },
             Object {
-              "$id": 12,
+              "$id": 37,
               "defs": Array [
                 Object {
                   "name": Object {
-                    "name": "is",
+                    "name": "await",
                     "range": Array [
-                      101,
-                      103,
+                      105,
+                      110,
                     ],
                     "type": "Identifier",
                   },
                   "node": Object {
                     "range": Array [
-                      101,
-                      107,
+                      105,
+                      114,
                     ],
                     "type": "VariableDeclarator",
                   },
                   "parent": Object {
                     "range": Array [
-                      95,
-                      108,
+                      99,
+                      115,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "await",
+                  "range": Array [
+                    105,
+                    110,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "await",
+              "references": Array [
+                Object {
+                  "$ref": 68,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 38,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "boolean",
+                    "range": Array [
+                      124,
+                      131,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      124,
+                      135,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      118,
+                      136,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "boolean",
+                  "range": Array [
+                    124,
+                    131,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "boolean",
+              "references": Array [
+                Object {
+                  "$ref": 69,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 39,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "constructor",
+                    "range": Array [
+                      145,
+                      156,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      145,
+                      160,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      139,
+                      161,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "constructor",
+                  "range": Array [
+                    145,
+                    156,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "constructor",
+              "references": Array [
+                Object {
+                  "$ref": 70,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 40,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "declare",
+                    "range": Array [
+                      170,
+                      177,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      170,
+                      181,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      164,
+                      182,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "declare",
+                  "range": Array [
+                    170,
+                    177,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "declare",
+              "references": Array [
+                Object {
+                  "$ref": 71,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 41,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "get",
+                    "range": Array [
+                      191,
+                      194,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      191,
+                      198,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      185,
+                      199,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "get",
+                  "range": Array [
+                    191,
+                    194,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "get",
+              "references": Array [
+                Object {
+                  "$ref": 72,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 42,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "infer",
+                    "range": Array [
+                      208,
+                      213,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      208,
+                      217,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      202,
+                      218,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "infer",
+                  "range": Array [
+                    208,
+                    213,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "infer",
+              "references": Array [
+                Object {
+                  "$ref": 73,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 43,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "is",
+                    "range": Array [
+                      227,
+                      229,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      227,
+                      233,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      221,
+                      234,
                     ],
                     "type": "VariableDeclaration",
                   },
@@ -20791,8 +21763,8 @@ Object {
                 Object {
                   "name": "is",
                   "range": Array [
-                    101,
-                    103,
+                    227,
+                    229,
                   ],
                   "type": "Identifier",
                 },
@@ -20800,36 +21772,936 @@ Object {
               "name": "is",
               "references": Array [
                 Object {
-                  "$ref": 19,
+                  "$ref": 74,
                 },
               ],
               "scope": Object {
-                "$ref": 21,
+                "$ref": 94,
               },
             },
             Object {
-              "$id": 13,
+              "$id": 44,
               "defs": Array [
                 Object {
                   "name": Object {
-                    "name": "of",
+                    "name": "keyof",
                     "range": Array [
-                      117,
-                      119,
+                      243,
+                      248,
                     ],
                     "type": "Identifier",
                   },
                   "node": Object {
                     "range": Array [
-                      117,
-                      123,
+                      243,
+                      252,
                     ],
                     "type": "VariableDeclarator",
                   },
                   "parent": Object {
                     "range": Array [
-                      111,
-                      124,
+                      237,
+                      253,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "keyof",
+                  "range": Array [
+                    243,
+                    248,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "keyof",
+              "references": Array [
+                Object {
+                  "$ref": 75,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 45,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "module",
+                    "range": Array [
+                      262,
+                      268,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      262,
+                      272,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      256,
+                      273,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "module",
+                  "range": Array [
+                    262,
+                    268,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "module",
+              "references": Array [
+                Object {
+                  "$ref": 76,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 46,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "namespace",
+                    "range": Array [
+                      282,
+                      291,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      282,
+                      295,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      276,
+                      296,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "namespace",
+                  "range": Array [
+                    282,
+                    291,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "namespace",
+              "references": Array [
+                Object {
+                  "$ref": 77,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 47,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "never",
+                    "range": Array [
+                      305,
+                      310,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      305,
+                      314,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      299,
+                      315,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "never",
+                  "range": Array [
+                    305,
+                    310,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "never",
+              "references": Array [
+                Object {
+                  "$ref": 78,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 48,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "readonly",
+                    "range": Array [
+                      324,
+                      332,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      324,
+                      336,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      318,
+                      337,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "readonly",
+                  "range": Array [
+                    324,
+                    332,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "readonly",
+              "references": Array [
+                Object {
+                  "$ref": 79,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 49,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "require",
+                    "range": Array [
+                      346,
+                      353,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      346,
+                      357,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      340,
+                      358,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "require",
+                  "range": Array [
+                    346,
+                    353,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "require",
+              "references": Array [
+                Object {
+                  "$ref": 80,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 50,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "number",
+                    "range": Array [
+                      367,
+                      373,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      367,
+                      377,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      361,
+                      378,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "number",
+                  "range": Array [
+                    367,
+                    373,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "number",
+              "references": Array [
+                Object {
+                  "$ref": 81,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 51,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "object",
+                    "range": Array [
+                      387,
+                      393,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      387,
+                      397,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      381,
+                      398,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "object",
+                  "range": Array [
+                    387,
+                    393,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "object",
+              "references": Array [
+                Object {
+                  "$ref": 82,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 52,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "set",
+                    "range": Array [
+                      407,
+                      410,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      407,
+                      414,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      401,
+                      415,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "set",
+                  "range": Array [
+                    407,
+                    410,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "set",
+              "references": Array [
+                Object {
+                  "$ref": 83,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 53,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "string",
+                    "range": Array [
+                      424,
+                      430,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      424,
+                      434,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      418,
+                      435,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "string",
+                  "range": Array [
+                    424,
+                    430,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "string",
+              "references": Array [
+                Object {
+                  "$ref": 84,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 54,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "symbol",
+                    "range": Array [
+                      444,
+                      450,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      444,
+                      454,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      438,
+                      455,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "symbol",
+                  "range": Array [
+                    444,
+                    450,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "symbol",
+              "references": Array [
+                Object {
+                  "$ref": 85,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 55,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "type",
+                    "range": Array [
+                      464,
+                      468,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      464,
+                      472,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      458,
+                      473,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "type",
+                  "range": Array [
+                    464,
+                    468,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "type",
+              "references": Array [
+                Object {
+                  "$ref": 86,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 56,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "undefined",
+                    "range": Array [
+                      482,
+                      491,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      482,
+                      495,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      476,
+                      496,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "undefined",
+                  "range": Array [
+                    482,
+                    491,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "undefined",
+              "references": Array [
+                Object {
+                  "$ref": 87,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 57,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "unique",
+                    "range": Array [
+                      505,
+                      511,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      505,
+                      515,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      499,
+                      516,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "unique",
+                  "range": Array [
+                    505,
+                    511,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "unique",
+              "references": Array [
+                Object {
+                  "$ref": 88,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 58,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "unknown",
+                    "range": Array [
+                      525,
+                      532,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      525,
+                      536,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      519,
+                      537,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "unknown",
+                  "range": Array [
+                    525,
+                    532,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "unknown",
+              "references": Array [
+                Object {
+                  "$ref": 89,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 59,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "from",
+                    "range": Array [
+                      546,
+                      550,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      546,
+                      554,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      540,
+                      555,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "from",
+                  "range": Array [
+                    546,
+                    550,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "from",
+              "references": Array [
+                Object {
+                  "$ref": 90,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 60,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "global",
+                    "range": Array [
+                      564,
+                      570,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      564,
+                      574,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      558,
+                      575,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "global",
+                  "range": Array [
+                    564,
+                    570,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "global",
+              "references": Array [
+                Object {
+                  "$ref": 91,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 61,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "bigint",
+                    "range": Array [
+                      584,
+                      590,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      584,
+                      594,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      578,
+                      595,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "bigint",
+                  "range": Array [
+                    584,
+                    590,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "bigint",
+              "references": Array [
+                Object {
+                  "$ref": 92,
+                },
+              ],
+              "scope": Object {
+                "$ref": 94,
+              },
+            },
+            Object {
+              "$id": 62,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "of",
+                    "range": Array [
+                      604,
+                      606,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      604,
+                      610,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      598,
+                      611,
                     ],
                     "type": "VariableDeclaration",
                   },
@@ -20841,8 +22713,8 @@ Object {
                 Object {
                   "name": "of",
                   "range": Array [
-                    117,
-                    119,
+                    604,
+                    606,
                   ],
                   "type": "Identifier",
                 },
@@ -20850,11 +22722,320 @@ Object {
               "name": "of",
               "references": Array [
                 Object {
-                  "$ref": 20,
+                  "$ref": 93,
                 },
               ],
               "scope": Object {
-                "$ref": 21,
+                "$ref": 94,
+              },
+            },
+          ],
+        },
+        Object {
+          "$id": 106,
+          "block": Object {
+            "range": Array [
+              962,
+              1077,
+            ],
+            "type": "ClassDeclaration",
+          },
+          "childScopes": Array [
+            Object {
+              "$id": 97,
+              "block": Object {
+                "range": Array [
+                  995,
+                  1000,
+                ],
+                "type": "FunctionExpression",
+              },
+              "childScopes": Array [],
+              "functionExpressionScope": false,
+              "isStrict": true,
+              "references": Array [],
+              "throughReferences": Array [],
+              "type": "function",
+              "upperScope": Object {
+                "$ref": 106,
+              },
+              "variableMap": Object {
+                "arguments": Object {
+                  "$ref": 96,
+                },
+              },
+              "variableScope": Object {
+                "$ref": 97,
+              },
+              "variables": Array [
+                Object {
+                  "$id": 96,
+                  "defs": Array [],
+                  "eslintUsed": undefined,
+                  "identifiers": Array [],
+                  "name": "arguments",
+                  "references": Array [],
+                  "scope": Object {
+                    "$ref": 97,
+                  },
+                },
+              ],
+            },
+            Object {
+              "$id": 99,
+              "block": Object {
+                "range": Array [
+                  1012,
+                  1017,
+                ],
+                "type": "FunctionExpression",
+              },
+              "childScopes": Array [],
+              "functionExpressionScope": false,
+              "isStrict": true,
+              "references": Array [],
+              "throughReferences": Array [],
+              "type": "function",
+              "upperScope": Object {
+                "$ref": 106,
+              },
+              "variableMap": Object {
+                "arguments": Object {
+                  "$ref": 98,
+                },
+              },
+              "variableScope": Object {
+                "$ref": 99,
+              },
+              "variables": Array [
+                Object {
+                  "$id": 98,
+                  "defs": Array [],
+                  "eslintUsed": undefined,
+                  "identifiers": Array [],
+                  "name": "arguments",
+                  "references": Array [],
+                  "scope": Object {
+                    "$ref": 99,
+                  },
+                },
+              ],
+            },
+            Object {
+              "$id": 101,
+              "block": Object {
+                "range": Array [
+                  1028,
+                  1033,
+                ],
+                "type": "FunctionExpression",
+              },
+              "childScopes": Array [],
+              "functionExpressionScope": false,
+              "isStrict": true,
+              "references": Array [],
+              "throughReferences": Array [],
+              "type": "function",
+              "upperScope": Object {
+                "$ref": 106,
+              },
+              "variableMap": Object {
+                "arguments": Object {
+                  "$ref": 100,
+                },
+              },
+              "variableScope": Object {
+                "$ref": 101,
+              },
+              "variables": Array [
+                Object {
+                  "$id": 100,
+                  "defs": Array [],
+                  "eslintUsed": undefined,
+                  "identifiers": Array [],
+                  "name": "arguments",
+                  "references": Array [],
+                  "scope": Object {
+                    "$ref": 101,
+                  },
+                },
+              ],
+            },
+            Object {
+              "$id": 105,
+              "block": Object {
+                "range": Array [
+                  1048,
+                  1075,
+                ],
+                "type": "FunctionExpression",
+              },
+              "childScopes": Array [],
+              "functionExpressionScope": false,
+              "isStrict": true,
+              "references": Array [
+                Object {
+                  "$id": 104,
+                  "from": Object {
+                    "$ref": 105,
+                  },
+                  "identifier": Object {
+                    "name": "x",
+                    "range": Array [
+                      1061,
+                      1062,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "kind": "w",
+                  "resolved": Object {
+                    "$ref": 103,
+                  },
+                  "writeExpr": Object {
+                    "range": Array [
+                      1065,
+                      1070,
+                    ],
+                    "type": "YieldExpression",
+                  },
+                },
+              ],
+              "throughReferences": Array [],
+              "type": "function",
+              "upperScope": Object {
+                "$ref": 106,
+              },
+              "variableMap": Object {
+                "arguments": Object {
+                  "$ref": 102,
+                },
+                "x": Object {
+                  "$ref": 103,
+                },
+              },
+              "variableScope": Object {
+                "$ref": 105,
+              },
+              "variables": Array [
+                Object {
+                  "$id": 102,
+                  "defs": Array [],
+                  "eslintUsed": undefined,
+                  "identifiers": Array [],
+                  "name": "arguments",
+                  "references": Array [],
+                  "scope": Object {
+                    "$ref": 105,
+                  },
+                },
+                Object {
+                  "$id": 103,
+                  "defs": Array [
+                    Object {
+                      "name": Object {
+                        "name": "x",
+                        "range": Array [
+                          1061,
+                          1062,
+                        ],
+                        "type": "Identifier",
+                      },
+                      "node": Object {
+                        "range": Array [
+                          1061,
+                          1070,
+                        ],
+                        "type": "VariableDeclarator",
+                      },
+                      "parent": Object {
+                        "range": Array [
+                          1057,
+                          1071,
+                        ],
+                        "type": "VariableDeclaration",
+                      },
+                      "type": "Variable",
+                    },
+                  ],
+                  "eslintUsed": undefined,
+                  "identifiers": Array [
+                    Object {
+                      "name": "x",
+                      "range": Array [
+                        1061,
+                        1062,
+                      ],
+                      "type": "Identifier",
+                    },
+                  ],
+                  "name": "x",
+                  "references": Array [
+                    Object {
+                      "$ref": 104,
+                    },
+                  ],
+                  "scope": Object {
+                    "$ref": 105,
+                  },
+                },
+              ],
+            },
+          ],
+          "functionExpressionScope": false,
+          "isStrict": true,
+          "references": Array [],
+          "throughReferences": Array [],
+          "type": "class",
+          "upperScope": Object {
+            "$ref": 107,
+          },
+          "variableMap": Object {
+            "C": Object {
+              "$ref": 95,
+            },
+          },
+          "variableScope": Object {
+            "$ref": 107,
+          },
+          "variables": Array [
+            Object {
+              "$id": 95,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "C",
+                    "range": Array [
+                      968,
+                      969,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      962,
+                      1077,
+                    ],
+                    "type": "ClassDeclaration",
+                  },
+                  "parent": undefined,
+                  "type": "ClassName",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "C",
+                  "range": Array [
+                    968,
+                    969,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "C",
+              "references": Array [],
+              "scope": Object {
+                "$ref": 106,
               },
             },
           ],
@@ -20866,33 +23047,108 @@ Object {
       "throughReferences": Array [],
       "type": "module",
       "upperScope": Object {
-        "$ref": 23,
+        "$ref": 108,
       },
       "variableMap": Object {
+        "C": Object {
+          "$ref": 31,
+        },
+        "abstract": Object {
+          "$ref": 0,
+        },
+        "any": Object {
+          "$ref": 3,
+        },
+        "as": Object {
+          "$ref": 1,
+        },
+        "asserts": Object {
+          "$ref": 2,
+        },
         "async": Object {
           "$ref": 4,
         },
-        "get": Object {
-          "$ref": 0,
-        },
-        "is": Object {
+        "await": Object {
           "$ref": 5,
         },
-        "module": Object {
-          "$ref": 2,
+        "bigint": Object {
+          "$ref": 29,
         },
-        "of": Object {
+        "boolean": Object {
           "$ref": 6,
         },
+        "constructor": Object {
+          "$ref": 7,
+        },
+        "declare": Object {
+          "$ref": 8,
+        },
+        "from": Object {
+          "$ref": 27,
+        },
+        "get": Object {
+          "$ref": 9,
+        },
+        "global": Object {
+          "$ref": 28,
+        },
+        "infer": Object {
+          "$ref": 10,
+        },
+        "is": Object {
+          "$ref": 11,
+        },
+        "keyof": Object {
+          "$ref": 12,
+        },
+        "module": Object {
+          "$ref": 13,
+        },
+        "namespace": Object {
+          "$ref": 14,
+        },
+        "never": Object {
+          "$ref": 15,
+        },
+        "number": Object {
+          "$ref": 18,
+        },
+        "object": Object {
+          "$ref": 19,
+        },
+        "of": Object {
+          "$ref": 30,
+        },
+        "readonly": Object {
+          "$ref": 16,
+        },
+        "require": Object {
+          "$ref": 17,
+        },
         "set": Object {
-          "$ref": 1,
+          "$ref": 20,
+        },
+        "string": Object {
+          "$ref": 21,
+        },
+        "symbol": Object {
+          "$ref": 22,
         },
         "type": Object {
-          "$ref": 3,
+          "$ref": 23,
+        },
+        "undefined": Object {
+          "$ref": 24,
+        },
+        "unique": Object {
+          "$ref": 25,
+        },
+        "unknown": Object {
+          "$ref": 26,
         },
       },
       "variableScope": Object {
-        "$ref": 22,
+        "$ref": 107,
       },
       "variables": Array [
         Object {
@@ -20900,24 +23156,24 @@ Object {
           "defs": Array [
             Object {
               "name": Object {
-                "name": "get",
+                "name": "abstract",
                 "range": Array [
-                  139,
-                  142,
+                  626,
+                  634,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  139,
-                  142,
+                  626,
+                  634,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  128,
-                  211,
+                  615,
+                  945,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -20927,18 +23183,18 @@ Object {
           "eslintUsed": undefined,
           "identifiers": Array [
             Object {
-              "name": "get",
+              "name": "abstract",
               "range": Array [
-                139,
-                142,
+                626,
+                634,
               ],
               "type": "Identifier",
             },
           ],
-          "name": "get",
+          "name": "abstract",
           "references": Array [],
           "scope": Object {
-            "$ref": 22,
+            "$ref": 107,
           },
         },
         Object {
@@ -20946,24 +23202,24 @@ Object {
           "defs": Array [
             Object {
               "name": Object {
-                "name": "set",
+                "name": "as",
                 "range": Array [
-                  146,
-                  149,
+                  638,
+                  640,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  146,
-                  149,
+                  638,
+                  640,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  128,
-                  211,
+                  615,
+                  945,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -20973,18 +23229,18 @@ Object {
           "eslintUsed": undefined,
           "identifiers": Array [
             Object {
-              "name": "set",
+              "name": "as",
               "range": Array [
-                146,
-                149,
+                638,
+                640,
               ],
               "type": "Identifier",
             },
           ],
-          "name": "set",
+          "name": "as",
           "references": Array [],
           "scope": Object {
-            "$ref": 22,
+            "$ref": 107,
           },
         },
         Object {
@@ -20992,24 +23248,24 @@ Object {
           "defs": Array [
             Object {
               "name": Object {
-                "name": "module",
+                "name": "asserts",
                 "range": Array [
-                  153,
-                  159,
+                  644,
+                  651,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  153,
-                  159,
+                  644,
+                  651,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  128,
-                  211,
+                  615,
+                  945,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -21019,18 +23275,18 @@ Object {
           "eslintUsed": undefined,
           "identifiers": Array [
             Object {
-              "name": "module",
+              "name": "asserts",
               "range": Array [
-                153,
-                159,
+                644,
+                651,
               ],
               "type": "Identifier",
             },
           ],
-          "name": "module",
+          "name": "asserts",
           "references": Array [],
           "scope": Object {
-            "$ref": 22,
+            "$ref": 107,
           },
         },
         Object {
@@ -21038,24 +23294,24 @@ Object {
           "defs": Array [
             Object {
               "name": Object {
-                "name": "type",
+                "name": "any",
                 "range": Array [
-                  163,
-                  167,
+                  655,
+                  658,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  163,
-                  167,
+                  655,
+                  658,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  128,
-                  211,
+                  615,
+                  945,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -21065,18 +23321,18 @@ Object {
           "eslintUsed": undefined,
           "identifiers": Array [
             Object {
-              "name": "type",
+              "name": "any",
               "range": Array [
-                163,
-                167,
+                655,
+                658,
               ],
               "type": "Identifier",
             },
           ],
-          "name": "type",
+          "name": "any",
           "references": Array [],
           "scope": Object {
-            "$ref": 22,
+            "$ref": 107,
           },
         },
         Object {
@@ -21086,22 +23342,22 @@ Object {
               "name": Object {
                 "name": "async",
                 "range": Array [
-                  171,
-                  176,
+                  662,
+                  667,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  171,
-                  176,
+                  662,
+                  667,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  128,
-                  211,
+                  615,
+                  945,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -21113,8 +23369,8 @@ Object {
             Object {
               "name": "async",
               "range": Array [
-                171,
-                176,
+                662,
+                667,
               ],
               "type": "Identifier",
             },
@@ -21122,7 +23378,7 @@ Object {
           "name": "async",
           "references": Array [],
           "scope": Object {
-            "$ref": 22,
+            "$ref": 107,
           },
         },
         Object {
@@ -21130,24 +23386,300 @@ Object {
           "defs": Array [
             Object {
               "name": Object {
-                "name": "is",
+                "name": "await",
                 "range": Array [
-                  180,
-                  182,
+                  671,
+                  676,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  180,
-                  182,
+                  671,
+                  676,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  128,
-                  211,
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "await",
+              "range": Array [
+                671,
+                676,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "await",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 6,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "boolean",
+                "range": Array [
+                  680,
+                  687,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  680,
+                  687,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "boolean",
+              "range": Array [
+                680,
+                687,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "boolean",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 7,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "constructor",
+                "range": Array [
+                  691,
+                  702,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  691,
+                  702,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "constructor",
+              "range": Array [
+                691,
+                702,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "constructor",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 8,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "declare",
+                "range": Array [
+                  706,
+                  713,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  706,
+                  713,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "declare",
+              "range": Array [
+                706,
+                713,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "declare",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 9,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "get",
+                "range": Array [
+                  717,
+                  720,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  717,
+                  720,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "get",
+              "range": Array [
+                717,
+                720,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "get",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 10,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "infer",
+                "range": Array [
+                  724,
+                  729,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  724,
+                  729,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "infer",
+              "range": Array [
+                724,
+                729,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "infer",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 11,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "is",
+                "range": Array [
+                  733,
+                  735,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  733,
+                  735,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -21159,8 +23691,8 @@ Object {
             Object {
               "name": "is",
               "range": Array [
-                180,
-                182,
+                733,
+                735,
               ],
               "type": "Identifier",
             },
@@ -21168,32 +23700,860 @@ Object {
           "name": "is",
           "references": Array [],
           "scope": Object {
-            "$ref": 22,
+            "$ref": 107,
           },
         },
         Object {
-          "$id": 6,
+          "$id": 12,
           "defs": Array [
             Object {
               "name": Object {
-                "name": "of",
+                "name": "keyof",
                 "range": Array [
-                  186,
-                  188,
+                  739,
+                  744,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  186,
-                  188,
+                  739,
+                  744,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  128,
-                  211,
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "keyof",
+              "range": Array [
+                739,
+                744,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "keyof",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 13,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "module",
+                "range": Array [
+                  748,
+                  754,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  748,
+                  754,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "module",
+              "range": Array [
+                748,
+                754,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "module",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 14,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "namespace",
+                "range": Array [
+                  758,
+                  767,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  758,
+                  767,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "namespace",
+              "range": Array [
+                758,
+                767,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "namespace",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 15,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "never",
+                "range": Array [
+                  771,
+                  776,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  771,
+                  776,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "never",
+              "range": Array [
+                771,
+                776,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "never",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 16,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "readonly",
+                "range": Array [
+                  780,
+                  788,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  780,
+                  788,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "readonly",
+              "range": Array [
+                780,
+                788,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "readonly",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 17,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "require",
+                "range": Array [
+                  792,
+                  799,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  792,
+                  799,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "require",
+              "range": Array [
+                792,
+                799,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "require",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 18,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "number",
+                "range": Array [
+                  803,
+                  809,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  803,
+                  809,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "number",
+              "range": Array [
+                803,
+                809,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "number",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 19,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "object",
+                "range": Array [
+                  813,
+                  819,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  813,
+                  819,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "object",
+              "range": Array [
+                813,
+                819,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "object",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 20,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "set",
+                "range": Array [
+                  823,
+                  826,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  823,
+                  826,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "set",
+              "range": Array [
+                823,
+                826,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "set",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 21,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "string",
+                "range": Array [
+                  830,
+                  836,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  830,
+                  836,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "string",
+              "range": Array [
+                830,
+                836,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "string",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 22,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "symbol",
+                "range": Array [
+                  840,
+                  846,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  840,
+                  846,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "symbol",
+              "range": Array [
+                840,
+                846,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "symbol",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 23,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "type",
+                "range": Array [
+                  850,
+                  854,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  850,
+                  854,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "type",
+              "range": Array [
+                850,
+                854,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "type",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 24,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "undefined",
+                "range": Array [
+                  858,
+                  867,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  858,
+                  867,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "undefined",
+              "range": Array [
+                858,
+                867,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "undefined",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 25,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "unique",
+                "range": Array [
+                  871,
+                  877,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  871,
+                  877,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "unique",
+              "range": Array [
+                871,
+                877,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "unique",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 26,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "unknown",
+                "range": Array [
+                  881,
+                  888,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  881,
+                  888,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "unknown",
+              "range": Array [
+                881,
+                888,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "unknown",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 27,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "from",
+                "range": Array [
+                  892,
+                  896,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  892,
+                  896,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "from",
+              "range": Array [
+                892,
+                896,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "from",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 28,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "global",
+                "range": Array [
+                  900,
+                  906,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  900,
+                  906,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "global",
+              "range": Array [
+                900,
+                906,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "global",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 29,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "bigint",
+                "range": Array [
+                  910,
+                  916,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  910,
+                  916,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "bigint",
+              "range": Array [
+                910,
+                916,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "bigint",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 30,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "of",
+                "range": Array [
+                  920,
+                  922,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  920,
+                  922,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  615,
+                  945,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -21205,8 +24565,8 @@ Object {
             Object {
               "name": "of",
               "range": Array [
-                186,
-                188,
+                920,
+                922,
               ],
               "type": "Identifier",
             },
@@ -21214,7 +24574,47 @@ Object {
           "name": "of",
           "references": Array [],
           "scope": Object {
-            "$ref": 22,
+            "$ref": 107,
+          },
+        },
+        Object {
+          "$id": 31,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "C",
+                "range": Array [
+                  968,
+                  969,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  962,
+                  1077,
+                ],
+                "type": "ClassDeclaration",
+              },
+              "parent": null,
+              "type": "ClassName",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "C",
+              "range": Array [
+                968,
+                969,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "C",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 107,
           },
         },
       ],
@@ -21228,7 +24628,7 @@ Object {
   "upperScope": null,
   "variableMap": Object {},
   "variableScope": Object {
-    "$ref": 23,
+    "$ref": 108,
   },
   "variables": Array [],
 }

--- a/packages/parser/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/parser/tests/lib/__snapshots__/typescript.ts.snap
@@ -20267,31 +20267,31 @@ Object {
 
 exports[`typescript fixtures/basics/keyword-variables.src 1`] = `
 Object {
-  "$id": 20,
+  "$id": 23,
   "block": Object {
     "range": Array [
       0,
-      190,
+      212,
     ],
     "type": "Program",
   },
   "childScopes": Array [
     Object {
-      "$id": 19,
+      "$id": 22,
       "block": Object {
         "range": Array [
           0,
-          190,
+          212,
         ],
         "type": "Program",
       },
       "childScopes": Array [
         Object {
-          "$id": 18,
+          "$id": 21,
           "block": Object {
             "range": Array [
               0,
-              110,
+              126,
             ],
             "type": "BlockStatement",
           },
@@ -20300,9 +20300,9 @@ Object {
           "isStrict": true,
           "references": Array [
             Object {
-              "$id": 12,
+              "$id": 14,
               "from": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "get",
@@ -20314,7 +20314,7 @@ Object {
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 6,
+                "$ref": 7,
               },
               "writeExpr": Object {
                 "range": Array [
@@ -20325,9 +20325,9 @@ Object {
               },
             },
             Object {
-              "$id": 13,
+              "$id": 15,
               "from": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "set",
@@ -20339,7 +20339,7 @@ Object {
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 7,
+                "$ref": 8,
               },
               "writeExpr": Object {
                 "range": Array [
@@ -20350,9 +20350,9 @@ Object {
               },
             },
             Object {
-              "$id": 14,
+              "$id": 16,
               "from": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "module",
@@ -20364,7 +20364,7 @@ Object {
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 8,
+                "$ref": 9,
               },
               "writeExpr": Object {
                 "range": Array [
@@ -20375,9 +20375,9 @@ Object {
               },
             },
             Object {
-              "$id": 15,
+              "$id": 17,
               "from": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "type",
@@ -20389,7 +20389,7 @@ Object {
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 9,
+                "$ref": 10,
               },
               "writeExpr": Object {
                 "range": Array [
@@ -20400,9 +20400,9 @@ Object {
               },
             },
             Object {
-              "$id": 16,
+              "$id": 18,
               "from": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "async",
@@ -20414,7 +20414,7 @@ Object {
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 10,
+                "$ref": 11,
               },
               "writeExpr": Object {
                 "range": Array [
@@ -20425,9 +20425,9 @@ Object {
               },
             },
             Object {
-              "$id": 17,
+              "$id": 19,
               "from": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
               "identifier": Object {
                 "name": "is",
@@ -20439,7 +20439,7 @@ Object {
               },
               "kind": "w",
               "resolved": Object {
-                "$ref": 11,
+                "$ref": 12,
               },
               "writeExpr": Object {
                 "range": Array [
@@ -20449,38 +20449,66 @@ Object {
                 "type": "Literal",
               },
             },
+            Object {
+              "$id": 20,
+              "from": Object {
+                "$ref": 21,
+              },
+              "identifier": Object {
+                "name": "of",
+                "range": Array [
+                  117,
+                  119,
+                ],
+                "type": "Identifier",
+              },
+              "kind": "w",
+              "resolved": Object {
+                "$ref": 13,
+              },
+              "writeExpr": Object {
+                "range": Array [
+                  122,
+                  123,
+                ],
+                "type": "Literal",
+              },
+            },
           ],
           "throughReferences": Array [],
           "type": "block",
           "upperScope": Object {
-            "$ref": 19,
+            "$ref": 22,
           },
           "variableMap": Object {
             "async": Object {
-              "$ref": 10,
-            },
-            "get": Object {
-              "$ref": 6,
-            },
-            "is": Object {
               "$ref": 11,
             },
-            "module": Object {
-              "$ref": 8,
-            },
-            "set": Object {
+            "get": Object {
               "$ref": 7,
             },
-            "type": Object {
+            "is": Object {
+              "$ref": 12,
+            },
+            "module": Object {
               "$ref": 9,
+            },
+            "of": Object {
+              "$ref": 13,
+            },
+            "set": Object {
+              "$ref": 8,
+            },
+            "type": Object {
+              "$ref": 10,
             },
           },
           "variableScope": Object {
-            "$ref": 19,
+            "$ref": 22,
           },
           "variables": Array [
             Object {
-              "$id": 6,
+              "$id": 7,
               "defs": Array [
                 Object {
                   "name": Object {
@@ -20522,15 +20550,15 @@ Object {
               "name": "get",
               "references": Array [
                 Object {
-                  "$ref": 12,
+                  "$ref": 14,
                 },
               ],
               "scope": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
             },
             Object {
-              "$id": 7,
+              "$id": 8,
               "defs": Array [
                 Object {
                   "name": Object {
@@ -20572,15 +20600,15 @@ Object {
               "name": "set",
               "references": Array [
                 Object {
-                  "$ref": 13,
+                  "$ref": 15,
                 },
               ],
               "scope": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
             },
             Object {
-              "$id": 8,
+              "$id": 9,
               "defs": Array [
                 Object {
                   "name": Object {
@@ -20622,15 +20650,15 @@ Object {
               "name": "module",
               "references": Array [
                 Object {
-                  "$ref": 14,
+                  "$ref": 16,
                 },
               ],
               "scope": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
             },
             Object {
-              "$id": 9,
+              "$id": 10,
               "defs": Array [
                 Object {
                   "name": Object {
@@ -20672,15 +20700,15 @@ Object {
               "name": "type",
               "references": Array [
                 Object {
-                  "$ref": 15,
+                  "$ref": 17,
                 },
               ],
               "scope": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
             },
             Object {
-              "$id": 10,
+              "$id": 11,
               "defs": Array [
                 Object {
                   "name": Object {
@@ -20722,15 +20750,15 @@ Object {
               "name": "async",
               "references": Array [
                 Object {
-                  "$ref": 16,
+                  "$ref": 18,
                 },
               ],
               "scope": Object {
-                "$ref": 18,
+                "$ref": 21,
               },
             },
             Object {
-              "$id": 11,
+              "$id": 12,
               "defs": Array [
                 Object {
                   "name": Object {
@@ -20772,11 +20800,61 @@ Object {
               "name": "is",
               "references": Array [
                 Object {
-                  "$ref": 17,
+                  "$ref": 19,
                 },
               ],
               "scope": Object {
-                "$ref": 18,
+                "$ref": 21,
+              },
+            },
+            Object {
+              "$id": 13,
+              "defs": Array [
+                Object {
+                  "name": Object {
+                    "name": "of",
+                    "range": Array [
+                      117,
+                      119,
+                    ],
+                    "type": "Identifier",
+                  },
+                  "node": Object {
+                    "range": Array [
+                      117,
+                      123,
+                    ],
+                    "type": "VariableDeclarator",
+                  },
+                  "parent": Object {
+                    "range": Array [
+                      111,
+                      124,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                  "type": "Variable",
+                },
+              ],
+              "eslintUsed": undefined,
+              "identifiers": Array [
+                Object {
+                  "name": "of",
+                  "range": Array [
+                    117,
+                    119,
+                  ],
+                  "type": "Identifier",
+                },
+              ],
+              "name": "of",
+              "references": Array [
+                Object {
+                  "$ref": 20,
+                },
+              ],
+              "scope": Object {
+                "$ref": 21,
               },
             },
           ],
@@ -20788,7 +20866,7 @@ Object {
       "throughReferences": Array [],
       "type": "module",
       "upperScope": Object {
-        "$ref": 20,
+        "$ref": 23,
       },
       "variableMap": Object {
         "async": Object {
@@ -20803,6 +20881,9 @@ Object {
         "module": Object {
           "$ref": 2,
         },
+        "of": Object {
+          "$ref": 6,
+        },
         "set": Object {
           "$ref": 1,
         },
@@ -20811,7 +20892,7 @@ Object {
         },
       },
       "variableScope": Object {
-        "$ref": 19,
+        "$ref": 22,
       },
       "variables": Array [
         Object {
@@ -20821,22 +20902,22 @@ Object {
               "name": Object {
                 "name": "get",
                 "range": Array [
-                  123,
-                  126,
+                  139,
+                  142,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  123,
-                  126,
+                  139,
+                  142,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  112,
-                  189,
+                  128,
+                  211,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -20848,8 +20929,8 @@ Object {
             Object {
               "name": "get",
               "range": Array [
-                123,
-                126,
+                139,
+                142,
               ],
               "type": "Identifier",
             },
@@ -20857,7 +20938,7 @@ Object {
           "name": "get",
           "references": Array [],
           "scope": Object {
-            "$ref": 19,
+            "$ref": 22,
           },
         },
         Object {
@@ -20867,22 +20948,22 @@ Object {
               "name": Object {
                 "name": "set",
                 "range": Array [
-                  130,
-                  133,
+                  146,
+                  149,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  130,
-                  133,
+                  146,
+                  149,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  112,
-                  189,
+                  128,
+                  211,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -20894,8 +20975,8 @@ Object {
             Object {
               "name": "set",
               "range": Array [
-                130,
-                133,
+                146,
+                149,
               ],
               "type": "Identifier",
             },
@@ -20903,7 +20984,7 @@ Object {
           "name": "set",
           "references": Array [],
           "scope": Object {
-            "$ref": 19,
+            "$ref": 22,
           },
         },
         Object {
@@ -20913,22 +20994,22 @@ Object {
               "name": Object {
                 "name": "module",
                 "range": Array [
-                  137,
-                  143,
+                  153,
+                  159,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  137,
-                  143,
+                  153,
+                  159,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  112,
-                  189,
+                  128,
+                  211,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -20940,8 +21021,8 @@ Object {
             Object {
               "name": "module",
               "range": Array [
-                137,
-                143,
+                153,
+                159,
               ],
               "type": "Identifier",
             },
@@ -20949,7 +21030,7 @@ Object {
           "name": "module",
           "references": Array [],
           "scope": Object {
-            "$ref": 19,
+            "$ref": 22,
           },
         },
         Object {
@@ -20959,22 +21040,22 @@ Object {
               "name": Object {
                 "name": "type",
                 "range": Array [
-                  147,
-                  151,
+                  163,
+                  167,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  147,
-                  151,
+                  163,
+                  167,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  112,
-                  189,
+                  128,
+                  211,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -20986,8 +21067,8 @@ Object {
             Object {
               "name": "type",
               "range": Array [
-                147,
-                151,
+                163,
+                167,
               ],
               "type": "Identifier",
             },
@@ -20995,7 +21076,7 @@ Object {
           "name": "type",
           "references": Array [],
           "scope": Object {
-            "$ref": 19,
+            "$ref": 22,
           },
         },
         Object {
@@ -21005,22 +21086,22 @@ Object {
               "name": Object {
                 "name": "async",
                 "range": Array [
-                  155,
-                  160,
+                  171,
+                  176,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  155,
-                  160,
+                  171,
+                  176,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  112,
-                  189,
+                  128,
+                  211,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -21032,8 +21113,8 @@ Object {
             Object {
               "name": "async",
               "range": Array [
-                155,
-                160,
+                171,
+                176,
               ],
               "type": "Identifier",
             },
@@ -21041,7 +21122,7 @@ Object {
           "name": "async",
           "references": Array [],
           "scope": Object {
-            "$ref": 19,
+            "$ref": 22,
           },
         },
         Object {
@@ -21051,22 +21132,22 @@ Object {
               "name": Object {
                 "name": "is",
                 "range": Array [
-                  164,
-                  166,
+                  180,
+                  182,
                 ],
                 "type": "Identifier",
               },
               "node": Object {
                 "range": Array [
-                  164,
-                  166,
+                  180,
+                  182,
                 ],
                 "type": "ImportSpecifier",
               },
               "parent": Object {
                 "range": Array [
-                  112,
-                  189,
+                  128,
+                  211,
                 ],
                 "type": "ImportDeclaration",
               },
@@ -21078,8 +21159,8 @@ Object {
             Object {
               "name": "is",
               "range": Array [
-                164,
-                166,
+                180,
+                182,
               ],
               "type": "Identifier",
             },
@@ -21087,7 +21168,53 @@ Object {
           "name": "is",
           "references": Array [],
           "scope": Object {
-            "$ref": 19,
+            "$ref": 22,
+          },
+        },
+        Object {
+          "$id": 6,
+          "defs": Array [
+            Object {
+              "name": Object {
+                "name": "of",
+                "range": Array [
+                  186,
+                  188,
+                ],
+                "type": "Identifier",
+              },
+              "node": Object {
+                "range": Array [
+                  186,
+                  188,
+                ],
+                "type": "ImportSpecifier",
+              },
+              "parent": Object {
+                "range": Array [
+                  128,
+                  211,
+                ],
+                "type": "ImportDeclaration",
+              },
+              "type": "ImportBinding",
+            },
+          ],
+          "eslintUsed": undefined,
+          "identifiers": Array [
+            Object {
+              "name": "of",
+              "range": Array [
+                186,
+                188,
+              ],
+              "type": "Identifier",
+            },
+          ],
+          "name": "of",
+          "references": Array [],
+          "scope": Object {
+            "$ref": 22,
           },
         },
       ],
@@ -21101,7 +21228,7 @@ Object {
   "upperScope": null,
   "variableMap": Object {},
   "variableScope": Object {
-    "$ref": 20,
+    "$ref": 23,
   },
   "variables": Array [],
 }

--- a/packages/shared-fixtures/fixtures/typescript/basics/keyword-variables.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/keyword-variables.src.ts
@@ -5,6 +5,7 @@
   const type = 1;
   const async = 1;
   const is = 1;
+  const of = 1;
 }
 
 import {
@@ -14,4 +15,5 @@ import {
   type,
   async,
   is,
+  of,
 } from 'fake-module';

--- a/packages/shared-fixtures/fixtures/typescript/basics/keyword-variables.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/keyword-variables.src.ts
@@ -1,19 +1,77 @@
 {
-  const get = 1;
-  const set = 1;
-  const module = 1;
-  const type = 1;
+  const abstract = 1;
+  const as = 1;
+  const asserts = 1;
+  const any = 1;
   const async = 1;
+  const await = 1;
+  const boolean = 1;
+  const constructor = 1;
+  const declare = 1;
+  const get = 1;
+  const infer = 1;
   const is = 1;
+  const keyof = 1;
+  const module = 1;
+  const namespace = 1;
+  const never = 1;
+  const readonly = 1;
+  const require = 1;
+  const number = 1;
+  const object = 1;
+  const set = 1;
+  const string = 1;
+  const symbol = 1;
+  const type = 1;
+  const undefined = 1;
+  const unique = 1;
+  const unknown = 1;
+  const from = 1;
+  const global = 1;
+  const bigint = 1;
   const of = 1;
 }
 
 import {
-  get,
-  set,
-  module,
-  type,
+  abstract,
+  as,
+  asserts,
+  any,
   async,
+  await,
+  boolean,
+  constructor,
+  declare,
+  get,
+  infer,
   is,
+  keyof,
+  module,
+  namespace,
+  never,
+  readonly,
+  require,
+  number,
+  object,
+  set,
+  string,
+  symbol,
+  type,
+  undefined,
+  unique,
+  unknown,
+  from,
+  global,
+  bigint,
   of,
 } from 'fake-module';
+
+interface X {}
+class C implements X {
+  static a() {}
+  private b() {}
+  public c() {}
+  protected *d() {
+    let x = yield;
+  }
+}

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -468,6 +468,7 @@ export function getTokenType(
       case SyntaxKind.ModuleKeyword:
       case SyntaxKind.AsyncKeyword:
       case SyntaxKind.IsKeyword:
+      case SyntaxKind.OfKeyword:
         return AST_TOKEN_TYPES.Identifier;
 
       default:

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -456,24 +456,16 @@ export function isOptional(node: {
 export function getTokenType(
   token: ts.Identifier | ts.Token<ts.SyntaxKind>,
 ): AST_TOKEN_TYPES {
-  // Need two checks for keywords since some are also identifiers
   if ('originalKeywordKind' in token && token.originalKeywordKind) {
-    switch (token.originalKeywordKind) {
-      case SyntaxKind.NullKeyword:
-        return AST_TOKEN_TYPES.Null;
-
-      case SyntaxKind.GetKeyword:
-      case SyntaxKind.SetKeyword:
-      case SyntaxKind.TypeKeyword:
-      case SyntaxKind.ModuleKeyword:
-      case SyntaxKind.AsyncKeyword:
-      case SyntaxKind.IsKeyword:
-      case SyntaxKind.OfKeyword:
-        return AST_TOKEN_TYPES.Identifier;
-
-      default:
-        return AST_TOKEN_TYPES.Keyword;
+    if (token.originalKeywordKind === SyntaxKind.NullKeyword) {
+      return AST_TOKEN_TYPES.Null;
+    } else if (
+      token.originalKeywordKind >= SyntaxKind.FirstFutureReservedWord &&
+      token.originalKeywordKind <= SyntaxKind.LastKeyword
+    ) {
+      return AST_TOKEN_TYPES.Identifier;
     }
+    return AST_TOKEN_TYPES.Keyword;
   }
 
   if (

--- a/packages/typescript-estree/tests/lib/__snapshots__/javascript.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/javascript.ts.snap
@@ -21870,7 +21870,7 @@ Object {
         9,
         15,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "static",
     },
     Object {
@@ -24218,7 +24218,7 @@ Object {
         16,
         22,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "static",
     },
     Object {
@@ -120511,7 +120511,7 @@ Object {
         11,
         16,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "await",
     },
     Object {
@@ -138207,7 +138207,7 @@ Object {
         10,
         19,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "undefined",
     },
     Object {

--- a/packages/typescript-estree/tests/lib/__snapshots__/jsx.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/jsx.ts.snap
@@ -1158,7 +1158,7 @@ Object {
         11,
         17,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "object",
     },
     Object {
@@ -1249,7 +1249,7 @@ Object {
         26,
         34,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "abstract",
     },
     Object {
@@ -10601,7 +10601,7 @@ Object {
         28,
         35,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "declare",
     },
     Object {
@@ -10637,7 +10637,7 @@ Object {
         36,
         42,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "static",
     },
     Object {
@@ -10781,7 +10781,7 @@ Object {
         56,
         63,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "declare",
     },
     Object {
@@ -10817,7 +10817,7 @@ Object {
         64,
         70,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "static",
     },
     Object {

--- a/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
@@ -11018,7 +11018,7 @@ Object {
         0,
         8,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "abstract",
     },
     Object {
@@ -11222,7 +11222,7 @@ Object {
         0,
         7,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "declare",
     },
     Object {
@@ -24094,7 +24094,7 @@ Object {
         33,
         42,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "undefined",
     },
     Object {
@@ -27094,7 +27094,7 @@ Object {
         27,
         36,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "undefined",
     },
     Object {
@@ -69535,7 +69535,7 @@ Object {
         10,
         18,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "abstract",
     },
     Object {
@@ -69625,7 +69625,7 @@ Object {
         32,
         34,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "as",
     },
     Object {
@@ -69715,7 +69715,7 @@ Object {
         48,
         55,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "asserts",
     },
     Object {
@@ -69805,7 +69805,7 @@ Object {
         69,
         72,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "any",
     },
     Object {
@@ -69985,7 +69985,7 @@ Object {
         105,
         110,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "await",
     },
     Object {
@@ -70075,7 +70075,7 @@ Object {
         124,
         131,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "boolean",
     },
     Object {
@@ -70165,7 +70165,7 @@ Object {
         145,
         156,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "constructor",
     },
     Object {
@@ -70255,7 +70255,7 @@ Object {
         170,
         177,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "declare",
     },
     Object {
@@ -70435,7 +70435,7 @@ Object {
         208,
         213,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "infer",
     },
     Object {
@@ -70615,7 +70615,7 @@ Object {
         243,
         248,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "keyof",
     },
     Object {
@@ -70795,7 +70795,7 @@ Object {
         282,
         291,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "namespace",
     },
     Object {
@@ -70885,7 +70885,7 @@ Object {
         305,
         310,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "never",
     },
     Object {
@@ -70975,7 +70975,7 @@ Object {
         324,
         332,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "readonly",
     },
     Object {
@@ -71065,7 +71065,7 @@ Object {
         346,
         353,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "require",
     },
     Object {
@@ -71155,7 +71155,7 @@ Object {
         367,
         373,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "number",
     },
     Object {
@@ -71245,7 +71245,7 @@ Object {
         387,
         393,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "object",
     },
     Object {
@@ -71425,7 +71425,7 @@ Object {
         424,
         430,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "string",
     },
     Object {
@@ -71515,7 +71515,7 @@ Object {
         444,
         450,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "symbol",
     },
     Object {
@@ -71695,7 +71695,7 @@ Object {
         482,
         491,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "undefined",
     },
     Object {
@@ -71785,7 +71785,7 @@ Object {
         505,
         511,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "unique",
     },
     Object {
@@ -71875,7 +71875,7 @@ Object {
         525,
         532,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "unknown",
     },
     Object {
@@ -71965,7 +71965,7 @@ Object {
         546,
         550,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "from",
     },
     Object {
@@ -72055,7 +72055,7 @@ Object {
         564,
         570,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "global",
     },
     Object {
@@ -72145,7 +72145,7 @@ Object {
         584,
         590,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "bigint",
     },
     Object {
@@ -72361,7 +72361,7 @@ Object {
         626,
         634,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "abstract",
     },
     Object {
@@ -72397,7 +72397,7 @@ Object {
         638,
         640,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "as",
     },
     Object {
@@ -72433,7 +72433,7 @@ Object {
         644,
         651,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "asserts",
     },
     Object {
@@ -72469,7 +72469,7 @@ Object {
         655,
         658,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "any",
     },
     Object {
@@ -72541,7 +72541,7 @@ Object {
         671,
         676,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "await",
     },
     Object {
@@ -72577,7 +72577,7 @@ Object {
         680,
         687,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "boolean",
     },
     Object {
@@ -72613,7 +72613,7 @@ Object {
         691,
         702,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "constructor",
     },
     Object {
@@ -72649,7 +72649,7 @@ Object {
         706,
         713,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "declare",
     },
     Object {
@@ -72721,7 +72721,7 @@ Object {
         724,
         729,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "infer",
     },
     Object {
@@ -72793,7 +72793,7 @@ Object {
         739,
         744,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "keyof",
     },
     Object {
@@ -72865,7 +72865,7 @@ Object {
         758,
         767,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "namespace",
     },
     Object {
@@ -72901,7 +72901,7 @@ Object {
         771,
         776,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "never",
     },
     Object {
@@ -72937,7 +72937,7 @@ Object {
         780,
         788,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "readonly",
     },
     Object {
@@ -72973,7 +72973,7 @@ Object {
         792,
         799,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "require",
     },
     Object {
@@ -73009,7 +73009,7 @@ Object {
         803,
         809,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "number",
     },
     Object {
@@ -73045,7 +73045,7 @@ Object {
         813,
         819,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "object",
     },
     Object {
@@ -73117,7 +73117,7 @@ Object {
         830,
         836,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "string",
     },
     Object {
@@ -73153,7 +73153,7 @@ Object {
         840,
         846,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "symbol",
     },
     Object {
@@ -73225,7 +73225,7 @@ Object {
         858,
         867,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "undefined",
     },
     Object {
@@ -73261,7 +73261,7 @@ Object {
         871,
         877,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "unique",
     },
     Object {
@@ -73297,7 +73297,7 @@ Object {
         881,
         888,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "unknown",
     },
     Object {
@@ -73333,7 +73333,7 @@ Object {
         892,
         896,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "from",
     },
     Object {
@@ -73369,7 +73369,7 @@ Object {
         900,
         906,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "global",
     },
     Object {
@@ -73405,7 +73405,7 @@ Object {
         910,
         916,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "bigint",
     },
     Object {
@@ -146941,7 +146941,7 @@ Object {
         8,
         14,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "global",
     },
     Object {
@@ -147013,7 +147013,7 @@ Object {
         36,
         42,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "global",
     },
     Object {
@@ -147103,7 +147103,7 @@ Object {
         74,
         80,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "global",
     },
     Object {

--- a/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
@@ -65384,11 +65384,85 @@ Object {
           ],
           "type": "VariableDeclaration",
         },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 10,
+                    "line": 8,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 8,
+                  },
+                },
+                "name": "of",
+                "range": Array [
+                  117,
+                  119,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 8,
+                  },
+                  "start": Object {
+                    "column": 13,
+                    "line": 8,
+                  },
+                },
+                "range": Array [
+                  122,
+                  123,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 14,
+                  "line": 8,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 8,
+                },
+              },
+              "range": Array [
+                117,
+                123,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 15,
+              "line": 8,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 8,
+            },
+          },
+          "range": Array [
+            111,
+            124,
+          ],
+          "type": "VariableDeclaration",
+        },
       ],
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 8,
+          "line": 9,
         },
         "start": Object {
           "column": 0,
@@ -65397,7 +65471,7 @@ Object {
       },
       "range": Array [
         0,
-        110,
+        126,
       ],
       "type": "BlockStatement",
     },
@@ -65405,31 +65479,31 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 21,
-          "line": 17,
+          "line": 19,
         },
         "start": Object {
           "column": 0,
-          "line": 10,
+          "line": 11,
         },
       },
       "range": Array [
-        112,
-        189,
+        128,
+        211,
       ],
       "source": Object {
         "loc": Object {
           "end": Object {
             "column": 20,
-            "line": 17,
+            "line": 19,
           },
           "start": Object {
             "column": 7,
-            "line": 17,
+            "line": 19,
           },
         },
         "range": Array [
-          175,
-          188,
+          197,
+          210,
         ],
         "raw": "'fake-module'",
         "type": "Literal",
@@ -65441,51 +65515,51 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 5,
-                "line": 11,
+                "line": 12,
               },
               "start": Object {
                 "column": 2,
-                "line": 11,
+                "line": 12,
               },
             },
             "name": "get",
             "range": Array [
-              123,
-              126,
+              139,
+              142,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 5,
-              "line": 11,
+              "line": 12,
             },
             "start": Object {
               "column": 2,
-              "line": 11,
+              "line": 12,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 5,
-                "line": 11,
+                "line": 12,
               },
               "start": Object {
                 "column": 2,
-                "line": 11,
+                "line": 12,
               },
             },
             "name": "get",
             "range": Array [
-              123,
-              126,
+              139,
+              142,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            123,
-            126,
+            139,
+            142,
           ],
           "type": "ImportSpecifier",
         },
@@ -65494,51 +65568,51 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 5,
-                "line": 12,
+                "line": 13,
               },
               "start": Object {
                 "column": 2,
-                "line": 12,
+                "line": 13,
               },
             },
             "name": "set",
             "range": Array [
-              130,
-              133,
+              146,
+              149,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 5,
-              "line": 12,
+              "line": 13,
             },
             "start": Object {
               "column": 2,
-              "line": 12,
+              "line": 13,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 5,
-                "line": 12,
+                "line": 13,
               },
               "start": Object {
                 "column": 2,
-                "line": 12,
+                "line": 13,
               },
             },
             "name": "set",
             "range": Array [
-              130,
-              133,
+              146,
+              149,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            130,
-            133,
+            146,
+            149,
           ],
           "type": "ImportSpecifier",
         },
@@ -65547,51 +65621,51 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 8,
-                "line": 13,
+                "line": 14,
               },
               "start": Object {
                 "column": 2,
-                "line": 13,
+                "line": 14,
               },
             },
             "name": "module",
             "range": Array [
-              137,
-              143,
+              153,
+              159,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 8,
-              "line": 13,
+              "line": 14,
             },
             "start": Object {
               "column": 2,
-              "line": 13,
+              "line": 14,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 8,
-                "line": 13,
+                "line": 14,
               },
               "start": Object {
                 "column": 2,
-                "line": 13,
+                "line": 14,
               },
             },
             "name": "module",
             "range": Array [
-              137,
-              143,
+              153,
+              159,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            137,
-            143,
+            153,
+            159,
           ],
           "type": "ImportSpecifier",
         },
@@ -65600,51 +65674,51 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 6,
-                "line": 14,
+                "line": 15,
               },
               "start": Object {
                 "column": 2,
-                "line": 14,
+                "line": 15,
               },
             },
             "name": "type",
             "range": Array [
-              147,
-              151,
+              163,
+              167,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 6,
-              "line": 14,
+              "line": 15,
             },
             "start": Object {
               "column": 2,
-              "line": 14,
+              "line": 15,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 6,
-                "line": 14,
+                "line": 15,
               },
               "start": Object {
                 "column": 2,
-                "line": 14,
+                "line": 15,
               },
             },
             "name": "type",
             "range": Array [
-              147,
-              151,
+              163,
+              167,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            147,
-            151,
+            163,
+            167,
           ],
           "type": "ImportSpecifier",
         },
@@ -65653,51 +65727,51 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 7,
-                "line": 15,
+                "line": 16,
               },
               "start": Object {
                 "column": 2,
-                "line": 15,
+                "line": 16,
               },
             },
             "name": "async",
             "range": Array [
-              155,
-              160,
+              171,
+              176,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 7,
-              "line": 15,
+              "line": 16,
             },
             "start": Object {
               "column": 2,
-              "line": 15,
+              "line": 16,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 7,
-                "line": 15,
+                "line": 16,
               },
               "start": Object {
                 "column": 2,
-                "line": 15,
+                "line": 16,
               },
             },
             "name": "async",
             "range": Array [
-              155,
-              160,
+              171,
+              176,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            155,
-            160,
+            171,
+            176,
           ],
           "type": "ImportSpecifier",
         },
@@ -65706,51 +65780,104 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 4,
-                "line": 16,
+                "line": 17,
               },
               "start": Object {
                 "column": 2,
-                "line": 16,
+                "line": 17,
               },
             },
             "name": "is",
             "range": Array [
-              164,
-              166,
+              180,
+              182,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 4,
-              "line": 16,
+              "line": 17,
             },
             "start": Object {
               "column": 2,
-              "line": 16,
+              "line": 17,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 4,
-                "line": 16,
+                "line": 17,
               },
               "start": Object {
                 "column": 2,
-                "line": 16,
+                "line": 17,
               },
             },
             "name": "is",
             "range": Array [
-              164,
-              166,
+              180,
+              182,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            164,
-            166,
+            180,
+            182,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 4,
+                "line": 18,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 18,
+              },
+            },
+            "name": "of",
+            "range": Array [
+              186,
+              188,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 4,
+              "line": 18,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 18,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 4,
+                "line": 18,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 18,
+              },
+            },
+            "name": "of",
+            "range": Array [
+              186,
+              188,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            186,
+            188,
           ],
           "type": "ImportSpecifier",
         },
@@ -65761,7 +65888,7 @@ Object {
   "loc": Object {
     "end": Object {
       "column": 0,
-      "line": 18,
+      "line": 20,
     },
     "start": Object {
       "column": 0,
@@ -65770,7 +65897,7 @@ Object {
   },
   "range": Array [
     0,
-    190,
+    212,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -66335,17 +66462,107 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 1,
+          "column": 7,
           "line": 8,
         },
         "start": Object {
-          "column": 0,
+          "column": 2,
           "line": 8,
         },
       },
       "range": Array [
-        109,
-        110,
+        111,
+        116,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        117,
+        119,
+      ],
+      "type": "Keyword",
+      "value": "of",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        120,
+        121,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        122,
+        123,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        123,
+        124,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        125,
+        126,
       ],
       "type": "Punctuator",
       "value": "}",
@@ -66354,16 +66571,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 10,
+          "line": 11,
         },
         "start": Object {
           "column": 0,
-          "line": 10,
+          "line": 11,
         },
       },
       "range": Array [
-        112,
-        118,
+        128,
+        134,
       ],
       "type": "Keyword",
       "value": "import",
@@ -66372,16 +66589,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 8,
-          "line": 10,
+          "line": 11,
         },
         "start": Object {
           "column": 7,
-          "line": 10,
+          "line": 11,
         },
       },
       "range": Array [
-        119,
-        120,
+        135,
+        136,
       ],
       "type": "Punctuator",
       "value": "{",
@@ -66390,16 +66607,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 5,
-          "line": 11,
+          "line": 12,
         },
         "start": Object {
           "column": 2,
-          "line": 11,
+          "line": 12,
         },
       },
       "range": Array [
-        123,
-        126,
+        139,
+        142,
       ],
       "type": "Identifier",
       "value": "get",
@@ -66408,16 +66625,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 11,
+          "line": 12,
         },
         "start": Object {
           "column": 5,
-          "line": 11,
+          "line": 12,
         },
       },
       "range": Array [
-        126,
-        127,
+        142,
+        143,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66426,16 +66643,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 5,
-          "line": 12,
+          "line": 13,
         },
         "start": Object {
           "column": 2,
-          "line": 12,
+          "line": 13,
         },
       },
       "range": Array [
-        130,
-        133,
+        146,
+        149,
       ],
       "type": "Identifier",
       "value": "set",
@@ -66444,16 +66661,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 12,
+          "line": 13,
         },
         "start": Object {
           "column": 5,
-          "line": 12,
+          "line": 13,
         },
       },
       "range": Array [
-        133,
-        134,
+        149,
+        150,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66462,16 +66679,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 8,
-          "line": 13,
+          "line": 14,
         },
         "start": Object {
           "column": 2,
-          "line": 13,
+          "line": 14,
         },
       },
       "range": Array [
-        137,
-        143,
+        153,
+        159,
       ],
       "type": "Identifier",
       "value": "module",
@@ -66480,16 +66697,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 9,
-          "line": 13,
+          "line": 14,
         },
         "start": Object {
           "column": 8,
-          "line": 13,
+          "line": 14,
         },
       },
       "range": Array [
-        143,
-        144,
+        159,
+        160,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66498,16 +66715,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 14,
+          "line": 15,
         },
         "start": Object {
           "column": 2,
-          "line": 14,
+          "line": 15,
         },
       },
       "range": Array [
-        147,
-        151,
+        163,
+        167,
       ],
       "type": "Identifier",
       "value": "type",
@@ -66516,16 +66733,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 7,
-          "line": 14,
+          "line": 15,
         },
         "start": Object {
           "column": 6,
-          "line": 14,
+          "line": 15,
         },
       },
       "range": Array [
-        151,
-        152,
+        167,
+        168,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66534,16 +66751,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 7,
-          "line": 15,
+          "line": 16,
         },
         "start": Object {
           "column": 2,
-          "line": 15,
+          "line": 16,
         },
       },
       "range": Array [
-        155,
-        160,
+        171,
+        176,
       ],
       "type": "Identifier",
       "value": "async",
@@ -66552,16 +66769,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 8,
-          "line": 15,
+          "line": 16,
         },
         "start": Object {
           "column": 7,
-          "line": 15,
+          "line": 16,
         },
       },
       "range": Array [
-        160,
-        161,
+        176,
+        177,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66570,16 +66787,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 4,
-          "line": 16,
+          "line": 17,
         },
         "start": Object {
           "column": 2,
-          "line": 16,
+          "line": 17,
         },
       },
       "range": Array [
-        164,
-        166,
+        180,
+        182,
       ],
       "type": "Identifier",
       "value": "is",
@@ -66588,16 +66805,52 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 5,
-          "line": 16,
+          "line": 17,
         },
         "start": Object {
           "column": 4,
-          "line": 16,
+          "line": 17,
         },
       },
       "range": Array [
-        166,
-        167,
+        182,
+        183,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 18,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 18,
+        },
+      },
+      "range": Array [
+        186,
+        188,
+      ],
+      "type": "Keyword",
+      "value": "of",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 18,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 18,
+        },
+      },
+      "range": Array [
+        188,
+        189,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66606,16 +66859,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 17,
+          "line": 19,
         },
         "start": Object {
           "column": 0,
-          "line": 17,
+          "line": 19,
         },
       },
       "range": Array [
-        168,
-        169,
+        190,
+        191,
       ],
       "type": "Punctuator",
       "value": "}",
@@ -66624,16 +66877,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 17,
+          "line": 19,
         },
         "start": Object {
           "column": 2,
-          "line": 17,
+          "line": 19,
         },
       },
       "range": Array [
-        170,
-        174,
+        192,
+        196,
       ],
       "type": "Identifier",
       "value": "from",
@@ -66642,16 +66895,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 20,
-          "line": 17,
+          "line": 19,
         },
         "start": Object {
           "column": 7,
-          "line": 17,
+          "line": 19,
         },
       },
       "range": Array [
-        175,
-        188,
+        197,
+        210,
       ],
       "type": "String",
       "value": "'fake-module'",
@@ -66660,16 +66913,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 21,
-          "line": 17,
+          "line": 19,
         },
         "start": Object {
           "column": 20,
-          "line": 17,
+          "line": 19,
         },
       },
       "range": Array [
-        188,
-        189,
+        210,
+        211,
       ],
       "type": "Punctuator",
       "value": ";",

--- a/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
@@ -64946,7 +64946,7 @@ Object {
               "id": Object {
                 "loc": Object {
                   "end": Object {
-                    "column": 11,
+                    "column": 16,
                     "line": 2,
                   },
                   "start": Object {
@@ -64954,27 +64954,27 @@ Object {
                     "line": 2,
                   },
                 },
-                "name": "get",
+                "name": "abstract",
                 "range": Array [
                   10,
-                  13,
+                  18,
                 ],
                 "type": "Identifier",
               },
               "init": Object {
                 "loc": Object {
                   "end": Object {
-                    "column": 15,
+                    "column": 20,
                     "line": 2,
                   },
                   "start": Object {
-                    "column": 14,
+                    "column": 19,
                     "line": 2,
                   },
                 },
                 "range": Array [
-                  16,
-                  17,
+                  21,
+                  22,
                 ],
                 "raw": "1",
                 "type": "Literal",
@@ -64982,7 +64982,7 @@ Object {
               },
               "loc": Object {
                 "end": Object {
-                  "column": 15,
+                  "column": 20,
                   "line": 2,
                 },
                 "start": Object {
@@ -64992,7 +64992,7 @@ Object {
               },
               "range": Array [
                 10,
-                17,
+                22,
               ],
               "type": "VariableDeclarator",
             },
@@ -65000,7 +65000,7 @@ Object {
           "kind": "const",
           "loc": Object {
             "end": Object {
-              "column": 16,
+              "column": 21,
               "line": 2,
             },
             "start": Object {
@@ -65010,7 +65010,155 @@ Object {
           },
           "range": Array [
             4,
-            18,
+            23,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 10,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 3,
+                  },
+                },
+                "name": "as",
+                "range": Array [
+                  32,
+                  34,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 3,
+                  },
+                  "start": Object {
+                    "column": 13,
+                    "line": 3,
+                  },
+                },
+                "range": Array [
+                  37,
+                  38,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 14,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 3,
+                },
+              },
+              "range": Array [
+                32,
+                38,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 15,
+              "line": 3,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 3,
+            },
+          },
+          "range": Array [
+            26,
+            39,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 4,
+                  },
+                },
+                "name": "asserts",
+                "range": Array [
+                  48,
+                  55,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 19,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 18,
+                    "line": 4,
+                  },
+                },
+                "range": Array [
+                  58,
+                  59,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 19,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 4,
+                },
+              },
+              "range": Array [
+                48,
+                59,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 20,
+              "line": 4,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 4,
+            },
+          },
+          "range": Array [
+            42,
+            60,
           ],
           "type": "VariableDeclaration",
         },
@@ -65021,17 +65169,17 @@ Object {
                 "loc": Object {
                   "end": Object {
                     "column": 11,
-                    "line": 3,
+                    "line": 5,
                   },
                   "start": Object {
                     "column": 8,
-                    "line": 3,
+                    "line": 5,
                   },
                 },
-                "name": "set",
+                "name": "any",
                 "range": Array [
-                  27,
-                  30,
+                  69,
+                  72,
                 ],
                 "type": "Identifier",
               },
@@ -65039,16 +65187,16 @@ Object {
                 "loc": Object {
                   "end": Object {
                     "column": 15,
-                    "line": 3,
+                    "line": 5,
                   },
                   "start": Object {
                     "column": 14,
-                    "line": 3,
+                    "line": 5,
                   },
                 },
                 "range": Array [
-                  33,
-                  34,
+                  75,
+                  76,
                 ],
                 "raw": "1",
                 "type": "Literal",
@@ -65057,16 +65205,16 @@ Object {
               "loc": Object {
                 "end": Object {
                   "column": 15,
-                  "line": 3,
+                  "line": 5,
                 },
                 "start": Object {
                   "column": 8,
-                  "line": 3,
+                  "line": 5,
                 },
               },
               "range": Array [
-                27,
-                34,
+                69,
+                76,
               ],
               "type": "VariableDeclarator",
             },
@@ -65075,154 +65223,6 @@ Object {
           "loc": Object {
             "end": Object {
               "column": 16,
-              "line": 3,
-            },
-            "start": Object {
-              "column": 2,
-              "line": 3,
-            },
-          },
-          "range": Array [
-            21,
-            35,
-          ],
-          "type": "VariableDeclaration",
-        },
-        Object {
-          "declarations": Array [
-            Object {
-              "id": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 14,
-                    "line": 4,
-                  },
-                  "start": Object {
-                    "column": 8,
-                    "line": 4,
-                  },
-                },
-                "name": "module",
-                "range": Array [
-                  44,
-                  50,
-                ],
-                "type": "Identifier",
-              },
-              "init": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 18,
-                    "line": 4,
-                  },
-                  "start": Object {
-                    "column": 17,
-                    "line": 4,
-                  },
-                },
-                "range": Array [
-                  53,
-                  54,
-                ],
-                "raw": "1",
-                "type": "Literal",
-                "value": 1,
-              },
-              "loc": Object {
-                "end": Object {
-                  "column": 18,
-                  "line": 4,
-                },
-                "start": Object {
-                  "column": 8,
-                  "line": 4,
-                },
-              },
-              "range": Array [
-                44,
-                54,
-              ],
-              "type": "VariableDeclarator",
-            },
-          ],
-          "kind": "const",
-          "loc": Object {
-            "end": Object {
-              "column": 19,
-              "line": 4,
-            },
-            "start": Object {
-              "column": 2,
-              "line": 4,
-            },
-          },
-          "range": Array [
-            38,
-            55,
-          ],
-          "type": "VariableDeclaration",
-        },
-        Object {
-          "declarations": Array [
-            Object {
-              "id": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 12,
-                    "line": 5,
-                  },
-                  "start": Object {
-                    "column": 8,
-                    "line": 5,
-                  },
-                },
-                "name": "type",
-                "range": Array [
-                  64,
-                  68,
-                ],
-                "type": "Identifier",
-              },
-              "init": Object {
-                "loc": Object {
-                  "end": Object {
-                    "column": 16,
-                    "line": 5,
-                  },
-                  "start": Object {
-                    "column": 15,
-                    "line": 5,
-                  },
-                },
-                "range": Array [
-                  71,
-                  72,
-                ],
-                "raw": "1",
-                "type": "Literal",
-                "value": 1,
-              },
-              "loc": Object {
-                "end": Object {
-                  "column": 16,
-                  "line": 5,
-                },
-                "start": Object {
-                  "column": 8,
-                  "line": 5,
-                },
-              },
-              "range": Array [
-                64,
-                72,
-              ],
-              "type": "VariableDeclarator",
-            },
-          ],
-          "kind": "const",
-          "loc": Object {
-            "end": Object {
-              "column": 17,
               "line": 5,
             },
             "start": Object {
@@ -65231,8 +65231,8 @@ Object {
             },
           },
           "range": Array [
-            58,
-            73,
+            63,
+            77,
           ],
           "type": "VariableDeclaration",
         },
@@ -65252,8 +65252,8 @@ Object {
                 },
                 "name": "async",
                 "range": Array [
-                  82,
-                  87,
+                  86,
+                  91,
                 ],
                 "type": "Identifier",
               },
@@ -65269,8 +65269,8 @@ Object {
                   },
                 },
                 "range": Array [
-                  90,
-                  91,
+                  94,
+                  95,
                 ],
                 "raw": "1",
                 "type": "Literal",
@@ -65287,8 +65287,8 @@ Object {
                 },
               },
               "range": Array [
-                82,
-                91,
+                86,
+                95,
               ],
               "type": "VariableDeclarator",
             },
@@ -65305,8 +65305,452 @@ Object {
             },
           },
           "range": Array [
-            76,
-            92,
+            80,
+            96,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 13,
+                    "line": 7,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 7,
+                  },
+                },
+                "name": "await",
+                "range": Array [
+                  105,
+                  110,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 7,
+                  },
+                  "start": Object {
+                    "column": 16,
+                    "line": 7,
+                  },
+                },
+                "range": Array [
+                  113,
+                  114,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 17,
+                  "line": 7,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 7,
+                },
+              },
+              "range": Array [
+                105,
+                114,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 18,
+              "line": 7,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 7,
+            },
+          },
+          "range": Array [
+            99,
+            115,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 8,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 8,
+                  },
+                },
+                "name": "boolean",
+                "range": Array [
+                  124,
+                  131,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 19,
+                    "line": 8,
+                  },
+                  "start": Object {
+                    "column": 18,
+                    "line": 8,
+                  },
+                },
+                "range": Array [
+                  134,
+                  135,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 19,
+                  "line": 8,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 8,
+                },
+              },
+              "range": Array [
+                124,
+                135,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 20,
+              "line": 8,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 8,
+            },
+          },
+          "range": Array [
+            118,
+            136,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 19,
+                    "line": 9,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 9,
+                  },
+                },
+                "name": "constructor",
+                "range": Array [
+                  145,
+                  156,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 23,
+                    "line": 9,
+                  },
+                  "start": Object {
+                    "column": 22,
+                    "line": 9,
+                  },
+                },
+                "range": Array [
+                  159,
+                  160,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 23,
+                  "line": 9,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 9,
+                },
+              },
+              "range": Array [
+                145,
+                160,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 24,
+              "line": 9,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 9,
+            },
+          },
+          "range": Array [
+            139,
+            161,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 10,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 10,
+                  },
+                },
+                "name": "declare",
+                "range": Array [
+                  170,
+                  177,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 19,
+                    "line": 10,
+                  },
+                  "start": Object {
+                    "column": 18,
+                    "line": 10,
+                  },
+                },
+                "range": Array [
+                  180,
+                  181,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 19,
+                  "line": 10,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 10,
+                },
+              },
+              "range": Array [
+                170,
+                181,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 20,
+              "line": 10,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 10,
+            },
+          },
+          "range": Array [
+            164,
+            182,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 11,
+                    "line": 11,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 11,
+                  },
+                },
+                "name": "get",
+                "range": Array [
+                  191,
+                  194,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 11,
+                  },
+                  "start": Object {
+                    "column": 14,
+                    "line": 11,
+                  },
+                },
+                "range": Array [
+                  197,
+                  198,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 15,
+                  "line": 11,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 11,
+                },
+              },
+              "range": Array [
+                191,
+                198,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 16,
+              "line": 11,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 11,
+            },
+          },
+          "range": Array [
+            185,
+            199,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 13,
+                    "line": 12,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 12,
+                  },
+                },
+                "name": "infer",
+                "range": Array [
+                  208,
+                  213,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 12,
+                  },
+                  "start": Object {
+                    "column": 16,
+                    "line": 12,
+                  },
+                },
+                "range": Array [
+                  216,
+                  217,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 17,
+                  "line": 12,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 12,
+                },
+              },
+              "range": Array [
+                208,
+                217,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 18,
+              "line": 12,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 12,
+            },
+          },
+          "range": Array [
+            202,
+            218,
           ],
           "type": "VariableDeclaration",
         },
@@ -65317,17 +65761,17 @@ Object {
                 "loc": Object {
                   "end": Object {
                     "column": 10,
-                    "line": 7,
+                    "line": 13,
                   },
                   "start": Object {
                     "column": 8,
-                    "line": 7,
+                    "line": 13,
                   },
                 },
                 "name": "is",
                 "range": Array [
-                  101,
-                  103,
+                  227,
+                  229,
                 ],
                 "type": "Identifier",
               },
@@ -65335,16 +65779,16 @@ Object {
                 "loc": Object {
                   "end": Object {
                     "column": 14,
-                    "line": 7,
+                    "line": 13,
                   },
                   "start": Object {
                     "column": 13,
-                    "line": 7,
+                    "line": 13,
                   },
                 },
                 "range": Array [
-                  106,
-                  107,
+                  232,
+                  233,
                 ],
                 "raw": "1",
                 "type": "Literal",
@@ -65353,16 +65797,16 @@ Object {
               "loc": Object {
                 "end": Object {
                   "column": 14,
-                  "line": 7,
+                  "line": 13,
                 },
                 "start": Object {
                   "column": 8,
-                  "line": 7,
+                  "line": 13,
                 },
               },
               "range": Array [
-                101,
-                107,
+                227,
+                233,
               ],
               "type": "VariableDeclarator",
             },
@@ -65371,16 +65815,1348 @@ Object {
           "loc": Object {
             "end": Object {
               "column": 15,
-              "line": 7,
+              "line": 13,
             },
             "start": Object {
               "column": 2,
-              "line": 7,
+              "line": 13,
             },
           },
           "range": Array [
-            95,
-            108,
+            221,
+            234,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 13,
+                    "line": 14,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 14,
+                  },
+                },
+                "name": "keyof",
+                "range": Array [
+                  243,
+                  248,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 14,
+                  },
+                  "start": Object {
+                    "column": 16,
+                    "line": 14,
+                  },
+                },
+                "range": Array [
+                  251,
+                  252,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 17,
+                  "line": 14,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 14,
+                },
+              },
+              "range": Array [
+                243,
+                252,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 18,
+              "line": 14,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 14,
+            },
+          },
+          "range": Array [
+            237,
+            253,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 15,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 15,
+                  },
+                },
+                "name": "module",
+                "range": Array [
+                  262,
+                  268,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 15,
+                  },
+                  "start": Object {
+                    "column": 17,
+                    "line": 15,
+                  },
+                },
+                "range": Array [
+                  271,
+                  272,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 15,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 15,
+                },
+              },
+              "range": Array [
+                262,
+                272,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 15,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 15,
+            },
+          },
+          "range": Array [
+            256,
+            273,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 16,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 16,
+                  },
+                },
+                "name": "namespace",
+                "range": Array [
+                  282,
+                  291,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 21,
+                    "line": 16,
+                  },
+                  "start": Object {
+                    "column": 20,
+                    "line": 16,
+                  },
+                },
+                "range": Array [
+                  294,
+                  295,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 21,
+                  "line": 16,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 16,
+                },
+              },
+              "range": Array [
+                282,
+                295,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 22,
+              "line": 16,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 16,
+            },
+          },
+          "range": Array [
+            276,
+            296,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 13,
+                    "line": 17,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 17,
+                  },
+                },
+                "name": "never",
+                "range": Array [
+                  305,
+                  310,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 17,
+                  },
+                  "start": Object {
+                    "column": 16,
+                    "line": 17,
+                  },
+                },
+                "range": Array [
+                  313,
+                  314,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 17,
+                  "line": 17,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 17,
+                },
+              },
+              "range": Array [
+                305,
+                314,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 18,
+              "line": 17,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 17,
+            },
+          },
+          "range": Array [
+            299,
+            315,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 16,
+                    "line": 18,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 18,
+                  },
+                },
+                "name": "readonly",
+                "range": Array [
+                  324,
+                  332,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 20,
+                    "line": 18,
+                  },
+                  "start": Object {
+                    "column": 19,
+                    "line": 18,
+                  },
+                },
+                "range": Array [
+                  335,
+                  336,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 20,
+                  "line": 18,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 18,
+                },
+              },
+              "range": Array [
+                324,
+                336,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 21,
+              "line": 18,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 18,
+            },
+          },
+          "range": Array [
+            318,
+            337,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 19,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 19,
+                  },
+                },
+                "name": "require",
+                "range": Array [
+                  346,
+                  353,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 19,
+                    "line": 19,
+                  },
+                  "start": Object {
+                    "column": 18,
+                    "line": 19,
+                  },
+                },
+                "range": Array [
+                  356,
+                  357,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 19,
+                  "line": 19,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 19,
+                },
+              },
+              "range": Array [
+                346,
+                357,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 20,
+              "line": 19,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 19,
+            },
+          },
+          "range": Array [
+            340,
+            358,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 20,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 20,
+                  },
+                },
+                "name": "number",
+                "range": Array [
+                  367,
+                  373,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 20,
+                  },
+                  "start": Object {
+                    "column": 17,
+                    "line": 20,
+                  },
+                },
+                "range": Array [
+                  376,
+                  377,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 20,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 20,
+                },
+              },
+              "range": Array [
+                367,
+                377,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 20,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 20,
+            },
+          },
+          "range": Array [
+            361,
+            378,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 21,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 21,
+                  },
+                },
+                "name": "object",
+                "range": Array [
+                  387,
+                  393,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 21,
+                  },
+                  "start": Object {
+                    "column": 17,
+                    "line": 21,
+                  },
+                },
+                "range": Array [
+                  396,
+                  397,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 21,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 21,
+                },
+              },
+              "range": Array [
+                387,
+                397,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 21,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 21,
+            },
+          },
+          "range": Array [
+            381,
+            398,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 11,
+                    "line": 22,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 22,
+                  },
+                },
+                "name": "set",
+                "range": Array [
+                  407,
+                  410,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 22,
+                  },
+                  "start": Object {
+                    "column": 14,
+                    "line": 22,
+                  },
+                },
+                "range": Array [
+                  413,
+                  414,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 15,
+                  "line": 22,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 22,
+                },
+              },
+              "range": Array [
+                407,
+                414,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 16,
+              "line": 22,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 22,
+            },
+          },
+          "range": Array [
+            401,
+            415,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 23,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 23,
+                  },
+                },
+                "name": "string",
+                "range": Array [
+                  424,
+                  430,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 23,
+                  },
+                  "start": Object {
+                    "column": 17,
+                    "line": 23,
+                  },
+                },
+                "range": Array [
+                  433,
+                  434,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 23,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 23,
+                },
+              },
+              "range": Array [
+                424,
+                434,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 23,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 23,
+            },
+          },
+          "range": Array [
+            418,
+            435,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 24,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 24,
+                  },
+                },
+                "name": "symbol",
+                "range": Array [
+                  444,
+                  450,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 24,
+                  },
+                  "start": Object {
+                    "column": 17,
+                    "line": 24,
+                  },
+                },
+                "range": Array [
+                  453,
+                  454,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 24,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 24,
+                },
+              },
+              "range": Array [
+                444,
+                454,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 24,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 24,
+            },
+          },
+          "range": Array [
+            438,
+            455,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 12,
+                    "line": 25,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 25,
+                  },
+                },
+                "name": "type",
+                "range": Array [
+                  464,
+                  468,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 16,
+                    "line": 25,
+                  },
+                  "start": Object {
+                    "column": 15,
+                    "line": 25,
+                  },
+                },
+                "range": Array [
+                  471,
+                  472,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 25,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 25,
+                },
+              },
+              "range": Array [
+                464,
+                472,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 17,
+              "line": 25,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 25,
+            },
+          },
+          "range": Array [
+            458,
+            473,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 17,
+                    "line": 26,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 26,
+                  },
+                },
+                "name": "undefined",
+                "range": Array [
+                  482,
+                  491,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 21,
+                    "line": 26,
+                  },
+                  "start": Object {
+                    "column": 20,
+                    "line": 26,
+                  },
+                },
+                "range": Array [
+                  494,
+                  495,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 21,
+                  "line": 26,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 26,
+                },
+              },
+              "range": Array [
+                482,
+                495,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 22,
+              "line": 26,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 26,
+            },
+          },
+          "range": Array [
+            476,
+            496,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 27,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 27,
+                  },
+                },
+                "name": "unique",
+                "range": Array [
+                  505,
+                  511,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 27,
+                  },
+                  "start": Object {
+                    "column": 17,
+                    "line": 27,
+                  },
+                },
+                "range": Array [
+                  514,
+                  515,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 27,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 27,
+                },
+              },
+              "range": Array [
+                505,
+                515,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 27,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 27,
+            },
+          },
+          "range": Array [
+            499,
+            516,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 28,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 28,
+                  },
+                },
+                "name": "unknown",
+                "range": Array [
+                  525,
+                  532,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 19,
+                    "line": 28,
+                  },
+                  "start": Object {
+                    "column": 18,
+                    "line": 28,
+                  },
+                },
+                "range": Array [
+                  535,
+                  536,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 19,
+                  "line": 28,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 28,
+                },
+              },
+              "range": Array [
+                525,
+                536,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 20,
+              "line": 28,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 28,
+            },
+          },
+          "range": Array [
+            519,
+            537,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 12,
+                    "line": 29,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 29,
+                  },
+                },
+                "name": "from",
+                "range": Array [
+                  546,
+                  550,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 16,
+                    "line": 29,
+                  },
+                  "start": Object {
+                    "column": 15,
+                    "line": 29,
+                  },
+                },
+                "range": Array [
+                  553,
+                  554,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 29,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 29,
+                },
+              },
+              "range": Array [
+                546,
+                554,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 17,
+              "line": 29,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 29,
+            },
+          },
+          "range": Array [
+            540,
+            555,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 30,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 30,
+                  },
+                },
+                "name": "global",
+                "range": Array [
+                  564,
+                  570,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 30,
+                  },
+                  "start": Object {
+                    "column": 17,
+                    "line": 30,
+                  },
+                },
+                "range": Array [
+                  573,
+                  574,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 30,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 30,
+                },
+              },
+              "range": Array [
+                564,
+                574,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 30,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 30,
+            },
+          },
+          "range": Array [
+            558,
+            575,
+          ],
+          "type": "VariableDeclaration",
+        },
+        Object {
+          "declarations": Array [
+            Object {
+              "id": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 14,
+                    "line": 31,
+                  },
+                  "start": Object {
+                    "column": 8,
+                    "line": 31,
+                  },
+                },
+                "name": "bigint",
+                "range": Array [
+                  584,
+                  590,
+                ],
+                "type": "Identifier",
+              },
+              "init": Object {
+                "loc": Object {
+                  "end": Object {
+                    "column": 18,
+                    "line": 31,
+                  },
+                  "start": Object {
+                    "column": 17,
+                    "line": 31,
+                  },
+                },
+                "range": Array [
+                  593,
+                  594,
+                ],
+                "raw": "1",
+                "type": "Literal",
+                "value": 1,
+              },
+              "loc": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 31,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 31,
+                },
+              },
+              "range": Array [
+                584,
+                594,
+              ],
+              "type": "VariableDeclarator",
+            },
+          ],
+          "kind": "const",
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 31,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 31,
+            },
+          },
+          "range": Array [
+            578,
+            595,
           ],
           "type": "VariableDeclaration",
         },
@@ -65391,17 +67167,17 @@ Object {
                 "loc": Object {
                   "end": Object {
                     "column": 10,
-                    "line": 8,
+                    "line": 32,
                   },
                   "start": Object {
                     "column": 8,
-                    "line": 8,
+                    "line": 32,
                   },
                 },
                 "name": "of",
                 "range": Array [
-                  117,
-                  119,
+                  604,
+                  606,
                 ],
                 "type": "Identifier",
               },
@@ -65409,16 +67185,16 @@ Object {
                 "loc": Object {
                   "end": Object {
                     "column": 14,
-                    "line": 8,
+                    "line": 32,
                   },
                   "start": Object {
                     "column": 13,
-                    "line": 8,
+                    "line": 32,
                   },
                 },
                 "range": Array [
-                  122,
-                  123,
+                  609,
+                  610,
                 ],
                 "raw": "1",
                 "type": "Literal",
@@ -65427,16 +67203,16 @@ Object {
               "loc": Object {
                 "end": Object {
                   "column": 14,
-                  "line": 8,
+                  "line": 32,
                 },
                 "start": Object {
                   "column": 8,
-                  "line": 8,
+                  "line": 32,
                 },
               },
               "range": Array [
-                117,
-                123,
+                604,
+                610,
               ],
               "type": "VariableDeclarator",
             },
@@ -65445,16 +67221,16 @@ Object {
           "loc": Object {
             "end": Object {
               "column": 15,
-              "line": 8,
+              "line": 32,
             },
             "start": Object {
               "column": 2,
-              "line": 8,
+              "line": 32,
             },
           },
           "range": Array [
-            111,
-            124,
+            598,
+            611,
           ],
           "type": "VariableDeclaration",
         },
@@ -65462,7 +67238,7 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 9,
+          "line": 33,
         },
         "start": Object {
           "column": 0,
@@ -65471,7 +67247,7 @@ Object {
       },
       "range": Array [
         0,
-        126,
+        613,
       ],
       "type": "BlockStatement",
     },
@@ -65479,31 +67255,31 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 21,
-          "line": 19,
+          "line": 67,
         },
         "start": Object {
           "column": 0,
-          "line": 11,
+          "line": 35,
         },
       },
       "range": Array [
-        128,
-        211,
+        615,
+        945,
       ],
       "source": Object {
         "loc": Object {
           "end": Object {
             "column": 20,
-            "line": 19,
+            "line": 67,
           },
           "start": Object {
             "column": 7,
-            "line": 19,
+            "line": 67,
           },
         },
         "range": Array [
-          197,
-          210,
+          931,
+          944,
         ],
         "raw": "'fake-module'",
         "type": "Literal",
@@ -65514,211 +67290,211 @@ Object {
           "imported": Object {
             "loc": Object {
               "end": Object {
-                "column": 5,
-                "line": 12,
+                "column": 10,
+                "line": 36,
               },
               "start": Object {
                 "column": 2,
-                "line": 12,
+                "line": 36,
               },
             },
-            "name": "get",
+            "name": "abstract",
             "range": Array [
-              139,
-              142,
+              626,
+              634,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 10,
+              "line": 36,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 36,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 10,
+                "line": 36,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 36,
+              },
+            },
+            "name": "abstract",
+            "range": Array [
+              626,
+              634,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            626,
+            634,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 4,
+                "line": 37,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 37,
+              },
+            },
+            "name": "as",
+            "range": Array [
+              638,
+              640,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 4,
+              "line": 37,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 37,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 4,
+                "line": 37,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 37,
+              },
+            },
+            "name": "as",
+            "range": Array [
+              638,
+              640,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            638,
+            640,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 38,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 38,
+              },
+            },
+            "name": "asserts",
+            "range": Array [
+              644,
+              651,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 9,
+              "line": 38,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 38,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 38,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 38,
+              },
+            },
+            "name": "asserts",
+            "range": Array [
+              644,
+              651,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            644,
+            651,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 39,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 39,
+              },
+            },
+            "name": "any",
+            "range": Array [
+              655,
+              658,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 5,
-              "line": 12,
+              "line": 39,
             },
             "start": Object {
               "column": 2,
-              "line": 12,
+              "line": 39,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 5,
-                "line": 12,
+                "line": 39,
               },
               "start": Object {
                 "column": 2,
-                "line": 12,
+                "line": 39,
               },
             },
-            "name": "get",
+            "name": "any",
             "range": Array [
-              139,
-              142,
+              655,
+              658,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            139,
-            142,
-          ],
-          "type": "ImportSpecifier",
-        },
-        Object {
-          "imported": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 5,
-                "line": 13,
-              },
-              "start": Object {
-                "column": 2,
-                "line": 13,
-              },
-            },
-            "name": "set",
-            "range": Array [
-              146,
-              149,
-            ],
-            "type": "Identifier",
-          },
-          "loc": Object {
-            "end": Object {
-              "column": 5,
-              "line": 13,
-            },
-            "start": Object {
-              "column": 2,
-              "line": 13,
-            },
-          },
-          "local": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 5,
-                "line": 13,
-              },
-              "start": Object {
-                "column": 2,
-                "line": 13,
-              },
-            },
-            "name": "set",
-            "range": Array [
-              146,
-              149,
-            ],
-            "type": "Identifier",
-          },
-          "range": Array [
-            146,
-            149,
-          ],
-          "type": "ImportSpecifier",
-        },
-        Object {
-          "imported": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 8,
-                "line": 14,
-              },
-              "start": Object {
-                "column": 2,
-                "line": 14,
-              },
-            },
-            "name": "module",
-            "range": Array [
-              153,
-              159,
-            ],
-            "type": "Identifier",
-          },
-          "loc": Object {
-            "end": Object {
-              "column": 8,
-              "line": 14,
-            },
-            "start": Object {
-              "column": 2,
-              "line": 14,
-            },
-          },
-          "local": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 8,
-                "line": 14,
-              },
-              "start": Object {
-                "column": 2,
-                "line": 14,
-              },
-            },
-            "name": "module",
-            "range": Array [
-              153,
-              159,
-            ],
-            "type": "Identifier",
-          },
-          "range": Array [
-            153,
-            159,
-          ],
-          "type": "ImportSpecifier",
-        },
-        Object {
-          "imported": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 6,
-                "line": 15,
-              },
-              "start": Object {
-                "column": 2,
-                "line": 15,
-              },
-            },
-            "name": "type",
-            "range": Array [
-              163,
-              167,
-            ],
-            "type": "Identifier",
-          },
-          "loc": Object {
-            "end": Object {
-              "column": 6,
-              "line": 15,
-            },
-            "start": Object {
-              "column": 2,
-              "line": 15,
-            },
-          },
-          "local": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 6,
-                "line": 15,
-              },
-              "start": Object {
-                "column": 2,
-                "line": 15,
-              },
-            },
-            "name": "type",
-            "range": Array [
-              163,
-              167,
-            ],
-            "type": "Identifier",
-          },
-          "range": Array [
-            163,
-            167,
+            655,
+            658,
           ],
           "type": "ImportSpecifier",
         },
@@ -65727,51 +67503,369 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 7,
-                "line": 16,
+                "line": 40,
               },
               "start": Object {
                 "column": 2,
-                "line": 16,
+                "line": 40,
               },
             },
             "name": "async",
             "range": Array [
-              171,
-              176,
+              662,
+              667,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 7,
-              "line": 16,
+              "line": 40,
             },
             "start": Object {
               "column": 2,
-              "line": 16,
+              "line": 40,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 7,
-                "line": 16,
+                "line": 40,
               },
               "start": Object {
                 "column": 2,
-                "line": 16,
+                "line": 40,
               },
             },
             "name": "async",
             "range": Array [
-              171,
-              176,
+              662,
+              667,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            171,
-            176,
+            662,
+            667,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 41,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 41,
+              },
+            },
+            "name": "await",
+            "range": Array [
+              671,
+              676,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 7,
+              "line": 41,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 41,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 41,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 41,
+              },
+            },
+            "name": "await",
+            "range": Array [
+              671,
+              676,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            671,
+            676,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 42,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 42,
+              },
+            },
+            "name": "boolean",
+            "range": Array [
+              680,
+              687,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 9,
+              "line": 42,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 42,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 42,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 42,
+              },
+            },
+            "name": "boolean",
+            "range": Array [
+              680,
+              687,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            680,
+            687,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 13,
+                "line": 43,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 43,
+              },
+            },
+            "name": "constructor",
+            "range": Array [
+              691,
+              702,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 13,
+              "line": 43,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 43,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 13,
+                "line": 43,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 43,
+              },
+            },
+            "name": "constructor",
+            "range": Array [
+              691,
+              702,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            691,
+            702,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 44,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 44,
+              },
+            },
+            "name": "declare",
+            "range": Array [
+              706,
+              713,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 9,
+              "line": 44,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 44,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 44,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 44,
+              },
+            },
+            "name": "declare",
+            "range": Array [
+              706,
+              713,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            706,
+            713,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 45,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 45,
+              },
+            },
+            "name": "get",
+            "range": Array [
+              717,
+              720,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 5,
+              "line": 45,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 45,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 45,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 45,
+              },
+            },
+            "name": "get",
+            "range": Array [
+              717,
+              720,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            717,
+            720,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 46,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 46,
+              },
+            },
+            "name": "infer",
+            "range": Array [
+              724,
+              729,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 7,
+              "line": 46,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 46,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 46,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 46,
+              },
+            },
+            "name": "infer",
+            "range": Array [
+              724,
+              729,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            724,
+            729,
           ],
           "type": "ImportSpecifier",
         },
@@ -65780,51 +67874,1005 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 4,
-                "line": 17,
+                "line": 47,
               },
               "start": Object {
                 "column": 2,
-                "line": 17,
+                "line": 47,
               },
             },
             "name": "is",
             "range": Array [
-              180,
-              182,
+              733,
+              735,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 4,
-              "line": 17,
+              "line": 47,
             },
             "start": Object {
               "column": 2,
-              "line": 17,
+              "line": 47,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 4,
-                "line": 17,
+                "line": 47,
               },
               "start": Object {
                 "column": 2,
-                "line": 17,
+                "line": 47,
               },
             },
             "name": "is",
             "range": Array [
-              180,
-              182,
+              733,
+              735,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            180,
-            182,
+            733,
+            735,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 48,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 48,
+              },
+            },
+            "name": "keyof",
+            "range": Array [
+              739,
+              744,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 7,
+              "line": 48,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 48,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 48,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 48,
+              },
+            },
+            "name": "keyof",
+            "range": Array [
+              739,
+              744,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            739,
+            744,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 49,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 49,
+              },
+            },
+            "name": "module",
+            "range": Array [
+              748,
+              754,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 8,
+              "line": 49,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 49,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 49,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 49,
+              },
+            },
+            "name": "module",
+            "range": Array [
+              748,
+              754,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            748,
+            754,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 11,
+                "line": 50,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 50,
+              },
+            },
+            "name": "namespace",
+            "range": Array [
+              758,
+              767,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 11,
+              "line": 50,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 50,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 11,
+                "line": 50,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 50,
+              },
+            },
+            "name": "namespace",
+            "range": Array [
+              758,
+              767,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            758,
+            767,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 51,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 51,
+              },
+            },
+            "name": "never",
+            "range": Array [
+              771,
+              776,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 7,
+              "line": 51,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 51,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 51,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 51,
+              },
+            },
+            "name": "never",
+            "range": Array [
+              771,
+              776,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            771,
+            776,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 10,
+                "line": 52,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 52,
+              },
+            },
+            "name": "readonly",
+            "range": Array [
+              780,
+              788,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 10,
+              "line": 52,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 52,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 10,
+                "line": 52,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 52,
+              },
+            },
+            "name": "readonly",
+            "range": Array [
+              780,
+              788,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            780,
+            788,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 53,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 53,
+              },
+            },
+            "name": "require",
+            "range": Array [
+              792,
+              799,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 9,
+              "line": 53,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 53,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 53,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 53,
+              },
+            },
+            "name": "require",
+            "range": Array [
+              792,
+              799,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            792,
+            799,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 54,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 54,
+              },
+            },
+            "name": "number",
+            "range": Array [
+              803,
+              809,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 8,
+              "line": 54,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 54,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 54,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 54,
+              },
+            },
+            "name": "number",
+            "range": Array [
+              803,
+              809,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            803,
+            809,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 55,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 55,
+              },
+            },
+            "name": "object",
+            "range": Array [
+              813,
+              819,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 8,
+              "line": 55,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 55,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 55,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 55,
+              },
+            },
+            "name": "object",
+            "range": Array [
+              813,
+              819,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            813,
+            819,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 56,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 56,
+              },
+            },
+            "name": "set",
+            "range": Array [
+              823,
+              826,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 5,
+              "line": 56,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 56,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 56,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 56,
+              },
+            },
+            "name": "set",
+            "range": Array [
+              823,
+              826,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            823,
+            826,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 57,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 57,
+              },
+            },
+            "name": "string",
+            "range": Array [
+              830,
+              836,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 8,
+              "line": 57,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 57,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 57,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 57,
+              },
+            },
+            "name": "string",
+            "range": Array [
+              830,
+              836,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            830,
+            836,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 58,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 58,
+              },
+            },
+            "name": "symbol",
+            "range": Array [
+              840,
+              846,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 8,
+              "line": 58,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 58,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 58,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 58,
+              },
+            },
+            "name": "symbol",
+            "range": Array [
+              840,
+              846,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            840,
+            846,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 6,
+                "line": 59,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 59,
+              },
+            },
+            "name": "type",
+            "range": Array [
+              850,
+              854,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 6,
+              "line": 59,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 59,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 6,
+                "line": 59,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 59,
+              },
+            },
+            "name": "type",
+            "range": Array [
+              850,
+              854,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            850,
+            854,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 11,
+                "line": 60,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 60,
+              },
+            },
+            "name": "undefined",
+            "range": Array [
+              858,
+              867,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 11,
+              "line": 60,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 60,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 11,
+                "line": 60,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 60,
+              },
+            },
+            "name": "undefined",
+            "range": Array [
+              858,
+              867,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            858,
+            867,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 61,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 61,
+              },
+            },
+            "name": "unique",
+            "range": Array [
+              871,
+              877,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 8,
+              "line": 61,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 61,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 61,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 61,
+              },
+            },
+            "name": "unique",
+            "range": Array [
+              871,
+              877,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            871,
+            877,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 62,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 62,
+              },
+            },
+            "name": "unknown",
+            "range": Array [
+              881,
+              888,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 9,
+              "line": 62,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 62,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 9,
+                "line": 62,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 62,
+              },
+            },
+            "name": "unknown",
+            "range": Array [
+              881,
+              888,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            881,
+            888,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 6,
+                "line": 63,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 63,
+              },
+            },
+            "name": "from",
+            "range": Array [
+              892,
+              896,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 6,
+              "line": 63,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 63,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 6,
+                "line": 63,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 63,
+              },
+            },
+            "name": "from",
+            "range": Array [
+              892,
+              896,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            892,
+            896,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 64,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 64,
+              },
+            },
+            "name": "global",
+            "range": Array [
+              900,
+              906,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 8,
+              "line": 64,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 64,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 64,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 64,
+              },
+            },
+            "name": "global",
+            "range": Array [
+              900,
+              906,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            900,
+            906,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 65,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 65,
+              },
+            },
+            "name": "bigint",
+            "range": Array [
+              910,
+              916,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 8,
+              "line": 65,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 65,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 8,
+                "line": 65,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 65,
+              },
+            },
+            "name": "bigint",
+            "range": Array [
+              910,
+              916,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            910,
+            916,
           ],
           "type": "ImportSpecifier",
         },
@@ -65833,62 +68881,597 @@ Object {
             "loc": Object {
               "end": Object {
                 "column": 4,
-                "line": 18,
+                "line": 66,
               },
               "start": Object {
                 "column": 2,
-                "line": 18,
+                "line": 66,
               },
             },
             "name": "of",
             "range": Array [
-              186,
-              188,
+              920,
+              922,
             ],
             "type": "Identifier",
           },
           "loc": Object {
             "end": Object {
               "column": 4,
-              "line": 18,
+              "line": 66,
             },
             "start": Object {
               "column": 2,
-              "line": 18,
+              "line": 66,
             },
           },
           "local": Object {
             "loc": Object {
               "end": Object {
                 "column": 4,
-                "line": 18,
+                "line": 66,
               },
               "start": Object {
                 "column": 2,
-                "line": 18,
+                "line": 66,
               },
             },
             "name": "of",
             "range": Array [
-              186,
-              188,
+              920,
+              922,
             ],
             "type": "Identifier",
           },
           "range": Array [
-            186,
-            188,
+            920,
+            922,
           ],
           "type": "ImportSpecifier",
         },
       ],
       "type": "ImportDeclaration",
     },
+    Object {
+      "body": Object {
+        "body": Array [],
+        "loc": Object {
+          "end": Object {
+            "column": 14,
+            "line": 69,
+          },
+          "start": Object {
+            "column": 12,
+            "line": 69,
+          },
+        },
+        "range": Array [
+          959,
+          961,
+        ],
+        "type": "TSInterfaceBody",
+      },
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 11,
+            "line": 69,
+          },
+          "start": Object {
+            "column": 10,
+            "line": 69,
+          },
+        },
+        "name": "X",
+        "range": Array [
+          957,
+          958,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 69,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 69,
+        },
+      },
+      "range": Array [
+        947,
+        961,
+      ],
+      "type": "TSInterfaceDeclaration",
+    },
+    Object {
+      "body": Object {
+        "body": Array [
+          Object {
+            "computed": false,
+            "key": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 10,
+                  "line": 71,
+                },
+                "start": Object {
+                  "column": 9,
+                  "line": 71,
+                },
+              },
+              "name": "a",
+              "range": Array [
+                994,
+                995,
+              ],
+              "type": "Identifier",
+            },
+            "kind": "method",
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 71,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 71,
+              },
+            },
+            "range": Array [
+              987,
+              1000,
+            ],
+            "static": true,
+            "type": "MethodDefinition",
+            "value": Object {
+              "async": false,
+              "body": Object {
+                "body": Array [],
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 71,
+                  },
+                  "start": Object {
+                    "column": 13,
+                    "line": 71,
+                  },
+                },
+                "range": Array [
+                  998,
+                  1000,
+                ],
+                "type": "BlockStatement",
+              },
+              "expression": false,
+              "generator": false,
+              "id": null,
+              "loc": Object {
+                "end": Object {
+                  "column": 15,
+                  "line": 71,
+                },
+                "start": Object {
+                  "column": 10,
+                  "line": 71,
+                },
+              },
+              "params": Array [],
+              "range": Array [
+                995,
+                1000,
+              ],
+              "type": "FunctionExpression",
+            },
+          },
+          Object {
+            "accessibility": "private",
+            "computed": false,
+            "key": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 11,
+                  "line": 72,
+                },
+                "start": Object {
+                  "column": 10,
+                  "line": 72,
+                },
+              },
+              "name": "b",
+              "range": Array [
+                1011,
+                1012,
+              ],
+              "type": "Identifier",
+            },
+            "kind": "method",
+            "loc": Object {
+              "end": Object {
+                "column": 16,
+                "line": 72,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 72,
+              },
+            },
+            "range": Array [
+              1003,
+              1017,
+            ],
+            "static": false,
+            "type": "MethodDefinition",
+            "value": Object {
+              "async": false,
+              "body": Object {
+                "body": Array [],
+                "loc": Object {
+                  "end": Object {
+                    "column": 16,
+                    "line": 72,
+                  },
+                  "start": Object {
+                    "column": 14,
+                    "line": 72,
+                  },
+                },
+                "range": Array [
+                  1015,
+                  1017,
+                ],
+                "type": "BlockStatement",
+              },
+              "expression": false,
+              "generator": false,
+              "id": null,
+              "loc": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 72,
+                },
+                "start": Object {
+                  "column": 11,
+                  "line": 72,
+                },
+              },
+              "params": Array [],
+              "range": Array [
+                1012,
+                1017,
+              ],
+              "type": "FunctionExpression",
+            },
+          },
+          Object {
+            "accessibility": "public",
+            "computed": false,
+            "key": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 10,
+                  "line": 73,
+                },
+                "start": Object {
+                  "column": 9,
+                  "line": 73,
+                },
+              },
+              "name": "c",
+              "range": Array [
+                1027,
+                1028,
+              ],
+              "type": "Identifier",
+            },
+            "kind": "method",
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 73,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 73,
+              },
+            },
+            "range": Array [
+              1020,
+              1033,
+            ],
+            "static": false,
+            "type": "MethodDefinition",
+            "value": Object {
+              "async": false,
+              "body": Object {
+                "body": Array [],
+                "loc": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 73,
+                  },
+                  "start": Object {
+                    "column": 13,
+                    "line": 73,
+                  },
+                },
+                "range": Array [
+                  1031,
+                  1033,
+                ],
+                "type": "BlockStatement",
+              },
+              "expression": false,
+              "generator": false,
+              "id": null,
+              "loc": Object {
+                "end": Object {
+                  "column": 15,
+                  "line": 73,
+                },
+                "start": Object {
+                  "column": 10,
+                  "line": 73,
+                },
+              },
+              "params": Array [],
+              "range": Array [
+                1028,
+                1033,
+              ],
+              "type": "FunctionExpression",
+            },
+          },
+          Object {
+            "accessibility": "protected",
+            "computed": false,
+            "key": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 14,
+                  "line": 74,
+                },
+                "start": Object {
+                  "column": 13,
+                  "line": 74,
+                },
+              },
+              "name": "d",
+              "range": Array [
+                1047,
+                1048,
+              ],
+              "type": "Identifier",
+            },
+            "kind": "method",
+            "loc": Object {
+              "end": Object {
+                "column": 3,
+                "line": 76,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 74,
+              },
+            },
+            "range": Array [
+              1036,
+              1075,
+            ],
+            "static": false,
+            "type": "MethodDefinition",
+            "value": Object {
+              "async": false,
+              "body": Object {
+                "body": Array [
+                  Object {
+                    "declarations": Array [
+                      Object {
+                        "id": Object {
+                          "loc": Object {
+                            "end": Object {
+                              "column": 9,
+                              "line": 75,
+                            },
+                            "start": Object {
+                              "column": 8,
+                              "line": 75,
+                            },
+                          },
+                          "name": "x",
+                          "range": Array [
+                            1061,
+                            1062,
+                          ],
+                          "type": "Identifier",
+                        },
+                        "init": Object {
+                          "argument": null,
+                          "delegate": false,
+                          "loc": Object {
+                            "end": Object {
+                              "column": 17,
+                              "line": 75,
+                            },
+                            "start": Object {
+                              "column": 12,
+                              "line": 75,
+                            },
+                          },
+                          "range": Array [
+                            1065,
+                            1070,
+                          ],
+                          "type": "YieldExpression",
+                        },
+                        "loc": Object {
+                          "end": Object {
+                            "column": 17,
+                            "line": 75,
+                          },
+                          "start": Object {
+                            "column": 8,
+                            "line": 75,
+                          },
+                        },
+                        "range": Array [
+                          1061,
+                          1070,
+                        ],
+                        "type": "VariableDeclarator",
+                      },
+                    ],
+                    "kind": "let",
+                    "loc": Object {
+                      "end": Object {
+                        "column": 18,
+                        "line": 75,
+                      },
+                      "start": Object {
+                        "column": 4,
+                        "line": 75,
+                      },
+                    },
+                    "range": Array [
+                      1057,
+                      1071,
+                    ],
+                    "type": "VariableDeclaration",
+                  },
+                ],
+                "loc": Object {
+                  "end": Object {
+                    "column": 3,
+                    "line": 76,
+                  },
+                  "start": Object {
+                    "column": 17,
+                    "line": 74,
+                  },
+                },
+                "range": Array [
+                  1051,
+                  1075,
+                ],
+                "type": "BlockStatement",
+              },
+              "expression": false,
+              "generator": true,
+              "id": null,
+              "loc": Object {
+                "end": Object {
+                  "column": 3,
+                  "line": 76,
+                },
+                "start": Object {
+                  "column": 14,
+                  "line": 74,
+                },
+              },
+              "params": Array [],
+              "range": Array [
+                1048,
+                1075,
+              ],
+              "type": "FunctionExpression",
+            },
+          },
+        ],
+        "loc": Object {
+          "end": Object {
+            "column": 1,
+            "line": 77,
+          },
+          "start": Object {
+            "column": 21,
+            "line": 70,
+          },
+        },
+        "range": Array [
+          983,
+          1077,
+        ],
+        "type": "ClassBody",
+      },
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 7,
+            "line": 70,
+          },
+          "start": Object {
+            "column": 6,
+            "line": 70,
+          },
+        },
+        "name": "C",
+        "range": Array [
+          968,
+          969,
+        ],
+        "type": "Identifier",
+      },
+      "implements": Array [
+        Object {
+          "expression": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 20,
+                "line": 70,
+              },
+              "start": Object {
+                "column": 19,
+                "line": 70,
+              },
+            },
+            "name": "X",
+            "range": Array [
+              981,
+              982,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 20,
+              "line": 70,
+            },
+            "start": Object {
+              "column": 19,
+              "line": 70,
+            },
+          },
+          "range": Array [
+            981,
+            982,
+          ],
+          "type": "TSClassImplements",
+        },
+      ],
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 77,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 70,
+        },
+      },
+      "range": Array [
+        962,
+        1077,
+      ],
+      "superClass": null,
+      "type": "ClassDeclaration",
+    },
   ],
   "loc": Object {
     "end": Object {
       "column": 0,
-      "line": 20,
+      "line": 78,
     },
     "start": Object {
       "column": 0,
@@ -65897,7 +69480,7 @@ Object {
   },
   "range": Array [
     0,
-    212,
+    1078,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -65940,7 +69523,7 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 11,
+          "column": 16,
           "line": 2,
         },
         "start": Object {
@@ -65950,226 +69533,208 @@ Object {
       },
       "range": Array [
         10,
-        13,
-      ],
-      "type": "Identifier",
-      "value": "get",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 13,
-          "line": 2,
-        },
-        "start": Object {
-          "column": 12,
-          "line": 2,
-        },
-      },
-      "range": Array [
-        14,
-        15,
-      ],
-      "type": "Punctuator",
-      "value": "=",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 15,
-          "line": 2,
-        },
-        "start": Object {
-          "column": 14,
-          "line": 2,
-        },
-      },
-      "range": Array [
-        16,
-        17,
-      ],
-      "type": "Numeric",
-      "value": "1",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 16,
-          "line": 2,
-        },
-        "start": Object {
-          "column": 15,
-          "line": 2,
-        },
-      },
-      "range": Array [
-        17,
         18,
       ],
-      "type": "Punctuator",
-      "value": ";",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 7,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 2,
-          "line": 3,
-        },
-      },
-      "range": Array [
-        21,
-        26,
-      ],
       "type": "Keyword",
-      "value": "const",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 11,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 8,
-          "line": 3,
-        },
-      },
-      "range": Array [
-        27,
-        30,
-      ],
-      "type": "Identifier",
-      "value": "set",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 13,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 12,
-          "line": 3,
-        },
-      },
-      "range": Array [
-        31,
-        32,
-      ],
-      "type": "Punctuator",
-      "value": "=",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 15,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 14,
-          "line": 3,
-        },
-      },
-      "range": Array [
-        33,
-        34,
-      ],
-      "type": "Numeric",
-      "value": "1",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 16,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 15,
-          "line": 3,
-        },
-      },
-      "range": Array [
-        34,
-        35,
-      ],
-      "type": "Punctuator",
-      "value": ";",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 7,
-          "line": 4,
-        },
-        "start": Object {
-          "column": 2,
-          "line": 4,
-        },
-      },
-      "range": Array [
-        38,
-        43,
-      ],
-      "type": "Keyword",
-      "value": "const",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 14,
-          "line": 4,
-        },
-        "start": Object {
-          "column": 8,
-          "line": 4,
-        },
-      },
-      "range": Array [
-        44,
-        50,
-      ],
-      "type": "Identifier",
-      "value": "module",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 16,
-          "line": 4,
-        },
-        "start": Object {
-          "column": 15,
-          "line": 4,
-        },
-      },
-      "range": Array [
-        51,
-        52,
-      ],
-      "type": "Punctuator",
-      "value": "=",
+      "value": "abstract",
     },
     Object {
       "loc": Object {
         "end": Object {
           "column": 18,
-          "line": 4,
+          "line": 2,
         },
         "start": Object {
           "column": 17,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        19,
+        20,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        21,
+        22,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        22,
+        23,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        26,
+        31,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        32,
+        34,
+      ],
+      "type": "Keyword",
+      "value": "as",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        35,
+        36,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        37,
+        38,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        38,
+        39,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 2,
           "line": 4,
         },
       },
       "range": Array [
-        53,
-        54,
+        42,
+        47,
       ],
-      "type": "Numeric",
-      "value": "1",
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        48,
+        55,
+      ],
+      "type": "Keyword",
+      "value": "asserts",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        56,
+        57,
+      ],
+      "type": "Punctuator",
+      "value": "=",
     },
     Object {
       "loc": Object {
@@ -66183,8 +69748,26 @@ Object {
         },
       },
       "range": Array [
-        54,
-        55,
+        58,
+        59,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        59,
+        60,
       ],
       "type": "Punctuator",
       "value": ";",
@@ -66201,8 +69784,8 @@ Object {
         },
       },
       "range": Array [
-        58,
         63,
+        68,
       ],
       "type": "Keyword",
       "value": "const",
@@ -66210,7 +69793,7 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 12,
+          "column": 11,
           "line": 5,
         },
         "start": Object {
@@ -66219,29 +69802,47 @@ Object {
         },
       },
       "range": Array [
-        64,
-        68,
+        69,
+        72,
       ],
-      "type": "Identifier",
-      "value": "type",
+      "type": "Keyword",
+      "value": "any",
     },
     Object {
       "loc": Object {
         "end": Object {
-          "column": 14,
+          "column": 13,
           "line": 5,
         },
         "start": Object {
-          "column": 13,
+          "column": 12,
           "line": 5,
         },
       },
       "range": Array [
-        69,
-        70,
+        73,
+        74,
       ],
       "type": "Punctuator",
       "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        75,
+        76,
+      ],
+      "type": "Numeric",
+      "value": "1",
     },
     Object {
       "loc": Object {
@@ -66255,26 +69856,8 @@ Object {
         },
       },
       "range": Array [
-        71,
-        72,
-      ],
-      "type": "Numeric",
-      "value": "1",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 17,
-          "line": 5,
-        },
-        "start": Object {
-          "column": 16,
-          "line": 5,
-        },
-      },
-      "range": Array [
-        72,
-        73,
+        76,
+        77,
       ],
       "type": "Punctuator",
       "value": ";",
@@ -66291,8 +69874,8 @@ Object {
         },
       },
       "range": Array [
-        76,
-        81,
+        80,
+        85,
       ],
       "type": "Keyword",
       "value": "const",
@@ -66309,8 +69892,8 @@ Object {
         },
       },
       "range": Array [
-        82,
-        87,
+        86,
+        91,
       ],
       "type": "Identifier",
       "value": "async",
@@ -66327,8 +69910,8 @@ Object {
         },
       },
       "range": Array [
-        88,
-        89,
+        92,
+        93,
       ],
       "type": "Punctuator",
       "value": "=",
@@ -66345,8 +69928,8 @@ Object {
         },
       },
       "range": Array [
-        90,
-        91,
+        94,
+        95,
       ],
       "type": "Numeric",
       "value": "1",
@@ -66363,8 +69946,8 @@ Object {
         },
       },
       "range": Array [
-        91,
-        92,
+        95,
+        96,
       ],
       "type": "Punctuator",
       "value": ";",
@@ -66381,8 +69964,8 @@ Object {
         },
       },
       "range": Array [
-        95,
-        100,
+        99,
+        104,
       ],
       "type": "Keyword",
       "value": "const",
@@ -66390,7 +69973,7 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 10,
+          "column": 13,
           "line": 7,
         },
         "start": Object {
@@ -66399,8 +69982,548 @@ Object {
         },
       },
       "range": Array [
-        101,
-        103,
+        105,
+        110,
+      ],
+      "type": "Keyword",
+      "value": "await",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        111,
+        112,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        113,
+        114,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 7,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 7,
+        },
+      },
+      "range": Array [
+        114,
+        115,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        118,
+        123,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        124,
+        131,
+      ],
+      "type": "Keyword",
+      "value": "boolean",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        132,
+        133,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        134,
+        135,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 8,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 8,
+        },
+      },
+      "range": Array [
+        135,
+        136,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        139,
+        144,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        145,
+        156,
+      ],
+      "type": "Keyword",
+      "value": "constructor",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        157,
+        158,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        159,
+        160,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 24,
+          "line": 9,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 9,
+        },
+      },
+      "range": Array [
+        160,
+        161,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        164,
+        169,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        170,
+        177,
+      ],
+      "type": "Keyword",
+      "value": "declare",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        178,
+        179,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        180,
+        181,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 10,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 10,
+        },
+      },
+      "range": Array [
+        181,
+        182,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 11,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 11,
+        },
+      },
+      "range": Array [
+        185,
+        190,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 11,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 11,
+        },
+      },
+      "range": Array [
+        191,
+        194,
+      ],
+      "type": "Identifier",
+      "value": "get",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 11,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 11,
+        },
+      },
+      "range": Array [
+        195,
+        196,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 11,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 11,
+        },
+      },
+      "range": Array [
+        197,
+        198,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 11,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 11,
+        },
+      },
+      "range": Array [
+        198,
+        199,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        202,
+        207,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        208,
+        213,
+      ],
+      "type": "Keyword",
+      "value": "infer",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        214,
+        215,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        216,
+        217,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 12,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 12,
+        },
+      },
+      "range": Array [
+        217,
+        218,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 13,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 13,
+        },
+      },
+      "range": Array [
+        221,
+        226,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 13,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 13,
+        },
+      },
+      "range": Array [
+        227,
+        229,
       ],
       "type": "Identifier",
       "value": "is",
@@ -66409,16 +70532,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 12,
-          "line": 7,
+          "line": 13,
         },
         "start": Object {
           "column": 11,
-          "line": 7,
+          "line": 13,
         },
       },
       "range": Array [
-        104,
-        105,
+        230,
+        231,
       ],
       "type": "Punctuator",
       "value": "=",
@@ -66427,16 +70550,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 14,
-          "line": 7,
+          "line": 13,
         },
         "start": Object {
           "column": 13,
-          "line": 7,
+          "line": 13,
         },
       },
       "range": Array [
-        106,
-        107,
+        232,
+        233,
       ],
       "type": "Numeric",
       "value": "1",
@@ -66445,16 +70568,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 15,
-          "line": 7,
+          "line": 13,
         },
         "start": Object {
           "column": 14,
-          "line": 7,
+          "line": 13,
         },
       },
       "range": Array [
-        107,
-        108,
+        233,
+        234,
       ],
       "type": "Punctuator",
       "value": ";",
@@ -66463,16 +70586,1636 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 7,
-          "line": 8,
+          "line": 14,
         },
         "start": Object {
           "column": 2,
-          "line": 8,
+          "line": 14,
         },
       },
       "range": Array [
-        111,
-        116,
+        237,
+        242,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 14,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 14,
+        },
+      },
+      "range": Array [
+        243,
+        248,
+      ],
+      "type": "Keyword",
+      "value": "keyof",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 14,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 14,
+        },
+      },
+      "range": Array [
+        249,
+        250,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 14,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 14,
+        },
+      },
+      "range": Array [
+        251,
+        252,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 14,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 14,
+        },
+      },
+      "range": Array [
+        252,
+        253,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 15,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 15,
+        },
+      },
+      "range": Array [
+        256,
+        261,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 15,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 15,
+        },
+      },
+      "range": Array [
+        262,
+        268,
+      ],
+      "type": "Identifier",
+      "value": "module",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 15,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 15,
+        },
+      },
+      "range": Array [
+        269,
+        270,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 15,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 15,
+        },
+      },
+      "range": Array [
+        271,
+        272,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 15,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 15,
+        },
+      },
+      "range": Array [
+        272,
+        273,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 16,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 16,
+        },
+      },
+      "range": Array [
+        276,
+        281,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 16,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 16,
+        },
+      },
+      "range": Array [
+        282,
+        291,
+      ],
+      "type": "Keyword",
+      "value": "namespace",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 16,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 16,
+        },
+      },
+      "range": Array [
+        292,
+        293,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 16,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 16,
+        },
+      },
+      "range": Array [
+        294,
+        295,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 16,
+        },
+        "start": Object {
+          "column": 21,
+          "line": 16,
+        },
+      },
+      "range": Array [
+        295,
+        296,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 17,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 17,
+        },
+      },
+      "range": Array [
+        299,
+        304,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 17,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 17,
+        },
+      },
+      "range": Array [
+        305,
+        310,
+      ],
+      "type": "Keyword",
+      "value": "never",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 17,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 17,
+        },
+      },
+      "range": Array [
+        311,
+        312,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 17,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 17,
+        },
+      },
+      "range": Array [
+        313,
+        314,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 17,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 17,
+        },
+      },
+      "range": Array [
+        314,
+        315,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 18,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 18,
+        },
+      },
+      "range": Array [
+        318,
+        323,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 18,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 18,
+        },
+      },
+      "range": Array [
+        324,
+        332,
+      ],
+      "type": "Keyword",
+      "value": "readonly",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 18,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 18,
+        },
+      },
+      "range": Array [
+        333,
+        334,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 18,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 18,
+        },
+      },
+      "range": Array [
+        335,
+        336,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 18,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 18,
+        },
+      },
+      "range": Array [
+        336,
+        337,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 19,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 19,
+        },
+      },
+      "range": Array [
+        340,
+        345,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 19,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 19,
+        },
+      },
+      "range": Array [
+        346,
+        353,
+      ],
+      "type": "Keyword",
+      "value": "require",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 19,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 19,
+        },
+      },
+      "range": Array [
+        354,
+        355,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 19,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 19,
+        },
+      },
+      "range": Array [
+        356,
+        357,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 19,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 19,
+        },
+      },
+      "range": Array [
+        357,
+        358,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 20,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 20,
+        },
+      },
+      "range": Array [
+        361,
+        366,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 20,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 20,
+        },
+      },
+      "range": Array [
+        367,
+        373,
+      ],
+      "type": "Keyword",
+      "value": "number",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 20,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 20,
+        },
+      },
+      "range": Array [
+        374,
+        375,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 20,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 20,
+        },
+      },
+      "range": Array [
+        376,
+        377,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 20,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 20,
+        },
+      },
+      "range": Array [
+        377,
+        378,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 21,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 21,
+        },
+      },
+      "range": Array [
+        381,
+        386,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 21,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 21,
+        },
+      },
+      "range": Array [
+        387,
+        393,
+      ],
+      "type": "Keyword",
+      "value": "object",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 21,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 21,
+        },
+      },
+      "range": Array [
+        394,
+        395,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 21,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 21,
+        },
+      },
+      "range": Array [
+        396,
+        397,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 21,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 21,
+        },
+      },
+      "range": Array [
+        397,
+        398,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 22,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 22,
+        },
+      },
+      "range": Array [
+        401,
+        406,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 22,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 22,
+        },
+      },
+      "range": Array [
+        407,
+        410,
+      ],
+      "type": "Identifier",
+      "value": "set",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 22,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 22,
+        },
+      },
+      "range": Array [
+        411,
+        412,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 22,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 22,
+        },
+      },
+      "range": Array [
+        413,
+        414,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 22,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 22,
+        },
+      },
+      "range": Array [
+        414,
+        415,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 23,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 23,
+        },
+      },
+      "range": Array [
+        418,
+        423,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 23,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 23,
+        },
+      },
+      "range": Array [
+        424,
+        430,
+      ],
+      "type": "Keyword",
+      "value": "string",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 23,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 23,
+        },
+      },
+      "range": Array [
+        431,
+        432,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 23,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 23,
+        },
+      },
+      "range": Array [
+        433,
+        434,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 23,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 23,
+        },
+      },
+      "range": Array [
+        434,
+        435,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 24,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 24,
+        },
+      },
+      "range": Array [
+        438,
+        443,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 24,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 24,
+        },
+      },
+      "range": Array [
+        444,
+        450,
+      ],
+      "type": "Keyword",
+      "value": "symbol",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 24,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 24,
+        },
+      },
+      "range": Array [
+        451,
+        452,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 24,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 24,
+        },
+      },
+      "range": Array [
+        453,
+        454,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 24,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 24,
+        },
+      },
+      "range": Array [
+        454,
+        455,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 25,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 25,
+        },
+      },
+      "range": Array [
+        458,
+        463,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 25,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 25,
+        },
+      },
+      "range": Array [
+        464,
+        468,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 25,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 25,
+        },
+      },
+      "range": Array [
+        469,
+        470,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 25,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 25,
+        },
+      },
+      "range": Array [
+        471,
+        472,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 25,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 25,
+        },
+      },
+      "range": Array [
+        472,
+        473,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 26,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 26,
+        },
+      },
+      "range": Array [
+        476,
+        481,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 26,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 26,
+        },
+      },
+      "range": Array [
+        482,
+        491,
+      ],
+      "type": "Keyword",
+      "value": "undefined",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 26,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 26,
+        },
+      },
+      "range": Array [
+        492,
+        493,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 26,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 26,
+        },
+      },
+      "range": Array [
+        494,
+        495,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 26,
+        },
+        "start": Object {
+          "column": 21,
+          "line": 26,
+        },
+      },
+      "range": Array [
+        495,
+        496,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 27,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 27,
+        },
+      },
+      "range": Array [
+        499,
+        504,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 27,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 27,
+        },
+      },
+      "range": Array [
+        505,
+        511,
+      ],
+      "type": "Keyword",
+      "value": "unique",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 27,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 27,
+        },
+      },
+      "range": Array [
+        512,
+        513,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 27,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 27,
+        },
+      },
+      "range": Array [
+        514,
+        515,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 27,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 27,
+        },
+      },
+      "range": Array [
+        515,
+        516,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 28,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 28,
+        },
+      },
+      "range": Array [
+        519,
+        524,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 28,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 28,
+        },
+      },
+      "range": Array [
+        525,
+        532,
+      ],
+      "type": "Keyword",
+      "value": "unknown",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 28,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 28,
+        },
+      },
+      "range": Array [
+        533,
+        534,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 28,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 28,
+        },
+      },
+      "range": Array [
+        535,
+        536,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 28,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 28,
+        },
+      },
+      "range": Array [
+        536,
+        537,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 29,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 29,
+        },
+      },
+      "range": Array [
+        540,
+        545,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 29,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 29,
+        },
+      },
+      "range": Array [
+        546,
+        550,
+      ],
+      "type": "Keyword",
+      "value": "from",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 29,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 29,
+        },
+      },
+      "range": Array [
+        551,
+        552,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 29,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 29,
+        },
+      },
+      "range": Array [
+        553,
+        554,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 29,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 29,
+        },
+      },
+      "range": Array [
+        554,
+        555,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 30,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 30,
+        },
+      },
+      "range": Array [
+        558,
+        563,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 30,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 30,
+        },
+      },
+      "range": Array [
+        564,
+        570,
+      ],
+      "type": "Keyword",
+      "value": "global",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 30,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 30,
+        },
+      },
+      "range": Array [
+        571,
+        572,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 30,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 30,
+        },
+      },
+      "range": Array [
+        573,
+        574,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 30,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 30,
+        },
+      },
+      "range": Array [
+        574,
+        575,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 31,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 31,
+        },
+      },
+      "range": Array [
+        578,
+        583,
+      ],
+      "type": "Keyword",
+      "value": "const",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 31,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 31,
+        },
+      },
+      "range": Array [
+        584,
+        590,
+      ],
+      "type": "Keyword",
+      "value": "bigint",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 31,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 31,
+        },
+      },
+      "range": Array [
+        591,
+        592,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 31,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 31,
+        },
+      },
+      "range": Array [
+        593,
+        594,
+      ],
+      "type": "Numeric",
+      "value": "1",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 31,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 31,
+        },
+      },
+      "range": Array [
+        594,
+        595,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 32,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 32,
+        },
+      },
+      "range": Array [
+        598,
+        603,
       ],
       "type": "Keyword",
       "value": "const",
@@ -66481,16 +72224,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 10,
-          "line": 8,
+          "line": 32,
         },
         "start": Object {
           "column": 8,
-          "line": 8,
+          "line": 32,
         },
       },
       "range": Array [
-        117,
-        119,
+        604,
+        606,
       ],
       "type": "Identifier",
       "value": "of",
@@ -66499,16 +72242,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 12,
-          "line": 8,
+          "line": 32,
         },
         "start": Object {
           "column": 11,
-          "line": 8,
+          "line": 32,
         },
       },
       "range": Array [
-        120,
-        121,
+        607,
+        608,
       ],
       "type": "Punctuator",
       "value": "=",
@@ -66517,16 +72260,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 14,
-          "line": 8,
+          "line": 32,
         },
         "start": Object {
           "column": 13,
-          "line": 8,
+          "line": 32,
         },
       },
       "range": Array [
-        122,
-        123,
+        609,
+        610,
       ],
       "type": "Numeric",
       "value": "1",
@@ -66535,16 +72278,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 15,
-          "line": 8,
+          "line": 32,
         },
         "start": Object {
           "column": 14,
-          "line": 8,
+          "line": 32,
         },
       },
       "range": Array [
-        123,
-        124,
+        610,
+        611,
       ],
       "type": "Punctuator",
       "value": ";",
@@ -66553,16 +72296,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 9,
+          "line": 33,
         },
         "start": Object {
           "column": 0,
-          "line": 9,
+          "line": 33,
         },
       },
       "range": Array [
-        125,
-        126,
+        612,
+        613,
       ],
       "type": "Punctuator",
       "value": "}",
@@ -66571,16 +72314,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 11,
+          "line": 35,
         },
         "start": Object {
           "column": 0,
-          "line": 11,
+          "line": 35,
         },
       },
       "range": Array [
-        128,
-        134,
+        615,
+        621,
       ],
       "type": "Keyword",
       "value": "import",
@@ -66589,16 +72332,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 8,
-          "line": 11,
+          "line": 35,
         },
         "start": Object {
           "column": 7,
-          "line": 11,
+          "line": 35,
         },
       },
       "range": Array [
-        135,
-        136,
+        622,
+        623,
       ],
       "type": "Punctuator",
       "value": "{",
@@ -66606,35 +72349,35 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 5,
-          "line": 12,
+          "column": 10,
+          "line": 36,
         },
         "start": Object {
           "column": 2,
-          "line": 12,
+          "line": 36,
         },
       },
       "range": Array [
-        139,
-        142,
+        626,
+        634,
       ],
-      "type": "Identifier",
-      "value": "get",
+      "type": "Keyword",
+      "value": "abstract",
     },
     Object {
       "loc": Object {
         "end": Object {
-          "column": 6,
-          "line": 12,
+          "column": 11,
+          "line": 36,
         },
         "start": Object {
-          "column": 5,
-          "line": 12,
+          "column": 10,
+          "line": 36,
         },
       },
       "range": Array [
-        142,
-        143,
+        634,
+        635,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66642,71 +72385,71 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 5,
-          "line": 13,
+          "column": 4,
+          "line": 37,
         },
         "start": Object {
           "column": 2,
-          "line": 13,
+          "line": 37,
         },
       },
       "range": Array [
-        146,
-        149,
+        638,
+        640,
       ],
-      "type": "Identifier",
-      "value": "set",
+      "type": "Keyword",
+      "value": "as",
     },
     Object {
       "loc": Object {
         "end": Object {
-          "column": 6,
-          "line": 13,
+          "column": 5,
+          "line": 37,
         },
         "start": Object {
-          "column": 5,
-          "line": 13,
+          "column": 4,
+          "line": 37,
         },
       },
       "range": Array [
-        149,
-        150,
+        640,
+        641,
       ],
       "type": "Punctuator",
       "value": ",",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 8,
-          "line": 14,
-        },
-        "start": Object {
-          "column": 2,
-          "line": 14,
-        },
-      },
-      "range": Array [
-        153,
-        159,
-      ],
-      "type": "Identifier",
-      "value": "module",
     },
     Object {
       "loc": Object {
         "end": Object {
           "column": 9,
-          "line": 14,
+          "line": 38,
         },
         "start": Object {
-          "column": 8,
-          "line": 14,
+          "column": 2,
+          "line": 38,
         },
       },
       "range": Array [
-        159,
-        160,
+        644,
+        651,
+      ],
+      "type": "Keyword",
+      "value": "asserts",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 38,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 38,
+        },
+      },
+      "range": Array [
+        651,
+        652,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66714,35 +72457,35 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 6,
-          "line": 15,
+          "column": 5,
+          "line": 39,
         },
         "start": Object {
           "column": 2,
-          "line": 15,
+          "line": 39,
         },
       },
       "range": Array [
-        163,
-        167,
+        655,
+        658,
       ],
-      "type": "Identifier",
-      "value": "type",
+      "type": "Keyword",
+      "value": "any",
     },
     Object {
       "loc": Object {
         "end": Object {
-          "column": 7,
-          "line": 15,
+          "column": 6,
+          "line": 39,
         },
         "start": Object {
-          "column": 6,
-          "line": 15,
+          "column": 5,
+          "line": 39,
         },
       },
       "range": Array [
-        167,
-        168,
+        658,
+        659,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66751,16 +72494,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 7,
-          "line": 16,
+          "line": 40,
         },
         "start": Object {
           "column": 2,
-          "line": 16,
+          "line": 40,
         },
       },
       "range": Array [
-        171,
-        176,
+        662,
+        667,
       ],
       "type": "Identifier",
       "value": "async",
@@ -66769,16 +72512,232 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 8,
-          "line": 16,
+          "line": 40,
         },
         "start": Object {
           "column": 7,
-          "line": 16,
+          "line": 40,
         },
       },
       "range": Array [
-        176,
-        177,
+        667,
+        668,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 41,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 41,
+        },
+      },
+      "range": Array [
+        671,
+        676,
+      ],
+      "type": "Keyword",
+      "value": "await",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 41,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 41,
+        },
+      },
+      "range": Array [
+        676,
+        677,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 42,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 42,
+        },
+      },
+      "range": Array [
+        680,
+        687,
+      ],
+      "type": "Keyword",
+      "value": "boolean",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 42,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 42,
+        },
+      },
+      "range": Array [
+        687,
+        688,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 43,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 43,
+        },
+      },
+      "range": Array [
+        691,
+        702,
+      ],
+      "type": "Keyword",
+      "value": "constructor",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 43,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 43,
+        },
+      },
+      "range": Array [
+        702,
+        703,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 44,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 44,
+        },
+      },
+      "range": Array [
+        706,
+        713,
+      ],
+      "type": "Keyword",
+      "value": "declare",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 44,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 44,
+        },
+      },
+      "range": Array [
+        713,
+        714,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 45,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 45,
+        },
+      },
+      "range": Array [
+        717,
+        720,
+      ],
+      "type": "Identifier",
+      "value": "get",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 45,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 45,
+        },
+      },
+      "range": Array [
+        720,
+        721,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 46,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 46,
+        },
+      },
+      "range": Array [
+        724,
+        729,
+      ],
+      "type": "Keyword",
+      "value": "infer",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 46,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 46,
+        },
+      },
+      "range": Array [
+        729,
+        730,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66787,16 +72746,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 4,
-          "line": 17,
+          "line": 47,
         },
         "start": Object {
           "column": 2,
-          "line": 17,
+          "line": 47,
         },
       },
       "range": Array [
-        180,
-        182,
+        733,
+        735,
       ],
       "type": "Identifier",
       "value": "is",
@@ -66805,16 +72764,664 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 5,
-          "line": 17,
+          "line": 47,
         },
         "start": Object {
           "column": 4,
-          "line": 17,
+          "line": 47,
         },
       },
       "range": Array [
-        182,
-        183,
+        735,
+        736,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 48,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 48,
+        },
+      },
+      "range": Array [
+        739,
+        744,
+      ],
+      "type": "Keyword",
+      "value": "keyof",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 48,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 48,
+        },
+      },
+      "range": Array [
+        744,
+        745,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 49,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 49,
+        },
+      },
+      "range": Array [
+        748,
+        754,
+      ],
+      "type": "Identifier",
+      "value": "module",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 49,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 49,
+        },
+      },
+      "range": Array [
+        754,
+        755,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 50,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 50,
+        },
+      },
+      "range": Array [
+        758,
+        767,
+      ],
+      "type": "Keyword",
+      "value": "namespace",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 50,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 50,
+        },
+      },
+      "range": Array [
+        767,
+        768,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 51,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 51,
+        },
+      },
+      "range": Array [
+        771,
+        776,
+      ],
+      "type": "Keyword",
+      "value": "never",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 51,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 51,
+        },
+      },
+      "range": Array [
+        776,
+        777,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 52,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 52,
+        },
+      },
+      "range": Array [
+        780,
+        788,
+      ],
+      "type": "Keyword",
+      "value": "readonly",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 52,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 52,
+        },
+      },
+      "range": Array [
+        788,
+        789,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 53,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 53,
+        },
+      },
+      "range": Array [
+        792,
+        799,
+      ],
+      "type": "Keyword",
+      "value": "require",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 53,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 53,
+        },
+      },
+      "range": Array [
+        799,
+        800,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 54,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 54,
+        },
+      },
+      "range": Array [
+        803,
+        809,
+      ],
+      "type": "Keyword",
+      "value": "number",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 54,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 54,
+        },
+      },
+      "range": Array [
+        809,
+        810,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 55,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 55,
+        },
+      },
+      "range": Array [
+        813,
+        819,
+      ],
+      "type": "Keyword",
+      "value": "object",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 55,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 55,
+        },
+      },
+      "range": Array [
+        819,
+        820,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 56,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 56,
+        },
+      },
+      "range": Array [
+        823,
+        826,
+      ],
+      "type": "Identifier",
+      "value": "set",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 56,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 56,
+        },
+      },
+      "range": Array [
+        826,
+        827,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 57,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 57,
+        },
+      },
+      "range": Array [
+        830,
+        836,
+      ],
+      "type": "Keyword",
+      "value": "string",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 57,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 57,
+        },
+      },
+      "range": Array [
+        836,
+        837,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 58,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 58,
+        },
+      },
+      "range": Array [
+        840,
+        846,
+      ],
+      "type": "Keyword",
+      "value": "symbol",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 58,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 58,
+        },
+      },
+      "range": Array [
+        846,
+        847,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 59,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 59,
+        },
+      },
+      "range": Array [
+        850,
+        854,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 59,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 59,
+        },
+      },
+      "range": Array [
+        854,
+        855,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 60,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 60,
+        },
+      },
+      "range": Array [
+        858,
+        867,
+      ],
+      "type": "Keyword",
+      "value": "undefined",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 60,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 60,
+        },
+      },
+      "range": Array [
+        867,
+        868,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 61,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 61,
+        },
+      },
+      "range": Array [
+        871,
+        877,
+      ],
+      "type": "Keyword",
+      "value": "unique",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 61,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 61,
+        },
+      },
+      "range": Array [
+        877,
+        878,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 62,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 62,
+        },
+      },
+      "range": Array [
+        881,
+        888,
+      ],
+      "type": "Keyword",
+      "value": "unknown",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 62,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 62,
+        },
+      },
+      "range": Array [
+        888,
+        889,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 63,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 63,
+        },
+      },
+      "range": Array [
+        892,
+        896,
+      ],
+      "type": "Keyword",
+      "value": "from",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 63,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 63,
+        },
+      },
+      "range": Array [
+        896,
+        897,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 64,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 64,
+        },
+      },
+      "range": Array [
+        900,
+        906,
+      ],
+      "type": "Keyword",
+      "value": "global",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 64,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 64,
+        },
+      },
+      "range": Array [
+        906,
+        907,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 65,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 65,
+        },
+      },
+      "range": Array [
+        910,
+        916,
+      ],
+      "type": "Keyword",
+      "value": "bigint",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 65,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 65,
+        },
+      },
+      "range": Array [
+        916,
+        917,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66823,16 +73430,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 4,
-          "line": 18,
+          "line": 66,
         },
         "start": Object {
           "column": 2,
-          "line": 18,
+          "line": 66,
         },
       },
       "range": Array [
-        186,
-        188,
+        920,
+        922,
       ],
       "type": "Identifier",
       "value": "of",
@@ -66841,16 +73448,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 5,
-          "line": 18,
+          "line": 66,
         },
         "start": Object {
           "column": 4,
-          "line": 18,
+          "line": 66,
         },
       },
       "range": Array [
-        188,
-        189,
+        922,
+        923,
       ],
       "type": "Punctuator",
       "value": ",",
@@ -66859,16 +73466,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 19,
+          "line": 67,
         },
         "start": Object {
           "column": 0,
-          "line": 19,
+          "line": 67,
         },
       },
       "range": Array [
-        190,
-        191,
+        924,
+        925,
       ],
       "type": "Punctuator",
       "value": "}",
@@ -66877,16 +73484,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 6,
-          "line": 19,
+          "line": 67,
         },
         "start": Object {
           "column": 2,
-          "line": 19,
+          "line": 67,
         },
       },
       "range": Array [
-        192,
-        196,
+        926,
+        930,
       ],
       "type": "Identifier",
       "value": "from",
@@ -66895,16 +73502,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 20,
-          "line": 19,
+          "line": 67,
         },
         "start": Object {
           "column": 7,
-          "line": 19,
+          "line": 67,
         },
       },
       "range": Array [
-        197,
-        210,
+        931,
+        944,
       ],
       "type": "String",
       "value": "'fake-module'",
@@ -66913,19 +73520,739 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 21,
-          "line": 19,
+          "line": 67,
         },
         "start": Object {
           "column": 20,
-          "line": 19,
+          "line": 67,
         },
       },
       "range": Array [
-        210,
-        211,
+        944,
+        945,
       ],
       "type": "Punctuator",
       "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 69,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 69,
+        },
+      },
+      "range": Array [
+        947,
+        956,
+      ],
+      "type": "Keyword",
+      "value": "interface",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 69,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 69,
+        },
+      },
+      "range": Array [
+        957,
+        958,
+      ],
+      "type": "Identifier",
+      "value": "X",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 69,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 69,
+        },
+      },
+      "range": Array [
+        959,
+        960,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 69,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 69,
+        },
+      },
+      "range": Array [
+        960,
+        961,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 70,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 70,
+        },
+      },
+      "range": Array [
+        962,
+        967,
+      ],
+      "type": "Keyword",
+      "value": "class",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 70,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 70,
+        },
+      },
+      "range": Array [
+        968,
+        969,
+      ],
+      "type": "Identifier",
+      "value": "C",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 70,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 70,
+        },
+      },
+      "range": Array [
+        970,
+        980,
+      ],
+      "type": "Keyword",
+      "value": "implements",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 20,
+          "line": 70,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 70,
+        },
+      },
+      "range": Array [
+        981,
+        982,
+      ],
+      "type": "Identifier",
+      "value": "X",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 70,
+        },
+        "start": Object {
+          "column": 21,
+          "line": 70,
+        },
+      },
+      "range": Array [
+        983,
+        984,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 71,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 71,
+        },
+      },
+      "range": Array [
+        987,
+        993,
+      ],
+      "type": "Keyword",
+      "value": "static",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 71,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 71,
+        },
+      },
+      "range": Array [
+        994,
+        995,
+      ],
+      "type": "Identifier",
+      "value": "a",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 71,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 71,
+        },
+      },
+      "range": Array [
+        995,
+        996,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 71,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 71,
+        },
+      },
+      "range": Array [
+        996,
+        997,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 71,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 71,
+        },
+      },
+      "range": Array [
+        998,
+        999,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 71,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 71,
+        },
+      },
+      "range": Array [
+        999,
+        1000,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 72,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 72,
+        },
+      },
+      "range": Array [
+        1003,
+        1010,
+      ],
+      "type": "Keyword",
+      "value": "private",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 72,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 72,
+        },
+      },
+      "range": Array [
+        1011,
+        1012,
+      ],
+      "type": "Identifier",
+      "value": "b",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 72,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 72,
+        },
+      },
+      "range": Array [
+        1012,
+        1013,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 72,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 72,
+        },
+      },
+      "range": Array [
+        1013,
+        1014,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 72,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 72,
+        },
+      },
+      "range": Array [
+        1015,
+        1016,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 72,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 72,
+        },
+      },
+      "range": Array [
+        1016,
+        1017,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 73,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 73,
+        },
+      },
+      "range": Array [
+        1020,
+        1026,
+      ],
+      "type": "Keyword",
+      "value": "public",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 10,
+          "line": 73,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 73,
+        },
+      },
+      "range": Array [
+        1027,
+        1028,
+      ],
+      "type": "Identifier",
+      "value": "c",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 73,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 73,
+        },
+      },
+      "range": Array [
+        1028,
+        1029,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 73,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 73,
+        },
+      },
+      "range": Array [
+        1029,
+        1030,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 73,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 73,
+        },
+      },
+      "range": Array [
+        1031,
+        1032,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 73,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 73,
+        },
+      },
+      "range": Array [
+        1032,
+        1033,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 74,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 74,
+        },
+      },
+      "range": Array [
+        1036,
+        1045,
+      ],
+      "type": "Keyword",
+      "value": "protected",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 74,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 74,
+        },
+      },
+      "range": Array [
+        1046,
+        1047,
+      ],
+      "type": "Punctuator",
+      "value": "*",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 74,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 74,
+        },
+      },
+      "range": Array [
+        1047,
+        1048,
+      ],
+      "type": "Identifier",
+      "value": "d",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 74,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 74,
+        },
+      },
+      "range": Array [
+        1048,
+        1049,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 74,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 74,
+        },
+      },
+      "range": Array [
+        1049,
+        1050,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 74,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 74,
+        },
+      },
+      "range": Array [
+        1051,
+        1052,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 75,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 75,
+        },
+      },
+      "range": Array [
+        1057,
+        1060,
+      ],
+      "type": "Keyword",
+      "value": "let",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 75,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 75,
+        },
+      },
+      "range": Array [
+        1061,
+        1062,
+      ],
+      "type": "Identifier",
+      "value": "x",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 75,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 75,
+        },
+      },
+      "range": Array [
+        1063,
+        1064,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 75,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 75,
+        },
+      },
+      "range": Array [
+        1065,
+        1070,
+      ],
+      "type": "Keyword",
+      "value": "yield",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 75,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 75,
+        },
+      },
+      "range": Array [
+        1070,
+        1071,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 76,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 76,
+        },
+      },
+      "range": Array [
+        1074,
+        1075,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 77,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 77,
+        },
+      },
+      "range": Array [
+        1076,
+        1077,
+      ],
+      "type": "Punctuator",
+      "value": "}",
     },
   ],
   "type": "Program",

--- a/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/typescript.ts.snap
@@ -66492,7 +66492,7 @@ Object {
         117,
         119,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "of",
     },
     Object {
@@ -66834,7 +66834,7 @@ Object {
         186,
         188,
       ],
-      "type": "Keyword",
+      "type": "Identifier",
       "value": "of",
     },
     Object {


### PR DESCRIPTION
As in #681 and #750, the `of` keyword wasn't correctly handled in the parser with respect to variable names, so the token it created was typed as Keyword instead of Identifier.

Fixes https://github.com/lydell/eslint-plugin-simple-import-sort/issues/33