### PR TITLE
test(typescript-estree): remove AST transformation of chain elements

### DIFF
--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@babel/code-frame": "^7.12.11",
-    "@babel/parser": "^7.12.11",
+    "@babel/parser": "^7.12.15",
     "@babel/types": "^7.12.12",
     "@types/babel__code-frame": "^7.0.2",
     "@types/debug": "*",

--- a/packages/typescript-estree/tests/ast-alignment/utils.ts
+++ b/packages/typescript-estree/tests/ast-alignment/utils.ts
@@ -236,26 +236,6 @@ export function preprocessBabylonAST(ast: BabelTypes.File): any {
           }
         }
       },
-      /**
-       * TS 3.7: optional chaining
-       * babel: sets optional property as true/undefined
-       * ts-estree: sets optional property as true/false
-       */
-      MemberExpression(node) {
-        if (!node.optional) {
-          node.optional = false;
-        }
-      },
-      CallExpression(node) {
-        if (!node.optional) {
-          node.optional = false;
-        }
-      },
-      OptionalCallExpression(node) {
-        if (!node.optional) {
-          node.optional = false;
-        }
-      },
     },
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,6 +148,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
 
+"@babel/parser@^7.12.15":
+  version "7.12.15"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.15.tgz#2b20de7f0b4b332d9b119dd9c33409c538b8aacf"
+  integrity sha512-AQBOU2Z9kWwSZMd6lNjCX0GUgFonL1wAM1db8L8PMk9UDaGsRCArBkU4Sc+UCM3AE4hjbXx+h58Lb3QT4oRmrA==
+
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"


### PR DESCRIPTION
https://github.com/babel/babel/pull/12562 has been merged and released. So AST transformation of chain elements can be removed from alignment tests.