### PR TITLE
feat(eslint-plugin): new option allowExplicitAny strict-boolean-exp

### DIFF
--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
@@ -59,6 +59,7 @@ Options may be provided as an object with:
 - `allowNullable` to allow `undefined` and `null` in addition to `boolean` as a type of all boolean expressions. (`false` by default).
 - `allowSafe` to allow non-falsy types (i.e. non string / number / boolean) in addition to `boolean` as a type of all boolean expressions. (`false` by default).
 - `ignoreRhs` to skip the check on the right hand side of expressions like `a && b` or `a || b` - allows these operators to be used for their short-circuiting behavior. (`false` by default).
+- `allowExplicitAny` to allow explicit `any` typed variables to be lint free.
 
 ## Related To
 

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -223,8 +223,11 @@ ruleTester.run('strict-boolean-expressions', rule, {
       `,
     }),
     {
-      code: `const x: any;
-    if (x) {}`,
+      code: `
+const x: any;
+if (x) {
+}
+      `,
       options: [{ allowExplicitAny: true }],
     },
     {
@@ -1269,8 +1272,11 @@ ruleTester.run('strict-boolean-expressions', rule, {
       ],
     },
     {
-      code: `const x: any;
-    if (x) {}`,
+      code: `
+const x: any;
+if (x) {
+}
+      `,
       options: [{ allowExplicitAny: false }],
       errors: [
         {

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -1280,8 +1280,8 @@ if (x) {
       options: [{ allowExplicitAny: false }],
       errors: [
         {
-          line: 2,
-          column: 9,
+          line: 3,
+          column: 5,
           messageId: 'conditionErrorAny',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -222,6 +222,21 @@ ruleTester.run('strict-boolean-expressions', rule, {
         function f5(x: never | boolean) { if (!x) { } }
       `,
     }),
+    {
+      code: `const x: any;
+    if (x) {}`,
+      options: [{ allowExplicitAny: true }],
+    },
+    {
+      code: `
+        let bool1: any;
+        let bool2 = true;
+        while (bool1 && bool2) {
+          return;
+        }
+      `,
+      options: [{ allowExplicitAny: true }],
+    },
   ],
 
   invalid: [
@@ -1235,5 +1250,52 @@ ruleTester.run('strict-boolean-expressions', rule, {
         const f3 = (x?: { x: any } | null) => (x ? 1 : 0);
       `,
     }),
+    {
+      code: `
+        let bool1: any;
+        let bool2: boolean = true;
+        let bool3;
+        while (bool3 && bool2) {
+          return;
+        }
+      `,
+      options: [{ allowExplicitAny: true }],
+      errors: [
+        {
+          line: 5,
+          column: 16,
+          messageId: 'conditionErrorNullish',
+        },
+      ],
+    },
+    {
+      code: `const x: any;
+    if (x) {}`,
+      options: [{ allowExplicitAny: false }],
+      errors: [
+        {
+          line: 2,
+          column: 9,
+          messageId: 'conditionErrorAny',
+        },
+      ],
+    },
+    {
+      code: `
+        let bool1: any;
+        let bool2 = true;
+        while (bool1 && bool2) {
+          return;
+        }
+      `,
+      options: [{ allowExplicitAny: false }],
+      errors: [
+        {
+          line: 4,
+          column: 16,
+          messageId: 'conditionErrorAny',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Added a new option in `strict-boolean-expression` rule

- `allowExplicitAny` - type : `boolean` - default : `false` 
fixes #754