### PR TITLE
feat(eslint-plugin): [switch-exhaustiveness-check] Require default case if discriminant type is not a union

### DIFF
--- a/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.md
+++ b/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.md
@@ -2,6 +2,8 @@
 
 Union type may have a lot of parts. It's easy to forget to consider all cases in switch. This rule reminds which parts are missing. If domain of the problem requires to have only a partial switch, developer may _explicitly_ add a default clause.
 
+If the switch statement's expression is not a union type (e.g. string, number, any, unknown), a default case is required.
+
 Examples of **incorrect** code for this rule:
 
 ```ts
@@ -13,6 +15,20 @@ type Day =
   | 'Friday'
   | 'Saturday'
   | 'Sunday';
+
+const day = 'Monday' as Day;
+let result = 0;
+
+switch (day) {
+  case 'Monday': {
+    result = 1;
+    break;
+  }
+}
+```
+
+```ts
+type Day = string;
 
 const day = 'Monday' as Day;
 let result = 0;

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -165,23 +165,7 @@ switch (day) {
   }
 }
     `,
-    // Exhaustiveness check only works for union types...
-    `
-const day = 'Monday' as string;
-let result = 0;
-
-switch (day) {
-  case 'Monday': {
-    result = 1;
-    break;
-  }
-  case 'Tuesday': {
-    result = 2;
-    break;
-  }
-}
-    `,
-    // ... and enums (at least for now).
+    // Exhaustiveness check works for enums.
     `
 enum Enum {
   A,
@@ -194,17 +178,6 @@ function test(value: Enum): number {
       return 1;
     case Enum.B:
       return 2;
-  }
-}
-    `,
-    // Object union types won't work either, unless it's a discriminated union
-    `
-type ObjectUnion = { a: 1 } | { b: 2 };
-
-function test(value: ObjectUnion): number {
-  switch (value.a) {
-    case 1:
-      return 1;
   }
 }
     `,
@@ -598,6 +571,77 @@ function test(arg: Enum): string {
               `.trimRight(),
             },
           ],
+        },
+      ],
+    },
+    {
+      // Requires default case for primitive types.
+      code: `
+const day = 'Monday' as string;
+let result = 0;
+
+switch (day) {
+  case 'Monday': {
+    result = 1;
+    break;
+  }
+  case 'Tuesday': {
+    result = 2;
+    break;
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'addDefaultCase',
+          line: 5,
+          column: 9,
+        },
+      ],
+    },
+    {
+      // Requires default case for unknown types.
+      code: `
+type Day = any;
+const day = 'Monday' as Day;
+let result = 0;
+
+switch (day) {
+  case 'Monday': {
+    result = 1;
+    break;
+  }
+  case 'Tuesday': {
+    result = 2;
+    break;
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'addDefaultCase',
+          line: 6,
+          column: 9,
+        },
+      ],
+    },
+    {
+      // Object union types won't work either, unless it's a discriminated union
+      code: `
+type ObjectUnion = { a: 1 } | { b: 2 };
+
+function test(value: ObjectUnion): number {
+  switch (value.a) {
+    case 1:
+      return 1;
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'addDefaultCase',
+          line: 5,
+          column: 11,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -181,6 +181,21 @@ function test(value: Enum): number {
   }
 }
     `,
+    // Non-union types are valid with a default case.
+    `
+const day = 'Monday' as string;
+let result = 0;
+
+switch (day) {
+  case 'Monday': {
+    result = 1;
+    break;
+  }
+  default: {
+    result = 42;
+  }
+}
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #2959.

This is a breaking change! Curious to know how we'd evaluate level of risk / appetite.