### PR TITLE
feat(eslint-plugin): [naming-convention] add modifiers `exported`, `global`, and `destructured` modifiers - add selectors `classProperty`, `objectLiteralProperty`, `typeProperty`, `classMethod`, `objectLiteralMethod`, `typeMethod`

### DIFF
--- a/packages/eslint-plugin/docs/rules/naming-convention.md
+++ b/packages/eslint-plugin/docs/rules/naming-convention.md
@@ -154,21 +154,30 @@ If these are provided, the identifier must start with one of the provided values
 
 ### Selector Options
 
-- `selector` (see "Allowed Selectors, Modifiers and Types" below).
+- `selector` allows you to specify what types of identifiers to target.
   - Accepts one or array of selectors to define an option block that applies to one or multiple selectors.
   - For example, if you provide `{ selector: ['variable', 'function'] }`, then it will apply the same option to variable and function nodes.
+  - See [Allowed Selectors, Modifiers and Types](#allowed-selectors-modifiers-and-types) below for the complete list of allowed selectors.
 - `modifiers` allows you to specify which modifiers to granularly apply to, such as the accessibility (`private`/`public`/`protected`), or if the thing is `static`, etc.
   - The name must match _all_ of the modifiers.
   - For example, if you provide `{ modifiers: ['private', 'static', 'readonly'] }`, then it will only match something that is `private static readonly`, and something that is just `private` will not match.
+  - The following `modifiers` are allowed:
+    - `const` - matches a variable declared as being `const` (`const x = 1`).
+    - `destructured` - matches a variable declared via an object destructuring pattern (`const {x, ignored: y, z = 2}`).
+    - `global` - matches a variable/function declared in the top-level scope.
+    - `exported` - matches anything that is exported from the module.
+    - `public` - matches any member that is either explicitly declared as `public`, or has no visibility modifier (i.e. implicitly public).
+    - `readonly`, `static`, `abstract`, `protected`, `private` - matches any member explicitly declared with the given modifier.
 - `types` allows you to specify which types to match. This option supports simple, primitive types only (`boolean`, `string`, `number`, `array`, `function`).
   - The name must match _one_ of the types.
   - **_NOTE - Using this option will require that you lint with type information._**
   - For example, this lets you do things like enforce that `boolean` variables are prefixed with a verb.
-  - `boolean` matches any type assignable to `boolean | null | undefined`
-  - `string` matches any type assignable to `string | null | undefined`
-  - `number` matches any type assignable to `number | null | undefined`
-  - `array` matches any type assignable to `Array<unknown> | null | undefined`
-  - `function` matches any type assignable to `Function | null | undefined`
+  - The following `types` are allowed:
+    - `boolean` matches any type assignable to `boolean | null | undefined`
+    - `string` matches any type assignable to `string | null | undefined`
+    - `number` matches any type assignable to `number | null | undefined`
+    - `array` matches any type assignable to `Array<unknown> | null | undefined`
+    - `function` matches any type assignable to `Function | null | undefined`
 
 The ordering of selectors does not matter. The implementation will automatically sort the selectors to ensure they match from most-specific to least specific. It will keep checking selectors in that order until it finds one that matches the name.
 
@@ -194,21 +203,33 @@ There are two types of selectors, individual selectors, and grouped selectors.
 Individual Selectors match specific, well-defined sets. There is no overlap between each of the individual selectors.
 
 - `variable` - matches any `var` / `let` / `const` variable name.
-  - Allowed `modifiers`: `const`.
+  - Allowed `modifiers`: `const`, `destructured`, `global`, `exported`.
   - Allowed `types`: `boolean`, `string`, `number`, `function`, `array`.
 - `function` - matches any named function declaration or named function expression.
-  - Allowed `modifiers`: none.
+  - Allowed `modifiers`: `global`, `exported`.
   - Allowed `types`: none.
 - `parameter` - matches any function parameter. Does not match parameter properties.
   - Allowed `modifiers`: none.
   - Allowed `types`: `boolean`, `string`, `number`, `function`, `array`.
-- `property` - matches any object, class, or object type property. Does not match properties that have direct function expression or arrow function expression values.
+- `classProperty` - matches any class property. Does not match properties that have direct function expression or arrow function expression values.
+  - Allowed `modifiers`: `private`, `protected`, `public`, `static`, `readonly`, `abstract`.
+  - Allowed `types`: `boolean`, `string`, `number`, `function`, `array`.
+- `objectLiteralProperty` - matches any object literal property. Does not match properties that have direct function expression or arrow function expression values.
+  - Allowed `modifiers`: `private`, `protected`, `public`, `static`, `readonly`, `abstract`.
+  - Allowed `types`: `boolean`, `string`, `number`, `function`, `array`.
+- `typeProperty` - matches any object type property. Does not match properties that have direct function expression or arrow function expression values.
   - Allowed `modifiers`: `private`, `protected`, `public`, `static`, `readonly`, `abstract`.
   - Allowed `types`: `boolean`, `string`, `number`, `function`, `array`.
 - `parameterProperty` - matches any parameter property.
   - Allowed `modifiers`: `private`, `protected`, `public`, `readonly`.
   - Allowed `types`: `boolean`, `string`, `number`, `function`, `array`.
-- `method` - matches any object, class, or object type method. Also matches properties that have direct function expression or arrow function expression values. Does not match accessors.
+- `classMethod` - matches any class method. Also matches properties that have direct function expression or arrow function expression values. Does not match accessors.
+  - Allowed `modifiers`: `private`, `protected`, `public`, `static`, `readonly`, `abstract`.
+  - Allowed `types`: none.
+- `objectLiteralMethod` - matches any object literal method. Also matches properties that have direct function expression or arrow function expression values. Does not match accessors.
+  - Allowed `modifiers`: `private`, `protected`, `public`, `static`, `readonly`, `abstract`.
+  - Allowed `types`: none.
+- `typeMethod` - matches any object type method. Also matches properties that have direct function expression or arrow function expression values. Does not match accessors.
   - Allowed `modifiers`: `private`, `protected`, `public`, `static`, `readonly`, `abstract`.
   - Allowed `types`: none.
 - `accessor` - matches any accessor.
@@ -218,16 +239,16 @@ Individual Selectors match specific, well-defined sets. There is no overlap betw
   - Allowed `modifiers`: none.
   - Allowed `types`: none.
 - `class` - matches any class declaration.
-  - Allowed `modifiers`: `abstract`.
+  - Allowed `modifiers`: `abstract`, `exported`.
   - Allowed `types`: none.
 - `interface` - matches any interface declaration.
-  - Allowed `modifiers`: none.
+  - Allowed `modifiers`: `exported`.
   - Allowed `types`: none.
 - `typeAlias` - matches any type alias declaration.
-  - Allowed `modifiers`: none.
+  - Allowed `modifiers`: `exported`.
   - Allowed `types`: none.
 - `enum` - matches any enum declaration.
-  - Allowed `modifiers`: none.
+  - Allowed `modifiers`: `exported`.
   - Allowed `types`: none.
 - `typeParameter` - matches any generic type parameter declaration.
   - Allowed `modifiers`: none.
@@ -243,11 +264,17 @@ Group Selectors are provided for convenience, and essentially bundle up sets of 
 - `variableLike` - matches the same as `variable`, `function` and `parameter`.
   - Allowed `modifiers`: none.
   - Allowed `types`: none.
-- `memberLike` - matches the same as `property`, `parameterProperty`, `method`, `accessor`, `enumMember`.
+- `memberLike` - matches the same as `classProperty`, `objectLiteralProperty`, `typeProperty`, `parameterProperty`, `classMethod`, `objectLiteralMethod`, `typeMethod`, `accessor`, `enumMember`.
   - Allowed `modifiers`: `private`, `protected`, `public`, `static`, `readonly`, `abstract`.
   - Allowed `types`: none.
 - `typeLike` - matches the same as `class`, `interface`, `typeAlias`, `enum`, `typeParameter`.
-  - Allowed `modifiers`: `abstract`.
+  - Allowed `modifiers`: `abstract`, `exported`.
+  - Allowed `types`: none.
+- `property` - matches the same as `classProperty`, `objectLiteralProperty`, `typeProperty`.
+  - Allowed `modifiers`: `private`, `protected`, `public`, `static`, `readonly`, `abstract`.
+  - Allowed `types`: `boolean`, `string`, `number`, `function`, `array`.
+- `method` - matches the same as `classMethod`, `objectLiteralMethod`, `typeMethod`.
+  - Allowed `modifiers`: `private`, `protected`, `public`, `static`, `readonly`, `abstract`.
   - Allowed `types`: none.
 
 ## Examples
@@ -418,6 +445,25 @@ You can use the `filter` option to ignore names that require quoting:
         "regex": "[- ]",
         "match": false
       }
+    }
+  ]
+}
+```
+
+### Ignore destructured names
+
+Sometimes you might want to allow destructured properties to retain their original name, even if it breaks your naming convention.
+
+You can use the `destructured` modifier to match these names, and explicitly set `format: null` to apply no formatting:
+
+```jsonc
+{
+  "@typescript-eslint/naming-convention": [
+    "error",
+    {
+      "selector": "variable",
+      "modifiers": ["destructured"],
+      "format": null
     }
   ]
 }

--- a/packages/eslint-plugin/tests/rules/naming-convention.test.ts
+++ b/packages/eslint-plugin/tests/rules/naming-convention.test.ts
@@ -214,7 +214,9 @@ function createInvalidTestCases(
             ...(selector !== 'default' &&
             selector !== 'variableLike' &&
             selector !== 'memberLike' &&
-            selector !== 'typeLike'
+            selector !== 'typeLike' &&
+            selector !== 'property' &&
+            selector !== 'method'
               ? {
                   data: {
                     type: selectorTypeToMessageString(selector),
@@ -444,12 +446,6 @@ const cases: Cases = [
   // #region property
   {
     code: [
-      'const ignored = { % };',
-      'const ignored = { "%": 1 };',
-      'interface Ignored { % }',
-      'interface Ignored { "%": string }',
-      'type Ignored = { % }',
-      'type Ignored = { "%": string }',
       'class Ignored { private % }',
       'class Ignored { private "%" = 1 }',
       'class Ignored { private readonly % = 1 }',
@@ -459,16 +455,24 @@ const cases: Cases = [
       'class Ignored { declare % }',
     ],
     options: {
-      selector: 'property',
+      selector: 'classProperty',
+    },
+  },
+  {
+    code: ['const ignored = { % };', 'const ignored = { "%": 1 };'],
+    options: {
+      selector: 'objectLiteralProperty',
     },
   },
   {
     code: [
-      'class Ignored { abstract private static readonly % = 1; ignoredDueToModifiers = 1; }',
+      'interface Ignored { % }',
+      'interface Ignored { "%": string }',
+      'type Ignored = { % }',
+      'type Ignored = { "%": string }',
     ],
     options: {
-      selector: 'property',
-      modifiers: ['static', 'readonly'],
+      selector: 'typeProperty',
     },
   },
   // #endregion property
@@ -484,25 +488,11 @@ const cases: Cases = [
       selector: 'parameterProperty',
     },
   },
-  {
-    code: ['class Ignored { constructor(private readonly %) {} }'],
-    options: {
-      selector: 'parameterProperty',
-      modifiers: ['readonly'],
-    },
-  },
   // #endregion parameterProperty
 
   // #region method
   {
     code: [
-      'const ignored = { %() {} };',
-      'const ignored = { "%"() {} };',
-      'const ignored = { %: () => {} };',
-      'interface Ignored { %(): string }',
-      'interface Ignored { "%"(): string }',
-      'type Ignored = { %(): string }',
-      'type Ignored = { "%"(): string }',
       'class Ignored { private %() {} }',
       'class Ignored { private "%"() {} }',
       'class Ignored { private readonly %() {} }',
@@ -513,16 +503,28 @@ const cases: Cases = [
       'class Ignored { declare %() }',
     ],
     options: {
-      selector: 'method',
+      selector: 'classMethod',
     },
   },
   {
     code: [
-      'class Ignored { abstract private static %() {}; ignoredDueToModifiers() {}; }',
+      'const ignored = { %() {} };',
+      'const ignored = { "%"() {} };',
+      'const ignored = { %: () => {} };',
     ],
     options: {
-      selector: 'method',
-      modifiers: ['abstract', 'static'],
+      selector: 'objectLiteralMethod',
+    },
+  },
+  {
+    code: [
+      'interface Ignored { %(): string }',
+      'interface Ignored { "%"(): string }',
+      'type Ignored = { %(): string }',
+      'type Ignored = { "%"(): string }',
+    ],
+    options: {
+      selector: 'typeMethod',
     },
   },
   // #endregion method
@@ -538,15 +540,6 @@ const cases: Cases = [
     ],
     options: {
       selector: 'accessor',
-    },
-  },
-  {
-    code: [
-      'class Ignored { private static get %() {}; get ignoredDueToModifiers() {}; }',
-    ],
-    options: {
-      selector: 'accessor',
-      modifiers: ['private', 'static'],
     },
   },
   // #endregion accessor
@@ -565,13 +558,6 @@ const cases: Cases = [
     code: ['class % {}', 'abstract class % {}', 'const ignored = class % {}'],
     options: {
       selector: 'class',
-    },
-  },
-  {
-    code: ['abstract class % {}; class ignoredDueToModifier {}'],
-    options: {
-      selector: 'class',
-      modifiers: ['abstract'],
     },
   },
   // #endregion class
@@ -914,10 +900,278 @@ ruleTester.run('naming-convention', rule, {
 
         export const { OtherConstant: otherConstant } = SomeClass;
       `,
-      parserOptions,
       options: [
         { selector: 'property', format: ['PascalCase'] },
         { selector: 'variable', format: ['camelCase'] },
+      ],
+    },
+    {
+      code: `
+        const camelCaseVar = 1;
+        enum camelCaseEnum {}
+        class camelCaseClass {}
+        function camelCaseFunction() {}
+        interface camelCaseInterface {}
+        type camelCaseType = {};
+
+        export const PascalCaseVar = 1;
+        export enum PascalCaseEnum {}
+        export class PascalCaseClass {}
+        export function PascalCaseFunction() {}
+        export interface PascalCaseInterface {}
+        export type PascalCaseType = {};
+      `,
+      options: [
+        { selector: 'default', format: ['camelCase'] },
+        {
+          selector: 'variable',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'function',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'class',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'interface',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'typeAlias',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'enum',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+      ],
+    },
+    {
+      code: `
+        const camelCaseVar = 1;
+        enum camelCaseEnum {}
+        class camelCaseClass {}
+        function camelCaseFunction() {}
+        interface camelCaseInterface {}
+        type camelCaseType = {};
+
+        const PascalCaseVar = 1;
+        enum PascalCaseEnum {}
+        class PascalCaseClass {}
+        function PascalCaseFunction() {}
+        interface PascalCaseInterface {}
+        type PascalCaseType = {};
+
+        export {
+          PascalCaseVar,
+          PascalCaseEnum,
+          PascalCaseClass,
+          PascalCaseFunction,
+          PascalCaseInterface,
+          PascalCaseType,
+        };
+      `,
+      options: [
+        { selector: 'default', format: ['camelCase'] },
+        {
+          selector: 'variable',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'function',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'class',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'interface',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'typeAlias',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'enum',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+      ],
+    },
+    {
+      code: `
+        {
+          const camelCaseVar = 1;
+          function camelCaseFunction() {}
+          declare function camelCaseDeclaredFunction() {
+          };
+        }
+
+        const PascalCaseVar = 1;
+        function PascalCaseFunction() {}
+        declare function PascalCaseDeclaredFunction() {
+        };
+      `,
+      options: [
+        { selector: 'default', format: ['camelCase'] },
+        {
+          selector: 'variable',
+          format: ['PascalCase'],
+          modifiers: ['global'],
+        },
+        {
+          selector: 'function',
+          format: ['PascalCase'],
+          modifiers: ['global'],
+        },
+      ],
+    },
+    {
+      code: `
+        const { some_name1 } = {};
+        const { ignore: IgnoredDueToModifiers1 } = {};
+        const { some_name2 = 2 } = {};
+
+        const IgnoredDueToModifiers2 = 1;
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'variable',
+          format: ['snake_case'],
+          modifiers: ['destructured'],
+        },
+      ],
+    },
+    {
+      code: `
+        class Ignored {
+          private static abstract readonly some_name = 1;
+          IgnoredDueToModifiers = 1;
+        }
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'classProperty',
+          format: ['snake_case'],
+          modifiers: ['static', 'readonly'],
+        },
+      ],
+    },
+    {
+      code: `
+        class Ignored {
+          constructor(private readonly some_name, IgnoredDueToModifiers) {}
+        }
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'parameterProperty',
+          format: ['snake_case'],
+          modifiers: ['readonly'],
+        },
+      ],
+    },
+    {
+      code: `
+        class Ignored {
+          private static abstract some_name() {}
+          IgnoredDueToModifiers() {}
+        }
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'classMethod',
+          format: ['snake_case'],
+          modifiers: ['abstract', 'static'],
+        },
+      ],
+    },
+    {
+      code: `
+        class Ignored {
+          private static get some_name() {}
+          get IgnoredDueToModifiers() {}
+        }
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'accessor',
+          format: ['snake_case'],
+          modifiers: ['private', 'static'],
+        },
+      ],
+    },
+    {
+      code: `
+        abstract class some_name {}
+        class IgnoredDueToModifier {}
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'class',
+          format: ['snake_case'],
+          modifiers: ['abstract'],
+        },
+      ],
+    },
+    {
+      code: `
+        const { some_name1 } = {};
+        const { ignore: IgnoredDueToModifiers1 } = {};
+        const { some_name2 = 2 } = {};
+
+        const IgnoredDueToModifiers2 = 1;
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'variable',
+          format: null,
+          modifiers: ['destructured'],
+        },
       ],
     },
   ],
@@ -1239,8 +1493,7 @@ ruleTester.run('naming-convention', rule, {
           line: 3,
           messageId: 'doesNotMatchFormat',
           data: {
-            // eslint-disable-next-line @typescript-eslint/internal/prefer-ast-types-enum
-            type: 'Property',
+            type: 'Object Literal Property',
             name: 'Property Name',
             formats: 'strictCamelCase',
           },
@@ -1330,6 +1583,246 @@ ruleTester.run('naming-convention', rule, {
           messageId: 'doesNotMatchFormat',
         },
       ],
+    },
+    {
+      code: `
+        export const PascalCaseVar = 1;
+        export enum PascalCaseEnum {}
+        export class PascalCaseClass {}
+        export function PascalCaseFunction() {}
+        export interface PascalCaseInterface {}
+        export type PascalCaseType = {};
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['snake_case'],
+        },
+        {
+          selector: 'variable',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'function',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'class',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'interface',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'typeAlias',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'enum',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+      ],
+      errors: Array(6).fill({ messageId: 'doesNotMatchFormat' }),
+    },
+    {
+      code: `
+        const PascalCaseVar = 1;
+        enum PascalCaseEnum {}
+        class PascalCaseClass {}
+        function PascalCaseFunction() {}
+        interface PascalCaseInterface {}
+        type PascalCaseType = {};
+
+        export {
+          PascalCaseVar,
+          PascalCaseEnum,
+          PascalCaseClass,
+          PascalCaseFunction,
+          PascalCaseInterface,
+          PascalCaseType,
+        };
+      `,
+      options: [
+        { selector: 'default', format: ['snake_case'] },
+        {
+          selector: 'variable',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'function',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'class',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'interface',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'typeAlias',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'enum',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+      ],
+      errors: Array(6).fill({ messageId: 'doesNotMatchFormat' }),
+    },
+    {
+      code: `
+        const PascalCaseVar = 1;
+        function PascalCaseFunction() {}
+        declare function PascalCaseDeclaredFunction() {
+        };
+      `,
+      options: [
+        { selector: 'default', format: ['snake_case'] },
+        {
+          selector: 'variable',
+          format: ['camelCase'],
+          modifiers: ['global'],
+        },
+        {
+          selector: 'function',
+          format: ['camelCase'],
+          modifiers: ['global'],
+        },
+      ],
+      errors: Array(3).fill({ messageId: 'doesNotMatchFormat' }),
+    },
+    {
+      code: `
+        const { some_name1 } = {};
+        const { ignore: IgnoredDueToModifiers1 } = {};
+        const { some_name2 = 2 } = {};
+
+        const IgnoredDueToModifiers2 = 1;
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'variable',
+          format: ['UPPER_CASE'],
+          modifiers: ['destructured'],
+        },
+      ],
+      errors: Array(2).fill({ messageId: 'doesNotMatchFormat' }),
+    },
+    {
+      code: `
+        class Ignored {
+          private static abstract readonly some_name = 1;
+          IgnoredDueToModifiers = 1;
+        }
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'classProperty',
+          format: ['UPPER_CASE'],
+          modifiers: ['static', 'readonly'],
+        },
+      ],
+      errors: [{ messageId: 'doesNotMatchFormat' }],
+    },
+    {
+      code: `
+        class Ignored {
+          constructor(private readonly some_name, IgnoredDueToModifiers) {}
+        }
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'parameterProperty',
+          format: ['UPPER_CASE'],
+          modifiers: ['readonly'],
+        },
+      ],
+      errors: [{ messageId: 'doesNotMatchFormat' }],
+    },
+    {
+      code: `
+        class Ignored {
+          private static abstract some_name() {}
+          IgnoredDueToModifiers() {}
+        }
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'classMethod',
+          format: ['UPPER_CASE'],
+          modifiers: ['abstract', 'static'],
+        },
+      ],
+      errors: [{ messageId: 'doesNotMatchFormat' }],
+    },
+    {
+      code: `
+        class Ignored {
+          private static get some_name() {}
+          get IgnoredDueToModifiers() {}
+        }
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'accessor',
+          format: ['UPPER_CASE'],
+          modifiers: ['private', 'static'],
+        },
+      ],
+      errors: [{ messageId: 'doesNotMatchFormat' }],
+    },
+    {
+      code: `
+        abstract class some_name {}
+        class IgnoredDueToModifier {}
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'class',
+          format: ['UPPER_CASE'],
+          modifiers: ['abstract'],
+        },
+      ],
+      errors: [{ messageId: 'doesNotMatchFormat' }],
     },
   ],
 });

--- a/packages/scope-manager/src/referencer/PatternVisitor.ts
+++ b/packages/scope-manager/src/referencer/PatternVisitor.ts
@@ -52,6 +52,15 @@ class PatternVisitor extends VisitorBase {
     this.#callback = callback;
   }
 
+  private visitAssignment(
+    node: TSESTree.AssignmentExpression | TSESTree.AssignmentPattern,
+  ): void {
+    this.#assignments.push(node);
+    this.visit(node.left);
+    this.rightHandNodes.push(node.right);
+    this.#assignments.pop();
+  }
+
   protected ArrayExpression(node: TSESTree.ArrayExpression): void {
     node.elements.forEach(this.visit, this);
   }
@@ -62,19 +71,9 @@ class PatternVisitor extends VisitorBase {
     }
   }
 
-  protected AssignmentExpression(node: TSESTree.AssignmentExpression): void {
-    this.#assignments.push(node);
-    this.visit(node.left);
-    this.rightHandNodes.push(node.right);
-    this.#assignments.pop();
-  }
+  protected AssignmentExpression = this.visitAssignment;
 
-  protected AssignmentPattern(pattern: TSESTree.AssignmentPattern): void {
-    this.#assignments.push(pattern);
-    this.visit(pattern.left);
-    this.rightHandNodes.push(pattern.right);
-    this.#assignments.pop();
-  }
+  protected AssignmentPattern = this.visitAssignment;
 
   protected CallExpression(node: TSESTree.CallExpression): void {
     // arguments are right hand nodes.


### PR DESCRIPTION
Fixes #2239
Fixes #2512
Fixes #2318
Fixes #1477
Closes #2691

Big update to add a bunch of stuff.
I couldn't be bothered splitting this out into separate PRs.

Adds the following modifiers:
- `exported` - matches anything that is exported from the module.
- `global` - matches a variable/function declared in the top-level scope.
- `destructured` - matches a variable declared via an object destructuring pattern (`const {x, ignored: y, z = 2}`).

Adds the following selectors (self explanatory - just breaking the selectors up):
- `classProperty`
- `objectLiteralProperty`
- `typeProperty`
- `classMethod`
- `objectLiteralMethod`
- `typeMethod`

Converts
- `property` to a meta selector for `classProperty`, `objectLiteralProperty`, `typeProperty`
- `method` to a meta selector for `classMethod`, `objectLiteralMethod`, `typeMethod`