### PR TITLE
fix: add missing intrinsic keyword node to AST

### DIFF
--- a/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
@@ -49,6 +49,7 @@ function getGroup(node: TSESTree.TypeNode): Group {
     case AST_NODE_TYPES.TSSymbolKeyword:
     case AST_NODE_TYPES.TSThisType:
     case AST_NODE_TYPES.TSUnknownKeyword:
+    case AST_NODE_TYPES.TSIntrinsicKeyword:
       return Group.keyword;
 
     case AST_NODE_TYPES.TSNullKeyword:

--- a/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
@@ -43,10 +43,13 @@ const valid = (operator: '|' | '&'): TSESLint.ValidTestCase<Options>[] => [
 type T =
   ${operator} A
   ${operator} B
+  ${operator} intrinsic
   ${operator} number[]
   ${operator} string[]
   ${operator} any
   ${operator} string
+  ${operator} symbol
+  ${operator} this
   ${operator} readonly number[]
   ${operator} readonly string[]
   ${operator} 'a'

--- a/packages/shared-fixtures/fixtures/typescript/basics/intrinsic-keyword.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/intrinsic-keyword.src.ts
@@ -1,0 +1,4 @@
+type Uppercase<S extends string> = intrinsic;
+type Lowercase<S extends string> = intrinsic;
+type Capitalize<S extends string> = intrinsic;
+type Uncapitalize<S extends string> = intrinsic;

--- a/packages/types/src/ast-node-types.ts
+++ b/packages/types/src/ast-node-types.ts
@@ -118,6 +118,7 @@ enum AST_NODE_TYPES {
   TSInterfaceDeclaration = 'TSInterfaceDeclaration',
   TSInterfaceHeritage = 'TSInterfaceHeritage',
   TSIntersectionType = 'TSIntersectionType',
+  TSIntrinsicKeyword = 'TSIntrinsicKeyword',
   TSLiteralType = 'TSLiteralType',
   TSMappedType = 'TSMappedType',
   TSMethodSignature = 'TSMethodSignature',

--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -249,6 +249,7 @@ export type Node =
   | TSInterfaceDeclaration
   | TSInterfaceHeritage
   | TSIntersectionType
+  | TSIntrinsicKeyword
   | TSLiteralType
   | TSMappedType
   | TSMethodSignature
@@ -544,6 +545,7 @@ export type TypeNode =
   | TSInferType
   | TSInterfaceHeritage
   | TSIntersectionType
+  | TSIntrinsicKeyword
   | TSLiteralType
   | TSMappedType
   | TSNamedTupleMember
@@ -1467,6 +1469,10 @@ export interface TSInterfaceHeritage extends TSHeritageBase {
 export interface TSIntersectionType extends BaseNode {
   type: AST_NODE_TYPES.TSIntersectionType;
   types: TypeNode[];
+}
+
+export interface TSIntrinsicKeyword extends BaseNode {
+  type: AST_NODE_TYPES.TSIntrinsicKeyword;
 }
 
 export interface TSLiteralType extends BaseNode {

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -2211,7 +2211,8 @@ export class Converter {
       case SyntaxKind.SymbolKeyword:
       case SyntaxKind.UnknownKeyword:
       case SyntaxKind.VoidKeyword:
-      case SyntaxKind.UndefinedKeyword: {
+      case SyntaxKind.UndefinedKeyword:
+      case SyntaxKind.IntrinsicKeyword: {
         return this.createNode<any>(node, {
           type: AST_NODE_TYPES[`TS${SyntaxKind[node.kind]}` as AST_NODE_TYPES],
         });

--- a/packages/typescript-estree/src/ts-estree/estree-to-ts-node-types.ts
+++ b/packages/typescript-estree/src/ts-estree/estree-to-ts-node-types.ts
@@ -254,6 +254,7 @@ export interface EstreeToTsNodeTypes {
   [AST_NODE_TYPES.TSAnyKeyword]: ts.KeywordTypeNode;
   [AST_NODE_TYPES.TSBigIntKeyword]: ts.KeywordTypeNode;
   [AST_NODE_TYPES.TSBooleanKeyword]: ts.KeywordTypeNode;
+  [AST_NODE_TYPES.TSIntrinsicKeyword]: ts.KeywordTypeNode;
   [AST_NODE_TYPES.TSNeverKeyword]: ts.KeywordTypeNode;
   [AST_NODE_TYPES.TSNumberKeyword]: ts.KeywordTypeNode;
   [AST_NODE_TYPES.TSObjectKeyword]: ts.KeywordTypeNode;

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
@@ -1993,6 +1993,8 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" e
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-without-type-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/intrinsic-keyword.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/keyof-operator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/keyword-variables.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/intrinsic-keyword.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/intrinsic-keyword.src.ts.shot
@@ -1,0 +1,1243 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`typescript basics intrinsic-keyword.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 14,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 5,
+            "line": 1,
+          },
+        },
+        "name": "Uppercase",
+        "range": Array [
+          5,
+          14,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 45,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        45,
+      ],
+      "type": "TSTypeAliasDeclaration",
+      "typeAnnotation": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 44,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 35,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          35,
+          44,
+        ],
+        "type": "TSIntrinsicKeyword",
+      },
+      "typeParameters": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 32,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 14,
+            "line": 1,
+          },
+        },
+        "params": Array [
+          Object {
+            "constraint": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 31,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 25,
+                  "line": 1,
+                },
+              },
+              "range": Array [
+                25,
+                31,
+              ],
+              "type": "TSStringKeyword",
+            },
+            "default": undefined,
+            "loc": Object {
+              "end": Object {
+                "column": 31,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 15,
+                "line": 1,
+              },
+            },
+            "name": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 1,
+                },
+                "start": Object {
+                  "column": 15,
+                  "line": 1,
+                },
+              },
+              "name": "S",
+              "range": Array [
+                15,
+                16,
+              ],
+              "type": "Identifier",
+            },
+            "range": Array [
+              15,
+              31,
+            ],
+            "type": "TSTypeParameter",
+          },
+        ],
+        "range": Array [
+          14,
+          32,
+        ],
+        "type": "TSTypeParameterDeclaration",
+      },
+    },
+    Object {
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 14,
+            "line": 2,
+          },
+          "start": Object {
+            "column": 5,
+            "line": 2,
+          },
+        },
+        "name": "Lowercase",
+        "range": Array [
+          51,
+          60,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 45,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        46,
+        91,
+      ],
+      "type": "TSTypeAliasDeclaration",
+      "typeAnnotation": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 44,
+            "line": 2,
+          },
+          "start": Object {
+            "column": 35,
+            "line": 2,
+          },
+        },
+        "range": Array [
+          81,
+          90,
+        ],
+        "type": "TSIntrinsicKeyword",
+      },
+      "typeParameters": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 32,
+            "line": 2,
+          },
+          "start": Object {
+            "column": 14,
+            "line": 2,
+          },
+        },
+        "params": Array [
+          Object {
+            "constraint": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 31,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 25,
+                  "line": 2,
+                },
+              },
+              "range": Array [
+                71,
+                77,
+              ],
+              "type": "TSStringKeyword",
+            },
+            "default": undefined,
+            "loc": Object {
+              "end": Object {
+                "column": 31,
+                "line": 2,
+              },
+              "start": Object {
+                "column": 15,
+                "line": 2,
+              },
+            },
+            "name": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 15,
+                  "line": 2,
+                },
+              },
+              "name": "S",
+              "range": Array [
+                61,
+                62,
+              ],
+              "type": "Identifier",
+            },
+            "range": Array [
+              61,
+              77,
+            ],
+            "type": "TSTypeParameter",
+          },
+        ],
+        "range": Array [
+          60,
+          78,
+        ],
+        "type": "TSTypeParameterDeclaration",
+      },
+    },
+    Object {
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 15,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 5,
+            "line": 3,
+          },
+        },
+        "name": "Capitalize",
+        "range": Array [
+          97,
+          107,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 46,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        92,
+        138,
+      ],
+      "type": "TSTypeAliasDeclaration",
+      "typeAnnotation": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 45,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 36,
+            "line": 3,
+          },
+        },
+        "range": Array [
+          128,
+          137,
+        ],
+        "type": "TSIntrinsicKeyword",
+      },
+      "typeParameters": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 33,
+            "line": 3,
+          },
+          "start": Object {
+            "column": 15,
+            "line": 3,
+          },
+        },
+        "params": Array [
+          Object {
+            "constraint": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 32,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 26,
+                  "line": 3,
+                },
+              },
+              "range": Array [
+                118,
+                124,
+              ],
+              "type": "TSStringKeyword",
+            },
+            "default": undefined,
+            "loc": Object {
+              "end": Object {
+                "column": 32,
+                "line": 3,
+              },
+              "start": Object {
+                "column": 16,
+                "line": 3,
+              },
+            },
+            "name": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 17,
+                  "line": 3,
+                },
+                "start": Object {
+                  "column": 16,
+                  "line": 3,
+                },
+              },
+              "name": "S",
+              "range": Array [
+                108,
+                109,
+              ],
+              "type": "Identifier",
+            },
+            "range": Array [
+              108,
+              124,
+            ],
+            "type": "TSTypeParameter",
+          },
+        ],
+        "range": Array [
+          107,
+          125,
+        ],
+        "type": "TSTypeParameterDeclaration",
+      },
+    },
+    Object {
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 17,
+            "line": 4,
+          },
+          "start": Object {
+            "column": 5,
+            "line": 4,
+          },
+        },
+        "name": "Uncapitalize",
+        "range": Array [
+          144,
+          156,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 48,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        139,
+        187,
+      ],
+      "type": "TSTypeAliasDeclaration",
+      "typeAnnotation": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 47,
+            "line": 4,
+          },
+          "start": Object {
+            "column": 38,
+            "line": 4,
+          },
+        },
+        "range": Array [
+          177,
+          186,
+        ],
+        "type": "TSIntrinsicKeyword",
+      },
+      "typeParameters": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 35,
+            "line": 4,
+          },
+          "start": Object {
+            "column": 17,
+            "line": 4,
+          },
+        },
+        "params": Array [
+          Object {
+            "constraint": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 34,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 28,
+                  "line": 4,
+                },
+              },
+              "range": Array [
+                167,
+                173,
+              ],
+              "type": "TSStringKeyword",
+            },
+            "default": undefined,
+            "loc": Object {
+              "end": Object {
+                "column": 34,
+                "line": 4,
+              },
+              "start": Object {
+                "column": 18,
+                "line": 4,
+              },
+            },
+            "name": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 19,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 18,
+                  "line": 4,
+                },
+              },
+              "name": "S",
+              "range": Array [
+                157,
+                158,
+              ],
+              "type": "Identifier",
+            },
+            "range": Array [
+              157,
+              173,
+            ],
+            "type": "TSTypeParameter",
+          },
+        ],
+        "range": Array [
+          156,
+          174,
+        ],
+        "type": "TSTypeParameterDeclaration",
+      },
+    },
+  ],
+  "comments": Array [],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 5,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    188,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        4,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        5,
+        14,
+      ],
+      "type": "Identifier",
+      "value": "Uppercase",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        14,
+        15,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        15,
+        16,
+      ],
+      "type": "Identifier",
+      "value": "S",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 24,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        17,
+        24,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 31,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        25,
+        31,
+      ],
+      "type": "Identifier",
+      "value": "string",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 32,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        31,
+        32,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 34,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        33,
+        34,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 44,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        35,
+        44,
+      ],
+      "type": "Identifier",
+      "value": "intrinsic",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 45,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        44,
+        45,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        46,
+        50,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        51,
+        60,
+      ],
+      "type": "Identifier",
+      "value": "Lowercase",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        60,
+        61,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        61,
+        62,
+      ],
+      "type": "Identifier",
+      "value": "S",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 24,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        63,
+        70,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 31,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 25,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        71,
+        77,
+      ],
+      "type": "Identifier",
+      "value": "string",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 32,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 31,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        77,
+        78,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 34,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 33,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        79,
+        80,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 44,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        81,
+        90,
+      ],
+      "type": "Identifier",
+      "value": "intrinsic",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 45,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 44,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        90,
+        91,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        92,
+        96,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        97,
+        107,
+      ],
+      "type": "Identifier",
+      "value": "Capitalize",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        107,
+        108,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        108,
+        109,
+      ],
+      "type": "Identifier",
+      "value": "S",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        110,
+        117,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 32,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        118,
+        124,
+      ],
+      "type": "Identifier",
+      "value": "string",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 33,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 32,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        124,
+        125,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 35,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 34,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        126,
+        127,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 45,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 36,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        128,
+        137,
+      ],
+      "type": "Identifier",
+      "value": "intrinsic",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 46,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 45,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        137,
+        138,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 4,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        139,
+        143,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 17,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        144,
+        156,
+      ],
+      "type": "Identifier",
+      "value": "Uncapitalize",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        156,
+        157,
+      ],
+      "type": "Punctuator",
+      "value": "<",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 19,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 18,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        157,
+        158,
+      ],
+      "type": "Identifier",
+      "value": "S",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 27,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 20,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        159,
+        166,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 34,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 28,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        167,
+        173,
+      ],
+      "type": "Identifier",
+      "value": "string",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 35,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 34,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        173,
+        174,
+      ],
+      "type": "Punctuator",
+      "value": ">",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 37,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 36,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        175,
+        176,
+      ],
+      "type": "Punctuator",
+      "value": "=",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 47,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 38,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        177,
+        186,
+      ],
+      "type": "Identifier",
+      "value": "intrinsic",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 48,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 47,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        186,
+        187,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;

--- a/packages/visitor-keys/src/visitor-keys.ts
+++ b/packages/visitor-keys/src/visitor-keys.ts
@@ -99,6 +99,7 @@ const additionalKeys: AdditionalKeys = {
   TSInterfaceDeclaration: ['id', 'typeParameters', 'extends', 'body'],
   TSInterfaceHeritage: ['expression', 'typeParameters'],
   TSIntersectionType: ['types'],
+  TSIntrinsicKeyword: [],
   TSLiteralType: ['literal'],
   TSMappedType: ['nameType', 'typeParameter', 'typeAnnotation'],
   TSMethodSignature: ['typeParameters', 'key', 'params', 'returnType'],


### PR DESCRIPTION
This PR adds missing AST definition for intrinsic keyword

```ts
type Uppercase<S extends string> = intrinsic;
```

fixes #3079