### PR TITLE
fix(eslint-plugin): [consistent-indexed-object-style] convert readonly index signature to readonly record

### DIFF
--- a/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md
+++ b/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md
@@ -46,14 +46,6 @@ Examples of **correct** code with `record` option.
 
 ```ts
 type Foo = Record<string, unknown>;
-
-interface Foo {
-  readonly [key: string]: unknown;
-}
-
-type Foo = {
-  readonly [key: string]: unknown;
-};
 ```
 
 Examples of **incorrect** code with `index-signature` option.

--- a/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md
+++ b/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md
@@ -46,6 +46,14 @@ Examples of **correct** code with `record` option.
 
 ```ts
 type Foo = Record<string, unknown>;
+
+interface Foo {
+  readonly [key: string]: unknown;
+}
+
+type Foo = {
+  readonly [key: string]: unknown;
+};
 ```
 
 Examples of **incorrect** code with `index-signature` option.

--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -76,10 +76,6 @@ export default createRule<Options, MessageIds>({
         return;
       }
 
-      if (member.readonly) {
-        return;
-      }
-
       const [parameter] = member.parameters;
 
       if (!parameter) {
@@ -105,10 +101,10 @@ export default createRule<Options, MessageIds>({
         fix(fixer) {
           const key = sourceCode.getText(keyType.typeAnnotation);
           const value = sourceCode.getText(valueType.typeAnnotation);
-          return fixer.replaceText(
-            node,
-            `${prefix}Record<${key}, ${value}>${postfix}`,
-          );
+          const record = member.readonly
+            ? `Readonly<Record<${key}, ${value}>>`
+            : `Record<${key}, ${value}>`;
+          return fixer.replaceText(node, `${prefix}${record}${postfix}`);
         },
       });
     }

--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -76,6 +76,10 @@ export default createRule<Options, MessageIds>({
         return;
       }
 
+      if (member.readonly) {
+        return;
+      }
+
       const [parameter] = member.parameters;
 
       if (!parameter) {

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -51,18 +51,6 @@ type Foo = {
 };
     `,
 
-    // Readonly
-    `
-interface Foo {
-  readonly [key: string]: any;
-}
-    `,
-    `
-type Foo = {
-  readonly [key: string]: any;
-};
-    `,
-
     // Generic
     `
 type Foo = Generic<{
@@ -152,6 +140,19 @@ type Foo = Record<string, any>;
       errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
     },
 
+    // Readonly interface
+    {
+      code: `
+interface Foo {
+  readonly [key: string]: any;
+}
+      `,
+      output: `
+type Foo = Readonly<Record<string, any>>;
+      `,
+      errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
+    },
+
     // Interface with generic parameter
     {
       code: `
@@ -161,6 +162,19 @@ interface Foo<A> {
       `,
       output: `
 type Foo<A> = Record<string, A>;
+      `,
+      errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
+    },
+
+    // Readonly interface with generic parameter
+    {
+      code: `
+interface Foo<A> {
+  readonly [key: string]: A;
+}
+      `,
+      output: `
+type Foo<A> = Readonly<Record<string, A>>;
       `,
       errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
     },
@@ -178,6 +192,19 @@ type Foo<A, B> = Record<A, B>;
       errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
     },
 
+    // Readonly interface with multiple generic parameters
+    {
+      code: `
+interface Foo<A, B> {
+  readonly [key: A]: B;
+}
+      `,
+      output: `
+type Foo<A, B> = Readonly<Record<A, B>>;
+      `,
+      errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
+    },
+
     // Type literal
     {
       code: 'type Foo = { [key: string]: any };',
@@ -185,10 +212,24 @@ type Foo<A, B> = Record<A, B>;
       errors: [{ messageId: 'preferRecord', line: 1, column: 12 }],
     },
 
+    // Readonly type literal
+    {
+      code: 'type Foo = { readonly [key: string]: any };',
+      output: 'type Foo = Readonly<Record<string, any>>;',
+      errors: [{ messageId: 'preferRecord', line: 1, column: 12 }],
+    },
+
     // Generic
     {
       code: 'type Foo = Generic<{ [key: string]: any }>;',
       output: 'type Foo = Generic<Record<string, any>>;',
+      errors: [{ messageId: 'preferRecord', line: 1, column: 20 }],
+    },
+
+    // Readonly Generic
+    {
+      code: 'type Foo = Generic<{ readonly [key: string]: any }>;',
+      output: 'type Foo = Generic<Readonly<Record<string, any>>>;',
       errors: [{ messageId: 'preferRecord', line: 1, column: 20 }],
     },
 
@@ -201,6 +242,18 @@ type Foo<A, B> = Record<A, B>;
     {
       code: 'function foo(): { [key: string]: any } {}',
       output: 'function foo(): Record<string, any> {}',
+      errors: [{ messageId: 'preferRecord', line: 1, column: 17 }],
+    },
+
+    // Readonly function types
+    {
+      code: 'function foo(arg: { readonly [key: string]: any }) {}',
+      output: 'function foo(arg: Readonly<Record<string, any>>) {}',
+      errors: [{ messageId: 'preferRecord', line: 1, column: 19 }],
+    },
+    {
+      code: 'function foo(): { readonly [key: string]: any } {}',
+      output: 'function foo(): Readonly<Record<string, any>> {}',
       errors: [{ messageId: 'preferRecord', line: 1, column: 17 }],
     },
 

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -51,6 +51,18 @@ type Foo = {
 };
     `,
 
+    // Readonly
+    `
+interface Foo {
+  readonly [key: string]: any;
+}
+    `,
+    `
+type Foo = {
+  readonly [key: string]: any;
+};
+    `,
+
     // Generic
     `
 type Foo = Generic<{


### PR DESCRIPTION
Fixes #2797 

- ~~Update the rule to skip readonly index signature.~~
- ~~Update the rule document.~~

Update the rule to fix a readonly index signature by `Readonly<Record<key, value>>` type.
(https://github.com/typescript-eslint/typescript-eslint/pull/2798#pullrequestreview-536112524)
