### PR TITLE
feat(experimental-utils): update eslint types to match v6.8

### DIFF
--- a/packages/experimental-utils/src/ts-eslint-scope/ScopeManager.ts
+++ b/packages/experimental-utils/src/ts-eslint-scope/ScopeManager.ts
@@ -1,5 +1,6 @@
 import ESLintScopeManager from 'eslint-scope/lib/scope-manager';
 import { TSESTree } from '../ts-estree';
+import { EcmaVersion } from '../ts-eslint';
 import { Scope } from './Scope';
 import { Variable } from './Variable';
 
@@ -10,7 +11,7 @@ interface ScopeManagerOptions {
   nodejsScope?: boolean;
   sourceType?: 'module' | 'script';
   impliedStrict?: boolean;
-  ecmaVersion?: number;
+  ecmaVersion?: EcmaVersion;
 }
 
 interface ScopeManager {

--- a/packages/experimental-utils/src/ts-eslint-scope/analyze.ts
+++ b/packages/experimental-utils/src/ts-eslint-scope/analyze.ts
@@ -1,4 +1,5 @@
 import { analyze as ESLintAnalyze } from 'eslint-scope';
+import { EcmaVersion } from '../ts-eslint';
 import { ScopeManager } from './ScopeManager';
 
 interface AnalysisOptions {
@@ -9,7 +10,7 @@ interface AnalysisOptions {
   impliedStrict?: boolean;
   fallback?: string | ((node: {}) => string[]);
   sourceType?: 'script' | 'module';
-  ecmaVersion?: number;
+  ecmaVersion?: EcmaVersion;
 }
 const analyze = ESLintAnalyze as (
   ast: {},

--- a/packages/experimental-utils/src/ts-eslint/Linter.ts
+++ b/packages/experimental-utils/src/ts-eslint/Linter.ts
@@ -60,15 +60,35 @@ namespace Linter {
 
   export type RuleLevelAndOptions = [RuleLevel, ...unknown[]];
 
-  export interface Config {
-    rules?: {
-      [name: string]: RuleLevel | RuleLevelAndOptions;
-    };
+  export type RuleEntry = RuleLevel | RuleLevelAndOptions;
+  export type RulesRecord = Partial<Record<string, RuleEntry>>;
+
+  // https://github.com/eslint/eslint/blob/v6.8.0/conf/config-schema.js
+  interface BaseConfig {
+    $schema?: string;
+    env?: { [name: string]: boolean };
+    extends?: string | string[];
+    globals?: { [name: string]: boolean };
+    noInlineConfig?: boolean;
+    overrides?: ConfigOverride[];
     parser?: string;
     parserOptions?: ParserOptions;
+    plugins?: string[];
+    processor?: string;
+    reportUnusedDisableDirectives?: boolean;
     settings?: { [name: string]: unknown };
-    env?: { [name: string]: boolean };
-    globals?: { [name: string]: boolean };
+    rules?: RulesRecord;
+  }
+
+  export interface ConfigOverride extends BaseConfig {
+    excludedFiles?: string | string[];
+    files: string | string[];
+  }
+  export type RuleOverride = ConfigOverride; // TODO - delete this next major
+
+  export interface Config extends BaseConfig {
+    ignorePatterns?: string | string[];
+    root?: boolean;
   }
 
   export type ParserOptions = TSParserOptions;

--- a/packages/experimental-utils/src/ts-eslint/ParserOptions.ts
+++ b/packages/experimental-utils/src/ts-eslint/ParserOptions.ts
@@ -1,12 +1,28 @@
 import { TSESTreeOptions } from '@typescript-eslint/typescript-estree';
 
+type EcmaVersion =
+  | 3
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 2015
+  | 2016
+  | 2017
+  | 2018
+  | 2019
+  | 2020;
+
 interface ParserOptions {
   comment?: boolean;
   ecmaFeatures?: {
     globalReturn?: boolean;
     jsx?: boolean;
   };
-  ecmaVersion?: 3 | 5 | 6 | 7 | 8 | 9 | 10 | 2015 | 2016 | 2017 | 2018 | 2019;
+  ecmaVersion?: EcmaVersion;
   errorOnTypeScriptSyntacticAndSemanticIssues?: boolean;
   errorOnUnknownASTType?: boolean;
   extraFileExtensions?: string[];
@@ -25,4 +41,4 @@ interface ParserOptions {
   warnOnUnsupportedTypeScriptVersion?: boolean;
 }
 
-export { ParserOptions };
+export { EcmaVersion, ParserOptions };

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -128,6 +128,7 @@ interface ReportDescriptorBase<TMessageIds extends string> {
    * The messageId which is being reported.
    */
   messageId: TMessageIds;
+
   // we disallow this because it's much better to use messageIds for reusable errors that are easily testable
   // desc?: string;
 }

--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -24,6 +24,8 @@ interface SuggestionOutput<TMessageIds extends string> {
    * Each individual error has its own suggestion, so you have to show the correct, _isolated_ output for each suggestion.
    */
   output: string;
+  // we disallow this because it's much better to use messageIds for reusable errors that are easily testable
+  // desc?: string;
 }
 
 interface InvalidTestCase<
@@ -36,6 +38,8 @@ interface InvalidTestCase<
 
 interface TestCaseError<TMessageIds extends string> {
   messageId: TMessageIds;
+  // we disallow this because it's much better to use messageIds for reusable errors that are easily testable
+  // message?: string;
   data?: Record<string, unknown>;
   type?: AST_NODE_TYPES | AST_TOKEN_TYPES;
   line?: number;


### PR DESCRIPTION
went through the history on the definitely typed types to update our copies.
I need to pay a bit more attention to ESLint releases so that I don't miss this stuff.