### PR TITLE
feat(eslint-plugin): add global modifier to naming-convention

### DIFF
--- a/packages/eslint-plugin/docs/rules/naming-convention.md
+++ b/packages/eslint-plugin/docs/rules/naming-convention.md
@@ -194,7 +194,7 @@ There are two types of selectors, individual selectors, and grouped selectors.
 Individual Selectors match specific, well-defined sets. There is no overlap between each of the individual selectors.
 
 - `variable` - matches any `var` / `let` / `const` variable name.
-  - Allowed `modifiers`: `const`.
+  - Allowed `modifiers`: `const`, `global`.
   - Allowed `types`: `boolean`, `string`, `number`, `function`, `array`.
 - `function` - matches any named function declaration or named function expression.
   - Allowed `modifiers`: none.
@@ -312,6 +312,8 @@ Group Selectors are provided for convenience, and essentially bundle up sets of 
 ```
 
 ### Enforce that all const variables are in UPPER_CASE
+
+Optionally, a `global` modifier can be used to only validate variables defined in the top level of the file / module.
 
 ```json
 {

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -87,6 +87,7 @@ enum Modifiers {
   protected = 1 << 4,
   private = 1 << 5,
   abstract = 1 << 6,
+  global = 1 << 7,
 }
 type ModifiersString = keyof typeof Modifiers;
 
@@ -309,7 +310,7 @@ const SCHEMA: JSONSchema.JSONSchema4 = {
       ...selectorSchema('default', false, util.getEnumNames(Modifiers)),
 
       ...selectorSchema('variableLike', false),
-      ...selectorSchema('variable', true, ['const']),
+      ...selectorSchema('variable', true, ['const', 'global']),
       ...selectorSchema('function', false),
       ...selectorSchema('parameter', true),
 
@@ -501,6 +502,11 @@ export default util.createRule<Options, MessageIds>({
           parent.kind === 'const'
         ) {
           modifiers.add(Modifiers.const);
+        }
+
+        const scope = context.getScope();
+        if (scope.type === 'global' || scope.type === 'module') {
+          modifiers.add(Modifiers.global);
         }
 
         identifiers.forEach(i => {

--- a/packages/eslint-plugin/tests/rules/naming-convention.test.ts
+++ b/packages/eslint-plugin/tests/rules/naming-convention.test.ts
@@ -639,6 +639,22 @@ ruleTester.run('naming-convention', rule, {
     },
     {
       code: `
+        const CONSTANT_VALUE = 42;
+        function inner() {
+          const localConstant = 2;
+        }
+      `,
+      parserOptions,
+      options: [
+        {
+          selector: 'variable',
+          modifiers: ['const', 'global'],
+          format: ['UPPER_CASE'],
+        },
+      ],
+    },
+    {
+      code: `
         declare const ANY_UPPER_CASE: any;
         declare const ANY_UPPER_CASE: any | null;
         declare const ANY_UPPER_CASE: any | null | undefined;


### PR DESCRIPTION
Fixes #2318

Added a new `global` modifier to the `naming-convention` rule. This is only valid for variable selectors with the `const` modifier. It allows for configuring top-level/global constants differently than constants defined inside nested function scopes.

Something to look at is the naming of `global`. The issue describes `topLevel` as another possible name. Another is whether this global modifier should be valid for function selectors (it is not in this PR.)

The implementation was based on the description of [this comment](https://github.com/typescript-eslint/typescript-eslint/issues/2318#issuecomment-700184644) in the issue