### PR TITLE
chore: improve token type guards part 2

### DIFF
--- a/packages/eslint-plugin/src/rules/comma-spacing.ts
+++ b/packages/eslint-plugin/src/rules/comma-spacing.ts
@@ -101,8 +101,8 @@ export default createRule<Options, MessageIds>({
      */
     function validateCommaSpacing(
       commaToken: TSESTree.PunctuatorToken,
-      prevToken: TSESTree.Token | TSESTree.Comment | null,
-      nextToken: TSESTree.Token | TSESTree.Comment | null,
+      prevToken: TSESTree.TokenOrComment | null,
+      nextToken: TSESTree.TokenOrComment | null,
     ): void {
       if (
         prevToken &&

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/BinarySearchTree.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/BinarySearchTree.ts
@@ -4,10 +4,9 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import createTree from 'functional-red-black-tree';
 
-export type TokenOrComment = TSESTree.Token | TSESTree.Comment;
 export interface TreeValue {
   offset: number;
-  from: TokenOrComment | null;
+  from: TSESTree.TokenOrComment | null;
   force: boolean;
 }
 

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/OffsetStorage.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/OffsetStorage.ts
@@ -2,11 +2,7 @@
 // License: https://github.com/eslint/eslint/blob/48700fc8408f394887cdedd071b22b757700fdcb/LICENSE
 
 import { TSESTree } from '@typescript-eslint/experimental-utils';
-import {
-  BinarySearchTree,
-  TokenOrComment,
-  TreeValue,
-} from './BinarySearchTree';
+import { BinarySearchTree, TreeValue } from './BinarySearchTree';
 import { TokenInfo } from './TokenInfo';
 
 /**
@@ -17,9 +13,12 @@ export class OffsetStorage {
   private readonly indentSize: number;
   private readonly indentType: string;
   private readonly tree: BinarySearchTree;
-  private readonly lockedFirstTokens: WeakMap<TokenOrComment, TokenOrComment>;
-  private readonly desiredIndentCache: WeakMap<TokenOrComment, string>;
-  private readonly ignoredTokens: WeakSet<TokenOrComment>;
+  private readonly lockedFirstTokens: WeakMap<
+    TSESTree.TokenOrComment,
+    TSESTree.TokenOrComment
+  >;
+  private readonly desiredIndentCache: WeakMap<TSESTree.TokenOrComment, string>;
+  private readonly ignoredTokens: WeakSet<TSESTree.TokenOrComment>;
   /**
    * @param tokenInfo a TokenInfo instance
    * @param indentSize The desired size of each indentation level
@@ -38,7 +37,7 @@ export class OffsetStorage {
     this.ignoredTokens = new WeakSet();
   }
 
-  private getOffsetDescriptor(token: TokenOrComment): TreeValue {
+  private getOffsetDescriptor(token: TSESTree.TokenOrComment): TreeValue {
     return this.tree.findLe(token.range[0]).value;
   }
 
@@ -50,8 +49,8 @@ export class OffsetStorage {
    * @param offsetToken The second token, whose offset should be matched to the first token
    */
   public matchOffsetOf(
-    baseToken: TokenOrComment,
-    offsetToken: TokenOrComment,
+    baseToken: TSESTree.TokenOrComment,
+    offsetToken: TSESTree.TokenOrComment,
   ): void {
     /*
      * lockedFirstTokens is a map from a token whose indentation is controlled by the "first" option to
@@ -120,8 +119,8 @@ export class OffsetStorage {
    * @param offset The desired indent level
    */
   public setDesiredOffset(
-    token: TokenOrComment,
-    fromToken: TokenOrComment | null,
+    token: TSESTree.TokenOrComment,
+    fromToken: TSESTree.TokenOrComment | null,
     offset: number,
   ): void {
     this.setDesiredOffsets(token.range, fromToken, offset);
@@ -154,7 +153,7 @@ export class OffsetStorage {
    */
   public setDesiredOffsets(
     range: [number, number],
-    fromToken: TokenOrComment | null,
+    fromToken: TSESTree.TokenOrComment | null,
     offset = 0,
     force = false,
   ): void {
@@ -212,7 +211,7 @@ export class OffsetStorage {
    * Gets the desired indent of a token
    * @returns The desired indent of the token
    */
-  public getDesiredIndent(token: TokenOrComment): string {
+  public getDesiredIndent(token: TSESTree.TokenOrComment): string {
     if (!this.desiredIndentCache.has(token)) {
       if (this.ignoredTokens.has(token)) {
         /*
@@ -263,7 +262,7 @@ export class OffsetStorage {
   /**
    * Ignores a token, preventing it from being reported.
    */
-  ignoreToken(token: TokenOrComment): void {
+  ignoreToken(token: TSESTree.TokenOrComment): void {
     if (this.tokenInfo.isFirstTokenOfLine(token)) {
       this.ignoredTokens.add(token);
     }
@@ -274,8 +273,12 @@ export class OffsetStorage {
    * @returns The token that the given token depends on, or `null` if the given token is at the top level
    */
   getFirstDependency(token: TSESTree.Token): TSESTree.Token | null;
-  getFirstDependency(token: TokenOrComment): TokenOrComment | null;
-  getFirstDependency(token: TokenOrComment): TokenOrComment | null {
+  getFirstDependency(
+    token: TSESTree.TokenOrComment,
+  ): TSESTree.TokenOrComment | null;
+  getFirstDependency(
+    token: TSESTree.TokenOrComment,
+  ): TSESTree.TokenOrComment | null {
     return this.getOffsetDescriptor(token).from;
   }
 }

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/TokenInfo.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/TokenInfo.ts
@@ -2,7 +2,6 @@
 // License: https://github.com/eslint/eslint/blob/48700fc8408f394887cdedd071b22b757700fdcb/LICENSE
 
 import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
-import { TokenOrComment } from './BinarySearchTree';
 
 /**
  * A helper class to get token-based info related to indentation
@@ -37,8 +36,8 @@ export class TokenInfo {
    * @returns The first token on the given line
    */
   public getFirstTokenOfLine(
-    token: TokenOrComment | TSESTree.Node,
-  ): TokenOrComment {
+    token: TSESTree.TokenOrComment | TSESTree.Node,
+  ): TSESTree.TokenOrComment {
     return this.firstTokensByLineNumber.get(token.loc.start.line)!;
   }
 
@@ -46,7 +45,7 @@ export class TokenInfo {
    * Determines whether a token is the first token in its line
    * @returns `true` if the token is the first on its line
    */
-  public isFirstTokenOfLine(token: TokenOrComment): boolean {
+  public isFirstTokenOfLine(token: TSESTree.TokenOrComment): boolean {
     return this.getFirstTokenOfLine(token) === token;
   }
 
@@ -55,7 +54,7 @@ export class TokenInfo {
    * @param token Token to examine. This should be the first token on its line.
    * @returns The indentation characters that precede the token
    */
-  public getTokenIndent(token: TokenOrComment): string {
+  public getTokenIndent(token: TSESTree.TokenOrComment): string {
     return this.sourceCode.text.slice(
       token.range[0] - token.loc.start.column,
       token.range[0],

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
@@ -20,7 +20,6 @@ import {
   isOpeningParenToken,
   isSemicolonToken,
 } from 'eslint-utils';
-import { TokenOrComment } from './BinarySearchTree';
 import { OffsetStorage } from './OffsetStorage';
 import { TokenInfo } from './TokenInfo';
 import { createRule, ExcludeKeys, RequireKeys } from '../../util';
@@ -471,7 +470,10 @@ export default createRule<Options, MessageIds>({
      * @param token Token violating the indent rule
      * @param neededIndent Expected indentation string
      */
-    function report(token: TokenOrComment, neededIndent: string): void {
+    function report(
+      token: TSESTree.TokenOrComment,
+      neededIndent: string,
+    ): void {
       const actualIndent = Array.from(tokenInfo.getTokenIndent(token));
       const numSpaces = actualIndent.filter(char => char === ' ').length;
       const numTabs = actualIndent.filter(char => char === '\t').length;
@@ -500,7 +502,7 @@ export default createRule<Options, MessageIds>({
      * @returns `true` if the token's indentation is correct
      */
     function validateTokenIndent(
-      token: TokenOrComment,
+      token: TSESTree.TokenOrComment,
       desiredIndent: string,
     ): boolean {
       const indentation = tokenInfo.getTokenIndent(token);

--- a/packages/eslint-plugin/src/util/astUtils.ts
+++ b/packages/eslint-plugin/src/util/astUtils.ts
@@ -4,27 +4,29 @@ import {
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 
+type NegateGuard<T, U> = T extends U ? T : U;
+
 const LINEBREAK_MATCHER = /\r\n|[\r\n\u2028\u2029]/;
 
 function isOptionalChainPunctuator(
-  token: TSESTree.Token | TSESTree.Comment,
-): token is TSESTree.PunctuatorToken & { value: '?.' } {
+  token: TSESTree.TokenOrComment,
+): token is TSESTree.PunctuatorToken<'?.'> {
   return token.type === AST_TOKEN_TYPES.Punctuator && token.value === '?.';
 }
-function isNotOptionalChainPunctuator(
-  token: TSESTree.Token | TSESTree.Comment,
-): boolean {
+function isNotOptionalChainPunctuator<T extends TSESTree.TokenOrComment>(
+  token: T,
+): token is NegateGuard<TSESTree.PunctuatorToken<'?.'>, T> {
   return !isOptionalChainPunctuator(token);
 }
 
 function isNonNullAssertionPunctuator(
-  token: TSESTree.Token | TSESTree.Comment,
-): token is TSESTree.PunctuatorToken & { value: '!' } {
+  token: TSESTree.TokenOrComment,
+): token is TSESTree.PunctuatorToken<'!'> {
   return token.type === AST_TOKEN_TYPES.Punctuator && token.value === '!';
 }
-function isNotNonNullAssertionPunctuator(
-  token: TSESTree.Token | TSESTree.Comment,
-): boolean {
+function isNotNonNullAssertionPunctuator<T extends TSESTree.TokenOrComment>(
+  token: T,
+): token is NegateGuard<TSESTree.PunctuatorToken<'!'>, T> {
   return !isNonNullAssertionPunctuator(token);
 }
 
@@ -57,8 +59,8 @@ function isLogicalOrOperator(
  * Determines whether two adjacent tokens are on the same line
  */
 function isTokenOnSameLine(
-  left: TSESTree.Token | TSESTree.Comment,
-  right: TSESTree.Token | TSESTree.Comment,
+  left: TSESTree.TokenOrComment,
+  right: TSESTree.TokenOrComment,
 ): boolean {
   return left.loc.end.line === right.loc.start.line;
 }

--- a/packages/eslint-plugin/typings/eslint-utils.d.ts
+++ b/packages/eslint-plugin/typings/eslint-utils.d.ts
@@ -111,70 +111,82 @@ declare module 'eslint-utils' {
     }
   }
 
+  type NegateGuard<T, U> = T extends U ? T : U;
+
   export function isArrowToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): token is TSESTree.PunctuatorToken & { value: '=>' };
-  export function isNotArrowToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): boolean;
+    token: TSESTree.TokenOrComment,
+  ): token is TSESTree.PunctuatorToken<'=>'>;
+  export function isNotArrowToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is NegateGuard<TSESTree.PunctuatorToken<'=>'>, T>;
+
   export function isClosingBraceToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): token is TSESTree.PunctuatorToken & { value: '}' };
-  export function isNotClosingBraceToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): boolean;
+    token: TSESTree.TokenOrComment,
+  ): token is TSESTree.PunctuatorToken<'}'>;
+  export function isNotClosingBraceToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is NegateGuard<TSESTree.PunctuatorToken<'}'>, T>;
+
   export function isClosingBracketToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): token is TSESTree.PunctuatorToken & { value: ']' };
-  export function isNotClosingBracketToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): boolean;
+    token: TSESTree.TokenOrComment,
+  ): token is TSESTree.PunctuatorToken<']'>;
+  export function isNotClosingBracketToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is NegateGuard<TSESTree.PunctuatorToken<']'>, T>;
+
   export function isClosingParenToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): token is TSESTree.PunctuatorToken & { value: ')' };
-  export function isNotClosingParenToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): boolean;
+    token: TSESTree.TokenOrComment,
+  ): token is TSESTree.PunctuatorToken<')'>;
+  export function isNotClosingParenToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is NegateGuard<TSESTree.PunctuatorToken<')'>, T>;
+
   export function isColonToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): token is TSESTree.PunctuatorToken & { value: ':' };
-  export function isNotColonToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): boolean;
+    token: TSESTree.TokenOrComment,
+  ): token is TSESTree.PunctuatorToken<':'>;
+  export function isNotColonToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is NegateGuard<TSESTree.PunctuatorToken<':'>, T>;
+
   export function isCommaToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): token is TSESTree.PunctuatorToken & { value: ',' };
-  export function isNotCommaToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): boolean;
+    token: TSESTree.TokenOrComment,
+  ): token is TSESTree.PunctuatorToken<','>;
+  export function isNotCommaToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is NegateGuard<TSESTree.PunctuatorToken<','>, T>;
+
   export function isCommentToken(
-    token: TSESTree.Token | TSESTree.Comment,
+    token: TSESTree.TokenOrComment,
   ): token is TSESTree.Comment;
-  export function isNotCommentToken<
-    T extends TSESTree.Token | TSESTree.Comment
-  >(token: T): token is Exclude<T, TSESTree.Comment>;
+  export function isNotCommentToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is Exclude<T, TSESTree.Comment>;
+
   export function isOpeningBraceToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): token is TSESTree.PunctuatorToken & { value: '{' };
-  export function isNotOpeningBraceToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): boolean;
+    token: TSESTree.TokenOrComment,
+  ): token is TSESTree.PunctuatorToken<'{'>;
+  export function isNotOpeningBraceToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is NegateGuard<TSESTree.PunctuatorToken<'{'>, T>;
+
   export function isOpeningBracketToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): token is TSESTree.PunctuatorToken & { value: '[' };
-  export function isNotOpeningBracketToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): boolean;
+    token: TSESTree.TokenOrComment,
+  ): token is TSESTree.PunctuatorToken<'['>;
+  export function isNotOpeningBracketToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is NegateGuard<TSESTree.PunctuatorToken<'['>, T>;
+
   export function isOpeningParenToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): token is TSESTree.PunctuatorToken & { value: '(' };
-  export function isNotOpeningParenToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): boolean;
+    token: TSESTree.TokenOrComment,
+  ): token is TSESTree.PunctuatorToken<'('>;
+  export function isNotOpeningParenToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is NegateGuard<TSESTree.PunctuatorToken<'('>, T>;
+
   export function isSemicolonToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): token is TSESTree.PunctuatorToken & { value: ';' };
-  export function isNotSemicolonToken(
-    token: TSESTree.Token | TSESTree.Comment,
-  ): boolean;
+    token: TSESTree.TokenOrComment,
+  ): token is TSESTree.PunctuatorToken<';'>;
+  export function isNotSemicolonToken<T extends TSESTree.TokenOrComment>(
+    token: T,
+  ): token is NegateGuard<TSESTree.PunctuatorToken<';'>, T>;
 }

--- a/packages/experimental-utils/src/ts-eslint/SourceCode.ts
+++ b/packages/experimental-utils/src/ts-eslint/SourceCode.ts
@@ -33,8 +33,8 @@ declare interface SourceCode {
   getNodeByRangeIndex(index: number): TSESTree.Node | null;
 
   isSpaceBetween(
-    first: TSESTree.Token | TSESTree.Comment | TSESTree.Node,
-    second: TSESTree.Token | TSESTree.Comment | TSESTree.Node,
+    first: TSESTree.TokenOrComment | TSESTree.Node,
+    second: TSESTree.TokenOrComment | TSESTree.Node,
   ): boolean;
 
   /**
@@ -75,52 +75,52 @@ declare interface SourceCode {
   ): SourceCode.ReturnTypeFromOptions<T>[];
 
   getTokenBefore<T extends SourceCode.CursorWithSkipOptions>(
-    node: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    node: TSESTree.Node | TSESTree.TokenOrComment,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T> | null;
 
   getTokensBefore<T extends SourceCode.CursorWithCountOptions>(
-    node: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    node: TSESTree.Node | TSESTree.TokenOrComment,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T>[];
 
   getTokenAfter<T extends SourceCode.CursorWithSkipOptions>(
-    node: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    node: TSESTree.Node | TSESTree.TokenOrComment,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T> | null;
 
   getTokensAfter<T extends SourceCode.CursorWithCountOptions>(
-    node: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    node: TSESTree.Node | TSESTree.TokenOrComment,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T>[];
 
   getFirstTokenBetween<T extends SourceCode.CursorWithSkipOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.TokenOrComment,
+    right: TSESTree.Node | TSESTree.TokenOrComment,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T> | null;
 
   getFirstTokensBetween<T extends SourceCode.CursorWithCountOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.TokenOrComment,
+    right: TSESTree.Node | TSESTree.TokenOrComment,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T>[];
 
   getLastTokenBetween<T extends SourceCode.CursorWithSkipOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.TokenOrComment,
+    right: TSESTree.Node | TSESTree.TokenOrComment,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T> | null;
 
   getLastTokensBetween<T extends SourceCode.CursorWithCountOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.TokenOrComment,
+    right: TSESTree.Node | TSESTree.TokenOrComment,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T>[];
 
   getTokensBetween<T extends SourceCode.CursorWithCountOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.TokenOrComment,
+    right: TSESTree.Node | TSESTree.TokenOrComment,
     padding?: T,
   ): SourceCode.ReturnTypeFromOptions<T>[];
 
@@ -169,11 +169,11 @@ namespace SourceCode {
   }
 
   export type FilterPredicate = (
-    tokenOrComment: TSESTree.Token | TSESTree.Comment,
+    tokenOrComment: TSESTree.TokenOrComment,
   ) => boolean;
 
   export type ReturnTypeFromOptions<T> = T extends { includeComments: true }
-    ? TSESTree.Token | TSESTree.Comment
+    ? TSESTree.TokenOrComment
     : TSESTree.Token;
 
   export type CursorWithSkipOptions =

--- a/packages/typescript-estree/src/ts-estree/ts-estree.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-estree.ts
@@ -84,8 +84,9 @@ export interface NumericToken extends BaseToken {
   type: AST_TOKEN_TYPES.Numeric;
 }
 
-export interface PunctuatorToken extends BaseToken {
+export interface PunctuatorToken<T extends string = string> extends BaseToken {
   type: AST_TOKEN_TYPES.Punctuator;
+  value: T;
 }
 
 export interface RegularExpressionToken extends BaseToken {
@@ -125,6 +126,8 @@ export type Token =
   | RegularExpressionToken
   | StringToken
   | TemplateToken;
+
+export type TokenOrComment = Token | Comment;
 
 export type OptionalRangeAndLoc<T> = Pick<
   T,


### PR DESCRIPTION
This is follow up PR that adds missing type guards for negated functions and adds new union type `TokenOrComment` (moved out from indent rule)