### PR TITLE
test(typescript-estree): [babel alignment] remove now unnecessary AST transformation for ImportDeclaration

### DIFF
--- a/packages/typescript-estree/tests/ast-alignment/utils.ts
+++ b/packages/typescript-estree/tests/ast-alignment/utils.ts
@@ -266,14 +266,6 @@ export function preprocessBabylonAST(ast: BabelTypes.File): any {
           node.asserts = false;
         }
       },
-      ImportDeclaration(node) {
-        /**
-         * TS 3.8: import type
-         */
-        if (!node.importKind) {
-          node.importKind = 'value';
-        }
-      },
     },
   );
 }


### PR DESCRIPTION
I've fixed the AST difference from Babel's side, so I think we can get rid of this AST transformation. See https://github.com/babel/babel/pull/12170