### PR TITLE
fix(eslint-plugin): [explicit-module-boundary-types] cyclical reference infinite recursion crash

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -96,6 +96,10 @@ export default util.createRule<Options, MessageIds>({
     // tracks functions that were found whilst traversing
     const foundFunctions: FunctionNode[] = [];
 
+    // all nodes visited, avoids infinite recursion for cyclic references
+    // (such as class member referring to itself)
+    const alreadyVisited = new Set<TSESTree.Node>();
+
     /*
     # How the rule works:
 
@@ -106,7 +110,6 @@ export default util.createRule<Options, MessageIds>({
     After it's finished traversing the AST, it then iterates through the list of found functions, and checks to see if
     any of them are part of a higher-order function
     */
-    const alreadyVisited = new Set<TSESTree.Node>();
 
     return {
       ExportDefaultDeclaration(node): void {
@@ -310,6 +313,7 @@ export default util.createRule<Options, MessageIds>({
         }
       }
     }
+
     function checkNode(node: TSESTree.Node | null): void {
       if (node == null || alreadyVisited.has(node)) {
         return;

--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -106,6 +106,7 @@ export default util.createRule<Options, MessageIds>({
     After it's finished traversing the AST, it then iterates through the list of found functions, and checks to see if
     any of them are part of a higher-order function
     */
+    const alreadyVisited = new Set<TSESTree.Node>();
 
     return {
       ExportDefaultDeclaration(node): void {
@@ -309,11 +310,11 @@ export default util.createRule<Options, MessageIds>({
         }
       }
     }
-
     function checkNode(node: TSESTree.Node | null): void {
-      if (node == null) {
+      if (node == null || alreadyVisited.has(node)) {
         return;
       }
+      alreadyVisited.add(node);
 
       switch (node.type) {
         case AST_NODE_TYPES.ArrowFunctionExpression:

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -656,6 +656,11 @@ export declare class Foo {
   set time(seconds: number);
 }
     `,
+    `
+class A {
+  b = A;
+}
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -657,7 +657,7 @@ export declare class Foo {
 }
     `,
     `
-class A {
+export class A {
   b = A;
 }
     `,


### PR DESCRIPTION
Fixes #2309

the recursive logic added by #2135 is setup to check members that are not directly exported but used by public members of an exported class, for example here `A.method` needs to be explicit return type because `A` ends up being exported:

```ts
class A {
    method(){}
}
export class B{
    public ref = A;
}
```

However when the class refers to itself (or any reference loop) this would cause infinite recursion.

To get around this I've just added a set of all nodes we've already visited so recursion will be bounded.

NOTE: it is very possible the `checkedFunctions` and `alreadyVisited` sets can be merged. I tried the unit tests where `checkFunctions` was removed entirely and `isExportedHigherOrderFunction` used the `alreadyVisited` set instead, all unit tests passed but it feels unsound since some nodes like the private fields of a class end up added to the visited set so there may be an edge case where, if `isExportedHigherOrderFunction` used any visited node to detect it's exported, we'd end up with a false positive for requiring annotations. So to be on the safe side I just added a second set.