### PR TITLE
fix(eslint-plugin): [no-extra-non-null-assertion] dont report for assertions not followed by the optional chain

### DIFF
--- a/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts
@@ -1,5 +1,5 @@
-import * as util from '../util';
 import { TSESTree } from '@typescript-eslint/experimental-utils';
+import * as util from '../util';
 
 export default util.createRule({
   name: 'no-extra-non-null-assertion',
@@ -32,8 +32,8 @@ export default util.createRule({
 
     return {
       'TSNonNullExpression > TSNonNullExpression': checkExtraNonNullAssertion,
-      'OptionalMemberExpression > TSNonNullExpression': checkExtraNonNullAssertion,
-      'OptionalCallExpression > TSNonNullExpression.callee': checkExtraNonNullAssertion,
+      'OptionalMemberExpression[optional = true] > TSNonNullExpression': checkExtraNonNullAssertion,
+      'OptionalCallExpression[optional = true] > TSNonNullExpression.callee': checkExtraNonNullAssertion,
     };
   },
 });

--- a/packages/eslint-plugin/tests/rules/no-extra-non-null-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extra-non-null-assertion.test.ts
@@ -27,6 +27,12 @@ function foo(bar?: { n: number }) {
 }
       `,
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2166
+    {
+      code: `
+checksCounter?.textContent!.trim();
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #2166