### PR TITLE
fix(experimental-utils): Do not re-export 'ESLint'

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/index.ts
+++ b/packages/experimental-utils/src/ts-eslint/index.ts
@@ -1,6 +1,5 @@
 export * from './AST';
 export * from './CLIEngine';
-export * from './ESLint';
 export * from './Linter';
 export * from './ParserOptions';
 export * from './Rule';


### PR DESCRIPTION
Closes #2100.