### PR TITLE
feat(typescript-estree): add `parseWithNodeMaps` API

### DIFF
--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -220,6 +220,18 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
   createDefaultProgram?: boolean;
 }
 
+interface ParserServices {
+  program: ts.Program;
+  esTreeNodeToTSNodeMap: WeakMap<TSESTree.Node, ts.Node | ts.Token>;
+  tsNodeToESTreeNodeMap: WeakMap<ts.Node | ts.Token, TSESTree.Node>;
+  hasFullTypeInformation: boolean;
+}
+
+interface ParseAndGenerateServicesResult<T extends TSESTreeOptions> {
+  ast: TSESTree.Program;
+  services: ParserServices;
+}
+
 const PARSE_AND_GENERATE_SERVICES_DEFAULT_OPTIONS: ParseOptions = {
   ...PARSE_DEFAULT_OPTIONS,
   errorOnTypeScriptSyntacticAndSemanticIssues: false,
@@ -233,7 +245,7 @@ const PARSE_AND_GENERATE_SERVICES_DEFAULT_OPTIONS: ParseOptions = {
 declare function parseAndGenerateServices(
   code: string,
   options: ParseOptions = PARSE_DEFAULT_OPTIONS,
-): TSESTree.Program;
+): ParseAndGenerateServicesResult;
 ```
 
 Example usage:
@@ -242,12 +254,45 @@ Example usage:
 import { parseAndGenerateServices } from '@typescript-eslint/typescript-estree';
 
 const code = `const hello: string = 'world';`;
-const ast = parseAndGenerateServices(code, {
+const { ast, services } = parseAndGenerateServices(code, {
   filePath: '/some/path/to/file/foo.ts',
   loc: true,
   project: './tsconfig.json',
   range: true,
 });
+```
+
+#### `parseWithNodeMaps(code, options)`
+
+Parses the given string of code with the options provided and returns both the ESTree-compatible AST as well as the node maps.
+This allows you to work with both ASTs without the overhead of types that may come with `parseAndGenerateServices`.
+
+```ts
+interface ParseWithNodeMapsResult<T extends TSESTreeOptions> {
+  ast: TSESTree.Program;
+  esTreeNodeToTSNodeMap: ParserServices['esTreeNodeToTSNodeMap'];
+  tsNodeToESTreeNodeMap: ParserServices['tsNodeToESTreeNodeMap'];
+}
+
+declare function parseWithNodeMaps(
+  code: string,
+  options: ParseOptions = PARSE_DEFAULT_OPTIONS,
+): ParseWithNodeMapsResult;
+```
+
+Example usage:
+
+```js
+import { parseWithNodeMaps } from '@typescript-eslint/typescript-estree';
+
+const code = `const hello: string = 'world';`;
+const { ast, esTreeNodeToTSNodeMap, tsNodeToESTreeNodeMap } = parseWithNodeMaps(
+  code,
+  {
+    loc: true,
+    range: true,
+  },
+);
 ```
 
 ### `TSESTree`, `AST_NODE_TYPES` and `AST_TOKEN_TYPES`

--- a/packages/typescript-estree/src/index.ts
+++ b/packages/typescript-estree/src/index.ts
@@ -1,9 +1,4 @@
-export {
-  AST,
-  parse,
-  parseAndGenerateServices,
-  ParseAndGenerateServicesResult,
-} from './parser';
+export * from './parser';
 export { ParserServices, TSESTreeOptions } from './parser-options';
 export { simpleTraverse } from './simple-traverse';
 export * from './ts-estree';

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -321,11 +321,24 @@ interface ParseAndGenerateServicesResult<T extends TSESTreeOptions> {
   ast: AST<T>;
   services: ParserServices;
 }
+interface ParseWithNodeMapsResult<T extends TSESTreeOptions> {
+  ast: AST<T>;
+  esTreeNodeToTSNodeMap: ParserServices['esTreeNodeToTSNodeMap'];
+  tsNodeToESTreeNodeMap: ParserServices['tsNodeToESTreeNodeMap'];
+}
 
 function parse<T extends TSESTreeOptions = TSESTreeOptions>(
   code: string,
   options?: T,
 ): AST<T> {
+  const { ast } = parseWithNodeMaps(code, options);
+  return ast;
+}
+
+function parseWithNodeMaps<T extends TSESTreeOptions = TSESTreeOptions>(
+  code: string,
+  options?: T,
+): ParseWithNodeMapsResult<T> {
   /**
    * Reset the parse configuration
    */
@@ -367,8 +380,13 @@ function parse<T extends TSESTreeOptions = TSESTreeOptions>(
   /**
    * Convert the TypeScript AST to an ESTree-compatible one
    */
-  const { estree } = astConverter(ast, extra, false);
-  return estree as AST<T>;
+  const { estree, astMaps } = astConverter(ast, extra, false);
+
+  return {
+    ast: estree as AST<T>,
+    esTreeNodeToTSNodeMap: astMaps.esTreeNodeToTSNodeMap,
+    tsNodeToESTreeNodeMap: astMaps.tsNodeToESTreeNodeMap,
+  };
 }
 
 function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
@@ -450,4 +468,11 @@ function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
   };
 }
 
-export { AST, parse, parseAndGenerateServices, ParseAndGenerateServicesResult };
+export {
+  AST,
+  parse,
+  parseAndGenerateServices,
+  parseWithNodeMaps,
+  ParseAndGenerateServicesResult,
+  ParseWithNodeMapsResult,
+};

--- a/packages/typescript-estree/tests/lib/__snapshots__/parse.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/parse.test.ts.snap
@@ -1,373 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`parse() general output should not contain loc 1`] = `
-Object {
-  "body": Array [
-    Object {
-      "declarations": Array [
-        Object {
-          "id": Object {
-            "name": "foo",
-            "range": Array [
-              4,
-              7,
-            ],
-            "type": "Identifier",
-          },
-          "init": Object {
-            "name": "bar",
-            "range": Array [
-              10,
-              13,
-            ],
-            "type": "Identifier",
-          },
-          "range": Array [
-            4,
-            13,
-          ],
-          "type": "VariableDeclarator",
-        },
-      ],
-      "kind": "let",
-      "range": Array [
-        0,
-        14,
-      ],
-      "type": "VariableDeclaration",
-    },
-  ],
-  "range": Array [
-    0,
-    14,
-  ],
-  "sourceType": "script",
-  "type": "Program",
-}
-`;
-
-exports[`parse() general output should not contain range 1`] = `
-Object {
-  "body": Array [
-    Object {
-      "declarations": Array [
-        Object {
-          "id": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 7,
-                "line": 1,
-              },
-              "start": Object {
-                "column": 4,
-                "line": 1,
-              },
-            },
-            "name": "foo",
-            "type": "Identifier",
-          },
-          "init": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 13,
-                "line": 1,
-              },
-              "start": Object {
-                "column": 10,
-                "line": 1,
-              },
-            },
-            "name": "bar",
-            "type": "Identifier",
-          },
-          "loc": Object {
-            "end": Object {
-              "column": 13,
-              "line": 1,
-            },
-            "start": Object {
-              "column": 4,
-              "line": 1,
-            },
-          },
-          "type": "VariableDeclarator",
-        },
-      ],
-      "kind": "let",
-      "loc": Object {
-        "end": Object {
-          "column": 14,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 1,
-        },
-      },
-      "type": "VariableDeclaration",
-    },
-  ],
-  "loc": Object {
-    "end": Object {
-      "column": 14,
-      "line": 1,
-    },
-    "start": Object {
-      "column": 0,
-      "line": 1,
-    },
-  },
-  "sourceType": "script",
-  "type": "Program",
-}
-`;
-
-exports[`parse() general output tokens, comments, locs, and ranges when called with those options 1`] = `
-Object {
-  "body": Array [
-    Object {
-      "declarations": Array [
-        Object {
-          "id": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 7,
-                "line": 1,
-              },
-              "start": Object {
-                "column": 4,
-                "line": 1,
-              },
-            },
-            "name": "foo",
-            "range": Array [
-              4,
-              7,
-            ],
-            "type": "Identifier",
-          },
-          "init": Object {
-            "loc": Object {
-              "end": Object {
-                "column": 13,
-                "line": 1,
-              },
-              "start": Object {
-                "column": 10,
-                "line": 1,
-              },
-            },
-            "name": "bar",
-            "range": Array [
-              10,
-              13,
-            ],
-            "type": "Identifier",
-          },
-          "loc": Object {
-            "end": Object {
-              "column": 13,
-              "line": 1,
-            },
-            "start": Object {
-              "column": 4,
-              "line": 1,
-            },
-          },
-          "range": Array [
-            4,
-            13,
-          ],
-          "type": "VariableDeclarator",
-        },
-      ],
-      "kind": "let",
-      "loc": Object {
-        "end": Object {
-          "column": 14,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 1,
-        },
-      },
-      "range": Array [
-        0,
-        14,
-      ],
-      "type": "VariableDeclaration",
-    },
-  ],
-  "comments": Array [],
-  "loc": Object {
-    "end": Object {
-      "column": 14,
-      "line": 1,
-    },
-    "start": Object {
-      "column": 0,
-      "line": 1,
-    },
-  },
-  "range": Array [
-    0,
-    14,
-  ],
-  "sourceType": "script",
-  "tokens": Array [
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 3,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 1,
-        },
-      },
-      "range": Array [
-        0,
-        3,
-      ],
-      "type": "Keyword",
-      "value": "let",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 7,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 4,
-          "line": 1,
-        },
-      },
-      "range": Array [
-        4,
-        7,
-      ],
-      "type": "Identifier",
-      "value": "foo",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 9,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 8,
-          "line": 1,
-        },
-      },
-      "range": Array [
-        8,
-        9,
-      ],
-      "type": "Punctuator",
-      "value": "=",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 13,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 10,
-          "line": 1,
-        },
-      },
-      "range": Array [
-        10,
-        13,
-      ],
-      "type": "Identifier",
-      "value": "bar",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 14,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 13,
-          "line": 1,
-        },
-      },
-      "range": Array [
-        13,
-        14,
-      ],
-      "type": "Punctuator",
-      "value": ";",
-    },
-  ],
-  "type": "Program",
-}
-`;
-
-exports[`parse() invalid file error messages "parserOptions.extraFileExtensions" is empty the extension does not match 1`] = `
+exports[`parseAndGenerateServices invalid file error messages "parserOptions.extraFileExtensions" is empty the extension does not match 1`] = `
 "\\"parserOptions.project\\" has been set for @typescript-eslint/parser.
 The file does not match your project config: other/unknownFileType.unknown.
 The extension for the file (.unknown) is non-standard. You should add \\"parserOptions.extraFileExtensions\\" to your config."
 `;
 
-exports[`parse() invalid file error messages "parserOptions.extraFileExtensions" is non-empty invalid extension 1`] = `
+exports[`parseAndGenerateServices invalid file error messages "parserOptions.extraFileExtensions" is non-empty invalid extension 1`] = `
 "\\"parserOptions.project\\" has been set for @typescript-eslint/parser.
 The file does not match your project config: other/unknownFileType.unknown.
 Found unexpected extension \\"unknown\\" specified with the \\"extraFileExtensions\\" option. Did you mean \\".unknown\\"?
 The extension for the file (.unknown) is non-standard. It should be added to your existing \\"parserOptions.extraFileExtensions\\"."
 `;
 
-exports[`parse() invalid file error messages "parserOptions.extraFileExtensions" is non-empty the extension does not match 1`] = `
+exports[`parseAndGenerateServices invalid file error messages "parserOptions.extraFileExtensions" is non-empty the extension does not match 1`] = `
 "\\"parserOptions.project\\" has been set for @typescript-eslint/parser.
 The file does not match your project config: other/unknownFileType.unknown.
 The extension for the file (.unknown) is non-standard. It should be added to your existing \\"parserOptions.extraFileExtensions\\"."
 `;
 
-exports[`parse() invalid file error messages "parserOptions.extraFileExtensions" is non-empty the extension matches duplicate extension 1`] = `
+exports[`parseAndGenerateServices invalid file error messages "parserOptions.extraFileExtensions" is non-empty the extension matches duplicate extension 1`] = `
 "\\"parserOptions.project\\" has been set for @typescript-eslint/parser.
 The file does not match your project config: ts/notIncluded.ts.
 You unnecessarily included the extension \\".ts\\" with the \\"extraFileExtensions\\" option. This extension is already handled by the parser by default.
 The file must be included in at least one of the projects provided."
 `;
 
-exports[`parse() invalid file error messages "parserOptions.extraFileExtensions" is non-empty the extension matches the file isn't included 1`] = `
+exports[`parseAndGenerateServices invalid file error messages "parserOptions.extraFileExtensions" is non-empty the extension matches the file isn't included 1`] = `
 "\\"parserOptions.project\\" has been set for @typescript-eslint/parser.
 The file does not match your project config: other/notIncluded.vue.
 The file must be included in at least one of the projects provided."
 `;
 
-exports[`parse() invalid file error messages project includes errors for not included files 1`] = `
+exports[`parseAndGenerateServices invalid file error messages project includes errors for not included files 1`] = `
 "\\"parserOptions.project\\" has been set for @typescript-eslint/parser.
 The file does not match your project config: ts/notIncluded.ts.
 The file must be included in at least one of the projects provided."
 `;
 
-exports[`parse() invalid file error messages project includes errors for not included files 2`] = `
+exports[`parseAndGenerateServices invalid file error messages project includes errors for not included files 2`] = `
 "\\"parserOptions.project\\" has been set for @typescript-eslint/parser.
 The file does not match your project config: ts/notIncluded.tsx.
 The file must be included in at least one of the projects provided."
 `;
 
-exports[`parse() invalid file error messages project includes errors for not included files 3`] = `
+exports[`parseAndGenerateServices invalid file error messages project includes errors for not included files 3`] = `
 "\\"parserOptions.project\\" has been set for @typescript-eslint/parser.
 The file does not match your project config: js/notIncluded.js.
 The file must be included in at least one of the projects provided."
 `;
 
-exports[`parse() invalid file error messages project includes errors for not included files 4`] = `
+exports[`parseAndGenerateServices invalid file error messages project includes errors for not included files 4`] = `
 "\\"parserOptions.project\\" has been set for @typescript-eslint/parser.
 The file does not match your project config: js/notIncluded.jsx.
 The file must be included in at least one of the projects provided."
 `;
 
-exports[`parse() isolated parsing should parse .js file - with JSX content - parserOptions.jsx = false 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .js file - with JSX content - parserOptions.jsx = false 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -657,7 +346,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .js file - with JSX content - parserOptions.jsx = true 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .js file - with JSX content - parserOptions.jsx = true 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -947,7 +636,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .js file - without JSX content - parserOptions.jsx = false 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .js file - without JSX content - parserOptions.jsx = false 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -1127,7 +816,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .js file - without JSX content - parserOptions.jsx = true 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .js file - without JSX content - parserOptions.jsx = true 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -1307,7 +996,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .json file - without JSX content - parserOptions.jsx = false 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .json file - without JSX content - parserOptions.jsx = false 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -1526,7 +1215,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .jsx file - with JSX content - parserOptions.jsx = false 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .jsx file - with JSX content - parserOptions.jsx = false 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -1816,7 +1505,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .jsx file - with JSX content - parserOptions.jsx = true 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .jsx file - with JSX content - parserOptions.jsx = true 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -2106,7 +1795,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .jsx file - without JSX content - parserOptions.jsx = false 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .jsx file - without JSX content - parserOptions.jsx = false 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -2286,7 +1975,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .jsx file - without JSX content - parserOptions.jsx = true 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .jsx file - without JSX content - parserOptions.jsx = true 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -2466,7 +2155,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .ts file - without JSX content - parserOptions.jsx = false 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .ts file - without JSX content - parserOptions.jsx = false 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -2646,7 +2335,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .ts file - without JSX content - parserOptions.jsx = true 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .ts file - without JSX content - parserOptions.jsx = true 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -2826,7 +2515,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .tsx file - with JSX content - parserOptions.jsx = false 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .tsx file - with JSX content - parserOptions.jsx = false 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -3116,7 +2805,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .tsx file - with JSX content - parserOptions.jsx = true 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .tsx file - with JSX content - parserOptions.jsx = true 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -3406,7 +3095,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .tsx file - without JSX content - parserOptions.jsx = false 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .tsx file - without JSX content - parserOptions.jsx = false 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -3586,7 +3275,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .tsx file - without JSX content - parserOptions.jsx = true 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .tsx file - without JSX content - parserOptions.jsx = true 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -3766,7 +3455,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .vue file - with JSX content - parserOptions.jsx = true 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .vue file - with JSX content - parserOptions.jsx = true 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -4056,7 +3745,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .vue file - without JSX content - parserOptions.jsx = false 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .vue file - without JSX content - parserOptions.jsx = false 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -4236,7 +3925,7 @@ Object {
 }
 `;
 
-exports[`parse() isolated parsing should parse .vue file - without JSX content - parserOptions.jsx = true 1`] = `
+exports[`parseAndGenerateServices isolated parsing should parse .vue file - without JSX content - parserOptions.jsx = true 1`] = `
 Object {
   "ast": Object {
     "body": Array [
@@ -4416,7 +4105,318 @@ Object {
 }
 `;
 
-exports[`parse() non string code should correctly convert code to a string for parse() 1`] = `
+exports[`parseWithNodeMaps() general output should not contain loc 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "name": "foo",
+            "range": Array [
+              4,
+              7,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "name": "bar",
+            "range": Array [
+              10,
+              13,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            4,
+            13,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "let",
+      "range": Array [
+        0,
+        14,
+      ],
+      "type": "VariableDeclaration",
+    },
+  ],
+  "range": Array [
+    0,
+    14,
+  ],
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`parseWithNodeMaps() general output should not contain range 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 1,
+              },
+            },
+            "name": "foo",
+            "type": "Identifier",
+          },
+          "init": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 13,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 10,
+                "line": 1,
+              },
+            },
+            "name": "bar",
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 13,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 1,
+            },
+          },
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "let",
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "type": "VariableDeclaration",
+    },
+  ],
+  "loc": Object {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "sourceType": "script",
+  "type": "Program",
+}
+`;
+
+exports[`parseWithNodeMaps() general output tokens, comments, locs, and ranges when called with those options 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declarations": Array [
+        Object {
+          "id": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 7,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 1,
+              },
+            },
+            "name": "foo",
+            "range": Array [
+              4,
+              7,
+            ],
+            "type": "Identifier",
+          },
+          "init": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 13,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 10,
+                "line": 1,
+              },
+            },
+            "name": "bar",
+            "range": Array [
+              10,
+              13,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 13,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            4,
+            13,
+          ],
+          "type": "VariableDeclarator",
+        },
+      ],
+      "kind": "let",
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        14,
+      ],
+      "type": "VariableDeclaration",
+    },
+  ],
+  "comments": Array [],
+  "loc": Object {
+    "end": Object {
+      "column": 14,
+      "line": 1,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    14,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        3,
+      ],
+      "type": "Keyword",
+      "value": "let",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 7,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        4,
+        7,
+      ],
+      "type": "Identifier",
+      "value": "foo",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 9,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        8,
+        9,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        10,
+        13,
+      ],
+      "type": "Identifier",
+      "value": "bar",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        13,
+        14,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
+exports[`parseWithNodeMaps() non string code should correctly convert code to a string for parse() 1`] = `
 Object {
   "body": Array [
     Object {
@@ -4496,7 +4496,7 @@ Object {
 }
 `;
 
-exports[`parse() non string code should correctly convert code to a string for parseAndGenerateServices() 1`] = `
+exports[`parseWithNodeMaps() non string code should correctly convert code to a string for parseAndGenerateServices() 1`] = `
 Object {
   "body": Array [
     Object {


### PR DESCRIPTION
Ref: https://github.com/prettier/prettier/pull/9636

This allows consumers to reach into the underlying TS AST in cases where our AST doesn't quite solve the use case.

Motivating example:

We don't (currently) error for code unless TS itself throws an error.
TS is _very_ permissive, but that leads to some weird (and invalid) code we don't error for, and don't include in the AST.
For example - this is _syntactically_ valid in the TS parser, but they emit a _semantic_ error (we currently ignore semantic errors as they're expensive to calculate)
```ts
@decorator
enum Foo {
  A = 1
}
```
As it's not a valid place for a decorator - we do not emit its information in the ESTree AST, but as TS treats this as a semantic error - it is parse-time valid.
This creates weird states for consumers wherein they cannot see a decorator exists there, which can cause them to ignore it entirely.
For linting - this isn't a problem. But for something like prettier - this means that they'll delete the decorator at format time!
This is very bad.

Until we implement a solution for #1852 - this will allow consumers to bridge the gap themselves.