### PR TITLE
docs(eslint-plugin): fix plugin name in config example

### DIFF
--- a/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md
+++ b/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md
@@ -22,7 +22,7 @@ For example:
 
 ```CJSON
 {
-    "@typescript-eslint/consistent-type-definitions": ["error", "index-signature"]
+    "@typescript-eslint/consistent-indexed-object-style": ["error", "index-signature"]
 }
 ```
 


### PR DESCRIPTION
Fixes a small typo in the code sample supplied for `consistent-indexed-object-style`