### PR TITLE
feat(eslint-plugin): [ban-types] allow selective disable of default options with `false` value

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -14,6 +14,7 @@ Note that it does not ban the corresponding runtime objects from being used.
 type Options = {
   types?: {
     [typeName: string]:
+      | false
       | string
       | {
           message: string;
@@ -28,7 +29,7 @@ The rule accepts a single object as options, with the following keys:
 
 - `types` - An object whose keys are the types you want to ban, and the values are error messages.
   - The type can either be a type name literal (`Foo`), a type name with generic parameter instantiation(s) (`Foo<Bar>`), or the empty object literal (`{}`).
-  - The values can be a string, which is the error message to be reported,
+  - The values can be a string, which is the error message to be reported, `false` to specifically disable this type
     or it can be an object with the following properties:
     - `message: string` - the message to display when the type is matched.
     - `fixWith?: string` - a string to replace the banned type with when the fixer is run. If this is omitted, no fix will be done.

--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -7,8 +7,9 @@ import * as util from '../util';
 
 type Types = Record<
   string,
-  | string
   | null
+  | false
+  | string
   | {
       message: string;
       fixWith?: string;
@@ -138,6 +139,7 @@ export default util.createRule<Options, MessageIds>({
             additionalProperties: {
               oneOf: [
                 { type: 'null' },
+                { type: 'boolean' },
                 { type: 'string' },
                 {
                   type: 'object',
@@ -177,23 +179,25 @@ export default util.createRule<Options, MessageIds>({
     ): void {
       const bannedType = bannedTypes.get(name);
 
-      if (bannedType !== undefined) {
-        const customMessage = getCustomMessage(bannedType);
-        const fixWith =
-          bannedType && typeof bannedType === 'object' && bannedType.fixWith;
-
-        context.report({
-          node: typeNode,
-          messageId: 'bannedTypeMessage',
-          data: {
-            name,
-            customMessage,
-          },
-          fix: fixWith
-            ? (fixer): TSESLint.RuleFix => fixer.replaceText(typeNode, fixWith)
-            : null,
-        });
+      if (bannedType === undefined || bannedType === false) {
+        return;
       }
+
+      const customMessage = getCustomMessage(bannedType);
+      const fixWith =
+        bannedType && typeof bannedType === 'object' && bannedType.fixWith;
+
+      context.report({
+        node: typeNode,
+        messageId: 'bannedTypeMessage',
+        data: {
+          name,
+          customMessage,
+        },
+        fix: fixWith
+          ? (fixer): TSESLint.RuleFix => fixer.replaceText(typeNode, fixWith)
+          : null,
+      });
     }
 
     const keywordSelectors = util.objectReduceKey(

--- a/packages/eslint-plugin/tests/rules/ban-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-types.test.ts
@@ -97,6 +97,17 @@ ruleTester.run('ban-types', rule, {
         },
       ],
     },
+    {
+      code: 'type Props = {};',
+      options: [
+        {
+          types: {
+            '{}': false,
+          },
+          extendDefaults: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Following #2115 @bradzacher guidelines, I've added a way to selectively disable a default type rule for ban-types. Currently if you want to keep every banned-types defaults except one, you have to manually inline the remaining types.

This allow a simpler API:

```js
{
  types: {
    '{}': false,
  },
  extendDefaults: true,
}
```

