### PR TITLE
fix(eslint-plugin): [naming-convention] fix precedence of method and property meta selectors

### DIFF
--- a/packages/eslint-plugin/src/rules/naming-convention-utils/shared.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/shared.ts
@@ -17,4 +17,16 @@ function isMetaSelector(
   return selector in MetaSelectors;
 }
 
-export { selectorTypeToMessageString, isMetaSelector };
+function isMethodOrPropertySelector(
+  selector: IndividualAndMetaSelectorsString | Selectors | MetaSelectors,
+): boolean {
+  return (
+    selector === MetaSelectors.method || selector === MetaSelectors.property
+  );
+}
+
+export {
+  selectorTypeToMessageString,
+  isMetaSelector,
+  isMethodOrPropertySelector,
+};

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/validator.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/validator.ts
@@ -13,7 +13,11 @@ import {
   UnderscoreOptions,
 } from './enums';
 import { PredefinedFormatToCheckFunction } from './format';
-import { isMetaSelector, selectorTypeToMessageString } from './shared';
+import {
+  isMetaSelector,
+  isMethodOrPropertySelector,
+  selectorTypeToMessageString,
+} from './shared';
 import type { Context, NormalizedSelector } from './types';
 import * as util from '../../util';
 
@@ -47,6 +51,14 @@ function createValidator(
       }
       if (!aIsMeta && bIsMeta) {
         return -1;
+      }
+
+      // for backward compatibility, method and property have higher precedence than other meta selectors
+      if (isMethodOrPropertySelector(a.selector)) {
+        return -1;
+      }
+      if (isMethodOrPropertySelector(b.selector)) {
+        return 1;
       }
 
       // both aren't meta selectors

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/validator.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/validator.ts
@@ -53,11 +53,14 @@ function createValidator(
         return -1;
       }
 
+      const aIsMethodOrProperty = isMethodOrPropertySelector(a.selector);
+      const bIsMethodOrProperty = isMethodOrPropertySelector(b.selector);
+
       // for backward compatibility, method and property have higher precedence than other meta selectors
-      if (isMethodOrPropertySelector(a.selector)) {
+      if (aIsMethodOrProperty && !bIsMethodOrProperty) {
         return -1;
       }
-      if (isMethodOrPropertySelector(b.selector)) {
+      if (!aIsMethodOrProperty && bIsMethodOrProperty) {
         return 1;
       }
 

--- a/packages/eslint-plugin/tests/rules/naming-convention.test.ts
+++ b/packages/eslint-plugin/tests/rules/naming-convention.test.ts
@@ -1453,6 +1453,31 @@ ruleTester.run('naming-convention', rule, {
         },
       ],
     },
+    {
+      code: `
+        const obj = {
+          Foo: 42,
+          Bar() {
+            return 42;
+          },
+        };
+      `,
+      parserOptions,
+      options: [
+        {
+          selector: 'memberLike',
+          format: ['camelCase'],
+        },
+        {
+          selector: 'property',
+          format: ['PascalCase'],
+        },
+        {
+          selector: 'method',
+          format: ['PascalCase'],
+        },
+      ],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #2860
