### PR TITLE
test: fix coverage reports from codecov

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,6 @@ jobs:
       - bash: bash <(curl -s https://codecov.io/bash) -P "$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"
         env:
           CODECOV_TOKEN: $(CODECOV_TOKEN)
-          CI_BUILD_ID: $(Build.BuildNumber)
         displayName: 'Publish code coverage report'
 
   - job: unit_tests_on_other_node_versions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,8 +44,10 @@ jobs:
           yarn integration-tests
         displayName: 'Run integrations tests'
 
-      - script: |
-          bash <(curl -s https://codecov.io/bash) -t $(CODECOV_TOKEN)
+      - bash: bash <(curl -s https://codecov.io/bash) -P "$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"
+        env:
+          CODECOV_TOKEN: $(CODECOV_TOKEN)
+          CI_BUILD_ID: $(Build.BuildNumber)
         displayName: 'Publish code coverage report'
 
   - job: unit_tests_on_other_node_versions


### PR DESCRIPTION
Bash uploader used for sending coverage reports to codecov currently is broken for azure pipelines.

This fixes missing pr in query sent to codecov by providing it as parameter

Codecov bash script https://codecov.io/bash

> -P pr
> Specify the pull request number

Pipelines docs https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml

> System.PullRequest.PullRequestNumber
> The number of the pull request that caused this build. This variable is populated for pull requests from GitHub which have a different pull request ID and pull request number.

-------------------

### Codecov link
https://codecov.io/gh/typescript-eslint/typescript-eslint/pull/1528/commits

### Pipelines action
https://dev.azure.com/typescript-eslint/TypeScript%20ESLint/_build/results?buildId=3139&view=logs&jobId=18ce2c0c-8e5f-561b-2a1a-c5027ed6632f&j=18ce2c0c-8e5f-561b-2a1a-c5027ed6632f&t=477fddef-3d25-5c61-8626-53dac583e4f5
> pr=1528
```
query: branch=merge&commit=23be3107029912cf459f3b3cb9de1bdb768d7a9b&build=20200126.2&build_url=https%3A%2F%2Fdev.azure.com%2Ftypescript-eslint%2FTypeScript%20ESLint%2F_build%2Fresults%3FbuildId%3D3139&name=&tag=&slug=typescript-eslint%2Ftypescript-eslint&service=azure_pipelines&flags=&pr=1528&job=3139&project=TypeScriptESLint&server_uri=https://dev.azure.com/typescript-eslint/
```

https://github.com/codecov/codecov-bash/issues/189