### PR TITLE
fix(eslint-plugin): [no-throw-literal] fix crash caused by getBaseTypes

### DIFF
--- a/packages/eslint-plugin/src/rules/no-throw-literal.ts
+++ b/packages/eslint-plugin/src/rules/no-throw-literal.ts
@@ -43,10 +43,11 @@ export default util.createRule({
         }
       }
 
-      const baseTypes = checker.getBaseTypes(type as ts.InterfaceType);
-      for (const baseType of baseTypes) {
-        if (isErrorLike(baseType)) {
-          return true;
+      if (symbol.flags & (ts.SymbolFlags.Class | ts.SymbolFlags.Interface)) {
+        for (const baseType of checker.getBaseTypes(type as ts.InterfaceType)) {
+          if (isErrorLike(baseType)) {
+            return true;
+          }
         }
       }
 

--- a/packages/eslint-plugin/tests/rules/no-throw-literal.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-throw-literal.test.ts
@@ -321,5 +321,36 @@ throw new CustomError();
         },
       ],
     },
+    {
+      code: `
+function foo<T>() {
+  const res: T;
+  throw res;
+}
+      `,
+      errors: [
+        {
+          messageId: 'object',
+          line: 4,
+          column: 9,
+        },
+      ],
+    },
+    {
+      code: `
+function foo<T>(fn: () => Promise<T>) {
+  const promise = fn();
+  const res = promise.then(() => {}).catch(() => {});
+  throw res;
+}
+      `,
+      errors: [
+        {
+          messageId: 'object',
+          line: 5,
+          column: 9,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Fixes #1775 