### PR TITLE
chore: fix CI

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,8 +2,7 @@ name: "Lock threads"
 
 on:
   schedule:
-    # TODO - change to "0 0 * * *" once the backlog is processed
-    - cron: "0 * * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   lock:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint:markdown:fix": "lint:markdown --fix",
     "pre-commit": "yarn lint-staged",
     "pre-push": "yarn format-check",
-    "postinstall": "lerna bootstrap && yarn build && lerna link",
+    "postinstall": "lerna bootstrap -- --ignore-engines && yarn build && lerna link",
     "check-clean-workspace-after-install": "git diff --quiet --exit-code",
     "test": "lerna run test --concurrency 1",
     "typecheck": "lerna run typecheck"


### PR DESCRIPTION
it appears a newer version of yarn is running on the CI, which is more strict about the noop install that bootstrap does.