### PR TITLE
docs(typescript-estree): warn users about performance of glob in project option

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -151,9 +151,11 @@ This option allows you to provide a path to your project's `tsconfig.json`. **Th
   project: ['./packages/**/tsconfig.json', './separate-package/tsconfig.json'];
   ```
 
+- If you use glob patterns to specify your projects, parser will perform synchronous glob search individually for every single scanned file. **This will incur significant performance costs on projects with large number of files and subdirectories.** It's recommended to use path in such cases.
+
 - If you use project references, TypeScript will not automatically use project references to resolve files. This means that you will have to add each referenced tsconfig to the `project` field either separately, or via a glob.
 
-- TypeScript will ignore files with duplicate filenames in the same folder (for example, `src/file.ts` and `src/file.js`). TypeScript purposely ignore all but one of the files, only keeping the one file with the highest priority extension (the extension priority order (from highest to lowest) is `.ts`, `.tsx`, `.d.ts`, `.js`, `.jsx`). For more info see #955.
+- TypeScript will ignore files with duplicate filenames in the same folder (for example, `src/file.ts` and `src/file.js`). TypeScript purposely ignore all but one of the files, only keeping the one file with the highest priority extension (the extension priority order (from highest to lowest) is `.ts`, `.tsx`, `.d.ts`, `.js`, `.jsx`). For more info see [#955](https://github.com/typescript-eslint/typescript-eslint/issues/955).
 
 - Note that if this setting is specified and `createDefaultProgram` is not, you must only lint files that are included in the projects as defined by the provided `tsconfig.json` files. If your existing configuration does not include all of the files you would like to lint, you can create a separate `tsconfig.eslint.json` as follows:
 


### PR DESCRIPTION
When parser resolves project files referenced via glob pattern - it does so for every single scanned file individually. This causes huge performance downgrade when scanning large projects and using wide glob pattern (e.g. **/tsconfig.json). 

We could consider improving performance in such cases (maybe caching?) but in the meantime, I am proposing addition to docs that warns users about this corner case.

Any feedback appreciated!
