### PR TITLE
feat(eslint-plugin): [consistent-type-imports] add option `type-imports-mixed`

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -6,7 +6,7 @@ import {
 } from '@typescript-eslint/experimental-utils';
 import * as util from '../util';
 
-type Prefer = 'type-imports' | 'no-type-imports';
+type Prefer = 'type-imports' | 'no-type-imports' | 'type-imports-mixed';
 
 type Options = [
   {
@@ -67,7 +67,7 @@ export default util.createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           prefer: {
-            enum: ['type-imports', 'no-type-imports'],
+            enum: ['type-imports', 'no-type-imports', 'type-imports-mixed'],
           },
           disallowTypeAnnotations: {
             type: 'boolean',
@@ -94,7 +94,7 @@ export default util.createRule<Options, MessageIds>({
     const sourceImportsMap: { [key: string]: SourceImports } = {};
 
     return {
-      ...(prefer === 'type-imports'
+      ...(prefer !== 'no-type-imports'
         ? {
             // prefer type imports
             ImportDeclaration(node: TSESTree.ImportDeclaration): void {
@@ -157,7 +157,10 @@ export default util.createRule<Options, MessageIds>({
                 }
               }
 
-              if (typeSpecifiers.length) {
+              if (
+                typeSpecifiers.length &&
+                (prefer === 'type-imports' || valueSpecifiers.length === 0)
+              ) {
                 sourceImports.reportValueImports.push({
                   node,
                   typeSpecifiers,

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -109,6 +109,23 @@ ruleTester.run('consistent-type-imports', rule, {
       `,
       options: [{ prefer: 'no-type-imports' }],
     },
+    // type-imports-mixed
+    {
+      code: `
+        import { A, B } from 'foo';
+        const foo: A = B();
+      `,
+      options: [{ prefer: 'type-imports-mixed' }],
+    },
+    {
+      code: `
+        import type A from 'foo';
+        import B from 'foo';
+        let foo: A;
+        let bar = B;
+      `,
+      options: [{ prefer: 'type-imports-mixed' }],
+    },
     // exports
     `
       import Type from 'foo';
@@ -1210,6 +1227,26 @@ const a: Default = '';
       errors: [
         {
           messageId: 'aImportIsOnlyTypes',
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+import { A, B } from 'foo';
+let foo: A;
+let bar: B;
+      `,
+      output: `
+import type { A, B } from 'foo';
+let foo: A;
+let bar: B;
+      `,
+      options: [{ prefer: 'type-imports-mixed' }],
+      errors: [
+        {
+          messageId: 'typeOverValue',
           line: 2,
           column: 1,
         },


### PR DESCRIPTION
This ads a new mode called "type-imports-mixed" for consistent-type-imports rule which will only trigger, if all imports of an import declaration are type only imports.

Fixes #2769