### PR TITLE
docs: include npm install instructions in getting started

### DIFF
--- a/docs/getting-started/linting/README.md
+++ b/docs/getting-started/linting/README.md
@@ -7,7 +7,13 @@ Whether you're adding linting to a new TypeScript codebase, adding TypeScript to
 First step is to make sure you've got the required packages installed:
 
 ```bash
-$ yarn add -D eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin
+$ ] add -D eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin
+```
+
+or with NPM:
+
+```bash
+$ npm i --save=dev eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin
 ```
 
 ## Configuration
@@ -70,6 +76,12 @@ With that configured, open a terminal to the root of your project, and run the f
 
 ```bash
 $ yarn eslint . --ext .js,.jsx,.ts,.tsx
+```
+
+or with NPM:
+
+```bash
+$ npx eslint . --ext .js,.jsx,.ts,.tsx
 ```
 
 That's it - ESLint will lint all `.js`, `.jsx`, `.ts`, and `.tsx` files within the current folder, and will output the results to your terminal.

--- a/docs/getting-started/linting/README.md
+++ b/docs/getting-started/linting/README.md
@@ -7,7 +7,7 @@ Whether you're adding linting to a new TypeScript codebase, adding TypeScript to
 First step is to make sure you've got the required packages installed:
 
 ```bash
-$ ] add -D eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin
+$ yarn add -D eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin
 ```
 
 or with NPM:


### PR DESCRIPTION
This PR adds NPM commands for installing and running typescript-eslint with the NPM package manager.