### PR TITLE
chore: remove lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/glob": "^7.1.3",
     "@types/jest": "^26.0.10",
     "@types/jest-specific-snapshot": "^0.5.4",
-    "@types/lodash": "^4.14.149",
+    "@types/lodash.memoize": "^4.1.6",
     "@types/node": "^14.6.2",
     "@types/prettier": "^2.1.0",
     "@types/rimraf": "^3.0.0",

--- a/packages/eslint-plugin-tslint/package.json
+++ b/packages/eslint-plugin-tslint/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@typescript-eslint/experimental-utils": "4.1.0",
-    "lodash": "^4.17.15"
+    "lodash.memoize": "^4.1.2"
   },
   "peerDependencies": {
     "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0",
@@ -47,7 +47,7 @@
     "typescript": "*"
   },
   "devDependencies": {
-    "@types/lodash": "*",
+    "@types/lodash.memoize": "*",
     "@typescript-eslint/parser": "4.1.0"
   }
 }

--- a/packages/eslint-plugin-tslint/src/rules/config.ts
+++ b/packages/eslint-plugin-tslint/src/rules/config.ts
@@ -1,5 +1,5 @@
 import { ESLintUtils } from '@typescript-eslint/experimental-utils';
-import memoize from 'lodash/memoize';
+import memoize from 'lodash.memoize';
 import { Configuration, RuleSeverity } from 'tslint';
 import { CustomLinter } from '../custom-linter';
 

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -46,7 +46,6 @@
     "debug": "^4.1.1",
     "globby": "^11.0.1",
     "is-glob": "^4.0.1",
-    "lodash": "^4.17.15",
     "semver": "^7.3.2",
     "tsutils": "^3.17.1"
   },
@@ -58,7 +57,6 @@
     "@types/debug": "*",
     "@types/glob": "*",
     "@types/is-glob": "^4.0.1",
-    "@types/lodash": "*",
     "@types/semver": "^7.1.0",
     "@types/tmp": "^0.2.0",
     "@typescript-eslint/shared-fixtures": "4.1.0",

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -20,7 +20,6 @@ import {
   isESTreeClassMember,
   isOptional,
   TSError,
-  unescapeStringLiteralText,
   isChainExpression,
 } from './node-utils';
 import { ParserWeakMap, ParserWeakMapESTreeToTSNode } from './parser-options';
@@ -1927,11 +1926,7 @@ export class Converter {
           value: '',
         });
         result.raw = this.ast.text.slice(result.range[0], result.range[1]);
-        if ('name' in parent && parent.name === node) {
-          result.value = node.text;
-        } else {
-          result.value = unescapeStringLiteralText(node.text);
-        }
+        result.value = node.text;
         return result;
       }
 

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -1,4 +1,3 @@
-import unescape from 'lodash/unescape';
 import * as ts from 'typescript';
 import { AST_NODE_TYPES, AST_TOKEN_TYPES, TSESTree } from './ts-estree';
 
@@ -406,15 +405,6 @@ export function findFirstMatchingAncestor(
  */
 export function hasJSXAncestor(node: ts.Node): boolean {
   return !!findFirstMatchingAncestor(node, isJSXToken);
-}
-
-/**
- * Unescape the text content of string literals, e.g. &amp; -> &
- * @param text The escaped string literal text.
- * @returns The unescaped string literal text.
- */
-export function unescapeStringLiteralText(text: string): string {
-  return unescape(text);
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1661,7 +1661,14 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@*", "@types/lodash@^4.14.149":
+"@types/lodash.memoize@*", "@types/lodash.memoize@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz#3221f981790a415cab1a239f25c17efd8b604c23"
+  integrity sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
   version "4.14.161"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
   integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
@@ -5977,7 +5984,7 @@ lodash.map@^4.5.1:
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
 
-lodash.memoize@4.x:
+lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=


### PR DESCRIPTION
Fixes #2279.

There are actually two functions from lodash being used today:

**`memoize`** is, IMO, a nice little thing to have. Since it doesn't use regular expressions the way the parts of lodash that sometimes get CVEs do, I figured we could keep it via specifically `lodash.memoize`.

**`unescape`** is the direct part of an `unescapeStringLiteralText` that actually does fail unit tests when removed: https://github.com/typescript-eslint/typescript-eslint/pull/2517/checks?check_run_id=1083789433. 

```diff
-  "value": "&amp;",
+  "value": "&",
```

IMO there's still benefit to the "lodash ideology" of using the same stable functions & high quality docs across projects -and `unescape` is itself also pretty stable- this PR also switches to `lodash.unescape` instead of inlining it.