### PR TITLE
feat(eslint-plugin): [naming-convention] better error message and docs for prefix/suffix

### DIFF
--- a/packages/eslint-plugin/docs/rules/naming-convention.md
+++ b/packages/eslint-plugin/docs/rules/naming-convention.md
@@ -150,6 +150,8 @@ The `prefix` / `suffix` options control which prefix/suffix strings must exist f
 
 If these are provided, the identifier must start with one of the provided values. For example, if you provide `{ prefix: ['IFace', 'Class', 'Type'] }`, then the following names are valid: `IFaceFoo`, `ClassBar`, `TypeBaz`, but the name `Bang` is not valid, as it contains none of the prefixes.
 
+**Note:** As [documented above](#format-options), the prefix is trimmed before format is validated, therefore PascalCase must be used to allow variables such as `isEnabled` using the prefix `is`.
+
 ### Selector Options
 
 - `selector` (see "Allowed Selectors, Modifiers and Types" below).
@@ -276,6 +278,8 @@ Group Selectors are provided for convenience, and essentially bundle up sets of 
 ```
 
 ### Enforce that boolean variables are prefixed with an allowed verb
+
+**Note:** As [documented above](#format-options), the prefix is trimmed before format is validated, thus PascalCase must be used to allow variables such as `isEnabled`.
 
 ```json
 {

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -1058,7 +1058,10 @@ function createValidator(
 
     context.report({
       node,
-      messageId: originalName === name ? 'doesNotMatchFormat' : 'doesNotMatchFormatTrimmed',
+      messageId:
+        originalName === name
+          ? 'doesNotMatchFormat'
+          : 'doesNotMatchFormatTrimmed',
       data: formatReportData({
         originalName,
         processedName: name,

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -12,7 +12,8 @@ type MessageIds =
   | 'missingUnderscore'
   | 'missingAffix'
   | 'satisfyCustom'
-  | 'doesNotMatchFormat';
+  | 'doesNotMatchFormat'
+  | 'doesNotMatchFormatTrimmed';
 
 // #region Options Type Config
 
@@ -355,6 +356,8 @@ export default util.createRule<Options, MessageIds>({
         '{{type}} name `{{name}}` must {{regexMatch}} the RegExp: {{regex}}',
       doesNotMatchFormat:
         '{{type}} name `{{name}}` must match one of the following formats: {{formats}}',
+      doesNotMatchFormatTrimmed:
+        '{{type}} name `{{name}}` trimmed as `{{processedName}}` must match one of the following formats: {{formats}}',
     },
     schema: SCHEMA,
   },
@@ -869,18 +872,21 @@ function createValidator(
     affixes,
     formats,
     originalName,
+    processedName,
     position,
     custom,
   }: {
     affixes?: string[];
     formats?: PredefinedFormats[];
     originalName: string;
+    processedName?: string;
     position?: 'leading' | 'trailing' | 'prefix' | 'suffix';
     custom?: NonNullable<NormalizedSelector['custom']>;
   }): Record<string, unknown> {
     return {
       type: selectorTypeToMessageString(type),
       name: originalName,
+      processedName,
       position,
       affixes: affixes?.join(', '),
       formats: formats?.map(f => PredefinedFormats[f]).join(', '),
@@ -1052,9 +1058,10 @@ function createValidator(
 
     context.report({
       node,
-      messageId: 'doesNotMatchFormat',
+      messageId: originalName === name ? 'doesNotMatchFormat' : 'doesNotMatchFormatTrimmed',
       data: formatReportData({
         originalName,
+        processedName: name,
         formats,
       }),
     });

--- a/packages/eslint-plugin/tests/rules/naming-convention.test.ts
+++ b/packages/eslint-plugin/tests/rules/naming-convention.test.ts
@@ -864,7 +864,7 @@ ruleTester.run('naming-convention', rule, {
         },
       ],
       parserOptions,
-      errors: Array(16).fill({ messageId: 'doesNotMatchFormat' }),
+      errors: Array(16).fill({ messageId: 'doesNotMatchFormatTrimmed' }),
     },
     {
       code: `
@@ -886,7 +886,7 @@ ruleTester.run('naming-convention', rule, {
         },
       ],
       parserOptions,
-      errors: Array(4).fill({ messageId: 'doesNotMatchFormat' }),
+      errors: Array(4).fill({ messageId: 'doesNotMatchFormatTrimmed' }),
     },
     {
       code: `
@@ -918,7 +918,7 @@ ruleTester.run('naming-convention', rule, {
         },
       ],
       parserOptions,
-      errors: Array(8).fill({ messageId: 'doesNotMatchFormat' }),
+      errors: Array(8).fill({ messageId: 'doesNotMatchFormatTrimmed' }),
     },
     {
       code: `


### PR DESCRIPTION
* Make error message more clear about trimming.
* Docs: add a note about prefix being trimmed before format is validated to make it more noticeable.

Addresses #2187

Here's the current error message:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/633524/84122141-445c1f80-aa38-11ea-8bfc-4ad6ec8e9789.png)

Proposed error message:
> Variable name `isStore` trimmed as `Store` must match one of the following formats: UPPER_CASE, camelCase

Better wording can be considered, I tried to keep it short and informative.
