### PR TITLE
feat(eslint-plugin): [prefer-nullish-coalescing] ignoreStrings option

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
@@ -46,6 +46,7 @@ type Options = [
   {
     ignoreConditionalTests?: boolean;
     ignoreMixedLogicalExpressions?: boolean;
+    ignoreStrings?: boolean;
     forceSuggestionFixer?: boolean;
   },
 ];
@@ -54,6 +55,7 @@ const defaultOptions = [
   {
     ignoreConditionalTests: true,
     ignoreMixedLogicalExpressions: true,
+    ignoreStrings: false,
     forceSuggestionFixer: false,
   },
 ];
@@ -132,6 +134,40 @@ a ?? (b && c && d);
 ```
 
 **_NOTE:_** Errors for this specific case will be presented as suggestions (see below), instead of fixes. This is because it is not always safe to automatically convert `||` to `??` within a mixed logical expression, as we cannot tell the intended precedence of the operator. Note that by design, `??` requires parentheses when used with `&&` or `||` in the same expression.
+
+### `ignoreStrings`
+
+Setting this option to `true` will cause the rule to be ignored when the left-hand's TypeScript type is `string`, whether it may be nullish or not.
+
+This can be useful if you want to enforce the use of `??` on every types but `string`, because you want to handle empty strings.
+
+Incorrect code for `ignoreStrings: false`, and correct code for `ignoreStrings: true`:
+
+```ts
+declare const nullString: string | null;
+const emptyString = '';
+
+const a = nullString || 'fallback';
+const b = emptyString || 'fallback';
+
+// a === 'fallback'
+// b === 'fallback'
+```
+
+Correct code for `ignoreStrings: false`:
+
+```ts
+declare const nullString: string | null;
+const emptyString = '';
+
+const a = nullString || 'fallback';
+const b = emptyString || 'fallback';
+const c = !emptyString ? 'fallback' : emptyString;
+
+// a === 'fallback'
+// b === ''
+// c === 'fallback'
+```
 
 ### `forceSuggestionFixer`
 

--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
@@ -160,8 +160,8 @@ Correct code for `ignoreStrings: false`:
 declare const nullString: string | null;
 const emptyString = '';
 
-const a = nullString || 'fallback';
-const b = emptyString || 'fallback';
+const a = nullString ?? 'fallback';
+const b = emptyString ?? 'fallback';
 const c = !emptyString ? 'fallback' : emptyString;
 
 // a === 'fallback'

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -5,11 +5,13 @@ import {
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import * as util from '../util';
+import * as ts from 'typescript';
 
 export type Options = [
   {
     ignoreConditionalTests?: boolean;
     ignoreMixedLogicalExpressions?: boolean;
+    ignoreStrings?: boolean;
     forceSuggestionFixer?: boolean;
   },
 ];
@@ -41,6 +43,9 @@ export default util.createRule<Options, MessageIds>({
           ignoreMixedLogicalExpressions: {
             type: 'boolean',
           },
+          ignoreStrings: {
+            type: 'boolean',
+          },
           forceSuggestionFixer: {
             type: 'boolean',
           },
@@ -53,6 +58,7 @@ export default util.createRule<Options, MessageIds>({
     {
       ignoreConditionalTests: true,
       ignoreMixedLogicalExpressions: true,
+      ignoreStrings: false,
       forceSuggestionFixer: false,
     },
   ],
@@ -62,6 +68,7 @@ export default util.createRule<Options, MessageIds>({
       {
         ignoreConditionalTests,
         ignoreMixedLogicalExpressions,
+        ignoreStrings,
         forceSuggestionFixer,
       },
     ],
@@ -87,6 +94,10 @@ export default util.createRule<Options, MessageIds>({
 
         const isMixedLogical = isMixedLogicalExpression(node);
         if (ignoreMixedLogicalExpressions === true && isMixedLogical) {
+          return;
+        }
+
+        if (ignoreStrings === true && isStringOrNullish(checker, type)) {
           return;
         }
 
@@ -198,4 +209,13 @@ function isMixedLogicalExpression(node: TSESTree.LogicalExpression): boolean {
   }
 
   return false;
+}
+
+function isStringOrNullish(checker: ts.TypeChecker, type: ts.Type): boolean {
+  return util
+    .getTypeName(checker, type)
+    .split(' ')
+    .every(resolvedType =>
+      ['string', 'undefined', 'null', '|', '&'].includes(resolvedType),
+    );
 }


### PR DESCRIPTION
Hi everyone ! :wave:

It's my first contribution to this project, so don't hesitate to correct me if anything is wrong.
Also, I didn't find any issue about this, so I directly created a PR. Once again, just tell me if I'm doing it wrong. :ok_hand:

## Original use case

TL;DR: I need `||` for strings, but please tell me if there's a better solution for the community

I work on a pretty big "middleware" kind of API, of which one of the main job is to clean the data from a multitude of other services, before sending it to many kind of front-end clients on different platforms.

One of its cleaning tasks is to replace any empty string with either `undefined` or a fallback value.

We really want to use `prefer-nullish-coalescing` to enforce the use of `??`, to avoid accidentally removing `false` or `0`, but we also don't want to replace `aString || 'fallback'` by `!aString ? 'fallback' : aString`. Keep in mind that most of the time it even looks like `a.path.that.i.cant.always?.trust || 'fallback'` VS   `!a.path.that.i.cant.always?.trust ? 'fallback' : a.path.that.i.cant.always.trust`.

This problem might be a bit specific and I'm 100% open to code a better solution, answering everyone needs, if required.

## Solution:`ignoreStrings` (just copying the doc I just commited)

Setting this option to `true` will cause the rule to be ignored when the left-hand's TypeScript type is `string`, whether it may be nullish or not.

This can be useful if you want to enforce the use of `??` on every types but `string`, because you want to handle empty strings.

Incorrect code for `ignoreStrings: false`, and correct code for `ignoreStrings: true`:

```ts
declare const nullString: string | null;
const emptyString = '';
const a = nullString || 'fallback';
const b = emptyString || 'fallback';
// a === 'fallback'
// b === 'fallback'
```

Correct code for `ignoreStrings: false`:

```ts
declare const nullString: string | null;
const emptyString = '';
const a = nullString ?? 'fallback';
const b = emptyString ?? 'fallback';
const c = !emptyString ? 'fallback' : emptyString;
// a === 'fallback'
// b === ''
// c === 'fallback'
```

Please tell me if there's any error, subpar code or any rephrasing needed.

Thank you very much !