### PR TITLE
fix(eslint-plugin): [type-annotation-spacing] handle constructor types

### DIFF
--- a/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
+++ b/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
@@ -5,6 +5,7 @@ import {
   isFunction,
   isFunctionOrFunctionType,
   isIdentifier,
+  isTSConstructorType,
   isTSFunctionType,
   isVariableDeclarator,
 } from '../util';
@@ -93,7 +94,7 @@ function getRules(
 ): WhitespaceRule {
   const scope = node?.parent?.parent;
 
-  if (isTSFunctionType(scope)) {
+  if (isTSFunctionType(scope) || isTSConstructorType(scope)) {
     return rules.arrow;
   } else if (isIdentifier(scope)) {
     return getIdentifierRules(rules, scope);

--- a/packages/eslint-plugin/src/util/astUtils.ts
+++ b/packages/eslint-plugin/src/util/astUtils.ts
@@ -109,6 +109,7 @@ function isFunctionType(
   node: TSESTree.Node | undefined,
 ): node is
   | TSESTree.TSCallSignatureDeclaration
+  | TSESTree.TSConstructorType
   | TSESTree.TSConstructSignatureDeclaration
   | TSESTree.TSEmptyBodyFunctionExpression
   | TSESTree.TSFunctionType
@@ -119,6 +120,7 @@ function isFunctionType(
 
   return [
     AST_NODE_TYPES.TSCallSignatureDeclaration,
+    AST_NODE_TYPES.TSConstructorType,
     AST_NODE_TYPES.TSConstructSignatureDeclaration,
     AST_NODE_TYPES.TSEmptyBodyFunctionExpression,
     AST_NODE_TYPES.TSFunctionType,
@@ -133,6 +135,7 @@ function isFunctionOrFunctionType(
   | TSESTree.FunctionDeclaration
   | TSESTree.FunctionExpression
   | TSESTree.TSCallSignatureDeclaration
+  | TSESTree.TSConstructorType
   | TSESTree.TSConstructSignatureDeclaration
   | TSESTree.TSEmptyBodyFunctionExpression
   | TSESTree.TSFunctionType
@@ -144,6 +147,12 @@ function isTSFunctionType(
   node: TSESTree.Node | undefined,
 ): node is TSESTree.TSFunctionType {
   return node?.type === AST_NODE_TYPES.TSFunctionType;
+}
+
+function isTSConstructorType(
+  node: TSESTree.Node | undefined,
+): node is TSESTree.TSConstructorType {
+  return node?.type === AST_NODE_TYPES.TSConstructorType;
 }
 
 function isClassOrTypeElement(
@@ -248,6 +257,7 @@ export {
   isOptionalOptionalChain,
   isSetter,
   isTokenOnSameLine,
+  isTSConstructorType,
   isTSFunctionType,
   isTypeAssertion,
   isVariableDeclarator,

--- a/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
@@ -1174,6 +1174,8 @@ interface Foo {
         },
       ],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/1663
+    'type ConstructorFn = new (...args: any[]) => any;',
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #1663