### PR TITLE
chore(eslint-plugin): use getFixturesRootDir in tests

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-dynamic-delete.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-dynamic-delete.test.ts
@@ -1,15 +1,14 @@
-import path from 'path';
 import rule from '../../src/rules/no-dynamic-delete';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootDir = path.join(process.cwd(), 'tests/fixtures');
+const rootPath = getFixturesRootDir();
+
 const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2015,
-    tsconfigRootDir: rootDir,
+    tsconfigRootDir: rootPath,
     project: './tsconfig.json',
   },
-  parser: '@typescript-eslint/parser',
 });
 
 ruleTester.run('no-dynamic-delete', rule, {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1,15 +1,14 @@
-import path from 'path';
-import rule, {
-  Options,
-  MessageId,
-} from '../../src/rules/no-unnecessary-condition';
-import { RuleTester } from '../RuleTester';
 import {
   TestCaseError,
   InvalidTestCase,
 } from '@typescript-eslint/experimental-utils/dist/ts-eslint';
+import rule, {
+  Options,
+  MessageId,
+} from '../../src/rules/no-unnecessary-condition';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-qualifier.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-qualifier.test.ts
@@ -7,6 +7,7 @@ const rootPath = getFixturesRootDir();
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
   parserOptions: {
+    sourceType: 'module',
     tsconfigRootDir: rootPath,
     project: './tsconfig.json',
   },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-qualifier.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-qualifier.test.ts
@@ -1,20 +1,18 @@
-import path from 'path';
-import rule from '../../src/rules/no-unnecessary-qualifier';
-import { RuleTester } from '../RuleTester';
 import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+import rule from '../../src/rules/no-unnecessary-qualifier';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const messageId = 'unnecessaryQualifier';
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
   parserOptions: {
     tsconfigRootDir: rootPath,
     project: './tsconfig.json',
-    sourceType: 'module',
-    ecmaVersion: 6,
   },
 });
+
+const messageId = 'unnecessaryQualifier';
 
 ruleTester.run('no-unnecessary-qualifier', rule, {
   valid: [

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
@@ -6,6 +6,7 @@ const rootPath = getFixturesRootDir();
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
   parserOptions: {
+    sourceType: 'module',
     tsconfigRootDir: rootPath,
     project: './tsconfig.json',
   },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
@@ -1,16 +1,14 @@
-import path from 'path';
 import rule from '../../src/rules/no-unnecessary-type-arguments';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootDir = path.join(process.cwd(), 'tests/fixtures');
+const rootPath = getFixturesRootDir();
+
 const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2015,
-    sourceType: 'module',
-    tsconfigRootDir: rootDir,
+    tsconfigRootDir: rootPath,
     project: './tsconfig.json',
   },
-  parser: '@typescript-eslint/parser',
 });
 
 ruleTester.run('no-unnecessary-type-arguments', rule, {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -5,7 +5,7 @@ import { RuleTester } from '../RuleTester';
 const rootDir = path.resolve(__dirname, '../fixtures/');
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 2015,
+    sourceType: 'module',
     tsconfigRootDir: rootDir,
     project: './tsconfig.json',
   },

--- a/packages/eslint-plugin/tests/rules/prefer-includes.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-includes.test.ts
@@ -1,12 +1,9 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import path from 'path';
 import rule from '../../src/rules/prefer-includes';
 import * as util from '../../src/util';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
-
-type MessageIds = util.InferMessageIdsTypeFromRule<typeof rule>;
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
@@ -15,6 +12,8 @@ const ruleTester = new RuleTester({
     project: './tsconfig.json',
   },
 });
+
+type MessageIds = util.InferMessageIdsTypeFromRule<typeof rule>;
 
 type InvalidTestCase = TSESLint.InvalidTestCase<MessageIds, never>;
 type ValidTestCase = TSESLint.ValidTestCase<never> | string;

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -1,12 +1,11 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import path from 'path';
 import rule, {
   MessageIds,
   Options,
 } from '../../src/rules/prefer-nullish-coalescing';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin/tests/rules/prefer-regexp-exec.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-regexp-exec.test.ts
@@ -1,8 +1,7 @@
-import path from 'path';
 import rule from '../../src/rules/prefer-regexp-exec';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
@@ -1,9 +1,8 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import path from 'path';
 import rule from '../../src/rules/prefer-string-starts-ends-with';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin/tests/rules/require-array-sort-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-array-sort-compare.test.ts
@@ -1,8 +1,7 @@
-import path from 'path';
 import rule from '../../src/rules/require-array-sort-compare';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
@@ -1,8 +1,7 @@
-import path from 'path';
 import rule from '../../src/rules/restrict-plus-operands';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
@@ -1,8 +1,7 @@
-import path from 'path';
 import rule from '../../src/rules/restrict-template-expressions';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -1,8 +1,7 @@
-import path from 'path';
 import rule from '../../src/rules/strict-boolean-expressions';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -1,9 +1,8 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import path from 'path';
 import rule, { MessageIds, Options } from '../../src/rules/unbound-method';
-import { RuleTester } from '../RuleTester';
+import { RuleTester, getFixturesRootDir } from '../RuleTester';
 
-const rootPath = path.join(process.cwd(), 'tests/fixtures/');
+const rootPath = getFixturesRootDir();
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',


### PR DESCRIPTION
Noticed that there were some tests that weren't using the utility function.