### PR TITLE
fix(eslint-plugin): [ban-types] allow banning types with specific parameters

### DIFF
--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -28,7 +28,7 @@ function removeSpaces(str: string): string {
   return str.replace(/ /g, '');
 }
 
-function stringifyTypeName(
+function stringifyNode(
   node: TSESTree.Node,
   sourceCode: TSESLint.SourceCode,
 ): string {
@@ -175,7 +175,7 @@ export default util.createRule<Options, MessageIds>({
 
     function checkBannedTypes(
       typeNode: TSESTree.Node,
-      name = stringifyTypeName(typeNode, context.getSourceCode()),
+      name = stringifyNode(typeNode, context.getSourceCode()),
     ): void {
       const bannedType = bannedTypes.get(name);
 
@@ -223,8 +223,12 @@ export default util.createRule<Options, MessageIds>({
 
         checkBannedTypes(node);
       },
-      TSTypeReference({ typeName }): void {
-        checkBannedTypes(typeName);
+      TSTypeReference(node): void {
+        checkBannedTypes(node.typeName);
+
+        if (node.typeParameters) {
+          checkBannedTypes(node);
+        }
       },
     };
   },

--- a/packages/eslint-plugin/tests/rules/ban-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-types.test.ts
@@ -487,6 +487,48 @@ let bar: object = {};
         },
       ],
     },
+    {
+      code: 'type Foo = Bar<any>;',
+      errors: [
+        {
+          messageId: 'bannedTypeMessage',
+          data: {
+            name: 'Bar<any>',
+            customMessage: " Don't use `any` as a type parameter to `Bar`",
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+      options: [
+        {
+          types: {
+            'Bar<any>': "Don't use `any` as a type parameter to `Bar`",
+          },
+        },
+      ],
+    },
+    {
+      code: noFormat`type Foo = Bar<A,B>;`,
+      errors: [
+        {
+          messageId: 'bannedTypeMessage',
+          data: {
+            name: 'Bar<A,B>',
+            customMessage: " Don't pass `A, B` as parameters to `Bar`",
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+      options: [
+        {
+          types: {
+            'Bar<A, B>': "Don't pass `A, B` as parameters to `Bar`",
+          },
+        },
+      ],
+    },
     ...objectReduceKey(
       TYPE_KEYWORDS,
       (acc: TSESLint.InvalidTestCase<MessageIds, Options>[], key) => {


### PR DESCRIPTION
Fixes https://github.com/typescript-eslint/typescript-eslint/issues/2657.

The docs for `ban-types` claims that `ban-types` can be used with "a type name with generic parameter instantiation(s)", but this functionality never seems to have been implemented. The previous implementation only compared against the `typeName` node of the type reference, but now we also compare against the entire `TypeReference` node if there are any type parameters.