### PR TITLE
fix(typescript-estree): mark TS 3.8 and 3.9 as "supported"

### DIFF
--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -20,7 +20,7 @@ const log = debug('typescript-eslint:typescript-estree:parser');
  * This needs to be kept in sync with the top-level README.md in the
  * typescript-eslint monorepo
  */
-const SUPPORTED_TYPESCRIPT_VERSIONS = '>=3.3.1 <3.8.0';
+const SUPPORTED_TYPESCRIPT_VERSIONS = '>=3.3.1 <3.10.0';
 /*
  * The semver package will ignore prerelease ranges, and we don't want to explicitly document every one
  * List them all separately here, so we can automatically create the full string


### PR DESCRIPTION
3.8 isn't truly supported yet (#1436), but it will work fine - just can't lint private fields.
We _want_ people to upgrade as 3.9 is much better and faster!

So this increases the version range so 3.8 and 3.9 will stop logging the unsupported warning.
#1436 is pinned in our issues, so that's about as good as we can do.