### PR TITLE
fix(eslint-plugin): [require-await] handle async generators

### DIFF
--- a/packages/eslint-plugin/src/rules/require-await.ts
+++ b/packages/eslint-plugin/src/rules/require-await.ts
@@ -62,7 +62,12 @@ export default util.createRule({
         return;
       }
 
-      if (node.async && !scopeInfo.hasAwait && !isEmptyFunction(node)) {
+      if (
+        !node.generator &&
+        node.async &&
+        !scopeInfo.hasAwait &&
+        !isEmptyFunction(node)
+      ) {
         context.report({
           node,
           loc: getFunctionHeadLoc(node, sourceCode),

--- a/packages/eslint-plugin/src/rules/require-await.ts
+++ b/packages/eslint-plugin/src/rules/require-await.ts
@@ -57,23 +57,6 @@ export default util.createRule({
     }
 
     /**
-     * Returns `true` if the node is asycn, generator and returnType is Promise
-     */
-    function isValidAsyncGenerator(node: FunctionNode): Boolean {
-      const { async, generator, returnType } = node;
-      if (async && generator && returnType) {
-        if (
-          !!~['Promise'].indexOf(
-            node.returnType?.typeAnnotation?.typeName?.name,
-          )
-        ) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    /**
      * Pop the top scope info object from the stack.
      * Also, it reports the function if needed.
      */
@@ -84,7 +67,6 @@ export default util.createRule({
       }
 
       if (
-        !isValidAsyncGenerator(node) &&
         node.async &&
         !scopeInfo.hasAwait &&
         !isEmptyFunction(node) &&
@@ -126,8 +108,8 @@ export default util.createRule({
      * mark `scopeInfo.isAsyncYield` to `true` if its a generator
      * function and the delegate is `true`
      */
-    function markAsHasDelegateGen(node: FunctionNode): void {
-      if (!scopeInfo || !scopeInfo.isGen) {
+    function markAsHasDelegateGen(node: TSESTree.YieldExpression): void {
+      if (!scopeInfo || !scopeInfo.isGen || !node.argument) {
         return;
       }
 

--- a/packages/eslint-plugin/src/rules/require-await.ts
+++ b/packages/eslint-plugin/src/rules/require-await.ts
@@ -114,7 +114,7 @@ export default util.createRule({
       }
 
       if (node?.argument?.type === AST_NODE_TYPES.Literal) {
-        // making this `false` as for literals we dont need to check the defination
+        // making this `false` as for literals we don't need to check the definition
         // eg : async function* run() { yield* 1 }
         scopeInfo.isAsyncYield = false;
       }

--- a/packages/eslint-plugin/src/rules/require-await.ts
+++ b/packages/eslint-plugin/src/rules/require-await.ts
@@ -114,9 +114,9 @@ export default util.createRule({
       }
 
       if (node?.argument?.type === AST_NODE_TYPES.Literal) {
-        // making this `true` as for literals we dont need to check the defination
+        // making this `false` as for literals we dont need to check the defination
         // eg : async function* run() { yield* 1 }
-        scopeInfo.isAsyncYield = true;
+        scopeInfo.isAsyncYield = false;
       }
 
       const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node?.argument);

--- a/packages/eslint-plugin/tests/rules/require-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-await.test.ts
@@ -16,116 +16,107 @@ ruleTester.run('require-await', rule, {
   valid: [
     // Non-async function declaration
     `function numberOne(): number {
-      return 1;
-    }`,
+          return 1;
+        }`,
     // Non-async function expression
     `const numberOne = function(): number {
-      return 1;
-    }`,
+          return 1;
+        }`,
     // Non-async arrow function expression (concise-body)
     `const numberOne = (): number => 1;`,
     // Non-async arrow function expression (block-body)
     `const numberOne = (): number => {
-      return 1;
-    };`,
+          return 1;
+        };`,
     // Non-async function that returns a promise
     // https://github.com/typescript-eslint/typescript-eslint/issues/1226
     `
-function delay() {
-  return Promise.resolve();
-}
-    `,
+    function delay() {
+      return Promise.resolve();
+    }
+        `,
     `
-const delay = () => {
-  return Promise.resolve();
-}
-    `,
+    const delay = () => {
+      return Promise.resolve();
+    }
+        `,
     `const delay = () => Promise.resolve();`,
     // Async function declaration with await
     `async function numberOne(): Promise<number> {
-      return await 1;
-    }`,
+          return await 1;
+        }`,
     // Async function expression with await
     `const numberOne = async function(): Promise<number> {
-      return await 1;
-    }`,
+          return await 1;
+        }`,
     // Async arrow function expression with await (concise-body)
     `const numberOne = async (): Promise<number> => await 1;`,
     // Async arrow function expression with await (block-body)
     `const numberOne = async (): Promise<number> => {
-      return await 1;
-    };`,
+          return await 1;
+        };`,
     // Async function declaration with promise return
     `async function numberOne(): Promise<number> {
-      return Promise.resolve(1);
-    }`,
+          return Promise.resolve(1);
+        }`,
     // Async function expression with promise return
     `const numberOne = async function(): Promise<number> {
-      return Promise.resolve(1);
-    }`,
+          return Promise.resolve(1);
+        }`,
     // Async arrow function with promise return (concise-body)
     `const numberOne = async (): Promise<number> => Promise.resolve(1);`,
     // Async arrow function with promise return (block-body)
     `const numberOne = async (): Promise<number> => {
-      return Promise.resolve(1);
-    };`,
+          return Promise.resolve(1);
+        };`,
     // Async function declaration with async function return
     `async function numberOne(): Promise<number> {
-      return getAsyncNumber(1);
-    }
-    async function getAsyncNumber(x: number): Promise<number> {
-      return Promise.resolve(x);
-    }`,
+          return getAsyncNumber(1);
+        }
+        async function getAsyncNumber(x: number): Promise<number> {
+          return Promise.resolve(x);
+        }`,
     // Async function expression with async function return
     `const numberOne = async function(): Promise<number> {
-      return getAsyncNumber(1);
-    }
-    const getAsyncNumber = async function(x: number): Promise<number> {
-      return Promise.resolve(x);
-    }`,
+          return getAsyncNumber(1);
+        }
+        const getAsyncNumber = async function(x: number): Promise<number> {
+          return Promise.resolve(x);
+        }`,
     // Async arrow function with async function return (concise-body)
     `const numberOne = async (): Promise<number> => getAsyncNumber(1);
-    const getAsyncNumber = async function(x: number): Promise<number> {
-      return Promise.resolve(x);
-    }`,
+        const getAsyncNumber = async function(x: number): Promise<number> {
+          return Promise.resolve(x);
+        }`,
     // Async arrow function with async function return (block-body)
     `const numberOne = async (): Promise<number> => {
-      return getAsyncNumber(1);
-    };
-    const getAsyncNumber = async function(x: number): Promise<number> {
-      return Promise.resolve(x);
-    }`,
+          return getAsyncNumber(1);
+        };
+        const getAsyncNumber = async function(x: number): Promise<number> {
+          return Promise.resolve(x);
+        }`,
     // https://github.com/typescript-eslint/typescript-eslint/issues/1188
     `
-async function testFunction(): Promise<void> {
-  await Promise.all([1, 2, 3].map(
-    // this should not trigger an error on the parent function
-    async value => Promise.resolve(value)
-  ))
-}
-    `,
-    'async function* run() { yield * anotherAsyncGenerator() }',
-    `async function* foo() {
-        await Promise.resolve()
-        yield 1
-      }
-      async function* bar() {
-        yield* foo()
-      }`,
-    `
-    async function* run() {
-      await new Promise(resolve => setTimeout(resolve, 100));
-      yield 'Hello';
-      console.log('World');
+    async function testFunction(): Promise<void> {
+      await Promise.all([1, 2, 3].map(
+        // this should not trigger an error on the parent function
+        async value => Promise.resolve(value)
+      ))
     }
-    `,
+        `,
+    `
+        async function* run() {
+          await new Promise(resolve => setTimeout(resolve, 100));
+          yield 'Hello';
+          console.log('World');
+        }
+        `,
     'async function* run() { }',
     'async function* run() { yield* 1 }',
     'async function* asyncGenerator() { await Promise.resolve(); yield 1 }',
     'function* test6() { yield* syncGenerator() }',
     'function* test8() { yield syncGenerator() }',
     'function* syncGenerator() { yield 1 }',
-    // FIXME
     `
     async function* asyncGenerator() {
       await Promise.resolve()
@@ -133,6 +124,13 @@ async function testFunction(): Promise<void> {
     }
     async function* test1() {yield* asyncGenerator() }
     `,
+    `async function* foo() {
+            await Promise.resolve()
+            yield 1
+          }
+          async function* bar() {
+            yield* foo()
+          }`,
     'const foo : () => void = async function *(){}',
     'async function* foo() : Promise<string> { return new Promise((res) => res(`hello`)) }',
   ],
@@ -141,8 +139,8 @@ async function testFunction(): Promise<void> {
     {
       // Async function declaration with no await
       code: `async function numberOne(): Promise<number> {
-        return 1;
-      }`,
+            return 1;
+          }`,
       errors: [
         {
           messageId: 'missingAwait',
@@ -155,8 +153,8 @@ async function testFunction(): Promise<void> {
     {
       // Async function expression with no await
       code: `const numberOne = async function(): Promise<number> {
-        return 1;
-      }`,
+            return 1;
+          }`,
       errors: [
         {
           messageId: 'missingAwait',
@@ -270,7 +268,6 @@ async function testFunction(): Promise<void> {
     },
   ],
 });
-
 // base eslint tests
 // https://github.com/eslint/eslint/blob/03a69dbe86d5b5768a310105416ae726822e3c1c/tests/lib/rules/require-await.js#L25-L132
 ruleTester.run('require-await', rule, {
@@ -283,27 +280,23 @@ ruleTester.run('require-await', rule, {
     'class A { async foo() { await doSomething() } }',
     '(class { async foo() { await doSomething() } })',
     'async function foo() { await (async () => { await doSomething() }) }',
-
     // empty functions are ok.
     'async function foo() {}',
     'async () => {}',
-
     // normal functions are ok.
     'function foo() { doSomething() }',
-
     // for-await-of
     'async function foo() { for await (x of xs); }',
-
     // global await
     {
       code: 'await foo()',
     },
     {
       code: `
-        for await (let num of asyncIterable) {
-            console.log(num);
-        }
-      `,
+            for await (let num of asyncIterable) {
+                console.log(num);
+            }
+          `,
     },
   ],
   invalid: [
@@ -394,6 +387,15 @@ ruleTester.run('require-await', rule, {
         {
           messageId: 'missingAwait',
           data: { name: 'Async arrow function' },
+        },
+      ],
+    },
+    {
+      code: 'async function* run() { yield * anotherAsyncGenerator() }',
+      errors: [
+        {
+          messageId: 'missingAwait',
+          data: { name: "Async generator function 'run'" },
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/require-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-await.test.ts
@@ -120,9 +120,21 @@ async function testFunction(): Promise<void> {
     }
     `,
     'async function* run() { }',
+    'async function* run() { yield* 1 }',
+    'async function* asyncGenerator() { await Promise.resolve(); yield 1 }',
+    'function* test6() { yield* syncGenerator() }',
+    'function* test8() { yield syncGenerator() }',
+    'function* syncGenerator() { yield 1 }',
+    // FIXME
+    `
+    async function* asyncGenerator() {
+      await Promise.resolve()
+      yield 1
+    }
+    async function* test1() {yield* asyncGenerator() }
+    `,
     'const foo : () => void = async function *(){}',
-    'const foo = async function *(){ console.log("bar") }',
-    'async function* run() { console.log("bar") }',
+    'async function* foo() : Promise<string> { return new Promise((res) => res(`hello`)) }',
   ],
 
   invalid: [
@@ -175,6 +187,83 @@ async function testFunction(): Promise<void> {
           messageId: 'missingAwait',
           data: {
             name: "Async function 'foo'",
+          },
+        },
+      ],
+    },
+    {
+      code: 'async function* foo() : void { doSomething() }',
+      errors: [
+        {
+          messageId: 'missingAwait',
+          data: {
+            name: "Async generator function 'foo'",
+          },
+        },
+      ],
+    },
+    {
+      code: 'async function* foo() { yield 1 }',
+      errors: [
+        {
+          messageId: 'missingAwait',
+          data: {
+            name: "Async generator function 'foo'",
+          },
+        },
+      ],
+    },
+    {
+      code: 'async function* run() { console.log("bar") }',
+      errors: [
+        {
+          messageId: 'missingAwait',
+          data: {
+            name: "Async generator function 'run'",
+          },
+        },
+      ],
+    },
+    {
+      code: 'const foo = async function *(){ console.log("bar") }',
+      errors: [
+        {
+          messageId: 'missingAwait',
+          data: {
+            name: 'Async generator function',
+          },
+        },
+      ],
+    },
+    {
+      code: 'async function* syncGenerator() { yield 1 }',
+      errors: [
+        {
+          messageId: 'missingAwait',
+          data: {
+            name: "Async generator function 'syncGenerator'",
+          },
+        },
+      ],
+    },
+    {
+      code: 'async function* test3() { yield asyncGenerator() }',
+      errors: [
+        {
+          messageId: 'missingAwait',
+          data: {
+            name: "Async generator function 'test3'",
+          },
+        },
+      ],
+    },
+    {
+      code: 'async function* test7() { yield syncGenerator() }',
+      errors: [
+        {
+          messageId: 'missingAwait',
+          data: {
+            name: "Async generator function 'test7'",
           },
         },
       ],

--- a/packages/eslint-plugin/tests/rules/require-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-await.test.ts
@@ -104,6 +104,25 @@ async function testFunction(): Promise<void> {
   ))
 }
     `,
+    'async function* run() { yield * anotherAsyncGenerator() }',
+    `async function* foo() {
+        await Promise.resolve()
+        yield 1
+      }
+      async function* bar() {
+        yield* foo()
+      }`,
+    `
+    async function* run() {
+      await new Promise(resolve => setTimeout(resolve, 100));
+      yield 'Hello';
+      console.log('World');
+    }
+    `,
+    'async function* run() { }',
+    'const foo : () => void = async function *(){}',
+    'const foo = async function *(){ console.log("bar") }',
+    'async function* run() { console.log("bar") }',
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/require-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-await.test.ts
@@ -112,7 +112,6 @@ ruleTester.run('require-await', rule, {
         }
         `,
     'async function* run() { }',
-    'async function* run() { yield* 1 }',
     'async function* asyncGenerator() { await Promise.resolve(); yield 1 }',
     'function* test6() { yield* syncGenerator() }',
     'function* test8() { yield syncGenerator() }',
@@ -392,6 +391,15 @@ ruleTester.run('require-await', rule, {
     },
     {
       code: 'async function* run() { yield * anotherAsyncGenerator() }',
+      errors: [
+        {
+          messageId: 'missingAwait',
+          data: { name: "Async generator function 'run'" },
+        },
+      ],
+    },
+    {
+      code: 'async function* run() { yield* 1 }',
       errors: [
         {
           messageId: 'missingAwait',


### PR DESCRIPTION
Fixes #1691 

- added `!node.generator` before checking starts as to ignore the checks for generators
- added tests