### PR TITLE
feat(eslint-plugin): [no-unsafe-assignment/return] allow assigning any => unknown

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-assignment.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-assignment.md
@@ -56,6 +56,16 @@ const x: Set<string[]> = new Set<string[]>();
 const x: Set<Set<Set<string>>> = new Set<Set<Set<string>>>();
 ```
 
+There are cases where the rule allows assignment of `any` to `unknown`.
+
+Example of `any` to `unknown` assignment that are allowed.
+
+```ts
+const x: unknown = y as any;
+const x: unknown[] = y as any[];
+const x: Set<unknown> = y as Set<any>;
+```
+
 ## Related to
 
 - [`no-explicit-any`](./no-explicit-any.md)

--- a/packages/eslint-plugin/docs/rules/no-unsafe-return.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-return.md
@@ -69,6 +69,20 @@ type TAssign = () => Set<string>;
 const assignability2: TAssign = () => new Set(['foo']);
 ```
 
+There are cases where the rule allows to return `any` to `unknown`.
+
+Examples of `any` to `unknown` return that are allowed.
+
+```ts
+function foo1(): unknown {
+  return JSON.parse(singleObjString); // Return type for JSON.parse is any.
+}
+
+function foo2(): unknown[] {
+  return [] as any[];
+}
+```
+
 ## Related to
 
 - [`no-explicit-any`](./no-explicit-any.md)

--- a/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts
@@ -238,6 +238,11 @@ export default util.createRule({
       );
 
       if (util.isTypeAnyType(senderType)) {
+        // handle cases when we assign any ==> unknown.
+        if (util.isTypeUnknownType(receiverType)) {
+          return false;
+        }
+
         context.report({
           node: reportingNode,
           messageId: 'anyAssignment',

--- a/packages/eslint-plugin/src/rules/no-unsafe-return.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-return.ts
@@ -82,7 +82,8 @@ export default util.createRule({
       }
 
       if (anyType !== util.AnyType.Safe) {
-        // Handle cases when the return type of the function is either unknown or unknown[].
+        // Allow cases when the declared return type of the function is either unknown or unknown[]
+        // and the function is returning any or any[].
         for (const signature of functionType.getCallSignatures()) {
           const functionReturnType = signature.getReturnType();
           if (
@@ -99,6 +100,7 @@ export default util.createRule({
           }
         }
 
+        // If the function return type was not unknown/unknown[], mark usage as unsafeReturn.
         return context.report({
           node: reportingNode,
           messageId: 'unsafeReturn',

--- a/packages/eslint-plugin/src/rules/no-unsafe-return.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-return.ts
@@ -58,16 +58,6 @@ export default util.createRule({
     ): void {
       const tsNode = esTreeNodeToTSNodeMap.get(returnNode);
       const anyType = util.isAnyOrAnyArrayTypeDiscriminated(tsNode, checker);
-      if (anyType !== util.AnyType.Safe) {
-        return context.report({
-          node: reportingNode,
-          messageId: 'unsafeReturn',
-          data: {
-            type: anyType === util.AnyType.Any ? 'any' : 'any[]',
-          },
-        });
-      }
-
       const functionNode = getParentFunctionNode(returnNode);
       /* istanbul ignore if */ if (!functionNode) {
         return;
@@ -89,6 +79,33 @@ export default util.createRule({
         : checker.getTypeAtLocation(functionTSNode);
       if (!functionType) {
         functionType = checker.getTypeAtLocation(functionTSNode);
+      }
+
+      if (anyType !== util.AnyType.Safe) {
+        // Handle cases when the return type of the function is either unknown or unknown[].
+        for (const signature of functionType.getCallSignatures()) {
+          const functionReturnType = signature.getReturnType();
+          if (
+            anyType === util.AnyType.Any &&
+            util.isTypeUnknownType(functionReturnType)
+          ) {
+            return;
+          }
+          if (
+            anyType === util.AnyType.AnyArray &&
+            util.isTypeUnknownArrayType(functionReturnType, checker)
+          ) {
+            return;
+          }
+        }
+
+        return context.report({
+          node: reportingNode,
+          messageId: 'unsafeReturn',
+          data: {
+            type: anyType === util.AnyType.Any ? 'any' : 'any[]',
+          },
+        });
       }
 
       for (const signature of functionType.getCallSignatures()) {

--- a/packages/eslint-plugin/tests/rules/no-unsafe-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-assignment.test.ts
@@ -119,6 +119,15 @@ declare function Foo(props: Props): never;
       `,
       filename: 'react.tsx',
     },
+    `
+      const x: unknown = y as any;
+    `,
+    `
+      const x: unknown[] = y as any[];
+    `,
+    `
+      const x: Set<unknown> = y as Set<any>;
+    `,
   ],
   invalid: [
     ...batchedSingleLineTests({

--- a/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
@@ -77,6 +77,21 @@ function foo(): Set<number> {
         return x;
       }
     `,
+    `
+      function fn<T extends any>(x: T): unknown {
+        return x as any;
+      }
+    `,
+    `
+      function fn<T extends any>(x: T): unknown[] {
+        return x as any[];
+      }
+    `,
+    `
+      function fn<T extends any>(x: T): Set<unknown> {
+        return x as Set<any>;
+      }
+    `,
   ],
   invalid: [
     ...batchedSingleLineTests({

--- a/packages/eslint-plugin/tests/util/isUnsafeAssignment.test.ts
+++ b/packages/eslint-plugin/tests/util/isUnsafeAssignment.test.ts
@@ -166,5 +166,29 @@ describe('isUnsafeAssignment', () => {
 
       expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
     });
+
+    it('any to a unknown', () => {
+      const { sender, receiver, checker } = getTypes(
+        'const test: unknown = [] as any;',
+      );
+
+      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+    });
+
+    it('any[] in a generic position to a unknown[]', () => {
+      const { sender, receiver, checker } = getTypes(
+        'const test: unknown[] = [] as any[]',
+      );
+
+      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+    });
+
+    it('any in a generic position to a unknown (nested)', () => {
+      const { sender, receiver, checker } = getTypes(
+        'const test: Set<Set<Set<unknown>>> = new Set<Set<Set<any>>>();',
+      );
+
+      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+    });
   });
 });


### PR DESCRIPTION
Fixes #2325 

### Overview

This PR looks to relax restrictions to allow any => unknown assignment for `no-unsafe-assignment` and `no-unsafe-return`.

#### Approach
Initially we are checking for `Any` or `AnyArray` as `senderType`, if found we used to stop processing with the relevant message.
Now we additionally check if the `recieverType` is `Unknown` or `Unknown` array. If yes - then we do not treat this as an error case.

#### Special Focus
I would like you to specifically look at the coding style, so that we don't adversely affect future contributors. I have tried to align with the existing style. Feel free to point out where we could align more.

**Checklist**

- [x] Have updated the documentation for these rule and called these relaxation separately.
- [x] Have added UTs for the cases added.

