### PR TITLE
fix(eslint-plugin): [triple-slash-reference] fix crash with external module reference

### DIFF
--- a/packages/eslint-plugin/src/rules/triple-slash-reference.ts
+++ b/packages/eslint-plugin/src/rules/triple-slash-reference.ts
@@ -1,4 +1,5 @@
 import {
+  AST_NODE_TYPES,
   AST_TOKEN_TYPES,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
@@ -81,9 +82,11 @@ export default util.createRule<Options, MessageIds>({
       },
       TSImportEqualsDeclaration(node): void {
         if (programNode) {
-          const source = (node.moduleReference as TSESTree.TSExternalModuleReference)
-            .expression as TSESTree.Literal;
-          hasMatchingReference(source);
+          const reference = node.moduleReference;
+
+          if (reference.type === AST_NODE_TYPES.TSExternalModuleReference) {
+            hasMatchingReference(reference.expression as TSESTree.Literal);
+          }
         }
       },
       Program(node): void {

--- a/packages/eslint-plugin/tests/rules/triple-slash-reference.test.ts
+++ b/packages/eslint-plugin/tests/rules/triple-slash-reference.test.ts
@@ -55,6 +55,28 @@ ruleTester.run('triple-slash-reference', rule, {
       options: [{ path: 'always', types: 'always', lib: 'always' }],
     },
     {
+      code: `
+        /// <reference path="foo" />
+        /// <reference types="bar" />
+        /// <reference lib="baz" />
+        import foo = foo;
+        import bar = bar;
+        import baz = baz;
+      `,
+      options: [{ path: 'always', types: 'always', lib: 'always' }],
+    },
+    {
+      code: `
+        /// <reference path="foo" />
+        /// <reference types="bar" />
+        /// <reference lib="baz" />
+        import foo = foo.foo;
+        import bar = bar.bar.bar.bar;
+        import baz = baz.baz;
+      `,
+      options: [{ path: 'always', types: 'always', lib: 'always' }],
+    },
+    {
       code: "import * as foo from 'foo';",
       options: [{ path: 'never' }],
     },

--- a/packages/eslint-plugin/tests/rules/triple-slash-reference.test.ts
+++ b/packages/eslint-plugin/tests/rules/triple-slash-reference.test.ts
@@ -55,28 +55,6 @@ ruleTester.run('triple-slash-reference', rule, {
       options: [{ path: 'always', types: 'always', lib: 'always' }],
     },
     {
-      code: `
-        /// <reference path="foo" />
-        /// <reference types="bar" />
-        /// <reference lib="baz" />
-        import foo = foo;
-        import bar = bar;
-        import baz = baz;
-      `,
-      options: [{ path: 'always', types: 'always', lib: 'always' }],
-    },
-    {
-      code: `
-        /// <reference path="foo" />
-        /// <reference types="bar" />
-        /// <reference lib="baz" />
-        import foo = foo.foo;
-        import bar = bar.bar.bar.bar;
-        import baz = baz.baz;
-      `,
-      options: [{ path: 'always', types: 'always', lib: 'always' }],
-    },
-    {
       code: "import * as foo from 'foo';",
       options: [{ path: 'never' }],
     },


### PR DESCRIPTION
fixes #2762

https://astexplorer.net/#/gist/cde0bd7d85e03d135e604e7913a999cd/c034332f4ccf256e809629b0552578191e38b3fe

I'm not sure about the solution cuz it's weird that there was used `as TSESTree.TSExternalModuleReference` and didn't handle any other types considering that `moduleReference` has already been typed.