### PR TITLE
docs(eslint-plugin): [explicit-module-boundary-types] fix doc & code examples

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
@@ -148,11 +148,10 @@ Examples of **incorrect** code for this rule with `{ allowDirectConstAssertionIn
 
 ```ts
 export const func = (value: number) => ({ type: 'X', value });
-export const foo = () => (
-  {
+export const foo = () =>
+  ({
     bar: true,
-  } as const
-);
+  } as const);
 export const bar = () => 1;
 ```
 
@@ -160,11 +159,10 @@ Examples of **correct** code for this rule with `{ allowDirectConstAssertionInAr
 
 ```ts
 export const func = (value: number) => ({ type: 'X', value } as const);
-export const foo = () => (
-  {
+export const foo = () =>
+  ({
     bar: true,
-  } as const
-);
+  } as const);
 export const bar = () => 1 as const;
 ```
 

--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
@@ -130,45 +130,42 @@ If you are working on a codebase within which you lint non-TypeScript code (i.e.
 
 ### `allowArgumentsExplicitlyTypedAsAny`
 
-Examples of **incorrect** code for this rule with `{ allowArgumentsExplicitlyTypedAsAny: true }`:
+Examples of **incorrect** code for this rule with `{ allowArgumentsExplicitlyTypedAsAny: false }`:
 
 ```ts
-export const func = (value: any): void => ({ type: 'X', value });
-export function foo(value: any): void {}
+export const func = (value: any): number => value + 1;
 ```
 
 Examples of **correct** code for this rule with `{ allowArgumentsExplicitlyTypedAsAny: true }`:
 
 ```ts
-export const func = (value: number): void => ({ type: 'X', value });
-export function foo(value: number): void {}
+export const func = (value: number): number => value + 1;
 ```
 
 ### `allowDirectConstAssertionInArrowFunctions`
 
-Examples of **incorrect** code for this rule with `{ allowDirectConstAssertionInArrowFunctions: true }`:
+Examples of **incorrect** code for this rule with `{ allowDirectConstAssertionInArrowFunctions: false }`:
 
 ```ts
 export const func = (value: number) => ({ type: 'X', value });
-export const foo = () => {
-  return {
+export const foo = () => (
+  {
     bar: true,
-  } as const;
-};
+  } as const
+);
 export const bar = () => 1;
-export const baz = arg => arg as const;
 ```
 
 Examples of **correct** code for this rule with `{ allowDirectConstAssertionInArrowFunctions: true }`:
 
 ```ts
 export const func = (value: number) => ({ type: 'X', value } as const);
-export const foo = () =>
-  ({
+export const foo = () => (
+  {
     bar: true,
-  } as const);
+  } as const
+);
 export const bar = () => 1 as const;
-export const baz = (arg: string) => arg as const;
 ```
 
 ### `allowedNames`
@@ -188,24 +185,24 @@ You may pass function/method names you would like this rule to ignore, like so:
 
 ### `allowHigherOrderFunctions`
 
-Examples of **incorrect** code for this rule with `{ allowHigherOrderFunctions: true }`:
+Examples of **incorrect** code for this rule with `{ allowHigherOrderFunctions: false }`:
 
 ```ts
-export var arrowFn = () => () => {};
+export const arrowFn = () => (): void => {};
 
 export function fn() {
-  return function () {};
+  return function (): void {};
 }
 
-export function foo(outer) {
-  return function (inner): void {};
+export function foo(outer: string) {
+  return function (inner: string): void {};
 }
 ```
 
 Examples of **correct** code for this rule with `{ allowHigherOrderFunctions: true }`:
 
 ```ts
-export var arrowFn = () => (): void => {};
+export const arrowFn = () => (): void => {};
 
 export function fn() {
   return function (): void {};
@@ -218,7 +215,7 @@ export function foo(outer: string) {
 
 ### `allowTypedFunctionExpressions`
 
-Examples of **incorrect** code for this rule with `{ allowTypedFunctionExpressions: true }`:
+Examples of **incorrect** code for this rule with `{ allowTypedFunctionExpressions: false }`:
 
 ```ts
 export let arrowFn = () => 'test';


### PR DESCRIPTION
1. For each option of the rule, the sentences `Examples of incorrect/correct code for this rule with ...` were wrong when the option's value had to be `false`.

2. Slight simplification of a few code examples, less confusing.

3. Fix and homogenise code examples.