### PR TITLE
fix(eslint-plugin): [no-unused-expressions] inherit `messages` from base rule

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-expressions.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-expressions.ts
@@ -13,7 +13,7 @@ export default util.createRule({
       extendsBaseRule: true,
     },
     schema: baseRule.meta.schema,
-    messages: {},
+    messages: baseRule.meta.messages,
   },
   defaultOptions: [],
   create(context) {


### PR DESCRIPTION
I'm not sure what changed in ESLint 7 that means this is now an error as it was working up until now and nothing else seems to be broken.

I've checked & tested all the other base rules and they either do this or have their own `messages`, so I don't think it's worth creating an internal rule over (but am happy to do so if it becomes a regular thing - feel free to `@` me if so 🙂 )

This works in both eslint 6 & 7, so 🤷 