### PR TITLE
fix(eslint-plugin): [no-extra-non-null-assertion] false positive with non-nullable computed key

### DIFF
--- a/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts
@@ -32,7 +32,7 @@ export default util.createRule({
 
     return {
       'TSNonNullExpression > TSNonNullExpression': checkExtraNonNullAssertion,
-      'MemberExpression[optional = true] > TSNonNullExpression': checkExtraNonNullAssertion,
+      'MemberExpression[optional = true] > TSNonNullExpression.object': checkExtraNonNullAssertion,
       'CallExpression[optional = true] > TSNonNullExpression.callee': checkExtraNonNullAssertion,
     };
   },

--- a/packages/eslint-plugin/tests/rules/no-extra-non-null-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extra-non-null-assertion.test.ts
@@ -33,6 +33,15 @@ function foo(bar?: { n: number }) {
 checksCounter?.textContent!.trim();
       `,
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2732
+    {
+      code: `
+function foo(key: string | null) {
+  const obj = {};
+  return obj?.[key!];
+}
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #2732

```
function foo(key: string | null) {
  const obj = {};
  return obj?.[key!];
}

function foo(key: string | null) {
  const obj = {};
  return obj?.[a!?.key!];
}

function foo(key: string | null) {
  const obj = {};
  return obj!?.[key!];
}
```

Some extra code tests that were used in [AST](https://astexplorer.net/) to check the solution