### PR TITLE
fix(typescript-estree): correct issues in AST definition

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -408,10 +408,12 @@ export default util.createRule<Options, MessageIds>({
         return cached;
       }
 
-      for (const statement of node.body?.body ?? []) {
-        if (statement.type === AST_NODE_TYPES.TSExportAssignment) {
-          MODULE_DECL_CACHE.set(node, true);
-          return true;
+      if (node.body && node.body.type !== AST_NODE_TYPES.TSModuleDeclaration) {
+        for (const statement of node.body.body ?? []) {
+          if (statement.type === AST_NODE_TYPES.TSExportAssignment) {
+            MODULE_DECL_CACHE.set(node, true);
+            return true;
+          }
         }
       }
 

--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -408,8 +408,8 @@ export default util.createRule<Options, MessageIds>({
         return cached;
       }
 
-      if (node.body && node.body.type !== AST_NODE_TYPES.TSModuleDeclaration) {
-        for (const statement of node.body.body ?? []) {
+      if (node.body && node.body.type === AST_NODE_TYPES.TSModuleBlock) {
+        for (const statement of node.body.body) {
           if (statement.type === AST_NODE_TYPES.TSExportAssignment) {
             MODULE_DECL_CACHE.set(node, true);
             return true;

--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -427,11 +427,9 @@ export type MethodDefinition =
 export type Modifier =
   | TSAbstractKeyword
   | TSAsyncKeyword
-  | TSDeclareKeyword
-  | TSExportKeyword
-  | TSPublicKeyword
   | TSPrivateKeyword
   | TSProtectedKeyword
+  | TSPublicKeyword
   | TSReadonlyKeyword
   | TSStaticKeyword;
 export type ObjectLiteralElementLike =
@@ -464,20 +462,8 @@ export type PrimaryExpression =
   | TemplateLiteral
   | ThisExpression
   | TSNullKeyword;
-export type ProgramStatement =
-  | ClassDeclaration
-  | ExportAllDeclaration
-  | ExportDefaultDeclaration
-  | ExportNamedDeclaration
-  | ImportDeclaration
-  | Statement
-  | TSDeclareFunction
-  | TSEnumDeclaration
-  | TSExportAssignment
-  | TSImportEqualsDeclaration
-  | TSInterfaceDeclaration
-  | TSNamespaceExportDeclaration
-  | TSTypeAliasDeclaration;
+/** @deprecated TODO: delete this in next major release */
+export type ProgramStatement = Statement;
 export type Property = PropertyComputedName | PropertyNonComputedName;
 export type PropertyName = PropertyNameComputed | PropertyNameNonComputed;
 export type PropertyNameComputed = Expression;
@@ -488,16 +474,27 @@ export type PropertyNameNonComputed =
 export type Statement =
   | BlockStatement
   | BreakStatement
+  | ClassDeclaration
   | ContinueStatement
   | DebuggerStatement
   | DeclarationStatement
   | EmptyStatement
+  | ExportAllDeclaration
+  | ExportDefaultDeclaration
+  | ExportNamedDeclaration
   | ExpressionStatement
   | IfStatement
   | IterationStatement
   | ImportDeclaration
   | LabeledStatement
+  | TSDeclareFunction
+  | TSEnumDeclaration
+  | TSExportAssignment
+  | TSImportEqualsDeclaration
+  | TSInterfaceDeclaration
   | TSModuleBlock
+  | TSNamespaceExportDeclaration
+  | TSTypeAliasDeclaration
   | ReturnStatement
   | SwitchStatement
   | ThrowStatement
@@ -1077,7 +1074,7 @@ export interface JSXOpeningElement extends BaseNode {
   typeParameters?: TSTypeParameterInstantiation;
   selfClosing: boolean;
   name: JSXTagNameExpression;
-  attributes: JSXAttribute[];
+  attributes: (JSXAttribute | JSXSpreadAttribute)[];
 }
 
 export interface JSXOpeningFragment extends BaseNode {
@@ -1168,7 +1165,7 @@ export interface ObjectPattern extends BaseNode {
 
 export interface Program extends BaseNode {
   type: AST_NODE_TYPES.Program;
-  body: ProgramStatement[];
+  body: Statement[];
   sourceType: 'module' | 'script';
   comments?: Comment[];
   tokens?: Token[];
@@ -1186,7 +1183,7 @@ export interface PropertyNonComputedName extends PropertyBase {
 
 export interface RegExpLiteral extends LiteralBase {
   type: AST_NODE_TYPES.Literal;
-  value: RegExp;
+  value: RegExp | null;
 }
 
 export interface RestElement extends BaseNode {
@@ -1269,7 +1266,7 @@ export interface TryStatement extends BaseNode {
   type: AST_NODE_TYPES.TryStatement;
   block: BlockStatement;
   handler: CatchClause | null;
-  finalizer: BlockStatement;
+  finalizer: BlockStatement | null;
 }
 
 export interface TSAbstractClassPropertyComputedName
@@ -1496,13 +1493,13 @@ export interface TSMethodSignatureNonComputedName
 
 export interface TSModuleBlock extends BaseNode {
   type: AST_NODE_TYPES.TSModuleBlock;
-  body: ProgramStatement[];
+  body: Statement[];
 }
 
 export interface TSModuleDeclaration extends BaseNode {
   type: AST_NODE_TYPES.TSModuleDeclaration;
   id: Identifier | Literal;
-  body?: TSModuleBlock;
+  body?: TSModuleBlock | TSModuleDeclaration;
   global?: boolean;
   declare?: boolean;
   modifiers?: Modifier[];

--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -462,7 +462,7 @@ export type PrimaryExpression =
   | TemplateLiteral
   | ThisExpression
   | TSNullKeyword;
-/** @deprecated TODO: re-align this with EStree spec in next major release */
+/** TODO: re-align this with EStree spec in next major release */
 export type ProgramStatement = Statement;
 export type Property = PropertyComputedName | PropertyNonComputedName;
 export type PropertyName = PropertyNameComputed | PropertyNameNonComputed;

--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -462,7 +462,7 @@ export type PrimaryExpression =
   | TemplateLiteral
   | ThisExpression
   | TSNullKeyword;
-/** @deprecated TODO: delete this in next major release */
+/** @deprecated TODO: re-align this with EStree spec in next major release */
 export type ProgramStatement = Statement;
 export type Property = PropertyComputedName | PropertyNonComputedName;
 export type PropertyName = PropertyNameComputed | PropertyNameNonComputed;

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1921,7 +1921,7 @@ export class Converter {
       // Literals
 
       case SyntaxKind.StringLiteral: {
-        return this.createNode<TSESTree.Literal>(node, {
+        return this.createNode<TSESTree.StringLiteral>(node, {
           type: AST_NODE_TYPES.Literal,
           value:
             parent.kind === SyntaxKind.JsxAttribute
@@ -1932,7 +1932,7 @@ export class Converter {
       }
 
       case SyntaxKind.NumericLiteral: {
-        return this.createNode<TSESTree.Literal>(node, {
+        return this.createNode<TSESTree.NumericLiteral>(node, {
           type: AST_NODE_TYPES.Literal,
           value: Number(node.text),
           raw: node.getText(),
@@ -1969,7 +1969,7 @@ export class Converter {
           regex = null;
         }
 
-        return this.createNode<TSESTree.Literal>(node, {
+        return this.createNode<TSESTree.RegExpLiteral>(node, {
           type: AST_NODE_TYPES.Literal,
           value: regex,
           raw: node.text,
@@ -1981,14 +1981,14 @@ export class Converter {
       }
 
       case SyntaxKind.TrueKeyword:
-        return this.createNode<TSESTree.Literal>(node, {
+        return this.createNode<TSESTree.BooleanLiteral>(node, {
           type: AST_NODE_TYPES.Literal,
           value: true,
           raw: 'true',
         });
 
       case SyntaxKind.FalseKeyword:
-        return this.createNode<TSESTree.Literal>(node, {
+        return this.createNode<TSESTree.BooleanLiteral>(node, {
           type: AST_NODE_TYPES.Literal,
           value: false,
           raw: 'false',
@@ -2002,7 +2002,7 @@ export class Converter {
           });
         }
 
-        return this.createNode<TSESTree.Literal>(node, {
+        return this.createNode<TSESTree.NullLiteral>(node, {
           type: AST_NODE_TYPES.Literal,
           value: null,
           raw: 'null',

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1932,7 +1932,7 @@ export class Converter {
       }
 
       case SyntaxKind.NumericLiteral: {
-        return this.createNode<TSESTree.NumericLiteral>(node, {
+        return this.createNode<TSESTree.NumberLiteral>(node, {
           type: AST_NODE_TYPES.Literal,
           value: Number(node.text),
           raw: node.getText(),


### PR DESCRIPTION
Those changes has been extracted from #3078

fixes #2912

### `ProgramStatement` and `Statement` nodes can contain same set of nodes
```ts
if (x) export {x}
if (x) import test from 'x'
// -----
for (x in foo) {
  export {x}
}
// -----
function test (x: string) {
  export {x}
}
```

### `LeftHandSideExpression` can be a `AwaitExpression`
```ts
const a = ++(await x)
```

### `TryStatement` finalizer can be `null`
```ts
try {} catch {}
```

### `RegExpLiteral` value can be `null` if regexp is invalid or unsupported by env
good example in this case can be any proposal that has not been accepted yet 
eg. https://github.com/tc39/proposal-regexp-match-indices
```tsx
const x = /a+(?<Z>z)?/d
```

### `JSXOpeningElement` attributes can be a `JSXSpreadAttribute`
```ts
const foo = <x {...spread}></x>
```

### `TSModuleDeclaration` body can be `TSModuleDeclaration`
```ts
// TSModuleDeclaration without body
module "x";
// TSModuleDeclaration -> TSModuleBlock
module x {
}
// TSModuleDeclaration -> TSModuleDeclaration **
module x.x {
}
```
