### PR TITLE
fix: Allow `message` property in TSESLint RuleTester

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -93,9 +93,13 @@ interface TestCaseError<TMessageIds extends string> {
    */
   readonly line?: number;
   /**
+   * Reported message.
+   */
+  readonly message?: string;
+  /**
    * Reported message ID.
    */
-  readonly messageId: TMessageIds;
+  readonly messageId?: TMessageIds;
   /**
    * Reported suggestions.
    */


### PR DESCRIPTION
I was trying to author a new test, to discover that ESLint supports this property to render the full message. This package lacks the typing. ESLint will:

* Use `message` if provided.
* Use `messageId` if otherwise provided.
* Fail if both are provided.
* Allow both to be omitted.

https://github.com/eslint/eslint/blob/e0b05c704f3ce6f549d14718236d22fe49fcb611/lib/rule-tester/rule-tester.js#L701-L704