### PR TITLE
test(typescript-estree):[babel alignment] remove AST transformation of TSTypePredicate

### DIFF
--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@babel/code-frame": "^7.10.4",
-    "@babel/parser": "^7.12.5",
+    "@babel/parser": "^7.12.7",
     "@babel/types": "^7.12.6",
     "@types/babel__code-frame": "^7.0.2",
     "@types/debug": "*",

--- a/packages/typescript-estree/tests/ast-alignment/utils.ts
+++ b/packages/typescript-estree/tests/ast-alignment/utils.ts
@@ -256,16 +256,6 @@ export function preprocessBabylonAST(ast: BabelTypes.File): any {
           node.optional = false;
         }
       },
-      /**
-       * TS 3.7: type assertion function
-       * babel: sets asserts property as true/undefined
-       * ts-estree: sets asserts property as true/false
-       */
-      TSTypePredicate(node) {
-        if (!node.asserts) {
-          node.asserts = false;
-        }
-      },
     },
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,10 +148,10 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.4.tgz#6fa1a118b8b0d80d0267b719213dc947e88cc0ca"
   integrity sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==
 
-"@babel/parser@^7.12.5":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
-  integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
+"@babel/parser@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.7.tgz#fee7b39fe809d0e73e5b25eecaf5780ef3d73056"
+  integrity sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"


### PR DESCRIPTION
https://github.com/babel/babel/pull/12352 and https://github.com/babel/babel/pull/12167 remove the difference of AST. So we can remove transformation of TSTypePredicate.