### PR TITLE
fix(eslint-plugin): [prefer-function-type] generate correct code in union and intersection

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-function-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-function-type.ts
@@ -88,6 +88,10 @@ export default util.createRule({
         colonPos + 1,
       )}`;
 
+      const lastChar = suggestion.endsWith(';') ? ';' : '';
+      if (lastChar) {
+        suggestion = suggestion.slice(0, -1);
+      }
       if (shouldWrapSuggestion(parent.parent)) {
         suggestion = `(${suggestion})`;
       }
@@ -98,16 +102,17 @@ export default util.createRule({
             .slice(
               parent.id.range[0],
               parent.typeParameters.range[1],
-            )} = ${suggestion}`;
+            )} = ${suggestion}${lastChar}`;
         }
-        return `type ${parent.id.name} = ${suggestion}`;
+        return `type ${parent.id.name} = ${suggestion}${lastChar}`;
       }
-      return suggestion.endsWith(';') ? suggestion.slice(0, -1) : suggestion;
+      return suggestion;
     }
 
     /**
      * @param member The TypeElement being checked
      * @param node The parent of member being checked
+     * @param tsThisTypes
      */
     function checkMember(
       member: TSESTree.TypeElement,

--- a/packages/eslint-plugin/tests/rules/prefer-function-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-function-type.test.ts
@@ -268,5 +268,39 @@ type Foo = () => {
   };
       `,
     },
+    {
+      code: noFormat`
+type X = {} | { (): void; }
+      `,
+      errors: [
+        {
+          messageId: 'functionTypeOverCallableType',
+          type: AST_NODE_TYPES.TSCallSignatureDeclaration,
+          data: {
+            literalOrInterface: phrases[AST_NODE_TYPES.TSTypeLiteral],
+          },
+        },
+      ],
+      output: noFormat`
+type X = {} | (() => void)
+      `,
+    },
+    {
+      code: noFormat`
+type X = {} & { (): void; };
+      `,
+      errors: [
+        {
+          messageId: 'functionTypeOverCallableType',
+          type: AST_NODE_TYPES.TSCallSignatureDeclaration,
+          data: {
+            literalOrInterface: phrases[AST_NODE_TYPES.TSTypeLiteral],
+          },
+        },
+      ],
+      output: noFormat`
+type X = {} & (() => void);
+      `,
+    },
   ],
 });


### PR DESCRIPTION
fix generates correct code from rule [prefer-function-type] when used with union or intersection types

fixes #3000