### PR TITLE
fix(eslint-plugin): [sort-type-union-intersection-members] consider `void` as a `nullish`

### DIFF
--- a/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
@@ -49,11 +49,11 @@ function getGroup(node: TSESTree.TypeNode): Group {
     case AST_NODE_TYPES.TSSymbolKeyword:
     case AST_NODE_TYPES.TSThisType:
     case AST_NODE_TYPES.TSUnknownKeyword:
-    case AST_NODE_TYPES.TSVoidKeyword:
       return Group.keyword;
 
     case AST_NODE_TYPES.TSNullKeyword:
     case AST_NODE_TYPES.TSUndefinedKeyword:
+    case AST_NODE_TYPES.TSVoidKeyword:
       return Group.nullish;
 
     case AST_NODE_TYPES.TSLiteralType:


### PR DESCRIPTION
Fixes #2940