### PR TITLE
fix(eslint-plugin): [prefer-function-type] handle `this` type

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-function-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-function-type.ts
@@ -109,7 +109,8 @@ export default util.createRule({
       if (
         (member.type === AST_NODE_TYPES.TSCallSignatureDeclaration ||
           member.type === AST_NODE_TYPES.TSConstructSignatureDeclaration) &&
-        typeof member.returnType !== 'undefined'
+        typeof member.returnType !== 'undefined' &&
+        member.returnType?.typeAnnotation?.type !== AST_NODE_TYPES.TSThisType
       ) {
         const suggestion = renderSuggestion(member, node);
         const fixStart =

--- a/packages/eslint-plugin/tests/rules/prefer-function-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-function-type.test.ts
@@ -38,8 +38,6 @@ interface Foo {
 interface Bar extends Function, Foo {
   (): void;
 }`,
-    'interface Interface {(): this}',
-    'interface Interface {(arg: this): this}',
     'interface Interface {(arg: this): this, [key : number] : string}',
   ],
 
@@ -140,7 +138,57 @@ type Foo<T> = (bar: T) => string;`,
           tyoe: AST_NODE_TYPES.TSCallSignatureDeclaration,
         },
       ],
+      output: `type Foo = () => () => Foo;`,
+    },
+    {
+      code: 'interface Foo { (): () => string; }',
+      errors: [
+        {
+          messageId: 'functionTypeOverCallableType',
+          tyoe: AST_NODE_TYPES.TSCallSignatureDeclaration,
+        },
+      ],
+      output: `type Foo = () => () => string;`,
+    },
+    {
+      code: 'interface Interface {(): this}',
+      errors: [
+        {
+          messageId: 'functionTypeOverCallableType',
+          tyoe: AST_NODE_TYPES.TSCallSignatureDeclaration,
+        },
+      ],
+      output: `type Interface = () => Interface`,
+    },
+    {
+      code: 'interface Interface {(): Object<this>}',
+      errors: [
+        {
+          messageId: 'functionTypeOverCallableType',
+          tyoe: AST_NODE_TYPES.TSCallSignatureDeclaration,
+        },
+      ],
       output: `type Foo = () => () => this;`,
+    },
+    {
+      code: 'interface Interface {() : string}',
+      errors: [
+        {
+          messageId: 'functionTypeOverCallableType',
+          tyoe: AST_NODE_TYPES.TSCallSignatureDeclaration,
+        },
+      ],
+      output: `type Interface = ()  => string`,
+    },
+    {
+      code: 'interface Interface {(arg: this): this}',
+      errors: [
+        {
+          messageId: 'functionTypeOverCallableType',
+          tyoe: AST_NODE_TYPES.TSCallSignatureDeclaration,
+        },
+      ],
+      output: `type Interface = (arg: Interface) => Interface`,
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/prefer-function-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-function-type.test.ts
@@ -38,6 +38,9 @@ interface Foo {
 interface Bar extends Function, Foo {
   (): void;
 }`,
+    'interface Interface {(): this}',
+    'interface Interface {(arg: this): this}',
+    'interface Interface {(arg: this): this, [key : number] : string}',
   ],
 
   invalid: [
@@ -128,6 +131,16 @@ interface Foo<T> {
       ],
       output: `
 type Foo<T> = (bar: T) => string;`,
+    },
+    {
+      code: 'interface Foo { (): () => this; }',
+      errors: [
+        {
+          messageId: 'functionTypeOverCallableType',
+          tyoe: AST_NODE_TYPES.TSCallSignatureDeclaration,
+        },
+      ],
+      output: `type Foo = () => () => this;`,
     },
   ],
 });


### PR DESCRIPTION
fixes #1756 

- added a no check when return type is `this` for interface declarations
- added tests