### PR TITLE
fix(eslint-plugin): [explicit-module-boundary-types] dont report return type errors on constructor overloads

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -380,7 +380,10 @@ export default util.createRule<Options, MessageIds>({
     function checkEmptyBodyFunctionExpression(
       node: TSESTree.TSEmptyBodyFunctionExpression,
     ): void {
-      if (!node.returnType) {
+      const isConstructor =
+        node.parent?.type === AST_NODE_TYPES.MethodDefinition &&
+        node.parent.kind === 'constructor';
+      if (!isConstructor && !node.returnType) {
         context.report({
           node,
           messageId: 'missingReturnType',

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -83,6 +83,25 @@ export class Test {
       `,
     },
     {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/2150
+      code: `
+export class Test {
+  constructor();
+  constructor(value?: string) {
+    console.log(value);
+  }
+}
+      `,
+    },
+    {
+      code: `
+declare class MyClass {
+  constructor(options?: MyClass.Options);
+}
+export { MyClass };
+      `,
+    },
+    {
       code: `
 export function test(): void {
   nested();


### PR DESCRIPTION
Fixes #2150