### PR TITLE
fix(eslint-plugin): [no-unused-vars-experimental] handle processable private accessors

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-vars-experimental.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars-experimental.ts
@@ -149,6 +149,8 @@ export default util.createRule<Options, MessageIds>({
           report('Interface');
           break;
 
+        case ts.SyntaxKind.GetAccessor:
+        case ts.SyntaxKind.SetAccessor:
         case ts.SyntaxKind.MethodDeclaration:
           report('Method');
           break;


### PR DESCRIPTION
# What is this PR?
If `no-unused-vars-experimental` rule found private get/set accessor in class, throw 
`Error: Unknown node with kind 162/163.`
because of accessor is not treated correctly.

So this pr fix that problems.

# Reproduce

## package.json
```json
{
  "name": "project",
  "version": "1.0.0",
  "description": "",
  "main": "",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "devDependencies": {
    "@typescript-eslint/eslint-plugin": "^3.0.2",
    "@typescript-eslint/parser": "^3.0.2",
    "@typescript-eslint/typescript-estree": "^3.0.2",
    "eslint": "^7.1.0",
    "typescript": "^3.9.3"
  }
}
```

## .eslintrc.js
```javascript
module.exports = {
  root: true,
  plugins: ['@typescript-eslint'],
  rules: {
    '@typescript-eslint/no-unused-vars-experimental': [
      'error',
      {
        ignoreArgsIfArgsAfterAreUsed: true,
        ignoredNamesRegex: '^unused'
      }
    ]
  },
  parser: '@typescript-eslint/parser',
  parserOptions: {
    project: './tsconfig.json',
  }
}
```

## Project structure
```
project +
        |
        + - package.json
        | 
        + - .eslintrc.js
        | 
        +- src
             |
             +- a.ts
```

## a.ts
```typescript
class Test {
  private get name() {
    return "test";
  }
}
```

## Command
```
npx eslint --fix --max-warnings 0 'src/a.ts'
```

## Error message
```
➜ npx eslint --fix --max-warnings 0 'src/a.ts'

Oops! Something went wrong! :(

ESLint: 7.1.0

Error: Unknown node with kind 163.
Occurred while linting /private/tmp/project/src/a.ts:1
    at handleIdentifier (/private/tmp/project/node_modules/@typescript-eslint/eslint-plugin/dist/rules/no-unused-vars-experimental.js:163:27)
    at /private/tmp/project/node_modules/@typescript-eslint/eslint-plugin/dist/rules/no-unused-vars-experimental.js:266:33
    at Array.forEach (<anonymous>)
    at Program:exit (/private/tmp/project/node_modules/@typescript-eslint/eslint-plugin/dist/rules/no-unused-vars-experimental.js:260:29)
    at /private/tmp/project/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/private/tmp/project/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/private/tmp/project/node_modules/eslint/lib/linter/node-event-generator.js:254:26)
    at NodeEventGenerator.applySelectors (/private/tmp/project/node_modules/eslint/lib/linter/node-event-generator.js:283:22)
    at NodeEventGenerator.leaveNode (/private/tmp/project/node_modules/eslint/lib/linter/node-event-generator.js:306:14)
```
