### PR TITLE
fix(eslint-plugin): [consistent-indexed-object-style] do not autofix if interface has extends

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -115,6 +115,9 @@ export default createRule<Options, MessageIds>({
       },
 
       TSInterfaceDeclaration(node): void {
+        if (node.extends?.length) {
+          return;
+        }
         let genericTypes = '';
 
         if ((node.typeParameters?.params ?? []).length > 0) {

--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -2,6 +2,7 @@ import { createRule } from '../util';
 import {
   AST_NODE_TYPES,
   TSESTree,
+  TSESLint,
 } from '@typescript-eslint/experimental-utils';
 
 type MessageIds = 'preferRecord' | 'preferIndexSignature';
@@ -66,6 +67,7 @@ export default createRule<Options, MessageIds>({
       node: TSESTree.Node,
       prefix: string,
       postfix: string,
+      safeFix = true,
     ): void {
       if (members.length !== 1) {
         return;
@@ -98,14 +100,16 @@ export default createRule<Options, MessageIds>({
       context.report({
         node,
         messageId: 'preferRecord',
-        fix(fixer) {
-          const key = sourceCode.getText(keyType.typeAnnotation);
-          const value = sourceCode.getText(valueType.typeAnnotation);
-          const record = member.readonly
-            ? `Readonly<Record<${key}, ${value}>>`
-            : `Record<${key}, ${value}>`;
-          return fixer.replaceText(node, `${prefix}${record}${postfix}`);
-        },
+        fix: safeFix
+          ? (fixer): TSESLint.RuleFix => {
+              const key = sourceCode.getText(keyType.typeAnnotation);
+              const value = sourceCode.getText(valueType.typeAnnotation);
+              const record = member.readonly
+                ? `Readonly<Record<${key}, ${value}>>`
+                : `Record<${key}, ${value}>`;
+              return fixer.replaceText(node, `${prefix}${record}${postfix}`);
+            }
+          : null,
       });
     }
 
@@ -115,9 +119,6 @@ export default createRule<Options, MessageIds>({
       },
 
       TSInterfaceDeclaration(node): void {
-        if (node.extends?.length) {
-          return;
-        }
         let genericTypes = '';
 
         if ((node.typeParameters?.params ?? []).length > 0) {
@@ -131,6 +132,7 @@ export default createRule<Options, MessageIds>({
           node,
           `type ${node.id.name}${genericTypes} = `,
           ';',
+          !node.extends?.length,
         );
       },
     };

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -76,7 +76,11 @@ interface Foo {
   [];
 }
     `,
-
+    `
+interface B extends A {
+  [index: number]: unknown;
+}
+    `,
     // 'index-signature'
     // Unhandled type
     {

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -76,11 +76,6 @@ interface Foo {
   [];
 }
     `,
-    `
-interface B extends A {
-  [index: number]: unknown;
-}
-    `,
     // 'index-signature'
     // Unhandled type
     {
@@ -170,6 +165,20 @@ type Foo<A> = Record<string, A>;
       errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
     },
 
+    // Interface with extends
+    {
+      code: `
+interface B extends A {
+  [index: number]: unknown;
+}
+      `,
+      output: `
+interface B extends A {
+  [index: number]: unknown;
+}
+      `,
+      errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
+    },
     // Readonly interface with generic parameter
     {
       code: `


### PR DESCRIPTION
Disable reporting when interface has extends

fixes #3007