### PR TITLE
fix(eslint-plugin): [no-base-to-string] handle intersection types

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -112,6 +112,24 @@ export default util.createRule<Options, MessageIds>({
         return Usefulness.Always;
       }
 
+      if (type.isIntersection()) {
+        let someSubtypeUseful = false;
+
+        for (const subType of type.types) {
+          const subtypeUsefulness = collectToStringCertainty(subType);
+
+          if (subtypeUsefulness === Usefulness.Always) {
+            return Usefulness.Always;
+          }
+
+          if (subtypeUsefulness !== Usefulness.Never) {
+            someSubtypeUseful = true;
+          }
+        }
+
+        return someSubtypeUseful ? Usefulness.Sometimes : Usefulness.Never;
+      }
+
       if (!type.isUnion()) {
         return Usefulness.Never;
       }

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -113,21 +113,15 @@ export default util.createRule<Options, MessageIds>({
       }
 
       if (type.isIntersection()) {
-        let someSubtypeUseful = false;
-
         for (const subType of type.types) {
           const subtypeUsefulness = collectToStringCertainty(subType);
 
           if (subtypeUsefulness === Usefulness.Always) {
             return Usefulness.Always;
           }
-
-          if (subtypeUsefulness !== Usefulness.Never) {
-            someSubtypeUseful = true;
-          }
         }
 
-        return someSubtypeUseful ? Usefulness.Sometimes : Usefulness.Never;
+        return Usefulness.Never;
       }
 
       if (!type.isUnion()) {

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -107,6 +107,12 @@ tag\`\${{}}\`;
       function tag() {}
       tag\`\${{}}\`;
     `,
+    `
+      interface Brand {}
+      function test(v: string & Brand): string {
+        return v + "";
+      }
+    `,
   ],
   invalid: [
     {
@@ -212,6 +218,24 @@ tag\`\${{}}\`;
           data: {
             certainty: 'will',
             name: 'someObjectOrObject',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+    },
+    {
+      code: `
+        interface A {}
+        interface B {}
+        function test(intersection: A & B): string {
+          return intersection + '';
+        }
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'will',
+            name: 'intersection',
           },
           messageId: 'baseToString',
         },

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -110,7 +110,7 @@ tag\`\${{}}\`;
     `
       interface Brand {}
       function test(v: string & Brand): string {
-        return v + "";
+        return v + '';
       }
     `,
   ],

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -110,7 +110,7 @@ tag\`\${{}}\`;
     `
       interface Brand {}
       function test(v: string & Brand): string {
-        return v + '';
+        return \`\${v}\`;
       }
     `,
   ],
@@ -228,7 +228,7 @@ tag\`\${{}}\`;
         interface A {}
         interface B {}
         function test(intersection: A & B): string {
-          return intersection + '';
+          return \`\${intersection}\`;
         }
       `,
       errors: [


### PR DESCRIPTION
Fixes #2162 [no-base-to-string] complains about intersection types