### PR TITLE
feat(typescript-estree): add flag EXPERIMENTAL_useSourceOfProjectReferenceRedirect

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     ],
     tsconfigRootDir: __dirname,
     warnOnUnsupportedTypeScriptVersion: false,
+    EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
   },
   rules: {
     //

--- a/packages/eslint-plugin-internal/tsconfig.json
+++ b/packages/eslint-plugin-internal/tsconfig.json
@@ -4,5 +4,6 @@
     "composite": false,
     "rootDir": "."
   },
-  "include": ["src", "typings", "tests"]
+  "include": ["src", "typings", "tests"],
+  "references": [{ "path": "../experimental-utils/tsconfig.build.json" }]
 }

--- a/packages/eslint-plugin-tslint/tsconfig.build.json
+++ b/packages/eslint-plugin-tslint/tsconfig.build.json
@@ -6,9 +6,5 @@
     "resolveJsonModule": true
   },
   "include": ["src"],
-  "references": [
-    { "path": "../experimental-utils/tsconfig.build.json" },
-    { "path": "../parser/tsconfig.build.json" },
-    { "path": "../typescript-estree/tsconfig.build.json" }
-  ]
+  "references": [{ "path": "../experimental-utils/tsconfig.build.json" }]
 }

--- a/packages/eslint-plugin-tslint/tsconfig.json
+++ b/packages/eslint-plugin-tslint/tsconfig.json
@@ -5,5 +5,6 @@
     "rootDir": "."
   },
   "include": ["src", "tests"],
-  "exclude": ["tests/test-project", "tests/test-tslint-rules-directory"]
+  "exclude": ["tests/test-project", "tests/test-tslint-rules-directory"],
+  "references": [{ "path": "../experimental-utils/tsconfig.build.json" }]
 }

--- a/packages/eslint-plugin/tsconfig.build.json
+++ b/packages/eslint-plugin/tsconfig.build.json
@@ -12,7 +12,6 @@
   "references": [
     { "path": "../experimental-utils/tsconfig.build.json" },
     { "path": "../parser/tsconfig.build.json" },
-    { "path": "../scope-manager/tsconfig.build.json" },
-    { "path": "../typescript-estree/tsconfig.build.json" }
+    { "path": "../scope-manager/tsconfig.build.json" }
   ]
 }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -4,5 +4,10 @@
     "composite": false,
     "rootDir": "."
   },
-  "include": ["src", "typings", "tests", "tools"]
+  "include": ["src", "typings", "tests", "tools"],
+  "references": [
+    { "path": "../experimental-utils/tsconfig.build.json" },
+    { "path": "../parser/tsconfig.build.json" },
+    { "path": "../scope-manager/tsconfig.build.json" }
+  ]
 }

--- a/packages/experimental-utils/tsconfig.json
+++ b/packages/experimental-utils/tsconfig.json
@@ -4,5 +4,10 @@
     "composite": false,
     "rootDir": "."
   },
-  "include": ["src", "typings", "tests", "tools"]
+  "include": ["src", "typings", "tests", "tools"],
+  "references": [
+    { "path": "../scope-manager/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../typescript-estree/tsconfig.build.json" }
+  ]
 }

--- a/packages/parser/tsconfig.build.json
+++ b/packages/parser/tsconfig.build.json
@@ -9,9 +9,9 @@
   "include": ["src"],
   "references": [
     { "path": "../experimental-utils/tsconfig.build.json" },
-    { "path": "../types/tsconfig.build.json" },
-    { "path": "../typescript-estree/tsconfig.build.json" },
     { "path": "../scope-manager/tsconfig.build.json" },
-    { "path": "../shared-fixtures/tsconfig.build.json" }
+    { "path": "../shared-fixtures/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../typescript-estree/tsconfig.build.json" }
   ]
 }

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -5,5 +5,12 @@
     "rootDir": "."
   },
   "include": ["src", "tests", "tools"],
-  "exclude": ["tests/fixtures"]
+  "exclude": ["tests/fixtures"],
+  "references": [
+    { "path": "../experimental-utils/tsconfig.build.json" },
+    { "path": "../scope-manager/tsconfig.build.json" },
+    { "path": "../shared-fixtures/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../typescript-estree/tsconfig.build.json" }
+  ]
 }

--- a/packages/scope-manager/tsconfig.json
+++ b/packages/scope-manager/tsconfig.json
@@ -4,5 +4,10 @@
     "composite": false,
     "rootDir": "."
   },
-  "include": ["src", "typings", "tests", "tools"]
+  "include": ["src", "typings", "tests", "tools"],
+  "references": [
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../typescript-estree/tsconfig.build.json" },
+    { "path": "../visitor-keys/tsconfig.build.json" }
+  ]
 }

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -37,6 +37,7 @@ interface ParserOptions {
   debugLevel?: DebugLevel;
   errorOnTypeScriptSyntacticAndSemanticIssues?: boolean;
   errorOnUnknownASTType?: boolean;
+  EXPERIMENTAL_useSourceOfProjectReferenceRedirect?: boolean; // purposely undocumented for now
   extraFileExtensions?: string[];
   filePath?: string;
   loc?: boolean;

--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -153,6 +153,18 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
   errorOnTypeScriptSyntacticAndSemanticIssues?: boolean;
 
   /**
+   * ***EXPERIMENTAL FLAG*** - Use this at your own risk.
+   *
+   * Causes TS to use the source files for referenced projects instead of the compiled .d.ts files.
+   * This feature is not yet optimized, and is likely to cause OOMs for medium to large projects.
+   *
+   * This flag REQUIRES at least TS v3.9, otherwise it does nothing.
+   *
+   * See: https://github.com/typescript-eslint/typescript-eslint/issues/2094
+   */
+  EXPERIMENTAL_useSourceOfProjectReferenceRedirect?: boolean;
+
+  /**
    * When `project` is provided, this controls the non-standard file extensions which will be parsed.
    * It accepts an array of file extensions, each preceded by a `.`.
    */

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -117,6 +117,20 @@ function createHash(content: string): string {
   return content;
 }
 
+function updateCachedFileList(
+  tsconfigPath: CanonicalPath,
+  program: ts.Program,
+  extra: Extra,
+): Set<CanonicalPath> {
+  const fileList = extra.EXPERIMENTAL_useSourceOfProjectReferenceRedirect
+    ? new Set(
+        program.getSourceFiles().map(sf => getCanonicalFileName(sf.fileName)),
+      )
+    : new Set(program.getRootFileNames().map(f => getCanonicalFileName(f)));
+  programFileListCache.set(tsconfigPath, fileList);
+  return fileList;
+}
+
 /**
  * Calculate project environments using options provided by consumer and paths from config
  * @param code The code being linted
@@ -154,21 +168,12 @@ function getProgramsForProjects(
    * before we go into the process of attempting to find and update every program
    * see if we know of a program that contains this file
    */
-  for (const rawTsconfigPath of extra.projects) {
-    const tsconfigPath = getTsconfigPath(rawTsconfigPath, extra);
-    const existingWatch = knownWatchProgramMap.get(tsconfigPath);
-    if (!existingWatch) {
-      continue;
-    }
-
+  for (const [tsconfigPath, existingWatch] of knownWatchProgramMap.entries()) {
     let fileList = programFileListCache.get(tsconfigPath);
     let updatedProgram: ts.Program | null = null;
     if (!fileList) {
       updatedProgram = existingWatch.getProgram().getProgram();
-      fileList = new Set(
-        updatedProgram.getRootFileNames().map(f => getCanonicalFileName(f)),
-      );
-      programFileListCache.set(tsconfigPath, fileList);
+      fileList = updateCachedFileList(tsconfigPath, updatedProgram, extra);
     }
 
     if (fileList.has(filePath)) {
@@ -209,18 +214,39 @@ function getProgramsForProjects(
 
       // sets parent pointers in source files
       updatedProgram.getTypeChecker();
-      results.push(updatedProgram);
 
+      // cache and check the file list
+      const fileList = updateCachedFileList(
+        tsconfigPath,
+        updatedProgram,
+        extra,
+      );
+      if (fileList.has(filePath)) {
+        log('Found updated program for file. %s', filePath);
+        // we can return early because we know this program contains the file
+        return [updatedProgram];
+      }
+
+      results.push(updatedProgram);
       continue;
     }
 
     const programWatch = createWatchProgram(tsconfigPath, extra);
     const program = programWatch.getProgram().getProgram();
+    program.getTypeChecker();
 
     // cache watch program and return current program
     knownWatchProgramMap.set(tsconfigPath, programWatch);
+
+    // cache and check the file list
+    const fileList = updateCachedFileList(tsconfigPath, program, extra);
+    if (fileList.has(filePath)) {
+      log('Found program for file. %s', filePath);
+      // we can return early because we know this program contains the file
+      return [program];
+    }
+
     // sets parent pointers in source files
-    program.getTypeChecker();
     results.push(program);
   }
 
@@ -323,6 +349,13 @@ function createWatchProgram(
     }),
   );
   watchCompilerHost.trace = log;
+
+  /**
+   * TODO(bradzacher): this needs refinement and development, but we're allowing users to opt-in to this for now
+   * See https://github.com/typescript-eslint/typescript-eslint/issues/2094
+   */
+  watchCompilerHost.useSourceOfProjectReferenceRedirect = (): boolean =>
+    extra.EXPERIMENTAL_useSourceOfProjectReferenceRedirect;
 
   // Since we don't want to asynchronously update program we want to disable timeout methods
   // So any changes in the program will be delayed and updated when getProgram is called on watch

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -351,7 +351,7 @@ function createWatchProgram(
   watchCompilerHost.trace = log;
 
   /**
-   * TODO(bradzacher): this needs refinement and development, but we're allowing users to opt-in to this for now
+   * TODO: this needs refinement and development, but we're allowing users to opt-in to this for now for testing and feedback.
    * See https://github.com/typescript-eslint/typescript-eslint/issues/2094
    */
   watchCompilerHost.useSourceOfProjectReferenceRedirect = (): boolean =>

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -232,11 +232,11 @@ function getProgramsForProjects(
     }
 
     const programWatch = createWatchProgram(tsconfigPath, extra);
-    const program = programWatch.getProgram().getProgram();
-    program.getTypeChecker();
-
-    // cache watch program and return current program
     knownWatchProgramMap.set(tsconfigPath, programWatch);
+
+    const program = programWatch.getProgram().getProgram();
+    // sets parent pointers in source files
+    program.getTypeChecker();
 
     // cache and check the file list
     const fileList = updateCachedFileList(tsconfigPath, program, extra);
@@ -246,7 +246,6 @@ function getProgramsForProjects(
       return [program];
     }
 
-    // sets parent pointers in source files
     results.push(program);
   }
 

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -12,6 +12,7 @@ export interface Extra {
   debugLevel: Set<DebugModule>;
   errorOnTypeScriptSyntacticAndSemanticIssues: boolean;
   errorOnUnknownASTType: boolean;
+  EXPERIMENTAL_useSourceOfProjectReferenceRedirect: boolean;
   extraFileExtensions: string[];
   filePath: string;
   jsx: boolean;
@@ -110,6 +111,18 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
    * Causes the parser to error if the TypeScript compiler returns any unexpected syntax/semantic errors.
    */
   errorOnTypeScriptSyntacticAndSemanticIssues?: boolean;
+
+  /**
+   * ***EXPERIMENTAL FLAG*** - Use this at your own risk.
+   *
+   * Causes TS to use the source files for referenced projects instead of the compiled .d.ts files.
+   * This feature is not yet optimized, and is likely to cause OOMs for medium to large projects.
+   *
+   * This flag REQUIRES at least TS v3.9, otherwise it does nothing.
+   *
+   * See: https://github.com/typescript-eslint/typescript-eslint/issues/2094
+   */
+  EXPERIMENTAL_useSourceOfProjectReferenceRedirect?: boolean;
 
   /**
    * When `project` is provided, this controls the non-standard file extensions which will be parsed.

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -93,6 +93,7 @@ function resetExtra(): void {
     debugLevel: new Set(),
     errorOnTypeScriptSyntacticAndSemanticIssues: false,
     errorOnUnknownASTType: false,
+    EXPERIMENTAL_useSourceOfProjectReferenceRedirect: false,
     extraFileExtensions: [],
     filePath: getFileName(),
     jsx: false,
@@ -168,7 +169,7 @@ function applyParserOptionsToExtra(options: TSESTreeOptions): void {
     if (
       extra.debugLevel.has('eslint') ||
       // make sure we don't turn off the eslint debug if it was enabled via --debug
-      debug.enabled('eslint:*')
+      debug.enabled('eslint:*,-eslint:code-path')
     ) {
       // https://github.com/eslint/eslint/blob/9dfc8501fb1956c90dc11e6377b4cb38a6bea65d/bin/eslint.js#L25
       namespaces.push('eslint:*,-eslint:code-path');
@@ -284,6 +285,10 @@ function applyParserOptionsToExtra(options: TSESTreeOptions): void {
   extra.createDefaultProgram =
     typeof options.createDefaultProgram === 'boolean' &&
     options.createDefaultProgram;
+
+  extra.EXPERIMENTAL_useSourceOfProjectReferenceRedirect =
+    typeof options.EXPERIMENTAL_useSourceOfProjectReferenceRedirect ===
+      'boolean' && options.EXPERIMENTAL_useSourceOfProjectReferenceRedirect;
 }
 
 function warnAboutTSVersion(): void {

--- a/packages/typescript-estree/tsconfig.build.json
+++ b/packages/typescript-estree/tsconfig.build.json
@@ -6,5 +6,10 @@
     "rootDir": "./src",
     "resolveJsonModule": true
   },
-  "include": ["src", "typings"]
+  "include": ["src", "typings"],
+  "references": [
+    { "path": "../shared-fixtures/tsconfig.build.json" },
+    { "path": "../types/tsconfig.build.json" },
+    { "path": "../visitor-keys/tsconfig.build.json" }
+  ]
 }


### PR DESCRIPTION
See #2094

This is quick-and-dirty to get this out there for some users to see what sort of perf improvements this squeezes out.
Intentionally not documenting the flag as it isn't ready to be used by the wider world

<details>
<summary>With the flag turned on</summary>

```bash
bradzacher@bradzacher-mbp typescript-eslint % DEBUG=typescript-eslint:* yarn eslint ./packages/types/src/index.ts ./packages/eslint-plugin/src/index.ts
yarn run v1.22.4
$ /Users/bradzacher/github/typescript-eslint/node_modules/.bin/eslint ./packages/types/src/index.ts ./packages/eslint-plugin/src/index.ts
  typescript-eslint:typescript-estree:parser parserOptions.project (excluding ignored) matched projects: [
  './tsconfig.eslint.json',
  './tests/integration/utils/jsconfig.json',
  './packages/eslint-plugin/tsconfig.json',
  './packages/eslint-plugin-internal/tsconfig.json',
  './packages/eslint-plugin-tslint/tsconfig.json',
  './packages/experimental-utils/tsconfig.json',
  './packages/parser/tsconfig.json',
  './packages/scope-manager/tsconfig.json',
  './packages/shared-fixtures/tsconfig.json',
  './packages/types/tsconfig.json',
  './packages/typescript-estree/tsconfig.json',
  './packages/visitor-keys/tsconfig.json'
] +0ms
  typescript-eslint:typescript-estree:createProjectProgram Creating project program for: /Users/bradzacher/github/typescript-eslint/packages/types/src/index.ts +0ms
  typescript-eslint:typescript-estree:createWatchProgram File did not belong to any existing programs, moving to create/update. /users/bradzacher/github/typescript-eslint/packages/types/src/index.ts +0ms
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/tsconfig.eslint.json. +0ms
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/tests/integration/utils/jsconfig.json. +1s
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/packages/eslint-plugin/tsconfig.json. +844ms
  typescript-eslint:typescript-estree:createWatchProgram Found program for file. /users/bradzacher/github/typescript-eslint/packages/types/src/index.ts +2s
  typescript-eslint:parser:parser Resolved libs from program: [ 'es2017' ] +0ms
  typescript-eslint:typescript-estree:parser parserOptions.project (excluding ignored) matched projects: [
  './tsconfig.eslint.json',
  './tests/integration/utils/jsconfig.json',
  './packages/eslint-plugin/tsconfig.json',
  './packages/eslint-plugin-internal/tsconfig.json',
  './packages/eslint-plugin-tslint/tsconfig.json',
  './packages/experimental-utils/tsconfig.json',
  './packages/parser/tsconfig.json',
  './packages/scope-manager/tsconfig.json',
  './packages/shared-fixtures/tsconfig.json',
  './packages/types/tsconfig.json',
  './packages/typescript-estree/tsconfig.json',
  './packages/visitor-keys/tsconfig.json'
] +5s
  typescript-eslint:typescript-estree:createProjectProgram Creating project program for: /Users/bradzacher/github/typescript-eslint/packages/eslint-plugin/src/index.ts +5s
  typescript-eslint:typescript-estree:createWatchProgram Found existing program for file. /users/bradzacher/github/typescript-eslint/packages/eslint-plugin/src/index.ts +74ms
  typescript-eslint:parser:parser Resolved libs from program: [ 'es2017' ] +70ms
✨  Done in 6.50s.
```

</details>

<details>
<summary>With the flag turned off</summary>

```bash
bradzacher@bradzacher-mbp typescript-eslint % DEBUG=typescript-eslint:* yarn eslint ./packages/types/src/index.ts ./packages/eslint-plugin/src/index.ts
yarn run v1.22.4
$ /Users/bradzacher/github/typescript-eslint/node_modules/.bin/eslint ./packages/types/src/index.ts ./packages/eslint-plugin/src/index.ts
  typescript-eslint:typescript-estree:parser parserOptions.project (excluding ignored) matched projects: [
  './tsconfig.eslint.json',
  './tests/integration/utils/jsconfig.json',
  './packages/eslint-plugin/tsconfig.json',
  './packages/eslint-plugin-internal/tsconfig.json',
  './packages/eslint-plugin-tslint/tsconfig.json',
  './packages/experimental-utils/tsconfig.json',
  './packages/parser/tsconfig.json',
  './packages/scope-manager/tsconfig.json',
  './packages/shared-fixtures/tsconfig.json',
  './packages/types/tsconfig.json',
  './packages/typescript-estree/tsconfig.json',
  './packages/visitor-keys/tsconfig.json'
] +0ms
  typescript-eslint:typescript-estree:createProjectProgram Creating project program for: /Users/bradzacher/github/typescript-eslint/packages/types/src/index.ts +0ms
  typescript-eslint:typescript-estree:createWatchProgram File did not belong to any existing programs, moving to create/update. /users/bradzacher/github/typescript-eslint/packages/types/src/index.ts +0ms
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/tsconfig.eslint.json. +1ms
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/tests/integration/utils/jsconfig.json. +1s
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/packages/eslint-plugin/tsconfig.json. +976ms
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/packages/eslint-plugin-internal/tsconfig.json. +2s
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/packages/eslint-plugin-tslint/tsconfig.json. +1s
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/packages/experimental-utils/tsconfig.json. +1s
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/packages/parser/tsconfig.json. +961ms
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/packages/scope-manager/tsconfig.json. +888ms
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/packages/shared-fixtures/tsconfig.json. +996ms
  typescript-eslint:typescript-estree:createWatchProgram Creating watch program for /users/bradzacher/github/typescript-eslint/packages/types/tsconfig.json. +561ms
  typescript-eslint:typescript-estree:createWatchProgram Found program for file. /users/bradzacher/github/typescript-eslint/packages/types/src/index.ts +567ms
  typescript-eslint:parser:parser Resolved libs from program: [ 'es2017' ] +0ms
  typescript-eslint:typescript-estree:parser parserOptions.project (excluding ignored) matched projects: [
  './tsconfig.eslint.json',
  './tests/integration/utils/jsconfig.json',
  './packages/eslint-plugin/tsconfig.json',
  './packages/eslint-plugin-internal/tsconfig.json',
  './packages/eslint-plugin-tslint/tsconfig.json',
  './packages/experimental-utils/tsconfig.json',
  './packages/parser/tsconfig.json',
  './packages/scope-manager/tsconfig.json',
  './packages/shared-fixtures/tsconfig.json',
  './packages/types/tsconfig.json',
  './packages/typescript-estree/tsconfig.json',
  './packages/visitor-keys/tsconfig.json'
] +11s
  typescript-eslint:typescript-estree:createProjectProgram Creating project program for: /Users/bradzacher/github/typescript-eslint/packages/eslint-plugin/src/index.ts +11s
  typescript-eslint:typescript-estree:createWatchProgram Found existing program for file. /users/bradzacher/github/typescript-eslint/packages/eslint-plugin/src/index.ts +64ms
  typescript-eslint:parser:parser Resolved libs from program: [ 'es2017' ] +60ms
✨  Done in 12.26s.
```

</details>

Comparisons:

With the flag turned on, runtime is ~6s.
With the flag turned off, runtime is ~12s.

With the flag turned on, we're able to find `./packages/types/src/index.ts` within the `eslint-plugin` program and exit early.
With the flag turned off, we have to iterate and calculate almost all of the programs to find the program for `typescript-estree` (because our config is alphabetically sorted). 

***Important note that I just found out*** - `projects` are not carried through tsconfig `extends`!
To test this I had to duplicate the project references config between from the build tsconfigs into the dev tsconfigs.
Kind of annoying but w/e 🤷‍♂️ 