### PR TITLE
fix(typescript-estree): export * regression from 133f622f

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1602,7 +1602,12 @@ export class Converter {
             source: this.convertChild(node.moduleSpecifier),
             exportKind: node.isTypeOnly ? 'type' : 'value',
             exported:
-              node.exportClause?.kind === SyntaxKind.NamespaceExport
+              // note - for compat with 3.7.x, where node.exportClause is always undefined and
+              //        SyntaxKind.NamespaceExport does not exist yet (i.e. is undefined), this
+              //        cannot be shortened to an optional chain, or else you end up with
+              //        undefined === undefined, and the true path will hard error at runtime
+              node.exportClause &&
+              node.exportClause.kind === SyntaxKind.NamespaceExport
                 ? this.convertChild(node.exportClause.name)
                 : null,
           });


### PR DESCRIPTION
Fixes #1746

133f622f / #1698 introduced a regression.
This was a case I didn't think about in the original implementation.
It's a hole in the types due to the fact that the SyntaxKind enum member, ofc always exists in 3.8.x.

Tested this via:
- change the resolved typescript version in the root package.json to `3.7.5`
- `yarn lint` - no parsing errors 