### PR TITLE
feat(eslint-plugin): allowPackageDotJson option for no-var-requires

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-var-requires.md
+++ b/packages/eslint-plugin/docs/rules/no-var-requires.md
@@ -20,6 +20,40 @@ require('foo');
 import foo from 'foo';
 ```
 
+## Options
+
+```ts
+interface options {
+  allowPackageDotJson?: boolean;
+}
+```
+
+- `allowPackageDotJson` : allows to use require for `package.json` alone. default is `false`
+
+configuration
+
+```CJSON
+{
+    // Use type for object definitions
+    "@typescript-eslint/no-var-requires": ["error", { allowPackageDotJson : true } ]
+}
+```
+
+Examples of **incorrect** code for this rule:
+
+```ts
+var foo = require('foo');
+const foo = require('package.jsons');
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import foo = require('package.json');
+import foo = require('../package.json');
+import foo = require('../packages/package.json');
+```
+
 ## When Not To Use It
 
 If you don't care about TypeScript module syntax, then you will not need this rule.

--- a/packages/eslint-plugin/src/rules/no-var-requires.ts
+++ b/packages/eslint-plugin/src/rules/no-var-requires.ts
@@ -44,7 +44,9 @@ export default util.createRule<Options, MessageIds>({
       ): void {
         if (
           allowPackageDotJson &&
-          /package.json$/.test(node.arguments[0]?.value)
+          node.arguments[0]?.type === AST_NODE_TYPES.Literal &&
+          typeof node.arguments[0]?.value === 'string' &&
+          /package.json$/.test(node.arguments[0].value)
         ) {
           return;
         }

--- a/packages/eslint-plugin/src/rules/no-var-requires.ts
+++ b/packages/eslint-plugin/src/rules/no-var-requires.ts
@@ -4,7 +4,11 @@ import {
 } from '@typescript-eslint/experimental-utils';
 import * as util from '../util';
 
-type Options = [];
+type Options = [
+  {
+    allowPackageDotJson?: boolean;
+  },
+];
 type MessageIds = 'noVarReqs';
 
 export default util.createRule<Options, MessageIds>({
@@ -20,14 +24,31 @@ export default util.createRule<Options, MessageIds>({
     messages: {
       noVarReqs: 'Require statement not part of import statement.',
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowPackageDotJson: {
+            type: 'boolean',
+          },
+        },
+      },
+    ],
   },
-  defaultOptions: [],
+  defaultOptions: [{ allowPackageDotJson: false }],
   create(context) {
+    const allowPackageDotJson = context.options[0]?.allowPackageDotJson;
     return {
       'CallExpression, OptionalCallExpression'(
         node: TSESTree.CallExpression | TSESTree.OptionalCallExpression,
       ): void {
+        if (
+          allowPackageDotJson &&
+          /package.json$/.test(node.arguments[0]?.value)
+        ) {
+          return;
+        }
+
         if (
           node.callee.type === AST_NODE_TYPES.Identifier &&
           node.callee.name === 'require' &&

--- a/packages/eslint-plugin/tests/rules/no-var-requires.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-var-requires.test.ts
@@ -10,6 +10,19 @@ ruleTester.run('no-var-requires', rule, {
     "import foo = require('foo');",
     "require('foo');",
     "require?.('foo');",
+    'require();',
+    {
+      code: "const pkg = require('package.json');",
+      options: [{ allowPackageDotJson: true }],
+    },
+    {
+      code: "const pkg = require('../package.json');",
+      options: [{ allowPackageDotJson: true }],
+    },
+    {
+      code: "const pkg = require('../packages/package.json');",
+      options: [{ allowPackageDotJson: true }],
+    },
   ],
   invalid: [
     {
@@ -99,6 +112,48 @@ ruleTester.run('no-var-requires', rule, {
           messageId: 'noVarReqs',
           line: 1,
           column: 19,
+        },
+      ],
+    },
+    {
+      code: "const pkg = require('package.json');",
+      errors: [
+        {
+          line: 1,
+          column: 13,
+          messageId: 'noVarReqs',
+        },
+      ],
+    },
+    {
+      code: 'const pkg = require();',
+      errors: [
+        {
+          line: 1,
+          column: 13,
+          messageId: 'noVarReqs',
+        },
+      ],
+    },
+    {
+      code: 'const pkg = require();',
+      options: [{ allowPackageDotJson: true }],
+      errors: [
+        {
+          line: 1,
+          column: 13,
+          messageId: 'noVarReqs',
+        },
+      ],
+    },
+    {
+      code: "const pkg = require('package.jsons');",
+      options: [{ allowPackageDotJson: true }],
+      errors: [
+        {
+          line: 1,
+          column: 13,
+          messageId: 'noVarReqs',
         },
       ],
     },


### PR DESCRIPTION
fixes #1902

added new option 

- `allowPackageDotJson` -  type : `boolean` - default  : `false`

it will ignore all require calls ending with `package.json` in it. 
