### PR TITLE
fix(eslint-plugin): added safe getTypeOfPropertyOfType wrapper

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -24,7 +24,7 @@ import {
   isTypeAnyType,
   isTypeUnknownType,
   getTypeName,
-  getTypeOfPropertyOfType,
+  getTypeOfPropertyOfName,
 } from '../util';
 
 // Truthiness utilities
@@ -500,7 +500,7 @@ export default createRule<Options, MessageId>({
         );
       }
       if (propertyType.isNumberLiteral() || propertyType.isStringLiteral()) {
-        const propType = getTypeOfPropertyOfType(
+        const propType = getTypeOfPropertyOfName(
           checker,
           objType,
           propertyType.value.toString(),
@@ -537,7 +537,7 @@ export default createRule<Options, MessageId>({
             const propertyType = getNodeType(node.property);
             return isNullablePropertyType(type, propertyType);
           }
-          const propType = getTypeOfPropertyOfType(
+          const propType = getTypeOfPropertyOfName(
             checker,
             type,
             property.name,

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -24,6 +24,7 @@ import {
   isTypeAnyType,
   isTypeUnknownType,
   getTypeName,
+  getTypeOfPropertyOfType,
 } from '../util';
 
 // Truthiness utilities
@@ -499,7 +500,8 @@ export default createRule<Options, MessageId>({
         );
       }
       if (propertyType.isNumberLiteral() || propertyType.isStringLiteral()) {
-        const propType = checker.getTypeOfPropertyOfType(
+        const propType = getTypeOfPropertyOfType(
+          checker,
           objType,
           propertyType.value.toString(),
         );
@@ -535,7 +537,11 @@ export default createRule<Options, MessageId>({
             const propertyType = getNodeType(node.property);
             return isNullablePropertyType(type, propertyType);
           }
-          const propType = checker.getTypeOfPropertyOfType(type, property.name);
+          const propType = getTypeOfPropertyOfType(
+            checker,
+            type,
+            property.name,
+          );
           return propType && isNullableType(propType, { allowUndefined: true });
         });
         return (

--- a/packages/eslint-plugin/src/util/index.ts
+++ b/packages/eslint-plugin/src/util/index.ts
@@ -6,6 +6,7 @@ export * from './isTypeReadonly';
 export * from './misc';
 export * from './nullThrows';
 export * from './objectIterators';
+export * from './propertyTypes';
 export * from './types';
 
 // this is done for convenience - saves migrating all of the old rules

--- a/packages/eslint-plugin/src/util/isTypeReadonly.ts
+++ b/packages/eslint-plugin/src/util/isTypeReadonly.ts
@@ -6,7 +6,7 @@ import {
   isPropertyReadonlyInType,
 } from 'tsutils';
 import * as ts from 'typescript';
-import { nullThrows, NullThrowsReasons } from '.';
+import { getTypeOfPropertyOfType, nullThrows, NullThrowsReasons } from '.';
 
 const enum Readonlyness {
   /** the type cannot be handled by the function */
@@ -100,9 +100,10 @@ function isTypeReadonlyObject(
     // as we might be able to bail out early due to a mutable property before
     // doing this deep, potentially expensive check.
     for (const property of properties) {
-      const propertyType = nullThrows(
-        checker.getTypeOfPropertyOfType(type, property.getName()),
-        NullThrowsReasons.MissingToken(`property "${property.name}"`, 'type'),
+      const propertyType = getTypeOfPropertyOfType(
+        checker,
+        type,
+        property.name,
       );
 
       // handle recursive types.

--- a/packages/eslint-plugin/src/util/isTypeReadonly.ts
+++ b/packages/eslint-plugin/src/util/isTypeReadonly.ts
@@ -100,10 +100,9 @@ function isTypeReadonlyObject(
     // as we might be able to bail out early due to a mutable property before
     // doing this deep, potentially expensive check.
     for (const property of properties) {
-      const propertyType = getTypeOfPropertyOfType(
-        checker,
-        type,
-        property.name,
+      const propertyType = nullThrows(
+        getTypeOfPropertyOfType(checker, type, property),
+        NullThrowsReasons.MissingToken(`property "${property.name}"`, 'type'),
       );
 
       // handle recursive types.

--- a/packages/eslint-plugin/src/util/propertyTypes.ts
+++ b/packages/eslint-plugin/src/util/propertyTypes.ts
@@ -1,25 +1,36 @@
 import * as ts from 'typescript';
 
-import { nullThrows, NullThrowsReasons } from './nullThrows';
+export function getTypeOfPropertyOfName(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  name: string,
+  escapedName?: ts.__String,
+): ts.Type | undefined {
+  // Most names are directly usable in the checker and aren't different from escaped names
+  if (!escapedName || !name.startsWith('__')) {
+    return checker.getTypeOfPropertyOfType(type, name);
+  }
+
+  // Symbolic names may differ in their escaped name compared to their human-readable name
+  // https://github.com/typescript-eslint/typescript-eslint/issues/2143
+  const escapedProperty = type
+    .getProperties()
+    .find(property => property.escapedName === escapedName);
+
+  return escapedProperty
+    ? checker.getDeclaredTypeOfSymbol(escapedProperty)
+    : undefined;
+}
 
 export function getTypeOfPropertyOfType(
   checker: ts.TypeChecker,
   type: ts.Type,
-  propertyName: string,
-): ts.Type {
-  const reason = NullThrowsReasons.MissingToken(
-    `property "${propertyName}"`,
-    'type',
+  property: ts.Symbol,
+): ts.Type | undefined {
+  return getTypeOfPropertyOfName(
+    checker,
+    type,
+    property.getName(),
+    property.getEscapedName(),
   );
-
-  return propertyName.startsWith('__')
-    ? checker.getDeclaredTypeOfSymbol(
-        nullThrows(
-          type
-            .getProperties()
-            .find(property => property.escapedName === propertyName),
-          reason,
-        ),
-      )
-    : nullThrows(checker.getTypeOfPropertyOfType(type, propertyName), reason);
 }

--- a/packages/eslint-plugin/src/util/propertyTypes.ts
+++ b/packages/eslint-plugin/src/util/propertyTypes.ts
@@ -1,0 +1,25 @@
+import * as ts from 'typescript';
+
+import { nullThrows, NullThrowsReasons } from './nullThrows';
+
+export function getTypeOfPropertyOfType(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  propertyName: string,
+): ts.Type {
+  const reason = NullThrowsReasons.MissingToken(
+    `property "${propertyName}"`,
+    'type',
+  );
+
+  return propertyName.startsWith('__')
+    ? checker.getDeclaredTypeOfSymbol(
+        nullThrows(
+          type
+            .getProperties()
+            .find(property => property.escapedName === propertyName),
+          reason,
+        ),
+      )
+    : nullThrows(checker.getTypeOfPropertyOfType(type, propertyName), reason);
+}

--- a/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
@@ -238,6 +238,15 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
       }
       function foo(arg: Readonly<Foo>) {}
     `,
+    `
+      const sym = Symbol('sym');
+
+      interface WithSymbol {
+        [sym]: number;
+      }
+
+      const willNotCrash = (foo: Readonly<WithSymbol>) => {};
+    `,
   ],
   invalid: [
     // arrays
@@ -640,6 +649,25 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
           line: 8,
           column: 22,
           endColumn: 30,
+        },
+      ],
+    },
+    {
+      code: `
+        const sym = Symbol('sym');
+
+        interface WithSymbol {
+          [sym]: number;
+        }
+
+        const willNot = (foo: WithSymbol) => {};
+      `,
+      errors: [
+        {
+          messageId: 'shouldBeReadonly',
+          line: 8,
+          column: 26,
+          endColumn: 41,
         },
       ],
     },


### PR DESCRIPTION
Fixes #2143. A quick find-all on `getTypeOfPropertyOfType` showed that the bug might also be able to pop up in `no-unnecessary-condition` as well.