### PR TITLE
fix(typescript-estree): correct AST regression introduced by TS4.0 upgrade

### DIFF
--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -1,7 +1,7 @@
 import unescape from 'lodash/unescape';
-import * as semver from 'semver';
 import * as ts from 'typescript';
 import { AST_NODE_TYPES, AST_TOKEN_TYPES, TSESTree } from './ts-estree';
+import { typescriptVersionIsAtLeast } from './version-check';
 
 const SyntaxKind = ts.SyntaxKind;
 
@@ -453,13 +453,6 @@ export function isOptionalChain(
 }
 
 /**
- * Returns true if the current TS version is TS 3.9
- */
-function isTSv3dot9(): boolean {
-  return !semver.satisfies(ts.version, '< 3.9.0 || < 3.9.1-rc || < 3.9.0-beta');
-}
-
-/**
  * Returns true of the child of property access expression is an optional chain
  */
 export function isChildOptionalChain(
@@ -477,7 +470,7 @@ export function isChildOptionalChain(
     return true;
   }
 
-  if (!isTSv3dot9()) {
+  if (!typescriptVersionIsAtLeast['3.9']) {
     return false;
   }
 

--- a/packages/typescript-estree/src/version-check.ts
+++ b/packages/typescript-estree/src/version-check.ts
@@ -1,0 +1,28 @@
+import * as semver from 'semver';
+import * as ts from 'typescript';
+
+function semverCheck(version: string): boolean {
+  return semver.satisfies(
+    ts.version,
+    `>= ${version}.0 || >= ${version}.1-rc || >= ${version}.0-beta`,
+    {
+      includePrerelease: true,
+    },
+  );
+}
+
+const versions = [
+  //
+  '3.7',
+  '3.8',
+  '3.9',
+  '4.0',
+] as const;
+type Versions = typeof versions extends ArrayLike<infer U> ? U : never;
+
+const typescriptVersionIsAtLeast = {} as Record<Versions, boolean>;
+for (const version of versions) {
+  typescriptVersionIsAtLeast[version] = semverCheck(version);
+}
+
+export { typescriptVersionIsAtLeast };


### PR DESCRIPTION
Reference: https://github.com/prettier/prettier/pull/8805

I had a major brainfart when implementing #2305 and didn't think about the fact that changes should be backwards compatible.

When handling the null type change introduced by `4.0`, I deleted the old branches instead of gating them behind a version check. This PR just gates the old logic for `< 4.0`.

We don't have automated testing against old TS versions yet (#1752) so I tested this by hand by doing the following:
- `yarn build` to build against `4.0.0-beta`.
- change the [resolved ts version](https://github.com/typescript-eslint/typescript-eslint/blob/30fafb09422b3aca881f4785d89b0536092d4952/package.json#L104) to `3.9.7`
- `yarn install --ignore-scripts` (the automatic rebuild after the install would fail due to incorrect types)
- `cd packages/typescript-estree && yarn test ast-fixtures`
- inspected the test output to ensure the only failures were due to fixtures for 4.0 features.

cc @thorn0 / @fisker