### PR TITLE
feat(eslint-plugin): [explicit-function-return-type] add option to allow concise arrows that start with void

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -69,6 +69,8 @@ type Options = {
   allowTypedFunctionExpressions?: boolean;
   // if true, functions immediately returning another function expression will not be checked
   allowHigherOrderFunctions?: boolean;
+  // if true, concise arrow functions that start with the void keyword will not be checked
+  allowConciseArrowFunctionExpressionStartingWithVoid?: boolean;
 };
 
 const defaults = {
@@ -196,6 +198,24 @@ var arrowFn = () => (): void => {};
 function fn() {
   return function(): void {};
 }
+```
+
+### `allowConciseArrowFunctionExpressionsStartingWithVoid`
+
+Examples of **incorrect** code for this rule with `{ allowConciseArrowFunctionExpressionsStartingWithVoid: true }`:
+
+```ts
+var join = (a: string, b: string) => `${a}${b}`;
+
+const log = (message: string) => {
+  console.log(message);
+};
+```
+
+Examples of **correct** code for this rule with `{ allowConciseArrowFunctionExpressionsStartingWithVoid: true }`:
+
+```ts
+var log = (message: string) => void console.log(message);
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -1060,15 +1060,19 @@ const func = (value: number) => ({ type: 'X', value } as const);
     },
     {
       filename: 'test.ts',
-      code: 'const log = (message: string) => { void console.log(message); }',
+      code: `
+        const log = (message: string) => {
+          void console.log(message);
+        };
+      `,
       options: [{ allowConciseArrowFunctionExpressionsStartingWithVoid: true }],
       errors: [
         {
           messageId: 'missingReturnType',
-          line: 1,
-          endLine: 1,
-          column: 13,
-          endColumn: 33,
+          line: 2,
+          endLine: 2,
+          column: 21,
+          endColumn: 41,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -366,6 +366,11 @@ new Foo(1, () => {});
         },
       ],
     },
+    {
+      filename: 'test.ts',
+      code: 'const log = (message: string) => void console.log(message);',
+      options: [{ allowConciseArrowFunctionExpressionsStartingWithVoid: true }],
+    },
   ],
   invalid: [
     {
@@ -1034,6 +1039,36 @@ const func = (value: number) => ({ type: 'X', value } as const);
           endLine: 2,
           column: 14,
           endColumn: 32,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: 'const log = (message: string) => void console.log(message);',
+      options: [
+        { allowConciseArrowFunctionExpressionsStartingWithVoid: false },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 1,
+          endLine: 1,
+          column: 13,
+          endColumn: 33,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: 'const log = (message: string) => { void console.log(message); }',
+      options: [{ allowConciseArrowFunctionExpressionsStartingWithVoid: true }],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 1,
+          endLine: 1,
+          column: 13,
+          endColumn: 33,
         },
       ],
     },


### PR DESCRIPTION
This is an option to complement [the `no-void` base rule allowing the use of `void` in the same conditions](https://github.com/eslint/eslint/issues/13020).

Since that issue is still being evaluated, I've not made any reference to it, but the use-case is still valid even if the team decide against it.

The idea is to not require you to double up `void`:

```
const log = (message: string): void => void console.log(message);
```

This change means that an option can be enabled that allows you to drop the `void` return type:

```
const log = (message: string) => void console.log(message);
```

This is only allowed when the option is enabled *and*: the arrow function is concise, and starts with the `void` operator.

-----

I'm completely open to bikeshedding on the name & such - I just didn't feel it was worth an issue given how small it is to implement, and makes more sense seeing it visually.