### PR TITLE
fix(eslint-plugin): [unbound-method] false positives for unary expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -244,7 +244,7 @@ function isSafeUse(node: TSESTree.Node): boolean {
       // the first case is safe for obvious
       // reasons. The second one is also fine
       // since we're returning something falsy
-      return ['typeof', '!'].includes(parent.operator);
+      return ['typeof', '!', 'void', 'delete'].includes(parent.operator);
 
     case AST_NODE_TYPES.BinaryExpression:
       return ['instanceof', '==', '!=', '===', '!=='].includes(parent.operator);

--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -241,7 +241,10 @@ function isSafeUse(node: TSESTree.Node): boolean {
       return parent.tag === node;
 
     case AST_NODE_TYPES.UnaryExpression:
-      return parent.operator === 'typeof';
+      // the first case is safe for obvious
+      // reasons. The second one is also fine
+      // since we're returning something falsy
+      return ['typeof', '!'].includes(parent.operator);
 
     case AST_NODE_TYPES.BinaryExpression:
       return ['instanceof', '==', '!=', '===', '!=='].includes(parent.operator);

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -150,6 +150,7 @@ ruleTester.run('unbound-method', rule, {
 
       'instance.unbound = () => {};',
       'instance.unbound = instance.unbound.bind(instance);',
+      'if (!!instance.unbound) {}',
     ].map(addContainsMethodsClass),
     `
 interface RecordA {

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -151,6 +151,8 @@ ruleTester.run('unbound-method', rule, {
       'instance.unbound = () => {};',
       'instance.unbound = instance.unbound.bind(instance);',
       'if (!!instance.unbound) {}',
+      'void instance.unbound',
+      'delete instance.unbound',
     ].map(addContainsMethodsClass),
     `
 interface RecordA {


### PR DESCRIPTION
Fixes #1934. 

Added an extra check to `isSafeUse` to deal with the case when an unbound method is made truthy/falsy (and therefore safe to reference) through the use of the `!` operator.