### PR TITLE
fix(scope-manager): correctly handle inferred types in nested type scopes

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
@@ -789,6 +789,20 @@ declare const [v6];
       `,
       filename: 'foo.d.ts',
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2459
+    `
+export type Test<U> = U extends (k: infer I) => void ? I : never;
+    `,
+    `
+export type Test<U> = U extends { [k: string]: infer I } ? I : never;
+    `,
+    `
+export type Test<U> = U extends (arg: {
+  [k: string]: (arg2: infer I) => void;
+}) => void
+  ? I
+  : never;
+    `,
   ],
 
   invalid: [

--- a/packages/scope-manager/tests/fixtures/type-declaration/conditional3.ts
+++ b/packages/scope-manager/tests/fixtures/type-declaration/conditional3.ts
@@ -1,0 +1,1 @@
+type Test<U> = U extends (k: infer I) => void ? I : never;

--- a/packages/scope-manager/tests/fixtures/type-declaration/conditional3.ts.shot
+++ b/packages/scope-manager/tests/fixtures/type-declaration/conditional3.ts.shot
@@ -1,0 +1,131 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`type-declaration conditional3 1`] = `
+ScopeManager {
+  variables: Array [
+    Variable$1 {
+      defs: Array [
+        TypeDefinition$1 {
+          name: Identifier<"Test">,
+          node: TSTypeAliasDeclaration$1,
+        },
+      ],
+      name: "Test",
+      references: Array [],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$2 {
+      defs: Array [
+        TypeDefinition$2 {
+          name: Identifier<"U">,
+          node: TSTypeParameter$2,
+        },
+      ],
+      name: "U",
+      references: Array [
+        Reference$1 {
+          identifier: Identifier<"U">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$2,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$3 {
+      defs: Array [
+        ParameterDefinition$3 {
+          name: Identifier<"k">,
+          node: TSFunctionType$3,
+        },
+      ],
+      name: "k",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: false,
+    },
+    Variable$4 {
+      defs: Array [
+        TypeDefinition$4 {
+          name: Identifier<"I">,
+          node: TSTypeParameter$4,
+        },
+      ],
+      name: "I",
+      references: Array [
+        Reference$2 {
+          identifier: Identifier<"I">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$4,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+  ],
+  scopes: Array [
+    GlobalScope$1 {
+      block: Program$5,
+      isStrict: false,
+      references: Array [],
+      set: Map {
+        "Test" => Variable$1,
+      },
+      type: "global",
+      upper: null,
+      variables: Array [
+        Variable$1,
+      ],
+    },
+    TypeScope$2 {
+      block: TSTypeAliasDeclaration$1,
+      isStrict: true,
+      references: Array [],
+      set: Map {
+        "U" => Variable$2,
+      },
+      type: "type",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$2,
+      ],
+    },
+    ConditionalTypeScope$3 {
+      block: TSConditionalType$6,
+      isStrict: true,
+      references: Array [
+        Reference$1,
+        Reference$2,
+      ],
+      set: Map {
+        "I" => Variable$4,
+      },
+      type: "conditionalType",
+      upper: TypeScope$2,
+      variables: Array [
+        Variable$4,
+      ],
+    },
+    FunctionTypeScope$4 {
+      block: TSFunctionType$3,
+      isStrict: true,
+      references: Array [],
+      set: Map {
+        "k" => Variable$3,
+      },
+      type: "functionType",
+      upper: ConditionalTypeScope$3,
+      variables: Array [
+        Variable$3,
+      ],
+    },
+  ],
+}
+`;

--- a/packages/scope-manager/tests/fixtures/type-declaration/conditional4.ts
+++ b/packages/scope-manager/tests/fixtures/type-declaration/conditional4.ts
@@ -1,0 +1,1 @@
+type Test<U> = U extends { [k: string]: infer I } ? I : never;

--- a/packages/scope-manager/tests/fixtures/type-declaration/conditional4.ts.shot
+++ b/packages/scope-manager/tests/fixtures/type-declaration/conditional4.ts.shot
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`type-declaration conditional4 1`] = `
+ScopeManager {
+  variables: Array [
+    Variable$1 {
+      defs: Array [
+        TypeDefinition$1 {
+          name: Identifier<"Test">,
+          node: TSTypeAliasDeclaration$1,
+        },
+      ],
+      name: "Test",
+      references: Array [],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$2 {
+      defs: Array [
+        TypeDefinition$2 {
+          name: Identifier<"U">,
+          node: TSTypeParameter$2,
+        },
+      ],
+      name: "U",
+      references: Array [
+        Reference$1 {
+          identifier: Identifier<"U">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$2,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$3 {
+      defs: Array [
+        TypeDefinition$3 {
+          name: Identifier<"I">,
+          node: TSTypeParameter$3,
+        },
+      ],
+      name: "I",
+      references: Array [
+        Reference$2 {
+          identifier: Identifier<"I">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$3,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+  ],
+  scopes: Array [
+    GlobalScope$1 {
+      block: Program$4,
+      isStrict: false,
+      references: Array [],
+      set: Map {
+        "Test" => Variable$1,
+      },
+      type: "global",
+      upper: null,
+      variables: Array [
+        Variable$1,
+      ],
+    },
+    TypeScope$2 {
+      block: TSTypeAliasDeclaration$1,
+      isStrict: true,
+      references: Array [],
+      set: Map {
+        "U" => Variable$2,
+      },
+      type: "type",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$2,
+      ],
+    },
+    ConditionalTypeScope$3 {
+      block: TSConditionalType$5,
+      isStrict: true,
+      references: Array [
+        Reference$1,
+        Reference$2,
+      ],
+      set: Map {
+        "I" => Variable$3,
+      },
+      type: "conditionalType",
+      upper: TypeScope$2,
+      variables: Array [
+        Variable$3,
+      ],
+    },
+  ],
+}
+`;

--- a/packages/scope-manager/tests/fixtures/type-declaration/conditional5.ts
+++ b/packages/scope-manager/tests/fixtures/type-declaration/conditional5.ts
@@ -1,0 +1,3 @@
+type Test<U> = U extends (arg: { [k: string]: (arg2: infer I) => void }) => void
+  ? I
+  : never;

--- a/packages/scope-manager/tests/fixtures/type-declaration/conditional5.ts.shot
+++ b/packages/scope-manager/tests/fixtures/type-declaration/conditional5.ts.shot
@@ -1,0 +1,156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`type-declaration conditional5 1`] = `
+ScopeManager {
+  variables: Array [
+    Variable$1 {
+      defs: Array [
+        TypeDefinition$1 {
+          name: Identifier<"Test">,
+          node: TSTypeAliasDeclaration$1,
+        },
+      ],
+      name: "Test",
+      references: Array [],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$2 {
+      defs: Array [
+        TypeDefinition$2 {
+          name: Identifier<"U">,
+          node: TSTypeParameter$2,
+        },
+      ],
+      name: "U",
+      references: Array [
+        Reference$1 {
+          identifier: Identifier<"U">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$2,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$3 {
+      defs: Array [
+        ParameterDefinition$3 {
+          name: Identifier<"arg">,
+          node: TSFunctionType$3,
+        },
+      ],
+      name: "arg",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: false,
+    },
+    Variable$4 {
+      defs: Array [
+        ParameterDefinition$4 {
+          name: Identifier<"arg2">,
+          node: TSFunctionType$4,
+        },
+      ],
+      name: "arg2",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: false,
+    },
+    Variable$5 {
+      defs: Array [
+        TypeDefinition$5 {
+          name: Identifier<"I">,
+          node: TSTypeParameter$5,
+        },
+      ],
+      name: "I",
+      references: Array [
+        Reference$2 {
+          identifier: Identifier<"I">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$5,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+  ],
+  scopes: Array [
+    GlobalScope$1 {
+      block: Program$6,
+      isStrict: false,
+      references: Array [],
+      set: Map {
+        "Test" => Variable$1,
+      },
+      type: "global",
+      upper: null,
+      variables: Array [
+        Variable$1,
+      ],
+    },
+    TypeScope$2 {
+      block: TSTypeAliasDeclaration$1,
+      isStrict: true,
+      references: Array [],
+      set: Map {
+        "U" => Variable$2,
+      },
+      type: "type",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$2,
+      ],
+    },
+    ConditionalTypeScope$3 {
+      block: TSConditionalType$7,
+      isStrict: true,
+      references: Array [
+        Reference$1,
+        Reference$2,
+      ],
+      set: Map {
+        "I" => Variable$5,
+      },
+      type: "conditionalType",
+      upper: TypeScope$2,
+      variables: Array [
+        Variable$5,
+      ],
+    },
+    FunctionTypeScope$4 {
+      block: TSFunctionType$3,
+      isStrict: true,
+      references: Array [],
+      set: Map {
+        "arg" => Variable$3,
+      },
+      type: "functionType",
+      upper: ConditionalTypeScope$3,
+      variables: Array [
+        Variable$3,
+      ],
+    },
+    FunctionTypeScope$5 {
+      block: TSFunctionType$4,
+      isStrict: true,
+      references: Array [],
+      set: Map {
+        "arg2" => Variable$4,
+      },
+      type: "functionType",
+      upper: FunctionTypeScope$4,
+      variables: Array [
+        Variable$4,
+      ],
+    },
+  ],
+}
+`;


### PR DESCRIPTION
Fixes #2459

This was a bit tricky. Nested scopes are wack.