### PR TITLE
feat(eslint-plugin): [type-annotation-spacing] handle space between ? and :

### DIFF
--- a/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
+++ b/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
@@ -177,6 +177,25 @@ export default util.createRule<Options, MessageIds>({
       const { before, after } = getRules(ruleSet, typeAnnotation);
 
       if (type === ':' && previousToken.value === '?') {
+        if (
+          !before &&
+          sourceCode.isSpaceBetween!(previousToken, punctuatorTokenStart)
+        ) {
+          context.report({
+            node: punctuatorTokenStart,
+            messageId: 'unexpectedSpaceBefore',
+            data: {
+              type,
+            },
+            fix(fixer) {
+              return fixer.removeRange([
+                previousToken.range[1],
+                punctuatorTokenStart.range[0],
+              ]);
+            },
+          });
+        }
+
         // shift the start to the ?
         type = '?:';
         punctuatorTokenStart = previousToken;

--- a/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
+++ b/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
@@ -177,10 +177,7 @@ export default util.createRule<Options, MessageIds>({
       const { before, after } = getRules(ruleSet, typeAnnotation);
 
       if (type === ':' && previousToken.value === '?') {
-        if (
-          !before &&
-          sourceCode.isSpaceBetween!(previousToken, punctuatorTokenStart)
-        ) {
+        if (sourceCode.isSpaceBetween!(previousToken, punctuatorTokenStart)) {
           context.report({
             node: punctuatorTokenStart,
             messageId: 'unexpectedSpaceBefore',

--- a/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
+++ b/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
@@ -180,7 +180,9 @@ export default util.createRule<Options, MessageIds>({
       const { before, after } = getRules(ruleSet, typeAnnotation);
 
       if (type === ':' && previousToken.value === '?') {
-        if (sourceCode.isSpaceBetween!(previousToken, punctuatorTokenStart)) {
+        if (
+          sourceCode.isSpaceBetweenTokens(previousToken, punctuatorTokenStart)
+        ) {
           context.report({
             node: punctuatorTokenStart,
             messageId: 'unexpectedSpaceBetween',

--- a/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
+++ b/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
@@ -35,7 +35,8 @@ type MessageIds =
   | 'expectedSpaceAfter'
   | 'expectedSpaceBefore'
   | 'unexpectedSpaceAfter'
-  | 'unexpectedSpaceBefore';
+  | 'unexpectedSpaceBefore'
+  | 'unexpectedSpaceBetween';
 
 const definition = {
   type: 'object',
@@ -122,6 +123,8 @@ export default util.createRule<Options, MessageIds>({
       expectedSpaceBefore: "Expected a space before the '{{type}}'.",
       unexpectedSpaceAfter: "Unexpected space after the '{{type}}'.",
       unexpectedSpaceBefore: "Unexpected space before the '{{type}}'.",
+      unexpectedSpaceBetween:
+        "Unexpected space between the '{{previousToken}}' and the '{{type}}'.",
     },
     schema: [
       {
@@ -180,9 +183,10 @@ export default util.createRule<Options, MessageIds>({
         if (sourceCode.isSpaceBetween!(previousToken, punctuatorTokenStart)) {
           context.report({
             node: punctuatorTokenStart,
-            messageId: 'unexpectedSpaceBefore',
+            messageId: 'unexpectedSpaceBetween',
             data: {
               type,
+              previousToken: previousToken.value,
             },
             fix(fixer) {
               return fixer.removeRange([

--- a/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
@@ -315,10 +315,6 @@ type Foo = {
       options: [{ after: true, before: true }],
     },
     {
-      code: 'function foo(a ? : string) {}',
-      options: [{ after: true, before: true }],
-    },
-    {
       code: `
 class Foo {
     name : string;
@@ -4754,6 +4750,32 @@ interface Foo {
           data: { type: '?:' },
           line: 3,
           column: 10,
+        },
+      ],
+    },
+    {
+      code: `
+interface Foo {
+    name ? : string;
+}
+      `,
+      output: `
+interface Foo {
+    name?: string;
+}
+      `,
+      errors: [
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { type: '?:' },
+          line: 3,
+          column: 10,
+        },
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { type: ':' },
+          line: 3,
+          column: 12,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
@@ -315,6 +315,10 @@ type Foo = {
       options: [{ after: true, before: true }],
     },
     {
+      code: 'function foo(a ? : string) {}',
+      options: [{ after: true, before: true }],
+    },
+    {
       code: `
 class Foo {
     name : string;
@@ -4594,6 +4598,54 @@ type Bar = Record<keyof Foo, string>
       ],
     },
     {
+      code: 'function foo(a? : string) {}',
+      output: 'function foo(a?: string) {}',
+      errors: [
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { type: ':' },
+          line: 1,
+          column: 17,
+        },
+      ],
+    },
+    {
+      code: 'function foo(a ? : string) {}',
+      output: 'function foo(a?: string) {}',
+      errors: [
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { type: '?:' },
+          line: 1,
+          column: 16,
+        },
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { type: ':' },
+          line: 1,
+          column: 18,
+        },
+      ],
+    },
+    {
+      code: 'function foo(a ?  : string) {}',
+      output: 'function foo(a?: string) {}',
+      errors: [
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { type: '?:' },
+          line: 1,
+          column: 16,
+        },
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { type: ':' },
+          line: 1,
+          column: 19,
+        },
+      ],
+    },
+    {
       code: `
 class Foo {
     name ?: string;
@@ -4630,6 +4682,32 @@ class Foo {
           data: { type: '?:' },
           line: 3,
           column: 25,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+    constructor(message ? : string);
+}
+      `,
+      output: `
+class Foo {
+    constructor(message?: string);
+}
+      `,
+      errors: [
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { type: '?:' },
+          line: 3,
+          column: 25,
+        },
+        {
+          messageId: 'unexpectedSpaceBefore',
+          data: { type: ':' },
+          line: 3,
+          column: 27,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
@@ -4598,8 +4598,8 @@ type Bar = Record<keyof Foo, string>
       output: 'function foo(a?: string) {}',
       errors: [
         {
-          messageId: 'unexpectedSpaceBefore',
-          data: { type: ':' },
+          messageId: 'unexpectedSpaceBetween',
+          data: { type: ':', previousToken: '?' },
           line: 1,
           column: 17,
         },
@@ -4616,8 +4616,8 @@ type Bar = Record<keyof Foo, string>
           column: 16,
         },
         {
-          messageId: 'unexpectedSpaceBefore',
-          data: { type: ':' },
+          messageId: 'unexpectedSpaceBetween',
+          data: { type: ':', previousToken: '?' },
           line: 1,
           column: 18,
         },
@@ -4634,8 +4634,8 @@ type Bar = Record<keyof Foo, string>
           column: 16,
         },
         {
-          messageId: 'unexpectedSpaceBefore',
-          data: { type: ':' },
+          messageId: 'unexpectedSpaceBetween',
+          data: { type: ':', previousToken: '?' },
           line: 1,
           column: 19,
         },
@@ -4700,8 +4700,8 @@ class Foo {
           column: 25,
         },
         {
-          messageId: 'unexpectedSpaceBefore',
-          data: { type: ':' },
+          messageId: 'unexpectedSpaceBetween',
+          data: { type: ':', previousToken: '?' },
           line: 3,
           column: 27,
         },
@@ -4772,8 +4772,8 @@ interface Foo {
           column: 10,
         },
         {
-          messageId: 'unexpectedSpaceBefore',
-          data: { type: ':' },
+          messageId: 'unexpectedSpaceBetween',
+          data: { type: ':', previousToken: '?' },
           line: 3,
           column: 12,
         },


### PR DESCRIPTION
Fixes type-annotation-spacing rule to give an error if there is a space between `?` and `:` in a type annotation.

Fixes #3140