### PR TITLE
fix(eslint-plugin): [explicit-module-boundary-types] ignore functions exported within typed object/array literals

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -390,6 +390,10 @@ export default util.createRule<Options, MessageIds>({
     function ancestorHasReturnType(node: FunctionNode): boolean {
       let ancestor = node.parent;
 
+      if (ancestor?.type === AST_NODE_TYPES.Property) {
+        ancestor = ancestor.value;
+      }
+
       // if the ancestor is not a return, then this function was not returned at all, so we can exit early
       const isReturnStatement =
         ancestor?.type === AST_NODE_TYPES.ReturnStatement;

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -661,6 +661,26 @@ export class A {
   b = A;
 }
     `,
+    `
+interface Foo {
+  f: (x: boolean) => boolean;
+}
+
+export const a: Foo[] = [
+  {
+    f: (x: boolean) => x,
+  },
+];
+    `,
+    `
+interface Foo {
+  f: (x: boolean) => boolean;
+}
+
+export const a: Foo = {
+  f: (x: boolean) => x,
+};
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #2183 by looking for the Property value's ancestor type instead of the Property's ancestor itself.