### PR TITLE
fix(eslint-plugin): no-empty-interface autofix

### DIFF
--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -64,10 +64,7 @@ export default util.createRule<Options, MessageIds>({
               fix: fixer => {
                 let typeParam = '';
                 if (node.typeParameters) {
-                  typeParam = sourceCode.text.substring(
-                    node.typeParameters.range[0],
-                    node.typeParameters.range[1],
-                  );
+                  typeParam = sourceCode.getText(node.typeParameters);
                 }
                 return fixer.replaceText(
                   node,

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -61,13 +61,21 @@ export default util.createRule<Options, MessageIds>({
             context.report({
               node: node.id,
               messageId: 'noEmptyWithSuper',
-              fix: fixer =>
-                fixer.replaceText(
+              fix: fixer => {
+                let typeParam = '';
+                if (node.typeParameters) {
+                  typeParam = sourceCode.text.substring(
+                    node.typeParameters.range[0],
+                    node.typeParameters.range[1],
+                  );
+                }
+                return fixer.replaceText(
                   node,
-                  `type ${sourceCode.getText(node.id)} = ${sourceCode.getText(
-                    extend[0],
-                  )}`,
-                ),
+                  `type ${sourceCode.getText(
+                    node.id,
+                  )}${typeParam} = ${sourceCode.getText(extend[0])}`,
+                );
+              },
             });
           }
         }

--- a/packages/eslint-plugin/tests/rules/no-empty-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-interface.test.ts
@@ -133,5 +133,20 @@ type Foo = R
         },
       ],
     },
+    {
+      code: `
+interface Foo<T> extends Bar<T> {}
+      `,
+      output: noFormat`
+type Foo<T> = Bar<T>
+      `,
+      errors: [
+        {
+          messageId: 'noEmptyWithSuper',
+          line: 2,
+          column: 11,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
# Summary

Ensures TypeParams are copied in autofix action for `no-empty-interface`

## Commit details

- Ensures type params are included in the autofix output
- Adds test case derived from **1864**

Resolves: #1864