### PR TITLE
fix(eslint-plugin): [naming-convention] check bodyless function parameters

### DIFF
--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -529,10 +529,11 @@ export default util.createRule<Options, MessageIds>({
       // #endregion function
 
       // #region parameter
-
-      'FunctionDeclaration, TSDeclareFunction, FunctionExpression, ArrowFunctionExpression'(
+      'FunctionDeclaration, TSDeclareFunction, TSEmptyBodyFunctionExpression, FunctionExpression, ArrowFunctionExpression'(
         node:
           | TSESTree.FunctionDeclaration
+          | TSESTree.TSDeclareFunction
+          | TSESTree.TSEmptyBodyFunctionExpression
           | TSESTree.FunctionExpression
           | TSESTree.ArrowFunctionExpression,
       ): void {

--- a/packages/eslint-plugin/tests/rules/naming-convention.test.ts
+++ b/packages/eslint-plugin/tests/rules/naming-convention.test.ts
@@ -1316,5 +1316,20 @@ ruleTester.run('naming-convention', rule, {
         },
       ],
     },
+    {
+      code: `
+        declare class Foo {
+          Bar(Baz: string): void;
+        }
+      `,
+      parserOptions,
+      options: [{ selector: 'parameter', format: ['camelCase'] }],
+      errors: [
+        {
+          line: 3,
+          messageId: 'doesNotMatchFormat',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Resolves #2663

