### PR TITLE
docs(typescript-estree): add the link for AST Alignment Tests

### DIFF
--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -265,7 +265,7 @@ Please check the current list of open and known issues and ensure the issue has 
 
 A couple of years after work on this parser began, the TypeScript Team at Microsoft began [officially supporting TypeScript parsing via Babel](https://blogs.msdn.microsoft.com/typescript/2018/08/27/typescript-and-babel-7/).
 
-I work closely with the TypeScript Team and we are gradually aligning the AST of this project with the one produced by Babel's parser. To that end, I have created a full test harness to compare the ASTs of the two projects which runs on every PR, please see the code for more details.
+I work closely with the TypeScript Team and we are gradually aligning the AST of this project with the one produced by Babel's parser. To that end, I have created a full test harness to compare the ASTs of the two projects which runs on every PR, please see [the code](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/typescript-estree/tests/ast-alignment) for more details.
 
 ## Build/Test Commands
 


### PR DESCRIPTION
I was curious about the differences between Babel and typescript-estree ASTs, so I tried to look into it, but I was confused because the link to the code does not exist.

This PR adds link for AST Alignment Tests to README.