### PR TITLE
fix(eslint-plugin): [prefer-includes] don't auto fix when `test` method's argument type doesn't have an 'includes' method

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-includes.ts
+++ b/packages/eslint-plugin/src/rules/prefer-includes.ts
@@ -191,6 +191,25 @@ export default createRule({
           return;
         }
 
+        const argument = callNode.arguments[0];
+        const tsNode = services.esTreeNodeToTSNodeMap.get(argument);
+        const argumentDeclarations = types
+          .getSymbolAtLocation(tsNode)
+          ?.getDeclarations();
+        if (argumentDeclarations == null || argumentDeclarations.length === 0) {
+          return;
+        }
+
+        for (const argumentDecl of argumentDeclarations) {
+          const type = types.getTypeAtLocation(argumentDecl);
+          const includesMethodDecl = type
+            .getProperty('includes')
+            ?.getDeclarations();
+          if (includesMethodDecl == null || includesMethodDecl == undefined) {
+            return;
+          }
+        }
+
         context.report({
           node: callNode,
           messageId: 'preferStringIncludes',

--- a/packages/eslint-plugin/tests/rules/prefer-includes.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-includes.test.ts
@@ -115,6 +115,12 @@ ruleTester.run('prefer-includes', rule, {
         something.test(a)
       }
     `,
+    `
+      const pattern = new RegExp("bar")
+      function f(a) {
+        return pattern.test(a)
+      }
+    `,
   ]),
   invalid: addOptional([
     // positive


### PR DESCRIPTION
Fixes #2349 

* Related Rule: prefer-includes
* add the code of checking argument type of `test` method. 

Please let me know if there are any required changes.