### PR TITLE
fix(eslint-plugin): [explicit-module-boundary-types] don't check returned functions if parent function has return type

### DIFF
--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -390,6 +390,7 @@ function ancestorHasReturnType(
     ancestor = ancestor.parent;
   }
 
+  /* istanbul ignore next */
   return false;
 }
 

--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -366,34 +366,31 @@ function ancestorHasReturnType(
   ancestor: TSESTree.Node | undefined,
   options: Options,
 ): boolean {
+  // Exit early if this ancestor is not a ReturnStatement.
+  if (ancestor?.type !== AST_NODE_TYPES.ReturnStatement) {
+    return false;
+  }
+
   // This boolean tells the `isValidFunctionReturnType` that it is being called
   // by an ancestor check.
   const isParentCheck = true;
-
-  // Has a valid type been found in any of the ancestors.
-  let hasType = false;
 
   while (ancestor) {
     switch (ancestor.type) {
       case AST_NODE_TYPES.ArrowFunctionExpression:
       case AST_NODE_TYPES.FunctionExpression:
-        hasType =
+        return (
           isValidFunctionExpressionReturnType(ancestor, options) ||
-          isValidFunctionReturnType(ancestor, options, isParentCheck);
-        break;
+          isValidFunctionReturnType(ancestor, options, isParentCheck)
+        );
       case AST_NODE_TYPES.FunctionDeclaration:
-        hasType = isValidFunctionReturnType(ancestor, options, isParentCheck);
-        break;
-    }
-
-    if (hasType) {
-      return hasType;
+        return isValidFunctionReturnType(ancestor, options, isParentCheck);
     }
 
     ancestor = ancestor.parent;
   }
 
-  return hasType;
+  return false;
 }
 
 export {

--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -240,31 +240,8 @@ interface Options {
 }
 
 /**
- * Checks if a function declaration/expression has a return type.
+ * True when the provided function expression is typed.
  */
-function checkFunctionReturnType(
-  node:
-    | TSESTree.ArrowFunctionExpression
-    | TSESTree.FunctionDeclaration
-    | TSESTree.FunctionExpression,
-  options: Options,
-  sourceCode: TSESLint.SourceCode,
-  report: (loc: TSESTree.SourceLocation) => void,
-): void {
-  if (
-    options.allowHigherOrderFunctions &&
-    doesImmediatelyReturnFunctionExpression(node)
-  ) {
-    return;
-  }
-
-  if (node.returnType || isConstructor(node.parent) || isSetter(node.parent)) {
-    return;
-  }
-
-  report(getReporLoc(node, sourceCode));
-}
-
 function isTypedFunctionExpression(
   node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
   options: Options,
@@ -286,16 +263,15 @@ function isTypedFunctionExpression(
 }
 
 /**
- * Checks if a function declaration/expression has a return type.
+ * Check whether the function expression return type is either typed or valid
+ * with the provided options.
  */
-function checkFunctionExpressionReturnType(
+function isValidFunctionExpressionReturnType(
   node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
   options: Options,
-  sourceCode: TSESLint.SourceCode,
-  report: (loc: TSESTree.SourceLocation) => void,
-): void {
+): boolean {
   if (isTypedFunctionExpression(node, options)) {
-    return;
+    return true;
   }
 
   const parent = nullThrows(node.parent, NullThrowsReasons.MissingParent);
@@ -306,7 +282,7 @@ function checkFunctionExpressionReturnType(
     parent.type !== AST_NODE_TYPES.ExportDefaultDeclaration &&
     parent.type !== AST_NODE_TYPES.ClassProperty
   ) {
-    return;
+    return true;
   }
 
   // https://github.com/typescript-eslint/typescript-eslint/issues/653
@@ -315,14 +291,114 @@ function checkFunctionExpressionReturnType(
     node.type === AST_NODE_TYPES.ArrowFunctionExpression &&
     returnsConstAssertionDirectly(node)
   ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Check that the function expression or declaration is valid.
+ */
+function isValidFunctionReturnType(
+  node:
+    | TSESTree.ArrowFunctionExpression
+    | TSESTree.FunctionDeclaration
+    | TSESTree.FunctionExpression,
+  options: Options,
+  isParentCheck = false,
+): boolean {
+  if (
+    !isParentCheck &&
+    options.allowHigherOrderFunctions &&
+    doesImmediatelyReturnFunctionExpression(node)
+  ) {
+    return true;
+  }
+
+  if (node.returnType || isConstructor(node.parent) || isSetter(node.parent)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Checks if a function declaration/expression has a return type.
+ */
+function checkFunctionReturnType(
+  node:
+    | TSESTree.ArrowFunctionExpression
+    | TSESTree.FunctionDeclaration
+    | TSESTree.FunctionExpression,
+  options: Options,
+  sourceCode: TSESLint.SourceCode,
+  report: (loc: TSESTree.SourceLocation) => void,
+): void {
+  if (isValidFunctionReturnType(node, options)) {
+    return;
+  }
+
+  report(getReporLoc(node, sourceCode));
+}
+
+/**
+ * Checks if a function declaration/expression has a return type.
+ */
+function checkFunctionExpressionReturnType(
+  node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+  options: Options,
+  sourceCode: TSESLint.SourceCode,
+  report: (loc: TSESTree.SourceLocation) => void,
+): void {
+  if (isValidFunctionExpressionReturnType(node, options)) {
     return;
   }
 
   checkFunctionReturnType(node, options, sourceCode, report);
 }
 
+/**
+ * Check whether any ancestor of the provided node has a valid return type, with
+ * the given options.
+ */
+function ancestorHasReturnType(
+  ancestor: TSESTree.Node | undefined,
+  options: Options,
+): boolean {
+  // This boolean tells the `isValidFunctionReturnType` that it is being called
+  // by an ancestor check.
+  const isParentCheck = true;
+
+  // Has a valid type been found in any of the ancestors.
+  let hasType = false;
+
+  while (ancestor) {
+    switch (ancestor.type) {
+      case AST_NODE_TYPES.ArrowFunctionExpression:
+      case AST_NODE_TYPES.FunctionExpression:
+        hasType =
+          isValidFunctionExpressionReturnType(ancestor, options) ||
+          isValidFunctionReturnType(ancestor, options, isParentCheck);
+        break;
+      case AST_NODE_TYPES.FunctionDeclaration:
+        hasType = isValidFunctionReturnType(ancestor, options, isParentCheck);
+        break;
+    }
+
+    if (hasType) {
+      return hasType;
+    }
+
+    ancestor = ancestor.parent;
+  }
+
+  return hasType;
+}
+
 export {
   checkFunctionReturnType,
   checkFunctionExpressionReturnType,
   isTypedFunctionExpression,
+  ancestorHasReturnType,
 };

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -437,6 +437,89 @@ export default { Foo };
       `,
       options: [{ shouldTrackReferences: true }],
     },
+    {
+      code: `
+export function foo(): (n: number) => string {
+  return n => String(n);
+}
+      `,
+    },
+    {
+      code: `
+export const foo = (a: string): ((n: number) => string) => {
+  return function (n) {
+    return String(n);
+  };
+};
+      `,
+    },
+    {
+      code: `
+export function a(): void {
+  function b() {}
+  const x = () => {};
+  (function () {});
+
+  function c() {
+    return () => {};
+  }
+
+  return;
+}
+      `,
+    },
+    {
+      code: `
+export function a(): void {
+  function b() {
+    function c() {}
+  }
+  const x = () => {
+    return () => 100;
+  };
+  (function () {
+    (function () {});
+  });
+
+  function c() {
+    return () => {
+      (function () {});
+    };
+  }
+
+  return;
+}
+      `,
+    },
+    {
+      code: `
+export function a() {
+  return function b(): () => void {
+    return function c() {};
+  };
+}
+      `,
+      options: [{ allowHigherOrderFunctions: true }],
+    },
+    {
+      code: `
+export var arrowFn = () => (): void => {};
+      `,
+    },
+    {
+      code: `
+export function fn() {
+  return function (): void {};
+}
+      `,
+    },
+    {
+      code: `
+export function foo(outer: string) {
+  return function (inner: string): void {};
+}
+      `,
+    },
   ],
   invalid: [
     {
@@ -1277,6 +1360,71 @@ export default test;
         {
           messageId: 'missingArgType',
           line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+export const foo = () => (a: string): ((n: number) => string) => {
+  return function (n) {
+    return String(n);
+  };
+};
+      `,
+      options: [{ allowHigherOrderFunctions: false }],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          column: 20,
+        },
+      ],
+    },
+    {
+      code: `
+export var arrowFn = () => () => {};
+      `,
+      options: [{ allowHigherOrderFunctions: true }],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          column: 28,
+        },
+      ],
+    },
+    {
+      code: `
+export function fn() {
+  return function () {};
+}
+      `,
+      options: [{ allowHigherOrderFunctions: true }],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          column: 10,
+        },
+      ],
+    },
+    {
+      code: `
+export function foo(outer) {
+  return function (inner): void {};
+}
+      `,
+      options: [{ allowHigherOrderFunctions: true }],
+      errors: [
+        {
+          messageId: 'missingArgType',
+          line: 2,
+          column: 8,
+        },
+        {
+          messageId: 'missingArgType',
+          line: 3,
+          column: 10,
         },
       ],
     },


### PR DESCRIPTION
## Description

Version 3.0.0 of the plugin enabled `explicit-module-boundary-types` by default. Unfortunately it doesn't currently handle the case where the parent function has a type signature. The following correct code produces an error. 

```ts
export const foo = (a: string): (n: number) => string => {
  return (n) => String(n)
}
```

This fixes the problem by checking the parent nodes of exported declarations to see if they are already typed. If they are typed it doesn't show the error for child functions.

Fixes #1845