### PR TITLE
chore: add gh action to lock old issues and PRs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,20 @@
+name: "Lock threads"
+
+on:
+  schedule:
+    # TODO - change to "0 0 * * *" once the backlog is processed
+    - cron: "0 * * * *"
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: "30"
+          issue-lock-reason: "resolved"
+          issue-lock-comment: ""
+          pr-lock-inactive-days: "30"
+          pr-lock-reason: "resolved"
+          pr-lock-comment: ""


### PR DESCRIPTION
As per our [contributing guidelines](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md#commenting), we prefer if users raise new issues instead of commenting on old, closed ones.
This adds a github action to automatically lock issues and PRs after they've been closed for 30 days.

Fixes #1767

I found this action because I got a notification on an old closed issue I had followed (`https://github.com/prettier/prettier-vscode/issues/763`).

It'll probably take a day or two to run over our entire repo, [as it only processes 50 items per run](https://github.com/dessant/lock-threads#why-are-only-some-issues-and-pull-requests-processed). I'll check back in a week and change the schedule to be daily instead of hourly.