### PR TITLE
fix(typescript-estree): add default value for `parserOptions.projectFolderIgnoreList` and deduplicate resolved projects

### DIFF
--- a/packages/typescript-estree/src/create-program/createDefaultProgram.ts
+++ b/packages/typescript-estree/src/create-program/createDefaultProgram.ts
@@ -4,7 +4,7 @@ import * as ts from 'typescript';
 import { Extra } from '../parser-options';
 import {
   ASTAndProgram,
-  getTsconfigPath,
+  CanonicalPath,
   createDefaultCompilerOptionsFromExtra,
 } from './shared';
 
@@ -27,7 +27,7 @@ function createDefaultProgram(
     return undefined;
   }
 
-  const tsconfigPath = getTsconfigPath(extra.projects[0], extra);
+  const tsconfigPath: CanonicalPath = extra.projects[0];
 
   const commandLine = ts.getParsedCommandLineOfConfigFile(
     tsconfigPath,

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -9,7 +9,6 @@ import {
   CanonicalPath,
   createDefaultCompilerOptionsFromExtra,
   getCanonicalFileName,
-  getTsconfigPath,
 } from './shared';
 
 const log = debug('typescript-eslint:typescript-estree:createWatchProgram');
@@ -197,9 +196,7 @@ function getProgramsForProjects(
    * - the required program hasn't been created yet, or
    * - the file is new/renamed, and the program hasn't been updated.
    */
-  for (const rawTsconfigPath of extra.projects) {
-    const tsconfigPath = getTsconfigPath(rawTsconfigPath, extra);
-
+  for (const tsconfigPath of extra.projects) {
     const existingWatch = knownWatchProgramMap.get(tsconfigPath);
 
     if (existingWatch) {

--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -60,10 +60,6 @@ function ensureAbsolutePath(p: string, extra: Extra): string {
     : path.join(extra.tsconfigRootDir || process.cwd(), p);
 }
 
-function getTsconfigPath(tsconfigPath: string, extra: Extra): CanonicalPath {
-  return getCanonicalFileName(ensureAbsolutePath(tsconfigPath, extra));
-}
-
 function canonicalDirname(p: CanonicalPath): CanonicalPath {
   return path.dirname(p) as CanonicalPath;
 }
@@ -105,5 +101,4 @@ export {
   ensureAbsolutePath,
   getCanonicalFileName,
   getScriptKind,
-  getTsconfigPath,
 };

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -1,6 +1,7 @@
 import { DebugLevel } from '@typescript-eslint/types';
 import { Program } from 'typescript';
 import { TSESTree, TSNode, TSESTreeToTSNode, TSToken } from './ts-estree';
+import { CanonicalPath } from './create-program/shared';
 
 type DebugModule = 'typescript-eslint' | 'eslint' | 'typescript';
 
@@ -19,7 +20,7 @@ export interface Extra {
   loc: boolean;
   log: (message: string) => void;
   preserveNodeMaps?: boolean;
-  projects: string[];
+  projects: CanonicalPath[];
   range: boolean;
   strict: boolean;
   tokens: null | TSESTree.Token[];


### PR DESCRIPTION
In #2418 I introduced a regression - I forgot to add in the default value for `projectFolderIgnoreList`.
This means that globs have been matching `node_modules` since the v4.0 release! Oops :(

This PR fixes that.
It also hoists the tsconfig path canonicalisation up so that we can deduplicate early.
Previously if you provided a config like `projects: ['./tsconfig.json', './**/tsconfig.json']`, then we would resolve this to `./tsconfig.json` and `tsconfig.json`, then later canonicalise them.
This meant we'd check that same tsconfig twice!
By hoisting the canonicalisation, we can deduplicate this early.

Fixes #2814