### PR TITLE
chore: explicitly define required types in tsconfig to speed up build

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,22 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2017",
-    "lib": ["es2017"]
+    "lib": ["es2017"],
+    "types": [
+      "@babel/code-frame",
+      "debug",
+      "eslint-visitor-keys",
+      "glob",
+      "is-glob",
+      "jest",
+      "jest-specific-snapshot",
+      "lodash",
+      "marked",
+      "node",
+      "prettier",
+      "rimraf",
+      "semver",
+      "tmp"
+    ]
   }
 }


### PR DESCRIPTION
By explicitly defining types in tsconfig build/typecheck/eslint time is reduced by ~7-11%

as example for yarn typecheck without this option on my machine it takes ~36-39s to finish it and ~30-32s