### PR TITLE
docs(eslint-plugin): Typo in no-unsafe-member-access

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-member-access.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-member-access.md
@@ -24,7 +24,7 @@ nestedAny.prop['a'];
 const key = 'a';
 nestedAny.prop[key];
 
-// usng an any to access a member is unsafe
+// Using an any to access a member is unsafe
 const arr = [1, 2, 3];
 arr[anyVar];
 nestedAny[anyVar];


### PR DESCRIPTION
Fix a very minor little typo in the docs for the `no-unsafe-member-access` rule in the plugin.