### PR TITLE
fix(eslint-plugin): [no-unsafe-member-access] ignore MemberExpression's whose parents are either TSClassImplements or TSInterfaceHeritage

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts
@@ -72,7 +72,7 @@ export default util.createRule({
 
     return {
       // ignore MemberExpression if it's parent is TSClassImplements or TSInterfaceHeritage
-      'MemberExpression:not(TSClassImplements > MemberExpression):not(TSInterfaceHeritage > MemberExpression)': checkMemberExpression,
+      ':not(TSClassImplements, TSInterfaceHeritage) > MemberExpression': checkMemberExpression,
       'MemberExpression[computed = true] > *.property'(
         node: TSESTree.Expression,
       ): void {

--- a/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts
@@ -71,7 +71,8 @@ export default util.createRule({
     }
 
     return {
-      MemberExpression: checkMemberExpression,
+      // ignore MemberExpression if it's parent is TSClassImplements or TSInterfaceHeritage
+      'MemberExpression:not(TSClassImplements > MemberExpression):not(TSInterfaceHeritage > MemberExpression)': checkMemberExpression,
       'MemberExpression[computed = true] > *.property'(
         node: TSESTree.Expression,
       ): void {

--- a/packages/eslint-plugin/tests/rules/no-unsafe-member-access.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-member-access.test.ts
@@ -66,6 +66,12 @@ function foo(x?: string[]) {
   x?.[(1 as any)++];
 }
     `,
+    `
+class B implements FG.A {}
+    `,
+    `
+interface B extends FG.A {}
+    `,
   ],
   invalid: [
     ...batchedSingleLineTests({


### PR DESCRIPTION
Fixes #2740 

- I feel like the selector is too long to be on one line, but it wouldn't work if I split it. Any recommendations to shorten it? Or is it good to go like it is.


