### PR TITLE
fix(typescript-estree): fix type-only regression for consumers not yet on TS 4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
     "typescript": ">=3.3.1 <4.2.0 || 4.1.1-rc"
   },
   "resolutions": {
-    "typescript": "4.1.1-rc"
+    "typescript": "4.1.2"
   }
 }

--- a/packages/typescript-estree/src/ts-estree/ts-nodes.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-nodes.ts
@@ -1,11 +1,12 @@
 import * as ts from 'typescript';
 
-// Workaround for
-// https://github.com/typescript-eslint/typescript-eslint/issues/2388
-// to support both TypeScript 3.9 & 4:
+// Workaround to support new TS version features for consumers on old TS versions
+// Eg: https://github.com/typescript-eslint/typescript-eslint/issues/2388, https://github.com/typescript-eslint/typescript-eslint/issues/2784
 declare module 'typescript' {
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  /* eslint-disable @typescript-eslint/no-empty-interface */
   export interface NamedTupleMember extends ts.Node {}
+  export interface TemplateLiteralTypeNode extends ts.Node {}
+  /* eslint-enable @typescript-eslint/no-empty-interface */
 }
 
 export type TSToken = ts.Token<ts.SyntaxKind>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8684,10 +8684,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*, typescript@4.1.1-rc, "typescript@>=3.3.1 <4.2.0 || 4.1.1-rc", typescript@^4.1.0-dev.20201026:
-  version "4.1.1-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.1-rc.tgz#4a335244b9b2754995849ca4b607c74d6ee73719"
-  integrity sha512-tgNcFrLIjlaMWEc7bKC0bxLNIt8BIAauY/HLUOQDyTP75HGskETtXOt46x4EKAHRKhWVLMc7yM02puTHa/yhCA==
+typescript@*, typescript@4.1.2, "typescript@>=3.3.1 <4.2.0 || 4.1.1-rc", typescript@^4.1.0-dev.20201026:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Fixes #2784