### PR TITLE
feat(experimental-utils): add `suggestion` property for rule  modules

### DIFF
--- a/packages/eslint-plugin-internal/src/rules/no-poorly-typed-ts-props.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-poorly-typed-ts-props.ts
@@ -39,6 +39,7 @@ export default createRule({
         "Enforces rules don't use TS API properties with known bad type definitions",
       category: 'Possible Errors',
       recommended: 'error',
+      suggestion: true,
       requiresTypeChecking: true,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -19,6 +19,7 @@ export default util.createRule<Options, MessageIds>({
       description: 'Disallow the declaration of empty interfaces',
       category: 'Best Practices',
       recommended: 'error',
+      suggestion: true,
     },
     fixable: 'code',
     messages: {

--- a/packages/eslint-plugin/src/rules/no-explicit-any.ts
+++ b/packages/eslint-plugin/src/rules/no-explicit-any.ts
@@ -21,6 +21,7 @@ export default util.createRule<Options, MessageIds>({
       description: 'Disallow usage of the `any` type',
       category: 'Best Practices',
       recommended: 'warn',
+      suggestion: true,
     },
     fixable: 'code',
     messages: {

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -24,6 +24,7 @@ export default util.createRule<Options, MessageId>({
       description: 'Requires Promise-like values to be handled appropriately',
       category: 'Best Practices',
       recommended: false,
+      suggestion: true,
       requiresTypeChecking: true,
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
@@ -12,6 +12,7 @@ export default util.createRule<[], MessageIds>({
         'Disallows using a non-null assertion after an optional chain expression',
       category: 'Possible Errors',
       recommended: false,
+      suggestion: true,
     },
     messages: {
       noNonNullOptionalChain:

--- a/packages/eslint-plugin/src/rules/no-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-assertion.ts
@@ -15,6 +15,7 @@ export default util.createRule<[], MessageIds>({
         'Disallows non-null assertions using the `!` postfix operator',
       category: 'Stylistic Issues',
       recommended: 'warn',
+      suggestion: true,
     },
     messages: {
       noNonNull: 'Forbidden non-null assertion.',

--- a/packages/eslint-plugin/src/rules/prefer-as-const.ts
+++ b/packages/eslint-plugin/src/rules/prefer-as-const.ts
@@ -13,6 +13,7 @@ export default util.createRule({
       description: 'Prefer usage of `as const` over literal type',
       category: 'Best Practices',
       recommended: false,
+      suggestion: true,
     },
     fixable: 'code',
     messages: {

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -24,6 +24,7 @@ export default util.createRule<Options, MessageIds>({
         'Enforce the usage of the nullish coalescing operator instead of logical chaining',
       category: 'Best Practices',
       recommended: false,
+      suggestion: true,
       requiresTypeChecking: true,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -48,6 +48,7 @@ export default util.createRule<Options, MessageIds>({
         'Prefer using concise optional chain expressions instead of chained logical ands',
       category: 'Best Practices',
       recommended: false,
+      suggestion: true,
     },
     fixable: 'code',
     messages: {

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -17,6 +17,7 @@ export default createRule({
       description: 'Exhaustiveness checking in switch with union type',
       category: 'Best Practices',
       recommended: false,
+      suggestion: true,
       requiresTypeChecking: true,
     },
     schema: [],

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -29,6 +29,10 @@ interface RuleMetaDataDocs {
    */
   url: string;
   /**
+   * Specifies whether the rule can return suggestions.
+   */
+  suggestion?: boolean;
+  /**
    * Does the rule require us to create a full TypeScript Program in order for it
    * to type-check code. This is only used for documentation purposes.
    */


### PR DESCRIPTION
This property doesn't seem to be used for anything by ESLint (suggestions still work without it), but it's in [the docs](https://eslint.org/docs/developer-guide/working-with-rules#rule-basics), and would let us plugin devs check if our rules have suggestions for documentation generation tooling.