### PR TITLE
fix(eslint-plugin): Remove prefer-regexp-exec from recommended-requiring-type-checking

### DIFF
--- a/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.ts
+++ b/packages/eslint-plugin/src/configs/recommended-requiring-type-checking.ts
@@ -15,7 +15,6 @@ export = {
     '@typescript-eslint/no-unsafe-call': 'error',
     '@typescript-eslint/no-unsafe-member-access': 'error',
     '@typescript-eslint/no-unsafe-return': 'error',
-    '@typescript-eslint/prefer-regexp-exec': 'error',
     'require-await': 'off',
     '@typescript-eslint/require-await': 'error',
     '@typescript-eslint/restrict-plus-operands': 'error',


### PR DESCRIPTION
As there is no proof that exec is faster - it doesn't make sense to insist on this rule in recommended list.
See discussion https://github.com/typescript-eslint/typescript-eslint/issues/2280