### PR TITLE
fix(eslint-plugin): [no-use-before-define] correctly handle typeof type references

### DIFF
--- a/packages/eslint-plugin/src/rules/no-use-before-define.ts
+++ b/packages/eslint-plugin/src/rules/no-use-before-define.ts
@@ -93,6 +93,16 @@ function isOuterVariable(
 }
 
 /**
+ * Checks whether or not a given reference is a type reference.
+ */
+function isTypeReference(reference: TSESLint.Scope.Reference): boolean {
+  return (
+    reference.isTypeReference ||
+    reference.identifier.parent?.parent?.type === AST_NODE_TYPES.TSTypeQuery
+  );
+}
+
+/**
  * Checks whether or not a given location is inside of the range of a given node.
  */
 function isInRange(
@@ -219,7 +229,7 @@ export default util.createRule<Options, MessageIds>({
       variable: TSESLint.Scope.Variable,
       reference: TSESLint.Scope.Reference,
     ): boolean {
-      if (reference.isTypeReference && options.ignoreTypeReferences) {
+      if (isTypeReference(reference) && options.ignoreTypeReferences) {
         return false;
       }
       if (isFunction(variable)) {

--- a/packages/eslint-plugin/src/rules/no-use-before-define.ts
+++ b/packages/eslint-plugin/src/rules/no-use-before-define.ts
@@ -96,13 +96,21 @@ function isOuterVariable(
  * Recursively checks whether or not a given reference has a type query declaration among it's parents
  */
 function referenceContainsTypeQuery(node: TSESTree.Node): boolean {
-  if (node.type === AST_NODE_TYPES.TSTypeQuery) {
-    return true;
-  } else if (!node.parent) {
-    return false;
-  }
+  switch (node.type) {
+    case AST_NODE_TYPES.TSTypeQuery:
+      return true;
 
-  return referenceContainsTypeQuery(node.parent);
+    case AST_NODE_TYPES.TSQualifiedName:
+    case AST_NODE_TYPES.Identifier:
+      if (!node.parent) {
+        return false;
+      }
+      return referenceContainsTypeQuery(node.parent);
+
+    default:
+      // if we find a different node, there's no chance that we're in a TSTypeQuery
+      return false;
+  }
 }
 
 /**

--- a/packages/eslint-plugin/src/rules/no-use-before-define.ts
+++ b/packages/eslint-plugin/src/rules/no-use-before-define.ts
@@ -93,12 +93,25 @@ function isOuterVariable(
 }
 
 /**
+ * Recursively checks whether or not a given reference has a type query declaration among it's parents
+ */
+function referenceContainsTypeQuery(node: TSESTree.Node): boolean {
+  if (node.type === AST_NODE_TYPES.TSTypeQuery) {
+    return true;
+  } else if (!node.parent) {
+    return false;
+  }
+
+  return referenceContainsTypeQuery(node.parent);
+}
+
+/**
  * Checks whether or not a given reference is a type reference.
  */
 function isTypeReference(reference: TSESLint.Scope.Reference): boolean {
   return (
     reference.isTypeReference ||
-    reference.identifier.parent?.parent?.type === AST_NODE_TYPES.TSTypeQuery
+    referenceContainsTypeQuery(reference.identifier)
   );
 }
 
@@ -229,7 +242,7 @@ export default util.createRule<Options, MessageIds>({
       variable: TSESLint.Scope.Variable,
       reference: TSESLint.Scope.Reference,
     ): boolean {
-      if (isTypeReference(reference) && options.ignoreTypeReferences) {
+      if (options.ignoreTypeReferences && isTypeReference(reference)) {
         return false;
       }
       if (isFunction(variable)) {

--- a/packages/eslint-plugin/tests/rules/no-use-before-define.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-use-before-define.test.ts
@@ -219,7 +219,29 @@ type Foo = string | number;
       `,
       options: [{ typedefs: false }],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2572
+    {
+      code: `
+interface Bar {
+  type: typeof Foo.FOO;
+}
 
+class Foo {
+  public static readonly FOO = '';
+}
+      `,
+      options: [{ ignoreTypeReferences: true }],
+    },
+    {
+      code: `
+const foo = 2;
+
+interface Bar {
+  type: typeof foo;
+}
+      `,
+      options: [{ ignoreTypeReferences: true }],
+    },
     // https://github.com/bradzacher/eslint-plugin-typescript/issues/141
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-use-before-define.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-use-before-define.test.ts
@@ -223,6 +223,16 @@ type Foo = string | number;
     {
       code: `
 interface Bar {
+  type: typeof Foo;
+}
+
+const Foo = 2;
+      `,
+      options: [{ ignoreTypeReferences: true }],
+    },
+    {
+      code: `
+interface Bar {
   type: typeof Foo.FOO;
 }
 
@@ -234,11 +244,15 @@ class Foo {
     },
     {
       code: `
-const foo = 2;
-
 interface Bar {
-  type: typeof foo;
+  type: typeof Foo.Bar.Baz;
 }
+
+const Foo = {
+  Bar: {
+    Baz: 1,
+  },
+};
       `,
       options: [{ ignoreTypeReferences: true }],
     },
@@ -881,6 +895,65 @@ for (var a of a) {
         {
           messageId: 'noUseBeforeDefine',
           data: { name: 'a' },
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+    },
+
+    // "ignoreTypeReferences" option
+    {
+      code: `
+interface Bar {
+  type: typeof Foo;
+}
+
+const Foo = 2;
+      `,
+      options: [{ ignoreTypeReferences: false }],
+      errors: [
+        {
+          messageId: 'noUseBeforeDefine',
+          data: { name: 'Foo' },
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+    },
+    {
+      code: `
+interface Bar {
+  type: typeof Foo.FOO;
+}
+
+class Foo {
+  public static readonly FOO = '';
+}
+      `,
+      options: [{ ignoreTypeReferences: false }],
+      errors: [
+        {
+          messageId: 'noUseBeforeDefine',
+          data: { name: 'Foo' },
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+    },
+    {
+      code: `
+interface Bar {
+  type: typeof Foo.Bar.Baz;
+}
+
+const Foo = {
+  Bar: {
+    Baz: 1,
+  },
+};
+      `,
+      options: [{ ignoreTypeReferences: false }],
+      errors: [
+        {
+          messageId: 'noUseBeforeDefine',
+          data: { name: 'Foo' },
           type: AST_NODE_TYPES.Identifier,
         },
       ],


### PR DESCRIPTION
Fixes #2572 

The `no-use-before-define` rule wasn't taking into account type reference that comes from values prefixed by the `typeof` operator.

Thank you @bradzacher for your help 🙂