### PR TITLE
fix(eslint-plugin): [comma-spacing] handle empty type params

### DIFF
--- a/packages/eslint-plugin/src/rules/comma-spacing.ts
+++ b/packages/eslint-plugin/src/rules/comma-spacing.ts
@@ -90,10 +90,13 @@ export default createRule<Options, MessageIds>({
     function addTypeParametersTrailingCommaToIgnoreList(
       node: TSESTree.TSTypeParameterDeclaration,
     ): void {
-      const param = node.params[node.params.length - 1];
-      const afterToken = sourceCode.getTokenAfter(param);
-      if (afterToken && isCommaToken(afterToken)) {
-        ignoredTokens.add(afterToken);
+      const paramLength = node.params.length;
+      if (paramLength) {
+        const param = node.params[paramLength - 1];
+        const afterToken = sourceCode.getTokenAfter(param);
+        if (afterToken && isCommaToken(afterToken)) {
+          ignoredTokens.add(afterToken);
+        }
       }
     }
 

--- a/packages/eslint-plugin/tests/rules/comma-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/comma-spacing.test.ts
@@ -280,6 +280,7 @@ ruleTester.run('comma-spacing', rule, {
     'function foo<T,>() {}',
     'class Foo<T, T1> {}',
     'interface Foo<T, T1,>{}',
+    'interface A<> {}',
   ],
 
   invalid: [


### PR DESCRIPTION
fixes #2906 