### PR TITLE
WIP: feat(eslint-plugin): [consistent-type-assertion] add `allowAsReturn` option

### DIFF
--- a/packages/eslint-plugin/docs/rules/consistent-type-assertions.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-assertions.md
@@ -12,15 +12,18 @@ Type assertions are also commonly referred as "type casting" in TypeScript (even
 type Options =
   | {
       assertionStyle: 'as' | 'angle-bracket';
-      objectLiteralTypeAssertions: 'allow' | 'allow-as-parameter' | 'never';
+      objectLiteralTypeAssertions?: 'allow' | 'allow-as-parameter' | 'never';
+      allowAsReturn?: boolean;
     }
   | {
       assertionStyle: 'never';
+      allowAsReturn?: boolean;
     };
 
 const defaultOptions: Options = {
   assertionStyle: 'as',
   objectLiteralTypeAssertions: 'allow',
+  allowAsReturn: false,
 };
 ```
 
@@ -44,10 +47,15 @@ The compiler will warn for excess properties with this syntax, but not missing _
 
 The const assertion `const x = { foo: 1 } as const`, introduced in TypeScript 3.4, is considered beneficial and is ignored by this option.
 
+### `allowAsReturn`
+
+Allow type assertions on object literals if they are in a return statement.
+
 Examples of **incorrect** code for `{ assertionStyle: 'as', objectLiteralTypeAssertions: 'never' }` (and for `{ assertionStyle: 'as', objectLiteralTypeAssertions: 'allow-as-parameter' }`)
 
 ```ts
 const x = { ... } as T;
+return {} as T;
 ```
 
 Examples of **correct** code for `{ assertionStyle: 'as', objectLiteralTypeAssertions: 'never' }`.
@@ -67,6 +75,12 @@ const z = { ... } as unknown;
 foo({ ... } as T);
 new Clazz({ ... } as T);
 function foo() { throw { bar: 5 } as Foo }
+```
+
+Examples of **correct** code for `{ assertionStyle: 'as', objectLiteralTypeAssertions: 'allow-as-parameter', allowAsReturn: true }`.
+
+```ts
+return {} as T;
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -15,9 +15,11 @@ type OptUnion =
   | {
       assertionStyle: 'as' | 'angle-bracket';
       objectLiteralTypeAssertions?: 'allow' | 'allow-as-parameter' | 'never';
+      allowAsReturn?: boolean;
     }
   | {
       assertionStyle: 'never';
+      allowAsReturn?: boolean;
     };
 type Options = [OptUnion];
 
@@ -45,6 +47,7 @@ export default util.createRule<Options, MessageIds>({
               assertionStyle: {
                 enum: ['never'],
               },
+              allowAsReturn: { type: 'boolean' },
             },
             additionalProperties: false,
             required: ['assertionStyle'],
@@ -58,6 +61,7 @@ export default util.createRule<Options, MessageIds>({
               objectLiteralTypeAssertions: {
                 enum: ['allow', 'allow-as-parameter', 'never'],
               },
+              allowAsReturn: { type: 'boolean' },
             },
             additionalProperties: false,
             required: ['assertionStyle'],
@@ -70,6 +74,7 @@ export default util.createRule<Options, MessageIds>({
     {
       assertionStyle: 'as',
       objectLiteralTypeAssertions: 'allow',
+      allowAsReturn: false,
     },
   ],
   create(context, [options]) {
@@ -127,6 +132,14 @@ export default util.createRule<Options, MessageIds>({
           node.parent.type === AST_NODE_TYPES.OptionalCallExpression ||
           node.parent.type === AST_NODE_TYPES.ThrowStatement ||
           node.parent.type === AST_NODE_TYPES.AssignmentPattern)
+      ) {
+        return;
+      }
+
+      if (
+        options.allowAsReturn &&
+        node.parent &&
+        node.parent.type === AST_NODE_TYPES.ReturnStatement
       ) {
         return;
       }

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -41,6 +41,9 @@ function foo() { throw <Foo>{ bar: 5 } }
 print?.(<Foo>{ bar: 5 })
 print?.call(<Foo>{ bar: 5 })
 `;
+const OBJECT_LITERAL_RETURN = `
+return {} as Foo
+`;
 
 ruleTester.run('consistent-type-assertions', rule, {
   valid: [
@@ -86,6 +89,16 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           assertionStyle: 'as',
           objectLiteralTypeAssertions: 'allow-as-parameter',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests({
+      code: OBJECT_LITERAL_RETURN,
+      options: [
+        {
+          assertionStyle: 'as',
+          objectLiteralTypeAssertions: 'never',
+          allowAsReturn: true,
         },
       ],
     }),
@@ -325,6 +338,22 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 7,
+        },
+      ],
+    }),
+    ...batchedSingleLineTests({
+      code: OBJECT_LITERAL_RETURN,
+      options: [
+        {
+          assertionStyle: 'as',
+          objectLiteralTypeAssertions: 'never',
+          allowAsReturn: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'unexpectedObjectTypeAssertion',
+          line: 2,
         },
       ],
     }),


### PR DESCRIPTION
This PR adds an option to `consistent-type-assertion` to allow type assertions as part of a return statement (but otherwise preferring `const x: T` format).

I'm not sure of the best way to add this new option while preserving backward compatibility. Once one of the maintainers points me in the right direction, I can adjust and complete this PR.

For more details, see this issue:
#1629

(Resolves #1629)