### PR TITLE
fix(eslint-plugin): [space-before-function-paren] incorrect handling of abstract methods

### DIFF
--- a/packages/eslint-plugin/src/rules/space-before-function-paren.ts
+++ b/packages/eslint-plugin/src/rules/space-before-function-paren.ts
@@ -76,9 +76,10 @@ export default util.createRule<Options, MessageIds>({
         | TSESTree.ArrowFunctionExpression
         | TSESTree.FunctionDeclaration
         | TSESTree.FunctionExpression
-        | TSESTree.TSAbstractMethodDefinition,
+        | TSESTree.TSEmptyBodyFunctionExpression
+        | TSESTree.TSDeclareFunction,
     ): boolean {
-      if ('id' in node && node.id != null) {
+      if (node.id != null) {
         return true;
       }
 
@@ -102,7 +103,8 @@ export default util.createRule<Options, MessageIds>({
         | TSESTree.ArrowFunctionExpression
         | TSESTree.FunctionDeclaration
         | TSESTree.FunctionExpression
-        | TSESTree.TSAbstractMethodDefinition,
+        | TSESTree.TSEmptyBodyFunctionExpression
+        | TSESTree.TSDeclareFunction,
     ): FuncOption {
       if (node.type === AST_NODE_TYPES.ArrowFunctionExpression) {
         // Always ignore non-async functions and arrow functions without parens, e.g. async foo => bar
@@ -116,7 +118,7 @@ export default util.createRule<Options, MessageIds>({
         return overrideConfig.named ?? baseConfig;
 
         // `generator-star-spacing` should warn anonymous generators. E.g. `function* () {}`
-      } else if (!('generator' in node) || node.generator === false) {
+      } else if (!node.generator) {
         return overrideConfig.anonymous ?? baseConfig;
       }
 
@@ -133,7 +135,8 @@ export default util.createRule<Options, MessageIds>({
         | TSESTree.ArrowFunctionExpression
         | TSESTree.FunctionDeclaration
         | TSESTree.FunctionExpression
-        | TSESTree.TSAbstractMethodDefinition,
+        | TSESTree.TSEmptyBodyFunctionExpression
+        | TSESTree.TSDeclareFunction,
     ): void {
       const functionConfig = getConfigForFunction(node);
 
@@ -165,7 +168,7 @@ export default util.createRule<Options, MessageIds>({
       } else if (
         !hasSpacing &&
         functionConfig === 'always' &&
-        (!node.typeParameters || ('id' in node && node != null))
+        (!node.typeParameters || node.id)
       ) {
         context.report({
           node,
@@ -180,7 +183,8 @@ export default util.createRule<Options, MessageIds>({
       ArrowFunctionExpression: checkFunction,
       FunctionDeclaration: checkFunction,
       FunctionExpression: checkFunction,
-      TSAbstractMethodDefinition: checkFunction,
+      TSEmptyBodyFunctionExpression: checkFunction,
+      TSDeclareFunction: checkFunction,
     };
   },
 });

--- a/packages/eslint-plugin/tests/rules/space-before-function-paren.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-before-function-paren.test.ts
@@ -153,6 +153,19 @@ ruleTester.run('space-before-function-paren', rule, {
       code: 'abstract class Foo { constructor() {} abstract method() }',
       options: ['never'],
     },
+    {
+      code: 'abstract class Foo { constructor() {} abstract method() }',
+      options: [{ anonymous: 'always', named: 'never' }],
+    },
+    'function foo ();',
+    {
+      code: 'function foo();',
+      options: ['never'],
+    },
+    {
+      code: 'function foo();',
+      options: [{ anonymous: 'always', named: 'never' }],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
Fixes #2274