### PR TITLE
fix(scope-manager): correct analysis of inferred types in conditional types

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow.test.ts
@@ -11,6 +11,14 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-shadow TS tests', rule, {
   valid: [
+    // nested conditional types
+    `
+export type ArrayInput<Func> = Func extends (arg0: Array<infer T>) => any
+  ? T[]
+  : Func extends (...args: infer T) => any
+  ? T
+  : never;
+    `,
     `
 function foo() {
   var Object = 0;

--- a/packages/scope-manager/src/referencer/TypeVisitor.ts
+++ b/packages/scope-manager/src/referencer/TypeVisitor.ts
@@ -94,6 +94,7 @@ class TypeVisitor extends Visitor {
     // which are only accessible from inside the conditional parameter
     this.#referencer.scopeManager.nestConditionalTypeScope(node);
 
+    // type parameters inferred in the condition clause are not accessible within the false branch
     this.visitChildren(node, ['falseType']);
 
     this.#referencer.close(node);

--- a/packages/scope-manager/src/referencer/TypeVisitor.ts
+++ b/packages/scope-manager/src/referencer/TypeVisitor.ts
@@ -94,9 +94,11 @@ class TypeVisitor extends Visitor {
     // which are only accessible from inside the conditional parameter
     this.#referencer.scopeManager.nestConditionalTypeScope(node);
 
-    this.visitChildren(node);
+    this.visitChildren(node, ['falseType']);
 
     this.#referencer.close(node);
+
+    this.visit(node.falseType);
   }
 
   protected TSConstructorType(node: TSESTree.TSConstructorType): void {

--- a/packages/scope-manager/tests/fixtures/type-declaration/conditional-nested.ts
+++ b/packages/scope-manager/tests/fixtures/type-declaration/conditional-nested.ts
@@ -1,0 +1,5 @@
+type Test<T> = T extends Array<infer U>
+  ? U
+  : T extends Set<infer U>
+  ? U
+  : never;

--- a/packages/scope-manager/tests/fixtures/type-declaration/conditional-nested.ts.shot
+++ b/packages/scope-manager/tests/fixtures/type-declaration/conditional-nested.ts.shot
@@ -1,0 +1,170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`type-declaration conditional-nested 1`] = `
+ScopeManager {
+  variables: Array [
+    ImplicitGlobalConstTypeVariable,
+    Variable$2 {
+      defs: Array [
+        TypeDefinition$1 {
+          name: Identifier<"Test">,
+          node: TSTypeAliasDeclaration$1,
+        },
+      ],
+      name: "Test",
+      references: Array [],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$3 {
+      defs: Array [
+        TypeDefinition$2 {
+          name: Identifier<"T">,
+          node: TSTypeParameter$2,
+        },
+      ],
+      name: "T",
+      references: Array [
+        Reference$1 {
+          identifier: Identifier<"T">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$3,
+        },
+        Reference$4 {
+          identifier: Identifier<"T">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$3,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$4 {
+      defs: Array [
+        TypeDefinition$3 {
+          name: Identifier<"U">,
+          node: TSTypeParameter$3,
+        },
+      ],
+      name: "U",
+      references: Array [
+        Reference$3 {
+          identifier: Identifier<"U">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$4,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$5 {
+      defs: Array [
+        TypeDefinition$4 {
+          name: Identifier<"U">,
+          node: TSTypeParameter$4,
+        },
+      ],
+      name: "U",
+      references: Array [
+        Reference$6 {
+          identifier: Identifier<"U">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$5,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+  ],
+  scopes: Array [
+    GlobalScope$1 {
+      block: Program$5,
+      isStrict: false,
+      references: Array [],
+      set: Map {
+        "const" => ImplicitGlobalConstTypeVariable,
+        "Test" => Variable$2,
+      },
+      type: "global",
+      upper: null,
+      variables: Array [
+        ImplicitGlobalConstTypeVariable,
+        Variable$2,
+      ],
+    },
+    TypeScope$2 {
+      block: TSTypeAliasDeclaration$1,
+      isStrict: true,
+      references: Array [],
+      set: Map {
+        "T" => Variable$3,
+      },
+      type: "type",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$3,
+      ],
+    },
+    ConditionalTypeScope$3 {
+      block: TSConditionalType$6,
+      isStrict: true,
+      references: Array [
+        Reference$1,
+        Reference$2 {
+          identifier: Identifier<"Array">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: null,
+        },
+        Reference$3,
+      ],
+      set: Map {
+        "U" => Variable$4,
+      },
+      type: "conditionalType",
+      upper: TypeScope$2,
+      variables: Array [
+        Variable$4,
+      ],
+    },
+    ConditionalTypeScope$4 {
+      block: TSConditionalType$7,
+      isStrict: true,
+      references: Array [
+        Reference$4,
+        Reference$5 {
+          identifier: Identifier<"Set">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: null,
+        },
+        Reference$6,
+      ],
+      set: Map {
+        "U" => Variable$5,
+      },
+      type: "conditionalType",
+      upper: TypeScope$2,
+      variables: Array [
+        Variable$5,
+      ],
+    },
+  ],
+}
+`;


### PR DESCRIPTION
This fixes #2526 
In a conditional type, the inferred types are not in scope in the "if false" type.