### PR TITLE
fix(typescript-estree): persisted parse and module none

### DIFF
--- a/packages/typescript-estree/src/create-program/createDefaultProgram.ts
+++ b/packages/typescript-estree/src/create-program/createDefaultProgram.ts
@@ -39,7 +39,10 @@ function createDefaultProgram(
     return undefined;
   }
 
-  const compilerHost = ts.createCompilerHost(commandLine.options, true);
+  const compilerHost = ts.createCompilerHost(
+    commandLine.options,
+    /* setParentNodes */ true,
+  );
   const oldReadFile = compilerHost.readFile;
   compilerHost.readFile = (fileName: string): string | undefined =>
     path.normalize(fileName) === path.normalize(extra.filePath)

--- a/packages/typescript-estree/src/create-program/createIsolatedProgram.ts
+++ b/packages/typescript-estree/src/create-program/createIsolatedProgram.ts
@@ -46,7 +46,7 @@ function createIsolatedProgram(code: string, extra: Extra): ASTAndProgram {
         filename,
         code,
         ts.ScriptTarget.Latest,
-        true,
+        /* setParentNodes */ true,
         getScriptKind(extra, filename),
       );
     },

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -175,8 +175,6 @@ function getProgramsForProjects(
 
       updatedProgram =
         updatedProgram ?? existingWatch.getProgram().getProgram();
-      // sets parent pointers in source files
-      updatedProgram.getTypeChecker();
 
       return [updatedProgram];
     }
@@ -206,8 +204,6 @@ function getProgramsForProjects(
         continue;
       }
 
-      // sets parent pointers in source files
-      updatedProgram.getTypeChecker();
       results.push(updatedProgram);
 
       continue;
@@ -218,8 +214,6 @@ function getProgramsForProjects(
 
     // cache watch program and return current program
     knownWatchProgramMap.set(tsconfigPath, programWatch);
-    // sets parent pointers in source files
-    program.getTypeChecker();
     results.push(program);
   }
 

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -175,7 +175,7 @@ function getProgramsForProjects(
 
       updatedProgram =
         updatedProgram ?? existingWatch.getProgram().getProgram();
-      // sets parent pointers in source files when module === none
+      // sets parent pointers in source files
       updatedProgram.getTypeChecker();
 
       return [updatedProgram];
@@ -206,7 +206,7 @@ function getProgramsForProjects(
         continue;
       }
 
-      // sets parent pointers in source files when module === none
+      // sets parent pointers in source files
       updatedProgram.getTypeChecker();
       results.push(updatedProgram);
 
@@ -218,7 +218,7 @@ function getProgramsForProjects(
 
     // cache watch program and return current program
     knownWatchProgramMap.set(tsconfigPath, programWatch);
-    // sets parent pointers in source files when module === none
+    // sets parent pointers in source files
     program.getTypeChecker();
     results.push(program);
   }

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -175,7 +175,7 @@ function getProgramsForProjects(
 
       updatedProgram =
         updatedProgram ?? existingWatch.getProgram().getProgram();
-      // sets parent pointers in source files
+      // sets parent pointers in source files when module === none
       updatedProgram.getTypeChecker();
 
       return [updatedProgram];
@@ -206,7 +206,7 @@ function getProgramsForProjects(
         continue;
       }
 
-      // sets parent pointers in source files
+      // sets parent pointers in source files when module === none
       updatedProgram.getTypeChecker();
       results.push(updatedProgram);
 
@@ -218,6 +218,8 @@ function getProgramsForProjects(
 
     // cache watch program and return current program
     knownWatchProgramMap.set(tsconfigPath, programWatch);
+    // sets parent pointers in source files when module === none
+    program.getTypeChecker();
     results.push(program);
   }
 

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -256,14 +256,14 @@ export function getLocFor(
 
 /**
  * Check whatever node can contain directive
- * @param node
  * @returns returns true if node can contain directive
  */
 export function canContainDirective(
   node: ts.SourceFile | ts.Block | ts.ModuleBlock,
+  parent: ts.Node,
 ): boolean {
   if (node.kind === ts.SyntaxKind.Block) {
-    switch (node.parent.kind) {
+    switch (parent.kind) {
       case ts.SyntaxKind.Constructor:
       case ts.SyntaxKind.GetAccessor:
       case ts.SyntaxKind.SetAccessor:

--- a/packages/typescript-estree/tests/lib/persistentParse.ts
+++ b/packages/typescript-estree/tests/lib/persistentParse.ts
@@ -8,6 +8,9 @@ const CONTENTS = {
   bar: 'console.log("bar")',
   'baz/bar': 'console.log("baz bar")',
   'bat/baz/bar': 'console.log("bat/baz/bar")',
+  number: 'const foo = 1;',
+  object: '(() => { })();',
+  string: 'let a: "a" | "b";',
 };
 
 const cwdCopy = process.cwd();
@@ -303,5 +306,24 @@ describe('persistent parse', () => {
     };
 
     baseTests(tsConfigExcludeBar, tsConfigIncludeAll);
+  });
+
+  describe('tsconfig with module none', () => {
+    const tsConfigIncludeAll = {
+      compilerOptions: {
+        module: 'none',
+      },
+      include: ['./**/*'],
+    };
+
+    const testNames = ['object', 'number', 'string', 'foo'] as const;
+
+    for (const name of testNames) {
+      it(`first parse of ${name} should not throw`, () => {
+        const PROJECT_DIR = setup(tsConfigIncludeAll);
+        writeFile(PROJECT_DIR, name);
+        expect(() => parseFile(name, PROJECT_DIR)).not.toThrow();
+      });
+    }
   });
 });

--- a/packages/typescript-estree/tests/lib/persistentParse.ts
+++ b/packages/typescript-estree/tests/lib/persistentParse.ts
@@ -308,21 +308,33 @@ describe('persistent parse', () => {
     baseTests(tsConfigExcludeBar, tsConfigIncludeAll);
   });
 
-  describe('tsconfig with module none', () => {
-    const tsConfigIncludeAll = {
-      compilerOptions: {
-        module: 'none',
-      },
-      include: ['./**/*'],
-    };
+  describe('tsconfig with module set', () => {
+    const moduleTypes = [
+      'None',
+      'CommonJS',
+      'AMD',
+      'System',
+      'UMD',
+      'ES6',
+      'ES2015',
+      'ESNext',
+    ];
 
-    const testNames = ['object', 'number', 'string', 'foo'] as const;
+    for (const module of moduleTypes) {
+      describe(`module ${module}`, () => {
+        const tsConfigIncludeAll = {
+          compilerOptions: { module },
+          include: ['./**/*'],
+        };
 
-    for (const name of testNames) {
-      it(`first parse of ${name} should not throw`, () => {
-        const PROJECT_DIR = setup(tsConfigIncludeAll);
-        writeFile(PROJECT_DIR, name);
-        expect(() => parseFile(name, PROJECT_DIR)).not.toThrow();
+        const testNames = ['object', 'number', 'string', 'foo'] as const;
+        for (const name of testNames) {
+          it(`first parse of ${name} should not throw`, () => {
+            const PROJECT_DIR = setup(tsConfigIncludeAll);
+            writeFile(PROJECT_DIR, name);
+            expect(() => parseFile(name, PROJECT_DIR)).not.toThrow();
+          });
+        }
       });
     }
   });


### PR DESCRIPTION
This is alternative (more extensive) change to how converter generates AST, this change simply removes needs of parent propagation for conversion logic. 

This change contains history from #1516, and its described in https://github.com/typescript-eslint/typescript-eslint/pull/1516#issuecomment-578369072

fixes #1502