### PR TITLE
fix(typescript-estree): ts.NamedTupleMember workaround for <TS4.0

### DIFF
--- a/packages/typescript-estree/src/ts-estree/ts-nodes.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-nodes.ts
@@ -4,6 +4,7 @@ import * as ts from 'typescript';
 // https://github.com/typescript-eslint/typescript-eslint/issues/2388
 // to support both TypeScript 3.9 & 4:
 declare module 'typescript' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export interface NamedTupleMember extends ts.Node {}
 }
 

--- a/packages/typescript-estree/src/ts-estree/ts-nodes.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-nodes.ts
@@ -1,5 +1,12 @@
 import * as ts from 'typescript';
 
+// Workaround for
+// https://github.com/typescript-eslint/typescript-eslint/issues/2388
+// to support both TypeScript 3.9 & 4:
+declare module 'typescript' {
+  export interface NamedTupleMember extends ts.Node {}
+}
+
 export type TSToken = ts.Token<ts.SyntaxKind>;
 
 export type TSNode =


### PR DESCRIPTION
with updated workaround from <https://github.com/typescript-eslint/typescript-eslint/issues/2388#issuecomment-676540952>, following suggestions by @bradzacher & @ExE-Boss, *tested* with <https://github.com/prettier/prettier/pull/8759>

If this can be integrated and published soon, we should be able to remove the ugly workaround from <https://github.com/prettier/prettier/pull/8759>.

resolves #2388

