### PR TITLE
Updated getting started README

### DIFF
--- a/docs/getting-started/linting/README.md
+++ b/docs/getting-started/linting/README.md
@@ -19,6 +19,9 @@ Next, create a `.eslintrc.js` config file in the root of your project, and popul
 ```js
 module.exports = {
   root: true,
+  env: {
+    node: true,
+  },
   parser: '@typescript-eslint/parser',
   plugins: [
     '@typescript-eslint',


### PR DESCRIPTION
`env: { node: true }` needs to be present, to avoid ESLint complaining about `module`.