### PR TITLE
fix(experimental-utils): widen type of `settings` property

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -179,7 +179,7 @@ interface RuleContext<
    * The shared settings from configuration.
    * We do not have any shared settings in this plugin.
    */
-  settings: {};
+  settings: Record<string, any>;
   /**
    * The name of the parser from configuration.
    */

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -179,7 +179,7 @@ interface RuleContext<
    * The shared settings from configuration.
    * We do not have any shared settings in this plugin.
    */
-  settings: Record<string, any>;
+  settings: Record<string, unknown>;
   /**
    * The name of the parser from configuration.
    */


### PR DESCRIPTION
Currently attempting to access `context.settings['<property>']` nets me

> TS7053: Element implicitly has an 'any' type because expression of type '"local/configs"' can't be used to index type '{}'.
>   Property 'local/configs' does not exist on type '{}'.