### PR TITLE
feat: merge AST structure of TSAsExpression with TSTypeAssertion

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -86,7 +86,7 @@ export default util.createRule<Options, MessageIds>({
     }
 
     function reportIncorrectAssertionType(
-      node: TSESTree.TSTypeAssertion | TSESTree.TSAsExpression,
+      node: TSESTree.TSTypeAssertion,
     ): void {
       // If this node is `as const`, then don't report an error.
       if (isConst(node.typeAnnotation)) {
@@ -123,9 +123,7 @@ export default util.createRule<Options, MessageIds>({
       }
     }
 
-    function checkExpression(
-      node: TSESTree.TSTypeAssertion | TSESTree.TSAsExpression,
-    ): void {
+    function checkExpression(node: TSESTree.TSTypeAssertion): void {
       if (
         options.assertionStyle === 'never' ||
         options.objectLiteralTypeAssertions === 'allow' ||
@@ -159,15 +157,7 @@ export default util.createRule<Options, MessageIds>({
 
     return {
       TSTypeAssertion(node): void {
-        if (options.assertionStyle !== 'angle-bracket') {
-          reportIncorrectAssertionType(node);
-          return;
-        }
-
-        checkExpression(node);
-      },
-      TSAsExpression(node): void {
-        if (options.assertionStyle !== 'as') {
+        if (options.assertionStyle !== node.kind) {
           reportIncorrectAssertionType(node);
           return;
         }

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
@@ -133,7 +133,6 @@ const KNOWN_NODES = new Set([
   AST_NODE_TYPES.TSAbstractClassProperty,
   AST_NODE_TYPES.TSAbstractMethodDefinition,
   AST_NODE_TYPES.TSArrayType,
-  AST_NODE_TYPES.TSAsExpression,
   AST_NODE_TYPES.TSCallSignatureDeclaration,
   AST_NODE_TYPES.TSConditionalType,
   AST_NODE_TYPES.TSConstructorType,

--- a/packages/eslint-plugin/src/rules/keyword-spacing.ts
+++ b/packages/eslint-plugin/src/rules/keyword-spacing.ts
@@ -31,7 +31,10 @@ export default util.createRule<Options, MessageIds>({
     const baseRules = baseRule.create(context);
     return {
       ...baseRules,
-      TSAsExpression(node): void {
+      TSTypeAssertion(node): void {
+        if (node.kind !== 'as') {
+          return;
+        }
         const asToken = util.nullThrows(
           sourceCode.getTokenAfter(
             node.expression,

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -206,9 +206,7 @@ export default util.createRule<Options, MessageIds>({
           }
         }
       },
-      'TSAsExpression, TSTypeAssertion'(
-        node: TSESTree.TSTypeAssertion | TSESTree.TSAsExpression,
-      ): void {
+      TSTypeAssertion(node: TSESTree.TSTypeAssertion): void {
         if (
           options.typesToIgnore?.includes(
             sourceCode.getText(node.typeAnnotation),
@@ -239,7 +237,7 @@ export default util.createRule<Options, MessageIds>({
             node,
             messageId: 'unnecessaryAssertion',
             fix(fixer) {
-              return originalNode.kind === ts.SyntaxKind.TypeAssertionExpression
+              return node.kind === 'angle-bracket'
                 ? fixer.removeRange([
                     node.range[0],
                     node.expression.range[0] - 1,

--- a/packages/eslint-plugin/src/rules/no-var-requires.ts
+++ b/packages/eslint-plugin/src/rules/no-var-requires.ts
@@ -36,7 +36,6 @@ export default util.createRule<Options, MessageIds>({
           parent &&
           (parent.type === AST_NODE_TYPES.VariableDeclarator ||
             parent.type === AST_NODE_TYPES.CallExpression ||
-            parent.type === AST_NODE_TYPES.TSAsExpression ||
             parent.type === AST_NODE_TYPES.TSTypeAssertion ||
             parent.type === AST_NODE_TYPES.MemberExpression)
         ) {

--- a/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
+++ b/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
@@ -72,9 +72,7 @@ export default util.createRule({
       return true;
     };
 
-    const isConstAssertion = (
-      node: TSESTree.TSTypeAssertion | TSESTree.TSAsExpression,
-    ): boolean => {
+    const isConstAssertion = (node: TSESTree.TSTypeAssertion): boolean => {
       return (
         node.typeAnnotation.type === AST_NODE_TYPES.TSTypeReference &&
         node.typeAnnotation.typeName.type === AST_NODE_TYPES.Identifier &&
@@ -83,9 +81,7 @@ export default util.createRule({
     };
 
     return {
-      'TSAsExpression, TSTypeAssertion'(
-        node: TSESTree.TSTypeAssertion | TSESTree.TSAsExpression,
-      ): void {
+      TSTypeAssertion(node: TSESTree.TSTypeAssertion): void {
         if (isConstAssertion(node)) {
           return;
         }

--- a/packages/eslint-plugin/src/rules/prefer-as-const.ts
+++ b/packages/eslint-plugin/src/rules/prefer-as-const.ts
@@ -63,9 +63,6 @@ export default util.createRule({
     }
 
     return {
-      TSAsExpression(node): void {
-        compareTypes(node.expression, node.typeAnnotation, true);
-      },
       TSTypeAssertion(node): void {
         compareTypes(node.expression, node.typeAnnotation, true);
       },

--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -309,7 +309,6 @@ function isSafeUse(node: TSESTree.Node): boolean {
 
     case AST_NODE_TYPES.ChainExpression:
     case AST_NODE_TYPES.TSNonNullExpression:
-    case AST_NODE_TYPES.TSAsExpression:
     case AST_NODE_TYPES.TSTypeAssertion:
       return isSafeUse(parent);
 

--- a/packages/eslint-plugin/tests/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin/tests/rules/indent/indent.test.ts
@@ -75,7 +75,7 @@ type foo = ArrType[];
     ],
   },
   {
-    node: AST_NODE_TYPES.TSAsExpression,
+    node: AST_NODE_TYPES.TSTypeAssertion,
     code: [
       `
 const foo = {} as {

--- a/packages/experimental-utils/src/ast-utils/predicates.ts
+++ b/packages/experimental-utils/src/ast-utils/predicates.ts
@@ -56,14 +56,11 @@ function isLogicalOrOperator(
  */
 function isTypeAssertion(
   node: TSESTree.Node | undefined | null,
-): node is TSESTree.TSAsExpression | TSESTree.TSTypeAssertion {
+): node is TSESTree.TSTypeAssertion {
   if (!node) {
     return false;
   }
-  return (
-    node.type === AST_NODE_TYPES.TSAsExpression ||
-    node.type === AST_NODE_TYPES.TSTypeAssertion
-  );
+  return node.type === AST_NODE_TYPES.TSTypeAssertion;
 }
 
 function isVariableDeclarator(

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -331,7 +331,6 @@ interface RuleListener {
   TSAbstractMethodDefinition?: RuleFunction<TSESTree.TSAbstractMethodDefinition>;
   TSAnyKeyword?: RuleFunction<TSESTree.TSAnyKeyword>;
   TSArrayType?: RuleFunction<TSESTree.TSArrayType>;
-  TSAsExpression?: RuleFunction<TSESTree.TSAsExpression>;
   TSAsyncKeyword?: RuleFunction<TSESTree.TSAsyncKeyword>;
   TSBigIntKeyword?: RuleFunction<TSESTree.TSBigIntKeyword>;
   TSBooleanKeyword?: RuleFunction<TSESTree.TSBooleanKeyword>;

--- a/packages/scope-manager/src/referencer/Referencer.ts
+++ b/packages/scope-manager/src/referencer/Referencer.ts
@@ -297,13 +297,6 @@ class Referencer extends Visitor {
     TypeVisitor.visit(this, node);
   }
 
-  protected visitTypeAssertion(
-    node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
-  ): void {
-    this.visit(node.expression);
-    this.visitType(node.typeAnnotation);
-  }
-
   /////////////////////
   // Visit selectors //
   /////////////////////
@@ -317,7 +310,6 @@ class Referencer extends Visitor {
   protected AssignmentExpression(node: TSESTree.AssignmentExpression): void {
     let left = node.left;
     switch (left.type) {
-      case AST_NODE_TYPES.TSAsExpression:
       case AST_NODE_TYPES.TSTypeAssertion:
         // explicitly visit the type annotation
         this.visit(left.typeAnnotation);
@@ -603,10 +595,6 @@ class Referencer extends Visitor {
     this.visitType(node.typeParameters);
   }
 
-  protected TSAsExpression(node: TSESTree.TSAsExpression): void {
-    this.visitTypeAssertion(node);
-  }
-
   protected TSDeclareFunction(node: TSESTree.TSDeclareFunction): void {
     this.visitFunction(node);
   }
@@ -707,7 +695,13 @@ class Referencer extends Visitor {
   }
 
   protected TSTypeAssertion(node: TSESTree.TSTypeAssertion): void {
-    this.visitTypeAssertion(node);
+    if (node.kind === 'as') {
+      this.visit(node.expression);
+      this.visitType(node.typeAnnotation);
+    } else {
+      this.visitType(node.typeAnnotation);
+      this.visit(node.expression);
+    }
   }
 
   protected UpdateExpression(node: TSESTree.UpdateExpression): void {

--- a/packages/scope-manager/tests/fixtures/type-assertion/angle-bracket.ts.shot
+++ b/packages/scope-manager/tests/fixtures/type-assertion/angle-bracket.ts.shot
@@ -23,7 +23,7 @@ ScopeManager {
           resolved: Variable$2,
           writeExpr: Literal$2,
         },
-        Reference$2 {
+        Reference$3 {
           identifier: Identifier<"x">,
           isRead: true,
           isTypeReference: false,
@@ -44,7 +44,7 @@ ScopeManager {
       ],
       name: "T",
       references: Array [
-        Reference$3 {
+        Reference$2 {
           identifier: Identifier<"T">,
           isRead: true,
           isTypeReference: true,

--- a/packages/types/src/ast-node-types.ts
+++ b/packages/types/src/ast-node-types.ts
@@ -91,7 +91,6 @@ enum AST_NODE_TYPES {
   TSAbstractMethodDefinition = 'TSAbstractMethodDefinition',
   TSAnyKeyword = 'TSAnyKeyword',
   TSArrayType = 'TSArrayType',
-  TSAsExpression = 'TSAsExpression',
   TSAsyncKeyword = 'TSAsyncKeyword',
   TSBigIntKeyword = 'TSBigIntKeyword',
   TSBooleanKeyword = 'TSBooleanKeyword',

--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -222,7 +222,6 @@ export type Node =
   | TSAbstractMethodDefinition
   | TSAnyKeyword
   | TSArrayType
-  | TSAsExpression
   | TSAsyncKeyword
   | TSBigIntKeyword
   | TSBooleanKeyword
@@ -373,7 +372,7 @@ export type Expression =
   | RestElement
   | SequenceExpression
   | SpreadElement
-  | TSAsExpression
+  | TSTypeAssertion
   | TSUnaryExpression
   | YieldExpression;
 export type ForInitialiser = Expression | VariableDeclaration;
@@ -409,7 +408,7 @@ export type LeftHandSideExpression =
   | PrimaryExpression
   | TaggedTemplateExpression
   | TSNonNullExpression
-  | TSAsExpression
+  | TSTypeAssertion
   | ArrowFunctionExpression;
 export type Literal =
   | BigIntLiteral
@@ -1261,7 +1260,7 @@ export interface ThisExpression extends BaseNode {
 
 export interface ThrowStatement extends BaseNode {
   type: AST_NODE_TYPES.ThrowStatement;
-  argument: Statement | TSAsExpression | null;
+  argument: Statement | TSTypeAssertion | null;
 }
 
 export interface TryStatement extends BaseNode {
@@ -1302,12 +1301,6 @@ export interface TSAnyKeyword extends BaseNode {
 export interface TSArrayType extends BaseNode {
   type: AST_NODE_TYPES.TSArrayType;
   elementType: TypeNode;
-}
-
-export interface TSAsExpression extends BaseNode {
-  type: AST_NODE_TYPES.TSAsExpression;
-  expression: Expression;
-  typeAnnotation: TypeNode;
 }
 
 export interface TSAsyncKeyword extends BaseNode {
@@ -1647,6 +1640,7 @@ export interface TSTypeAssertion extends BaseNode {
   type: AST_NODE_TYPES.TSTypeAssertion;
   typeAnnotation: TypeNode;
   expression: Expression;
+  kind: 'as' | 'angle-bracket';
 }
 
 export interface TSTypeLiteral extends BaseNode {

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -2619,10 +2619,11 @@ export class Converter {
         });
       }
       case SyntaxKind.AsExpression: {
-        return this.createNode<TSESTree.TSAsExpression>(node, {
-          type: AST_NODE_TYPES.TSAsExpression,
+        return this.createNode<TSESTree.TSTypeAssertion>(node, {
+          type: AST_NODE_TYPES.TSTypeAssertion,
           expression: this.convertChild(node.expression),
           typeAnnotation: this.convertType(node.type),
+          kind: 'as',
         });
       }
       case SyntaxKind.InferType: {
@@ -2656,6 +2657,7 @@ export class Converter {
           type: AST_NODE_TYPES.TSTypeAssertion,
           typeAnnotation: this.convertType(node.type),
           expression: this.convertChild(node.expression),
+          kind: 'angle-bracket',
         });
       }
       case SyntaxKind.ImportEqualsDeclaration: {

--- a/packages/typescript-estree/src/ts-estree/estree-to-ts-node-types.ts
+++ b/packages/typescript-estree/src/ts-estree/estree-to-ts-node-types.ts
@@ -156,7 +156,6 @@ export interface EstreeToTsNodeTypes {
     | ts.MethodDeclaration
     | ts.ConstructorDeclaration;
   [AST_NODE_TYPES.TSArrayType]: ts.ArrayTypeNode;
-  [AST_NODE_TYPES.TSAsExpression]: ts.AsExpression;
   [AST_NODE_TYPES.TSCallSignatureDeclaration]: ts.PropertySignature;
   [AST_NODE_TYPES.TSClassImplements]: ts.ExpressionWithTypeArguments;
   [AST_NODE_TYPES.TSConditionalType]: ts.ConditionalTypeNode;
@@ -203,7 +202,7 @@ export interface EstreeToTsNodeTypes {
   [AST_NODE_TYPES.TSTemplateLiteralType]: ts.TemplateLiteralTypeNode;
   [AST_NODE_TYPES.TSTypeAliasDeclaration]: ts.TypeAliasDeclaration;
   [AST_NODE_TYPES.TSTypeAnnotation]: undefined;
-  [AST_NODE_TYPES.TSTypeAssertion]: ts.TypeAssertion;
+  [AST_NODE_TYPES.TSTypeAssertion]: ts.TypeAssertion | ts.AsExpression;
   [AST_NODE_TYPES.TSTypeLiteral]: ts.TypeLiteralNode;
   [AST_NODE_TYPES.TSTypeOperator]: ts.TypeOperatorNode;
   [AST_NODE_TYPES.TSTypeParameter]: ts.TypeParameterDeclaration;

--- a/packages/typescript-estree/tests/ast-alignment/utils.ts
+++ b/packages/typescript-estree/tests/ast-alignment/utils.ts
@@ -241,6 +241,25 @@ export function preprocessBabylonAST(ast: BabelTypes.File): any {
           }
         }
       },
+      /**
+       * Change in ast structure
+       * https://github.com/typescript-eslint/typescript-eslint/issues/2142
+       */
+      TSAsExpression(node: any) {
+        node.type = AST_NODE_TYPES.TSTypeAssertion;
+        if (!node.kind) {
+          node.kind = 'as';
+        }
+      },
+      /**
+       * Change in ast structure
+       * https://github.com/typescript-eslint/typescript-eslint/issues/2142
+       */
+      TSTypeAssertion(node: any) {
+        if (!node.kind) {
+          node.kind = 'angle-bracket';
+        }
+      },
     },
   );
 }

--- a/packages/typescript-estree/tests/snapshots/comments/type-assertion-regression-test.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/comments/type-assertion-regression-test.src.ts.shot
@@ -43,6 +43,7 @@ Object {
               ],
               "type": "Identifier",
             },
+            "kind": "angle-bracket",
             "loc": Object {
               "end": Object {
                 "column": 5,

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/angle-bracket-type-assertion-arrow-function.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/angle-bracket-type-assertion-arrow-function.src.ts.shot
@@ -120,6 +120,7 @@ Object {
               ],
               "type": "ArrowFunctionExpression",
             },
+            "kind": "angle-bracket",
             "loc": Object {
               "end": Object {
                 "column": 43,

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/angle-bracket-type-assertion.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/angle-bracket-type-assertion.src.ts.shot
@@ -44,6 +44,7 @@ Object {
               "type": "Literal",
               "value": 2,
             },
+            "kind": "angle-bracket",
             "loc": Object {
               "end": Object {
                 "column": 27,

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/cast-as-expression.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/cast-as-expression.src.ts.shot
@@ -59,6 +59,7 @@ Object {
           },
           "type": "BinaryExpression",
         },
+        "kind": "as",
         "loc": Object {
           "end": Object {
             "column": 16,
@@ -73,7 +74,7 @@ Object {
           0,
           16,
         ],
-        "type": "TSAsExpression",
+        "type": "TSTypeAssertion",
         "typeAnnotation": Object {
           "loc": Object {
             "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/cast-as-multi-assign.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/cast-as-multi-assign.src.ts.shot
@@ -25,6 +25,7 @@ Object {
               ],
               "type": "Identifier",
             },
+            "kind": "as",
             "loc": Object {
               "end": Object {
                 "column": 12,
@@ -39,7 +40,7 @@ Object {
               1,
               12,
             ],
-            "type": "TSAsExpression",
+            "type": "TSTypeAssertion",
             "typeAnnotation": Object {
               "loc": Object {
                 "end": Object {
@@ -58,6 +59,7 @@ Object {
               "type": "TSNumberKeyword",
             },
           },
+          "kind": "as",
           "loc": Object {
             "end": Object {
               "column": 19,
@@ -72,7 +74,7 @@ Object {
             1,
             19,
           ],
-          "type": "TSAsExpression",
+          "type": "TSTypeAssertion",
           "typeAnnotation": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/cast-as-multi.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/cast-as-multi.src.ts.shot
@@ -24,6 +24,7 @@ Object {
             ],
             "type": "Identifier",
           },
+          "kind": "as",
           "loc": Object {
             "end": Object {
               "column": 8,
@@ -38,7 +39,7 @@ Object {
             0,
             8,
           ],
-          "type": "TSAsExpression",
+          "type": "TSTypeAssertion",
           "typeAnnotation": Object {
             "loc": Object {
               "end": Object {
@@ -57,6 +58,7 @@ Object {
             "type": "TSAnyKeyword",
           },
         },
+        "kind": "as",
         "loc": Object {
           "end": Object {
             "column": 13,
@@ -71,7 +73,7 @@ Object {
           0,
           13,
         ],
-        "type": "TSAsExpression",
+        "type": "TSTypeAssertion",
         "typeAnnotation": Object {
           "loc": Object {
             "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/cast-as-operator.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/cast-as-operator.src.ts.shot
@@ -58,6 +58,7 @@ Object {
             "type": "Literal",
             "value": 1,
           },
+          "kind": "as",
           "loc": Object {
             "end": Object {
               "column": 17,
@@ -72,7 +73,7 @@ Object {
             6,
             17,
           ],
-          "type": "TSAsExpression",
+          "type": "TSTypeAssertion",
           "typeAnnotation": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/cast-as-simple.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/cast-as-simple.src.ts.shot
@@ -43,6 +43,7 @@ Object {
               ],
               "type": "Identifier",
             },
+            "kind": "as",
             "loc": Object {
               "end": Object {
                 "column": 20,
@@ -57,7 +58,7 @@ Object {
               12,
               20,
             ],
-            "type": "TSAsExpression",
+            "type": "TSTypeAssertion",
             "typeAnnotation": Object {
               "loc": Object {
                 "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/const-assertions.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/const-assertions.src.ts.shot
@@ -44,6 +44,7 @@ Object {
               "type": "Literal",
               "value": 10,
             },
+            "kind": "as",
             "loc": Object {
               "end": Object {
                 "column": 19,
@@ -58,7 +59,7 @@ Object {
               21,
               32,
             ],
-            "type": "TSAsExpression",
+            "type": "TSTypeAssertion",
             "typeAnnotation": Object {
               "loc": Object {
                 "end": Object {
@@ -209,6 +210,7 @@ Object {
               ],
               "type": "ArrayExpression",
             },
+            "kind": "as",
             "loc": Object {
               "end": Object {
                 "column": 25,
@@ -223,7 +225,7 @@ Object {
               71,
               88,
             ],
-            "type": "TSAsExpression",
+            "type": "TSTypeAssertion",
             "typeAnnotation": Object {
               "loc": Object {
                 "end": Object {
@@ -394,6 +396,7 @@ Object {
               ],
               "type": "ObjectExpression",
             },
+            "kind": "as",
             "loc": Object {
               "end": Object {
                 "column": 34,
@@ -408,7 +411,7 @@ Object {
               136,
               162,
             ],
-            "type": "TSAsExpression",
+            "type": "TSTypeAssertion",
             "typeAnnotation": Object {
               "loc": Object {
                 "end": Object {
@@ -521,6 +524,7 @@ Object {
               "type": "Literal",
               "value": 10,
             },
+            "kind": "angle-bracket",
             "loc": Object {
               "end": Object {
                 "column": 17,
@@ -686,6 +690,7 @@ Object {
               ],
               "type": "ArrayExpression",
             },
+            "kind": "angle-bracket",
             "loc": Object {
               "end": Object {
                 "column": 23,
@@ -871,6 +876,7 @@ Object {
               ],
               "type": "ObjectExpression",
             },
+            "kind": "angle-bracket",
             "loc": Object {
               "end": Object {
                 "column": 32,

--- a/packages/visitor-keys/src/visitor-keys.ts
+++ b/packages/visitor-keys/src/visitor-keys.ts
@@ -67,7 +67,6 @@ const additionalKeys: AdditionalKeys = {
   TSAbstractMethodDefinition: ['key', 'value'],
   TSAnyKeyword: [],
   TSArrayType: ['elementType'],
-  TSAsExpression: ['expression', 'typeAnnotation'],
   TSAsyncKeyword: [],
   TSBigIntKeyword: [],
   TSBooleanKeyword: [],


### PR DESCRIPTION
This PR aims to merge AST structure of `TSAsExpression` with `TSTypeAssertion` 

**This is BREAKING CHANGE**

#### New AST structure

```ts
interface TSTypeAssertion extends Node {
  type: AST_NODE_TYPES.TSTypeAssertion;
  typeAnnotation: TypeNode;
  expression: Expression;
  kind: 'as' | 'angle-bracket';
}
```

#### TODO:
- [ ] Add unit tests for `indent` rule
- [ ] Add unit tests for `keyword-spacing` rule
- [ ] Add unit tests for `no-var-requires` rule

fixes #2142