### PR TITLE
docs: update supported TS versions to include 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The latest version under the `canary` tag **(latest commit to master)** is:
 
 ## Supported TypeScript Version
 
-**The version range of TypeScript currently supported by this parser is `>=3.3.1 <4.1.0`.**
+**The version range of TypeScript currently supported by this parser is `>=3.3.1 <4.2.0`.**
 
 These versions are what we test against.
 


### PR DESCRIPTION
The support for TS 4.1 features was added in #2748

SUPPORTED_TYPESCRIPT_VERSIONS in parser: https://github.com/typescript-eslint/typescript-eslint/blob/a8227a6185dd24de4bfc7d766931643871155021/packages/typescript-estree/src/parser.ts#L23