### PR TITLE
fix(eslint-plugin): [no-unused-vars] correct detection of unused vars in a declared module with `export =`

### DIFF
--- a/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
+++ b/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
@@ -10,7 +10,10 @@ type RuleNode =
   | TSESTree.TSModuleBlock
   | TSESTree.TSTypeLiteral
   | TSESTree.TSInterfaceBody;
-type Member = TSESTree.ClassElement | TSESTree.Statement | TSESTree.TypeElement;
+type Member =
+  | TSESTree.ClassElement
+  | TSESTree.ProgramStatement
+  | TSESTree.TypeElement;
 
 export default util.createRule({
   name: 'adjacent-overload-signatures',

--- a/packages/eslint-plugin/src/rules/indent.ts
+++ b/packages/eslint-plugin/src/rules/indent.ts
@@ -410,7 +410,7 @@ export default util.createRule<Options, MessageIds>({
         // transform it to a BlockStatement
         return rules['BlockStatement, ClassBody']({
           type: AST_NODE_TYPES.BlockStatement,
-          body: node.body,
+          body: node.body as any,
 
           // location data
           parent: node.parent,

--- a/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
@@ -848,6 +848,18 @@ export type Test<U> = U extends (arg: {
         jsxFragmentName: 'Fragment',
       },
     },
+    `
+declare module 'foo' {
+  type Test = 1;
+}
+    `,
+    `
+declare module 'foo' {
+  type Test = 1;
+  const x: Test = 1;
+  export = x;
+}
+    `,
   ],
 
   invalid: [
@@ -1418,6 +1430,26 @@ export const ComponentFoo = () => {
           line: 2,
           data: {
             varName: 'React',
+            action: 'defined',
+            additional: '',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+declare module 'foo' {
+  type Test = any;
+  const x = 1;
+  export = x;
+}
+      `,
+      errors: [
+        {
+          messageId: 'unusedVar',
+          line: 3,
+          data: {
+            varName: 'Test',
             action: 'defined',
             additional: '',
           },

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -48,7 +48,6 @@ declare module 'eslint/lib/rules/camelcase' {
 declare module 'eslint/lib/rules/indent' {
   import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 
-  type Listener = (node: TSESTree.Node) => void;
   type ElementList = number | 'first' | 'off';
   const rule: TSESLint.RuleModule<
     'wrongIndentation',

--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -457,6 +457,20 @@ export type PrimaryExpression =
   | TemplateLiteral
   | ThisExpression
   | TSNullKeyword;
+export type ProgramStatement =
+  | ClassDeclaration
+  | ExportAllDeclaration
+  | ExportDefaultDeclaration
+  | ExportNamedDeclaration
+  | ImportDeclaration
+  | Statement
+  | TSDeclareFunction
+  | TSEnumDeclaration
+  | TSExportAssignment
+  | TSImportEqualsDeclaration
+  | TSInterfaceDeclaration
+  | TSNamespaceExportDeclaration
+  | TSTypeAliasDeclaration;
 export type Property = PropertyComputedName | PropertyNonComputedName;
 export type PropertyName = PropertyNameComputed | PropertyNameNonComputed;
 export type PropertyNameComputed = Expression;
@@ -1146,7 +1160,7 @@ export interface ObjectPattern extends BaseNode {
 
 export interface Program extends BaseNode {
   type: AST_NODE_TYPES.Program;
-  body: Statement[];
+  body: ProgramStatement[];
   sourceType: 'module' | 'script';
   comments?: Comment[];
   tokens?: Token[];
@@ -1473,7 +1487,7 @@ export interface TSMethodSignatureNonComputedName
 
 export interface TSModuleBlock extends BaseNode {
   type: AST_NODE_TYPES.TSModuleBlock;
-  body: Statement[];
+  body: ProgramStatement[];
 }
 
 export interface TSModuleDeclaration extends BaseNode {


### PR DESCRIPTION
If a `declare module` has an `export =` in its body, then TS will only export that.
If it doesn't have an `export =`, then all things are implicitly exported.

This adds handling to correctly detect this case.

```ts
declare module 'foo' {
  type T = 1; // T is unused and not exported
  const x = 2;
  export = x;
}

declare module 'bar' {
  type T = 1;
  const x = 2;
  // T and x are both implicitly exported
}
```