### PR TITLE
feat(eslint-plugin): [no-unnecessary-boolean-literal-compare] add nullish check option for fixer

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
@@ -154,12 +154,12 @@ The follow table shows the output of the fixer on comparions that compare a bool
 
 The follow table shows the output of the fixer on comparions that compare a boolean expression to a boolean literal when the `fixWithExplicitNullishCheck` option is `{ nullishSymbol: "null" }`:
 
-|           Comparison           | Fixer Output                                        | Notes                                                                               |
-| :----------------------------: | --------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `nullableBooleanVar === true`  | `nullableBooleanVar != null && nullableBooleanVar`  | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
-| `nullableBooleanVar !== true`  | `nullableBooleanVar == null || !nullableBooleanVar` | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
-| `nullableBooleanVar === false` | `nullableBooleanVar != null && !nullableBooleanVar` | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
-| `nullableBooleanVar !== false` | `nullableBooleanVar == null || nullableBooleanVar`  | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
+|           Comparison           | Fixer Output                                          | Notes                                                                               |
+| :----------------------------: | ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `nullableBooleanVar === true`  | `nullableBooleanVar != null && nullableBooleanVar`    | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
+| `nullableBooleanVar !== true`  | `nullableBooleanVar == null \|\| !nullableBooleanVar` | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
+| `nullableBooleanVar === false` | `nullableBooleanVar != null && !nullableBooleanVar`   | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
+| `nullableBooleanVar !== false` | `nullableBooleanVar == null \|\| nullableBooleanVar`  | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
 
 ## Related to
 

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
@@ -130,9 +130,9 @@ if (someNullCondition == undefined || someNullCondition) {
 
 ## Fixer
 
-### Boolean Expresssions
+### Boolean Expressions
 
-The follow table shows the output of the fixer on comparions that compare a boolean expression to a boolean literal.
+The follow table shows the output of the fixer on comparisons that compare a boolean expression to a boolean literal.
 
 |       Comparison       | Fixer Output      |
 | :--------------------: | ----------------- |
@@ -143,7 +143,7 @@ The follow table shows the output of the fixer on comparions that compare a bool
 
 ### Nullable Boolean Expressions
 
-The follow table shows the output of the fixer on comparions that compare a boolean expression to a boolean literal when the `fixWithExplicitNullishCheck` option is `undefined`:
+The follow table shows the output of the fixer on comparisons that compare a boolean expression to a boolean literal when the `fixWithExplicitNullishCheck` option is `undefined`:
 
 |           Comparison           | Fixer Output                    | Notes                                                                               |
 | :----------------------------: | ------------------------------- | ----------------------------------------------------------------------------------- |
@@ -152,7 +152,7 @@ The follow table shows the output of the fixer on comparions that compare a bool
 | `nullableBooleanVar === false` | `nullableBooleanVar ?? true`    | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
 | `nullableBooleanVar !== false` | `!(nullableBooleanVar ?? true)` | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
 
-The follow table shows the output of the fixer on comparions that compare a boolean expression to a boolean literal when the `fixWithExplicitNullishCheck` option is `{ nullishSymbol: "null" }`:
+The follow table shows the output of the fixer on comparisons that compare a boolean expression to a boolean literal when the `fixWithExplicitNullishCheck` option is `{ nullishSymbol: "null" }`:
 
 |           Comparison           | Fixer Output                                          | Notes                                                                               |
 | :----------------------------: | ----------------------------------------------------- | ----------------------------------------------------------------------------------- |

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
@@ -5,7 +5,7 @@ Comparing boolean values to boolean literals is unnecessary, those comparisons r
 ## Rule Details
 
 This rule ensures that you do not include unnecessary comparisons with boolean literals.
-A comparison is considered unnecessary if it checks a boolean literal against any variable with just the `boolean` type.
+A comparison is considered unnecessary if it checks a boolean literal against any expression with just the `boolean` type.
 A comparison is **_not_** considered unnecessary if the type is a union of booleans (`string | boolean`, `someObject | boolean`).
 
 **Note**: Throughout this page, only strict equality (`===` and `!==`) are
@@ -44,23 +44,31 @@ The rule accepts an options object with the following properties.
 
 ```ts
 type Options = {
-  // if false, comparisons between a nullable boolean variable to `true` will be checked and fixed
+  // if false, comparisons between a nullable boolean expression to `true` will be checked and fixed
   allowComparingNullableBooleansToTrue?: boolean;
-  // if false, comparisons between a nullable boolean variable to `false` will be checked and fixed
+  // if false, comparisons between a nullable boolean expression to `false` will be checked and fixed
   allowComparingNullableBooleansToFalse?: boolean;
+  // if defined, comparisons between a nullable boolean expression to boolean literals are replaced
+  // with a preceeding null/undefined check
+  fixWithExplicitNullishCheck?: {
+    // whether the check should be against null or undefined.
+    // since loose equality (==, !=) is used for this check, this is just a style choice.
+    nullishSymbol: 'null' | 'undefined';
+  };
 };
 ```
 
 ### Defaults
 
-This rule always checks comparisons between a boolean variable and a boolean
-literal. Comparisons between nullable boolean variables and boolean literals
+This rule always checks comparisons between a boolean expression and a boolean
+literal. Comparisons between nullable boolean expressions and boolean literals
 are **not** checked by default.
 
 ```ts
 const defaults = {
   allowComparingNullableBooleansToTrue: true,
   allowComparingNullableBooleansToFalse: true,
+  fixWithExplicitNullishCheck: undefined,
 };
 ```
 
@@ -110,24 +118,48 @@ Examples of **correct** code for this rule with `{ allowComparingNullableBoolean
 declare const someUndefinedCondition: boolean | undefined;
 if (someUndefinedCondition ?? true) {
 }
+if (someUndefinedCondition != null && !someUndefinedCondition) {
+}
 
 declare const someNullCondition: boolean | null;
 if (!(someNullCondition ?? true)) {
+}
+if (someNullCondition == undefined || someNullCondition) {
 }
 ```
 
 ## Fixer
 
+### Boolean Expresssions
+
+The follow table shows the output of the fixer on comparions that compare a boolean expression to a boolean literal.
+
+|       Comparison       | Fixer Output      |
+| :--------------------: | ----------------- |
+| `booleanVar === true`  | `booleanLiteral`  |
+| `booleanVar !== true`  | `!booleanLiteral` |
+| `booleanVar === false` | `!booleanLiteral` |
+| `booleanVar !== false` | `booleanLiteral`  |
+
+### Nullable Boolean Expressions
+
+The follow table shows the output of the fixer on comparions that compare a boolean expression to a boolean literal when the `fixWithExplicitNullishCheck` option is `undefined`:
+
 |           Comparison           | Fixer Output                    | Notes                                                                               |
 | :----------------------------: | ------------------------------- | ----------------------------------------------------------------------------------- |
-|     `booleanVar === true`      | `booleanLiteral`                |                                                                                     |
-|     `booleanVar !== true`      | `!booleanLiteral`               |                                                                                     |
-|     `booleanVar === false`     | `!booleanLiteral`               |                                                                                     |
-|     `booleanVar !== false`     | `booleanLiteral`                |                                                                                     |
 | `nullableBooleanVar === true`  | `nullableBooleanVar`            | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
 | `nullableBooleanVar !== true`  | `!nullableBooleanVar`           | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
 | `nullableBooleanVar === false` | `nullableBooleanVar ?? true`    | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
 | `nullableBooleanVar !== false` | `!(nullableBooleanVar ?? true)` | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
+
+The follow table shows the output of the fixer on comparions that compare a boolean expression to a boolean literal when the `fixWithExplicitNullishCheck` option is `{ nullishSymbol: "null" }`:
+
+|           Comparison           | Fixer Output                                        | Notes                                                                               |
+| :----------------------------: | --------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `nullableBooleanVar === true`  | `nullableBooleanVar != null && nullableBooleanVar`  | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
+| `nullableBooleanVar !== true`  | `nullableBooleanVar == null || !nullableBooleanVar` | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
+| `nullableBooleanVar === false` | `nullableBooleanVar != null && !nullableBooleanVar` | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
+| `nullableBooleanVar !== false` | `nullableBooleanVar == null || nullableBooleanVar`  | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
 
 ## Related to
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -275,7 +275,7 @@ export default util.createRule<Options, MessageIds>({
               // `booleanOrFalse != null && booleanOrFalse`. We only apply these
               // fixes for identifiers, for more complicated expressions, we
               // could change the program behavior (e.g. if the expression is a
-              // function call, we would be eplacing one function call with two)
+              // function call, we would be replacing one function call with two)
               if (comparison.expression.type === AST_NODE_TYPES.Identifier) {
                 // remove the comparison and the boolean literal
                 yield fixer.removeRange(comparison.range);

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
@@ -257,8 +257,34 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
     },
     {
       code: `
-        declare const varFalseOrNull: false | null;
-        if (varFalseOrNull !== true) {
+        declare const varBoolOrNull: boolean | null;
+        if (varBoolOrNull === true) {
+        }
+      `,
+      options: [
+        {
+          allowComparingNullableBooleansToTrue: false,
+          fixWithExplicitNullishCheck: {
+            nullishSymbol: 'undefined',
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'comparingNullableToTrueDirect',
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
+      output: `
+        declare const varBoolOrNull: boolean | null;
+        if ((varBoolOrNull != undefined && varBoolOrNull)) {
+        }
+      `,
+    },
+    {
+      code: `
+        declare const varBoolOrNull: boolean | null;
+        if (varBoolOrNull !== true) {
         }
       `,
       options: [
@@ -276,8 +302,60 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
       ],
       // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
       output: `
-        declare const varFalseOrNull: false | null;
-        if ((varFalseOrNull == undefined || !varFalseOrNull)) {
+        declare const varBoolOrNull: boolean | null;
+        if ((varBoolOrNull == undefined || !varBoolOrNull)) {
+        }
+      `,
+    },
+    {
+      code: `
+        declare const varBoolOrNull: boolean | null;
+        if (varBoolOrNull === false) {
+        }
+      `,
+      options: [
+        {
+          allowComparingNullableBooleansToFalse: false,
+          fixWithExplicitNullishCheck: {
+            nullishSymbol: 'undefined',
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'comparingNullableToFalse',
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
+      output: `
+        declare const varBoolOrNull: boolean | null;
+        if ((varBoolOrNull != undefined && !varBoolOrNull)) {
+        }
+      `,
+    },
+    {
+      code: `
+        declare const varBoolOrNull: boolean | null;
+        if (varBoolOrNull !== false) {
+        }
+      `,
+      options: [
+        {
+          allowComparingNullableBooleansToFalse: false,
+          fixWithExplicitNullishCheck: {
+            nullishSymbol: 'undefined',
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'comparingNullableToFalse',
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
+      output: `
+        declare const varBoolOrNull: boolean | null;
+        if ((varBoolOrNull == undefined || varBoolOrNull)) {
         }
       `,
     },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
@@ -224,5 +224,117 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
         }
       `,
     },
+    {
+      code: `
+        function getBooleanOrNull(): false | null {
+          Math.random() > 0.5 ? false : null;
+        }
+        if (getBooleanOrNull() === true) {
+        }
+      `,
+      options: [
+        {
+          allowComparingNullableBooleansToTrue: false,
+          fixWithExplicitNullishCheck: {
+            nullishSymbol: 'null',
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'comparingNullableToTrueDirect',
+        },
+      ],
+      // can't fix because fixing would call the function twice:
+      // `getBooleanOrNull() != null && getBooleanOrNull()`
+      output: `
+        function getBooleanOrNull(): false | null {
+          Math.random() > 0.5 ? false : null;
+        }
+        if (getBooleanOrNull() === true) {
+        }
+      `,
+    },
+    {
+      code: `
+        declare const varFalseOrNull: false | null;
+        if (varFalseOrNull !== true) {
+        }
+      `,
+      options: [
+        {
+          allowComparingNullableBooleansToTrue: false,
+          fixWithExplicitNullishCheck: {
+            nullishSymbol: 'undefined',
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'comparingNullableToTrueNegated',
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
+      output: `
+        declare const varFalseOrNull: false | null;
+        if ((varFalseOrNull == undefined || !varFalseOrNull)) {
+        }
+      `,
+    },
+    {
+      code: `
+        declare const varBooleanOrNull: boolean | null;
+        declare const otherBoolean: boolean;
+        if (varBooleanOrNull === false && otherBoolean) {
+        }
+      `,
+      options: [
+        {
+          allowComparingNullableBooleansToFalse: false,
+          fixWithExplicitNullishCheck: {
+            nullishSymbol: 'null',
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'comparingNullableToFalse',
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
+      output: `
+        declare const varBooleanOrNull: boolean | null;
+        declare const otherBoolean: boolean;
+        if ((varBooleanOrNull != null && !varBooleanOrNull) && otherBoolean) {
+        }
+      `,
+    },
+    {
+      code: `
+        declare const varBoolOrUndefined: true | false | undefined;
+        declare const otherBoolean: boolean;
+        if (varBoolOrUndefined !== false && !otherBoolean) {
+        }
+      `,
+      options: [
+        {
+          allowComparingNullableBooleansToFalse: false,
+          fixWithExplicitNullishCheck: {
+            nullishSymbol: 'null',
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'comparingNullableToFalse',
+        },
+      ],
+      output: `
+        declare const varBoolOrUndefined: true | false | undefined;
+        declare const otherBoolean: boolean;
+        if ((varBoolOrUndefined == null || varBoolOrUndefined) && !otherBoolean) {
+        }
+      `,
+    },
   ],
 });


### PR DESCRIPTION
As a followup to https://github.com/typescript-eslint/typescript-eslint/pull/1983, I figured that probably the most clear solution to a nullable-boolean comparison is an actual null check.

Example: `myNullableBoolean === true`. The current fixer will change it to `myNullableBoolean`, which is a bit simpler but doesn't address the ambiguity. IMO, the most clear way to do this is `myNullableBoolean != null && myNullableBoolean`. This is similar in motivation to [strict-boolean-expressions](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md).

This proposal adds a `fixWithExplicitNullishCheck` option to the rule to modify the behavior of the fixer. You can see what this option does here: https://github.com/zachkirsch/typescript-eslint/blob/zk/explicit-nullable-boolean-cmp/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md#nullable-boolean-expressions