### PR TITLE
fix(eslint-plugin): [no-base-to-string] soft remove `ignoreTaggedTemplateExpressions` option

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-base-to-string.md
+++ b/packages/eslint-plugin/docs/rules/no-base-to-string.md
@@ -52,32 +52,6 @@ const literalWithToString = {
 `Value: ${literalWithToString}`;
 ```
 
-## Options
-
-The rule accepts an options object with the following properties:
-
-```ts
-type Options = {
-  // if true, interpolated expressions in tagged templates will not be checked
-  ignoreTaggedTemplateExpressions?: boolean;
-};
-
-const defaults = {
-  ignoreTaggedTemplateExpressions: false,
-};
-```
-
-### `ignoreTaggedTemplateExpressions`
-
-This allows to skip checking tagged templates, for cases where the tags do not necessarily stringify interpolated values.
-
-Examples of additional **correct** code for this rule with `{ ignoreTaggedTemplateExpressions: true }`:
-
-```ts
-function tag() {}
-tag`${{}}`;
-```
-
 ## When Not To Use It
 
 If you don't mind `"[object Object]"` in your strings, then you will not need this rule.

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -14,6 +14,7 @@ enum Usefulness {
 
 type Options = [
   {
+    /** @deprecated This option is now ignored and treated as always true, it will be removed in 3.0 */
     ignoreTaggedTemplateExpressions?: boolean;
   },
 ];
@@ -39,7 +40,7 @@ export default util.createRule<Options, MessageIds>({
         properties: {
           ignoreTaggedTemplateExpressions: {
             type: 'boolean',
-            default: false,
+            default: true,
           },
         },
         additionalProperties: false,
@@ -47,8 +48,8 @@ export default util.createRule<Options, MessageIds>({
     ],
     type: 'suggestion',
   },
-  defaultOptions: [{ ignoreTaggedTemplateExpressions: false }],
-  create(context, [options]) {
+  defaultOptions: [{ ignoreTaggedTemplateExpressions: true }],
+  create(context) {
     const parserServices = util.getParserServices(context);
     const typeChecker = parserServices.program.getTypeChecker();
 
@@ -130,7 +131,6 @@ export default util.createRule<Options, MessageIds>({
       },
       TemplateLiteral(node: TSESTree.TemplateLiteral): void {
         if (
-          options.ignoreTaggedTemplateExpressions &&
           node.parent &&
           node.parent.type === AST_NODE_TYPES.TaggedTemplateExpression
         ) {

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -70,6 +70,10 @@ const literalWithToString = {
     'let _ = {} ^ {};',
     'let _ = {} << {};',
     'let _ = {} >> {};',
+    `
+function tag() {}
+tag\`\${{}}\`;
+    `,
     {
       code: `
         function tag() {}
@@ -85,21 +89,6 @@ const literalWithToString = {
   invalid: [
     {
       code: '`${{}})`;',
-      errors: [
-        {
-          data: {
-            certainty: 'will',
-            name: '{}',
-          },
-          messageId: 'baseToString',
-        },
-      ],
-    },
-    {
-      code: `
-        function tag() {}
-        tag\`\${{}}\`;
-      `,
       errors: [
         {
           data: {


### PR DESCRIPTION
ref: #1914

This "soft" removes the `ignoreTaggedTemplateExpressions` option, treating it as always true.

In the next breaking change, 3.0, we can remove this option altogether ☺️ 

Let me know if you want to approach this in another way, this is my first PR here, happy to learn!