### PR TITLE
chore: standardise issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/eslint-plugin-tslint.md
+++ b/.github/ISSUE_TEMPLATE/eslint-plugin-tslint.md
@@ -6,15 +6,61 @@ labels: 'package: eslint-plugin-tslint, triage'
 assignees: ''
 ---
 
-**What code were you trying to parse?**
+<!--
+Please don't ignore this template.
 
-```ts
-// Please put code here
+If you ignore it, we're just going to respond asking you to fill it out, which wastes everyone's time.
+The more relevant information you can include, the faster we can find the issue and fix it without asking you for more info.
+-->
+
+<!--
+Make sure you read through our FAQ before posting.
+https://github.com/typescript-eslint/typescript-eslint/blob/issue-template-update/docs/getting-started/linting/FAQ.md
+-->
+
+**Repro**
+
+<!--
+Include a ***minimal*** reproduction case.
+The more irrelevant code/config you give, the harder it is for us to investigate.
+-->
+
+```JSON
+{
+  "rules": {
+    "@typescript-eslint/tslint/config": ["warn", {
+      "lintFile": "", // path to tslint.json of your project
+      "rules": {
+        "rule": "setting",
+      },
+      "rulesDirectory": [
+        "node_modules/foo"
+      ]
+    }],
+  }
+}
 ```
 
-**What did you expect to happen?**
+<!--
+Also include your tslint config, if you're using a separate file.
+-->
 
-**What actually happened?**
+```TS
+// your repro code case
+```
+
+**Expected Result**
+
+**Actual Result**
+
+**Additional Info**
+
+<!--
+Did eslint throw an exception?
+
+Please run your lint again with the --debug flag, and dump the output below.
+i.e. eslint --ext ".ts,.js" src --debug
+-->
 
 **Versions**
 

--- a/.github/ISSUE_TEMPLATE/eslint-plugin-tslint.md
+++ b/.github/ISSUE_TEMPLATE/eslint-plugin-tslint.md
@@ -29,7 +29,6 @@ The more irrelevant code/config you give, the harder it is for us to investigate
 {
   "rules": {
     "@typescript-eslint/tslint/config": ["warn", {
-      "lintFile": "", // path to tslint.json of your project
       "rules": {
         "rule": "setting",
       },

--- a/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.md
+++ b/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.md
@@ -1,7 +1,7 @@
 ---
 name: '@typescript-eslint/eslint-plugin'
 about: Report an issue with the '@typescript-eslint/eslint-plugin' package
-title: '[rulename] <issue title>'
+title: '[rulename] issue title'
 labels: 'package: eslint-plugin, triage'
 assignees: ''
 ---
@@ -24,6 +24,11 @@ Are you opening an issue because the rule you're trying to use is not found?
 2) Try installing the `canary` tag: `npm i @typescript-eslint/eslint-plugin@canary`.
     - The canary tag is built for every commit to master, so it contains the bleeding edge build.
 3) If ESLint still can't find the rule, then consider reporting an issue.
+-->
+
+<!--
+Make sure you read through our FAQ before posting.
+https://github.com/typescript-eslint/typescript-eslint/blob/issue-template-update/docs/getting-started/linting/FAQ.md
 -->
 
 **Repro**

--- a/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
+++ b/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
@@ -6,15 +6,44 @@ labels: 'package: parser, triage'
 assignees: ''
 ---
 
-**What code were you trying to parse?**
+<!--
+Please don't ignore this template.
 
-```ts
-// Please put code here
+If you ignore it, we're just going to respond asking you to fill it out, which wastes everyone's time.
+The more relevant information you can include, the faster we can find the issue and fix it without asking you for more info.
+-->
+
+**Repro**
+
+<!--
+Include a ***minimal*** reproduction case.
+The more irrelevant code/config you give, the harder it is for us to investigate.
+-->
+
+```JSON
+{
+  "rules": {
+    "@typescript-eslint/<rule>": ["<setting>"]
+  }
+}
 ```
 
-**What did you expect to happen?**
+```TS
+// your repro code case
+```
 
-**What actually happened?**
+**Expected Result**
+
+**Actual Result**
+
+**Additional Info**
+
+<!--
+Did eslint throw an exception?
+
+Please run your lint again with the --debug flag, and dump the output below.
+i.e. eslint --ext ".ts,.js" src --debug
+-->
 
 **Versions**
 

--- a/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
+++ b/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
@@ -13,6 +13,11 @@ If you ignore it, we're just going to respond asking you to fill it out, which w
 The more relevant information you can include, the faster we can find the issue and fix it without asking you for more info.
 -->
 
+<!--
+Make sure you read through our FAQ before posting.
+https://github.com/typescript-eslint/typescript-eslint/blob/issue-template-update/docs/getting-started/linting/FAQ.md
+-->
+
 **Repro**
 
 <!--

--- a/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
+++ b/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
@@ -24,6 +24,9 @@ The more irrelevant code/config you give, the harder it is for us to investigate
 {
   "rules": {
     "@typescript-eslint/<rule>": ["<setting>"]
+  },
+  "parserOptions": {
+    "...": "something"
   }
 }
 ```

--- a/.github/ISSUE_TEMPLATE/typescript-eslint-utils.md
+++ b/.github/ISSUE_TEMPLATE/typescript-eslint-utils.md
@@ -1,14 +1,57 @@
 ---
 name: '@typescript-eslint/experimental-utils'
-about: Report an issue with the `@typescript-eslint/experimental-utils` package
+about: Report an issue with the '@typescript-eslint/experimental-utils' package
 title: ''
 labels: 'package: utils, triage'
 assignees: ''
 ---
 
-**What did you expect to happen?**
+<!--
+Please don't ignore this template.
 
-**What actually happened?**
+If you ignore it, we're just going to respond asking you to fill it out, which wastes everyone's time.
+The more relevant information you can include, the faster we can find the issue and fix it without asking you for more info.
+-->
+
+<!--
+Make sure you read through our FAQ before posting.
+https://github.com/typescript-eslint/typescript-eslint/blob/issue-template-update/docs/getting-started/linting/FAQ.md
+-->
+
+**Repro**
+
+<!--
+Include a ***minimal*** reproduction case.
+The more irrelevant code/config you give, the harder it is for us to investigate.
+-->
+
+```JSON
+{
+  "rules": {
+    "@typescript-eslint/<rule>": ["<setting>"]
+  },
+  "parserOptions": {
+    "...": "something"
+  }
+}
+```
+
+```TS
+// your repro code case
+```
+
+**Expected Result**
+
+**Actual Result**
+
+**Additional Info**
+
+<!--
+Did eslint throw an exception?
+
+Please run your lint again with the --debug flag, and dump the output below.
+i.e. eslint --ext ".ts,.js" src --debug
+-->
 
 **Versions**
 

--- a/.github/ISSUE_TEMPLATE/typescript-estree.md
+++ b/.github/ISSUE_TEMPLATE/typescript-estree.md
@@ -1,20 +1,59 @@
 ---
 name: '@typescript-eslint/typescript-estree'
-about: Report an issue with the `@typescript-eslint/typescript-estree` package
+about: Report an issue with the '@typescript-eslint/typescript-estree' package
 title: ''
 labels: 'package: typescript-estree, triage'
 assignees: ''
 ---
 
-**What code were you trying to parse?**
+<!--
+Please don't ignore this template.
 
-```ts
-// Put your code here
+If you ignore it, we're just going to respond asking you to fill it out, which wastes everyone's time.
+The more relevant information you can include, the faster we can find the issue and fix it without asking you for more info.
+-->
+
+<!--
+Make sure you read through our FAQ before posting.
+https://github.com/typescript-eslint/typescript-eslint/blob/issue-template-update/docs/getting-started/linting/FAQ.md
+-->
+
+**Repro**
+
+<!--
+Include a ***minimal*** reproduction case.
+The more irrelevant code/config you give, the harder it is for us to investigate.
+
+Feel free to omit the eslint config if you are not using this module via ESLint.
+-->
+
+```JSON
+{
+  "rules": {
+    "@typescript-eslint/<rule>": ["<setting>"]
+  },
+  "parserOptions": {
+    "...": "something"
+  }
+}
 ```
 
-**What did you expect to happen?**
+```TS
+// your repro code case
+```
 
-**What actually happened?**
+**Expected Result**
+
+**Actual Result**
+
+**Additional Info**
+
+<!--
+Did eslint throw an exception?
+
+Please run your lint again with the --debug flag, and dump the output below.
+i.e. eslint --ext ".ts,.js" src --debug
+-->
 
 **Versions**
 


### PR DESCRIPTION
I've been getting annoyed as people use the wrong template, and then miss information, because it's not in that template.
This just standardises the templates, so that they all have the same basic structure and comments.