### PR TITLE
feat(eslint-plugin): [naming-convention] add modifiers `exported`, `global`, and `destructured`

### DIFF
--- a/packages/eslint-plugin/docs/rules/naming-convention.md
+++ b/packages/eslint-plugin/docs/rules/naming-convention.md
@@ -163,6 +163,10 @@ If these are provided, the identifier must start with one of the provided values
   - For example, if you provide `{ modifiers: ['private', 'static', 'readonly'] }`, then it will only match something that is `private static readonly`, and something that is just `private` will not match.
   - The following `modifiers` are allowed:
     - `const` - matches a variable declared as being `const` (`const x = 1`).
+    - `destructured` - matches a variable declared via an object destructuring pattern (`const {x, z = 2}`).
+      - Note that this does not match renamed destructured properties (`const {x: y, a: b = 2}`).
+    - `global` - matches a variable/function declared in the top-level scope.
+    - `exported` - matches anything that is exported from the module.
     - `public` - matches any member that is either explicitly declared as `public`, or has no visibility modifier (i.e. implicitly public).
     - `readonly`, `static`, `abstract`, `protected`, `private` - matches any member explicitly declared with the given modifier.
 - `types` allows you to specify which types to match. This option supports simple, primitive types only (`boolean`, `string`, `number`, `array`, `function`).
@@ -200,10 +204,10 @@ There are two types of selectors, individual selectors, and grouped selectors.
 Individual Selectors match specific, well-defined sets. There is no overlap between each of the individual selectors.
 
 - `variable` - matches any `var` / `let` / `const` variable name.
-  - Allowed `modifiers`: `const`.
+  - Allowed `modifiers`: `const`, `destructured`, `global`, `exported`.
   - Allowed `types`: `boolean`, `string`, `number`, `function`, `array`.
 - `function` - matches any named function declaration or named function expression.
-  - Allowed `modifiers`: none.
+  - Allowed `modifiers`: `global`, `exported`.
   - Allowed `types`: none.
 - `parameter` - matches any function parameter. Does not match parameter properties.
   - Allowed `modifiers`: none.
@@ -236,16 +240,16 @@ Individual Selectors match specific, well-defined sets. There is no overlap betw
   - Allowed `modifiers`: none.
   - Allowed `types`: none.
 - `class` - matches any class declaration.
-  - Allowed `modifiers`: `abstract`.
+  - Allowed `modifiers`: `abstract`, `exported`.
   - Allowed `types`: none.
 - `interface` - matches any interface declaration.
-  - Allowed `modifiers`: none.
+  - Allowed `modifiers`: `exported`.
   - Allowed `types`: none.
 - `typeAlias` - matches any type alias declaration.
-  - Allowed `modifiers`: none.
+  - Allowed `modifiers`: `exported`.
   - Allowed `types`: none.
 - `enum` - matches any enum declaration.
-  - Allowed `modifiers`: none.
+  - Allowed `modifiers`: `exported`.
   - Allowed `types`: none.
 - `typeParameter` - matches any generic type parameter declaration.
   - Allowed `modifiers`: none.
@@ -442,6 +446,25 @@ You can use the `filter` option to ignore names that require quoting:
         "regex": "[- ]",
         "match": false
       }
+    }
+  ]
+}
+```
+
+### Ignore destructured names
+
+Sometimes you might want to allow destructured properties to retain their original name, even if it breaks your naming convention.
+
+You can use the `destructured` modifier to match these names, and explicitly set `format: null` to apply no formatting:
+
+```jsonc
+{
+  "@typescript-eslint/naming-convention": [
+    "error",
+    {
+      "selector": "variable",
+      "modifiers": ["destructured"],
+      "format": null
     }
   ]
 }

--- a/packages/eslint-plugin/tests/rules/naming-convention.test.ts
+++ b/packages/eslint-plugin/tests/rules/naming-convention.test.ts
@@ -914,6 +914,177 @@ ruleTester.run('naming-convention', rule, {
     },
     {
       code: `
+        const camelCaseVar = 1;
+        enum camelCaseEnum {}
+        class camelCaseClass {}
+        function camelCaseFunction() {}
+        interface camelCaseInterface {}
+        type camelCaseType = {};
+        export const PascalCaseVar = 1;
+        export enum PascalCaseEnum {}
+        export class PascalCaseClass {}
+        export function PascalCaseFunction() {}
+        export interface PascalCaseInterface {}
+        export type PascalCaseType = {};
+      `,
+      options: [
+        { selector: 'default', format: ['camelCase'] },
+        {
+          selector: 'variable',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'function',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'class',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'interface',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'typeAlias',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'enum',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+      ],
+    },
+    {
+      code: `
+        const camelCaseVar = 1;
+        enum camelCaseEnum {}
+        class camelCaseClass {}
+        function camelCaseFunction() {}
+        interface camelCaseInterface {}
+        type camelCaseType = {};
+        const PascalCaseVar = 1;
+        enum PascalCaseEnum {}
+        class PascalCaseClass {}
+        function PascalCaseFunction() {}
+        interface PascalCaseInterface {}
+        type PascalCaseType = {};
+        export {
+          PascalCaseVar,
+          PascalCaseEnum,
+          PascalCaseClass,
+          PascalCaseFunction,
+          PascalCaseInterface,
+          PascalCaseType,
+        };
+      `,
+      options: [
+        { selector: 'default', format: ['camelCase'] },
+        {
+          selector: 'variable',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'function',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'class',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'interface',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'typeAlias',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'enum',
+          format: ['PascalCase'],
+          modifiers: ['exported'],
+        },
+      ],
+    },
+    {
+      code: `
+        {
+          const camelCaseVar = 1;
+          function camelCaseFunction() {}
+          declare function camelCaseDeclaredFunction() {
+          };
+        }
+        const PascalCaseVar = 1;
+        function PascalCaseFunction() {}
+        declare function PascalCaseDeclaredFunction() {
+        };
+      `,
+      options: [
+        { selector: 'default', format: ['camelCase'] },
+        {
+          selector: 'variable',
+          format: ['PascalCase'],
+          modifiers: ['global'],
+        },
+        {
+          selector: 'function',
+          format: ['PascalCase'],
+          modifiers: ['global'],
+        },
+      ],
+    },
+    {
+      code: `
+        const { some_name1 } = {};
+        const { ignore: IgnoredDueToModifiers1 } = {};
+        const { some_name2 = 2 } = {};
+        const IgnoredDueToModifiers2 = 1;
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'variable',
+          format: ['snake_case'],
+          modifiers: ['destructured'],
+        },
+      ],
+    },
+    {
+      code: `
+        const { some_name1 } = {};
+        const { ignore: IgnoredDueToModifiers1 } = {};
+        const { some_name2 = 2 } = {};
+        const IgnoredDueToModifiers2 = 1;
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'variable',
+          format: null,
+          modifiers: ['destructured'],
+        },
+      ],
+    },
+    {
+      code: `
         class Ignored {
           private static abstract readonly some_name = 1;
           IgnoredDueToModifiers = 1;
@@ -1413,6 +1584,147 @@ ruleTester.run('naming-convention', rule, {
           messageId: 'doesNotMatchFormat',
         },
       ],
+    },
+    {
+      code: `
+        export const PascalCaseVar = 1;
+        export enum PascalCaseEnum {}
+        export class PascalCaseClass {}
+        export function PascalCaseFunction() {}
+        export interface PascalCaseInterface {}
+        export type PascalCaseType = {};
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['snake_case'],
+        },
+        {
+          selector: 'variable',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'function',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'class',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'interface',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'typeAlias',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'enum',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+      ],
+      errors: Array(6).fill({ messageId: 'doesNotMatchFormat' }),
+    },
+    {
+      code: `
+        const PascalCaseVar = 1;
+        enum PascalCaseEnum {}
+        class PascalCaseClass {}
+        function PascalCaseFunction() {}
+        interface PascalCaseInterface {}
+        type PascalCaseType = {};
+        export {
+          PascalCaseVar,
+          PascalCaseEnum,
+          PascalCaseClass,
+          PascalCaseFunction,
+          PascalCaseInterface,
+          PascalCaseType,
+        };
+      `,
+      options: [
+        { selector: 'default', format: ['snake_case'] },
+        {
+          selector: 'variable',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'function',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'class',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'interface',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'typeAlias',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+        {
+          selector: 'enum',
+          format: ['camelCase'],
+          modifiers: ['exported'],
+        },
+      ],
+      errors: Array(6).fill({ messageId: 'doesNotMatchFormat' }),
+    },
+    {
+      code: `
+        const PascalCaseVar = 1;
+        function PascalCaseFunction() {}
+        declare function PascalCaseDeclaredFunction() {
+        };
+      `,
+      options: [
+        { selector: 'default', format: ['snake_case'] },
+        {
+          selector: 'variable',
+          format: ['camelCase'],
+          modifiers: ['global'],
+        },
+        {
+          selector: 'function',
+          format: ['camelCase'],
+          modifiers: ['global'],
+        },
+      ],
+      errors: Array(3).fill({ messageId: 'doesNotMatchFormat' }),
+    },
+    {
+      code: `
+        const { some_name1 } = {};
+        const { ignore: IgnoredDueToModifiers1 } = {};
+        const { some_name2 = 2 } = {};
+        const IgnoredDueToModifiers2 = 1;
+      `,
+      options: [
+        {
+          selector: 'default',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'variable',
+          format: ['UPPER_CASE'],
+          modifiers: ['destructured'],
+        },
+      ],
+      errors: Array(2).fill({ messageId: 'doesNotMatchFormat' }),
     },
     {
       code: `


### PR DESCRIPTION
Fixes #2239
Fixes #2512
Fixes #2318
Closes #2802

Adds the following modifiers:
- `exported` - matches anything that is exported from the module.
- `global` - matches a variable/function declared in the top-level scope.
- `destructured` - matches a variable declared via an object destructuring pattern (`const {x, z = 2}`)