### PR TITLE
feat(eslint-plugin): ignore static unbound method in recommended configs

### DIFF
--- a/packages/eslint-plugin/src/configs/all.json
+++ b/packages/eslint-plugin/src/configs/all.json
@@ -99,7 +99,12 @@
     "@typescript-eslint/triple-slash-reference": "error",
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/typedef": "error",
-    "@typescript-eslint/unbound-method": "error",
+    "@typescript-eslint/unbound-method": [
+      "error",
+      {
+        "ignoreStatic": true
+      }
+    ],
     "@typescript-eslint/unified-signatures": "error"
   }
 }

--- a/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.json
+++ b/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.json
@@ -10,7 +10,12 @@
     "@typescript-eslint/prefer-string-starts-ends-with": "error",
     "require-await": "off",
     "@typescript-eslint/require-await": "error",
-    "@typescript-eslint/unbound-method": "error",
+    "@typescript-eslint/unbound-method": [
+      "error",
+      {
+        "ignoreStatic": true
+      }
+    ],
     "no-var": "error",
     "prefer-const": "error",
     "prefer-rest-params": "error",


### PR DESCRIPTION
This PR adds `ignoreStatic` option set to `true` for `@typescript-eslint/unbound-method` rule in `recommended-requiring-type-checking.json` and `all.json`.

There is no reason to report such errors for static methods and `ignoreStatic` fixes it. 