### PR TITLE
feat(typescript-estree): update allowed TS version range

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The latest version under the `canary` tag **(latest commit to master)** is:
 
 ## Supported TypeScript Version
 
-**The version range of TypeScript currently supported by this parser is `>=3.3.1 <3.10.0`.**
+**The version range of TypeScript currently supported by this parser is `>=3.3.1 <4.1.0`.**
 
 These versions are what we test against.
 

--- a/package.json
+++ b/package.json
@@ -98,9 +98,9 @@
     "ts-jest": "^25.5.1",
     "ts-node": "^8.10.1",
     "tslint": "^6.1.2",
-    "typescript": ">=3.3.1 <4.0.0 || 4.0.0-beta"
+    "typescript": ">=3.3.1 <4.1.0"
   },
   "resolutions": {
-    "typescript": "4.0.0-beta"
+    "typescript": "4.0.2"
   }
 }

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -20,7 +20,7 @@ const log = debug('typescript-eslint:typescript-estree:parser');
  * This needs to be kept in sync with the top-level README.md in the
  * typescript-eslint monorepo
  */
-const SUPPORTED_TYPESCRIPT_VERSIONS = '>=3.3.1 <3.10.0';
+const SUPPORTED_TYPESCRIPT_VERSIONS = '>=3.3.1 <4.1.0';
 /*
  * The semver package will ignore prerelease ranges, and we don't want to explicitly document every one
  * List them all separately here, so we can automatically create the full string

--- a/yarn.lock
+++ b/yarn.lock
@@ -8610,10 +8610,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*, typescript@4.0.0-beta, "typescript@>=3.3.1 <4.0.0 || 4.0.0-beta", typescript@^3.8.0-dev.20200111:
-  version "4.0.0-beta"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.0-beta.tgz#a6a65e430562131de69496a3ef5484346bc0cdd2"
-  integrity sha512-d3s/CogGtB2uPZ2Z8ts6eoUxxyB9PH3R27/UrzvpthuOvpCg4FWWnBbBiqJ0K4eu6eTlgmLiqQkh2dquReJweA==
+typescript@*, typescript@4.0.2, "typescript@>=3.3.1 <4.1.0", typescript@^3.8.0-dev.20200111:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
TS v4.0 is released, we can now bump our range to allow it, as we have full support for it.