### PR TITLE
test: correct integration tests for eslint-plugin-markdown

### DIFF
--- a/tests/integration/fixtures/markdown/.eslintrc.js
+++ b/tests/integration/fixtures/markdown/.eslintrc.js
@@ -18,8 +18,17 @@ module.exports = {
     // Local version of @typescript-eslint/eslint-plugin
     '@typescript-eslint',
   ],
-  rules: {
-    '@typescript-eslint/no-explicit-any': 'error',
-    'no-console': 'error',
-  },
+  overrides: [
+    {
+      files: ['**/*.md'],
+      processor: 'markdown/markdown',
+    },
+    {
+      files: ['**/*.md/*.{js,ts,jsx,tsx}'],
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'error',
+        'no-console': 'error',
+      },
+    },
+  ],
 };

--- a/tests/integration/fixtures/markdown/.eslintrc.js
+++ b/tests/integration/fixtures/markdown/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
       processor: 'markdown/markdown',
     },
     {
-      files: ['**/*.md/*.{js,ts,jsx,tsx}'],
+      files: ['**/*.md/*.{js,ts,jsx,tsx,javascript,node}'],
       rules: {
         '@typescript-eslint/no-explicit-any': 'error',
         'no-console': 'error',


### PR DESCRIPTION
Integration tests are no longer working because `eslint-plugin-markdown` released new version that changed api.

https://github.com/eslint/eslint-plugin-markdown/tree/v2.0.0#migrating-from-eslint-plugin-markdown-v1