### PR TITLE
fix(eslint-plugin): [no-unused-vars] handle TSCallSignature

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -84,8 +84,9 @@ export default util.createRule<Options, MessageIds>({
 
     return {
       ...rules,
-      'TSConstructorType, TSConstructSignatureDeclaration, TSDeclareFunction, TSEmptyBodyFunctionExpression, TSFunctionType, TSMethodSignature'(
+      'TSCallSignatureDeclaration, TSConstructorType, TSConstructSignatureDeclaration, TSDeclareFunction, TSEmptyBodyFunctionExpression, TSFunctionType, TSMethodSignature'(
         node:
+          | TSESTree.TSCallSignatureDeclaration
           | TSESTree.TSConstructorType
           | TSESTree.TSConstructSignatureDeclaration
           | TSESTree.TSDeclareFunction

--- a/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
@@ -729,6 +729,26 @@ export function foo() {
   return new Promise<Foo>();
 }
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2331
+    {
+      code: `
+export interface Event<T> {
+  (
+    listener: (e: T) => any,
+    thisArgs?: any,
+    disposables?: Disposable[],
+  ): Disposable;
+}
+      `,
+      options: [
+        {
+          args: 'after-used',
+          argsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+          varsIgnorePattern: '^_$',
+        },
+      ],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
Fixes #2331