### PR TITLE
chore(eslint-plugin): standardise sentences in rule messages

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
@@ -17,8 +17,8 @@ export default util.createRule({
       recommended: false,
     },
     messages: {
-      interfaceOverType: 'Use an `interface` instead of a `type`',
-      typeOverInterface: 'Use a `type` instead of an `interface`',
+      interfaceOverType: 'Use an `interface` instead of a `type`.',
+      typeOverInterface: 'Use a `type` instead of an `interface`.',
     },
     schema: [
       {

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -349,7 +349,7 @@ export default util.createRule<Options, MessageIds>({
       unexpectedUnderscore:
         '{{type}} name {{name}} must not have a {{position}} underscore.',
       missingUnderscore:
-        '{{type}} name {{name}} must have a {{position}} underscore',
+        '{{type}} name {{name}} must have a {{position}} underscore.',
       missingAffix:
         '{{type}} name {{name}} must have one of the following {{position}}es: {{affixes}}',
       satisfyCustom:

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -27,11 +27,11 @@ export default util.createRule<Options, MessageId>({
       requiresTypeChecking: true,
     },
     messages: {
-      floating: 'Promises must be handled appropriately',
+      floating: 'Promises must be handled appropriately.',
       floatingVoid:
         'Promises must be handled appropriately' +
-        ' or explicitly marked as ignored with the `void` operator',
-      floatingFixVoid: 'Add void operator to ignore',
+        ' or explicitly marked as ignored with the `void` operator.',
+      floatingFixVoid: 'Add void operator to ignore.',
     },
     schema: [
       {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -28,7 +28,7 @@ export default util.createRule<[], MessageIds>({
     fixable: 'code',
     messages: {
       direct:
-        'This expression unnecessarily compares a boolean value to a boolean instead of using it directly',
+        'This expression unnecessarily compares a boolean value to a boolean instead of using it directly.',
       negated:
         'This expression unnecessarily compares a boolean value to a boolean instead of negating it.',
     },

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -108,17 +108,17 @@ export default createRule<Options, MessageId>({
       alwaysTruthy: 'Unnecessary conditional, value is always truthy.',
       alwaysFalsy: 'Unnecessary conditional, value is always falsy.',
       alwaysTruthyFunc:
-        'This callback should return a conditional, but return is always truthy',
+        'This callback should return a conditional, but return is always truthy.',
       alwaysFalsyFunc:
-        'This callback should return a conditional, but return is always falsy',
+        'This callback should return a conditional, but return is always falsy.',
       neverNullish:
         'Unnecessary conditional, expected left-hand side of `??` operator to be possibly null or undefined.',
       alwaysNullish:
-        'Unnecessary conditional, left-hand side of `??` operator is always `null` or `undefined`',
+        'Unnecessary conditional, left-hand side of `??` operator is always `null` or `undefined`.',
       literalBooleanExpression:
-        'Unnecessary conditional, both sides of the expression are literal values',
-      never: 'Unnecessary conditional, value is `never`',
-      neverOptionalChain: 'Unnecessary optional chain on a non-nullish value',
+        'Unnecessary conditional, both sides of the expression are literal values.',
+      never: 'Unnecessary conditional, value is `never`.',
+      neverOptionalChain: 'Unnecessary optional chain on a non-nullish value.',
     },
   },
   defaultOptions: [

--- a/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts
@@ -25,13 +25,13 @@ export default util.createRule({
       requiresTypeChecking: true,
     },
     messages: {
-      anyAssignment: 'Unsafe assignment of an any value',
-      unsafeArrayPattern: 'Unsafe array destructuring of an any array value',
+      anyAssignment: 'Unsafe assignment of an any value.',
+      unsafeArrayPattern: 'Unsafe array destructuring of an any array value.',
       unsafeArrayPatternFromTuple:
-        'Unsafe array destructuring of a tuple element with an any value',
+        'Unsafe array destructuring of a tuple element with an any value.',
       unsafeAssignment:
-        'Unsafe asignment of type {{sender}} to a variable of type {{receiver}}',
-      unsafeArraySpread: 'Unsafe spread of an any value in an array',
+        'Unsafe asignment of type {{sender}} to a variable of type {{receiver}}.',
+      unsafeArraySpread: 'Unsafe spread of an any value in an array.',
     },
     schema: [],
   },

--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -14,9 +14,9 @@ export default util.createRule<[], MessageIds>({
       requiresTypeChecking: true,
     },
     messages: {
-      unsafeCall: 'Unsafe call of an any typed value',
-      unsafeNew: 'Unsafe construction of an any type value',
-      unsafeTemplateTag: 'Unsafe any typed template tag',
+      unsafeCall: 'Unsafe call of an any typed value.',
+      unsafeNew: 'Unsafe construction of an any type value.',
+      unsafeTemplateTag: 'Unsafe any typed template tag.',
     },
     schema: [],
   },

--- a/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts
@@ -21,9 +21,9 @@ export default util.createRule({
     },
     messages: {
       unsafeMemberExpression:
-        'Unsafe member access {{property}} on an any value',
+        'Unsafe member access {{property}} on an any value.',
       unsafeComputedMemberAccess:
-        'Computed name {{property}} resolves to an any value',
+        'Computed name {{property}} resolves to an any value.',
     },
     schema: [],
   },

--- a/packages/eslint-plugin/src/rules/no-unsafe-return.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-return.ts
@@ -18,7 +18,7 @@ export default util.createRule({
     messages: {
       unsafeReturn: 'Unsafe return of an {{type}} typed value',
       unsafeReturnAssignment:
-        'Unsafe return of type {{sender}} from function with return type {{receiver}}',
+        'Unsafe return of type {{sender}} from function with return type {{receiver}}.',
     },
     schema: [],
   },

--- a/packages/eslint-plugin/src/rules/no-untyped-public-signature.ts
+++ b/packages/eslint-plugin/src/rules/no-untyped-public-signature.ts
@@ -19,8 +19,8 @@ export default util.createRule<Options, MessageIds>({
       recommended: false,
     },
     messages: {
-      noReturnType: 'Public method has no return type',
-      untypedParameter: 'Public method parameters should be typed',
+      noReturnType: 'Public method has no return type.',
+      untypedParameter: 'Public method parameters should be typed.',
     },
     schema: [
       {

--- a/packages/eslint-plugin/src/rules/no-unused-vars-experimental.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars-experimental.ts
@@ -56,7 +56,7 @@ export default util.createRule<Options, MessageIds>({
     messages: {
       unused: "{{type}} '{{name}}' is declared but its value is never read.",
       unusedWithIgnorePattern:
-        "{{type}} '{{name}}' is declared but its value is never read. Allowed unused names must match {{pattern}}",
+        "{{type}} '{{name}}' is declared but its value is never read. Allowed unused names must match {{pattern}}.",
       unusedImport: 'All imports in import declaration are unused.',
       unusedTypeParameters: 'All type parameters are unused.',
     },

--- a/packages/eslint-plugin/src/rules/prefer-as-const.ts
+++ b/packages/eslint-plugin/src/rules/prefer-as-const.ts
@@ -17,9 +17,9 @@ export default util.createRule({
     fixable: 'code',
     messages: {
       preferConstAssertion:
-        'Expected a `const` instead of a literal type assertion',
+        'Expected a `const` instead of a literal type assertion.',
       variableConstAssertion:
-        'Expected a `const` assertion instead of a literal type annotation',
+        'Expected a `const` assertion instead of a literal type annotation.',
       variableSuggest: 'You should use `as const` instead of type annotation.',
     },
     schema: [],

--- a/packages/eslint-plugin/src/rules/prefer-for-of.ts
+++ b/packages/eslint-plugin/src/rules/prefer-for-of.ts
@@ -17,7 +17,7 @@ export default util.createRule({
     },
     messages: {
       preferForOf:
-        'Expected a `for-of` loop instead of a `for` loop with this simple iteration',
+        'Expected a `for-of` loop instead of a `for` loop with this simple iteration.',
     },
     schema: [],
   },

--- a/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
@@ -34,7 +34,7 @@ export default util.createRule<Options, MessageIds>({
       },
     ],
     messages: {
-      shouldBeReadonly: 'Parameter should be a read only type',
+      shouldBeReadonly: 'Parameter should be a read only type.',
     },
   },
   defaultOptions: [

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -21,11 +21,11 @@ export default util.createRule({
     type: 'problem',
     messages: {
       nonPromiseAwait:
-        'returning an awaited value that is not a promise is not allowed',
+        'Returning an awaited value that is not a promise is not allowed.',
       disallowedPromiseAwait:
-        'returning an awaited promise is not allowed in this context',
+        'Returning an awaited promise is not allowed in this context.',
       requiredPromiseAwait:
-        'returning an awaited promise is required in this context',
+        'Returning an awaited promise is required in this context.',
     },
     schema: [
       {

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -23,7 +23,7 @@ export default createRule({
     messages: {
       switchIsNotExhaustive:
         'Switch is not exhaustive. Cases not matched: {{missingBranches}}',
-      addMissingCases: 'Add branches for missing cases',
+      addMissingCases: 'Add branches for missing cases.',
     },
   },
   defaultOptions: [],

--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -28,8 +28,8 @@ export default util.createRule<[Options], MessageIds>({
       recommended: false,
     },
     messages: {
-      expectedTypedef: 'expected a type annotation',
-      expectedTypedefNamed: 'expected {{name}} to have a type annotation',
+      expectedTypedef: 'Expected a type annotation.',
+      expectedTypedefNamed: 'Expected {{name}} to have a type annotation.',
     },
     schema: [
       {


### PR DESCRIPTION
**Current situation:** The majority of error messages in rules end with a period, and almost all error messages start with an uppercase character.

This PR standardizes this, with one exception being messages that end with a colon followed by a template literal like this: `Name must match one of the following formats: {{formats}}`