### PR TITLE
fix(eslint-plugin): [unbound-method] fix crash due to missing `Intl`

### DIFF
--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -82,6 +82,11 @@ const SUPPORTED_GLOBALS = [
   'Intl',
 ] as const;
 const nativelyBoundMembers = SUPPORTED_GLOBALS.map(namespace => {
+  if (!(namespace in global)) {
+    // node.js might not have namespaces like Intl depending on compilation options
+    // https://nodejs.org/api/intl.html#intl_options_for_building_node_js
+    return [];
+  }
   const object = global[namespace];
   return Object.getOwnPropertyNames(object)
     .filter(


### PR DESCRIPTION
When Node.js is compiled with the "--with-intl=none" option ( https://nodejs.org/api/intl.html#intl_options_for_building_node_js ) it will not have the Intl global. This rule however does expect all SUPPORTED_GLOBALS including Intl to always exist. As a result, any attempt to run eslint would result in an error like:
```
TypeError: Failed to load plugin '@typescript-eslint' declared in '.eslintrc.js': Cannot convert undefined or null to object
Referenced from: /home/dev/web/.eslintrc.js
    at Function.getOwnPropertyNames (<anonymous>)
    at /home/dev/web/node_modules/@typescript-eslint/eslint-plugin/dist/rules/unbound-method.js:91:19
```
We can silently ignore missing globals as a workaround.