### PR TITLE
docs(eslint-plugin): [no-non-null-assertion] correct example

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
@@ -23,7 +23,7 @@ interface Foo {
 }
 
 const foo: Foo = getFoo();
-const includesBaz: boolean = foo.bar && foo.bar.includes('baz');
+const includesBaz: boolean = foo.bar?.includes('baz') ?? false;
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
Previous example

```typescript
const includesBaz: boolean = foo.bar && foo.bar.includes('baz');
```

does not compile with `--strictNullChecks` because type of `foo.bar && foo.bar.includes('baz')` is `boolean | undefined`. Instead, using null coalescing operator and optional chaining is better example for safer and idiomatic TypeScript code.

```typescript
const includesBaz: boolean = foo.bar?.includes('baz') ?? false;
```