### PR TITLE
docs(eslint-plugin): added missing TSLint 5.20 rules to ROADMAP.md

### DIFF
--- a/packages/eslint-plugin/ROADMAP.md
+++ b/packages/eslint-plugin/ROADMAP.md
@@ -18,6 +18,7 @@ It lists all TSLint rules along side rules from the ESLint ecosystem that are th
 | [`adjacent-overload-signatures`]  | ✅  | [`@typescript-eslint/adjacent-overload-signatures`]  |
 | [`ban-ts-ignore`]                 | ✅  | [`@typescript-eslint/ban-ts-ignore`]                 |
 | [`ban-types`]                     | 🌓  | [`@typescript-eslint/ban-types`]<sup>[1]</sup>       |
+| [`invalid-void`]                  | 🛑  | N/A                                                  |
 | [`member-access`]                 | ✅  | [`@typescript-eslint/explicit-member-accessibility`] |
 | [`member-ordering`]               | ✅  | [`@typescript-eslint/member-ordering`]               |
 | [`no-any`]                        | ✅  | [`@typescript-eslint/no-explicit-any`]               |
@@ -74,7 +75,10 @@ It lists all TSLint rules along side rules from the ESLint ecosystem that are th
 | [`no-invalid-this`]                  | 🌟  | [`no-invalid-this`][no-invalid-this]                                  |
 | [`no-misused-new`]                   | ✅  | [`@typescript-eslint/no-misused-new`]                                 |
 | [`no-null-keyword`]                  | 🔌  | [`no-null/no-null`] (doesn’t handle `null` type)                      |
+| [`no-null-undefined-union`]          | 🛑  | N/A                                                                   |
 | [`no-object-literal-type-assertion`] | ✅  | [`@typescript-eslint/consistent-type-assertions`]                     |
+| [`no-promise-as-boolean`]            | 🛑  | N/A                                                                   |
+| [`no-restricted-globals`]            | ✅  | [`no-restricted-globals`][no-restricted-globals]                      |
 | [`no-return-await`]                  | 🌟  | [`no-return-await`][no-return-await]                                  |
 | [`no-shadowed-variable`]             | 🌟  | [`no-shadow`][no-shadow]                                              |
 | [`no-sparse-arrays`]                 | 🌟  | [`no-sparse-arrays`][no-sparse-arrays]                                |
@@ -82,6 +86,7 @@ It lists all TSLint rules along side rules from the ESLint ecosystem that are th
 | [`no-string-throw`]                  | ✅  | [`@typescript-eslint/no-throw-literal`]                               |
 | [`no-submodule-imports`]             | 🌓  | [`import/no-internal-modules`] (slightly different)                   |
 | [`no-switch-case-fall-through`]      | 🌟  | [`no-fallthrough`][no-fallthrough]                                    |
+| [`no-tautology-expression`]          | 🛑  | N/A                                                                   |
 | [`no-this-assignment`]               | ✅  | [`@typescript-eslint/no-this-alias`]                                  |
 | [`no-unbound-method`]                | ✅  | [`@typescript-eslint/unbound-method`]                                 |
 | [`no-unnecessary-class`]             | ✅  | [`@typescript-eslint/no-extraneous-class`]                            |
@@ -96,7 +101,9 @@ It lists all TSLint rules along side rules from the ESLint ecosystem that are th
 | [`prefer-object-spread`]             | 🌟  | [`prefer-object-spread`][prefer-object-spread]                        |
 | [`radix`]                            | 🌟  | [`radix`][radix]                                                      |
 | [`restrict-plus-operands`]           | ✅  | [`@typescript-eslint/restrict-plus-operands`]                         |
+| [`static-this`]                      | 🛑  | N/A                                                                   |
 | [`strict-boolean-expressions`]       | ✅  | [`@typescript-eslint/strict-boolean-expressions`]                     |
+| [`strict-string-expressions`]        | 🛑  | N/A                                                                   |
 | [`strict-type-predicates`]           | 🛑  | N/A                                                                   |
 | [`switch-default`]                   | 🌟  | [`default-case`][default-case]                                        |
 | [`triple-equals`]                    | 🌟  | [`eqeqeq`][eqeqeq]                                                    |
@@ -167,6 +174,7 @@ It lists all TSLint rules along side rules from the ESLint ecosystem that are th
 | [`no-reference-import`]             | 🛑  | N/A                                                                                 |
 | [`no-trailing-whitespace`]          | 🌟  | [`no-trailing-spaces`][no-trailing-spaces]                                          |
 | [`no-unnecessary-callback-wrapper`] | 🛑  | N/A and this might be unsafe (i.e. with `forEach`)                                  |
+| [`no-unnecessary-else`]             | 🌟  | [`no-else-return`][no-else-return] <sup>[2]</sup                                    |
 | [`no-unnecessary-initializer`]      | 🌟  | [`no-undef-init`][no-undef-init]                                                    |
 | [`no-unnecessary-qualifier`]        | ✅  | [`@typescript-eslint/no-unnecessary-qualifier`]                                     |
 | [`number-literal-format`]           | 🛑  | N/A                                                                                 |
@@ -188,11 +196,12 @@ It lists all TSLint rules along side rules from the ESLint ecosystem that are th
 | [`switch-final-break`]              | 🛑  | N/A                                                                                 |
 | [`type-literal-delimiter`]          | ✅  | [`@typescript-eslint/member-delimiter-style`]                                       |
 | [`unnecessary-bind`]                | 🌟  | [`no-extra-bind`][no-extra-bind]                                                    |
-| [`variable-name`]                   | 🌟  | <sup>[2]</sup>                                                                      |
+| [`variable-name`]                   | 🌟  | <sup>[3]</sup>                                                                      |
 | [`whitespace`]                      | 🔌  | Use [Prettier]                                                                      |
 
 <sup>[1]</sup> Recommended config: `["error", { blankLine: "always", prev: "*", next: "return" }]`<br>
-<sup>[2]</sup> [`camelcase`][camelcase], [`no-underscore-dangle`][no-underscore-dangle], [`id-blacklist`][id-blacklist], and/or [`id-match`][id-match]
+<sup>[2]</sup> Doesn't check other control flow statements, such as `break` or `continue`.
+<sup>[3]</sup> [`camelcase`][camelcase], [`no-underscore-dangle`][no-underscore-dangle], [`id-blacklist`][id-blacklist], and/or [`id-match`][id-match]
 
 ## tslint-microsoft-contrib rules
 
@@ -486,6 +495,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 [no-magic-numbers]: https://eslint.org/docs/rules/no-magic-numbers
 [no-param-reassign]: https://eslint.org/docs/rules/no-param-reassign
 [no-sequences]: https://eslint.org/docs/rules/no-sequences
+[no-restricted-globals]: https://eslint.org/docs/rules/no-restricted-globals
 [no-restricted-properties]: https://eslint.org/docs/rules/no-restricted-properties
 [no-restricted-syntax]: https://eslint.org/docs/rules/no-restricted-syntax
 [curly]: https://eslint.org/docs/rules/curly
@@ -541,6 +551,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 [padding-line-between-statements]: https://eslint.org/docs/rules/padding-line-between-statements
 [newline-per-chained-call]: https://eslint.org/docs/rules/newline-per-chained-call
 [new-parens]: https://eslint.org/docs/rules/new-parens
+[no-else-return]: https://eslint.org/docs/rules/no-else-return
 [no-multiple-empty-lines]: https://eslint.org/docs/rules/no-multiple-empty-lines
 [no-irregular-whitespace]: https://eslint.org/docs/rules/no-irregular-whitespace
 [no-trailing-spaces]: https://eslint.org/docs/rules/no-trailing-spaces

--- a/packages/eslint-plugin/ROADMAP.md
+++ b/packages/eslint-plugin/ROADMAP.md
@@ -44,73 +44,73 @@ It lists all TSLint rules along side rules from the ESLint ecosystem that are th
 
 ### Functionality
 
-| TSLint rule                          |     | ESLint rule                                                           |
-| ------------------------------------ | :-: | --------------------------------------------------------------------- |
-| [`await-promise`]                    | ✅  | [`@typescript-eslint/await-thenable`]                                 |
-| [`ban-comma-operator`]               | 🌟  | [`no-sequences`][no-sequences]                                        |
-| [`ban`]                              | 🌟  | [`no-restricted-properties`][no-restricted-properties]                |
-| [`curly`]                            | 🌟  | [`curly`][curly]                                                      |
-| [`forin`]                            | 🌟  | [`guard-for-in`][guard-for-in]                                        |
-| [`function-constructor`]             | 🌟  | [`no-new-func`][no-new-func]                                          |
-| [`import-blacklist`]                 | 🌟  | [`no-restricted-imports`][no-restricted-imports]                      |
-| [`label-position`]                   | 🌟  | [`no-unused-labels`][no-unused-labels] (similar)                      |
-| [`no-arg`]                           | 🌟  | [`no-caller`][no-caller] (also blocks `arguments.caller`)             |
-| [`no-async-without-await`]           | ✅  | [`@typescript-eslint/require-await`]                                  |
-| [`no-bitwise`]                       | 🌟  | [`no-bitwise`][no-bitwise]                                            |
-| [`no-conditional-assignment`]        | 🌟  | [`no-cond-assign`][no-cond-assign]<sup>[1]</sup>                      |
-| [`no-console`]                       | 🌟  | [`no-console`][no-console] (configuration works slightly differently) |
-| [`no-construct`]                     | 🌟  | [`no-new-wrappers`][no-new-wrappers]                                  |
-| [`no-debugger`]                      | 🌟  | [`no-debugger`][no-debugger]                                          |
-| [`no-duplicate-super`]               | 🌟  | [`constructor-super`][constructor-super]                              |
-| [`no-duplicate-switch-case`]         | 🌟  | [`no-duplicate-case`][no-duplicate-case]                              |
-| [`no-duplicate-variable`]            | 🌟  | [`no-redeclare`][no-redeclare]                                        |
-| [`no-dynamic-delete`]                | ✅  | [`@typescript-eslint/no-dynamic-delete`]                              |
-| [`no-empty`]                         | 🌟  | [`no-empty`][no-empty]                                                |
-| [`no-eval`]                          | 🌟  | [`no-eval`][no-eval]                                                  |
-| [`no-floating-promises`]             | ✅  | [`@typescript-eslint/no-floating-promises`]                           |
-| [`no-for-in-array`]                  | ✅  | [`@typescript-eslint/no-for-in-array`]                                |
-| [`no-implicit-dependencies`]         | 🔌  | [`import/no-extraneous-dependencies`]                                 |
-| [`no-inferred-empty-object-type`]    | 🛑  | N/A                                                                   |
-| [`no-invalid-template-strings`]      | 🌟  | [`no-template-curly-in-string`][no-template-curly-in-string]          |
-| [`no-invalid-this`]                  | 🌟  | [`no-invalid-this`][no-invalid-this]                                  |
-| [`no-misused-new`]                   | ✅  | [`@typescript-eslint/no-misused-new`]                                 |
-| [`no-null-keyword`]                  | 🔌  | [`no-null/no-null`] (doesn’t handle `null` type)                      |
-| [`no-null-undefined-union`]          | 🛑  | N/A                                                                   |
-| [`no-object-literal-type-assertion`] | ✅  | [`@typescript-eslint/consistent-type-assertions`]                     |
-| [`no-promise-as-boolean`]            | 🛑  | N/A                                                                   |
-| [`no-restricted-globals`]            | ✅  | [`no-restricted-globals`][no-restricted-globals]                      |
-| [`no-return-await`]                  | 🌟  | [`no-return-await`][no-return-await]                                  |
-| [`no-shadowed-variable`]             | 🌟  | [`no-shadow`][no-shadow]                                              |
-| [`no-sparse-arrays`]                 | 🌟  | [`no-sparse-arrays`][no-sparse-arrays]                                |
-| [`no-string-literal`]                | 🌟  | [`dot-notation`][dot-notation]                                        |
-| [`no-string-throw`]                  | ✅  | [`@typescript-eslint/no-throw-literal`]                               |
-| [`no-submodule-imports`]             | 🌓  | [`import/no-internal-modules`] (slightly different)                   |
-| [`no-switch-case-fall-through`]      | 🌟  | [`no-fallthrough`][no-fallthrough]                                    |
-| [`no-tautology-expression`]          | 🛑  | N/A                                                                   |
-| [`no-this-assignment`]               | ✅  | [`@typescript-eslint/no-this-alias`]                                  |
-| [`no-unbound-method`]                | ✅  | [`@typescript-eslint/unbound-method`]                                 |
-| [`no-unnecessary-class`]             | ✅  | [`@typescript-eslint/no-extraneous-class`]                            |
-| [`no-unsafe-any`]                    | 🛑  | N/A                                                                   |
-| [`no-unsafe-finally`]                | 🌟  | [`no-unsafe-finally`][no-unsafe-finally]                              |
-| [`no-unused-expression`]             | 🌟  | [`no-unused-expressions`][no-unused-expressions]                      |
-| [`no-unused-variable`]               | 🌓  | [`@typescript-eslint/no-unused-vars`]                                 |
-| [`no-use-before-declare`]            | ✅  | [`@typescript-eslint/no-use-before-define`]                           |
-| [`no-var-keyword`]                   | 🌟  | [`no-var`][no-var]                                                    |
-| [`no-void-expression`]               | 🌟  | [`no-void`][no-void]                                                  |
-| [`prefer-conditional-expression`]    | 🛑  | N/A                                                                   |
-| [`prefer-object-spread`]             | 🌟  | [`prefer-object-spread`][prefer-object-spread]                        |
-| [`radix`]                            | 🌟  | [`radix`][radix]                                                      |
-| [`restrict-plus-operands`]           | ✅  | [`@typescript-eslint/restrict-plus-operands`]                         |
-| [`static-this`]                      | 🛑  | N/A                                                                   |
-| [`strict-boolean-expressions`]       | ✅  | [`@typescript-eslint/strict-boolean-expressions`]                     |
-| [`strict-string-expressions`]        | 🛑  | N/A                                                                   |
-| [`strict-type-predicates`]           | 🛑  | N/A                                                                   |
-| [`switch-default`]                   | 🌟  | [`default-case`][default-case]                                        |
-| [`triple-equals`]                    | 🌟  | [`eqeqeq`][eqeqeq]                                                    |
-| [`typeof-compare`]                   | 🌟  | [`valid-typeof`][valid-typeof]                                        |
-| [`unnecessary-constructor`]          | 🌟  | [`no-useless-constructor`][no-useless-constructor]                    |
-| [`use-default-type-parameter`]       | ✅  | [`@typescript-eslint/no-unnecessary-type-arguments`]                  |
-| [`use-isnan`]                        | 🌟  | [`use-isnan`][use-isnan]                                              |
+| TSLint rule                          |     | ESLint rule                                                                                          |
+| ------------------------------------ | :-: | ---------------------------------------------------------------------------------------------------- |
+| [`await-promise`]                    | ✅  | [`@typescript-eslint/await-thenable`]                                                                |
+| [`ban-comma-operator`]               | 🌟  | [`no-sequences`][no-sequences]                                                                       |
+| [`ban`]                              | 🌟  | [`no-restricted-properties`][no-restricted-properties]                                               |
+| [`curly`]                            | 🌟  | [`curly`][curly]                                                                                     |
+| [`forin`]                            | 🌟  | [`guard-for-in`][guard-for-in]                                                                       |
+| [`function-constructor`]             | 🌟  | [`no-new-func`][no-new-func]                                                                         |
+| [`import-blacklist`]                 | 🌟  | [`no-restricted-imports`][no-restricted-imports]                                                     |
+| [`label-position`]                   | 🌟  | [`no-unused-labels`][no-unused-labels] (similar)                                                     |
+| [`no-arg`]                           | 🌟  | [`no-caller`][no-caller] (also blocks `arguments.caller`)                                            |
+| [`no-async-without-await`]           | ✅  | [`@typescript-eslint/require-await`]                                                                 |
+| [`no-bitwise`]                       | 🌟  | [`no-bitwise`][no-bitwise]                                                                           |
+| [`no-conditional-assignment`]        | 🌟  | [`no-cond-assign`][no-cond-assign]<sup>[1]</sup>                                                     |
+| [`no-console`]                       | 🌟  | [`no-console`][no-console] (configuration works slightly differently)                                |
+| [`no-construct`]                     | 🌟  | [`no-new-wrappers`][no-new-wrappers]                                                                 |
+| [`no-debugger`]                      | 🌟  | [`no-debugger`][no-debugger]                                                                         |
+| [`no-duplicate-super`]               | 🌟  | [`constructor-super`][constructor-super]                                                             |
+| [`no-duplicate-switch-case`]         | 🌟  | [`no-duplicate-case`][no-duplicate-case]                                                             |
+| [`no-duplicate-variable`]            | 🌟  | [`no-redeclare`][no-redeclare]                                                                       |
+| [`no-dynamic-delete`]                | ✅  | [`@typescript-eslint/no-dynamic-delete`]                                                             |
+| [`no-empty`]                         | 🌟  | [`no-empty`][no-empty]                                                                               |
+| [`no-eval`]                          | 🌟  | [`no-eval`][no-eval]                                                                                 |
+| [`no-floating-promises`]             | ✅  | [`@typescript-eslint/no-floating-promises`]                                                          |
+| [`no-for-in-array`]                  | ✅  | [`@typescript-eslint/no-for-in-array`]                                                               |
+| [`no-implicit-dependencies`]         | 🔌  | [`import/no-extraneous-dependencies`]                                                                |
+| [`no-inferred-empty-object-type`]    | 🛑  | N/A                                                                                                  |
+| [`no-invalid-template-strings`]      | 🌟  | [`no-template-curly-in-string`][no-template-curly-in-string]                                         |
+| [`no-invalid-this`]                  | 🌟  | [`no-invalid-this`][no-invalid-this]                                                                 |
+| [`no-misused-new`]                   | ✅  | [`@typescript-eslint/no-misused-new`]                                                                |
+| [`no-null-keyword`]                  | 🔌  | [`no-null/no-null`] (doesn’t handle `null` type)                                                     |
+| [`no-null-undefined-union`]          | 🛑  | N/A                                                                                                  |
+| [`no-object-literal-type-assertion`] | ✅  | [`@typescript-eslint/consistent-type-assertions`]                                                    |
+| [`no-promise-as-boolean`]            | ✅  | [`@typescript-eslint/no-misused-promises`]                                                           |
+| [`no-restricted-globals`]            | ✅  | [`no-restricted-globals`][no-restricted-globals]                                                     |
+| [`no-return-await`]                  | 🌟  | [`no-return-await`][no-return-await]                                                                 |
+| [`no-shadowed-variable`]             | 🌟  | [`no-shadow`][no-shadow]                                                                             |
+| [`no-sparse-arrays`]                 | 🌟  | [`no-sparse-arrays`][no-sparse-arrays]                                                               |
+| [`no-string-literal`]                | 🌟  | [`dot-notation`][dot-notation]                                                                       |
+| [`no-string-throw`]                  | ✅  | [`@typescript-eslint/no-throw-literal`]                                                              |
+| [`no-submodule-imports`]             | 🌓  | [`import/no-internal-modules`] (slightly different)                                                  |
+| [`no-switch-case-fall-through`]      | 🌟  | [`no-fallthrough`][no-fallthrough]                                                                   |
+| [`no-tautology-expression`]          | 🛑  | N/A                                                                                                  |
+| [`no-this-assignment`]               | ✅  | [`@typescript-eslint/no-this-alias`]                                                                 |
+| [`no-unbound-method`]                | ✅  | [`@typescript-eslint/unbound-method`]                                                                |
+| [`no-unnecessary-class`]             | ✅  | [`@typescript-eslint/no-extraneous-class`]                                                           |
+| [`no-unsafe-any`]                    | 🛑  | N/A                                                                                                  |
+| [`no-unsafe-finally`]                | 🌟  | [`no-unsafe-finally`][no-unsafe-finally]                                                             |
+| [`no-unused-expression`]             | 🌟  | [`no-unused-expressions`][no-unused-expressions]                                                     |
+| [`no-unused-variable`]               | 🌓  | [`@typescript-eslint/no-unused-vars`]                                                                |
+| [`no-use-before-declare`]            | ✅  | [`@typescript-eslint/no-use-before-define`]                                                          |
+| [`no-var-keyword`]                   | 🌟  | [`no-var`][no-var]                                                                                   |
+| [`no-void-expression`]               | 🌟  | [`no-void`][no-void]                                                                                 |
+| [`prefer-conditional-expression`]    | 🛑  | N/A                                                                                                  |
+| [`prefer-object-spread`]             | 🌟  | [`prefer-object-spread`][prefer-object-spread]                                                       |
+| [`radix`]                            | 🌟  | [`radix`][radix]                                                                                     |
+| [`restrict-plus-operands`]           | ✅  | [`@typescript-eslint/restrict-plus-operands`]                                                        |
+| [`static-this`]                      | 🛑  | N/A                                                                                                  |
+| [`strict-boolean-expressions`]       | ✅  | [`@typescript-eslint/strict-boolean-expressions`]                                                    |
+| [`strict-string-expressions`]        | ✅  | [`@typescript-eslint/restrict-plus-operands`] & [`@typescript-eslint/restrict-template-expressions`] |
+| [`strict-type-predicates`]           | 🛑  | N/A                                                                                                  |
+| [`switch-default`]                   | 🌟  | [`default-case`][default-case]                                                                       |
+| [`triple-equals`]                    | 🌟  | [`eqeqeq`][eqeqeq]                                                                                   |
+| [`typeof-compare`]                   | 🌟  | [`valid-typeof`][valid-typeof]                                                                       |
+| [`unnecessary-constructor`]          | 🌟  | [`no-useless-constructor`][no-useless-constructor]                                                   |
+| [`use-default-type-parameter`]       | ✅  | [`@typescript-eslint/no-unnecessary-type-arguments`]                                                 |
+| [`use-isnan`]                        | 🌟  | [`use-isnan`][use-isnan]                                                                             |
 
 <sup>[1]</sup> The ESLint rule also supports silencing with an extra set of parentheses (`if ((foo = bar)) {}`)<br>
 
@@ -171,7 +171,7 @@ It lists all TSLint rules along side rules from the ESLint ecosystem that are th
 | [`no-irregular-whitespace`]         | 🌟  | [`no-irregular-whitespace`][no-irregular-whitespace] with `skipStrings: false`      |
 | [`no-parameter-properties`]         | ✅  | [`@typescript-eslint/no-parameter-properties`]                                      |
 | [`no-redundant-jsdoc`]              | 🔌  | [`jsdoc/no-types`]                                                                  |
-| [`no-reference-import`]             | 🛑  | N/A                                                                                 |
+| [`no-reference-import`]             | ✅  | [`@typescript-eslint/triple-slash-reference`]                                       |
 | [`no-trailing-whitespace`]          | 🌟  | [`no-trailing-spaces`][no-trailing-spaces]                                          |
 | [`no-unnecessary-callback-wrapper`] | 🛑  | N/A and this might be unsafe (i.e. with `forEach`)                                  |
 | [`no-unnecessary-else`]             | 🌟  | [`no-else-return`][no-else-return] <sup>[2]</sup                                    |
@@ -196,12 +196,11 @@ It lists all TSLint rules along side rules from the ESLint ecosystem that are th
 | [`switch-final-break`]              | 🛑  | N/A                                                                                 |
 | [`type-literal-delimiter`]          | ✅  | [`@typescript-eslint/member-delimiter-style`]                                       |
 | [`unnecessary-bind`]                | 🌟  | [`no-extra-bind`][no-extra-bind]                                                    |
-| [`variable-name`]                   | 🌟  | <sup>[3]</sup>                                                                      |
+| [`variable-name`]                   | ✅  | [`@typescript-eslint/naming-convention`]                                            |
 | [`whitespace`]                      | 🔌  | Use [Prettier]                                                                      |
 
 <sup>[1]</sup> Recommended config: `["error", { blankLine: "always", prev: "*", next: "return" }]`<br>
 <sup>[2]</sup> Doesn't check other control flow statements, such as `break` or `continue`.
-<sup>[3]</sup> [`camelcase`][camelcase], [`no-underscore-dangle`][no-underscore-dangle], [`id-blacklist`][id-blacklist], and/or [`id-match`][id-match]
 
 ## tslint-microsoft-contrib rules
 
@@ -602,6 +601,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 [`@typescript-eslint/no-inferrable-types`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-inferrable-types.md
 [`@typescript-eslint/prefer-namespace-keyword`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-namespace-keyword.md
 [`@typescript-eslint/promise-function-async`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/promise-function-async.md
+[`@typescript-eslint/no-misused-promises`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md
 [`@typescript-eslint/no-namespace`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-namespace.md
 [`@typescript-eslint/no-non-null-assertion`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
 [`@typescript-eslint/triple-slash-reference`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/triple-slash-reference.md
@@ -625,6 +625,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 [`@typescript-eslint/array-type`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md
 [`@typescript-eslint/class-name-casing`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/class-name-casing.md
 [`@typescript-eslint/interface-name-prefix`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/interface-name-prefix.md
+[`@typescript-eslint/naming-convention`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md
 [`@typescript-eslint/no-parameter-properties`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-parameter-properties.md
 [`@typescript-eslint/member-delimiter-style`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/member-delimiter-style.md
 [`@typescript-eslint/prefer-for-of`]: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-for-of.md


### PR DESCRIPTION
We can be sure this is the last of the core rules to be added, because TSLint is deprecated now :smile:.

Fixes #1034.
Edit: also fixes #1627.