### PR TITLE
fix(eslint-plugin): no-base-to-string boolean expression detect

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-base-to-string.md
+++ b/packages/eslint-plugin/docs/rules/no-base-to-string.md
@@ -64,12 +64,12 @@ const defaultOptions: Options = {
 };
 ```
 
-### `ignoreTypeNames`
+### `ignoredTypeNames`
 
 A string array of type names to ignore, this is useful for types missing `toString()` (but actually has `toString()`).
 There are some types missing `toString()` in old version TypeScript, like `RegExp`, `URL`, `URLSearchParams` etc.
 
-The following patterns are considered correct with the default options `{ ignoreTypeNames: ["RegExp"] }`:
+The following patterns are considered correct with the default options `{ ignoredTypeNames: ["RegExp"] }`:
 
 ```ts
 `${/regex/}`;

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -99,7 +99,10 @@ export default util.createRule<Options, MessageIds>({
       }
 
       // Patch for old version TypeScript, the Boolean type definition missing toString()
-      if (type.flags & ts.TypeFlags.BooleanLiteral) {
+      if (
+        type.flags & ts.TypeFlags.Boolean ||
+        type.flags & ts.TypeFlags.BooleanLiteral
+      ) {
         return Usefulness.Always;
       }
 

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -23,6 +23,7 @@ const literalListBasic: string[] = [
 ];
 
 const literalListNeedParen: string[] = [
+  "__dirname === 'foobar'",
   '{}.constructor()',
   '() => {}',
   'function() {}',


### PR DESCRIPTION
docs typofix
fix boolean expression detect