### PR TITLE
fix(eslint-plugin): extend base config using plugin syntax relative path

### DIFF
--- a/packages/eslint-plugin/src/configs/all.json
+++ b/packages/eslint-plugin/src/configs/all.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./configs/base.json",
+  "extends": "plugin:@typescript-eslint/base",
   "rules": {
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": "error",

--- a/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.json
+++ b/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./configs/base.json",
+  "extends": "plugin:@typescript-eslint/base",
   "rules": {
     "@typescript-eslint/await-thenable": "error",
     "@typescript-eslint/no-for-in-array": "error",

--- a/packages/eslint-plugin/src/configs/recommended.json
+++ b/packages/eslint-plugin/src/configs/recommended.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./configs/base.json",
+  "extends": "plugin:@typescript-eslint/base",
   "rules": {
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/ban-ts-ignore": "error",

--- a/packages/eslint-plugin/tools/generate-configs.ts
+++ b/packages/eslint-plugin/tools/generate-configs.ts
@@ -143,7 +143,7 @@ console.log(
   '------------------------------------------------ all.json ------------------------------------------------',
 );
 const allConfig: LinterConfig = {
-  extends: './configs/base.json',
+  extends: 'plugin:@typescript-eslint/base',
   rules: ruleEntries.reduce<LinterConfigRules>(
     (config, entry) =>
       reducer(config, entry, { errorLevel: 'error', filterDeprecated: true }),
@@ -170,7 +170,7 @@ BASE_RULES_THAT_ARE_RECOMMENDED.forEach(ruleName => {
   recommendedRules[ruleName] = 'error';
 });
 const recommendedConfig: LinterConfig = {
-  extends: './configs/base.json',
+  extends: 'plugin:@typescript-eslint/base',
   rules: recommendedRules,
 };
 writeConfig(
@@ -196,7 +196,7 @@ BASE_RULES_THAT_ARE_RECOMMENDED.forEach(ruleName => {
   recommendedRulesRequiringProgram[ruleName] = 'error';
 });
 const recommendedRequiringTypeCheckingConfig: LinterConfig = {
-  extends: './configs/base.json',
+  extends: 'plugin:@typescript-eslint/base',
   rules: recommendedRulesRequiringProgram,
 };
 writeConfig(


### PR DESCRIPTION
Trying to make vue eslint typescript config compatible with yarn v2, I hit several blockers, one being extends with relative path prevent shimming.
This aims to make Yarn v2 compat less painful, but I'm not claiming I have the truth, this is a open discussion on how we can make it work together, thanks. 


