### PR TITLE
docs(parser): mention that relative paths rely on cwd

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -81,7 +81,7 @@ Enable parsing JSX when `true`. More details can be found [here](https://www.typ
 
 Default `undefined`.
 
-This option allows you to provide a path to your project's `tsconfig.json`. **This setting is required if you want to use rules which require type information**. You may want to use this setting in tandem with the `tsconfigRootDir` option below.
+This option allows you to provide a path to your project's `tsconfig.json`. **This setting is required if you want to use rules which require type information**. Relative paths are interpreted relative to the current working directory if `tsconfigRootDir` is not set. If you intend on running ESLint from directories other than the project root, you should consider using `tsconfigRootDir`.
 
 - Accepted values:
 


### PR DESCRIPTION
It was not clear that relative paths rely on the cwd. For example, a valid alternative interpretation could be that relative paths rely on the location of the eslintconfig file.

This change clarifies how the `parserOptions.project` relative paths are interpreted, and ties it in nicely with the existing recommendation to look at the `tsconfigRootDir` setting.