### PR TITLE
fix(eslint-plugin): [explicit-module-boundary-types] fix false positives

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -211,6 +211,7 @@ export default util.createRule<Options, MessageIds>({
     }
 
     function isUnexported(node: TSESTree.Node | undefined): boolean {
+      let isReturnedValue = false;
       while (node) {
         if (
           node.type === AST_NODE_TYPES.ExportDefaultDeclaration ||
@@ -218,6 +219,22 @@ export default util.createRule<Options, MessageIds>({
           node.type === AST_NODE_TYPES.ExportSpecifier
         ) {
           return false;
+        }
+
+        if (node.type === AST_NODE_TYPES.ReturnStatement) {
+          isReturnedValue = true;
+        }
+
+        if (
+          node.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+          node.type === AST_NODE_TYPES.FunctionDeclaration ||
+          node.type === AST_NODE_TYPES.FunctionExpression
+        ) {
+          isReturnedValue = false;
+        }
+
+        if (node.type === AST_NODE_TYPES.BlockStatement && !isReturnedValue) {
+          return true;
         }
 
         node = node.parent;

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -72,6 +72,39 @@ export class Test {
     {
       filename: 'test.ts',
       code: `
+export function test(): void {
+    nested();
+    return;
+
+    function nested() {}
+}
+            `,
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export function test(): string {
+    const nested = () => 'value';
+    return nested();
+}
+            `,
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export function test(): string {
+    class Nested {
+        public method() {
+            return 'value';
+        }
+    }
+    return new Nested().method();
+}
+            `,
+    },
+    {
+      filename: 'test.ts',
+      code: `
 export var arrowFn: Foo = () => 'test';
             `,
       options: [
@@ -449,6 +482,26 @@ export class Foo {
           endLine: 8,
           column: 14,
           endColumn: 25,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: 'export default () => true ? (() => {}) : ((): void => {});',
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 1,
+          endLine: 1,
+          column: 16,
+          endColumn: 21,
+        },
+        {
+          messageId: 'missingReturnType',
+          line: 1,
+          endLine: 1,
+          column: 30,
+          endColumn: 35,
         },
       ],
     },


### PR DESCRIPTION
Functions or classes nested, but not returned from inside an exported function should not be required to have an explicit type signature.

Fixes #1486