### PR TITLE
fix(typescript-estree): correct ChainExpression interaction with parentheses and non-nulls

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -234,6 +234,12 @@ export default util.createRule({
       }
 
       if (node.type === AST_NODE_TYPES.ChainExpression) {
+        /* istanbul ignore if */ if (
+          node.expression.type === AST_NODE_TYPES.TSNonNullExpression
+        ) {
+          // this shouldn't happen
+          return '';
+        }
         return getText(node.expression);
       }
 

--- a/packages/eslint-plugin/tests/rules/no-non-null-asserted-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-non-null-asserted-optional-chain.test.ts
@@ -8,7 +8,11 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-non-null-asserted-optional-chain', rule, {
   valid: [
     'foo.bar!;',
+    'foo.bar!.baz;',
+    'foo.bar!.baz();',
     'foo.bar()!;',
+    'foo.bar()!();',
+    'foo.bar()!.baz;',
     'foo?.bar;',
     'foo?.bar();',
     '(foo?.bar).baz!;',

--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -308,7 +308,10 @@ export type Node =
 export type Accessibility = 'public' | 'protected' | 'private';
 export type BindingPattern = ArrayPattern | ObjectPattern;
 export type BindingName = BindingPattern | Identifier;
-export type ChainElement = CallExpression | MemberExpression;
+export type ChainElement =
+  | CallExpression
+  | MemberExpression
+  | TSNonNullExpression;
 export type ClassElement =
   | ClassProperty
   | MethodDefinition

--- a/packages/typescript-estree/src/ts-estree/estree-to-ts-node-types.ts
+++ b/packages/typescript-estree/src/ts-estree/estree-to-ts-node-types.ts
@@ -23,7 +23,8 @@ export interface EstreeToTsNodeTypes {
   [AST_NODE_TYPES.ChainExpression]:
     | ts.CallExpression
     | ts.PropertyAccessExpression
-    | ts.ElementAccessExpression;
+    | ts.ElementAccessExpression
+    | ts.NonNullExpression;
   [AST_NODE_TYPES.ClassBody]: ts.ClassDeclaration | ts.ClassExpression;
   [AST_NODE_TYPES.ClassDeclaration]: ts.ClassDeclaration;
   [AST_NODE_TYPES.ClassExpression]: ts.ClassExpression;

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -411,21 +411,6 @@ tester.addFixturePatternConfig('typescript/basics', {
      * https://github.com/babel/babel/issues/11939
      */
     'catch-clause-with-annotation',
-
-    /**
-     * Optional chaining
-     * Babel has updated to ESTree's representation, and we haven't yet
-     * TODO: remove this with the v4 release
-     */
-    'optional-chain-call-with-non-null-assertion',
-    'optional-chain-call-with-parens',
-    'optional-chain-call',
-    'optional-chain-element-access-with-non-null-assertion',
-    'optional-chain-element-access-with-parens',
-    'optional-chain-element-access',
-    'optional-chain-with-non-null-assertion',
-    'optional-chain-with-parens',
-    'optional-chain',
   ],
   ignoreSourceType: [
     /**
@@ -479,14 +464,6 @@ tester.addFixturePatternConfig('typescript/decorators/property-decorators', {
 
 tester.addFixturePatternConfig('typescript/expressions', {
   fileType: 'ts',
-  ignore: [
-    /**
-     * Optional chaining
-     * Babel has updated to ESTree's representation, and we haven't yet
-     * TODO: remove this with the v4 release
-     */
-    'optional-call-expression-type-arguments',
-  ],
 });
 
 tester.addFixturePatternConfig('typescript/errorRecovery', {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/optional-chain-call-with-non-null-assertion.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/optional-chain-call-with-non-null-assertion.src.ts.shot
@@ -13,61 +13,7 @@ Object {
                 "arguments": Array [],
                 "callee": Object {
                   "expression": Object {
-                    "expression": Object {
-                      "computed": false,
-                      "loc": Object {
-                        "end": Object {
-                          "column": 10,
-                          "line": 2,
-                        },
-                        "start": Object {
-                          "column": 2,
-                          "line": 2,
-                        },
-                      },
-                      "object": Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 5,
-                            "line": 2,
-                          },
-                          "start": Object {
-                            "column": 2,
-                            "line": 2,
-                          },
-                        },
-                        "name": "one",
-                        "range": Array [
-                          40,
-                          43,
-                        ],
-                        "type": "Identifier",
-                      },
-                      "optional": true,
-                      "property": Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 10,
-                            "line": 2,
-                          },
-                          "start": Object {
-                            "column": 7,
-                            "line": 2,
-                          },
-                        },
-                        "name": "two",
-                        "range": Array [
-                          45,
-                          48,
-                        ],
-                        "type": "Identifier",
-                      },
-                      "range": Array [
-                        40,
-                        48,
-                      ],
-                      "type": "MemberExpression",
-                    },
+                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 10,
@@ -78,11 +24,48 @@ Object {
                         "line": 2,
                       },
                     },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 5,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 2,
+                          "line": 2,
+                        },
+                      },
+                      "name": "one",
+                      "range": Array [
+                        40,
+                        43,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "optional": true,
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 10,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 7,
+                          "line": 2,
+                        },
+                      },
+                      "name": "two",
+                      "range": Array [
+                        45,
+                        48,
+                      ],
+                      "type": "Identifier",
+                    },
                     "range": Array [
                       40,
                       48,
                     ],
-                    "type": "ChainExpression",
+                    "type": "MemberExpression",
                   },
                   "loc": Object {
                     "end": Object {
@@ -167,61 +150,7 @@ Object {
                   },
                   "object": Object {
                     "expression": Object {
-                      "expression": Object {
-                        "computed": false,
-                        "loc": Object {
-                          "end": Object {
-                            "column": 10,
-                            "line": 3,
-                          },
-                          "start": Object {
-                            "column": 2,
-                            "line": 3,
-                          },
-                        },
-                        "object": Object {
-                          "loc": Object {
-                            "end": Object {
-                              "column": 5,
-                              "line": 3,
-                            },
-                            "start": Object {
-                              "column": 2,
-                              "line": 3,
-                            },
-                          },
-                          "name": "one",
-                          "range": Array [
-                            55,
-                            58,
-                          ],
-                          "type": "Identifier",
-                        },
-                        "optional": true,
-                        "property": Object {
-                          "loc": Object {
-                            "end": Object {
-                              "column": 10,
-                              "line": 3,
-                            },
-                            "start": Object {
-                              "column": 7,
-                              "line": 3,
-                            },
-                          },
-                          "name": "two",
-                          "range": Array [
-                            60,
-                            63,
-                          ],
-                          "type": "Identifier",
-                        },
-                        "range": Array [
-                          55,
-                          63,
-                        ],
-                        "type": "MemberExpression",
-                      },
+                      "computed": false,
                       "loc": Object {
                         "end": Object {
                           "column": 10,
@@ -232,11 +161,48 @@ Object {
                           "line": 3,
                         },
                       },
+                      "object": Object {
+                        "loc": Object {
+                          "end": Object {
+                            "column": 5,
+                            "line": 3,
+                          },
+                          "start": Object {
+                            "column": 2,
+                            "line": 3,
+                          },
+                        },
+                        "name": "one",
+                        "range": Array [
+                          55,
+                          58,
+                        ],
+                        "type": "Identifier",
+                      },
+                      "optional": true,
+                      "property": Object {
+                        "loc": Object {
+                          "end": Object {
+                            "column": 10,
+                            "line": 3,
+                          },
+                          "start": Object {
+                            "column": 7,
+                            "line": 3,
+                          },
+                        },
+                        "name": "two",
+                        "range": Array [
+                          60,
+                          63,
+                        ],
+                        "type": "Identifier",
+                      },
                       "range": Array [
                         55,
                         63,
                       ],
-                      "type": "ChainExpression",
+                      "type": "MemberExpression",
                     },
                     "loc": Object {
                       "end": Object {
@@ -677,7 +643,7 @@ Object {
                   },
                   "loc": Object {
                     "end": Object {
-                      "column": 11,
+                      "column": 12,
                       "line": 6,
                     },
                     "start": Object {
@@ -687,9 +653,9 @@ Object {
                   },
                   "range": Array [
                     117,
-                    125,
+                    126,
                   ],
-                  "type": "ChainExpression",
+                  "type": "TSNonNullExpression",
                 },
                 "loc": Object {
                   "end": Object {
@@ -705,7 +671,7 @@ Object {
                   117,
                   126,
                 ],
-                "type": "TSNonNullExpression",
+                "type": "ChainExpression",
               },
               "loc": Object {
                 "end": Object {
@@ -814,7 +780,7 @@ Object {
                     },
                     "loc": Object {
                       "end": Object {
-                        "column": 11,
+                        "column": 12,
                         "line": 7,
                       },
                       "start": Object {
@@ -824,9 +790,9 @@ Object {
                     },
                     "range": Array [
                       134,
-                      142,
+                      143,
                     ],
-                    "type": "ChainExpression",
+                    "type": "TSNonNullExpression",
                   },
                   "loc": Object {
                     "end": Object {
@@ -842,7 +808,7 @@ Object {
                     134,
                     143,
                   ],
-                  "type": "TSNonNullExpression",
+                  "type": "ChainExpression",
                 },
                 "optional": false,
                 "property": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/optional-chain-call-with-parens.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/optional-chain-call-with-parens.src.ts.shot
@@ -935,11 +935,29 @@ Object {
               "expression": Object {
                 "arguments": Array [],
                 "callee": Object {
-                  "arguments": Array [],
-                  "callee": Object {
+                  "expression": Object {
+                    "arguments": Array [],
+                    "callee": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 6,
+                          "line": 10,
+                        },
+                        "start": Object {
+                          "column": 3,
+                          "line": 10,
+                        },
+                      },
+                      "name": "one",
+                      "range": Array [
+                        184,
+                        187,
+                      ],
+                      "type": "Identifier",
+                    },
                     "loc": Object {
                       "end": Object {
-                        "column": 6,
+                        "column": 10,
                         "line": 10,
                       },
                       "start": Object {
@@ -947,12 +965,12 @@ Object {
                         "line": 10,
                       },
                     },
-                    "name": "one",
+                    "optional": true,
                     "range": Array [
                       184,
-                      187,
+                      191,
                     ],
-                    "type": "Identifier",
+                    "type": "CallExpression",
                   },
                   "loc": Object {
                     "end": Object {
@@ -964,12 +982,11 @@ Object {
                       "line": 10,
                     },
                   },
-                  "optional": true,
                   "range": Array [
                     184,
                     191,
                   ],
-                  "type": "CallExpression",
+                  "type": "ChainExpression",
                 },
                 "loc": Object {
                   "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/optional-chain-element-access-with-non-null-assertion.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/optional-chain-element-access-with-non-null-assertion.src.ts.shot
@@ -23,62 +23,7 @@ Object {
                 },
                 "object": Object {
                   "expression": Object {
-                    "expression": Object {
-                      "computed": true,
-                      "loc": Object {
-                        "end": Object {
-                          "column": 14,
-                          "line": 2,
-                        },
-                        "start": Object {
-                          "column": 2,
-                          "line": 2,
-                        },
-                      },
-                      "object": Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 5,
-                            "line": 2,
-                          },
-                          "start": Object {
-                            "column": 2,
-                            "line": 2,
-                          },
-                        },
-                        "name": "one",
-                        "range": Array [
-                          40,
-                          43,
-                        ],
-                        "type": "Identifier",
-                      },
-                      "optional": true,
-                      "property": Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 13,
-                            "line": 2,
-                          },
-                          "start": Object {
-                            "column": 8,
-                            "line": 2,
-                          },
-                        },
-                        "range": Array [
-                          46,
-                          51,
-                        ],
-                        "raw": "'two'",
-                        "type": "Literal",
-                        "value": "two",
-                      },
-                      "range": Array [
-                        40,
-                        52,
-                      ],
-                      "type": "MemberExpression",
-                    },
+                    "computed": true,
                     "loc": Object {
                       "end": Object {
                         "column": 14,
@@ -89,11 +34,49 @@ Object {
                         "line": 2,
                       },
                     },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 5,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 2,
+                          "line": 2,
+                        },
+                      },
+                      "name": "one",
+                      "range": Array [
+                        40,
+                        43,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "optional": true,
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 13,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 8,
+                          "line": 2,
+                        },
+                      },
+                      "range": Array [
+                        46,
+                        51,
+                      ],
+                      "raw": "'two'",
+                      "type": "Literal",
+                      "value": "two",
+                    },
                     "range": Array [
                       40,
                       52,
                     ],
-                    "type": "ChainExpression",
+                    "type": "MemberExpression",
                   },
                   "loc": Object {
                     "end": Object {
@@ -385,7 +368,7 @@ Object {
                   },
                   "loc": Object {
                     "end": Object {
-                      "column": 15,
+                      "column": 16,
                       "line": 4,
                     },
                     "start": Object {
@@ -395,9 +378,9 @@ Object {
                   },
                   "range": Array [
                     89,
-                    101,
+                    102,
                   ],
-                  "type": "ChainExpression",
+                  "type": "TSNonNullExpression",
                 },
                 "loc": Object {
                   "end": Object {
@@ -413,7 +396,7 @@ Object {
                   89,
                   102,
                 ],
-                "type": "TSNonNullExpression",
+                "type": "ChainExpression",
               },
               "optional": false,
               "property": Object {
@@ -472,61 +455,7 @@ Object {
                 },
                 "object": Object {
                   "expression": Object {
-                    "expression": Object {
-                      "computed": false,
-                      "loc": Object {
-                        "end": Object {
-                          "column": 10,
-                          "line": 5,
-                        },
-                        "start": Object {
-                          "column": 2,
-                          "line": 5,
-                        },
-                      },
-                      "object": Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 5,
-                            "line": 5,
-                          },
-                          "start": Object {
-                            "column": 2,
-                            "line": 5,
-                          },
-                        },
-                        "name": "one",
-                        "range": Array [
-                          113,
-                          116,
-                        ],
-                        "type": "Identifier",
-                      },
-                      "optional": true,
-                      "property": Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 10,
-                            "line": 5,
-                          },
-                          "start": Object {
-                            "column": 7,
-                            "line": 5,
-                          },
-                        },
-                        "name": "two",
-                        "range": Array [
-                          118,
-                          121,
-                        ],
-                        "type": "Identifier",
-                      },
-                      "range": Array [
-                        113,
-                        121,
-                      ],
-                      "type": "MemberExpression",
-                    },
+                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 10,
@@ -537,11 +466,48 @@ Object {
                         "line": 5,
                       },
                     },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 5,
+                          "line": 5,
+                        },
+                        "start": Object {
+                          "column": 2,
+                          "line": 5,
+                        },
+                      },
+                      "name": "one",
+                      "range": Array [
+                        113,
+                        116,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "optional": true,
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 10,
+                          "line": 5,
+                        },
+                        "start": Object {
+                          "column": 7,
+                          "line": 5,
+                        },
+                      },
+                      "name": "two",
+                      "range": Array [
+                        118,
+                        121,
+                      ],
+                      "type": "Identifier",
+                    },
                     "range": Array [
                       113,
                       121,
                     ],
-                    "type": "ChainExpression",
+                    "type": "MemberExpression",
                   },
                   "loc": Object {
                     "end": Object {
@@ -833,7 +799,7 @@ Object {
                   },
                   "loc": Object {
                     "end": Object {
-                      "column": 11,
+                      "column": 12,
                       "line": 7,
                     },
                     "start": Object {
@@ -843,9 +809,9 @@ Object {
                   },
                   "range": Array [
                     160,
-                    168,
+                    169,
                   ],
-                  "type": "ChainExpression",
+                  "type": "TSNonNullExpression",
                 },
                 "loc": Object {
                   "end": Object {
@@ -861,7 +827,7 @@ Object {
                   160,
                   169,
                 ],
-                "type": "TSNonNullExpression",
+                "type": "ChainExpression",
               },
               "optional": false,
               "property": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/optional-chain-with-non-null-assertion.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/optional-chain-with-non-null-assertion.src.ts.shot
@@ -23,61 +23,7 @@ Object {
                 },
                 "object": Object {
                   "expression": Object {
-                    "expression": Object {
-                      "computed": false,
-                      "loc": Object {
-                        "end": Object {
-                          "column": 10,
-                          "line": 2,
-                        },
-                        "start": Object {
-                          "column": 2,
-                          "line": 2,
-                        },
-                      },
-                      "object": Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 5,
-                            "line": 2,
-                          },
-                          "start": Object {
-                            "column": 2,
-                            "line": 2,
-                          },
-                        },
-                        "name": "one",
-                        "range": Array [
-                          40,
-                          43,
-                        ],
-                        "type": "Identifier",
-                      },
-                      "optional": true,
-                      "property": Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 10,
-                            "line": 2,
-                          },
-                          "start": Object {
-                            "column": 7,
-                            "line": 2,
-                          },
-                        },
-                        "name": "two",
-                        "range": Array [
-                          45,
-                          48,
-                        ],
-                        "type": "Identifier",
-                      },
-                      "range": Array [
-                        40,
-                        48,
-                      ],
-                      "type": "MemberExpression",
-                    },
+                    "computed": false,
                     "loc": Object {
                       "end": Object {
                         "column": 10,
@@ -88,11 +34,48 @@ Object {
                         "line": 2,
                       },
                     },
+                    "object": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 5,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 2,
+                          "line": 2,
+                        },
+                      },
+                      "name": "one",
+                      "range": Array [
+                        40,
+                        43,
+                      ],
+                      "type": "Identifier",
+                    },
+                    "optional": true,
+                    "property": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 10,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 7,
+                          "line": 2,
+                        },
+                      },
+                      "name": "two",
+                      "range": Array [
+                        45,
+                        48,
+                      ],
+                      "type": "Identifier",
+                    },
                     "range": Array [
                       40,
                       48,
                     ],
-                    "type": "ChainExpression",
+                    "type": "MemberExpression",
                   },
                   "loc": Object {
                     "end": Object {
@@ -382,7 +365,7 @@ Object {
                   },
                   "loc": Object {
                     "end": Object {
-                      "column": 11,
+                      "column": 12,
                       "line": 4,
                     },
                     "start": Object {
@@ -392,9 +375,9 @@ Object {
                   },
                   "range": Array [
                     81,
-                    89,
+                    90,
                   ],
-                  "type": "ChainExpression",
+                  "type": "TSNonNullExpression",
                 },
                 "loc": Object {
                   "end": Object {
@@ -410,7 +393,7 @@ Object {
                   81,
                   90,
                 ],
-                "type": "TSNonNullExpression",
+                "type": "ChainExpression",
               },
               "optional": false,
               "property": Object {


### PR DESCRIPTION
I did some alignment testing against babel and found they handled some things differently. I decided their way was better, so updating the representation to match.

Previously:
- we emitted a different AST for pre-3.9 and post-3.9
- we treated `TSNonNullExpression` as a breakage in the chain, meaning that the `ChainExpression` would not move up through them.

Now:
- we emit the same AST regardless of TS version
- we treat `TSNonNullExpression` as a `ChainElement`, so the `ChainExpression` always moves past them in the tree