### PR TITLE
docs(eslint-plugin): [ban-types] add reference on how to type an empty object

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -74,6 +74,7 @@ The default options provide a set of "best practices", intended to provide safet
   - It accepts class declarations, which will fail when called, as they are called without the `new` keyword.
 - Avoid the `Object` and `{}` types, as they mean "any non-nullish value".
   - This is a point of confusion for many developers, who think it means "any object type".
+  - See [microsoft/TypeScript#2063](https://github.com/typescript-eslint/typescript-eslint/issues/2063).
 - Avoid the `object` type, as it is currently hard to use due to not being able to assert that keys exist.
   - See [microsoft/TypeScript#21732](https://github.com/microsoft/TypeScript/issues/21732).
 

--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -74,7 +74,7 @@ The default options provide a set of "best practices", intended to provide safet
   - It accepts class declarations, which will fail when called, as they are called without the `new` keyword.
 - Avoid the `Object` and `{}` types, as they mean "any non-nullish value".
   - This is a point of confusion for many developers, who think it means "any object type".
-  - See [microsoft/TypeScript#2063](https://github.com/typescript-eslint/typescript-eslint/issues/2063).
+  - See [this comment for more information](https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-675156492).
 - Avoid the `object` type, as it is currently hard to use due to not being able to assert that keys exist.
   - See [microsoft/TypeScript#21732](https://github.com/microsoft/TypeScript/issues/21732).
 

--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -93,6 +93,9 @@ const defaultTypes: Types = {
       '`{}` actually means "any non-nullish value".',
       '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
       '- If you want a type meaning "any value", you probably want `unknown` instead.',
+      '- If you want a type meaning "an empty object", you probably want to use the following instead:',
+      '  type NoElements<T> = { [P in keyof T]: never };',
+      '  type EmptyObject = NoElements<Record<string, never>>;',
     ].join('\n'),
   },
   object: {

--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -93,9 +93,7 @@ const defaultTypes: Types = {
       '`{}` actually means "any non-nullish value".',
       '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
       '- If you want a type meaning "any value", you probably want `unknown` instead.',
-      '- If you want a type meaning "an empty object", you probably want to use the following instead:',
-      '  type NoElements<T> = { [P in keyof T]: never };',
-      '  type EmptyObject = NoElements<Record<string, never>>;',
+      '- If you want a type meaning "empty object", you probably want `Record<string, never>` instead.',
     ].join('\n'),
   },
   object: {


### PR DESCRIPTION
I recently got a `ban-types` error when specifying an empty object to be allowed (`{}`), which correctly warned me that this is not what I intended. But the message only offered alternatives for cases that didn't apply to my case in particular. After a lot of digging I found this issue (https://github.com/typescript-eslint/typescript-eslint/issues/2063) thankfully explaining the solution to my problem.

I want to save some other devs the trouble of having to look for a solution in this case (or even worse, some people probably ignoring the error, should they not find a solution). This was also suggested here https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-659748424