### PR TITLE
fix(eslint-plugin): [prefer-literal-enum-member] allow pure template literal strings

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
+++ b/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
@@ -29,6 +29,13 @@ export default createRule({
         if (node.initializer.type === AST_NODE_TYPES.Literal) {
           return;
         }
+        // TemplateLiteral without expressions
+        if (
+          node.initializer.type === AST_NODE_TYPES.TemplateLiteral &&
+          node.initializer.expressions.length === 0
+        ) {
+          return;
+        }
         // -1 and +1
         if (
           node.initializer.type === AST_NODE_TYPES.UnaryExpression &&

--- a/packages/eslint-plugin/tests/rules/prefer-literal-enum-member.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-literal-enum-member.test.ts
@@ -18,6 +18,11 @@ enum ValidString {
 }
     `,
     `
+enum ValidLiteral {
+  A = \`test\`,
+}
+    `,
+    `
 enum ValidNumber {
   A = 42,
 }
@@ -90,7 +95,7 @@ enum InvalidArray {
     {
       code: `
 enum InvalidTemplateLiteral {
-  A = \`a\`,
+  A = \`foo \${0}\`,
 }
       `,
       errors: [


### PR DESCRIPTION
fixes #2785