### PR TITLE
fix: util.isLoop is not a util function

### DIFF
--- a/packages/eslint-plugin/src/util/collectUnusedVariables.ts
+++ b/packages/eslint-plugin/src/util/collectUnusedVariables.ts
@@ -2,6 +2,7 @@ import {
   AST_NODE_TYPES,
   TSESLint,
   TSESTree,
+  ASTUtils,
 } from '@typescript-eslint/experimental-utils';
 import { ImplicitLibVariable } from '@typescript-eslint/scope-manager';
 import { Visitor } from '@typescript-eslint/scope-manager/dist/referencer/Visitor';
@@ -549,7 +550,7 @@ function isUsedVariable(variable: TSESLint.Scope.Variable): boolean {
           break;
         }
 
-        if (util.isLoop(currentNode)) {
+        if (ASTUtils.isLoop(currentNode)) {
           return true;
         }
 


### PR DESCRIPTION
https://github.com/typescript-eslint/typescript-eslint/blob/fed89f24ebe42a6412f0eb19949d5d4771656189/packages/eslint-plugin/src/util/collectUnusedVariables.ts#L552
This line will throw `util.isLoop is not a function`


https://github.com/typescript-eslint/typescript-eslint/blob/a8227a6185dd24de4bfc7d766931643871155021/packages/experimental-utils/src/ast-utils/predicates.ts#L217
and `isLoop` is belongs to `ast-utils`, not `utils`:
