### PR TITLE
fix(eslint-plugin): [no-var-requires] report when used in type assertion

### DIFF
--- a/packages/eslint-plugin/src/rules/no-var-requires.ts
+++ b/packages/eslint-plugin/src/rules/no-var-requires.ts
@@ -37,6 +37,7 @@ export default util.createRule<Options, MessageIds>({
           (parent.type === AST_NODE_TYPES.VariableDeclarator ||
             parent.type === AST_NODE_TYPES.CallExpression ||
             parent.type === AST_NODE_TYPES.TSAsExpression ||
+            parent.type === AST_NODE_TYPES.TSTypeAssertion ||
             parent.type === AST_NODE_TYPES.MemberExpression)
         ) {
           context.report({

--- a/packages/eslint-plugin/tests/rules/no-var-requires.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-var-requires.test.ts
@@ -113,6 +113,16 @@ ruleTester.run('no-var-requires', rule, {
       ],
     },
     {
+      code: "const foo = <Foo>require('./foo.json');",
+      errors: [
+        {
+          messageId: 'noVarReqs',
+          line: 1,
+          column: 18,
+        },
+      ],
+    },
+    {
       code: "const foo: Foo = require('./foo.json').default;",
       errors: [
         {


### PR DESCRIPTION
This fixes issue with `no-var-requires` not reporting issues for `<Foo>require('./foo.json');`

i found this issue while doing https://github.com/typescript-eslint/typescript-eslint/pull/3005/files#r571368246