### PR TITLE
refactor(typescript-estree): simplify applyModifiersToResult

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -580,13 +580,13 @@ export class Converter {
     if (!modifiers || !modifiers.length) {
       return;
     }
+    const remainingModifiers: TSESTree.Modifier[] = [];
     /**
      * Some modifiers are explicitly handled by applying them as
      * boolean values on the result node. As well as adding them
      * to the result, we remove them from the array, so that they
      * are not handled twice.
      */
-    const handledModifierIndices: { [key: number]: boolean } = {};
     for (let i = 0; i < modifiers.length; i++) {
       const modifier = modifiers[i];
       switch (modifier.kind) {
@@ -596,17 +596,16 @@ export class Converter {
          */
         case SyntaxKind.ExportKeyword:
         case SyntaxKind.DefaultKeyword:
-          handledModifierIndices[i] = true;
           break;
         case SyntaxKind.ConstKeyword:
           (result as any).const = true;
-          handledModifierIndices[i] = true;
           break;
         case SyntaxKind.DeclareKeyword:
           result.declare = true;
-          handledModifierIndices[i] = true;
           break;
         default:
+          remainingModifiers.push(this.convertChild(modifier));
+          break;
       }
     }
     /**
@@ -614,13 +613,9 @@ export class Converter {
      * not been explicitly handled above, we just convert and
      * add the modifiers array to the result node.
      */
-    const remainingModifiers = modifiers.filter(
-      (_, i) => !handledModifierIndices[i],
-    );
-    if (!remainingModifiers || !remainingModifiers.length) {
-      return;
+    if (remainingModifiers.length) {
+      result.modifiers = remainingModifiers;
     }
-    result.modifiers = remainingModifiers.map(el => this.convertChild(el));
   }
 
   /**


### PR DESCRIPTION
Those changes has been extracted from #3078

simplifies logic used to generate deprecated `modifiers` field in some of nodes. instead of iterating over nodes collecting results, filtering them and mapping them again we perform entire operation in first loop

this change has negligible perf improvement