### PR TITLE
fix(eslint-plugin): [no-unsafe-call] allow import expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -41,10 +41,10 @@ export default util.createRule<[], MessageIds>({
     }
 
     return {
-      'CallExpression, OptionalCallExpression'(
-        node: TSESTree.CallExpression | TSESTree.OptionalCallExpression,
+      ':matches(CallExpression, OptionalCallExpression) > :not(Import)'(
+        node: Exclude<TSESTree.LeftHandSideExpression, TSESTree.Import>,
       ): void {
-        checkCall(node.callee, node.callee, 'unsafeCall');
+        checkCall(node, node, 'unsafeCall');
       },
       NewExpression(node): void {
         checkCall(node.callee, node, 'unsafeNew');

--- a/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
@@ -20,6 +20,7 @@ ruleTester.run('no-unsafe-call', rule, {
     'function foo(x: { a?: () => void }) { x.a?.() }',
     'new Map()',
     'String.raw`foo`',
+    'const x = import("./foo");',
   ],
   invalid: [
     ...batchedSingleLineTests({


### PR DESCRIPTION
Fixes #1717