### PR TITLE
docs: document additional allow options in no-empty-function

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-empty-function.md
+++ b/packages/eslint-plugin/docs/rules/no-empty-function.md
@@ -20,5 +20,59 @@ One example of valid TypeScript specific code that would otherwise trigger the `
 ## Options
 
 See [`eslint/no-empty-function` options](https://eslint.org/docs/rules/no-empty-function#options).
+This rule adds the following options:
+
+```ts
+type AdditionalAllowOptionEntries =
+  | 'private-constructors'
+  | 'protected-constructors'
+  | 'decoratedFunctions';
+
+type AllowOptionEntries =
+  | BaseNoEmptyFunctionAllowOptionEntries
+  | AdditionalAllowOptionEntries;
+
+interface Options extends BaseNoEmptyFunctionOptions {
+  allow?: Array<AllowOptionEntries>;
+}
+const defaultOptions: Options = {
+  ...baseNoEmptyFunctionDefaultOptions,
+  allow: [],
+};
+```
+
+### allow: `private-constructors`
+
+Examples of correct code for the `{ "allow": ["private-constructors"] }` option:
+
+```ts
+class Foo {
+  private constructor() {}
+}
+```
+
+### allow: `protected-constructors`
+
+Examples of correct code for the `{ "allow": ["protected-constructors"] }` option:
+
+```ts
+class Foo {
+  protected constructor() {}
+}
+```
+
+### allow: `decoratedFunctions`
+
+Examples of correct code for the `{ "allow": ["decoratedFunctions"] }` option:
+
+```ts
+@decorator()
+function foo() {}
+
+class Foo {
+  @decorator()
+  foo() {}
+}
+```
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-empty-function.md)</sup>


### PR DESCRIPTION
This PR adds missing pieces of the `no-empty-function` documentation, where the TS-specific `allow` entries were completely omitted. It adds both a general overview of the extended `Options` object (as  pseudo-code), and per entry descriptions with examples (taken directly from test cases).