### PR TITLE
fix(eslint-plugin): [dot-notation] fix typo in schema

### DIFF
--- a/packages/eslint-plugin/src/rules/dot-notation.ts
+++ b/packages/eslint-plugin/src/rules/dot-notation.ts
@@ -35,7 +35,7 @@ export default createRule<Options, MessageIds>({
             default: '',
           },
           allowPrivateClassPropertyAccess: {
-            tyoe: 'boolean',
+            type: 'boolean',
             default: false,
           },
         },


### PR DESCRIPTION
fixes #2040