### PR TITLE
fix(eslint-plugin): [no-unused-vars] don't report nested module declaration

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -264,6 +264,23 @@ export default util.createRule<Options, MessageIds>({
         markDeclarationChildAsUsed(node);
       },
 
+      // module declaration in module declaration should not report unused vars error
+      // this is workaround as this change should be done in better way
+      'TSModuleDeclaration > TSModuleDeclaration'(
+        node: TSESTree.TSModuleDeclaration,
+      ): void {
+        if (node.id.type === AST_NODE_TYPES.Identifier) {
+          let scope = context.getScope();
+          if (scope.upper) {
+            scope = scope.upper;
+          }
+          const superVar = scope.set.get(node.id.name);
+          if (superVar) {
+            superVar.eslintUsed = true;
+          }
+        }
+      },
+
       // children of a namespace that is a child of a declared namespace are auto-exported
       [ambientDeclarationSelector(
         'TSModuleDeclaration[declare = true] > TSModuleBlock TSModuleDeclaration > TSModuleBlock',

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -690,6 +690,13 @@ export namespace Foo {
   export const item: Foo = 1;
 }
     `,
+    `
+export namespace foo.bar {
+  export interface User {
+    name: string;
+  }
+}
+    `,
     // exported self-referencing types
     `
 export interface Foo {


### PR DESCRIPTION
This is workaround over bug in no-unused-vars as proper change will be a breaking change and can't be done as fix

fixes #2573