### PR TITLE
feat(eslint-plugin): [no-shadow] add option `ignoreFunctionTypeParameterNameValueShadow`

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
       "footer-max-length": [
         0
       ],
+      "footer-max-line-length": [
+        0
+      ],
       "header-max-length": [
         0
       ]

--- a/packages/eslint-plugin/docs/rules/no-shadow.md
+++ b/packages/eslint-plugin/docs/rules/no-shadow.md
@@ -23,17 +23,21 @@ This rule adds the following options:
 ```ts
 interface Options extends BaseNoShadowOptions {
   ignoreTypeValueShadow?: boolean;
+  ignoreFunctionTypeParameterNameValueShadow?: boolean;
 }
 
 const defaultOptions: Options = {
   ...baseNoShadowDefaultOptions,
   ignoreTypeValueShadow: true,
+  ignoreFunctionTypeParameterNameValueShadow: true,
 };
 ```
 
 ### `ignoreTypeValueShadow`
 
-When set to `true`, the rule will ignore when you name a type and a variable with the same name.
+When set to `true`, the rule will ignore the case when you name a type the same as a variable.
+
+TypeScript allows types and variables to shadow one-another. This is generally safe because you cannot use variables in type locations without a `typeof` operator, so there's little risk of confusion.
 
 Examples of **correct** code with `{ ignoreTypeValueShadow: true }`:
 
@@ -45,6 +49,39 @@ interface Bar {
   prop: number;
 }
 const Bar = 'test';
+```
+
+### `ignoreFunctionTypeParameterNameValueShadow`
+
+When set to `true`, the rule will ignore the case when you name a function type argument the same as a variable.
+
+Each of a function type's arguments creates a value variable within the scope of the function type. This is done so that you can reference the type later using the `typeof` operator:
+
+```ts
+type Func = (test: string) => typeof test;
+
+declare const fn: Func;
+const result = fn('str'); // typeof result === string
+```
+
+This means that function type arguments shadow value variable names in parent scopes:
+
+```ts
+let test = 1;
+type TestType = typeof test; // === number
+type Func = (test: string) => typeof test; // this "test" references the argument, not the variable
+
+declare const fn: Func;
+const result = fn('str'); // typeof result === string
+```
+
+If you do not use the `typeof` operator in a function type return type position, you can safely turn this option on.
+
+Examples of **correct** code with `{ ignoreFunctionTypeParameterNameValueShadow: true }`:
+
+```ts
+const test = 1;
+type Func = (test: string) => typeof test;
 ```
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-shadow.md)</sup>

--- a/packages/eslint-plugin/tests/rules/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow.test.ts
@@ -56,6 +56,58 @@ const x = 1;
   type x = string;
 }
     `,
+    {
+      code: `
+type Foo = 1;
+      `,
+      options: [{ ignoreTypeValueShadow: true }],
+      globals: {
+        Foo: 'writable',
+      },
+    },
+    {
+      code: `
+type Foo = 1;
+      `,
+      options: [
+        {
+          ignoreTypeValueShadow: false,
+          builtinGlobals: false,
+        },
+      ],
+      globals: {
+        Foo: 'writable',
+      },
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2360
+    `
+enum Direction {
+  left = 'left',
+  right = 'right',
+}
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2447
+    {
+      code: `
+const test = 1;
+type Fn = (test: string) => typeof test;
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
+    },
+    {
+      code: `
+type Fn = (Foo: string) => typeof Foo;
+      `,
+      options: [
+        {
+          ignoreFunctionTypeParameterNameValueShadow: true,
+          builtinGlobals: false,
+        },
+      ],
+      globals: {
+        Foo: 'writable',
+      },
+    },
   ],
   invalid: [
     {
@@ -106,6 +158,69 @@ const x = 1;
             name: 'x',
           },
           line: 4,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = 1;
+      `,
+      options: [
+        {
+          ignoreTypeValueShadow: false,
+          builtinGlobals: true,
+        },
+      ],
+      globals: {
+        Foo: 'writable',
+      },
+      errors: [
+        {
+          messageId: 'noShadow',
+          data: {
+            name: 'Foo',
+          },
+          line: 2,
+        },
+      ],
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2447
+    {
+      code: `
+const test = 1;
+type Fn = (test: string) => typeof test;
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }],
+      errors: [
+        {
+          messageId: 'noShadow',
+          data: {
+            name: 'test',
+          },
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+type Fn = (Foo: string) => typeof Foo;
+      `,
+      options: [
+        {
+          ignoreFunctionTypeParameterNameValueShadow: false,
+          builtinGlobals: true,
+        },
+      ],
+      globals: {
+        Foo: 'writable',
+      },
+      errors: [
+        {
+          messageId: 'noShadow',
+          data: {
+            name: 'Foo',
+          },
+          line: 2,
         },
       ],
     },
@@ -431,13 +546,6 @@ function foo(cb) {
       `,
       options: [{ allow: ['cb'] }],
     },
-    // https://github.com/typescript-eslint/typescript-eslint/issues/2360
-    `
-enum Direction {
-  left = 'left',
-  right = 'right',
-}
-    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #2447

Technically this is backwards incompatible, because I'm adding the option true by default, but I believe that the case it protects against is so rare that it's a substantially better experience this way, and it's what people expect