### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] handle assignment

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -135,7 +135,26 @@ export default util.createRule<Options, MessageIds>({
 
     return {
       TSNonNullExpression(node): void {
+        if (
+          node.parent?.type === AST_NODE_TYPES.AssignmentExpression &&
+          node.parent?.operator === '=' &&
+          node.parent.left === node
+        ) {
+          context.report({
+            node,
+            messageId: 'contextuallyUnnecessary',
+            fix(fixer) {
+              return fixer.removeRange([
+                node.expression.range[1],
+                node.range[1],
+              ]);
+            },
+          });
+          return;
+        }
+
         const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+
         const type = util.getConstrainedTypeAtLocation(
           checker,
           originalNode.expression,

--- a/packages/eslint-plugin/src/util/types.ts
+++ b/packages/eslint-plugin/src/util/types.ts
@@ -11,6 +11,7 @@ import {
   isVariableDeclaration,
   unionTypeParts,
   isPropertyAssignment,
+  isBinaryExpression,
 } from 'tsutils';
 import * as ts from 'typescript';
 
@@ -498,6 +499,13 @@ export function getContextualType(
     return checker.getContextualType(parent);
   } else if (isPropertyAssignment(parent) && isIdentifier(node)) {
     return checker.getContextualType(node);
+  } else if (
+    isBinaryExpression(parent) &&
+    parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    parent.right === node
+  ) {
+    // is RHS of assignment
+    return checker.getTypeAtLocation(parent.left);
   } else if (
     ![ts.SyntaxKind.TemplateSpan, ts.SyntaxKind.JsxExpression].includes(
       parent.kind,

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -186,6 +186,22 @@ const c = <const>[...a, ...b];
     {
       code: "const a = <const>{ foo: 'foo' };",
     },
+    {
+      code: `
+let a: number | undefined;
+let b: number | undefined;
+let c: number;
+a = b;
+c = b!;
+a! -= 1;
+      `,
+    },
+    {
+      code: `
+let a: { b?: string } | undefined;
+a!.b = '';
+      `,
+    },
   ],
 
   invalid: [
@@ -450,6 +466,30 @@ function Test(props: { id?: string | number }) {
         },
       ],
       filename: 'react.tsx',
+    },
+    {
+      code: `
+let x: number | undefined;
+let y: number | undefined;
+y = x!;
+y! = 0;
+      `,
+      output: `
+let x: number | undefined;
+let y: number | undefined;
+y = x;
+y = 0;
+      `,
+      errors: [
+        {
+          messageId: 'contextuallyUnnecessary',
+          line: 4,
+        },
+        {
+          messageId: 'contextuallyUnnecessary',
+          line: 5,
+        },
+      ],
     },
   ],
 });


### PR DESCRIPTION
should fix #2953

This is an aggressive move, but I don't why we don't use getContextualType directly. All current tests have passed. If this is feasible, I can add more test cases.