### PR TITLE
fix(eslint-plugin): [unbound-method] blacklist a few unbound natives

### DIFF
--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -324,5 +324,15 @@ const x = CommunicationError.prototype.foo;
         },
       ],
     },
+    {
+      // Promise.all is not auto-bound to Promise
+      code: 'const x = Promise.all',
+      errors: [
+        {
+          line: 1,
+          messageId: 'unbound',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
#1526 Added a whitelist of member expressions which are bound by default .
But of the ~100 methods in the list, ~15 aren't actually bound (for whatever reason).
This just adds a blacklist alongside the whitelist so we don't false-negative.

I highly doubt anyone will ever actually do `const x = Promise.all` in their code, but we might as well be correct.