### PR TITLE
fix(eslint-plugin): use `isTypeArrayTypeOrUnionOfArrayTypes` util for checking if type is array

### DIFF
--- a/packages/eslint-plugin/src/rules/no-for-in-array.ts
+++ b/packages/eslint-plugin/src/rules/no-for-in-array.ts
@@ -25,11 +25,13 @@ export default util.createRule({
         const checker = parserServices.program.getTypeChecker();
         const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node);
 
-        const type = checker.getTypeAtLocation(originalNode.expression);
+        const type = util.getConstrainedTypeAtLocation(
+          checker,
+          originalNode.expression,
+        );
 
         if (
-          (typeof type.symbol !== 'undefined' &&
-            type.symbol.name === 'Array') ||
+          util.isTypeArrayTypeOrUnionOfArrayTypes(type, checker) ||
           (type.flags & ts.TypeFlags.StringLike) !== 0
         ) {
           context.report({

--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -31,7 +31,8 @@ export default util.createRule<[], MessageIds>({
       messageId: MessageIds,
     ): void {
       const tsNode = esTreeNodeToTSNodeMap.get(node);
-      const type = checker.getTypeAtLocation(tsNode);
+      const type = util.getConstrainedTypeAtLocation(checker, tsNode);
+
       if (util.isTypeAnyType(type)) {
         context.report({
           node: reportingNode,

--- a/packages/eslint-plugin/src/rules/no-unsafe-return.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-return.ts
@@ -74,7 +74,8 @@ export default util.createRule({
       }
 
       // function has an explicit return type, so ensure it's a safe return
-      const returnNodeType = checker.getTypeAtLocation(
+      const returnNodeType = util.getConstrainedTypeAtLocation(
+        checker,
         esTreeNodeToTSNodeMap.get(returnNode),
       );
       const functionTSNode = esTreeNodeToTSNodeMap.get(functionNode);

--- a/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
+++ b/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
@@ -54,16 +54,6 @@ export default util.createRule<Options, MessageIds>({
      * Helper function to get base type of node
      */
     function getBaseTypeOfLiteralType(type: ts.Type): BaseLiteral {
-      const constraint = type.getConstraint();
-      if (
-        constraint &&
-        // for generic types with union constraints, it will return itself from getConstraint
-        // so we have to guard against infinite recursion...
-        constraint !== type
-      ) {
-        return getBaseTypeOfLiteralType(constraint);
-      }
-
       if (type.isNumberLiteral()) {
         return 'number';
       }
@@ -98,7 +88,7 @@ export default util.createRule<Options, MessageIds>({
      */
     function getNodeType(node: TSESTree.Expression): BaseLiteral {
       const tsNode = service.esTreeNodeToTSNodeMap.get(node);
-      const type = typeChecker.getTypeAtLocation(tsNode);
+      const type = util.getConstrainedTypeAtLocation(typeChecker, tsNode);
 
       return getBaseTypeOfLiteralType(type);
     }

--- a/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
+++ b/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
@@ -98,21 +98,12 @@ export default util.createRule<Options, MessageId>({
      */
     function getNodeType(node: TSESTree.Expression): BaseType[] {
       const tsNode = service.esTreeNodeToTSNodeMap.get(node);
-      const type = typeChecker.getTypeAtLocation(tsNode);
+      const type = util.getConstrainedTypeAtLocation(typeChecker, tsNode);
 
       return getBaseType(type);
     }
 
     function getBaseType(type: ts.Type): BaseType[] {
-      const constraint = type.getConstraint();
-      if (
-        constraint &&
-        // for generic types with union constraints, it will return itself
-        constraint !== type
-      ) {
-        return getBaseType(constraint);
-      }
-
       if (type.isStringLiteral()) {
         return ['string'];
       }

--- a/packages/eslint-plugin/src/util/types.ts
+++ b/packages/eslint-plugin/src/util/types.ts
@@ -14,6 +14,23 @@ import {
 import * as ts from 'typescript';
 
 /**
+ * Checks if the given type is either an array type,
+ * or a union made up solely of array types.
+ */
+export function isTypeArrayTypeOrUnionOfArrayTypes(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+): boolean {
+  for (const t of unionTypeParts(type)) {
+    if (!checker.isArrayType(t)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
  * @param type Type being checked by name.
  * @param allowedNames Symbol names checking on the type.
  * @returns Whether the type is, extends, or contains all of the allowed names.

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -60,7 +60,8 @@ const fn = (arr: number[]) => {
   for (const x in arr) {
     console.log(x);
   }
-}`,
+};
+      `,
       errors: [
         {
           messageId: 'forInViolation',
@@ -74,7 +75,8 @@ const fn = (arr: number[] | string[]) => {
   for (const x in arr) {
     console.log(x);
   }
-}`,
+};
+      `,
       errors: [
         {
           messageId: 'forInViolation',
@@ -88,7 +90,8 @@ const fn = <T extends any[]>(arr: T) => {
   for (const x in arr) {
     console.log(x);
   }
-}`,
+};
+      `,
       errors: [
         {
           messageId: 'forInViolation',

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -54,5 +54,47 @@ for (const x in z) {
         },
       ],
     },
+    {
+      code: `
+const fn = (arr: number[]) => {
+  for (const x in arr) {
+    console.log(x);
+  }
+}`,
+      errors: [
+        {
+          messageId: 'forInViolation',
+          type: AST_NODE_TYPES.ForInStatement,
+        },
+      ],
+    },
+    {
+      code: `
+const fn = (arr: number[] | string[]) => {
+  for (const x in arr) {
+    console.log(x);
+  }
+}`,
+      errors: [
+        {
+          messageId: 'forInViolation',
+          type: AST_NODE_TYPES.ForInStatement,
+        },
+      ],
+    },
+    {
+      code: `
+const fn = <T extends any[]>(arr: T) => {
+  for (const x in arr) {
+    console.log(x);
+  }
+}`,
+      errors: [
+        {
+          messageId: 'forInViolation',
+          type: AST_NODE_TYPES.ForInStatement,
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
@@ -47,6 +47,7 @@ function foo(x: any) { x() }
 function foo(x: any) { x?.() }
 function foo(x: any) { x.a.b.c.d.e.f.g() }
 function foo(x: any) { x.a.b.c.d.e.f.g?.() }
+function foo<T extends any>(x: T) { x() }
       `,
       errors: [
         {
@@ -72,6 +73,12 @@ function foo(x: any) { x.a.b.c.d.e.f.g?.() }
           line: 5,
           column: 24,
           endColumn: 39,
+        },
+        {
+          messageId: 'unsafeCall',
+          line: 6,
+          column: 37,
+          endColumn: 38,
         },
       ],
     }),

--- a/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
@@ -73,6 +73,20 @@ function foo(): Set<number> {
     `,
   ],
   invalid: [
+    {
+      code: 'function fn<T extends any>(x: T) { return x };',
+      errors: [
+        {
+          messageId: 'unsafeReturnAssignment',
+          data: {
+            sender: 'any',
+            receiver: 'T',
+          },
+          line: 1,
+          column: 36,
+        },
+      ],
+    },
     ...batchedSingleLineTests({
       code: noFormat`
 function foo() { return (1 as any); }

--- a/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
@@ -74,7 +74,11 @@ function foo(): Set<number> {
   ],
   invalid: [
     {
-      code: 'function fn<T extends any>(x: T) { return x };',
+      code: `
+function fn<T extends any>(x: T) {
+  return x;
+}
+      `,
       errors: [
         {
           messageId: 'unsafeReturnAssignment',
@@ -82,8 +86,8 @@ function foo(): Set<number> {
             sender: 'any',
             receiver: 'T',
           },
-          line: 1,
-          column: 36,
+          line: 3,
+          column: 3,
         },
       ],
     },


### PR DESCRIPTION
Based on discussion [here](https://github.com/typescript-eslint/typescript-eslint/pull/1707#discussion_r389402779), which was broken out into #1721.

I've not yet checked the rest of the rules for possible refactoring.