### PR TITLE
fix(eslint-plugin): [consistent-type-definitions] remove fixer when the interface is within a global module declaration

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
@@ -89,6 +89,10 @@ export default util.createRule({
           context.report({
             node: node.id,
             messageId: 'typeOverInterface',
+            /**
+             * remove automatically fix when the interface is within a declare global
+             * @see {@link https://github.com/typescript-eslint/typescript-eslint/issues/2707}
+             */
             fix: isNodeGrandparentGlobalModuleDeclaration(node)
               ? null
               : (fixer): TSESLint.RuleFix[] => {

--- a/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
@@ -68,7 +68,9 @@ export default util.createRule({
           });
         }
       },
-      TSInterfaceDeclaration(node): void {
+      ':not(TSModuleDeclaration > TSModuleBlock) > TSInterfaceDeclaration'(
+        node: TSESTree.TSInterfaceDeclaration,
+      ): void {
         if (option === 'type') {
           context.report({
             node: node.id,

--- a/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
@@ -263,5 +263,23 @@ declare global {
         },
       ],
     },
+    {
+      code: `
+declare global {
+  namespace Foo {
+    interface Bar {}
+  }
+}
+      `,
+      output: null,
+      options: ['type'],
+      errors: [
+        {
+          messageId: 'typeOverInterface',
+          line: 4,
+          column: 15,
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
@@ -199,6 +199,54 @@ export type W<T> = {
     },
     {
       code: `
+namespace JSX {
+  interface Array<T> {
+    foo(x: (x: number) => T): T[];
+  }
+}
+      `,
+      output: noFormat`
+namespace JSX {
+  type Array<T> = {
+    foo(x: (x: number) => T): T[];
+  }
+}
+      `,
+      options: ['type'],
+      errors: [
+        {
+          messageId: 'typeOverInterface',
+          line: 3,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: `
+global {
+  interface Array<T> {
+    foo(x: (x: number) => T): T[];
+  }
+}
+      `,
+      output: noFormat`
+global {
+  type Array<T> = {
+    foo(x: (x: number) => T): T[];
+  }
+}
+      `,
+      options: ['type'],
+      errors: [
+        {
+          messageId: 'typeOverInterface',
+          line: 3,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: `
 declare global {
   interface Array<T> {
     foo(x: (x: number) => T): T[];

--- a/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
@@ -59,6 +59,16 @@ export type W<T> = {
       `,
       options: ['type'],
     },
+    {
+      code: `
+declare global {
+  interface Array<T> {
+    foo(x: (x: number) => T): T[];
+  }
+}
+      `,
+      options: ['type'],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
@@ -59,16 +59,6 @@ export type W<T> = {
       `,
       options: ['type'],
     },
-    {
-      code: `
-declare global {
-  interface Array<T> {
-    foo(x: (x: number) => T): T[];
-  }
-}
-      `,
-      options: ['type'],
-    },
   ],
   invalid: [
     {
@@ -204,6 +194,24 @@ export type W<T> = {
           messageId: 'typeOverInterface',
           line: 2,
           column: 18,
+        },
+      ],
+    },
+    {
+      code: `
+declare global {
+  interface Array<T> {
+    foo(x: (x: number) => T): T[];
+  }
+}
+      `,
+      output: null,
+      options: ['type'],
+      errors: [
+        {
+          messageId: 'typeOverInterface',
+          line: 3,
+          column: 13,
         },
       ],
     },


### PR DESCRIPTION
fixes #2707 