### PR TITLE
fix(eslint-plugin): [no-unused-expressions] ignore import expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-expressions.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-expressions.ts
@@ -26,7 +26,8 @@ export default util.createRule<Options, MessageIds>({
       ExpressionStatement(node): void {
         if (
           node.directive ||
-          node.expression.type === AST_NODE_TYPES.OptionalCallExpression
+          node.expression.type === AST_NODE_TYPES.OptionalCallExpression ||
+          node.expression.type === AST_NODE_TYPES.ImportExpression
         ) {
           return;
         }

--- a/packages/eslint-plugin/tests/rules/no-unused-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-expressions.test.ts
@@ -65,6 +65,12 @@ ruleTester.run('no-unused-expressions', rule, {
         return null;
       }
     `,
+    `
+      import('./foo');
+    `,
+    `
+      import('./foo').then(() => {});
+    `,
   ],
   invalid: [
     {

--- a/packages/typescript-estree/src/ts-estree/ts-estree.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-estree.ts
@@ -359,7 +359,8 @@ export type Expression =
   | SpreadElement
   | TSAsExpression
   | TSUnaryExpression
-  | YieldExpression;
+  | YieldExpression
+  | ImportExpression;
 export type ExpressionWithTypeArguments =
   | TSClassImplements
   | TSInterfaceHeritage;


### PR DESCRIPTION
Fixes #2108 