### PR TITLE
docs: broken markdown link in Contributing Guide in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,6 @@ Support this project with your organization. Your logo will show up here with a 
   <img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" />
 </a>
 
-## Contributing
+## Contributing Guide
 
 [See the contributing guide here](./CONTRIBUTING.md)


### PR DESCRIPTION
presently, on https://github.com/typescript-eslint/typescript-eslint#contributing-guide if you click `Contributing Guide` in the table of contents at the top, it's broken because in https://github.com/typescript-eslint/typescript-eslint/commit/2b16019426b8f97b97796c6cd4ea3a20fd44ebb9#diff-04c6e90faac2675aa89e2176d2eec7d8L300 it was changed from `Contributing Guide` to `Contributing` without the TOC link being updated.

Corrected demo (from this PR) here https://github.com/typescript-eslint/typescript-eslint/blob/309a423e41b0c1f72d00c48f6d33f27a8940e04b/README.md#contributing-guide