### PR TITLE
feat(eslint-plugin): [no-unnecessary-condition] report when non-nullish is compared to `null`/`undefined`

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -103,6 +103,12 @@ function test(a: string) {
   return a === 'a';
 }
     `,
+    `
+function test(a?: string) {
+  const t1 = a === undefined;
+  const t3 = undefined === a;
+}
+    `,
 
     /**
      * Predicate functions
@@ -402,6 +408,31 @@ if (x === Foo.a) {
 }
       `,
       errors: [ruleError(8, 5, 'literalBooleanExpression')],
+    },
+    // Workaround https://github.com/microsoft/TypeScript/issues/37160
+    {
+      code: `
+function test(a: string) {
+  const t1 = a !== undefined;
+  const t3 = undefined === a;
+}
+      `,
+      errors: [
+        ruleError(3, 14, 'noOverlapBooleanExpression'),
+        ruleError(4, 14, 'noOverlapBooleanExpression'),
+      ],
+    },
+    {
+      code: `
+function test(a?: string) {
+  const t1 = a === null;
+  const t3 = null !== a;
+}
+      `,
+      errors: [
+        ruleError(3, 14, 'noOverlapBooleanExpression'),
+        ruleError(4, 14, 'noOverlapBooleanExpression'),
+      ],
     },
     // Nullish coalescing operator
     {


### PR DESCRIPTION
BREAKING CHANGE:

Fixes #1591 .  

This is a pretty minimal "handles exactly the case raised in the issue" fix.  While looking into this on the issue tracker, I also found [Typescript#32627](https://github.com/microsoft/TypeScript/issues/32627) which is another case that TS won't catch.  Might be worth trying to "beef up" this logic to handle this more generally.  

