### PR TITLE
docs(eslint-plugin): [no-namespace] fix typo

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-namespace.md
+++ b/packages/eslint-plugin/docs/rules/no-namespace.md
@@ -16,7 +16,7 @@ or more of the following you may pass an object with the options set as follows:
 
 - `allowDeclarations` set to `true` will allow you to `declare` custom TypeScript modules and namespaces (Default: `false`).
 - `allowDefinitionFiles` set to `true` will allow you to `declare` and use custom TypeScript modules and namespaces
-  inside definition files (Default: `false`).
+  inside definition files (Default: `true`).
 
 Examples of **incorrect** code for the default `{ "allowDeclarations": false, "allowDefinitionFiles": false }` options:
 


### PR DESCRIPTION
This PR fixes the default value for the `no-namespace` rule option `allowDefinitionFiles`.

See the default in the code:

https://github.com/typescript-eslint/typescript-eslint/blob/e5db36f140b6463965858ad4ed77f71a9a00c5a7/packages/eslint-plugin/src/rules/no-namespace.ts#L47