### PR TITLE
fix(eslint-plugin): fix message of no-base-to-string

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -24,7 +24,7 @@ export default util.createRule({
     },
     messages: {
       baseToString:
-        "'{{name}} {{certainty}} evaluate to '[Object object]' when stringified.",
+        "'{{name}} {{certainty}} evaluate to '[object Object]' when stringified.",
     },
     schema: [],
     type: 'suggestion',


### PR DESCRIPTION
`({}).toString() === "[object Object]"`