### PR TITLE
feat(eslint-plugin): [sort-type-union-intersection-members] add nullish group

### DIFF
--- a/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.md
+++ b/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.md
@@ -104,6 +104,7 @@ type Options = {
     | 'operator'
     | 'tuple'
     | 'union'
+    | 'nullish'
   )[];
 };
 
@@ -122,6 +123,7 @@ const defaultOptions: Options = {
     'tuple',
     'intersection',
     'union',
+    'nullish',
   ],
 };
 ```
@@ -142,3 +144,4 @@ The ordering of groups is determined by this option.
 - `operator` - Operator types (`keyof A`, `typeof B`, `readonly C[]`)
 - `tuple` - Tuple types (`[A, B, C]`)
 - `union` - Union types (`A | B`)
+- `nullish` - `null` and `undefined`

--- a/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
@@ -12,6 +12,7 @@ enum Group {
   import = 'import',
   intersection = 'intersection',
   keyword = 'keyword',
+  nullish = 'nullish',
   literal = 'literal',
   named = 'named',
   object = 'object',
@@ -42,16 +43,18 @@ function getGroup(node: TSESTree.TypeNode): Group {
     case AST_NODE_TYPES.TSBigIntKeyword:
     case AST_NODE_TYPES.TSBooleanKeyword:
     case AST_NODE_TYPES.TSNeverKeyword:
-    case AST_NODE_TYPES.TSNullKeyword:
     case AST_NODE_TYPES.TSNumberKeyword:
     case AST_NODE_TYPES.TSObjectKeyword:
     case AST_NODE_TYPES.TSStringKeyword:
     case AST_NODE_TYPES.TSSymbolKeyword:
     case AST_NODE_TYPES.TSThisType:
-    case AST_NODE_TYPES.TSUndefinedKeyword:
     case AST_NODE_TYPES.TSUnknownKeyword:
     case AST_NODE_TYPES.TSVoidKeyword:
       return Group.keyword;
+
+    case AST_NODE_TYPES.TSNullKeyword:
+    case AST_NODE_TYPES.TSUndefinedKeyword:
+      return Group.nullish;
 
     case AST_NODE_TYPES.TSLiteralType:
     case AST_NODE_TYPES.TSTemplateLiteralType:
@@ -150,6 +153,7 @@ export default util.createRule<Options, MessageIds>({
         Group.tuple,
         Group.intersection,
         Group.union,
+        Group.nullish,
       ],
     },
   ],

--- a/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
@@ -73,6 +73,8 @@ type T =
   ${operator} (B & C)
   ${operator} (A | B)
   ${operator} (B | C)
+  ${operator} null
+  ${operator} undefined
     `,
   },
 ];
@@ -185,6 +187,18 @@ const invalid = (
       ],
     },
     {
+      code: `type T = () => undefined ${operator} null;`,
+      output: `type T = () => null ${operator} undefined;`,
+      errors: [
+        {
+          messageId: 'notSorted',
+          data: {
+            type,
+          },
+        },
+      ],
+    },
+    {
       code: noFormat`
 type T =
   ${operator} [1, 2, 4]
@@ -203,12 +217,14 @@ type T =
   ${operator} number[]
   ${operator} B
   ${operator} A
+  ${operator} undefined
+  ${operator} null
   ${operator} string
   ${operator} any;
       `,
       output: noFormat`
 type T =
-  A ${operator} B ${operator} number[] ${operator} string[] ${operator} any ${operator} string ${operator} readonly number[] ${operator} readonly string[] ${operator} 'a' ${operator} 'b' ${operator} "a" ${operator} "b" ${operator} (() => string) ${operator} (() => void) ${operator} { a: string } ${operator} { b: string } ${operator} [1, 2, 3] ${operator} [1, 2, 4];
+  A ${operator} B ${operator} number[] ${operator} string[] ${operator} any ${operator} string ${operator} readonly number[] ${operator} readonly string[] ${operator} 'a' ${operator} 'b' ${operator} "a" ${operator} "b" ${operator} (() => string) ${operator} (() => void) ${operator} { a: string } ${operator} { b: string } ${operator} [1, 2, 3] ${operator} [1, 2, 4] ${operator} null ${operator} undefined;
       `,
       errors: [
         {


### PR DESCRIPTION
This adds a group called `nullish` to allow sorting `null` and `undefined` independently of the other types in the keywords group. Closes #2918