### PR TITLE
chore: provide more granularity in the CI logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ env:
   PRIMARY_NODE_VERSION: 12
 
 jobs:
-  primary_code_validation_and_tests:
-    name: Typecheck and tests
+  typecheck:
+    name: Typecheck
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -55,8 +55,75 @@ jobs:
       - name: Typecheck all packages
         run: yarn typecheck
 
-      - name: Run unit tests
+  test_on_primary_node_version:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: echo github.ref
+        run: echo ${{ github.ref }}
+
+      - name: Use Node.js ${{ env.PRIMARY_NODE_VERSION }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: |
+          yarn --ignore-engines --frozen-lockfile --ignore-scripts
+          yarn lerna:init
+          yarn check:clean-workspace-after-install
+
+      - name: Build
+        run: |
+          yarn build
+
+      - name: Run unit tests for typescript-estree
         run: yarn test
+        working-directory: packages/typescript-estree
+        env:
+          CI: true
+
+      - name: Run unit tests for experimental-utils
+        run: yarn test
+        working-directory: packages/experimental-utils
+        env:
+          CI: true
+
+      - name: Run unit tests for parser
+        run: yarn test
+        working-directory: packages/parser
+        env:
+          CI: true
+
+      - name: Run unit tests for eslint-plugin
+        run: yarn test
+        working-directory: packages/eslint-plugin
+        env:
+          CI: true
+
+      - name: Run unit tests for eslint-plugin-tslint
+        run: yarn test
+        working-directory: packages/eslint-plugin-tslint
+        env:
+          CI: true
+
+      - name: Run unit tests for eslint-plugin-internal
+        run: yarn test
+        working-directory: packages/eslint-plugin-internal
         env:
           CI: true
 
@@ -184,16 +251,42 @@ jobs:
         run: |
           yarn build
 
-      - name: Run unit tests
-        # the internal plugin is only run locally, so it doesn't have to support older versions
-        run: yarn test --ignore @typescript-eslint/eslint-plugin-internal
+      - name: Run unit tests for typescript-estree
+        run: yarn test
+        working-directory: packages/typescript-estree
         env:
           CI: true
+
+      - name: Run unit tests for experimental-utils
+        run: yarn test
+        working-directory: packages/experimental-utils
+        env:
+          CI: true
+
+      - name: Run unit tests for parser
+        run: yarn test
+        working-directory: packages/parser
+        env:
+          CI: true
+
+      - name: Run unit tests for eslint-plugin
+        run: yarn test
+        working-directory: packages/eslint-plugin
+        env:
+          CI: true
+
+      - name: Run unit tests for eslint-plugin-tslint
+        run: yarn test
+        working-directory: packages/eslint-plugin-tslint
+        env:
+          CI: true
+
+      # eslint-plugin-internal is internal only - so don't care about compat on other versions
 
   publish_canary_version:
     name: Publish the latest code as a canary version
     runs-on: ubuntu-latest
-    needs: [primary_code_validation_and_tests, unit_tests_on_other_node_versions, linting_and_style, integration_tests]
+    needs: [typecheck, test_on_primary_node_version, unit_tests_on_other_node_versions, linting_and_style, integration_tests]
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
@@ -238,7 +331,7 @@ jobs:
   publish_v3_prerelease_version:
     name: Publish the latest code as a v3 prerelease version
     runs-on: ubuntu-latest
-    needs: [primary_code_validation_and_tests, unit_tests_on_other_node_versions, linting_and_style, integration_tests]
+    needs: [typecheck, test_on_primary_node_version, unit_tests_on_other_node_versions, linting_and_style, integration_tests]
     if: github.ref == 'refs/heads/v3'
     steps:
       - uses: actions/checkout@v2
@@ -275,6 +368,6 @@ jobs:
           yarn build
 
       - name: Publish all packages to npm
-        run: npx lerna publish --loglevel=verbose --canary --exact --force-publish --yes --dist-tag rc-v3
+        run: npx lerna publish premajor --loglevel=verbose --canary --exact --force-publish --yes --dist-tag rc-v3
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Lerna is a bit of a pain in the CI.
You just see a single "test" step, so you can't tell how far done it is, nor can you tell what failed when it fails.
If it fails, you have to open up the logs and parse them yourself, which isn't easy due to the line prefixing.