### PR TITLE
fix(eslint-plugin): [unbound-method] allow `super` expressions in `this` assignments

### DIFF
--- a/packages/eslint-plugin/docs/rules/unbound-method.md
+++ b/packages/eslint-plugin/docs/rules/unbound-method.md
@@ -87,24 +87,6 @@ const { log } = OtherClass;
 log();
 ```
 
-### `allowSuper`
-
-Examples of **correct** code for this rule with `{ allowSuper: true }`:
-
-```ts
-class SuperClass {
-  method1(){ ... }
-}
-
-class baseClass extend SuperClass {
-  constructor(){
-    super();
-    this.baseVar = super.method1;
-  }
-}
-
-```
-
 ### Example
 
 ```json

--- a/packages/eslint-plugin/docs/rules/unbound-method.md
+++ b/packages/eslint-plugin/docs/rules/unbound-method.md
@@ -68,6 +68,7 @@ const { double } = arith;
 The rule accepts an options object with the following property:
 
 - `ignoreStatic` to not check whether `static` methods are correctly bound
+- `allowSuper` allows `Super` class methods to bound with base class.
 
 ### `ignoreStatic`
 
@@ -86,6 +87,24 @@ const { log } = OtherClass;
 log();
 ```
 
+### `allowSuper`
+
+Examples of **correct** code for this rule with `{ allowSuper: true }`:
+
+```ts
+class SuperClass {
+  method1(){ ... }
+}
+
+class baseClass extend SuperClass {
+  constructor(){
+    super();
+    this.baseVar = super.method1;
+  }
+}
+
+```
+
 ### Example
 
 ```json
@@ -93,7 +112,8 @@ log();
   "@typescript-eslint/unbound-method": [
     "error",
     {
-      "ignoreStatic": true
+      "ignoreStatic": true,
+      "allowSuper": false
     }
   ]
 }

--- a/packages/eslint-plugin/docs/rules/unbound-method.md
+++ b/packages/eslint-plugin/docs/rules/unbound-method.md
@@ -68,7 +68,6 @@ const { double } = arith;
 The rule accepts an options object with the following property:
 
 - `ignoreStatic` to not check whether `static` methods are correctly bound
-- `allowSuper` allows `Super` class methods to bound with base class.
 
 ### `ignoreStatic`
 
@@ -94,8 +93,7 @@ log();
   "@typescript-eslint/unbound-method": [
     "error",
     {
-      "ignoreStatic": true,
-      "allowSuper": false
+      "ignoreStatic": true
     }
   ]
 }

--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -12,7 +12,6 @@ import * as util from '../util';
 
 interface Config {
   ignoreStatic: boolean;
-  allowSuper?: boolean;
 }
 
 export type Options = [Config];
@@ -143,9 +142,6 @@ export default util.createRule<Options, MessageIds>({
           ignoreStatic: {
             type: 'boolean',
           },
-          allowSuper: {
-            type: 'boolean',
-          },
         },
         additionalProperties: false,
       },
@@ -155,10 +151,9 @@ export default util.createRule<Options, MessageIds>({
   defaultOptions: [
     {
       ignoreStatic: false,
-      allowSuper: false,
     },
   ],
-  create(context, [{ ignoreStatic, allowSuper }]) {
+  create(context, [{ ignoreStatic }]) {
     const parserServices = util.getParserServices(context);
     const checker = parserServices.program.getTypeChecker();
     const currentSourceFile = parserServices.program.getSourceFile(
@@ -279,7 +274,7 @@ function isDangerousMethod(symbol: ts.Symbol, ignoreStatic: boolean): boolean {
   return false;
 }
 
-function isSafeUse(node: TSESTree.Node, allowSuper = false): boolean {
+function isSafeUse(node: TSESTree.Node): boolean {
   const parent = node.parent;
 
   switch (parent?.type) {
@@ -313,8 +308,7 @@ function isSafeUse(node: TSESTree.Node, allowSuper = false): boolean {
       return (
         parent.operator === '=' &&
         (node === parent.left ||
-          (allowSuper &&
-            (node as TSESTree.MemberExpression) &&
+          (node.type === AST_NODE_TYPES.MemberExpression &&
             node.object.type === AST_NODE_TYPES.Super))
       );
 

--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -305,7 +305,10 @@ function isSafeUse(node: TSESTree.Node): boolean {
       return ['instanceof', '==', '!=', '===', '!=='].includes(parent.operator);
 
     case AST_NODE_TYPES.AssignmentExpression:
-      return parent.operator === '=' && node === parent.left;
+      return (
+        parent.operator === '=' &&
+        (node === parent.left || node.object.type === AST_NODE_TYPES.Super)
+      );
 
     case AST_NODE_TYPES.ChainExpression:
     case AST_NODE_TYPES.TSNonNullExpression:

--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -309,7 +309,9 @@ function isSafeUse(node: TSESTree.Node): boolean {
         parent.operator === '=' &&
         (node === parent.left ||
           (node.type === AST_NODE_TYPES.MemberExpression &&
-            node.object.type === AST_NODE_TYPES.Super))
+            node.object.type === AST_NODE_TYPES.Super &&
+            parent.left.type === AST_NODE_TYPES.MemberExpression &&
+            parent.left.object.type === AST_NODE_TYPES.ThisExpression))
       );
 
     case AST_NODE_TYPES.ChainExpression:

--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -279,7 +279,7 @@ function isDangerousMethod(symbol: ts.Symbol, ignoreStatic: boolean): boolean {
   return false;
 }
 
-function isSafeUse(node: TSESTree.Node, allowSuper: boolean = false): boolean {
+function isSafeUse(node: TSESTree.Node, allowSuper = false): boolean {
   const parent = node.parent;
 
   switch (parent?.type) {

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -54,7 +54,8 @@ ruleTester.run('unbound-method', rule, {
     "['1', '2', '3'].map(Number.parseInt);",
     '[5.2, 7.1, 3.6].map(Math.floor);',
     'const x = console.log;',
-    `
+    {
+      code: `
 class BaseClass {
   x: number = 42;
   logThis() {
@@ -73,6 +74,12 @@ class OtherClass extends BaseClass {
 const oc = new OtherClass();
 oc.superLogThis();
     `,
+      options: [
+        {
+          allowSuper: true,
+        },
+      ],
+    },
     ...[
       'instance.bound();',
       'instance.unbound();',
@@ -544,6 +551,39 @@ const { log } = console;
       errors: [
         {
           line: 1,
+          messageId: 'unbound',
+        },
+      ],
+    },
+    {
+      code: `
+class BaseClass {
+  x: number = 42;
+  logThis() {
+    console.log('x is ');
+  }
+}
+
+class OtherClass extends BaseClass {
+  superLogThis: any;
+  constructor() {
+    super();
+    this.superLogThis = super.logThis;
+  }
+}
+
+const oc = new OtherClass();
+oc.superLogThis();
+    `,
+      options: [
+        {
+          allowSuper: false,
+        },
+      ],
+      errors: [
+        {
+          line: 13,
+          column: 25,
           messageId: 'unbound',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -66,7 +66,7 @@ class OtherClass extends BaseClass {
   superLogThis: any;
   constructor() {
     super();
-    this.superLogThis = super.logThis; // X - Incorrect eslint error
+    this.superLogThis = super.logThis;
   }
 }
 

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -54,32 +54,6 @@ ruleTester.run('unbound-method', rule, {
     "['1', '2', '3'].map(Number.parseInt);",
     '[5.2, 7.1, 3.6].map(Math.floor);',
     'const x = console.log;',
-    {
-      code: `
-class BaseClass {
-  x: number = 42;
-  logThis() {
-    console.log('x is ');
-  }
-}
-
-class OtherClass extends BaseClass {
-  superLogThis: any;
-  constructor() {
-    super();
-    this.superLogThis = super.logThis;
-  }
-}
-
-const oc = new OtherClass();
-oc.superLogThis();
-      `,
-      options: [
-        {
-          allowSuper: true,
-        },
-      ],
-    },
     ...[
       'instance.bound();',
       'instance.unbound();',
@@ -290,6 +264,24 @@ class Foo {
   bound = () => 'foo';
 }
 const { bound } = new Foo();
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/1866
+    `
+class BaseClass {
+  x: number = 42;
+  logThis() {
+    console.log('x is ');
+  }
+}
+class OtherClass extends BaseClass {
+  superLogThis: any;
+  constructor() {
+    super();
+    this.superLogThis = super.logThis;
+  }
+}
+const oc = new OtherClass();
+oc.superLogThis();
     `,
   ],
   invalid: [
@@ -555,6 +547,7 @@ const { log } = console;
         },
       ],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/1866
     {
       code: `
 class BaseClass {
@@ -563,27 +556,18 @@ class BaseClass {
     console.log('x is ');
   }
 }
-
 class OtherClass extends BaseClass {
   superLogThis: any;
   constructor() {
     super();
-    this.superLogThis = super.logThis;
+    const x = super.logThis; // ERROR - unbound method
   }
 }
-
-const oc = new OtherClass();
-oc.superLogThis();
       `,
-      options: [
-        {
-          allowSuper: false,
-        },
-      ],
       errors: [
         {
-          line: 13,
-          column: 25,
+          line: 12,
+          column: 15,
           messageId: 'unbound',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -269,9 +269,7 @@ const { bound } = new Foo();
     `
 class BaseClass {
   x: number = 42;
-  logThis() {
-    console.log('x is ');
-  }
+  logThis() {}
 }
 class OtherClass extends BaseClass {
   superLogThis: any;
@@ -551,23 +549,41 @@ const { log } = console;
     {
       code: `
 class BaseClass {
-  x: number = 42;
-  logThis() {
-    console.log('x is ');
-  }
+  logThis() {}
 }
 class OtherClass extends BaseClass {
-  superLogThis: any;
   constructor() {
     super();
-    const x = super.logThis; // ERROR - unbound method
+    const x = super.logThis;
   }
 }
       `,
       errors: [
         {
-          line: 12,
+          line: 8,
           column: 15,
+          messageId: 'unbound',
+        },
+      ],
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/1866
+    {
+      code: `
+class BaseClass {
+  logThis() {}
+}
+class OtherClass extends BaseClass {
+  constructor() {
+    super();
+    let x;
+    x = super.logThis;
+  }
+}
+      `,
+      errors: [
+        {
+          line: 9,
+          column: 9,
           messageId: 'unbound',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -73,7 +73,7 @@ class OtherClass extends BaseClass {
 
 const oc = new OtherClass();
 oc.superLogThis();
-    `,
+      `,
       options: [
         {
           allowSuper: true,
@@ -574,7 +574,7 @@ class OtherClass extends BaseClass {
 
 const oc = new OtherClass();
 oc.superLogThis();
-    `,
+      `,
       options: [
         {
           allowSuper: false,

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -54,6 +54,25 @@ ruleTester.run('unbound-method', rule, {
     "['1', '2', '3'].map(Number.parseInt);",
     '[5.2, 7.1, 3.6].map(Math.floor);',
     'const x = console.log;',
+    `
+class BaseClass {
+  x: number = 42;
+  logThis() {
+    console.log('x is ');
+  }
+}
+
+class OtherClass extends BaseClass {
+  superLogThis: any;
+  constructor() {
+    super();
+    this.superLogThis = super.logThis; // X - Incorrect eslint error
+  }
+}
+
+const oc = new OtherClass();
+oc.superLogThis();
+    `,
     ...[
       'instance.bound();',
       'instance.unbound();',


### PR DESCRIPTION
This is rebased version of PR, #1925 with fixes.

fixes #1866