### PR TITLE
feat(experimental-utils): allow rule options to be a readonly tuple

### DIFF
--- a/packages/experimental-utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/experimental-utils/src/eslint-utils/RuleCreator.ts
@@ -17,7 +17,7 @@ function RuleCreator(urlCreator: (ruleName: string) => string) {
   // This function will get much easier to call when this is merged https://github.com/Microsoft/TypeScript/pull/26349
   // TODO - when the above PR lands; add type checking for the context.report `data` property
   return function createRule<
-    TOptions extends unknown[],
+    TOptions extends readonly unknown[],
     TMessageIds extends string,
     TRuleListener extends RuleListener = RuleListener
   >({

--- a/packages/experimental-utils/src/eslint-utils/applyDefault.ts
+++ b/packages/experimental-utils/src/eslint-utils/applyDefault.ts
@@ -7,12 +7,14 @@ import { deepMerge, isObjectNotArray } from './deepMerge';
  * @param userOptions the user opts
  * @returns the options with defaults
  */
-function applyDefault<TUser extends unknown[], TDefault extends TUser>(
+function applyDefault<TUser extends readonly unknown[], TDefault extends TUser>(
   defaultOptions: TDefault,
   userOptions: TUser | null,
 ): TDefault {
   // clone defaults
-  const options: TDefault = JSON.parse(JSON.stringify(defaultOptions));
+  const options: AsMutable<TDefault> = JSON.parse(
+    JSON.stringify(defaultOptions),
+  );
 
   if (userOptions === null || userOptions === undefined) {
     return options;
@@ -32,5 +34,7 @@ function applyDefault<TUser extends unknown[], TDefault extends TUser>(
 
   return options;
 }
+
+type AsMutable<T extends {}> = { -readonly [TKey in keyof T]: T[TKey] };
 
 export { applyDefault };


### PR DESCRIPTION
* Change `createRule`'s `TOptions` to a _readonly_ generic constraint ...
* ... and make it mutable exactly where it's necessary: within `applyDefault()` (after cloning it, the mutation happens in line 26 & 28)

=> This allows to create a rule this way: 

```ts
ESLintUtils.RuleCreator(name => name)<readonly [{ readonly prop: string }],
    "defaultMessage">({
    name: "name", meta: { /* ... */ },
    create(context, options) {

        // This is now a compile error ("Cannot assign to '0' because it
        //  is a read-only property"), which is gooodd:
        options[0] = { prop: "x" };

        return {};
    },
});
```