### PR TITLE
docs(eslint-plugin): [consistent-type-imports] note that it can't be used for decorator metadata

### DIFF
--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -61,4 +61,6 @@ const x: import('Bar') = 1;
 ## When Not To Use It
 
 - If you are not using TypeScript 3.8 (or greater), then you will not be able to use this rule, as type-only imports are not allowed.
+- Certain libraries use the non-inlined imports to infer information about the variables. For example, for dependency injection.  
+  type-only imports cannot be used with these libraries. See [#2559](https://github.com/typescript-eslint/typescript-eslint/issues/2559#issuecomment-692780580)
 - If you specifically want to use both import kinds for stylistic reasons, you can disable this rule.


### PR DESCRIPTION
 See https://github.com/typescript-eslint/typescript-eslint/issues/2559#issuecomment-692780580 for additional information