### PR TITLE
docs(eslint-plugin): [explicit-function-return-type] add missing default

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -77,6 +77,7 @@ const defaults = {
   allowExpressions: false,
   allowTypedFunctionExpressions: true,
   allowHigherOrderFunctions: true,
+  allowConciseArrowFunctionExpressionsStartingWithVoid: true,
 };
 ```
 


### PR DESCRIPTION
Not sure if the default is correct; feel free to fix.