### PR TITLE
chore: separate linting checks to their own step

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,7 +11,8 @@
     "**/**/ROADMAP.md",
     "**/*.{json,snap}",
     ".cspell.json",
-    "yarn.lock"
+    "yarn.lock",
+    ".github/workflows/**"
   ],
   "dictionaries": [
     "typescript",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   primary_code_validation_and_tests:
-    name: Primary code validation and tests
+    name: Typecheck and tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -49,15 +49,6 @@ jobs:
       - name: Typecheck all packages
         run: yarn typecheck
 
-      - name: Check code formatting
-        run: yarn format-check
-
-      - name: Run linting
-        run: yarn lint
-
-      - name: Validate spelling
-        run: yarn check:spelling
-
       - name: Run unit tests
         run: yarn test
         env:
@@ -70,6 +61,43 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittest
           name: codecov
+
+  linting_and_style:
+    name: Code style and lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ env.PRIMARY_NODE_VERSION }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      # This also runs a build as part of the postinstall bootstrap
+      - name: Install dependencies and build
+        run: |
+          yarn --ignore-engines --frozen-lockfile
+          yarn check-clean-workspace-after-install
+
+      - name: Check code formatting
+        run: yarn format-check
+
+      - name: Run linting
+        run: yarn lint
+
+      - name: Validate spelling
+        run: yarn check:spelling
 
   integration_tests:
     name: Run integration tests on primary Node.js version
@@ -143,7 +171,7 @@ jobs:
   publish_canary_version:
     name: Publish the latest code as a canary version
     runs-on: ubuntu-latest
-    needs: [primary_code_validation_and_tests, unit_tests_on_other_node_versions, integration_tests]
+    needs: [primary_code_validation_and_tests, unit_tests_on_other_node_versions, linting_and_style, integration_tests]
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
If linting/formatting/spelling fails, it should not block running the tests.
If they do block, they can increase the iteration time for contributors, because they will have to fix them before they can see the status of their tests.

By not blocking, a contributor will be able to submit a PR, and come back ~5min later knowing they will be able to see if their code passes linting _and_ tests.

This should also knock ~40-60s off of the perceived runtime, as it parallelises some of the work.