### PR TITLE
fix(eslint-plugin): [prefer-optional-chain] handling first member expression

### DIFF
--- a/packages/eslint-plugin-tslint/src/rules/config.ts
+++ b/packages/eslint-plugin-tslint/src/rules/config.ts
@@ -135,7 +135,7 @@ export default createRule<Options, MessageIds>({
     /**
      * Format the TSLint results for ESLint
      */
-    if (result.failures && result.failures.length) {
+    if (result.failures?.length) {
       result.failures.forEach(failure => {
         const start = failure.getStartPosition().getLineAndCharacter();
         const end = failure.getEndPosition().getLineAndCharacter();

--- a/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
+++ b/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
@@ -53,7 +53,7 @@ export default util.createRule({
         }
         case AST_NODE_TYPES.TSDeclareFunction:
         case AST_NODE_TYPES.FunctionDeclaration:
-          return member.id && member.id.name;
+          return member.id?.name ?? null;
         case AST_NODE_TYPES.TSMethodSignature:
           return util.getNameFromMember(member, sourceCode);
         case AST_NODE_TYPES.TSCallSignatureDeclaration:

--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -281,7 +281,7 @@ export default util.createRule<Options, MessageIds>({
         }
 
         const readonlyPrefix = isReadonlyArrayType ? 'readonly ' : '';
-        const typeParams = node.typeParameters && node.typeParameters.params;
+        const typeParams = node.typeParameters?.params;
         const messageId =
           defaultOption === 'array'
             ? 'errorStringArray'

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
@@ -537,7 +537,7 @@ export default createRule<Options, MessageIds>({
        * A "legal ancestor" is an expression or statement that causes the function to get executed immediately.
        * For example, `!(function(){})()` is an outer IIFE even though it is preceded by a ! operator.
        */
-      let statement = node.parent && node.parent.parent;
+      let statement = node.parent?.parent;
 
       while (
         statement &&

--- a/packages/eslint-plugin/src/rules/no-empty-function.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-function.ts
@@ -84,8 +84,7 @@ export default util.createRule<Options, MessageIds>({
       node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpression,
     ): boolean {
       return (
-        node.params &&
-        node.params.some(
+        node.params?.some(
           param => param.type === AST_NODE_TYPES.TSParameterProperty,
         )
       );

--- a/packages/eslint-plugin/src/rules/no-empty-function.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-function.ts
@@ -83,10 +83,8 @@ export default util.createRule<Options, MessageIds>({
     function hasParameterProperties(
       node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpression,
     ): boolean {
-      return (
-        node.params?.some(
-          param => param.type === AST_NODE_TYPES.TSParameterProperty,
-        )
+      return node.params?.some(
+        param => param.type === AST_NODE_TYPES.TSParameterProperty,
       );
     }
 

--- a/packages/eslint-plugin/src/rules/no-use-before-define.ts
+++ b/packages/eslint-plugin/src/rules/no-use-before-define.ts
@@ -137,8 +137,7 @@ function isInInitializer(
         return true;
       }
       if (
-        node.parent &&
-        node.parent.parent &&
+        node.parent?.parent &&
         (node.parent.parent.type === AST_NODE_TYPES.ForInStatement ||
           node.parent.parent.type === AST_NODE_TYPES.ForOfStatement) &&
         isInRange(node.parent.parent.right, location)

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -67,7 +67,7 @@ export default util.createRule({
         const initialExpression = initialIdentifierOrNotEqualsExpr.parent as TSESTree.LogicalExpression;
 
         if (initialExpression.left !== initialIdentifierOrNotEqualsExpr) {
-          // the node(identifier or memeber expression) is not the deepest left node
+          // the node(identifier or member expression) is not the deepest left node
           return;
         }
         if (!isValidChainTarget(initialIdentifierOrNotEqualsExpr, true)) {

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -61,7 +61,8 @@ export default util.createRule({
       ].join(',')](
         initialIdentifierOrNotEqualsExpr:
           | TSESTree.BinaryExpression
-          | TSESTree.Identifier,
+          | TSESTree.Identifier
+          | TSESTree.MemberExpression,
       ): void {
         // selector guarantees this cast
         const initialExpression = initialIdentifierOrNotEqualsExpr.parent as TSESTree.LogicalExpression;

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -55,6 +55,7 @@ export default util.createRule({
     return {
       [[
         'LogicalExpression[operator="&&"] > Identifier',
+        'LogicalExpression[operator="&&"] > MemberExpression',
         'LogicalExpression[operator="&&"] > BinaryExpression[operator="!=="]',
         'LogicalExpression[operator="&&"] > BinaryExpression[operator="!="]',
       ].join(',')](
@@ -66,7 +67,7 @@ export default util.createRule({
         const initialExpression = initialIdentifierOrNotEqualsExpr.parent as TSESTree.LogicalExpression;
 
         if (initialExpression.left !== initialIdentifierOrNotEqualsExpr) {
-          // the identifier is not the deepest left node
+          // the node(identifier or memeber expression) is not the deepest left node
           return;
         }
         if (!isValidChainTarget(initialIdentifierOrNotEqualsExpr, true)) {

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain.test.ts
@@ -17,22 +17,42 @@ const baseCases = [
     output: 'foo?.bar',
   },
   {
+    code: 'foo.bar && foo.bar.baz',
+    output: 'foo.bar?.baz',
+  },
+  {
     code: 'foo && foo()',
     output: 'foo?.()',
+  },
+  {
+    code: 'foo.bar && foo.bar()',
+    output: 'foo.bar?.()',
   },
   {
     code: 'foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz',
     output: 'foo?.bar?.baz?.buzz',
   },
   {
-    // case with a jump (i.e. a non-nullish prop)
+    code: 'foo.bar && foo.bar.baz && foo.bar.baz.buzz',
+    output: 'foo.bar?.baz?.buzz',
+  },
+  // case with a jump (i.e. a non-nullish prop)
+  {
     code: 'foo && foo.bar && foo.bar.baz.buzz',
     output: 'foo?.bar?.baz.buzz',
   },
   {
-    // case where for some reason there is a doubled up expression
+    code: 'foo.bar && foo.bar.baz.buzz',
+    output: 'foo.bar?.baz.buzz',
+  },
+  // case where for some reason there is a doubled up expression
+  {
     code: 'foo && foo.bar && foo.bar.baz && foo.bar.baz && foo.bar.baz.buzz',
     output: 'foo?.bar?.baz?.buzz',
+  },
+  {
+    code: 'foo.bar && foo.bar.baz && foo.bar.baz && foo.bar.baz.buzz',
+    output: 'foo.bar?.baz?.buzz',
   },
   // chained members with element access
   {
@@ -55,9 +75,17 @@ const baseCases = [
     output: 'foo?.bar?.baz?.buzz?.()',
   },
   {
-    // case with a jump (i.e. a non-nullish prop)
+    code: 'foo.bar && foo.bar.baz && foo.bar.baz.buzz && foo.bar.baz.buzz()',
+    output: 'foo.bar?.baz?.buzz?.()',
+  },
+  // case with a jump (i.e. a non-nullish prop)
+  {
     code: 'foo && foo.bar && foo.bar.baz.buzz()',
     output: 'foo?.bar?.baz.buzz()',
+  },
+  {
+    code: 'foo.bar && foo.bar.baz.buzz()',
+    output: 'foo.bar?.baz.buzz()',
   },
   {
     // case with a jump (i.e. a non-nullish prop)
@@ -93,6 +121,10 @@ const baseCases = [
   {
     code: 'foo && foo?.() && foo?.().bar',
     output: 'foo?.()?.bar',
+  },
+  {
+    code: 'foo.bar && foo.bar?.() && foo.bar?.().baz',
+    output: 'foo.bar?.()?.baz',
   },
 ].map(
   c =>
@@ -220,8 +252,8 @@ ruleTester.run('prefer-optional-chain', rule, {
         },
       ],
     },
+    // case with inconsistent checks
     {
-      // case with inconsistent checks
       code:
         'foo && foo.bar != null && foo.bar.baz !== undefined && foo.bar.baz.buzz;',
       output: null,
@@ -232,6 +264,21 @@ ruleTester.run('prefer-optional-chain', rule, {
             {
               messageId: 'optionalChainSuggest',
               output: 'foo?.bar?.baz?.buzz;',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: noFormat`foo.bar && foo.bar.baz != null && foo.bar.baz.qux !== undefined && foo.bar.baz.qux.buzz;`,
+      output: null,
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+          suggestions: [
+            {
+              messageId: 'optionalChainSuggest',
+              output: 'foo.bar?.baz?.qux?.buzz;',
             },
           ],
         },
@@ -399,6 +446,21 @@ foo?.bar(/* comment */a,
             {
               messageId: 'optionalChainSuggest',
               output: 'foo?.();',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'foo.bar && foo.bar?.();',
+      output: null,
+      errors: [
+        {
+          messageId: 'preferOptionalChain',
+          suggestions: [
+            {
+              messageId: 'optionalChainSuggest',
+              output: 'foo.bar?.();',
             },
           ],
         },

--- a/packages/experimental-utils/src/eslint-utils/RuleTester.ts
+++ b/packages/experimental-utils/src/eslint-utils/RuleTester.ts
@@ -40,9 +40,7 @@ class RuleTester extends TSESLint.RuleTester {
   }
   private getFilename(options?: TSESLint.ParserOptions): string {
     if (options) {
-      const filename = `file.ts${
-        options.ecmaFeatures?.jsx ? 'x' : ''
-      }`;
+      const filename = `file.ts${options.ecmaFeatures?.jsx ? 'x' : ''}`;
       if (options.project) {
         return path.join(
           options.tsconfigRootDir != null

--- a/packages/experimental-utils/src/eslint-utils/RuleTester.ts
+++ b/packages/experimental-utils/src/eslint-utils/RuleTester.ts
@@ -41,7 +41,7 @@ class RuleTester extends TSESLint.RuleTester {
   private getFilename(options?: TSESLint.ParserOptions): string {
     if (options) {
       const filename = `file.ts${
-        options.ecmaFeatures && options.ecmaFeatures.jsx ? 'x' : ''
+        options.ecmaFeatures?.jsx ? 'x' : ''
       }`;
       if (options.project) {
         return path.join(

--- a/packages/parser/src/analyze-scope.ts
+++ b/packages/parser/src/analyze-scope.ts
@@ -875,8 +875,7 @@ export function analyzeScope(
     directive: false,
     nodejsScope:
       parserOptions.sourceType === 'script' &&
-      (parserOptions.ecmaFeatures &&
-        parserOptions.ecmaFeatures.globalReturn) === true,
+      parserOptions.ecmaFeatures?.globalReturn === true,
     impliedStrict: false,
     sourceType: parserOptions.sourceType,
     ecmaVersion: parserOptions.ecmaVersion ?? 2018,

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -375,7 +375,7 @@ export class Converter {
     return parameters.map(param => {
       const convertedParam = this.convertChild(param) as TSESTree.Parameter;
 
-      if (param.decorators && param.decorators.length) {
+      if (param.decorators?.length) {
         convertedParam.decorators = param.decorators.map(el =>
           this.convertChild(el),
         );
@@ -1485,7 +1485,7 @@ export class Converter {
             );
           }
 
-          if (superClass.types[0] && superClass.types[0].typeArguments) {
+          if (superClass.types[0]?.typeArguments) {
             result.superTypeParameters = this.convertTypeArgumentsToTypeParameters(
               superClass.types[0].typeArguments,
               superClass.types[0],

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -111,7 +111,7 @@ function diagnosticReporter(diagnostic: ts.Diagnostic): void {
  */
 function createHash(content: string): string {
   // No ts.sys in browser environments.
-  if (ts.sys && ts.sys.createHash) {
+  if (ts.sys?.createHash) {
     return ts.sys.createHash(content);
   }
   return content;


### PR DESCRIPTION
There is a false negative when member expression comes first.

```ts
foo.bar && foo.bar.baz;  // no error
```