### PR TITLE
[explicit-module-boundary-types] add option to omit explicit return types on JSX functions

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -10,6 +10,7 @@ import {
   FunctionExpression,
   FunctionNode,
   isTypedFunctionExpression,
+  isJSXReturningFunction,
 } from '../util/explicitReturnTypeUtils';
 
 type Options = [
@@ -18,6 +19,7 @@ type Options = [
     allowDirectConstAssertionInArrowFunctions?: boolean;
     allowedNames?: string[];
     allowHigherOrderFunctions?: boolean;
+    allowJSXFunctions?: boolean;
     allowTypedFunctionExpressions?: boolean;
     shouldTrackReferences?: boolean;
   },
@@ -66,6 +68,9 @@ export default util.createRule<Options, MessageIds>({
           allowHigherOrderFunctions: {
             type: 'boolean',
           },
+          allowJSXFunctions: {
+            type: 'boolean',
+          },
           allowTypedFunctionExpressions: {
             type: 'boolean',
           },
@@ -84,6 +89,7 @@ export default util.createRule<Options, MessageIds>({
       allowDirectConstAssertionInArrowFunctions: true,
       allowedNames: [],
       allowHigherOrderFunctions: true,
+      allowJSXFunctions: false,
       allowTypedFunctionExpressions: true,
     },
   ],
@@ -455,7 +461,8 @@ export default util.createRule<Options, MessageIds>({
       if (
         isAllowedName(node.parent) ||
         isTypedFunctionExpression(node, options) ||
-        ancestorHasReturnType(node)
+        ancestorHasReturnType(node) ||
+        isJSXReturningFunction(node)
       ) {
         return;
       }
@@ -477,7 +484,11 @@ export default util.createRule<Options, MessageIds>({
       }
       checkedFunctions.add(node);
 
-      if (isAllowedName(node.parent) || ancestorHasReturnType(node)) {
+      if (
+        isAllowedName(node.parent) ||
+        ancestorHasReturnType(node) ||
+        isJSXReturningFunction(node)
+      ) {
         return;
       }
 

--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -346,6 +346,23 @@ function checkFunctionExpressionReturnType(
   checkFunctionReturnType(node, options, sourceCode, report);
 }
 
+function blockReturnsJSX(node: TSESTree.BlockStatement) {
+  return node.body.some(statement => {
+    if (statement.type === 'ReturnStatement') {
+      return statement.argument?.type === 'JSXElement';
+    }
+    return false;
+  });
+}
+function isJSXReturningFunction(node: FunctionNode) {
+  if (node.body.type === 'BlockStatement') {
+    return blockReturnsJSX(node.body);
+  } else if (node.body.type === 'JSXElement') {
+    return true;
+  }
+  return false;
+}
+
 export {
   checkFunctionExpressionReturnType,
   checkFunctionReturnType,
@@ -353,4 +370,5 @@ export {
   FunctionExpression,
   FunctionNode,
   isTypedFunctionExpression,
+  isJSXReturningFunction,
 };

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -661,6 +661,55 @@ export class A {
   b = A;
 }
     `,
+    {
+      code: `
+export function MyComponent(): JSX.Element {
+  return <div>Hello</div>;
+}
+      `,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: `
+export function MyComponent() {
+  return <div>Hello</div>;
+}
+      `,
+      options: [{ allowJSXFunctions: true }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: `
+export const MyComponent = () => {
+  return <div>Hello</div>;
+}
+      `,
+      options: [{ allowJSXFunctions: true }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    {
+      code: `
+export const MyComponent = () => <div>Hello</div>;
+      `,
+      options: [{ allowJSXFunctions: true }],
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
This PR's at the "proof of concept stage" - I got a very basic version working and wanted to check that the general concept for this option is okay, and double-check direction on implementation before proceeding.

---

#### Motivation

In concept, I'd like an option that ignores JSX functions for the explicit return type rules.  In particular, I'm thinking of React components, but I imagine the same would apply to other JSX functions. 

For one, I don't think the return annotation on react components is particularly helpful - from a readability standpoint, it's pretty easy to see at a glance that the function is a react component (capitalized name, usually in their own files); so it the annotation doesn't really convey readability.  

And from a safety perspective, not a lot is gained.  Yeah, it's possible to return invalid things from React components, but in that case it'll fail as soon as they try to use it as a component with `<Component />`; unlike some other mistakes that can be made with return types, it's not possible for the return type to appear to function correctly but be subtly wrong. 

Secondly, annotating the return type of a react component is often a meaningful hurdle for React/TS beginners.  It's not obvious what the correct return type is (`JSX.Element` or `React.ReactElement` are correct and maybe `null`, something like `ReactNode` might seem correct but is wrong).  

This sometimes causes React developers to use `React.FC` - side-stepping the issue of annotating the return type by annotating the whole function type - but that has it's [own set of issues](https://github.com/facebook/create-react-app/pull/8177).

#### Implementation

The current implementation here is really basic; I'm currently just starting at the function node and trying to step through the AST nodes to find a JSX element, I've currently got a very basic version:

```ts
// passed the function.body initially
function blockReturnsJSX(node: TSESTree.BlockStatement) {
  return node.body.some(statement => {
    if (statement.type === 'ReturnStatement') {
      return statement.argument?.type === 'JSXElement';
    }
    return false;
  });
}
```

which would have to be drastically expanded to be anything robust.

I didn't know if there's a more efficient way to essentially search for nodes of type `JSXElement` within a given node, to avoid basically writing my own AST walker.

---

The other way I think this could work would be to leverage the ESLint matchers to find the JSXElements, track which functions contain them, and then use that to determine which functions should be reported.  This would require more restructuring of the existing logic; rather than checking exported functions immediately, all functions would be collected, and then checked at the end (after enough the entire AST has been walked to determine whether the function returns JSX).

If there aren't any clean ways to expand my current approach I may try this approach.

---


Anyway, let me know your thoughts and whether you think this is an option worth having.