### PR TITLE
fix(typescript-estree): add visitor keys for JSXElement

### DIFF
--- a/packages/typescript-estree/src/visitor-keys.ts
+++ b/packages/typescript-estree/src/visitor-keys.ts
@@ -34,6 +34,13 @@ export const visitorKeys = eslintVisitorKeys.unionWith({
   NewExpression: ['callee', 'typeParameters', 'arguments'],
   CallExpression: ['callee', 'typeParameters', 'arguments'],
   // JSX
+  JSXElement: [
+    'attributes',
+    'openingElement',
+    'children',
+    'closingElement'
+    'typeParameters',
+  ],
   JSXOpeningElement: ['name', 'typeParameters', 'attributes'],
   JSXClosingFragment: [],
   JSXOpeningFragment: [],

--- a/packages/typescript-estree/src/visitor-keys.ts
+++ b/packages/typescript-estree/src/visitor-keys.ts
@@ -35,7 +35,6 @@ export const visitorKeys = eslintVisitorKeys.unionWith({
   CallExpression: ['callee', 'typeParameters', 'arguments'],
   // JSX
   JSXElement: [
-    'attributes',
     'openingElement',
     'children',
     'closingElement',

--- a/packages/typescript-estree/src/visitor-keys.ts
+++ b/packages/typescript-estree/src/visitor-keys.ts
@@ -38,7 +38,7 @@ export const visitorKeys = eslintVisitorKeys.unionWith({
     'attributes',
     'openingElement',
     'children',
-    'closingElement'
+    'closingElement',
     'typeParameters',
   ],
   JSXOpeningElement: ['name', 'typeParameters', 'attributes'],


### PR DESCRIPTION
Ref: https://github.com/cartant/eslint-plugin-rxjs/issues/46