### PR TITLE
docs(eslint-plugin): [explicit-function-return-type] fixed default `allowConciseArrowFunctionExpressionsStartingWithVoid` option value

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -80,7 +80,7 @@ const defaults = {
   allowTypedFunctionExpressions: true,
   allowHigherOrderFunctions: true,
   allowDirectConstAssertionInArrowFunctions: true,
-  allowConciseArrowFunctionExpressionsStartingWithVoid: true,
+  allowConciseArrowFunctionExpressionsStartingWithVoid: false,
 };
 ```
 


### PR DESCRIPTION
Fixed a minor issue about `allowConciseArrowFunctionExpressionsStartingWithVoid` option value missmatch in documentation.

https://github.com/typescript-eslint/typescript-eslint/blob/ef7dfb6836f5dd95a7a716068993ba3d880e8fdc/packages/eslint-plugin/src/rules/explicit-function-return-type.ts#L65