### PR TITLE
feat(eslint-plugin): [ban-ts-comment] support `ts-expect-error`

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-ts-comment.md
+++ b/packages/eslint-plugin/docs/rules/ban-ts-comment.md
@@ -15,10 +15,7 @@ The directive comments supported by TypeScript are:
 ## Rule Details
 
 This rule lets you set which directive comments you want to allow in your codebase.
-By default two directives are allowed:
-
-- `@ts-expect-error`, as this errors unless there is an actual error to suppress, making it a lot safer than `@ts-ignore`
-- `@ts-check`, since this enables TS checking in a file
+By default, only `@ts-check` is allowed, as it enables rather than suppresses errors.
 
 The configuration looks like this:
 
@@ -31,7 +28,7 @@ interface Options {
 }
 
 const defaultOptions: Options = {
-  'ts-expect-error': true,
+  'ts-expect-error': false,
   'ts-ignore': true,
   'ts-nocheck': true,
   'ts-check': false

--- a/packages/eslint-plugin/docs/rules/ban-ts-comment.md
+++ b/packages/eslint-plugin/docs/rules/ban-ts-comment.md
@@ -6,6 +6,7 @@ Using these to suppress TypeScript Compiler Errors reduces the effectiveness of 
 The directive comments supported by TypeScript are:
 
 ```
+// @ts-expect-error
 // @ts-ignore
 // @ts-nocheck
 // @ts-check
@@ -14,18 +15,23 @@ The directive comments supported by TypeScript are:
 ## Rule Details
 
 This rule lets you set which directive comments you want to allow in your codebase.
-By default, only `@ts-check` is allowed, as it enables rather then suppresses errors.
+By default two directives are allowed:
+
+- `@ts-expect-error`, as this errors unless there is an actual error to suppress, making it a lot safer than `@ts-ignore`
+- `@ts-check`, since this enables TS checking in a file
 
 The configuration looks like this:
 
 ```
 interface Options {
+  'ts-expect-error'?: boolean;
   'ts-ignore'?: boolean;
   'ts-nocheck'?: boolean;
   'ts-check'?: boolean;
 }
 
 const defaultOptions: Options = {
+  'ts-expect-error': true,
   'ts-ignore': true,
   'ts-nocheck': true,
   'ts-check': false

--- a/packages/eslint-plugin/docs/rules/ban-ts-comment.md
+++ b/packages/eslint-plugin/docs/rules/ban-ts-comment.md
@@ -28,7 +28,7 @@ interface Options {
 }
 
 const defaultOptions: Options = {
-  'ts-expect-error': false,
+  'ts-expect-error': true,
   'ts-ignore': true,
   'ts-nocheck': true,
   'ts-check': false

--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -10,7 +10,7 @@ interface Options {
 
 const defaultOptions: [Options] = [
   {
-    'ts-expect-error': false,
+    'ts-expect-error': true,
     'ts-ignore': true,
     'ts-nocheck': true,
     'ts-check': false,
@@ -38,7 +38,7 @@ export default util.createRule<[Options], MessageIds>({
         properties: {
           'ts-expect-error': {
             type: 'boolean',
-            default: false,
+            default: true,
           },
           'ts-ignore': {
             type: 'boolean',

--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -2,6 +2,7 @@ import { AST_TOKEN_TYPES } from '@typescript-eslint/experimental-utils';
 import * as util from '../util';
 
 interface Options {
+  'ts-expect-error'?: boolean;
   'ts-ignore'?: boolean;
   'ts-nocheck'?: boolean;
   'ts-check'?: boolean;
@@ -9,6 +10,7 @@ interface Options {
 
 const defaultOptions: [Options] = [
   {
+    'ts-expect-error': false,
     'ts-ignore': true,
     'ts-nocheck': true,
     'ts-check': false,
@@ -34,6 +36,10 @@ export default util.createRule<[Options], MessageIds>({
       {
         type: 'object',
         properties: {
+          'ts-expect-error': {
+            type: 'boolean',
+            default: false,
+          },
           'ts-ignore': {
             type: 'boolean',
             default: true,
@@ -53,7 +59,7 @@ export default util.createRule<[Options], MessageIds>({
   },
   defaultOptions,
   create(context, [options]) {
-    const tsCommentRegExp = /^\/*\s*@ts-(ignore|check|nocheck)/;
+    const tsCommentRegExp = /^\/*\s*@ts-(expect-error|ignore|check|nocheck)/;
     const sourceCode = context.getSourceCode();
 
     return {

--- a/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
@@ -5,7 +5,79 @@ const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
 
-ruleTester.run('ban-ts-comment', rule, {
+ruleTester.run('ts-expect-error', rule, {
+  valid: [
+    '// just a comment containing @ts-expect-error somewhere',
+    '/* @ts-expect-error */',
+    '/** @ts-expect-error */',
+    `
+/*
+// @ts-expect-error in a block
+*/
+    `,
+    {
+      code: '// @ts-expect-error',
+      options: [{ 'ts-expect-error': false }],
+    },
+  ],
+  invalid: [
+    {
+      code: '// @ts-expect-error',
+      options: [{ 'ts-expect-error': true }],
+      errors: [
+        {
+          data: { directive: 'expect-error' },
+          messageId: 'tsDirectiveComment',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: '// @ts-expect-error: Suppress next line',
+      options: [{ 'ts-expect-error': true }],
+      errors: [
+        {
+          data: { directive: 'expect-error' },
+          messageId: 'tsDirectiveComment',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: '/////@ts-expect-error: Suppress next line',
+      options: [{ 'ts-expect-error': true }],
+      errors: [
+        {
+          data: { directive: 'expect-error' },
+          messageId: 'tsDirectiveComment',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+if (false) {
+  // @ts-expect-error: Unreachable code error
+  console.log('hello');
+}
+      `,
+      options: [{ 'ts-expect-error': true }],
+      errors: [
+        {
+          data: { directive: 'expect-error' },
+          messageId: 'tsDirectiveComment',
+          line: 3,
+          column: 3,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('ts-ignore', rule, {
   valid: [
     '// just a comment containing @ts-ignore somewhere',
     '/* @ts-ignore */',


### PR DESCRIPTION
This one should be safe to merge without TS3.9 being released - it'll just meant the docs are a bit confusing for a few months, which we should solve by putting a note on them about "feature not being released".

I've made the default `true`, as I think `ts-expect-error` is safer, and it's possible to restrict a thing too much :)

closes #1709 