### PR TITLE
fix(eslint-plugin): fixed circular reference issue

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -96,7 +96,8 @@ export default createRule<Options, MessageIds>({
       }
       const value = sourceCode.getText(valueType.typeAnnotation);
       const name = node.parent?.id?.name;
-      if (value.includes(name)) {
+      const valueArray = value.split('|').map(v => v.trim());
+      if (valueArray.indexOf(name) != -1) {
         return;
       }
       context.report({

--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -94,13 +94,16 @@ export default createRule<Options, MessageIds>({
       if (!valueType) {
         return;
       }
-
+      const value = sourceCode.getText(valueType.typeAnnotation);
+      const name = node.parent?.id?.name;
+      if (value.includes(name)) {
+        return;
+      }
       context.report({
         node,
         messageId: 'preferRecord',
         fix(fixer) {
           const key = sourceCode.getText(keyType.typeAnnotation);
-          const value = sourceCode.getText(valueType.typeAnnotation);
           return fixer.replaceText(
             node,
             `${prefix}Record<${key}, ${value}>${postfix}`,

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -76,7 +76,8 @@ interface Foo {
   [];
 }
     `,
-
+    'type Foo = { [key: string]: string | Foo };',
+    'type Foo = { [key: string]: Foo };',
     // 'index-signature'
     // Unhandled type
     {

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -78,6 +78,7 @@ interface Foo {
     `,
     'type Foo = { [key: string]: string | Foo };',
     'type Foo = { [key: string]: Foo };',
+
     // 'index-signature'
     // Unhandled type
     {
@@ -172,6 +173,21 @@ type Foo<A, B> = Record<A, B>;
       code: 'type Foo = { [key: string]: any };',
       output: 'type Foo = Record<string, any>;',
       errors: [{ messageId: 'preferRecord', line: 1, column: 12 }],
+    },
+    {
+      code: 'type T = { [k: string]: AT };',
+      output: 'type T = Record<string, AT>;',
+      errors: [{ messageId: 'preferRecord', line: 1, column: 10 }],
+    },
+    {
+      code: 'type T = { [k: string]: TA };',
+      output: 'type T = Record<string, TA>;',
+      errors: [{ messageId: 'preferRecord', line: 1, column: 10 }],
+    },
+    {
+      code: 'type T = { [k: string]: A.T };',
+      output: 'type T = Record<string, A.T>;',
+      errors: [{ messageId: 'preferRecord', line: 1, column: 10 }],
     },
     {
       code: 'type Foo = { [key: string]: AnotherFoo };',

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -173,6 +173,11 @@ type Foo<A, B> = Record<A, B>;
       output: 'type Foo = Record<string, any>;',
       errors: [{ messageId: 'preferRecord', line: 1, column: 12 }],
     },
+    {
+      code: 'type Foo = { [key: string]: AnotherFoo };',
+      output: 'type Foo = Record<string, AnotherFoo>;',
+      errors: [{ messageId: 'preferRecord', line: 1, column: 12 }],
+    },
 
     // Generic
     {


### PR DESCRIPTION
The logic checks if the value includes the node name it'll not trigger the rule.

Fixes #2687 