### PR TITLE
fix(eslint-plugin): [no-unsafe-return] error with <TS3.7

### DIFF
--- a/packages/eslint-plugin/src/util/types.ts
+++ b/packages/eslint-plugin/src/util/types.ts
@@ -323,7 +323,12 @@ export function isAnyOrAnyArrayTypeDiscriminated(
   }
   if (
     checker.isArrayType(type) &&
-    isTypeAnyType(checker.getTypeArguments(type)[0])
+    isTypeAnyType(
+      // getTypeArguments was only added in TS3.7
+      checker.getTypeArguments
+        ? checker.getTypeArguments(type)[0]
+        : (type.typeArguments ?? [])[0],
+    )
   ) {
     return AnyType.AnyArray;
   }


### PR DESCRIPTION
Fixes #1807

tested by installing TS@3.6.2 and running the tests.
They passed.