### PR TITLE
docs(eslint-plugin): update version range of Typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ The latest version under the `canary` tag **(latest commit to master)** is:
 
 We will always endeavor to support the latest stable version of TypeScript. Sometimes, but not always, changes in TypeScript will not require breaking changes in this project, and so we are able to support more than one version of TypeScript. In some cases, we may even be able to support additional pre-releases (i.e. betas and release candidates) of TypeScript, but only if doing so does not require us to compromise on support for the latest stable version.
 
-**The version range of TypeScript currently supported by this parser is `>=3.2.1 <3.8.0`.**
+**The version range of TypeScript currently supported by this parser is `>=3.2.1 <3.9.0`.**
 
 This is reflected in the `devDependency` requirement within the package.json file, and it is what the tests will be run against. We have an open `peerDependency` requirement in order to allow for experimentation on newer/beta versions of TypeScript.
 


### PR DESCRIPTION
Update version range of Typescript currently supported by this parser due to package.json