### PR TITLE
feat(eslint-plugin): [explicit-module-boundary-types] improve accuracy and coverage

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,17 @@
       ],
       "sourceMaps": true,
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "skipFiles": [
+        "${workspaceFolder}/packages/experimental-utils/src/index.ts",
+        "${workspaceFolder}/packages/experimental-utils/dist/index.js",
+        "${workspaceFolder}/packages/experimental-utils/src/ts-estree.ts",
+        "${workspaceFolder}/packages/experimental-utils/dist/ts-estree.js",
+        "${workspaceFolder}/packages/parser/src/index.ts",
+        "${workspaceFolder}/packages/parser/dist/index.js",
+        "${workspaceFolder}/packages/typescript-estree/src/index.ts",
+        "${workspaceFolder}/packages/typescript-estree/dist/index.js",
+      ],
     },
     {
       "type": "node",
@@ -34,7 +44,17 @@
       ],
       "sourceMaps": true,
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "skipFiles": [
+        "${workspaceFolder}/packages/experimental-utils/src/index.ts",
+        "${workspaceFolder}/packages/experimental-utils/dist/index.js",
+        "${workspaceFolder}/packages/experimental-utils/src/ts-estree.ts",
+        "${workspaceFolder}/packages/experimental-utils/dist/ts-estree.js",
+        "${workspaceFolder}/packages/parser/src/index.ts",
+        "${workspaceFolder}/packages/parser/dist/index.js",
+        "${workspaceFolder}/packages/typescript-estree/src/index.ts",
+        "${workspaceFolder}/packages/typescript-estree/dist/index.js",
+      ],
     },
     {
       "type": "node",
@@ -50,7 +70,17 @@
       ],
       "sourceMaps": true,
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "skipFiles": [
+        "${workspaceFolder}/packages/experimental-utils/src/index.ts",
+        "${workspaceFolder}/packages/experimental-utils/dist/index.js",
+        "${workspaceFolder}/packages/experimental-utils/src/ts-estree.ts",
+        "${workspaceFolder}/packages/experimental-utils/dist/ts-estree.js",
+        "${workspaceFolder}/packages/parser/src/index.ts",
+        "${workspaceFolder}/packages/parser/dist/index.js",
+        "${workspaceFolder}/packages/typescript-estree/src/index.ts",
+        "${workspaceFolder}/packages/typescript-estree/dist/index.js",
+      ],
     },
     {
       "type": "node",
@@ -66,7 +96,17 @@
       ],
       "sourceMaps": true,
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "skipFiles": [
+        "${workspaceFolder}/packages/experimental-utils/src/index.ts",
+        "${workspaceFolder}/packages/experimental-utils/dist/index.js",
+        "${workspaceFolder}/packages/experimental-utils/src/ts-estree.ts",
+        "${workspaceFolder}/packages/experimental-utils/dist/ts-estree.js",
+        "${workspaceFolder}/packages/parser/src/index.ts",
+        "${workspaceFolder}/packages/parser/dist/index.js",
+        "${workspaceFolder}/packages/typescript-estree/src/index.ts",
+        "${workspaceFolder}/packages/typescript-estree/dist/index.js",
+      ],
     },
     {
       "type": "node",
@@ -82,7 +122,17 @@
       ],
       "sourceMaps": true,
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "skipFiles": [
+        "${workspaceFolder}/packages/experimental-utils/src/index.ts",
+        "${workspaceFolder}/packages/experimental-utils/dist/index.js",
+        "${workspaceFolder}/packages/experimental-utils/src/ts-estree.ts",
+        "${workspaceFolder}/packages/experimental-utils/dist/ts-estree.js",
+        "${workspaceFolder}/packages/parser/src/index.ts",
+        "${workspaceFolder}/packages/parser/dist/index.js",
+        "${workspaceFolder}/packages/typescript-estree/src/index.ts",
+        "${workspaceFolder}/packages/typescript-estree/dist/index.js",
+      ],
     }
   ]
 }

--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -7,10 +7,10 @@ import {
 import { isTypeAssertion, isConstructor, isSetter } from './astUtils';
 import { nullThrows, NullThrowsReasons } from './nullThrows';
 
-type FunctionNode =
+type FunctionExpression =
   | TSESTree.ArrowFunctionExpression
-  | TSESTree.FunctionDeclaration
   | TSESTree.FunctionExpression;
+type FunctionNode = FunctionExpression | TSESTree.FunctionDeclaration;
 
 /**
  * Creates a report location for the given function.
@@ -158,10 +158,7 @@ function isPropertyOfObjectWithType(
  */
 function doesImmediatelyReturnFunctionExpression({
   body,
-}:
-  | TSESTree.ArrowFunctionExpression
-  | TSESTree.FunctionDeclaration
-  | TSESTree.FunctionExpression): boolean {
+}: FunctionNode): boolean {
   // Should always have a body; really checking just in case
   /* istanbul ignore if */ if (!body) {
     return false;
@@ -196,7 +193,7 @@ function doesImmediatelyReturnFunctionExpression({
  */
 function isFunctionArgument(
   parent: TSESTree.Node,
-  callee?: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+  callee?: FunctionExpression,
 ): parent is TSESTree.CallExpression | TSESTree.OptionalCallExpression {
   return (
     (parent.type === AST_NODE_TYPES.CallExpression ||
@@ -243,7 +240,7 @@ interface Options {
  * True when the provided function expression is typed.
  */
 function isTypedFunctionExpression(
-  node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+  node: FunctionExpression,
   options: Options,
 ): boolean {
   const parent = nullThrows(node.parent, NullThrowsReasons.MissingParent);
@@ -267,7 +264,7 @@ function isTypedFunctionExpression(
  * with the provided options.
  */
 function isValidFunctionExpressionReturnType(
-  node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+  node: FunctionExpression,
   options: Options,
 ): boolean {
   if (isTypedFunctionExpression(node, options)) {
@@ -301,10 +298,7 @@ function isValidFunctionExpressionReturnType(
  * Check that the function expression or declaration is valid.
  */
 function isValidFunctionReturnType(
-  node:
-    | TSESTree.ArrowFunctionExpression
-    | TSESTree.FunctionDeclaration
-    | TSESTree.FunctionExpression,
+  node: FunctionNode,
   options: Options,
   isParentCheck = false,
 ): boolean {
@@ -327,10 +321,7 @@ function isValidFunctionReturnType(
  * Checks if a function declaration/expression has a return type.
  */
 function checkFunctionReturnType(
-  node:
-    | TSESTree.ArrowFunctionExpression
-    | TSESTree.FunctionDeclaration
-    | TSESTree.FunctionExpression,
+  node: FunctionNode,
   options: Options,
   sourceCode: TSESLint.SourceCode,
   report: (loc: TSESTree.SourceLocation) => void,
@@ -346,7 +337,7 @@ function checkFunctionReturnType(
  * Checks if a function declaration/expression has a return type.
  */
 function checkFunctionExpressionReturnType(
-  node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+  node: FunctionExpression,
   options: Options,
   sourceCode: TSESLint.SourceCode,
   report: (loc: TSESTree.SourceLocation) => void,
@@ -395,8 +386,11 @@ function ancestorHasReturnType(
 }
 
 export {
-  checkFunctionReturnType,
-  checkFunctionExpressionReturnType,
-  isTypedFunctionExpression,
   ancestorHasReturnType,
+  checkFunctionExpressionReturnType,
+  checkFunctionReturnType,
+  doesImmediatelyReturnFunctionExpression,
+  FunctionExpression,
+  FunctionNode,
+  isTypedFunctionExpression,
 };

--- a/packages/experimental-utils/src/ts-eslint/Scope.ts
+++ b/packages/experimental-utils/src/ts-eslint/Scope.ts
@@ -81,7 +81,11 @@ namespace Scope {
         node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpression;
         parent: null;
       }
-    | { type: 'ImplicitGlobalVariable'; node: TSESTree.Program; parent: null }
+    | {
+        type: 'ImplicitGlobalVariable';
+        node: TSESTree.Program;
+        parent: null;
+      }
     | {
         type: 'ImportBinding';
         node:
@@ -98,7 +102,6 @@ namespace Scope {
           | TSESTree.ArrowFunctionExpression;
         parent: null;
       }
-    | { type: 'TDZ'; node: unknown; parent: null }
     | {
         type: 'Variable';
         node: TSESTree.VariableDeclarator;


### PR DESCRIPTION
This is a large refactor of the code so that it only checks the functions that should be checked.
Fixes #2134

Also added an option `allowArgumentsExplicitlyTypedAsAny`  in case for some reason users want to allow explicit `any`s for argument types
Fixes #2119

Finally, this soft removes the `shouldTrackReferences` option. There's no reason you wouldn't want this set to true, because otherwise there are just a lot of cases it will miss.