### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    ignore:
+      - dependency-name: "typescript"
+      - dependency-name: "eslint"


### PR DESCRIPTION
currently we have bunch of out of date dependencies, this configuration will exclude unwanted eslint and typescript updates as changes require manual work

to my knowledge dependabot reports now only updates that have security updates in them.