### PR TITLE
fix(eslint-plugin): fix placeholder in `ban-ts-comment`

### DIFF
--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -28,7 +28,7 @@ export default util.createRule<[Options], MessageIds>({
     },
     messages: {
       tsDirectiveComment:
-        'Do not use "// @ts-{directive}" because it alters compilation errors.',
+        'Do not use "// @ts-{{directive}}" because it alters compilation errors.',
     },
     schema: [
       {

--- a/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
@@ -113,7 +113,7 @@ ruleTester.run('ts-nocheck', rule, {
       code: '// @ts-nocheck',
       errors: [
         {
-          data: { directive: 'check' },
+          data: { directive: 'nocheck' },
           messageId: 'tsDirectiveComment',
           line: 1,
           column: 1,
@@ -124,7 +124,7 @@ ruleTester.run('ts-nocheck', rule, {
       code: '// @ts-nocheck: Suppress next line',
       errors: [
         {
-          data: { directive: 'check' },
+          data: { directive: 'nocheck' },
           messageId: 'tsDirectiveComment',
           line: 1,
           column: 1,
@@ -135,7 +135,7 @@ ruleTester.run('ts-nocheck', rule, {
       code: '/////@ts-nocheck: Suppress next line',
       errors: [
         {
-          data: { directive: 'check' },
+          data: { directive: 'nocheck' },
           messageId: 'tsDirectiveComment',
           line: 1,
           column: 1,
@@ -151,7 +151,7 @@ if (false) {
             `,
       errors: [
         {
-          data: { directive: 'check' },
+          data: { directive: 'nocheck' },
           messageId: 'tsDirectiveComment',
           line: 3,
           column: 3,


### PR DESCRIPTION
Noticed this while working on a few new rules for `ts-expect-error`.

Also kicking myself slightly for using `comment` instead of `comments` :(