### PR TITLE
fix(eslint-plugin): [no-extra-parens] stop reporting on calling generic functions with one argument and type parameters containing parentheses

### DIFF
--- a/packages/eslint-plugin/src/rules/no-extra-parens.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-parens.ts
@@ -78,6 +78,25 @@ export default util.createRule<Options, MessageIds>({
         });
       }
 
+      if (
+        node.arguments.length === 1 &&
+        node.typeParameters?.params.some(
+          param =>
+            param.type === AST_NODE_TYPES.TSParenthesizedType ||
+            param.type === AST_NODE_TYPES.TSImportType,
+        )
+      ) {
+        return rule({
+          ...node,
+          arguments: [
+            {
+              ...node.arguments[0],
+              type: AST_NODE_TYPES.SequenceExpression as any,
+            },
+          ],
+        });
+      }
+
       return rule(node);
     }
     function unaryUpdateExpression(

--- a/packages/eslint-plugin/tests/rules/no-extra-parens.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extra-parens.test.ts
@@ -26,9 +26,9 @@ for (a of (b, c));
 for (a of b);
 for (a in b, c);
 for (a in b);
-a<import('')>(1)
-new a<import('')>(1)
-a<(A)>(1)
+a<import('')>(1);
+new a<import('')>(1);
+a<(A)>(1);
       `,
     }),
     ...batchedSingleLineTests({
@@ -236,8 +236,8 @@ for (a in (b, c));
 for (a in (b));
 for (a of (b));
 typeof (a);
-a<import('')>((1))
-new a<import('')>((1))
+a<import('')>((1));
+new a<import('')>((1));
       `,
       output: `
 a = b * c;
@@ -246,9 +246,9 @@ for (a in b, c);
 for (a in b);
 for (a of b);
 typeof a;
-a<import('')>(1)
-new a<import('')>(1)
-a<(A)>((1))
+a<import('')>(1);
+new a<import('')>(1);
+a<(A)>((1));
       `,
       errors: [
         {

--- a/packages/eslint-plugin/tests/rules/no-extra-parens.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extra-parens.test.ts
@@ -26,6 +26,9 @@ for (a of (b, c));
 for (a of b);
 for (a in b, c);
 for (a in b);
+a<import('')>(1)
+new a<import('')>(1)
+a<(A)>(1)
       `,
     }),
     ...batchedSingleLineTests({
@@ -233,6 +236,8 @@ for (a in (b, c));
 for (a in (b));
 for (a of (b));
 typeof (a);
+a<import('')>((1))
+new a<import('')>((1))
       `,
       output: `
 a = b * c;
@@ -241,6 +246,9 @@ for (a in b, c);
 for (a in b);
 for (a of b);
 typeof a;
+a<import('')>(1)
+new a<import('')>(1)
+a<(A)>((1))
       `,
       errors: [
         {
@@ -271,6 +279,21 @@ typeof a;
         {
           messageId: 'unexpected',
           line: 7,
+          column: 8,
+        },
+        {
+          messageId: 'unexpected',
+          line: 8,
+          column: 15,
+        },
+        {
+          messageId: 'unexpected',
+          line: 9,
+          column: 19,
+        },
+        {
+          messageId: 'unexpected',
+          line: 10,
           column: 8,
         },
       ],


### PR DESCRIPTION
Fixes #2314