### PR TITLE
fix(experimental-utils): getParserServices takes a readonly context

### DIFF
--- a/packages/experimental-utils/src/eslint-utils/getParserServices.ts
+++ b/packages/experimental-utils/src/eslint-utils/getParserServices.ts
@@ -11,7 +11,7 @@ function getParserServices<
   TMessageIds extends string,
   TOptions extends readonly unknown[]
 >(
-  context: TSESLint.RuleContext<TMessageIds, TOptions>,
+  context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
   allowWithoutFullTypeInformation = false,
 ): ParserServices {
   // backwards compatibility check


### PR DESCRIPTION
Fixes #2232