### PR TITLE
fix(eslint-plugin): [lines-between-class-members] fix typo in schema

### DIFF
--- a/packages/eslint-plugin/src/rules/lines-between-class-members.ts
+++ b/packages/eslint-plugin/src/rules/lines-between-class-members.ts
@@ -13,7 +13,7 @@ const schema = util.deepMerge(
   {
     1: {
       exceptAfterOverload: {
-        type: 'booleean',
+        type: 'boolean',
         default: true,
       },
     },


### PR DESCRIPTION
Rename `exceptAfterOverload` type from "booleean" to "boolean"