### PR TITLE
feat(eslint-plugin): [restrict-template-expressions] `allowNumber: true` by default

### DIFF
--- a/packages/eslint-plugin/docs/rules/restrict-template-expressions.md
+++ b/packages/eslint-plugin/docs/rules/restrict-template-expressions.md
@@ -38,8 +38,9 @@ type Options = {
 };
 
 const defaults = {
-  allowNumber: false,
+  allowNumber: true,
   allowBoolean: false,
+  allowAny: false,
   allowNullable: false,
 };
 ```

--- a/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
+++ b/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
@@ -41,7 +41,11 @@ export default util.createRule<Options, MessageId>({
       },
     ],
   },
-  defaultOptions: [{}],
+  defaultOptions: [
+    {
+      allowNumber: true,
+    },
+  ],
   create(context, [options]) {
     const service = util.getParserServices(context);
     const typeChecker = service.program.getTypeChecker();

--- a/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
@@ -214,6 +214,7 @@ ruleTester.run('restrict-template-expressions', rule, {
       code: `
         const msg = \`arg = \${123}\`;
       `,
+      options: [{ allowNumber: false }],
       errors: [{ messageId: 'invalidType', line: 2, column: 30 }],
     },
     {
@@ -233,6 +234,7 @@ ruleTester.run('restrict-template-expressions', rule, {
         declare const arg: number;
         const msg = \`arg = \${arg}\`;
       `,
+      options: [{ allowNumber: false }],
       errors: [{ messageId: 'invalidType', line: 3, column: 30 }],
     },
     {


### PR DESCRIPTION
BREAKING CHANGE:

I forgot this as part of the recommended config changes