### PR TITLE
Fix incorrect example on no-use-before-define.md

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-use-before-define.md
+++ b/packages/eslint-plugin/docs/rules/no-use-before-define.md
@@ -42,10 +42,10 @@ const defaultOptions: Options = {
 If this is `true`, this rule warns every reference to a enum before the enum declaration.
 If this is `false`, this rule will ignore references to enums, when the reference is in a child scope.
 
-Examples of **incorrect** code for the `{ "enums": false }` option:
+Examples of **incorrect** code for the `{ "enums": true }` option:
 
 ```ts
-/*eslint no-use-before-define: ["error", { "enums": false }]*/
+/*eslint no-use-before-define: ["error", { "enums": true }]*/
 
 const x = Foo.FOO;
 


### PR DESCRIPTION
In the "enums" section of the documentation its using the same example both times for the correct and incorrect example, I have updated the example so the rule "enums" is set to true, so the example will be incorrect usage as is stated.