### PR TITLE
fix(eslint-plugin): [method-signature-style] fix crash with methods without a return type

### DIFF
--- a/packages/eslint-plugin/tests/rules/method-signature-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/method-signature-style.test.ts
@@ -427,5 +427,24 @@ declare const Foo: {
         },
       ],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2834
+    {
+      code: `
+interface MyInterface {
+  methodReturningImplicitAny();
+}
+      `,
+      output: `
+interface MyInterface {
+  methodReturningImplicitAny: () => any;
+}
+      `,
+      errors: [
+        {
+          messageId: 'errorMethod',
+          line: 3,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Fixes #2834