### PR TITLE
fix(eslint-plugin): [return-await] correct handling of ternaries

### DIFF
--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -78,21 +78,14 @@ export default util.createRule({
 
     function removeAwait(
       fixer: TSESLint.RuleFixer,
-      node: TSESTree.ReturnStatement | TSESTree.ArrowFunctionExpression,
+      node: TSESTree.Expression,
     ): TSESLint.RuleFix | null {
-      const awaitNode =
-        node.type === AST_NODE_TYPES.ReturnStatement
-          ? node.argument
-          : node.body;
       // Should always be an await node; but let's be safe.
-      /* istanbul ignore if */ if (!util.isAwaitExpression(awaitNode)) {
+      /* istanbul ignore if */ if (!util.isAwaitExpression(node)) {
         return null;
       }
 
-      const awaitToken = sourceCode.getFirstToken(
-        awaitNode,
-        util.isAwaitKeyword,
-      );
+      const awaitToken = sourceCode.getFirstToken(node, util.isAwaitKeyword);
       // Should always be the case; but let's be safe.
       /* istanbul ignore if */ if (!awaitToken) {
         return null;
@@ -113,24 +106,17 @@ export default util.createRule({
 
     function insertAwait(
       fixer: TSESLint.RuleFixer,
-      node: TSESTree.ReturnStatement | TSESTree.ArrowFunctionExpression,
+      node: TSESTree.Expression,
     ): TSESLint.RuleFix | null {
-      const targetNode =
-        node.type === AST_NODE_TYPES.ReturnStatement
-          ? node.argument
-          : node.body;
       // There should always be a target node; but let's be safe.
-      /* istanbul ignore if */ if (!targetNode) {
+      /* istanbul ignore if */ if (!node) {
         return null;
       }
 
-      return fixer.insertTextBefore(targetNode, 'await ');
+      return fixer.insertTextBefore(node, 'await ');
     }
 
-    function test(
-      node: TSESTree.ReturnStatement | TSESTree.ArrowFunctionExpression,
-      expression: ts.Node,
-    ): void {
+    function test(node: TSESTree.Expression, expression: ts.Node): void {
       let child: ts.Node;
 
       const isAwait = tsutils.isAwaitExpression(expression);
@@ -201,6 +187,18 @@ export default util.createRule({
       }
     }
 
+    function findPossiblyReturnedNodes(
+        node: TSESTree.Expression
+    ): TSESTree.Expression[] {
+      if (node.type === AST_NODE_TYPES.ConditionalExpression) {
+        return [
+          ...findPossiblyReturnedNodes(node.alternate),
+          ...findPossiblyReturnedNodes(node.consequent),
+        ];
+      }
+      return [node];
+    }
+
     return {
       FunctionDeclaration: enterFunction,
       FunctionExpression: enterFunction,
@@ -214,23 +212,17 @@ export default util.createRule({
             node.body,
           );
 
-          test(node, expression);
+          test(node.body, expression);
         }
       },
       ReturnStatement(node): void {
-        if (!scopeInfo || !scopeInfo.hasAsync) {
+        if (!scopeInfo || !scopeInfo.hasAsync || !node.argument) {
           return;
         }
-
-        const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node);
-
-        const { expression } = originalNode;
-
-        if (!expression) {
-          return;
-        }
-
-        test(node, expression);
+        findPossiblyReturnedNodes(node.argument)?.forEach(node => {
+          const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+          test(node, tsNode);
+        });
       },
     };
   },

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -108,11 +108,6 @@ export default util.createRule({
       fixer: TSESLint.RuleFixer,
       node: TSESTree.Expression,
     ): TSESLint.RuleFix | null {
-      // There should always be a target node; but let's be safe.
-      /* istanbul ignore if */ if (!node) {
-        return null;
-      }
-
       return fixer.insertTextBefore(node, 'await ');
     }
 

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -188,7 +188,7 @@ export default util.createRule({
     }
 
     function findPossiblyReturnedNodes(
-        node: TSESTree.Expression
+      node: TSESTree.Expression,
     ): TSESTree.Expression[] {
       if (node.type === AST_NODE_TYPES.ConditionalExpression) {
         return [

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -208,18 +208,17 @@ export default util.createRule({
         node: TSESTree.ArrowFunctionExpression,
       ): void {
         if (node.body.type !== AST_NODE_TYPES.BlockStatement) {
-          const expression = parserServices.esTreeNodeToTSNodeMap.get(
-            node.body,
-          );
-
-          test(node.body, expression);
+          findPossiblyReturnedNodes(node.body).forEach(node => {
+            const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+            test(node, tsNode);
+          });
         }
       },
       ReturnStatement(node): void {
         if (!scopeInfo || !scopeInfo.hasAsync || !node.argument) {
           return;
         }
-        findPossiblyReturnedNodes(node.argument)?.forEach(node => {
+        findPossiblyReturnedNodes(node.argument).forEach(node => {
           const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
           test(node, tsNode);
         });

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -1,5 +1,5 @@
 import rule from '../../src/rules/return-await';
-import { getFixturesRootDir, RuleTester } from '../RuleTester';
+import { getFixturesRootDir, RuleTester, noFormat } from '../RuleTester';
 
 const rootDir = getFixturesRootDir();
 
@@ -596,6 +596,109 @@ ruleTester.run('return-await', rule, {
       errors: [
         {
           line: 1,
+          messageId: 'requiredPromiseAwait',
+        },
+      ],
+    },
+    {
+      options: ['always'],
+      code: `
+async function foo() {}
+async function bar() {}
+async function baz() {}
+async function qux() {}
+async function buzz() {
+  return (await foo()) ? bar() : baz();
+}
+      `,
+      output: `
+async function foo() {}
+async function bar() {}
+async function baz() {}
+async function qux() {}
+async function buzz() {
+  return (await foo()) ? await bar() : await baz();
+}
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'requiredPromiseAwait',
+        },
+        {
+          line: 7,
+          messageId: 'requiredPromiseAwait',
+        },
+      ],
+    },
+    {
+      options: ['always'],
+      code: noFormat`
+async function foo() {}
+async function bar() {}
+async function baz() {}
+async function qux() {}
+async function buzz() {
+  return (await foo())
+    ? (
+      bar ? bar() : baz()
+    ) : baz ? baz() : bar();
+}
+      `,
+      output: noFormat`
+async function foo() {}
+async function bar() {}
+async function baz() {}
+async function qux() {}
+async function buzz() {
+  return (await foo())
+    ? (
+      bar ? await bar() : await baz()
+    ) : baz ? await baz() : await bar();
+}
+      `,
+      errors: [
+        {
+          line: 9,
+          messageId: 'requiredPromiseAwait',
+        },
+        {
+          line: 9,
+          messageId: 'requiredPromiseAwait',
+        },
+        {
+          line: 10,
+          messageId: 'requiredPromiseAwait',
+        },
+        {
+          line: 10,
+          messageId: 'requiredPromiseAwait',
+        },
+      ],
+    },
+    {
+      options: ['always'],
+      code: noFormat`
+async function foo() {}
+async function bar() {}
+async function buzz() {
+  return (await foo()) ? await 1 : bar();
+}
+      `,
+      output: noFormat`
+async function foo() {}
+async function bar() {}
+async function buzz() {
+  return (await foo()) ? 1 : await bar();
+}
+      `,
+      errors: [
+        {
+          line: 5,
+          messageId: 'nonPromiseAwait',
+        },
+        {
+          line: 5,
           messageId: 'requiredPromiseAwait',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -704,31 +704,52 @@ async function buzz() {
       ],
     },
     {
-        options: ['always'],
-        code: `
+      options: ['always'],
+      code: `
 async function foo() {}
 async function bar() {}
 async function baz() {}
-async function qux() {}
 const buzz = async () => ((await foo()) ? bar() : baz());
-        `,
-        output: `
+      `,
+      output: `
 async function foo() {}
 async function bar() {}
 async function baz() {}
-async function qux() {}
 const buzz = async () => ((await foo()) ? await bar() : await baz());
-        `,
-        errors: [
-          {
-            line: 6,
-            messageId: 'requiredPromiseAwait',
-          },
-          {
-            line: 6,
-            messageId: 'requiredPromiseAwait',
-          },
-        ],
-      },
+      `,
+      errors: [
+        {
+          line: 5,
+          messageId: 'requiredPromiseAwait',
+        },
+        {
+          line: 5,
+          messageId: 'requiredPromiseAwait',
+        },
+      ],
+    },
+    {
+      options: ['always'],
+      code: `
+async function foo() {}
+async function bar() {}
+const buzz = async () => ((await foo()) ? await 1 : bar());
+      `,
+      output: `
+async function foo() {}
+async function bar() {}
+const buzz = async () => ((await foo()) ? 1 : await bar());
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'nonPromiseAwait',
+        },
+        {
+          line: 4,
+          messageId: 'requiredPromiseAwait',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -602,7 +602,7 @@ ruleTester.run('return-await', rule, {
     },
     {
       options: ['always'],
-      code: `
+      code: noFormat`
 async function foo() {}
 async function bar() {}
 async function baz() {}
@@ -611,7 +611,7 @@ async function buzz() {
   return (await foo()) ? bar() : baz();
 }
       `,
-      output: `
+      output: noFormat`
 async function foo() {}
 async function bar() {}
 async function baz() {}
@@ -678,14 +678,14 @@ async function buzz() {
     },
     {
       options: ['always'],
-      code: noFormat`
+      code: `
 async function foo() {}
 async function bar() {}
 async function buzz() {
   return (await foo()) ? await 1 : bar();
 }
       `,
-      output: noFormat`
+      output: `
 async function foo() {}
 async function bar() {}
 async function buzz() {
@@ -703,5 +703,32 @@ async function buzz() {
         },
       ],
     },
+    {
+        options: ['always'],
+        code: `
+async function foo() {}
+async function bar() {}
+async function baz() {}
+async function qux() {}
+const buzz = async () => ((await foo()) ? bar() : baz());
+        `,
+        output: `
+async function foo() {}
+async function bar() {}
+async function baz() {}
+async function qux() {}
+const buzz = async () => ((await foo()) ? await bar() : await baz());
+        `,
+        errors: [
+          {
+            line: 6,
+            messageId: 'requiredPromiseAwait',
+          },
+          {
+            line: 6,
+            messageId: 'requiredPromiseAwait',
+          },
+        ],
+      },
   ],
 });


### PR DESCRIPTION
Fixes #1838