### PR TITLE
feat(eslint-plugin): [ban-ts-comment] change default for `ts-expect-error` to `allow-with-description`

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-ts-comment.md
+++ b/packages/eslint-plugin/docs/rules/ban-ts-comment.md
@@ -29,7 +29,7 @@ interface Options {
 }
 
 const defaultOptions: Options = {
-  'ts-expect-error': true,
+  'ts-expect-error': 'allow-with-description',
   'ts-ignore': true,
   'ts-nocheck': true,
   'ts-check': false,

--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -11,16 +11,6 @@ interface Options {
 
 export const defaultMinimumDescriptionLength = 3;
 
-const defaultOptions: [Options] = [
-  {
-    'ts-expect-error': true,
-    'ts-ignore': true,
-    'ts-nocheck': true,
-    'ts-check': false,
-    minimumDescriptionLength: defaultMinimumDescriptionLength,
-  },
-];
-
 type MessageIds =
   | 'tsDirectiveComment'
   | 'tsDirectiveCommentRequiresDescription';
@@ -98,7 +88,15 @@ export default util.createRule<[Options], MessageIds>({
       },
     ],
   },
-  defaultOptions,
+  defaultOptions: [
+    {
+      'ts-expect-error': 'allow-with-description',
+      'ts-ignore': true,
+      'ts-nocheck': true,
+      'ts-check': false,
+      minimumDescriptionLength: defaultMinimumDescriptionLength,
+    },
+  ],
   create(context, [options]) {
     const tsCommentRegExp = /^\/*\s*@ts-(expect-error|ignore|check|nocheck)(.*)/;
     const sourceCode = context.getSourceCode();


### PR DESCRIPTION
Fixes #2146

BREAKING CHANGE:

Default rule options is a breaking change.