### PR TITLE
feat(eslint-plugin): [naming-convention] add `requireDouble`, `allowDouble`, `allowSingleOrDouble` options for underscores

### DIFF
--- a/packages/eslint-plugin/docs/rules/naming-convention.md
+++ b/packages/eslint-plugin/docs/rules/naming-convention.md
@@ -33,8 +33,20 @@ type Options = {
     regex: string;
     match: boolean;
   };
-  leadingUnderscore?: 'forbid' | 'allow' | 'require';
-  trailingUnderscore?: 'forbid' | 'allow' | 'require';
+  leadingUnderscore?:
+    | 'forbid'
+    | 'require'
+    | 'requireDouble'
+    | 'allow'
+    | 'allowDouble'
+    | 'allowSingleOrDouble';
+  trailingUnderscore?:
+    | 'forbid'
+    | 'require'
+    | 'requireDouble'
+    | 'allow'
+    | 'allowDouble'
+    | 'allowSingleOrDouble';
   prefix?: string[];
   suffix?: string[];
 
@@ -141,8 +153,11 @@ Alternatively, `filter` accepts a regular expression (anything accepted into `ne
 The `leadingUnderscore` / `trailingUnderscore` options control whether leading/trailing underscores are considered valid. Accepts one of the following values:
 
 - `forbid` - a leading/trailing underscore is not allowed at all.
-- `allow` - existence of a leading/trailing underscore is not explicitly enforced.
-- `require` - a leading/trailing underscore must be included.
+- `require` - a single leading/trailing underscore must be included.
+- `requireDouble` - two leading/trailing underscores must be included.
+- `allow` - existence of a single leading/trailing underscore is not explicitly enforced.
+- `allowDouble` - existence of a double leading/trailing underscore is not explicitly enforced.
+- `allowSingleOrDouble` - existence of a single or a double leading/trailing underscore is not explicitly enforced.
 
 #### `prefix` / `suffix`
 

--- a/packages/eslint-plugin/tests/rules/naming-convention.test.ts
+++ b/packages/eslint-plugin/tests/rules/naming-convention.test.ts
@@ -128,6 +128,11 @@ function createValidTestCases(cases: Cases): TSESLint.ValidTestCase<Options>[] {
             format,
             leadingUnderscore: 'require',
           }),
+          createCase(`__${name}`, {
+            ...test.options,
+            format,
+            leadingUnderscore: 'requireDouble',
+          }),
           createCase(`_${name}`, {
             ...test.options,
             format,
@@ -137,6 +142,36 @@ function createValidTestCases(cases: Cases): TSESLint.ValidTestCase<Options>[] {
             ...test.options,
             format,
             leadingUnderscore: 'allow',
+          }),
+          createCase(`__${name}`, {
+            ...test.options,
+            format,
+            leadingUnderscore: 'allowDouble',
+          }),
+          createCase(name, {
+            ...test.options,
+            format,
+            leadingUnderscore: 'allowDouble',
+          }),
+          createCase(`_${name}`, {
+            ...test.options,
+            format,
+            leadingUnderscore: 'allowSingleOrDouble',
+          }),
+          createCase(name, {
+            ...test.options,
+            format,
+            leadingUnderscore: 'allowSingleOrDouble',
+          }),
+          createCase(`__${name}`, {
+            ...test.options,
+            format,
+            leadingUnderscore: 'allowSingleOrDouble',
+          }),
+          createCase(name, {
+            ...test.options,
+            format,
+            leadingUnderscore: 'allowSingleOrDouble',
           }),
 
           // trailingUnderscore
@@ -150,6 +185,11 @@ function createValidTestCases(cases: Cases): TSESLint.ValidTestCase<Options>[] {
             format,
             trailingUnderscore: 'require',
           }),
+          createCase(`${name}__`, {
+            ...test.options,
+            format,
+            trailingUnderscore: 'requireDouble',
+          }),
           createCase(`${name}_`, {
             ...test.options,
             format,
@@ -159,6 +199,36 @@ function createValidTestCases(cases: Cases): TSESLint.ValidTestCase<Options>[] {
             ...test.options,
             format,
             trailingUnderscore: 'allow',
+          }),
+          createCase(`${name}__`, {
+            ...test.options,
+            format,
+            trailingUnderscore: 'allowDouble',
+          }),
+          createCase(name, {
+            ...test.options,
+            format,
+            trailingUnderscore: 'allowDouble',
+          }),
+          createCase(`${name}_`, {
+            ...test.options,
+            format,
+            trailingUnderscore: 'allowSingleOrDouble',
+          }),
+          createCase(name, {
+            ...test.options,
+            format,
+            trailingUnderscore: 'allowSingleOrDouble',
+          }),
+          createCase(`${name}__`, {
+            ...test.options,
+            format,
+            trailingUnderscore: 'allowSingleOrDouble',
+          }),
+          createCase(name, {
+            ...test.options,
+            format,
+            trailingUnderscore: 'allowSingleOrDouble',
           }),
 
           // prefix
@@ -283,7 +353,27 @@ function createInvalidTestCases(
               leadingUnderscore: 'require',
             },
             'missingUnderscore',
-            { position: 'leading' },
+            { position: 'leading', count: 'one' },
+          ),
+          createCase(
+            name,
+            {
+              ...test.options,
+              format,
+              leadingUnderscore: 'requireDouble',
+            },
+            'missingUnderscore',
+            { position: 'leading', count: 'two' },
+          ),
+          createCase(
+            `_${name}`,
+            {
+              ...test.options,
+              format,
+              leadingUnderscore: 'requireDouble',
+            },
+            'missingUnderscore',
+            { position: 'leading', count: 'two' },
           ),
 
           // trailingUnderscore
@@ -305,7 +395,27 @@ function createInvalidTestCases(
               trailingUnderscore: 'require',
             },
             'missingUnderscore',
-            { position: 'trailing' },
+            { position: 'trailing', count: 'one' },
+          ),
+          createCase(
+            name,
+            {
+              ...test.options,
+              format,
+              trailingUnderscore: 'requireDouble',
+            },
+            'missingUnderscore',
+            { position: 'trailing', count: 'two' },
+          ),
+          createCase(
+            `${name}_`,
+            {
+              ...test.options,
+              format,
+              trailingUnderscore: 'requireDouble',
+            },
+            'missingUnderscore',
+            { position: 'trailing', count: 'two' },
           ),
 
           // prefix
@@ -1188,7 +1298,7 @@ ruleTester.run('naming-convention', rule, {
           // this line is intentionally broken out
           UnusedTypeParam
         > = {};
-        
+
         export const used_var = 1;
         export function used_func(
           // this line is intentionally broken out


### PR DESCRIPTION
Fixes #1712

I chose not to add an unbounded `allowMultiple` for now. I don't think that it's a commonly used pattern.
Single and double I've seen, but I don't believe I've ever seen more than that.
I'd like to avoid adding something unbounded unless there's a strong usecase for it.