### PR TITLE
docs(eslint-plugin): reword misleading strict-boolean-expressions code example

### DIFF
--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
@@ -50,7 +50,7 @@ while (obj) {
 Examples of **correct** code for this rule:
 
 ```tsx
-// Using logical operators for their side effects is allowed
+// Using logical operator short-circuiting is allowed
 const Component = () => {
   const entry = map.get('foo') || {};
   return entry && <p>Name: {entry.name}</p>;


### PR DESCRIPTION
The code example is demonstrating that boolean _short-circuiting_ is allowed in certain cases, but the comment in the code block refers to this as "side effects", which is an unrelated concept. The page already refers to this correctly as "short-circuiting" in the opening paragraph.