### PR TITLE
test(typescript-estree): remove babel-parser plugins that are enabled by default

### DIFF
--- a/packages/typescript-estree/tests/ast-alignment/parse.ts
+++ b/packages/typescript-estree/tests/ast-alignment/parse.ts
@@ -21,18 +21,9 @@ function createError(
 function parseWithBabelParser(text: string, jsx = true): any {
   const babel = require('@babel/parser');
   const plugins: ParserPlugin[] = [
-    'asyncGenerators',
-    'bigInt',
     'classProperties',
     'decorators-legacy',
-    'dynamicImport',
     'estree',
-    'importMeta',
-    'logicalAssignment',
-    'nullishCoalescingOperator',
-    'numericSeparator',
-    'objectRestSpread',
-    'optionalChaining',
     'typescript',
   ];
   if (jsx) {


### PR DESCRIPTION
Some of the babel-parser plugins used in AST Alignment Tests are already enabled by default.

- `importMeta`: https://github.com/babel/babel/pull/11406
- `bigInt`: https://github.com/babel/babel/pull/11117
- `asyncGenerators`, `objectRestSpread`: https://github.com/babel/babel/pull/8448
- `dynamicImport`: https://github.com/babel/babel/pull/10843
- `logicalAssignment`: https://github.com/babel/babel/pull/11869
- `nullishCoalescingOperator `: https://github.com/babel/babel/pull/10819
- `optionalChaining`: https://github.com/babel/babel/pull/10817
- `numericSeparator`: https://github.com/babel/babel/pull/11863

If these are intentionally, please close this PR:smile: