### PR TITLE
fix(eslint-plugin): [return-await] do not auto-fix when type is `any`/`unknown`

### DIFF
--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -169,21 +169,24 @@ export default util.createRule({
         return;
       }
 
-      // any could be thenable; do not auto-fix
-      const useAutoFix = !util.isTypeAnyType(type);
-      const removeFix = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix | null =>
-        removeAwait(fixer, node);
       if (isAwait && !isThenable) {
+        // any/unknown could be thenable; do not auto-fix
+        const useAutoFix = !(
+          util.isTypeAnyType(type) || util.isTypeUnknownType(type)
+        );
+        const fix = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix | null =>
+          removeAwait(fixer, node);
+
         context.report({
           messageId: 'nonPromiseAwait',
           node,
           ...(useAutoFix
-            ? { fix: removeFix }
+            ? { fix }
             : {
                 suggest: [
                   {
                     messageId: 'nonPromiseAwait',
-                    fix: removeFix,
+                    fix,
                   },
                 ],
               }),

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -173,9 +173,6 @@ export default util.createRule({
       const useAutoFix = !util.isTypeAnyType(type);
       const removeFix = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix | null =>
         removeAwait(fixer, node);
-      const insertFix = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix | null =>
-        insertAwait(fixer, node);
-
       if (isAwait && !isThenable) {
         context.report({
           messageId: 'nonPromiseAwait',
@@ -199,16 +196,7 @@ export default util.createRule({
           context.report({
             messageId: 'requiredPromiseAwait',
             node,
-            ...(useAutoFix
-              ? { fix: insertFix }
-              : {
-                  suggest: [
-                    {
-                      messageId: 'requiredPromiseAwait',
-                      fix: insertFix,
-                    },
-                  ],
-                }),
+            fix: fixer => insertAwait(fixer, node),
           });
         }
 
@@ -220,16 +208,7 @@ export default util.createRule({
           context.report({
             messageId: 'disallowedPromiseAwait',
             node,
-            ...(useAutoFix
-              ? { fix: removeFix }
-              : {
-                  suggest: [
-                    {
-                      messageId: 'disallowedPromiseAwait',
-                      fix: removeFix,
-                    },
-                  ],
-                }),
+            fix: fixer => removeAwait(fixer, node),
           });
         }
 
@@ -242,16 +221,7 @@ export default util.createRule({
           context.report({
             messageId: 'disallowedPromiseAwait',
             node,
-            ...(useAutoFix
-              ? { fix: removeFix }
-              : {
-                  suggest: [
-                    {
-                      messageId: 'disallowedPromiseAwait',
-                      fix: removeFix,
-                    },
-                  ],
-                }),
+            fix: fixer => removeAwait(fixer, node),
           });
         } else if (!isAwait && isInTryCatch) {
           if (inCatch(expression) && !hasFinallyBlock(expression)) {
@@ -265,16 +235,7 @@ export default util.createRule({
           context.report({
             messageId: 'requiredPromiseAwait',
             node,
-            ...(useAutoFix
-              ? { fix: insertFix }
-              : {
-                  suggest: [
-                    {
-                      messageId: 'requiredPromiseAwait',
-                      fix: insertFix,
-                    },
-                  ],
-                }),
+            fix: fixer => insertAwait(fixer, node),
           });
         }
 

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -1,5 +1,5 @@
 import rule from '../../src/rules/return-await';
-import { getFixturesRootDir, RuleTester, noFormat } from '../RuleTester';
+import { getFixturesRootDir, noFormat, RuleTester } from '../RuleTester';
 
 const rootDir = getFixturesRootDir();
 
@@ -308,6 +308,27 @@ ruleTester.run('return-await', rule, {
       errors: [
         {
           line: 1,
+          messageId: 'nonPromiseAwait',
+        },
+      ],
+    },
+    {
+      code: `
+        const fn = (): any => null;
+        async function test() {
+          return await fn();
+        }
+      `,
+      // output matches input because return type any is suggestion only
+      output: `
+        const fn = (): any => null;
+        async function test() {
+          return await fn();
+        }
+      `,
+      errors: [
+        {
+          line: 4,
           messageId: 'nonPromiseAwait',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -334,6 +334,27 @@ ruleTester.run('return-await', rule, {
       ],
     },
     {
+      code: `
+        const fn = (): unknown => null;
+        async function test() {
+          return await fn();
+        }
+      `,
+      // output matches input because return type unknown is suggestion only
+      output: `
+        const fn = (): unknown => null;
+        async function test() {
+          return await fn();
+        }
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'nonPromiseAwait',
+        },
+      ],
+    },
+    {
       code: 'const test = async () => await Promise.resolve(1);',
       output: 'const test = async () => Promise.resolve(1);',
       errors: [

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -314,43 +314,51 @@ ruleTester.run('return-await', rule, {
     },
     {
       code: `
-        const fn = (): any => null;
-        async function test() {
-          return await fn();
-        }
-      `,
-      // output matches input because return type any is suggestion only
-      output: `
-        const fn = (): any => null;
-        async function test() {
-          return await fn();
-        }
-      `,
+const fn = (): any => null;
+async function test() {
+  return await fn();
+}
+      `.trimRight(),
       errors: [
         {
           line: 4,
           messageId: 'nonPromiseAwait',
+          suggestions: [
+            {
+              messageId: 'nonPromiseAwait',
+              output: `
+const fn = (): any => null;
+async function test() {
+  return fn();
+}
+              `.trimRight(),
+            },
+          ],
         },
       ],
     },
     {
       code: `
-        const fn = (): unknown => null;
-        async function test() {
-          return await fn();
-        }
-      `,
-      // output matches input because return type unknown is suggestion only
-      output: `
-        const fn = (): unknown => null;
-        async function test() {
-          return await fn();
-        }
-      `,
+const fn = (): unknown => null;
+async function test() {
+  return await fn();
+}
+      `.trimRight(),
       errors: [
         {
           line: 4,
           messageId: 'nonPromiseAwait',
+          suggestions: [
+            {
+              messageId: 'nonPromiseAwait',
+              output: `
+const fn = (): unknown => null;
+async function test() {
+  return fn();
+}
+              `.trimRight(),
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
Resolves #2598 

Specifically tadhgmister's solution:

> If it detected that the value is type any and make a suggestion instead of a fix would that be satisfactory? That way it still gives a warning and IDE has quick fix but the --fix command doesn't remove your await?