### PR TITLE
docs: be more explicit about the relation to typescript and tsc

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The documentation below will give you an overview of what this project is, why i
 
 - Behind the scenes, it uses a parser to turn your source code into a data format called an Abstract Syntax Tree (AST). This data format is then used by plugins to create assertions called lint rules around what your code should look or behave like.
 
-**TypeScript** is an awesome static code analyzer for JavaScript code, and some additional syntax that it provides on top of the underlying JavaScript language.
+**TypeScript Compiler** is an awesome static code analyzer for JavaScript code, and some additional syntax that TypeScript provides on top of the underlying JavaScript language.
 
 - Behind the scenes, it uses a parser to turn your source code into a data format called an Abstract Syntax Tree (AST). This data format is then used by other parts of the TypeScript Compiler to do things like give you feedback on issues, allow you to refactor easily, etc.
 
@@ -64,9 +64,9 @@ They sound similar, right? They are! Both projects are ultimately striving to he
 
 ## Why does this project exist?
 
-As covered by the previous section, both ESLint and TypeScript rely on turning your source code into a data format called an AST in order to do their jobs.
+As covered by the previous section, both ESLint and the TypeScript Compiler rely on turning your source code into a data format called an AST in order to do their jobs.
 
-However, it turns out that ESLint and TypeScript use _different_ ASTs to each other.
+However, it turns out that ESLint and the TypeScript Compiler use _different_ ASTs to each other.
 
 The reason for this difference is not so interesting or important and is simply the result of different evolutions, priorities, and timelines of the projects.
 
@@ -120,7 +120,7 @@ The great thing is, though, if we want to support non-standard JavaScript syntax
 
 Knowing we can do this is just the start, of course, we then need to set about creating a parser which is capable of parsing TypeScript source code, and delivering an AST which is compatible with the one ESLint expects (with some additions for things such as `: number`, as mentioned above).
 
-The [`@typescript-eslint/parser`](./packages/parser/) package in this monorepo is, in fact, the custom ESLint parser implementation we provide to ESLint in this scenario.
+The [`@typescript-eslint/parser`](./packages/parser/) package in this monorepo is, in fact, the custom parser (implemented on top of the TypeScript Compiler) we provide to ESLint in this scenario.
 
 The flow and transformations that happen look a little something like this:
 
@@ -161,7 +161,7 @@ Yes!
 
 One of the huge benefits of using TypeScript is the fact that type information can be used to assert expected behaviors.
 
-When the transformation steps outlined above take place, we keep references to the original TypeScript AST and associated parser services, and so ESLint rules authors can access them in their rules.
+When the transformation steps outlined above take place, we keep references to the original TypeScript AST and associated TypeScript Compiler services, and so ESLint rules authors can access them in their rules. This includes the possibility to ask the compiler to infer and check the type of any piece of code.
 
 We already do this in numerous rules within [`@typescript-eslint/eslint-plugin`](./packages/eslint-plugin/), for example, `no-unnecessary-type-assertion` and `no-inferrable-types`.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 
 ## Getting Started / Installation
 
+This project, `typescript-eslint`, is a collection of packages that add TypeScript language support to ESLint. You can see the list of packages [below](#packages-included-in-this-project). Under the hood, `typescript-eslint` uses the TypeScript Compiler for parsing and optionally for type inference.
+
 - **[You can find our Getting Started docs here](./docs/getting-started/README.md):**
   - **[I want to lint my TypeScript codebase.](./docs/getting-started/linting/README.md)**
   - **[I want linting to use type information.](./docs/getting-started/linting/TYPED_LINTING.md)**

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@
 
 ## Getting Started / Installation
 
-- **[You can find our Getting Started docs here](./docs/getting-started/README.md)**
+- **[You can find our Getting Started docs here](./docs/getting-started/README.md):**
+  - **[I want to lint my TypeScript codebase.](./docs/getting-started/linting/README.md)**
+  - **[I want linting to use type information.](./docs/getting-started/linting/TYPED_LINTING.md)**
+  - **[(TODO) I want to write an ESLint plugin in TypeScript.](./docs/getting-started/plugin-development/README.md)**
 - **[You can find our Linting FAQ / Troubleshooting docs here](./docs/getting-started/linting/FAQ.md)**
 
 The documentation below will give you an overview of what this project is, why it exists and how it works at a high level.

--- a/docs/getting-started/linting/README.md
+++ b/docs/getting-started/linting/README.md
@@ -7,7 +7,7 @@ Whether you're adding linting to a new TypeScript codebase, adding TypeScript to
 First step is to make sure you've got the required packages installed:
 
 ```bash
-$ yarn add -D eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin
+$ yarn add -D eslint typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin
 ```
 
 ## Configuration

--- a/docs/getting-started/linting/TYPED_LINTING.md
+++ b/docs/getting-started/linting/TYPED_LINTING.md
@@ -1,6 +1,6 @@
 # Getting Started - Linting with Type Information
 
-The parser you configured earlier has a little secret. Under the hood, it actually just uses TypeScript's compiler APIs to parse the files. This means that we can provide lint rules with access to all of the type information that TypeScript knows about your codebase.
+The parser you configured earlier has a little secret. Under the hood, it actually just uses the APIs of the TypeScript Compiler to parse the files. This means that we can provide lint rules with access to all of the type information that TypeScript can infer about your codebase.
 
 This provides a lot of additional power, unlocking many possibilities for static analysis.
 
@@ -36,7 +36,7 @@ With that done, simply run the same lint command you ran before. You will see ne
 
 _But wait_ - I hear you exclaim - _why would you ever not want type-aware rules?_
 
-Well (for full disclosure) there is a catch; by including `parserOptions.project` in your config, you are essentially asking TypeScript to do a build of your project before ESLint can do its linting. For small projects this takes a negligible amount of time (a few seconds); for large projects, it can take longer (30s or more).
+Well (for full disclosure) there is a catch; by including `parserOptions.project` in your config, you are essentially asking the TypeScript Compiler to do a build of your project before ESLint can do its linting. For small projects this takes a negligible amount of time (a few seconds); for large projects, it can take longer (30s or more).
 
 Most of our users are fine with this, as they think the power of type-aware static analysis is worth it.
 Additionally, most users primarily consume lint errors via IDE plugins which, through some caching magic, do not suffer the same penalties. This means that generally they usually only run a complete lint before a push, or via their CI, where the extra time really doesn't matter.

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -19,15 +19,15 @@ These docs walk you through setting up ESLint, this plugin, and our parser. If y
 
 ### Installation
 
-Make sure you have TypeScript and [`@typescript-eslint/parser`](../parser) installed, then install the plugin:
+Make sure you have TypeScript, [`@typescript-eslint/parser`](../parser) and the plugin installed:
 
 ```sh
-yarn add -D @typescript-eslint/eslint-plugin
+yarn add -D typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin
 ```
 
 It is important that you use the same version number for `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin`.
 
-**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `@typescript-eslint/eslint-plugin` globally.
+**Note:** If you installed ESLint and TypeScript globally (using the `-g` flag) then you must also install `@typescript-eslint/eslint-plugin` globally.
 
 ### Usage
 

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -21,7 +21,7 @@ These docs walk you through setting up ESLint, this parser, and our plugin. If y
 ### Installation
 
 ```sh
-yarn add -D @typescript-eslint/parser
+yarn add -D typescript @typescript-eslint/parser
 ```
 
 ### Usage

--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -24,7 +24,7 @@ In fact, it is already used within these hyper-popular open-source projects to p
 ## Installation
 
 ```sh
-yarn add -D @typescript-eslint/typescript-estree
+yarn add -D typescript @typescript-eslint/typescript-estree
 ```
 
 ## API


### PR DESCRIPTION
This is my first stab at clarifying the documentation with some of the information from the discussion at #2051.

Let me know if you have a different direction in mind for the documentation. To me, it looks like some of the sections in the README have become more of historical interest and could be moved to the FAQ or elsewhere as TypeScript awareness has exploded since typescript-eslint's early days.