### PR TITLE
docs: FAQ: update prettier config for v8

### DIFF
--- a/docs/getting-started/linting/README.md
+++ b/docs/getting-started/linting/README.md
@@ -132,7 +132,6 @@ Using this config is as simple as adding it to the end of your `extends`:
       'eslint:recommended',
       'plugin:@typescript-eslint/recommended',
 +     'prettier',
-+     'prettier/@typescript-eslint',
     ],
   };
 ```

--- a/docs/getting-started/linting/README.md
+++ b/docs/getting-started/linting/README.md
@@ -121,6 +121,8 @@ If you use [`prettier`](https://www.npmjs.com/package/prettier), there is also a
 
 Using this config is as simple as adding it to the end of your `extends`:
 
+> Note: [Since version `8.0.0` of eslint-config-prettier](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21), all you need to extend is `'prettier'`. That includes all plugins. Otherwise for `<8.0.0`, you need include `'prettier/@typescript-eslint'`.
+
 ```diff
   module.exports = {
     root: true,

--- a/docs/getting-started/linting/README.md
+++ b/docs/getting-started/linting/README.md
@@ -121,7 +121,7 @@ If you use [`prettier`](https://www.npmjs.com/package/prettier), there is also a
 
 Using this config is as simple as adding it to the end of your `extends`:
 
-> Note: [Since version `8.0.0` of eslint-config-prettier](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21), all you need to extend is `'prettier'`. That includes all plugins. Otherwise for `<8.0.0`, you need include `'prettier/@typescript-eslint'`.
+> Note: [Since version `8.0.0` of `eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21), all you need to extend is `'prettier'`. That includes all plugins. Otherwise for `<8.0.0`, you need include `'prettier/@typescript-eslint'`.
 
 ```diff
   module.exports = {


### PR DESCRIPTION
#### What's changed

Prettier config has since been merged into one, hence `prettier/@typescript-eslint` is deprecated/removed from latest release. All you need to do is declare `prettier` now.

https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21

#### Why should this be merged

While installing typescript-eslint for a new project, I wasted a few minutes trying to look find where is this `prettier/@typescript-eslint` to install.