### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] correct fixer for vue files

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -241,12 +241,12 @@ export default util.createRule<Options, MessageIds>({
             fix(fixer) {
               return originalNode.kind === ts.SyntaxKind.TypeAssertionExpression
                 ? fixer.removeRange([
-                    originalNode.getStart(),
-                    originalNode.expression.getStart(),
+                    node.range[0],
+                    node.expression.range[0] - 1,
                   ])
                 : fixer.removeRange([
-                    originalNode.expression.end,
-                    originalNode.end,
+                    node.expression.range[1] + 1,
+                    node.range[1],
                   ]);
             },
           });

--- a/tests/integration/fixtures/vue-sfc/.eslintrc.js
+++ b/tests/integration/fixtures/vue-sfc/.eslintrc.js
@@ -19,5 +19,7 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+    'semi-spacing': 'error',
   },
 };

--- a/tests/integration/fixtures/vue-sfc/Utility.vue
+++ b/tests/integration/fixtures/vue-sfc/Utility.vue
@@ -1,0 +1,15 @@
+<script lang="ts">
+/* https://github.com/typescript-eslint/typescript-eslint/issues/2591 */
+/* eslint-disable class-methods-use-this */
+export default class Utility {
+  get a() {
+    const list: Array<string> = [];
+    return list;
+  }
+
+  get b() {
+    const a = this.a as Array<string>;
+    return a;
+  }
+}
+</script>

--- a/tests/integration/fixtures/vue-sfc/test.js.snap
+++ b/tests/integration/fixtures/vue-sfc/test.js.snap
@@ -86,6 +86,31 @@ export default Vue.extend({
   },
   Object {
     "errorCount": 0,
+    "filePath": "/usr/linked/Utility.vue",
+    "fixableErrorCount": 0,
+    "fixableWarningCount": 0,
+    "messages": Array [],
+    "output": "<script lang=\\"ts\\">
+/* https://github.com/typescript-eslint/typescript-eslint/issues/2591 */
+/* eslint-disable class-methods-use-this */
+export default class Utility {
+  get a() {
+    const list: Array<string> = [];
+    return list;
+  }
+
+  get b() {
+    const a = this.a;
+    return a;
+  }
+}
+</script>
+",
+    "usedDeprecatedRules": Array [],
+    "warningCount": 0,
+  },
+  Object {
+    "errorCount": 0,
     "filePath": "/usr/linked/World.vue",
     "fixableErrorCount": 0,
     "fixableWarningCount": 0,

--- a/tests/integration/fixtures/vue-sfc/test.sh
+++ b/tests/integration/fixtures/vue-sfc/test.sh
@@ -23,7 +23,7 @@ npm install vuex@latest vue-property-decorator@latest
 
 # Run the linting
 # (the "|| true" helps make sure that we run our tests on failed linting runs as well)
-npx eslint --format json --output-file /usr/lint-output.json --config /usr/linked/.eslintrc.js /usr/linked/**/*.vue || true
+npx eslint --format json --output-file /usr/lint-output.json --config /usr/linked/.eslintrc.js /usr/linked/**/*.vue --fix-dry-run || true
 
 # Run our assertions against the linting output
 npx jest /usr/test.js --snapshotResolver=/usr/utils/jest-snapshot-resolver.js


### PR DESCRIPTION
Fixes #2591 

n.b. I've kept this fix tight, because I had some whitespace artefacts using `node` vs `originalNode`. If you think I should extend it to the rest of the file, or have some guidance of dealing with how node ranges don't quite match the originalNode.end values, let me know.