### PR TITLE
fix(typescript-estree): fix handling of range/loc removal

### DIFF
--- a/packages/typescript-estree/src/ast-converter.ts
+++ b/packages/typescript-estree/src/ast-converter.ts
@@ -36,7 +36,7 @@ export function astConverter(
   /**
    * Optionally remove range and loc if specified
    */
-  if (extra.range || extra.loc) {
+  if (!extra.range || !extra.loc) {
     simpleTraverse(estree, {
       enter: node => {
         if (!extra.range) {


### PR DESCRIPTION
if I pass the options with  
{
    comment: true,
    loc: false,
    range: false,
 }

when parsing, I expect it should remove loc & range both