### PR TITLE
feat(eslint-plugin): [prefer-readonly-parameter-types] add `ignoreInferredTypes` option

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
@@ -189,6 +189,7 @@ type AcceptsCallback = (callback: Callback) => void;
 
 export const acceptsCallback: AcceptsCallback;
 ```
+
 </details>
 
 Examples of **correct** code for this rule with `{ignoreInferredTypes: true}`:
@@ -196,7 +197,7 @@ Examples of **correct** code for this rule with `{ignoreInferredTypes: true}`:
 ```ts
 import { acceptsCallback } from 'external-dependency';
 
-acceceptsCallback((options) => {});
+acceceptsCallback(options => {});
 ```
 
 <details>
@@ -211,4 +212,5 @@ type AcceptsCallback = (callback: Callback) => void;
 
 export const acceptsCallback: AcceptsCallback;
 ```
+
 </details>

--- a/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
@@ -124,10 +124,12 @@ interface Foo {
 ```ts
 interface Options {
   checkParameterProperties?: boolean;
+  ignoreInferredTypes?: boolean;
 }
 
 const defaultOptions: Options = {
   checkParameterProperties: true,
+  ignoreInferredTypes: false,
 };
 ```
 
@@ -162,3 +164,51 @@ class Foo {
   ) {}
 }
 ```
+
+### `ignoreInferredTypes`
+
+This option allows you to ignore parameters which don't explicitly specify a type. This may be desirable in cases where an external dependency specifies a callback with mutable parameters, and manually annotating the callback's parameters is undesirable.
+
+Examples of **incorrect** code for this rule with `{ignoreInferredTypes: true}`:
+
+```ts
+import { acceptsCallback, CallbackOptions } from 'external-dependency';
+
+acceceptsCallback((options: CallbackOptions) => {});
+```
+
+<details>
+<summary>external-dependency.d.ts</summary>
+
+```ts
+export interface CallbackOptions {
+  prop: string;
+}
+type Callback = (options: CallbackOptions) => void;
+type AcceptsCallback = (callback: Callback) => void;
+
+export const acceptsCallback: AcceptsCallback;
+```
+</details>
+
+Examples of **correct** code for this rule with `{ignoreInferredTypes: true}`:
+
+```ts
+import { acceptsCallback } from 'external-dependency';
+
+acceceptsCallback((options) => {});
+```
+
+<details>
+<summary>external-dependency.d.ts</summary>
+
+```ts
+export interface CallbackOptions {
+  prop: string;
+}
+type Callback = (options: CallbackOptions) => void;
+type AcceptsCallback = (callback: Callback) => void;
+
+export const acceptsCallback: AcceptsCallback;
+```
+</details>

--- a/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
@@ -88,7 +88,7 @@ export default util.createRule<Options, MessageIds>({
               ? param.parameter
               : param;
 
-          if (!ignoreInferredTypes && actualParam.typeAnnotation == null) {
+          if (ignoreInferredTypes && actualParam.typeAnnotation == null) {
             continue;
           }
 

--- a/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
@@ -87,15 +87,19 @@ export default util.createRule<Options, MessageIds>({
             param.type === AST_NODE_TYPES.TSParameterProperty
               ? param.parameter
               : param;
+
+          if (
+            !ignoreInferredTypes &&
+            actualParam.typeAnnotation == null
+          ) {
+            continue;
+          }
+
           const tsNode = esTreeNodeToTSNodeMap.get(actualParam);
           const type = checker.getTypeAtLocation(tsNode);
           const isReadOnly = util.isTypeReadonly(checker, type);
-          const isIgnored =
-            !isReadOnly &&
-            ignoreInferredTypes &&
-            actualParam.typeAnnotation == null;
 
-          if (!isReadOnly && !isIgnored) {
+          if (!isReadOnly) {
             context.report({
               node: actualParam,
               messageId: 'shouldBeReadonly',

--- a/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
@@ -88,10 +88,7 @@ export default util.createRule<Options, MessageIds>({
               ? param.parameter
               : param;
 
-          if (
-            !ignoreInferredTypes &&
-            actualParam.typeAnnotation == null
-          ) {
+          if (!ignoreInferredTypes && actualParam.typeAnnotation == null) {
             continue;
           }
 

--- a/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
@@ -247,6 +247,30 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
 
       const willNotCrash = (foo: Readonly<WithSymbol>) => {};
     `,
+    {
+      code: `
+        interface CallbackOptions {
+          prop: string;
+        }
+
+        /* eslint-disable prefer-readonly-parameter-types -- These are
+         * expected to error, but for the purposes of this test it should
+         * be assumed that the types are defined by an external dependency.
+         * See: https://github.com/typescript-eslint/typescript-eslint/issues/2079
+         */
+        type Callback = (options: CallbackOptions) => void;
+
+        const acceptsCallback = (callback: Callback) => {};
+        /* eslint-enable prefer-readonly-parameter-types */
+
+        foo(options => {});
+      `,
+      options: [
+        {
+          ignoreInferredTypes: true,
+        },
+      ],
+    },
   ],
   invalid: [
     // arrays
@@ -668,6 +692,38 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
           line: 8,
           column: 26,
           endColumn: 41,
+        },
+      ],
+    },
+    {
+      code: `
+        interface CallbackOptions {
+          prop: string;
+        }
+
+        /* eslint-disable prefer-readonly-parameter-types -- These are
+         * expected to error, but for the purposes of this test it should
+         * be assumed that the types are defined by an external dependency.
+         * See: https://github.com/typescript-eslint/typescript-eslint/issues/2079
+         */
+        type Callback = (options: CallbackOptions) => void;
+
+        const acceptsCallback = (callback: Callback) => {};
+        /* eslint-enable prefer-readonly-parameter-types */
+
+        foo((options: CallbackOptions) => {});
+      `,
+      options: [
+        {
+          ignoreInferredTypes: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'shouldBeReadonly',
+          line: 16,
+          column: 14,
+          endColumn: 38,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
@@ -249,21 +249,15 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
     `,
     {
       code: `
+        type Callback<T> = (options: T) => void;
+
+        declare const acceptsCallback: <T>(callback: Callback<T>) => void;
+
         interface CallbackOptions {
           prop: string;
         }
 
-        /* eslint-disable prefer-readonly-parameter-types -- These are
-         * expected to error, but for the purposes of this test it should
-         * be assumed that the types are defined by an external dependency.
-         * See: https://github.com/typescript-eslint/typescript-eslint/issues/2079
-         */
-        type Callback = (options: CallbackOptions) => void;
-
-        const acceptsCallback = (callback: Callback) => {};
-        /* eslint-enable prefer-readonly-parameter-types */
-
-        foo(options => {});
+        acceptsCallback<CallbackOptions>(options => {});
       `,
       options: [
         {
@@ -697,21 +691,15 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
     },
     {
       code: `
+        type Callback<T> = (options: T) => void;
+
+        declare const acceptsCallback: <T>(callback: Callback<T>) => void;
+
         interface CallbackOptions {
           prop: string;
         }
 
-        /* eslint-disable prefer-readonly-parameter-types -- These are
-         * expected to error, but for the purposes of this test it should
-         * be assumed that the types are defined by an external dependency.
-         * See: https://github.com/typescript-eslint/typescript-eslint/issues/2079
-         */
-        type Callback = (options: CallbackOptions) => void;
-
-        const acceptsCallback = (callback: Callback) => {};
-        /* eslint-enable prefer-readonly-parameter-types */
-
-        foo((options: CallbackOptions) => {});
+        acceptsCallback<CallbackOptions>((options: CallbackOptions) => {});
       `,
       options: [
         {
@@ -721,9 +709,9 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
       errors: [
         {
           messageId: 'shouldBeReadonly',
-          line: 16,
-          column: 14,
-          endColumn: 38,
+          line: 10,
+          column: 43,
+          endColumn: 67,
         },
       ],
     },


### PR DESCRIPTION
This PR addresses part of #2079. I'm not sure whether I should mark this as `fixes`, since there's discussion of other wants. So I'll leave that determination up to the reporter and maintainers).

This introduces an `ignoreInferredTypes` option for `prefer-readonly-parameter-types`, which if `true` ignores errors on parameters with no explicit type parameter. This may be useful for cases where an external dependency specifies mutable parameter types, e.g. for parameters in callbacks.