### PR TITLE
feat(typescript-estree): add option to ignore certain folders from glob resolution

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/ParserOptions.ts
+++ b/packages/experimental-utils/src/ts-eslint/ParserOptions.ts
@@ -16,6 +16,7 @@ interface ParserOptions {
   loc?: boolean;
   noWatch?: boolean;
   project?: string | string[];
+  projectFolderIgnoreList?: (string | RegExp)[];
   range?: boolean;
   sourceType?: 'script' | 'module';
   tokens?: boolean;

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -54,6 +54,7 @@ interface ParserOptions {
     jsx?: boolean;
   };
   project?: string | string[];
+  projectFolderIgnoreList?: (string | RegExp)[];
   tsconfigRootDir?: string;
   extraFileExtensions?: string[];
   warnOnUnsupportedTypeScriptVersion?: boolean;
@@ -118,26 +119,36 @@ This option allows you to provide a path to your project's `tsconfig.json`. **Th
   }
   ```
 
-### `tsconfigRootDir`
+### `parserOptions.tsconfigRootDir`
 
 Default `undefined`.
 
 This option allows you to provide the root directory for relative tsconfig paths specified in the `project` option above.
 
-### `extraFileExtensions`
+### `parserOptions.projectFolderIgnoreList`
+
+Default `["/node_modules/"]`.
+
+This option allows you to ignore folders from being included in your provided list of `project`s.
+Any resolved project path that matches one or more of the provided regular expressions will be removed from the list.
+This is useful if you have configured glob patterns, but want to make sure you ignore certain folders.
+
+For example, by default it will ensure that a glob like `./**/tsconfig.json` will not match any `tsconfig`s within your `node_modules` folder (some npm packages do not exclude their source files from their published packages).
+
+### `parserOptions.extraFileExtensions`
 
 Default `undefined`.
 
 This option allows you to provide one or more additional file extensions which should be considered in the TypeScript Program compilation.
 The default extensions are `.ts`, `.tsx`, `.js`, and `.jsx`. Add extensions starting with `.`, followed by the file extension. E.g. for a `.vue` file use `"extraFileExtensions: [".vue"]`.
 
-### `warnOnUnsupportedTypeScriptVersion`
+### `parserOptions.warnOnUnsupportedTypeScriptVersion`
 
 Default `true`.
 
 This option allows you to toggle the warning that the parser will give you if you use a version of TypeScript which is not explicitly supported
 
-### `createDefaultProgram`
+### `parserOptions.createDefaultProgram`
 
 Default `false`.
 

--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -183,6 +183,16 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
   project?: string | string[];
 
   /**
+   * If you provide a glob (or globs) to the project option, you can use this option to blacklist
+   * certain folders from being matched by the globs.
+   * Any project path that matches one or more of the provided regular expressions will be removed from the list.
+   *
+   * Accepts an array of strings that are passed to new RegExp(), or an array of regular expressions.
+   * By default, this is set to ["/node_modules/"]
+   */
+  projectFolderIgnoreList?: (string | RegExp)[];
+
+  /**
    * The absolute path to the root directory for all provided `project`s.
    */
   tsconfigRootDir?: string;
@@ -205,6 +215,7 @@ const PARSE_AND_GENERATE_SERVICES_DEFAULT_OPTIONS: ParseOptions = {
   extraFileExtensions: [],
   preserveNodeMaps: false, // or true, if you do not set this, but pass `project`
   project: undefined,
+  projectFolderIgnoreList: ['/node_modules/'],
   tsconfigRootDir: process.cwd(),
 };
 

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -14,6 +14,8 @@ import { getFirstSemanticOrSyntacticError } from './semantic-or-syntactic-errors
 import { TSESTree } from './ts-estree';
 import { ensureAbsolutePath } from './create-program/shared';
 
+const log = debug('typescript-eslint:typescript-estree:parser');
+
 /**
  * This needs to be kept in sync with the top-level README.md in the
  * typescript-eslint monorepo
@@ -113,7 +115,6 @@ function resetExtra(): void {
 
 /**
  * Normalizes, sanitizes, resolves and filters the provided
- * @internal
  */
 function prepareAndTransformProjects(
   projectsInput: string | string[] | undefined,
@@ -164,7 +165,7 @@ function prepareAndTransformProjects(
   }
 
   // Remove any paths that match the ignore list
-  return projects.filter(project => {
+  const filtered = projects.filter(project => {
     for (const ignore of ignoreRegexes) {
       if (ignore.test(project)) {
         return false;
@@ -173,6 +174,11 @@ function prepareAndTransformProjects(
 
     return true;
   });
+
+  log('parserOptions.project matched projects: %s', projects);
+  log('ignore list applied to parserOptions.project: %s', filtered);
+
+  return filtered;
 }
 
 function applyParserOptionsToExtra(options: TSESTreeOptions): void {
@@ -492,7 +498,6 @@ export {
   parseAndGenerateServices,
   ParseAndGenerateServicesResult,
   version,
-  prepareAndTransformProjects,
 };
 export { ParserServices, TSESTreeOptions } from './parser-options';
 export { simpleTraverse } from './simple-traverse';

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -111,6 +111,70 @@ function resetExtra(): void {
   };
 }
 
+/**
+ * Normalizes, sanitizes, resolves and filters the provided
+ * @internal
+ */
+function prepareAndTransformProjects(
+  projectsInput: string | string[] | undefined,
+  ignoreListInput: (string | RegExp)[] | undefined,
+): string[] {
+  let projects: string[] = [];
+
+  // Normalize and sanitize the project paths
+  if (typeof projectsInput === 'string') {
+    projects.push(projectsInput);
+  } else if (Array.isArray(projectsInput)) {
+    for (const project of projectsInput) {
+      if (typeof project === 'string') {
+        projects.push(project);
+      }
+    }
+  }
+
+  if (projects.length === 0) {
+    return projects;
+  }
+
+  // Transform glob patterns into paths
+  projects = projects.reduce<string[]>(
+    (projects, project) =>
+      projects.concat(
+        isGlob(project)
+          ? globSync(project, {
+              cwd: extra.tsconfigRootDir,
+            })
+          : project,
+      ),
+    [],
+  );
+
+  // Normalize and sanitize the ignore regex list
+  const ignoreRegexes: RegExp[] = [];
+  if (Array.isArray(ignoreListInput)) {
+    for (const ignore of ignoreListInput) {
+      if (ignore instanceof RegExp) {
+        ignoreRegexes.push(ignore);
+      } else if (typeof ignore === 'string') {
+        ignoreRegexes.push(new RegExp(ignore));
+      }
+    }
+  } else {
+    ignoreRegexes.push(/\/node_modules\//);
+  }
+
+  // Remove any paths that match the ignore list
+  return projects.filter(project => {
+    for (const ignore of ignoreRegexes) {
+      if (ignore.test(project)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
 function applyParserOptionsToExtra(options: TSESTreeOptions): void {
   /**
    * Configure Debug logging
@@ -205,34 +269,18 @@ function applyParserOptionsToExtra(options: TSESTreeOptions): void {
     extra.log = Function.prototype;
   }
 
-  if (typeof options.project === 'string') {
-    extra.projects = [options.project];
-  } else if (
-    Array.isArray(options.project) &&
-    options.project.every(projectPath => typeof projectPath === 'string')
-  ) {
-    extra.projects = options.project;
-  }
-
   if (typeof options.tsconfigRootDir === 'string') {
     extra.tsconfigRootDir = options.tsconfigRootDir;
   }
+
+  // NOTE - ensureAbsolutePath relies upon having the correct tsconfigRootDir in extra
   extra.filePath = ensureAbsolutePath(extra.filePath, extra);
 
-  // Transform glob patterns into paths
-  if (extra.projects) {
-    extra.projects = extra.projects.reduce<string[]>(
-      (projects, project) =>
-        projects.concat(
-          isGlob(project)
-            ? globSync(project, {
-                cwd: extra.tsconfigRootDir || process.cwd(),
-              })
-            : project,
-        ),
-      [],
-    );
-  }
+  // NOTE - prepareAndTransformProjects relies upon having the correct tsconfigRootDir in extra
+  extra.projects = prepareAndTransformProjects(
+    options.project,
+    options.projectFolderIgnoreList,
+  );
 
   if (
     Array.isArray(options.extraFileExtensions) &&
@@ -444,6 +492,7 @@ export {
   parseAndGenerateServices,
   ParseAndGenerateServicesResult,
   version,
+  prepareAndTransformProjects,
 };
 export { ParserServices, TSESTreeOptions } from './parser-options';
 export { simpleTraverse } from './simple-traverse';

--- a/packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/ignoreme/file.ts
+++ b/packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/ignoreme/file.ts
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/ignoreme/tsconfig.json
+++ b/packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/ignoreme/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "include": ["./file.ts"]
+}

--- a/packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/includeme/file.ts
+++ b/packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/includeme/file.ts
@@ -1,0 +1,1 @@
+export const x = 2;

--- a/packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/includeme/tsconfig.json
+++ b/packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/includeme/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "include": ["./file.ts"]
+}

--- a/packages/typescript-estree/tests/lib/parse.ts
+++ b/packages/typescript-estree/tests/lib/parse.ts
@@ -578,19 +578,11 @@ describe('parse()', () => {
       filePath: 'ignoreme' | 'includeme',
       projectFolderIgnoreList: TSESTreeOptions['projectFolderIgnoreList'] = [],
     ) => (): void => {
-      try {
-        parser.parseAndGenerateServices(code, {
-          ...config,
-          projectFolderIgnoreList,
-          filePath: join(PROJECT_DIR, filePath, './file.ts'),
-        });
-      } catch (error) {
-        /**
-         * Aligns paths between environments, node for windows uses `\`, for linux and mac uses `/`
-         */
-        error.message = error.message.replace(/\\(?!["])/gm, '/');
-        throw error;
-      }
+      parser.parseAndGenerateServices(code, {
+        ...config,
+        projectFolderIgnoreList,
+        filePath: join(PROJECT_DIR, filePath, './file.ts'),
+      });
     };
 
     it('ignores nothing when given nothing', () => {

--- a/packages/typescript-estree/tests/lib/parse.ts
+++ b/packages/typescript-estree/tests/lib/parse.ts
@@ -557,4 +557,57 @@ describe('parse()', () => {
       );
     });
   });
+
+  describe('projectFolderIgnoreList', () => {
+    beforeEach(() => {
+      parser.clearCaches();
+    });
+
+    const PROJECT_DIR = resolve(FIXTURES_DIR, '../projectFolderIgnoreList');
+    const code = 'var a = true';
+    const config: TSESTreeOptions = {
+      comment: true,
+      tokens: true,
+      range: true,
+      loc: true,
+      tsconfigRootDir: PROJECT_DIR,
+      project: './**/tsconfig.json',
+    };
+
+    const testParse = (
+      filePath: 'ignoreme' | 'includeme',
+      projectFolderIgnoreList: TSESTreeOptions['projectFolderIgnoreList'] = [],
+    ) => (): void => {
+      try {
+        parser.parseAndGenerateServices(code, {
+          ...config,
+          projectFolderIgnoreList,
+          filePath: join(PROJECT_DIR, filePath, './file.ts'),
+        });
+      } catch (error) {
+        /**
+         * Aligns paths between environments, node for windows uses `\`, for linux and mac uses `/`
+         */
+        error.message = error.message.replace(/\\(?!["])/gm, '/');
+        throw error;
+      }
+    };
+
+    it('ignores nothing when given nothing', () => {
+      expect(testParse('ignoreme')).not.toThrow();
+      expect(testParse('includeme')).not.toThrow();
+    });
+
+    it('ignores a folder when given a string regexp', () => {
+      const ignore = ['/ignoreme/'];
+      expect(testParse('ignoreme', ignore)).toThrow();
+      expect(testParse('includeme', ignore)).not.toThrow();
+    });
+
+    it('ignores a folder when given a RegExp', () => {
+      const ignore = [/\/ignoreme\//];
+      expect(testParse('ignoreme', ignore)).toThrow();
+      expect(testParse('includeme', ignore)).not.toThrow();
+    });
+  });
 });

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.base.json",
-  "include": ["tests/**/*.ts", "tools/**/*.ts"]
+  "include": ["tests/**/*.ts", "tools/**/*.ts", ".eslintrc.js"]
 }


### PR DESCRIPTION
Resolves #1771 

I didn't realise, but there's a lot of packages that are published to npm with tsconfigs, and even .ts source files.

If you provide a wide glob like `./**/tsconfig.json`, then it'll match those node modules, which means our parser will parse them, leading to wasted memory, and wasted parse time.

This PR adds an option for users to configure ignored folders. By default it just ignores `node_modules`.

I ran a test against our repo by changing the glob in our config to `./packages/**/tsconfig.json` (added an extra *), and the following logs were output, doubly showing it's working
```
  typescript-eslint:typescript-estree:parser parserOptions.project matched projects: [
  './tsconfig.eslint.json',
  './packages/eslint-plugin-internal/node_modules/@typescript-eslint/experimental-utils/tsconfig.json',
  './packages/eslint-plugin-internal/tsconfig.json',
  './packages/eslint-plugin-tslint/node_modules/@typescript-eslint/experimental-utils/tsconfig.json',
  './packages/eslint-plugin-tslint/node_modules/@typescript-eslint/parser/tsconfig.json',
  './packages/eslint-plugin-tslint/tests/fixture-project/tsconfig.json',
  './packages/eslint-plugin-tslint/tests/test-project/tsconfig.json',
  './packages/eslint-plugin-tslint/tests/tsconfig.json',
  './packages/eslint-plugin-tslint/tsconfig.json',
  './packages/eslint-plugin/node_modules/@typescript-eslint/experimental-utils/tsconfig.json',
  './packages/eslint-plugin/tests/fixtures/tsconfig.json',
  './packages/eslint-plugin/tsconfig.json',
  './packages/experimental-utils/node_modules/@typescript-eslint/typescript-estree/tsconfig.json',
  './packages/experimental-utils/tsconfig.json',
  './packages/parser/node_modules/@typescript-eslint/experimental-utils/tsconfig.json',
  './packages/parser/node_modules/@typescript-eslint/shared-fixtures/tsconfig.json',
  './packages/parser/node_modules/@typescript-eslint/typescript-estree/tsconfig.json',
  './packages/parser/tests/fixtures/services/tsconfig.json',
  './packages/parser/tsconfig.json',
  './packages/shared-fixtures/tsconfig.json',
  './packages/typescript-estree/node_modules/@typescript-eslint/shared-fixtures/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/invalidFileErrors/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/ignoreme/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/includeme/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/semanticInfo/badTSConfig/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/semanticInfo/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/simpleProject/tsconfig.json',
  './packages/typescript-estree/tsconfig.json'
] +0ms
  typescript-eslint:typescript-estree:parser ignore list applied to parserOptions.project: [
  './tsconfig.eslint.json',
  './packages/eslint-plugin-internal/tsconfig.json',
  './packages/eslint-plugin-tslint/tests/fixture-project/tsconfig.json',
  './packages/eslint-plugin-tslint/tests/test-project/tsconfig.json',
  './packages/eslint-plugin-tslint/tests/tsconfig.json',
  './packages/eslint-plugin-tslint/tsconfig.json',
  './packages/eslint-plugin/tests/fixtures/tsconfig.json',
  './packages/eslint-plugin/tsconfig.json',
  './packages/experimental-utils/tsconfig.json',
  './packages/parser/tests/fixtures/services/tsconfig.json',
  './packages/parser/tsconfig.json',
  './packages/shared-fixtures/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/invalidFileErrors/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/ignoreme/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/projectFolderIgnoreList/includeme/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/semanticInfo/badTSConfig/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/semanticInfo/tsconfig.json',
  './packages/typescript-estree/tests/fixtures/simpleProject/tsconfig.json',
  './packages/typescript-estree/tsconfig.json'
] +3ms
```