### PR TITLE
feat(eslint-plugin): [ban-types] support banning `[]`

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -28,7 +28,7 @@ type Options = {
 The rule accepts a single object as options, with the following keys:
 
 - `types` - An object whose keys are the types you want to ban, and the values are error messages.
-  - The type can either be a type name literal (`Foo`), a type name with generic parameter instantiation(s) (`Foo<Bar>`), or the empty object literal (`{}`).
+  - The type can either be a type name literal (`Foo`), a type name with generic parameter instantiation(s) (`Foo<Bar>`), the empty object literal (`{}`), or the empty tuple type (`[]`).
   - The values can be a string, which is the error message to be reported, `false` to specifically disable this type
     or it can be an object with the following properties:
     - `message: string` - the message to display when the type is matched.

--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -223,6 +223,11 @@ export default util.createRule<Options, MessageIds>({
 
         checkBannedTypes(node);
       },
+      TSTupleType(node): void {
+        if (node.elementTypes.length === 0) {
+          checkBannedTypes(node);
+        }
+      },
       TSTypeReference(node): void {
         checkBannedTypes(node.typeName);
 

--- a/packages/eslint-plugin/tests/rules/ban-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-types.test.ts
@@ -108,6 +108,7 @@ ruleTester.run('ban-types', rule, {
         },
       ],
     },
+    'let a: [];',
   ],
   invalid: [
     {
@@ -525,6 +526,94 @@ let bar: object = {};
         {
           types: {
             'Bar<A, B>': "Don't pass `A, B` as parameters to `Bar`",
+          },
+        },
+      ],
+    },
+    {
+      code: 'let a: [];',
+      errors: [
+        {
+          messageId: 'bannedTypeMessage',
+          data: {
+            name: '[]',
+            customMessage: ' `[]` does only allow empty arrays.',
+          },
+          line: 1,
+          column: 8,
+        },
+      ],
+      options: [
+        {
+          types: {
+            '[]': '`[]` does only allow empty arrays.',
+          },
+        },
+      ],
+    },
+    {
+      code: noFormat`let a:  [ ] ;`,
+      errors: [
+        {
+          messageId: 'bannedTypeMessage',
+          data: {
+            name: '[]',
+            customMessage: ' `[]` does only allow empty arrays.',
+          },
+          line: 1,
+          column: 9,
+        },
+      ],
+      options: [
+        {
+          types: {
+            '[]': '`[]` does only allow empty arrays.',
+          },
+        },
+      ],
+    },
+    {
+      code: 'let a: [];',
+      output: 'let a: any[];',
+      errors: [
+        {
+          messageId: 'bannedTypeMessage',
+          data: {
+            name: '[]',
+            customMessage: ' `[]` does only allow empty arrays.',
+          },
+          line: 1,
+          column: 8,
+        },
+      ],
+      options: [
+        {
+          types: {
+            '[]': {
+              message: '`[]` does only allow empty arrays.',
+              fixWith: 'any[]',
+            },
+          },
+        },
+      ],
+    },
+    {
+      code: 'let a: [[]];',
+      errors: [
+        {
+          messageId: 'bannedTypeMessage',
+          data: {
+            name: '[]',
+            customMessage: ' `[]` does only allow empty arrays.',
+          },
+          line: 1,
+          column: 9,
+        },
+      ],
+      options: [
+        {
+          types: {
+            '[]': '`[]` does only allow empty arrays.',
           },
         },
       ],


### PR DESCRIPTION
fix #2582

This PR only adds support for banning the empty tuple type `[]`, it does not change the default options of the `ban-types` rule. 

I think it might also be worth adding `[]` to the default banned types. As this would be a breaking change, I would do it in another PR, if the maintainers are ok with that.