### PR TITLE
feat(eslint-plugin): [typedef] remove all defaults

### DIFF
--- a/packages/eslint-plugin/docs/rules/typedef.md
+++ b/packages/eslint-plugin/docs/rules/typedef.md
@@ -16,29 +16,43 @@ class ContainsText {
 }
 ```
 
-> Note: requiring type annotations unnecessarily can be cumbersome to maintain and generally reduces code readability.
-> TypeScript is often better at inferring types than easily written type annotations would allow.
-> Instead of enabling `typedef`, it is generally recommended to use the `--noImplicitAny` and/or `--strictPropertyInitialization` compiler options to enforce type annotations only when useful.
+**_Note:_** requiring type annotations unnecessarily can be cumbersome to maintain and generally reduces code readability.
+TypeScript is often better at inferring types than easily written type annotations would allow.
+
+**Instead of enabling `typedef`, it is generally recommended to use the `--noImplicitAny` and `--strictPropertyInitialization` compiler options to enforce type annotations only when useful.**
 
 ## Rule Details
 
 This rule can enforce type annotations in locations regardless of whether they're required.
 This is typically used to maintain consistency for element types that sometimes require them.
 
-> To enforce type definitions existing on call signatures as per TSLint's `arrow-call-signature` and `call-signature` options, use `explicit-function-return-type`.
+> To enforce type definitions existing on call signatures as per TSLint's `arrow-call-signature` and `call-signature` options, use `explicit-function-return-type`, or `explicit-module-boundary-types`.
 
 ## Options
 
-This rule has an object option that may receive any of the following as booleans:
+```ts
+type Options = {
+  arrayDestructuring?: boolean;
+  arrowParameter?: boolean;
+  memberVariableDeclaration?: boolean;
+  objectDestructuring?: boolean;
+  parameter?: boolean;
+  propertyDeclaration?: boolean;
+  variableDeclaration?: boolean;
+  variableDeclarationIgnoreFunction?: boolean;
+};
 
-- `"arrayDestructuring"`
-- `"arrowParameter"`: `true` by default
-- `"memberVariableDeclaration"`: `true` by default
-- `"objectDestructuring"`
-- `"parameter"`: `true` by default
-- `"propertyDeclaration"`: `true` by default
-- `"variableDeclaration"`,
-- `"variableDeclarationIgnoreFunction"`
+const defaultOptions: Options = {
+  arrayDestructuring: false,
+  arrowParameter: false,
+  memberVariableDeclaration: false,
+  objectDestructuring: false,
+  parameter: false,
+  propertyDeclaration: false,
+  variableDeclaration: false,
+  variableDeclarationIgnoreFunction: false,
+};
+```
 
 For example, with the following configuration:
 
@@ -48,7 +62,7 @@ For example, with the following configuration:
     "@typescript-eslint/typedef": [
       "error",
       {
-        "arrowParameter": false,
+        "arrowParameter": true,
         "variableDeclaration": true
       }
     ]
@@ -56,9 +70,8 @@ For example, with the following configuration:
 }
 ```
 
-- Type annotations on arrow function parameters are not required
+- Type annotations on arrow function parameters are required
 - Type annotations on variables are required
-- Options otherwise adhere to the defaults
 
 ### `arrayDestructuring`
 

--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -50,10 +50,14 @@ export default util.createRule<[Options], MessageIds>({
   },
   defaultOptions: [
     {
-      [OptionKeys.ArrowParameter]: true,
-      [OptionKeys.MemberVariableDeclaration]: true,
-      [OptionKeys.Parameter]: true,
-      [OptionKeys.PropertyDeclaration]: true,
+      [OptionKeys.ArrayDestructuring]: false,
+      [OptionKeys.ArrowParameter]: false,
+      [OptionKeys.MemberVariableDeclaration]: false,
+      [OptionKeys.ObjectDestructuring]: false,
+      [OptionKeys.Parameter]: false,
+      [OptionKeys.PropertyDeclaration]: false,
+      [OptionKeys.VariableDeclaration]: false,
+      [OptionKeys.VariableDeclarationIgnoreFunction]: false,
     },
   ],
   create(context, [options]) {

--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -492,6 +492,11 @@ class Foo {
           messageId: 'expectedTypedefNamed',
         },
       ],
+      options: [
+        {
+          arrowParameter: true,
+        },
+      ],
     },
     {
       code: 'const receivesStrings = (a, b): void => {};',
@@ -503,6 +508,11 @@ class Foo {
         {
           data: { name: 'b' },
           messageId: 'expectedTypedefNamed',
+        },
+      ],
+      options: [
+        {
+          arrowParameter: true,
         },
       ],
     },
@@ -519,6 +529,11 @@ class Foo {
           messageId: 'expectedTypedefNamed',
         },
       ],
+      options: [
+        {
+          memberVariableDeclaration: true,
+        },
+      ],
     },
     {
       code: `
@@ -531,6 +546,11 @@ class Foo {
           messageId: 'expectedTypedef',
         },
       ],
+      options: [
+        {
+          memberVariableDeclaration: true,
+        },
+      ],
     },
     // Function parameters
     {
@@ -539,6 +559,11 @@ class Foo {
         {
           data: { name: 'a' },
           messageId: 'expectedTypedefNamed',
+        },
+      ],
+      options: [
+        {
+          parameter: true,
         },
       ],
     },
@@ -554,6 +579,11 @@ class Foo {
           messageId: 'expectedTypedefNamed',
         },
       ],
+      options: [
+        {
+          parameter: true,
+        },
+      ],
     },
     {
       code: 'function receivesNumber([a]): void {}',
@@ -561,6 +591,11 @@ class Foo {
         {
           column: 25,
           messageId: 'expectedTypedef',
+        },
+      ],
+      options: [
+        {
+          parameter: true,
         },
       ],
     },
@@ -572,6 +607,11 @@ class Foo {
           messageId: 'expectedTypedef',
         },
       ],
+      options: [
+        {
+          parameter: true,
+        },
+      ],
     },
     {
       code: 'function receivesString({ a }): void {}',
@@ -581,6 +621,11 @@ class Foo {
           messageId: 'expectedTypedef',
         },
       ],
+      options: [
+        {
+          parameter: true,
+        },
+      ],
     },
     {
       code: 'function receivesStrings({ a, b }): void {}',
@@ -588,6 +633,11 @@ class Foo {
         {
           column: 26,
           messageId: 'expectedTypedef',
+        },
+      ],
+      options: [
+        {
+          parameter: true,
         },
       ],
     },
@@ -604,6 +654,11 @@ class Foo {
           messageId: 'expectedTypedefNamed',
         },
       ],
+      options: [
+        {
+          parameter: true,
+        },
+      ],
     },
     {
       code: `
@@ -617,6 +672,11 @@ class Foo {
           messageId: 'expectedTypedef',
         },
       ],
+      options: [
+        {
+          parameter: true,
+        },
+      ],
     },
     {
       code: `
@@ -628,6 +688,11 @@ class Foo {
         {
           column: 23,
           messageId: 'expectedTypedef',
+        },
+      ],
+      options: [
+        {
+          parameter: true,
         },
       ],
     },
@@ -646,6 +711,11 @@ class Foo {
           messageId: 'expectedTypedefNamed',
         },
       ],
+      options: [
+        {
+          parameter: true,
+        },
+      ],
     },
     {
       code: `
@@ -661,6 +731,11 @@ class Foo {
           messageId: 'expectedTypedef',
         },
       ],
+      options: [
+        {
+          parameter: true,
+        },
+      ],
     },
     {
       code: `
@@ -672,6 +747,11 @@ class Foo {
         {
           column: 30,
           messageId: 'expectedTypedef',
+        },
+      ],
+      options: [
+        {
+          parameter: true,
         },
       ],
     },
@@ -688,6 +768,11 @@ class Foo {
           messageId: 'expectedTypedefNamed',
         },
       ],
+      options: [
+        {
+          propertyDeclaration: true,
+        },
+      ],
     },
     {
       code: `
@@ -699,6 +784,11 @@ class Foo {
       errors: [
         {
           messageId: 'expectedTypedef',
+        },
+      ],
+      options: [
+        {
+          propertyDeclaration: true,
         },
       ],
     },
@@ -714,6 +804,11 @@ class Foo {
           messageId: 'expectedTypedefNamed',
         },
       ],
+      options: [
+        {
+          propertyDeclaration: true,
+        },
+      ],
     },
     {
       code: `
@@ -725,6 +820,11 @@ class Foo {
       errors: [
         {
           messageId: 'expectedTypedef',
+        },
+      ],
+      options: [
+        {
+          propertyDeclaration: true,
         },
       ],
     },
@@ -879,6 +979,7 @@ class Foo {
       ],
       options: [
         {
+          memberVariableDeclaration: true,
           variableDeclaration: true,
           variableDeclarationIgnoreFunction: false,
         },


### PR DESCRIPTION
BREAKING CHANGE:

Removes all default options from `typedef`. Users will have to specifically opt-in to all options them selves.

This is intentional friction being introduced to setup the rule to help discourage it as it's not recommended for use.  
This also ensures this rule cannot conflict with any other rules (or even do anything) in the `all` config.

Fixes #2075