### PR TITLE
fix(prefer-ts-expect-error): change fix to suggestion

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
+++ b/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
@@ -76,9 +76,14 @@ export default util.createRule<[], MessageIds>({
             context.report({
               node: comment,
               messageId: 'preferExpectErrorComment',
-              fix: isLineComment(comment)
-                ? lineCommentRuleFixer
-                : blockCommentRuleFixer,
+              suggest: [
+                {
+                  messageId: 'preferExpectErrorComment',
+                  fix: isLineComment(comment)
+                    ? lineCommentRuleFixer
+                    : blockCommentRuleFixer,
+                }
+              ],
             });
           }
         });

--- a/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
+++ b/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
@@ -82,7 +82,7 @@ export default util.createRule<[], MessageIds>({
                   fix: isLineComment(comment)
                     ? lineCommentRuleFixer
                     : blockCommentRuleFixer,
-                }
+                },
               ],
             });
           }

--- a/packages/eslint-plugin/tests/rules/prefer-ts-expect-error.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-ts-expect-error.test.ts
@@ -37,35 +37,51 @@ if (false) {
   invalid: [
     {
       code: '// @ts-ignore',
-      output: '// @ts-expect-error',
-      errors: [
-        {
-          messageId: 'preferExpectErrorComment',
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: '// @ts-ignore: Suppress next line',
-      output: '// @ts-expect-error: Suppress next line',
 
       errors: [
         {
           messageId: 'preferExpectErrorComment',
           line: 1,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'preferExpectErrorComment',
+              output: '// @ts-expect-error',
+            },
+          ],
         },
       ],
     },
     {
-      code: '///@ts-ignore: Suppress next line',
-      output: '///@ts-expect-error: Suppress next line',
+      code: '// @ts-ignore: Suppress next line',
+
       errors: [
         {
           messageId: 'preferExpectErrorComment',
           line: 1,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'preferExpectErrorComment',
+              output: '// @ts-expect-error: Suppress next line',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: '///@ts-ignore: Suppress next line',
+      errors: [
+        {
+          messageId: 'preferExpectErrorComment',
+          line: 1,
+          column: 1,
+          suggestions: [
+            {
+              messageId: 'preferExpectErrorComment',
+              output: '///@ts-expect-error: Suppress next line',
+            },
+          ],
         },
       ],
     },
@@ -75,29 +91,39 @@ if (false) {
   // @ts-ignore: Unreachable code error
   console.log('hello');
 }
-      `,
-      output: `
-if (false) {
-  // @ts-expect-error: Unreachable code error
-  console.log('hello');
-}
-      `,
+      `.trimRight(),
       errors: [
         {
           messageId: 'preferExpectErrorComment',
           line: 3,
           column: 3,
+          suggestions: [
+            {
+              messageId: 'preferExpectErrorComment',
+              output: `
+if (false) {
+  // @ts-expect-error: Unreachable code error
+  console.log('hello');
+}
+              `.trimRight(),
+            },
+          ],
         },
       ],
     },
     {
       code: '/* @ts-ignore */',
-      output: '/* @ts-expect-error */',
       errors: [
         {
           messageId: 'preferExpectErrorComment',
           line: 1,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'preferExpectErrorComment',
+              output: '/* @ts-expect-error */',
+            },
+          ],
         },
       ],
     },
@@ -107,29 +133,39 @@ if (false) {
  * Explaining comment
  *
  * @ts-ignore */
-      `,
-      output: `
-/**
- * Explaining comment
- *
- * @ts-expect-error */
-      `,
+      `.trimRight(),
       errors: [
         {
           messageId: 'preferExpectErrorComment',
           line: 2,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'preferExpectErrorComment',
+              output: `
+/**
+ * Explaining comment
+ *
+ * @ts-expect-error */
+              `.trimRight(),
+            },
+          ],
         },
       ],
     },
     {
       code: '/* @ts-ignore in a single block */',
-      output: '/* @ts-expect-error in a single block */',
       errors: [
         {
           messageId: 'preferExpectErrorComment',
           line: 1,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'preferExpectErrorComment',
+              output: '/* @ts-expect-error in a single block */',
+            },
+          ],
         },
       ],
     },
@@ -137,16 +173,21 @@ if (false) {
       code: `
 /*
 // @ts-ignore in a block with single line comments */
-      `,
-      output: `
-/*
-// @ts-expect-error in a block with single line comments */
-      `,
+      `.trimRight(),
       errors: [
         {
           messageId: 'preferExpectErrorComment',
           line: 2,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'preferExpectErrorComment',
+              output: `
+/*
+// @ts-expect-error in a block with single line comments */
+              `.trimRight(),
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
There are use-cases for ts-ignore - somewhat rare, but legitimate. For example, usages of recent typescript features like variadic tuple types, with graceful downgrading:

```typescript
// @ts-ignore
type Push_ts4<A extends unknown[], B> = [...A, B];
type VariadicTuplesPrefixesSupported = Push_ts4<[1, 2], 3> extends { length: 3 } ? "yes" : "no";
type Push<A extends unknown[], B> = VariadicTuplesPrefixesSupported extends "yes"
    ? Push_ts4<A, B>
    : Array<A[number] | B>;
```

This will be a typescript error for users on typescript 3.9 or below, but will compile fine for typescript 4.0 and above. If we autofix to ts-expect-error, a developer might not notice it changing and have everything compile fine, only for another user to hit an "unused ts-expect-error" directive.

This change swaps the `fix` for a `suggest` so that the developer has to explicitly choose whether to apply the fix or determine whether it's a legitimate use of `ts-ignore`.