### PR TITLE
fix(eslint-plugin): [naming-convention] fix wrong member of `method` and `property` meta selectors

### DIFF
--- a/packages/eslint-plugin/src/rules/naming-convention-utils/enums.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/enums.ts
@@ -71,11 +71,11 @@ enum MetaSelectors {
   method = 0 |
     Selectors.classMethod |
     Selectors.objectLiteralMethod |
-    Selectors.typeProperty,
+    Selectors.typeMethod,
   property = 0 |
     Selectors.classProperty |
     Selectors.objectLiteralProperty |
-    Selectors.typeMethod,
+    Selectors.typeProperty,
 }
 type MetaSelectorsString = keyof typeof MetaSelectors;
 type IndividualAndMetaSelectorsString = SelectorsString | MetaSelectorsString;


### PR DESCRIPTION
In https://github.com/typescript-eslint/typescript-eslint/pull/2807, the `method` selector was converted to a meta selector for `[classMethod, objectLiteralMethod, typeMethod]`, but it incorrectly includes `typeProperty` as a member in place of `typeMethod`. Similarly, the `property` meta selector includes `typeMethod` in place of `typeProperty`. This PR fixes these meta selectors.