### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/eslint-plugin-tslint.md
+++ b/.github/ISSUE_TEMPLATE/eslint-plugin-tslint.md
@@ -14,15 +14,24 @@ The more relevant information you can include, the faster we can find the issue 
 -->
 
 <!--
-Make sure you read through our FAQ before posting.
-https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md
+🚨 STOP 🚨 𝗦𝗧𝗢𝗣 🚨 𝑺𝑻𝑶𝑷 🚨
+
+This issue template is only for problems specifically with the `@typescript-eslint/eslint-plugin-tslint` package.
+
+If you have a problem with a specific lint rule, please back out and select the `@typescript-eslint/eslint-plugin` template.
 -->
+
+- [ ] I have first restarting my IDE and the issue persists.
+- [ ] I have updated to the latest version of the packages.
+- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md) and my problem is not listed.
 
 **Repro**
 
 <!--
 Include a ***minimal*** reproduction case.
 The more irrelevant code/config you give, the harder it is for us to investigate.
+
+Please consider creating an isolated reproduction repo to make it easy for the volunteer maintainers debug your issue.
 -->
 
 ```JSON
@@ -50,7 +59,17 @@ Also include your tslint config, if you're using a separate file.
 
 **Expected Result**
 
+<!--
+What did you expect to happen?
+Please be specific here - list the exact lines and messages you expect.
+-->
+
 **Actual Result**
+
+<!--
+What actually happened?
+Please be specific here - list the exact lines and messages that caused errors
+-->
 
 **Additional Info**
 
@@ -70,4 +89,3 @@ i.e. eslint --ext ".ts,.js" src --debug
 | `TypeScript`                              | `X.Y.Z` |
 | `ESLint`                                  | `X.Y.Z` |
 | `node`                                    | `X.Y.Z` |
-| `npm`                                     | `X.Y.Z` |

--- a/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.md
+++ b/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.md
@@ -26,16 +26,17 @@ Are you opening an issue because the rule you're trying to use is not found?
 3) If ESLint still can't find the rule, then consider reporting an issue.
 -->
 
-<!--
-Make sure you read through our FAQ before posting.
-https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md
--->
+- [ ] I have first restarting my IDE and the issue persists.
+- [ ] I have updated to the latest version of the packages.
+- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md) and my problem is not listed.
 
 **Repro**
 
 <!--
 Include a ***minimal*** reproduction case.
 The more irrelevant code/config you give, the harder it is for us to investigate.
+
+Please consider creating an isolated reproduction repo to make it easy for the volunteer maintainers debug your issue.
 -->
 
 ```JSON
@@ -50,9 +51,23 @@ The more irrelevant code/config you give, the harder it is for us to investigate
 // your repro code case
 ```
 
+<!--
+Also include your tsconfig, if you're using type-aware linting
+-->
+
 **Expected Result**
 
+<!--
+What did you expect to happen?
+Please be specific here - list the exact lines and messages you expect.
+-->
+
 **Actual Result**
+
+<!--
+What actually happened?
+Please be specific here - list the exact lines and messages that caused errors
+-->
 
 **Additional Info**
 
@@ -72,4 +87,3 @@ i.e. eslint --ext ".ts,.js" src --debug
 | `TypeScript`                       | `X.Y.Z` |
 | `ESLint`                           | `X.Y.Z` |
 | `node`                             | `X.Y.Z` |
-| `npm`                              | `X.Y.Z` |

--- a/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
+++ b/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
@@ -14,15 +14,25 @@ The more relevant information you can include, the faster we can find the issue 
 -->
 
 <!--
-Make sure you read through our FAQ before posting.
-https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md
+🚨 STOP 🚨 𝗦𝗧𝗢𝗣 🚨 𝑺𝑻𝑶𝑷 🚨
+
+This issue template is only for problems specifically with the `@typescript-eslint/parser` package.
+That means you should only use this template if there are problems parsing some code.
+
+If you have a problem with a specific lint rule, please back out and select the `@typescript-eslint/eslint-plugin` template.
 -->
+
+- [ ] I have first restarting my IDE and the issue persists.
+- [ ] I have updated to the latest version of the packages.
+- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md) and my problem is not listed.
 
 **Repro**
 
 <!--
 Include a ***minimal*** reproduction case.
 The more irrelevant code/config you give, the harder it is for us to investigate.
+
+Please consider creating an isolated reproduction repo to make it easy for the volunteer maintainers debug your issue.
 -->
 
 ```JSON
@@ -40,9 +50,23 @@ The more irrelevant code/config you give, the harder it is for us to investigate
 // your repro code case
 ```
 
+<!--
+Also include your tsconfig, if you're using type-aware linting
+-->
+
 **Expected Result**
 
+<!--
+What did you expect to happen?
+Please be specific here - list the exact lines and messages you expect.
+-->
+
 **Actual Result**
+
+<!--
+What actually happened?
+Please be specific here - list the exact lines and messages that caused errors
+-->
 
 **Additional Info**
 
@@ -61,4 +85,3 @@ i.e. eslint --ext ".ts,.js" src --debug
 | `TypeScript`                | `X.Y.Z` |
 | `ESLint`                    | `X.Y.Z` |
 | `node`                      | `X.Y.Z` |
-| `npm`                       | `X.Y.Z` |

--- a/.github/ISSUE_TEMPLATE/typescript-eslint-utils.md
+++ b/.github/ISSUE_TEMPLATE/typescript-eslint-utils.md
@@ -14,27 +14,26 @@ The more relevant information you can include, the faster we can find the issue 
 -->
 
 <!--
-Make sure you read through our FAQ before posting.
-https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md
+🚨 STOP 🚨 𝗦𝗧𝗢𝗣 🚨 𝑺𝑻𝑶𝑷 🚨
+
+This issue template is only for problems specifically with the `@typescript-eslint/experimental-utils` package.
+
+If you have a problem with a specific lint rule, please back out and select the `@typescript-eslint/eslint-plugin` template.
+If you have a problem with the parser, please back out and select the `@typescript-eslint/parser` template.
 -->
+
+- [ ] I have first restarting my IDE and the issue persists.
+- [ ] I have updated to the latest version of the packages.
+- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md) and my problem is not listed.
 
 **Repro**
 
 <!--
 Include a ***minimal*** reproduction case.
 The more irrelevant code/config you give, the harder it is for us to investigate.
--->
 
-```JSON
-{
-  "rules": {
-    "@typescript-eslint/<rule>": ["<setting>"]
-  },
-  "parserOptions": {
-    "...": "something"
-  }
-}
-```
+Please consider creating an isolated reproduction repo to make it easy for the volunteer maintainers debug your issue.
+-->
 
 ```TS
 // your repro code case
@@ -42,7 +41,17 @@ The more irrelevant code/config you give, the harder it is for us to investigate
 
 **Expected Result**
 
+<!--
+What did you expect to happen?
+Please be specific here - list the exact lines and messages you expect.
+-->
+
 **Actual Result**
+
+<!--
+What actually happened?
+Please be specific here - list the exact lines and messages that caused errors
+-->
 
 **Additional Info**
 
@@ -60,4 +69,3 @@ i.e. eslint --ext ".ts,.js" src --debug
 | `@typescript-eslint/experimental-utils` | `X.Y.Z` |
 | `TypeScript`                            | `X.Y.Z` |
 | `node`                                  | `X.Y.Z` |
-| `npm`                                   | `X.Y.Z` |

--- a/.github/ISSUE_TEMPLATE/typescript-estree.md
+++ b/.github/ISSUE_TEMPLATE/typescript-estree.md
@@ -14,9 +14,16 @@ The more relevant information you can include, the faster we can find the issue 
 -->
 
 <!--
-Make sure you read through our FAQ before posting.
-https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md
+🚨 STOP 🚨 𝗦𝗧𝗢𝗣 🚨 𝑺𝑻𝑶𝑷 🚨
+
+This issue template is only for problems specifically with the `@typescript-eslint/typescript-estree` package.
+
+If you have a problem with a specific lint rule, please back out and select the `@typescript-eslint/eslint-plugin` template.
 -->
+
+- [ ] I have first restarting my IDE and the issue persists.
+- [ ] I have updated to the latest version of the packages.
+- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md) and my problem is not listed.
 
 **Repro**
 
@@ -24,27 +31,30 @@ https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-
 Include a ***minimal*** reproduction case.
 The more irrelevant code/config you give, the harder it is for us to investigate.
 
-Feel free to omit the eslint config if you are not using this module via ESLint.
+Please consider creating an isolated reproduction repo to make it easy for the volunteer maintainers debug your issue.
 -->
 
-```JSON
-{
-  "rules": {
-    "@typescript-eslint/<rule>": ["<setting>"]
-  },
-  "parserOptions": {
-    "...": "something"
-  }
-}
+```TS
+// the code you're trying to parse
 ```
 
 ```TS
-// your repro code case
+// the code you're using to do the parse of the aforementioned code
 ```
 
 **Expected Result**
 
+<!--
+What did you expect to happen?
+Please be specific here - list the exact lines and messages you expect.
+-->
+
 **Actual Result**
+
+<!--
+What actually happened?
+Please be specific here - list the exact lines and messages that caused errors
+-->
 
 **Additional Info**
 
@@ -62,4 +72,3 @@ i.e. eslint --ext ".ts,.js" src --debug
 | `@typescript-eslint/typescript-estree` | `X.Y.Z` |
 | `TypeScript`                           | `X.Y.Z` |
 | `node`                                 | `X.Y.Z` |
-| `npm`                                  | `X.Y.Z` |


### PR DESCRIPTION
I didn't want to add another comment to the template, as there's already enough that I don't think people read anyways.
So I've added a simple checklist to every template (for the first 3).

A few common problems people have when filing issues:

1) **people don't ever restart their IDE.**
Often times they've done git rebases, yarn installs/removals, added and deleted folders, and just generally caused things to get into a weird state.
Restarting the IDE almost always fixes the issue.

2) **people are running an old version of the package.**
In some cases people have filed issues using a 3+ month old versions of the tooling.
Updating ensures that they have all the latest fixes.

3) **people haven't read the FAQ.**
I've tried to keep it up-to-date with concise and helpful information, but some people just don't read it.
So it's a hard link to force them to check it.

4) **people file issues against `eslint-plugin-tslint` or `parser` when they meant to file it against `eslint-plugin`.**
I can _sort of_ understand this, because there are a lot of packages.
So I've added a big ***STOP*** section to every template to help point people to the right template.

5) **Issues are not reproducible due to it being a user config error.**
There have been a decent number of issues that just weren't reproducible based on the issue filed.
When asked to create a repro repo, the issue reporters were either unable to create an isolated repro, or they figured out their bad config when creating the isolated repro.
This one is hard, because we can't reasonably expect every reporter to create a repro repo for their issue.
I've added a one line note, maybe that inspires someone and wards off some noise.