### PR TITLE
fix(eslint-plugin): [explicit-module-boundary-types] ignore abstract setters

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -427,7 +427,10 @@ export default util.createRule<Options, MessageIds>({
       const isConstructor =
         node.parent?.type === AST_NODE_TYPES.MethodDefinition &&
         node.parent.kind === 'constructor';
-      if (!isConstructor && !node.returnType) {
+      const isAbstractSetAccessor =
+        node.parent?.type === AST_NODE_TYPES.TSAbstractMethodDefinition &&
+        node.parent.kind === 'set';
+      if (!isConstructor && !isAbstractSetAccessor && !node.returnType) {
         context.report({
           node,
           messageId: 'missingReturnType',

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -646,6 +646,11 @@ type Buz = () => (n: number) => string;
 
 export const buz: Buz = () => n => String(n);
     `,
+    `
+export abstract class Foo<T> {
+  abstract set value(element: T);
+}
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #2407