### PR TITLE
docs(eslint-plugin): [explicit-function-return-type] fix typo

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -70,7 +70,7 @@ type Options = {
   // if true, functions immediately returning another function expression will not be checked
   allowHigherOrderFunctions?: boolean;
   // if true, concise arrow functions that start with the void keyword will not be checked
-  allowConciseArrowFunctionExpressionStartingWithVoid?: boolean;
+  allowConciseArrowFunctionExpressionsStartingWithVoid?: boolean;
 };
 
 const defaults = {


### PR DESCRIPTION
Added a missing "s" into the property "allowConciseArrowFunctionExpression`s`StartingWithVoid".