### PR TITLE
fix(eslint-plugin): [no-unused-vars] fix false positives for duplicated names in namespaces

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
@@ -886,6 +886,20 @@ export declare namespace Foo {
   }
 }
     `,
+    {
+      code: `
+declare namespace A {
+  export interface A {};
+}
+            `,
+      filename: 'foo.d.ts',
+    },
+    {
+      code: `
+declare function A(A: string) {}
+            `,
+      filename: 'foo.d.ts',
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
@@ -889,15 +889,16 @@ export declare namespace Foo {
     {
       code: `
 declare namespace A {
-  export interface A {};
+  export interface A {}
 }
-            `,
+      `,
       filename: 'foo.d.ts',
     },
     {
       code: `
-declare function A(A: string) {}
-            `,
+declare function A(A: string) {
+};
+      `,
       filename: 'foo.d.ts',
     },
   ],

--- a/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars.test.ts
@@ -896,8 +896,7 @@ declare namespace A {
     },
     {
       code: `
-declare function A(A: string) {
-};
+declare function A(A: string): string;
       `,
       filename: 'foo.d.ts',
     },


### PR DESCRIPTION
Fixes #2595

This attempts to make `markDeclarationChildAsUsed` somewhat more targeted. 
In some cases it seems that `context.getScope().upper` is the correct scope where we should attempt to mark a variable as having been used, in order to avoid starting further down the tree and marking a variable in a child scope as used instead (`context.markVariableAsUsed` is an inside-out search, keying in on variable name only).

Tests have been added for the two cases where there appears to be a false positive (the ambient declaration of either a `function` or a `namespace` with a variable of the same name of the parent in scope)