### PR TITLE
feat(eslint-plugin): [member-delimiter-style] Add an option 'multilineDetection' to treat types and interfaces as single line if the last member ends on the same line as the closing bracket

### DIFF
--- a/packages/eslint-plugin/docs/rules/member-delimiter-style.md
+++ b/packages/eslint-plugin/docs/rules/member-delimiter-style.md
@@ -72,6 +72,7 @@ type Config = BaseConfig & {
     interface?: BaseConfig;
     typeLiteral?: BaseConfig;
   };
+  multilineDetection?: 'brackets' | 'last-member';
 };
 ```
 
@@ -86,13 +87,19 @@ Default config:
     "singleline": {
         "delimiter": "semi",
         "requireLast": false
-    }
+    },
+    "multilineDetection": "brackets"
 }
 ```
 
 `multiline` config only applies to multiline `interface`/`type` definitions.
 `singleline` config only applies to single line `interface`/`type` definitions.
 The two configs are entirely separate, and do not effect one another.
+
+`multilineDetection` determines what counts as multiline
+
+- `"brackets"` (default) any newlines in the type or interface make it multiline.
+- `"last-member"` if the last member of the interface is on the same line as the last bracket, it is counted as a single line.
 
 ### `delimiter`
 

--- a/packages/eslint-plugin/src/rules/member-delimiter-style.ts
+++ b/packages/eslint-plugin/src/rules/member-delimiter-style.ts
@@ -215,10 +215,16 @@ export default util.createRule<Options, MessageIds>({
     function checkMemberSeparatorStyle(
       node: TSESTree.TSInterfaceBody | TSESTree.TSTypeLiteral,
     ): void {
-      const isSingleLine = node.loc.start.line === node.loc.end.line;
-
       const members =
         node.type === AST_NODE_TYPES.TSInterfaceBody ? node.body : node.members;
+
+      let isSingleLine = node.loc.start.line === node.loc.end.line;
+      if (!isSingleLine && members.length > 0) {
+        const lastMember = members[members.length - 1];
+        if (lastMember.loc.end.line === node.loc.end.line) {
+          isSingleLine = true;
+        }
+      }
 
       const typeOpts =
         node.type === AST_NODE_TYPES.TSInterfaceBody

--- a/packages/eslint-plugin/src/rules/member-delimiter-style.ts
+++ b/packages/eslint-plugin/src/rules/member-delimiter-style.ts
@@ -21,6 +21,7 @@ type Config = BaseOptions & {
     typeLiteral?: BaseOptions;
     interface?: BaseOptions;
   };
+  multilineDetection?: 'brackets' | 'last-member';
 };
 type Options = [Config];
 type MessageIds =
@@ -82,6 +83,9 @@ export default util.createRule<Options, MessageIds>({
             },
             additionalProperties: false,
           },
+          multilineDetection: {
+            enum: ['brackets', 'last-member'],
+          },
         }),
         additionalProperties: false,
       },
@@ -97,6 +101,7 @@ export default util.createRule<Options, MessageIds>({
         delimiter: 'semi',
         requireLast: false,
       },
+      multilineDetection: 'brackets',
     },
   ],
   create(context, [options]) {
@@ -219,7 +224,11 @@ export default util.createRule<Options, MessageIds>({
         node.type === AST_NODE_TYPES.TSInterfaceBody ? node.body : node.members;
 
       let isSingleLine = node.loc.start.line === node.loc.end.line;
-      if (!isSingleLine && members.length > 0) {
+      if (
+        options.multilineDetection === 'last-member' &&
+        !isSingleLine &&
+        members.length > 0
+      ) {
         const lastMember = members[members.length - 1];
         if (lastMember.loc.end.line === node.loc.end.line) {
           isSingleLine = true;

--- a/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
@@ -705,17 +705,22 @@ type Bar = {
         },
       ],
     },
-    `
+    {
+      code: `
 type Foo = {a: {
   b: true;
 }};
-    `,
+      `,
+      options: [
+        {
+          multilineDetection: 'last-member',
+        },
+      ],
+    },
     `
-type Foo = {
-  a: {
-    b: true;
-  };
-};
+type Foo = {a: {
+  b: true;
+};};
     `,
     {
       code: `
@@ -725,7 +730,34 @@ type Foo = {a: {
       `,
       options: [
         {
+          multilineDetection: 'brackets',
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {
+  a: {
+    b: true;
+  };
+};
+      `,
+      options: [
+        {
+          multilineDetection: 'last-member',
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+};};
+      `,
+      options: [
+        {
           singleline: { delimiter: 'semi', requireLast: true },
+          multilineDetection: 'last-member',
         },
       ],
     },
@@ -738,6 +770,7 @@ type Foo = {
       options: [
         {
           singleline: { delimiter: 'semi', requireLast: true },
+          multilineDetection: 'last-member',
         },
       ],
     },
@@ -3412,11 +3445,35 @@ type Foo = {a: {
   b: true;
 }};
       `,
+      options: [
+        {
+          multilineDetection: 'last-member',
+        },
+      ],
       errors: [
         {
           messageId: 'unexpectedSemi',
           line: 4,
           column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+}};
+      `,
+      output: `
+type Foo = {a: {
+  b: true;
+};};
+      `,
+      errors: [
+        {
+          messageId: 'expectedSemi',
+          line: 4,
+          column: 2,
         },
       ],
     },
@@ -3435,6 +3492,11 @@ type Foo = {
   };
 };
       `,
+      options: [
+        {
+          multilineDetection: 'last-member',
+        },
+      ],
       errors: [
         {
           messageId: 'expectedSemi',
@@ -3457,6 +3519,7 @@ type Foo = {a: {
       options: [
         {
           singleline: { delimiter: 'semi', requireLast: true },
+          multilineDetection: 'last-member',
         },
       ],
       errors: [

--- a/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
@@ -710,6 +710,13 @@ type Foo = {a: {
   b: true;
 }};
     `,
+    `
+type Foo = {
+  a: {
+    b: true;
+  };
+};
+    `,
     {
       code: `
 type Foo = {a: {
@@ -3410,6 +3417,29 @@ type Foo = {a: {
           messageId: 'unexpectedSemi',
           line: 4,
           column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {
+  a: {
+    b: true;
+  }
+};
+      `,
+      output: `
+type Foo = {
+  a: {
+    b: true;
+  };
+};
+      `,
+      errors: [
+        {
+          messageId: 'expectedSemi',
+          line: 5,
+          column: 4,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
@@ -705,6 +705,35 @@ type Bar = {
         },
       ],
     },
+    `
+type Foo = {a: {
+  b: true;
+}};
+    `,
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+};};
+      `,
+      options: [
+        {
+          singleline: { delimiter: 'semi', requireLast: true },
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {
+
+};
+      `,
+      options: [
+        {
+          singleline: { delimiter: 'semi', requireLast: true },
+        },
+      ],
+    },
 
     {
       code: `
@@ -3362,6 +3391,49 @@ type Foo = {
           messageId: 'expectedSemi',
           line: 1,
           column: 21,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+};};
+      `,
+      output: `
+type Foo = {a: {
+  b: true;
+}};
+      `,
+      errors: [
+        {
+          messageId: 'unexpectedSemi',
+          line: 4,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+}};
+      `,
+      output: `
+type Foo = {a: {
+  b: true;
+};};
+      `,
+      options: [
+        {
+          singleline: { delimiter: 'semi', requireLast: true },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'expectedSemi',
+          line: 4,
+          column: 2,
         },
       ],
     },


### PR DESCRIPTION
Before this PR:
```js
"member-delimiter-style", {
    singleLine: {delimiter: 'comma', requireLast: false},
    multiLine: {delimiter: 'semi', requireLast: true},
}
```
```ts
type Nested = {inline: true, obj: {
//                         ^
// error: Expected a semicolon.
    inline: false;
} };
//^
//error: Expected a semicolon.
```
After this PR:
```js
"member-delimiter-style", {
    singleLine: {delimiter: 'comma', requireLast: false},
    multiLine: {delimiter: 'semi', requireLast: true},
    multilineDetection: 'last-member',
}
```
```ts
type Nested = {inline: true, obj: {
    inline: false;
}};
```

last-member is `brackets` by default, which keeps existing behaviour