### PR TITLE
Allow base indentation

### DIFF
--- a/packages/eslint-plugin/tests/rules/indent/indent-eslint.test.ts
+++ b/packages/eslint-plugin/tests/rules/indent/indent-eslint.test.ts
@@ -37,12 +37,12 @@ const ruleTester = new RuleTester({
 ruleTester.run('indent', rule, {
   valid: [
     {
-      code: unIndent`
-                bridge.callHandler(
-                  'getAppVersion', 'test23', function(responseData) {
-                    window.ah.mobileAppVersion = responseData;
-                  }
-                );
+      code: `
+bridge.callHandler(
+  'getAppVersion', 'test23', function(responseData) {
+    window.ah.mobileAppVersion = responseData;
+  }
+);
             `,
       options: [2],
     },
@@ -7330,11 +7330,6 @@ ruleTester.run('indent', rule, {
       ]),
     },
     {
-      code: '  // comment',
-      output: '// comment',
-      errors: expectedErrors([1, 0, 2, AST_TOKEN_TYPES.Line]),
-    },
-    {
       code: unIndent`
                 foo
                   // comment
@@ -7344,17 +7339,6 @@ ruleTester.run('indent', rule, {
                 // comment
             `,
       errors: expectedErrors([2, 0, 2, AST_TOKEN_TYPES.Line]),
-    },
-    {
-      code: unIndent`
-                  // comment
-                foo
-            `,
-      output: unIndent`
-                // comment
-                foo
-            `,
-      errors: expectedErrors([1, 0, 2, AST_TOKEN_TYPES.Line]),
     },
     {
       code: unIndent`
@@ -8176,11 +8160,6 @@ ruleTester.run('indent', rule, {
             `,
       options: [4, { CallExpression: { arguments: 'first' } }],
       errors: expectedErrors([[2, 4, 8, AST_TOKEN_TYPES.Identifier]]),
-    },
-    {
-      code: '  new Foo',
-      output: 'new Foo',
-      errors: expectedErrors([1, 0, 2, AST_TOKEN_TYPES.Keyword]),
     },
     {
       code: unIndent`


### PR DESCRIPTION
Fixes #1325 

TSLint allows for any base indentation in a file, as long as the indentation stays consistent. I've added this feature to the typescript-eslint indent rule.

```
  // comment
  console.log(
    "",
    ""
  );

```
The code in the code snippet above has a base indentation of two spaces, which previously wasn't allowed.


Three unit tests are no longer valid as a result of my changes. Please check the unit tests I removed to see if this is acceptable.

Thanks to @lugte098 for helping out