### PR TITLE
fix(experimental-utils): treat RuleTester arrays as readonly

### DIFF
--- a/packages/eslint-plugin/tests/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin/tests/rules/indent/indent.test.ts
@@ -621,6 +621,9 @@ type Foo = string | {
   (acc, testCase) => {
     const indent = '    ';
 
+    const validCases = [...acc.valid];
+    const invalidCases = [...acc.invalid];
+
     const codeCases = testCase.code.map(code =>
       [
         '', // newline to make test error messages nicer
@@ -631,7 +634,7 @@ type Foo = string | {
 
     codeCases.forEach(code => {
       // valid test case is just the code
-      acc.valid.push(code);
+      validCases.push(code);
 
       const invalid = {
         // test the fixer by removing all the spaces
@@ -663,11 +666,11 @@ type Foo = string | {
           ),
       };
       if (invalid.errors.length > 0) {
-        acc.invalid.push(invalid);
+        invalidCases.push(invalid);
       }
     });
 
-    return acc;
+    return { ...acc, valid: validCases, invalid: invalidCases };
   },
   { valid: [], invalid: [] },
 );

--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -64,7 +64,7 @@ interface InvalidTestCase<
   /**
    * Expected errors.
    */
-  readonly errors: TestCaseError<TMessageIds>[];
+  readonly errors: readonly TestCaseError<TMessageIds>[];
   /**
    * The expected code after autofixes are applied. If set to `null`, the test runner will assert that no autofix is suggested.
    */
@@ -114,8 +114,8 @@ interface RunTests<
   TOptions extends Readonly<unknown[]>
 > {
   // RuleTester.run also accepts strings for valid cases
-  readonly valid: (ValidTestCase<TOptions> | string)[];
-  readonly invalid: InvalidTestCase<TMessageIds, TOptions>[];
+  readonly valid: readonly (ValidTestCase<TOptions> | string)[];
+  readonly invalid: readonly InvalidTestCase<TMessageIds, TOptions>[];
 }
 interface RuleTesterConfig {
   // should be require.resolve(parserPackageName)


### PR DESCRIPTION
Similar story to https://github.com/typescript-eslint/typescript-eslint/issues/2232 and https://github.com/typescript-eslint/typescript-eslint/pull/2235