### PR TITLE
fix(eslint-plugin): [no-unused-expressions] handle ternary and short-circuit options

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-expressions.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-expressions.ts
@@ -30,8 +30,7 @@ export default util.createRule<Options, MessageIds>({
   ],
   create(context, options) {
     const rules = baseRule.create(context);
-    const { allowShortCircuit = false, allowTernary = false } =
-      options[0] ?? {};
+    const { allowShortCircuit = false, allowTernary = false } = options[0];
 
     function isValidExpression(node: TSESTree.Node): boolean {
       if (allowShortCircuit && node.type === AST_NODE_TYPES.LogicalExpression) {

--- a/packages/eslint-plugin/src/rules/no-unused-expressions.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-expressions.ts
@@ -1,4 +1,7 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+import {
+  AST_NODE_TYPES,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
 import baseRule from 'eslint/lib/rules/no-unused-expressions';
 import * as util from '../util';
 
@@ -18,17 +21,37 @@ export default util.createRule<Options, MessageIds>({
     schema: baseRule.meta.schema,
     messages: baseRule.meta.messages,
   },
-  defaultOptions: [],
-  create(context) {
+  defaultOptions: [
+    {
+      allowShortCircuit: false,
+      allowTernary: false,
+      allowTaggedTemplates: false,
+    },
+  ],
+  create(context, options) {
     const rules = baseRule.create(context);
+    const { allowShortCircuit = false, allowTernary = false } =
+      options[0] ?? {};
+
+    function isValidExpression(node: TSESTree.Node): boolean {
+      if (allowShortCircuit && node.type === AST_NODE_TYPES.LogicalExpression) {
+        return isValidExpression(node.right);
+      }
+      if (allowTernary && node.type === AST_NODE_TYPES.ConditionalExpression) {
+        return (
+          isValidExpression(node.alternate) &&
+          isValidExpression(node.consequent)
+        );
+      }
+      return (
+        node.type === AST_NODE_TYPES.OptionalCallExpression ||
+        node.type === AST_NODE_TYPES.ImportExpression
+      );
+    }
 
     return {
       ExpressionStatement(node): void {
-        if (
-          node.directive ||
-          node.expression.type === AST_NODE_TYPES.OptionalCallExpression ||
-          node.expression.type === AST_NODE_TYPES.ImportExpression
-        ) {
+        if (node.directive || isValidExpression(node.expression)) {
           return;
         }
 

--- a/packages/eslint-plugin/tests/rules/no-unused-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-expressions.test.ts
@@ -71,6 +71,18 @@ ruleTester.run('no-unused-expressions', rule, {
     `
       import('./foo').then(() => {});
     `,
+    {
+      code: 'foo && foo?.();',
+      options: [{ allowShortCircuit: true }],
+    },
+    {
+      code: "foo && import('./foo');",
+      options: [{ allowShortCircuit: true }],
+    },
+    {
+      code: "foo ? import('./foo') : import('./bar');",
+      options: [{ allowTernary: true }],
+    },
   ],
   invalid: [
     {
@@ -256,6 +268,30 @@ function foo() {
           endLine: 5,
           column: 3,
           endColumn: 16,
+        },
+      ]),
+    },
+    {
+      code: 'foo && foo?.bar;',
+      options: [{ allowShortCircuit: true }],
+      errors: error([
+        {
+          line: 1,
+          endLine: 1,
+          column: 1,
+          endColumn: 17,
+        },
+      ]),
+    },
+    {
+      code: 'foo ? foo?.bar : bar.baz;',
+      options: [{ allowTernary: true }],
+      errors: error([
+        {
+          line: 1,
+          endLine: 1,
+          column: 1,
+          endColumn: 26,
         },
       ]),
     },

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -416,7 +416,7 @@ declare module 'eslint/lib/rules/no-unused-expressions' {
         allowShortCircuit?: boolean;
         allowTernary?: boolean;
         allowTaggedTemplates?: boolean;
-      }?,
+      },
     ],
     {
       ExpressionStatement(node: TSESTree.ExpressionStatement): void;

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -411,15 +411,13 @@ declare module 'eslint/lib/rules/no-unused-expressions' {
 
   const rule: TSESLint.RuleModule<
     'expected',
-    (
-      | 'all'
-      | 'local'
-      | {
-          allowShortCircuit?: boolean;
-          allowTernary?: boolean;
-          allowTaggedTemplates?: boolean;
-        }
-    )[],
+    [
+      {
+        allowShortCircuit?: boolean;
+        allowTernary?: boolean;
+        allowTaggedTemplates?: boolean;
+      }?,
+    ],
     {
       ExpressionStatement(node: TSESTree.ExpressionStatement): void;
     }


### PR DESCRIPTION
Fixes #1764 😁