### PR TITLE
docs(eslint-plugin): [no-redeclare] fix type/variable names of base options

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-redeclare.md
+++ b/packages/eslint-plugin/docs/rules/no-redeclare.md
@@ -21,12 +21,12 @@ See [`eslint/no-redeclare` options](https://eslint.org/docs/rules/no-redeclare#o
 This rule adds the following options:
 
 ```ts
-interface Options extends BaseNoShadowOptions {
+interface Options extends BaseNoRedeclareOptions {
   ignoreDeclarationMerge?: boolean;
 }
 
 const defaultOptions: Options = {
-  ...baseNoShadowDefaultOptions,
+  ...baseNoRedeclareDefaultOptions,
   ignoreDeclarationMerge: true,
 };
 ```


### PR DESCRIPTION
Fixes type/variable names of the base options (possibly from `no-shadow`)
