### PR TITLE
feat(eslint-plugin): typedef:  variableDeclaration can ignore block scoped variables

### DIFF
--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -13,6 +13,7 @@ const enum OptionKeys {
   PropertyDeclaration = 'propertyDeclaration',
   VariableDeclaration = 'variableDeclaration',
   VariableDeclarationIgnoreFunction = 'variableDeclarationIgnoreFunction',
+  VariableDeclarationIgnoreBlockScoped = 'variableDeclarationIgnoreBlockScoped',
 }
 
 type Options = { [k in OptionKeys]?: boolean };
@@ -43,6 +44,9 @@ export default util.createRule<[Options], MessageIds>({
           [OptionKeys.PropertyDeclaration]: { type: 'boolean' },
           [OptionKeys.VariableDeclaration]: { type: 'boolean' },
           [OptionKeys.VariableDeclarationIgnoreFunction]: { type: 'boolean' },
+          [OptionKeys.VariableDeclarationIgnoreBlockScoped]: {
+            type: 'boolean',
+          },
         },
       },
     ],
@@ -58,6 +62,7 @@ export default util.createRule<[Options], MessageIds>({
       [OptionKeys.PropertyDeclaration]: false,
       [OptionKeys.VariableDeclaration]: false,
       [OptionKeys.VariableDeclarationIgnoreFunction]: false,
+      [OptionKeys.VariableDeclarationIgnoreBlockScoped]: false,
     },
   ],
   create(context, [options]) {
@@ -139,6 +144,16 @@ export default util.createRule<[Options], MessageIds>({
       );
     }
 
+    function isVariableDeclarationIgnoreBlockScoped(
+      node: TSESTree.Node,
+    ): boolean {
+      return (
+        !!options[OptionKeys.VariableDeclarationIgnoreBlockScoped] &&
+        !!node.parent?.parent &&
+        node.parent.parent.type === AST_NODE_TYPES.BlockStatement
+      );
+    }
+
     return {
       ArrayPattern(node): void {
         if (
@@ -213,7 +228,8 @@ export default util.createRule<[Options], MessageIds>({
             !options[OptionKeys.ArrayDestructuring]) ||
           (node.id.type === AST_NODE_TYPES.ObjectPattern &&
             !options[OptionKeys.ObjectDestructuring]) ||
-          (node.init && isVariableDeclarationIgnoreFunction(node.init))
+          (node.init && isVariableDeclarationIgnoreFunction(node.init)) ||
+          isVariableDeclarationIgnoreBlockScoped(node)
         ) {
           return;
         }

--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -442,6 +442,33 @@ class Foo {
         },
       ],
     },
+    // variable declaration ignore block scoped variables
+    {
+      code: `
+      const foo : () => void = () => {
+        const bar = 2;
+      }
+      `,
+      options: [
+        {
+          variableDeclaration: true,
+          variableDeclarationIgnoreBlockScoped: true,
+        },
+      ],
+    },
+    {
+      code: `
+      const foo : () => void = () => {
+        const bar : number = 2;
+      }
+      `,
+      options: [
+        {
+          variableDeclaration: true,
+          variableDeclarationIgnoreBlockScoped: true,
+        },
+      ],
+    },
   ],
   invalid: [
     // Array destructuring
@@ -995,6 +1022,37 @@ class Foo {
           memberVariableDeclaration: true,
           variableDeclaration: true,
           variableDeclarationIgnoreFunction: false,
+        },
+      ],
+    },
+    // variable declaration ignore block scoped
+    {
+      code: 'const foo = 1;',
+      errors: [
+        {
+          messageId: 'expectedTypedefNamed',
+          data: { name: 'foo' },
+        },
+      ],
+      options: [
+        {
+          variableDeclaration: true,
+          variableDeclarationIgnoreBlockScoped: true,
+        },
+      ],
+    },
+    {
+      code: 'const foo = 1;',
+      errors: [
+        {
+          messageId: 'expectedTypedefNamed',
+          data: { name: 'foo' },
+        },
+      ],
+      options: [
+        {
+          variableDeclaration: true,
+          variableDeclarationIgnoreBlockScoped: false,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -1041,20 +1041,5 @@ class Foo {
         },
       ],
     },
-    {
-      code: 'const foo = 1;',
-      errors: [
-        {
-          messageId: 'expectedTypedefNamed',
-          data: { name: 'foo' },
-        },
-      ],
-      options: [
-        {
-          variableDeclaration: true,
-          variableDeclarationIgnoreBlockScoped: false,
-        },
-      ],
-    },
   ],
 });


### PR DESCRIPTION
Sometimes it is necessary to explicitly specify variable types only at (root) module level, as it might be more inconvenient than helpful in a function scope. the option `variableDeclarationIgnoreBlockScoped` allows `typedef` to ignore block-scoped variables. 

for example with this configuration:

```js
"@typescript-eslint/typedef": [
      "error",
      {
        variableDeclaration: true,
        variableDeclarationIgnoreFunction: true,
        variableDeclarationIgnoreBlockScoped: true,
      },
    ],
```

only `moduleLevel` is expected to have a type annotation.

```ts
const moduleLevel = 1;

{ const blockScoped1 = 1; }

const func = () => {   
   const scopedVariable2 = "some value";
   ...
}