### PR TITLE
fix(eslint-plugin): [no-type-alias] handle readonly types in aliases

### DIFF
--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -262,7 +262,11 @@ export default util.createRule<Options, MessageIds>({
       } else if (
         // eslint-disable-next-line @typescript-eslint/internal/prefer-ast-types-enum
         type.node.type.endsWith('Keyword') ||
-        aliasTypes.has(type.node.type)
+        aliasTypes.has(type.node.type) ||
+        (type.node.type === AST_NODE_TYPES.TSTypeOperator &&
+          type.node.operator === 'readonly' &&
+          type.node.typeAnnotation &&
+          aliasTypes.has(type.node.typeAnnotation.type))
       ) {
         // alias / keyword
         checkAndReport(allowAliases!, isTopLevel, type, 'Aliases');

--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -214,6 +214,10 @@ type Foo = Bar & string;
       options: [{ allowAliases: 'in-unions-and-intersections' }],
     },
     {
+      code: 'type Foo = string | readonly string[];',
+      options: [{ allowAliases: 'in-unions-and-intersections' }],
+    },
+    {
       code: 'type Foo = string | string[];',
       options: [{ allowAliases: 'in-unions' }],
     },


### PR DESCRIPTION
Fixes #1981