### PR TITLE
fix(eslint-plugin): [naming-convention] support unicode in regex

### DIFF
--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -1213,7 +1213,7 @@ function normalizeOption(option: Selector): NormalizedSelector {
     format: option.format ? option.format.map(f => PredefinedFormats[f]) : null,
     custom: option.custom
       ? {
-          regex: new RegExp(option.custom.regex),
+          regex: new RegExp(option.custom.regex, 'u'),
           match: option.custom.match,
         }
       : null,
@@ -1236,9 +1236,9 @@ function normalizeOption(option: Selector): NormalizedSelector {
     filter:
       option.filter !== undefined
         ? typeof option.filter === 'string'
-          ? { regex: new RegExp(option.filter), match: true }
+          ? { regex: new RegExp(option.filter, 'u'), match: true }
           : {
-              regex: new RegExp(option.filter.regex),
+              regex: new RegExp(option.filter.regex, 'u'),
               match: option.filter.match,
             }
         : null,

--- a/packages/eslint-plugin/tests/rules/naming-convention.test.ts
+++ b/packages/eslint-plugin/tests/rules/naming-convention.test.ts
@@ -963,7 +963,7 @@ ruleTester.run('naming-convention', rule, {
           data: {
             type: 'Variable',
             name: 'unused_foo',
-            regex: '/^unused_\\w/',
+            regex: '/^unused_\\w/u',
             regexMatch: 'not match',
           },
         },
@@ -973,7 +973,7 @@ ruleTester.run('naming-convention', rule, {
           data: {
             type: 'Variable',
             name: '_unused_foo',
-            regex: '/^unused_\\w/',
+            regex: '/^unused_\\w/u',
             regexMatch: 'not match',
           },
         },
@@ -983,7 +983,7 @@ ruleTester.run('naming-convention', rule, {
           data: {
             type: 'Interface',
             name: 'IFoo',
-            regex: '/^I[A-Z]/',
+            regex: '/^I[A-Z]/u',
             regexMatch: 'not match',
           },
         },
@@ -993,7 +993,7 @@ ruleTester.run('naming-convention', rule, {
           data: {
             type: 'Class',
             name: 'IBar',
-            regex: '/^I[A-Z]/',
+            regex: '/^I[A-Z]/u',
             regexMatch: 'not match',
           },
         },
@@ -1003,7 +1003,7 @@ ruleTester.run('naming-convention', rule, {
           data: {
             type: 'Function',
             name: 'fooBar',
-            regex: '/function/',
+            regex: '/function/u',
             regexMatch: 'match',
           },
         },


### PR DESCRIPTION
**Add support for unicode regular expressions.**

[The rule docs](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md) present the example below, saying *"You can use the filter option to ignore names that require quoting"*:

```ts
{
  "@typescript-eslint/naming-convention": [
    "error",
    {
      "selector": "property",
      "format": ["strictCamelCase"],
      "filter": {
        // you can expand this regex as you find more cases that require quoting that you want to allow
        "regex": "[- ]",
        "match": false
      }
    }
  ]
}
```

(Aside: Ideally there should be a selector for detecting quoted names, since quotes can be a useful shorthand for bypassing lint rules.  But let's ignore that for now.  Instead we will follow the above example's premise, of substituting "must this name be quoted?" as an approximation of "was this name quoted?")

The example criteria of "does it have a minus or space?" is not an accurate test. Instead, it should be more like "Does it contain characters other than letters, numbers, and underscores?"  Something like this:
```ts
        "regex": "[^a-zA-Z0-9_]",
```

But the Spanish identifier `_animación` will fail this test.  To support languages besides English, the expression needs to be generalized to something like this:
```ts
        "regex": "[^\\p{L}\\p{N}_]",
```

Unfortunately we can't do this today with `@typescript-eslint/naming-convention`, because its RegExp doesn't accept Unicode character classes.

This PR fixes that.