### PR TITLE
docs: Adding FAQ entry saying TypeScript should be installed locally

### DIFF
--- a/docs/getting-started/linting/FAQ.md
+++ b/docs/getting-started/linting/FAQ.md
@@ -7,6 +7,7 @@
 - [I use a framework (like Vue) that requires custom file extensions, and I get errors like "You should add `parserOptions.extraFileExtensions` to your config"](#i-use-a-framework-like-vue-that-requires-custom-file-extensions-and-i-get-errors-like-you-should-add-parseroptionsextrafileextensions-to-your-config)
 - [I am using a rule from ESLint core, and it doesn't work correctly with TypeScript code](#i-am-using-a-rule-from-eslint-core-and-it-doesnt-work-correctly-with-typescript-code)
 - [One of my lint rules isn't working correctly on a pure JavaScript file](#one-of-my-lint-rules-isnt-working-correctly-on-a-pure-javascript-file)
+- [TypeScript should be installed globally](#typescript-should-be-installed-globally)
 
 ---
 
@@ -118,10 +119,7 @@ This is to be expected - ESLint rules do not check file extensions on purpose, a
 
 If you have some pure JavaScript code that you do not want to apply certain lint rules to, then you can use [ESLint's `overrides` configuration](https://eslint.org/docs/user-guide/configuring#configuration-based-on-glob-patterns) to turn off certain rules, or even change the parser based on glob patterns.
 
-
-
-
-----
+---
 
 ## TypeScript should be installed globally
 

--- a/docs/getting-started/linting/FAQ.md
+++ b/docs/getting-started/linting/FAQ.md
@@ -7,7 +7,7 @@
 - [I use a framework (like Vue) that requires custom file extensions, and I get errors like "You should add `parserOptions.extraFileExtensions` to your config"](#i-use-a-framework-like-vue-that-requires-custom-file-extensions-and-i-get-errors-like-you-should-add-parseroptionsextrafileextensions-to-your-config)
 - [I am using a rule from ESLint core, and it doesn't work correctly with TypeScript code](#i-am-using-a-rule-from-eslint-core-and-it-doesnt-work-correctly-with-typescript-code)
 - [One of my lint rules isn't working correctly on a pure JavaScript file](#one-of-my-lint-rules-isnt-working-correctly-on-a-pure-javascript-file)
-- [TypeScript should be installed globally](#typescript-should-be-installed-globally)
+- [TypeScript should be installed locally](#typescript-should-be-installed-locally)
 
 ---
 
@@ -121,7 +121,7 @@ If you have some pure JavaScript code that you do not want to apply certain lint
 
 ---
 
-## TypeScript should be installed globally
+## TypeScript should be installed locally
 
 Make sure that you have installed TypeScript locally i.e. by using `npm install typescript`, not `npm install -g typescript`,
 or by using `yarn add typescript`, not `yarn global add typescript`. See https://github.com/typescript-eslint/typescript-eslint/issues/2041 for more information.

--- a/docs/getting-started/linting/FAQ.md
+++ b/docs/getting-started/linting/FAQ.md
@@ -117,3 +117,13 @@ If you don't find an existing extension rule, or the extension rule doesn't work
 This is to be expected - ESLint rules do not check file extensions on purpose, as it causes issues in environments that use non-standard extensions (for example, a `.vue` and a `.md` file can both contain TypeScript code to be linted).
 
 If you have some pure JavaScript code that you do not want to apply certain lint rules to, then you can use [ESLint's `overrides` configuration](https://eslint.org/docs/user-guide/configuring#configuration-based-on-glob-patterns) to turn off certain rules, or even change the parser based on glob patterns.
+
+
+
+
+----
+
+## TypeScript should be installed globally
+
+Make sure that you have installed TypeScript locally i.e. by using `npm install typescript`, not `npm install -g typescript`,
+or by using `yarn add typescript`, not `yarn global add typescript`. See https://github.com/typescript-eslint/typescript-eslint/issues/2041 for more information.


### PR DESCRIPTION
On https://eslint.org/docs/user-guide/getting-started there is information that ESLint should be installed locally: "It is also possible to install ESLint globally rather than locally (using npm install eslint --global). However, this is not recommended, and any plugins or shareable configs that you use must be installed locally in either case."

But, I have not found anywhere information that TypeScript must be installed locally for ESLint to work. It took me several hours to figure it out. Such information would be very user friendly especially for novices.

See https://github.com/typescript-eslint/typescript-eslint/issues/2041