### PR TITLE
fix(eslint-plugin): update parser dependency range

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -60,7 +60,7 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^3.0.0",
+    "@typescript-eslint/parser": "^4.0.0",
     "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Fixes #2444

I'm pretty sure we've forgotten do bump this range every single release...