### PR TITLE
feat(eslint-plugin): [return-await] options for gradual application

### DIFF
--- a/packages/eslint-plugin/docs/rules/return-await.md
+++ b/packages/eslint-plugin/docs/rules/return-await.md
@@ -20,9 +20,16 @@ It expands upon the base rule to add support for optionally requiring `return aw
 ## Options
 
 ```ts
-type Options = 'in-try-catch' | 'always' | 'never';
+type Modes = 'in-try-catch' | 'always' | 'never';
 
-const defaultOptions: Options = 'in-try-catch';
+type Options = [Modes, { ignoreUnrecognisedTypes: boolean }];
+
+const defaultOptions: Options = [
+  'in-try-catch',
+  {
+    ignoreUnrecognisedTypes: false,
+  },
+];
 ```
 
 ### `in-try-catch`
@@ -204,5 +211,23 @@ async function validNever2() {
 
 async function validNever3() {
   return 'value';
+}
+```
+
+### `ignoreUnrecognisedTypes`
+
+Treat `any` and `unknown` as if they could return a promise, so never raise
+a warning for them.
+
+This function's argument is implicitly `any`, so it's not known if the code
+is right or not. With `ignoreUnrecognisedTypes: true`, no warning will be raised.
+
+By default, this code will raise a warning; you should fix your typing.
+
+```ts
+async function argWithImplicitAny(arg) {
+  try {
+    return await arg.foo();
+  } catch (e) {}
 }
 ```

--- a/packages/eslint-plugin/docs/rules/return-await.md
+++ b/packages/eslint-plugin/docs/rules/return-await.md
@@ -22,12 +22,19 @@ It expands upon the base rule to add support for optionally requiring `return aw
 ```ts
 type Modes = 'in-try-catch' | 'always' | 'never';
 
-type Options = [Modes, { ignoreUnrecognisedTypes: boolean }];
+type Options = [
+  Modes,
+  {
+    ignoreUnrecognisedTypes: boolean;
+    neverRemove: boolean;
+  },
+];
 
 const defaultOptions: Options = [
   'in-try-catch',
   {
     ignoreUnrecognisedTypes: false,
+    neverRemove: false,
   },
 ];
 ```
@@ -231,3 +238,11 @@ async function argWithImplicitAny(arg) {
   } catch (e) {}
 }
 ```
+
+### `neverRemove`
+
+Do not suggest removing `await`, which could be a breaking change.
+
+This is only useful in conjunction with `in-try-catch` mode, which will
+otherwise try to remove any `await` that is not provably necessary. This
+removal carries some risk.

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -125,6 +125,14 @@ ruleTester.run('return-await', rule, {
       `,
     },
     {
+      options: ['in-try-catch', { neverRemove: true }],
+      code: `
+        async function test(someValue: any) {
+          return await Promise.resolve(2);
+        }
+      `,
+    },
+    {
       options: ['in-try-catch'],
       code: `
         async function test() {

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -67,6 +67,18 @@ ruleTester.run('return-await', rule, {
       }
     `,
     {
+      options: ['in-try-catch', { ignoreUnrecognisedTypes: true }],
+      code: `
+        async function test(someValue: any) {
+          try {
+            return await someValue.one();
+          } catch (e) {
+            return await someValue.two();
+          }
+        }
+      `,
+    },
+    {
       options: ['in-try-catch'],
       code: `
         function test() {


### PR DESCRIPTION
Add two options to easy enabling `return-await` on existing partially-TS codebases.

This rule would be very useful for us for catching the real horrible bug: `try { return foo(); } catch (err) { important; }`. However, we cannot enable it; it attempts to remove hundreds of necessary or important `awaits`.

1) `ignoreUnrecognisedTypes` helps where the codebase has `any` in some places, such as when `foo` is `any` in the above code. It does not issue a warning for the line.
2) `neverRemove` allows one to mark `in-try-catch` as an error, without having to remove hundreds of unnecessary `await`s. One cannot use `always` for this, because then you must add hundreds of unnecessary `await`s.

---

I don't have a particularly strong opinion on the shape of the Mode/Options object. This way was easy, apart from the fact that typescript gets quite angry about it. Instead of `neverRemove`, I also considered `require-in-try-catch` as a new `Mode`?