### PR TITLE
docs(typescript-estree): fix sample code

### DIFF
--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -132,7 +132,9 @@ declare function parse(
 Example usage:
 
 ```js
-import { parse } from '@typescript-eslint/typescript-estree';
+import TypescriptEstree from '@typescript-eslint/typescript-estree';
+
+const { parse } = TypescriptEstree;
 
 const code = `const hello: string = 'world';`;
 const ast = parse(code, {
@@ -227,7 +229,9 @@ declare function parseAndGenerateServices(
 Example usage:
 
 ```js
-import { parseAndGenerateServices } from '@typescript-eslint/typescript-estree';
+import TypescriptEstree from '@typescript-eslint/typescript-estree';
+
+const { parseAndGenerateServices } = TypescriptEstree;
 
 const code = `const hello: string = 'world';`;
 const ast = parseAndGenerateServices(code, {


### PR DESCRIPTION
The following code works with `v14.13` in Node.js. However, it does not work with earlier versions.

```js
import { parse } from '@typescript-eslint/typescript-estree';
```

cf. https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#notable-changes-1