### PR TITLE
fix(eslint-plugin): [no-extra-parens] handle ESLint 7.19.0

### DIFF
--- a/packages/eslint-plugin/src/rules/no-extra-parens.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-parens.ts
@@ -242,7 +242,7 @@ export default util.createRule<Options, MessageIds>({
       },
     };
     if (semver.satisfies(TSESLint.ESLint.version, '>=7.19.0')) {
-      overrides.ForInStatement = function (node) {
+      overrides.ForInStatement = function (node): void {
         if (util.isTypeAssertion(node.right)) {
           // makes the rule skip checking of the right
           return rules.ForInStatement({
@@ -257,7 +257,7 @@ export default util.createRule<Options, MessageIds>({
 
         return rules.ForInStatement(node);
       };
-      overrides.ForOfStatement = function (node) {
+      overrides.ForOfStatement = function (node): void {
         if (util.isTypeAssertion(node.right)) {
           // makes the rule skip checking of the right
           return rules.ForOfStatement({
@@ -275,7 +275,7 @@ export default util.createRule<Options, MessageIds>({
     } else {
       overrides['ForInStatement, ForOfStatement'] = function (
         node: TSESTree.ForInStatement | TSESTree.ForOfStatement,
-      ) {
+      ): void {
         if (util.isTypeAssertion(node.right)) {
           // makes the rule skip checking of the right
           return rules['ForInStatement, ForOfStatement']({

--- a/packages/eslint-plugin/src/rules/no-extra-parens.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-parens.ts
@@ -1,7 +1,6 @@
 // any is required to work around manipulating the AST in weird ways
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import semver from 'semver';
 import {
   AST_NODE_TYPES,
   TSESTree,
@@ -241,7 +240,7 @@ export default util.createRule<Options, MessageIds>({
         }
       },
     };
-    if (semver.satisfies(TSESLint.ESLint.version, '>=7.19.0')) {
+    if (rules.ForInStatement && rules.ForOfStatement) {
       overrides.ForInStatement = function (node): void {
         if (util.isTypeAssertion(node.right)) {
           // makes the rule skip checking of the right

--- a/packages/eslint-plugin/src/rules/no-extra-parens.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-parens.ts
@@ -164,14 +164,12 @@ export default util.createRule<Options, MessageIds>({
         return rules.ConditionalExpression(node);
       },
       // DoWhileStatement
-      'ForInStatement, ForOfStatement'(
-        node: TSESTree.ForInStatement | TSESTree.ForOfStatement,
-      ) {
+      ForInStatement(node) {
         if (util.isTypeAssertion(node.right)) {
           // makes the rule skip checking of the right
-          return rules['ForInStatement, ForOfStatement']({
+          return rules.ForInStatement({
             ...node,
-            type: AST_NODE_TYPES.ForOfStatement as any,
+            type: AST_NODE_TYPES.ForInStatement,
             right: {
               ...node.right,
               type: AST_NODE_TYPES.SequenceExpression as any,
@@ -179,7 +177,22 @@ export default util.createRule<Options, MessageIds>({
           });
         }
 
-        return rules['ForInStatement, ForOfStatement'](node);
+        return rules.ForInStatement(node);
+      },
+      ForOfStatement(node) {
+        if (util.isTypeAssertion(node.right)) {
+          // makes the rule skip checking of the right
+          return rules.ForOfStatement({
+            ...node,
+            type: AST_NODE_TYPES.ForOfStatement,
+            right: {
+              ...node.right,
+              type: AST_NODE_TYPES.SequenceExpression as any,
+            },
+          });
+        }
+
+        return rules.ForOfStatement(node);
       },
       ForStatement(node) {
         // make the rule skip the piece by removing it entirely

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -520,9 +520,8 @@ declare module 'eslint/lib/rules/no-extra-parens' {
       ClassExpression(node: TSESTree.ClassExpression): void;
       ConditionalExpression(node: TSESTree.ConditionalExpression): void;
       DoWhileStatement(node: TSESTree.DoWhileStatement): void;
-      'ForInStatement, ForOfStatement'(
-        node: TSESTree.ForInStatement | TSESTree.ForOfStatement,
-      ): void;
+      ForInStatement(node: TSESTree.ForInStatement): void;
+      ForOfStatement(node: TSESTree.ForOfStatement): void;
       ForStatement(node: TSESTree.ForStatement): void;
       'ForStatement > *.init:exit'(node: TSESTree.Node): void;
       IfStatement(node: TSESTree.IfStatement): void;

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -520,6 +520,11 @@ declare module 'eslint/lib/rules/no-extra-parens' {
       ClassExpression(node: TSESTree.ClassExpression): void;
       ConditionalExpression(node: TSESTree.ConditionalExpression): void;
       DoWhileStatement(node: TSESTree.DoWhileStatement): void;
+      // eslint < 7.19.0
+      'ForInStatement, ForOfStatement'(
+        node: TSESTree.ForInStatement | TSESTree.ForOfStatement,
+      ): void;
+      // eslint >= 7.19.0
       ForInStatement(node: TSESTree.ForInStatement): void;
       ForOfStatement(node: TSESTree.ForOfStatement): void;
       ForStatement(node: TSESTree.ForStatement): void;


### PR DESCRIPTION
Fixes #2986.

This works on eslint 7.19.0, but breaks on earlier versions (I'd expect). If I left in the previous version of the function (and types) with `'ForInStatement, ForOfStatement'`, it might work on those as well.

If I don't do that, I think the version of eslint in `package.json` should be bumped.

Which would you prefer?