### PR TITLE
fix(eslint-plugin): [no-empty-interface] use suggestion fixer for ambient contexts

### DIFF
--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -1,4 +1,9 @@
 import * as util from '../util';
+import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+import {
+  RuleFix,
+  RuleFixer,
+} from '@typescript-eslint/experimental-utils/dist/ts-eslint';
 
 type Options = [
   {
@@ -43,6 +48,7 @@ export default util.createRule<Options, MessageIds>({
     return {
       TSInterfaceDeclaration(node): void {
         const sourceCode = context.getSourceCode();
+        const filename = context.getFilename();
 
         if (node.body.body.length !== 0) {
           // interface contains members --> Nothing to report
@@ -58,21 +64,45 @@ export default util.createRule<Options, MessageIds>({
         } else if (extend.length === 1) {
           // interface extends exactly 1 interface --> Report depending on rule setting
           if (!allowSingleExtends) {
+            const fix = (fixer: RuleFixer): RuleFix => {
+              let typeParam = '';
+              if (node.typeParameters) {
+                typeParam = sourceCode.getText(node.typeParameters);
+              }
+              return fixer.replaceText(
+                node,
+                `type ${sourceCode.getText(
+                  node.id,
+                )}${typeParam} = ${sourceCode.getText(extend[0])}`,
+              );
+            };
+
+            // Check if interface is within ambient declaration
+            let useAutoFix = true;
+            if (util.isDefinitionFile(filename)) {
+              const scope = context.getScope();
+              if (
+                scope.block.parent &&
+                scope.block.parent.type ===
+                  AST_NODE_TYPES.TSModuleDeclaration &&
+                scope.block.parent.declare
+              ) {
+                useAutoFix = false;
+              }
+            }
+
             context.report({
               node: node.id,
               messageId: 'noEmptyWithSuper',
-              fix: fixer => {
-                let typeParam = '';
-                if (node.typeParameters) {
-                  typeParam = sourceCode.getText(node.typeParameters);
-                }
-                return fixer.replaceText(
-                  node,
-                  `type ${sourceCode.getText(
-                    node.id,
-                  )}${typeParam} = ${sourceCode.getText(extend[0])}`,
-                );
-              },
+              fix: useAutoFix ? fix : undefined,
+              suggest: useAutoFix
+                ? undefined
+                : [
+                    {
+                      messageId: 'noEmptyWithSuper',
+                      fix,
+                    },
+                  ],
             });
           }
         }

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -1,9 +1,5 @@
 import * as util from '../util';
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
-import {
-  RuleFix,
-  RuleFixer,
-} from '@typescript-eslint/experimental-utils/dist/ts-eslint';
+import { AST_NODE_TYPES, TSESLint  } from '@typescript-eslint/experimental-utils';
 
 type Options = [
   {

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -93,15 +93,16 @@ export default util.createRule<Options, MessageIds>({
             context.report({
               node: node.id,
               messageId: 'noEmptyWithSuper',
-              fix: useAutoFix ? fix : undefined,
-              suggest: useAutoFix
-                ? undefined
-                : [
-                    {
-                      messageId: 'noEmptyWithSuper',
-                      fix,
-                    },
-                  ],
+              ...(useAutoFix
+                ? { fix }
+                : {
+                    suggest: [
+                      {
+                        messageId: 'noEmptyWithSuper',
+                        fix,
+                      },
+                    ],
+                  }),
             });
           }
         }

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -1,5 +1,8 @@
 import * as util from '../util';
-import { AST_NODE_TYPES, TSESLint  } from '@typescript-eslint/experimental-utils';
+import {
+  AST_NODE_TYPES,
+  TSESLint,
+} from '@typescript-eslint/experimental-utils';
 
 type Options = [
   {
@@ -60,7 +63,7 @@ export default util.createRule<Options, MessageIds>({
         } else if (extend.length === 1) {
           // interface extends exactly 1 interface --> Report depending on rule setting
           if (!allowSingleExtends) {
-            const fix = (fixer: RuleFixer): RuleFix => {
+            const fix = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix => {
               let typeParam = '';
               if (node.typeParameters) {
                 typeParam = sourceCode.getText(node.typeParameters);

--- a/packages/eslint-plugin/tests/rules/no-empty-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-interface.test.ts
@@ -155,11 +155,25 @@ declare module FooBar {
   type Baz = typeof baz;
   export interface Bar extends Baz {}
 }
-      `,
+      `.trimRight(),
       errors: [
         {
           messageId: 'noEmptyWithSuper',
           line: 4,
+          column: 20,
+          endLine: 4,
+          endColumn: 23,
+          suggestions: [
+            {
+              messageId: 'noEmptyWithSuper',
+              output: noFormat`
+declare module FooBar {
+  type Baz = typeof baz;
+  export type Bar = Baz
+}
+              `.trimRight(),
+            },
+          ],
         },
       ],
       // output matches input because a suggestion was made
@@ -168,7 +182,7 @@ declare module FooBar {
   type Baz = typeof baz;
   export interface Bar extends Baz {}
 }
-      `,
+      `.trimRight(),
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-empty-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-interface.test.ts
@@ -148,5 +148,27 @@ type Foo<T> = Bar<T>
         },
       ],
     },
+    {
+      filename: 'test.d.ts',
+      code: `
+declare module FooBar {
+  type Baz = typeof baz;
+  export interface Bar extends Baz {}
+}
+      `,
+      errors: [
+        {
+          messageId: 'noEmptyWithSuper',
+          line: 4,
+        },
+      ],
+      // output matches input because a suggestion was made
+      output: `
+declare module FooBar {
+  type Baz = typeof baz;
+  export interface Bar extends Baz {}
+}
+      `,
+    },
   ],
 });


### PR DESCRIPTION
# Summary

Uses a suggested fix (instead of auto-fix) when an empty interface is found inside an ambient declaration.

Resolves: #1875 