### PR TITLE
fix(eslint-plugin): [adjacent-overload-signatures] fix false positive on call signatures and a method named `call`

### DIFF
--- a/packages/eslint-plugin/tests/rules/adjacent-overload-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/adjacent-overload-signatures.test.ts
@@ -132,6 +132,17 @@ interface Foo {
     `,
     `
 interface Foo {
+  (s: string): void;
+  (n: number): void;
+  (sn: string | number): void;
+  foo(n: number): void;
+  bar(): void;
+  baz(): void;
+  call(): void;
+}
+    `,
+    `
+interface Foo {
   foo(s: string): void;
   foo(n: number): void;
   foo(sn: string | number): void;
@@ -534,6 +545,7 @@ interface Foo {
   (sn: string | number): void;
   bar(): void;
   baz(): void;
+  call(): void;
 }
       `,
       errors: [


### PR DESCRIPTION
Fixes #2312

This false positive occurred because `CallSignature` and normal methods named `call` were treated identically.
So I've fixed how to decide two methods are same or not.