### PR TITLE
fix(eslint-plugin): [naming-convention] ignore properties inside object patterns

### DIFF
--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -579,7 +579,7 @@ export default util.createRule<Options, MessageIds>({
 
       // #region property
 
-      'Property[computed = false][kind = "init"][value.type != "ArrowFunctionExpression"][value.type != "FunctionExpression"][value.type != "TSEmptyBodyFunctionExpression"]'(
+      ':not(ObjectPattern) > Property[computed = false][kind = "init"][value.type != "ArrowFunctionExpression"][value.type != "FunctionExpression"][value.type != "TSEmptyBodyFunctionExpression"]'(
         node: TSESTree.PropertyNonComputedName,
       ): void {
         const modifiers = new Set<Modifiers>([Modifiers.public]);

--- a/packages/eslint-plugin/tests/rules/naming-convention.test.ts
+++ b/packages/eslint-plugin/tests/rules/naming-convention.test.ts
@@ -906,6 +906,20 @@ ruleTester.run('naming-convention', rule, {
         },
       ],
     },
+    {
+      code: `
+        class SomeClass {
+          static OtherConstant = 'hello';
+        }
+
+        export const { OtherConstant: otherConstant } = SomeClass;
+      `,
+      parserOptions,
+      options: [
+        { selector: 'property', format: ['PascalCase'] },
+        { selector: 'variable', format: ['camelCase'] },
+      ],
+    },
   ],
   invalid: [
     {
@@ -1281,6 +1295,26 @@ ruleTester.run('naming-convention', rule, {
         },
       ],
       errors: [{ messageId: 'doesNotMatchFormatTrimmed' }],
+    },
+    {
+      code: `
+        class SomeClass {
+          static otherConstant = 'hello';
+        }
+
+        export const { otherConstant } = SomeClass;
+      `,
+      parserOptions,
+      options: [
+        { selector: 'property', format: ['PascalCase'] },
+        { selector: 'variable', format: ['camelCase'] },
+      ],
+      errors: [
+        {
+          line: 3,
+          messageId: 'doesNotMatchFormat',
+        },
+      ],
     },
   ],
 });


### PR DESCRIPTION
> _"**'Do it! Do it now!'** - Arnold Schwarzenegger"_ - Brad Zacher

Starts on #2244. Doesn't add the new rule options for more specific properties, but does ensure that object destructures _only_ match on variables -- not properties.