### PR TITLE
fix(typescript-estree): process.stdout can be undefined

### DIFF
--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -261,7 +261,7 @@ function applyParserOptionsToExtra(options: TSESTreeOptions): void {
 
 function warnAboutTSVersion(): void {
   if (!isRunningSupportedTypeScriptVersion && !warnedAboutTSVersion) {
-    const isTTY = typeof process === undefined ? false : process.stdout.isTTY;
+    const isTTY = typeof process === undefined ? false : process.stdout?.isTTY;
     if (isTTY) {
       const border = '=============';
       const versionWarning = [


### PR DESCRIPTION
This happens in Prettier's browser bundle.