### PR TITLE
fix(eslint-plugin): [promise-function-async] bad fixer with computed and literal methods

### DIFF
--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -3,7 +3,6 @@ import {
   AST_TOKEN_TYPES,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
-import { last } from 'lodash';
 import * as ts from 'typescript';
 import * as util from '../util';
 
@@ -161,7 +160,7 @@ export default util.createRule<Options, MessageIds>({
             // this function is a class method or object function property shorthand
             const method = node.parent;
 
-            /** the token to put `async` before */
+            // the token to put `async` before
             let keyToken = sourceCode.getFirstToken(method)!;
 
             // if there are decorators then skip past them
@@ -169,7 +168,8 @@ export default util.createRule<Options, MessageIds>({
               method.type === AST_NODE_TYPES.MethodDefinition &&
               method.decorators
             ) {
-              const lastDecorator = last(method.decorators)!;
+              const lastDecorator =
+                method.decorators[method.decorators.length - 1];
               keyToken = sourceCode.getTokenAfter(lastDecorator)!;
             }
 

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -169,28 +169,20 @@ export default util.createRule<Options, MessageIds>({
               method.type === AST_NODE_TYPES.MethodDefinition &&
               method.decorators
             ) {
-              const lastDecorator = last(method.decorators);
-              if (lastDecorator) {
-                keyToken = sourceCode.getTokenAfter(lastDecorator)!;
-              }
+              const lastDecorator = last(method.decorators)!;
+              keyToken = sourceCode.getTokenAfter(lastDecorator)!;
             }
 
             // if current token is a keyword like `static` or `public` then skip it
-            while (keyToken?.type === AST_TOKEN_TYPES.Keyword) {
+            while (keyToken.type === AST_TOKEN_TYPES.Keyword) {
               keyToken = sourceCode.getTokenAfter(keyToken)!;
             }
 
             // check if there is a space between key and previous token
-            let insertSpace = false;
-            if (keyToken) {
-              const beforeKeyToken = sourceCode.getTokenBefore(keyToken);
-              if (beforeKeyToken) {
-                insertSpace = !sourceCode.isSpaceBetween!(
-                  beforeKeyToken,
-                  keyToken,
-                );
-              }
-            }
+            const insertSpace = !sourceCode.isSpaceBetween!(
+              sourceCode.getTokenBefore(keyToken)!,
+              keyToken,
+            );
 
             let code = 'async ';
             if (insertSpace) {

--- a/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
+++ b/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
@@ -1,3 +1,4 @@
+import { noFormat } from '@typescript-eslint/experimental-utils/src/eslint-utils';
 import rule from '../../src/rules/promise-function-async';
 import { getFixturesRootDir, RuleTester } from '../RuleTester';
 
@@ -629,6 +630,41 @@ class Test {
   @decorator
   public async test() {
     return Promise.resolve(123);
+  }
+}
+      `,
+    },
+    {
+      code: noFormat`
+class Test {
+  @decorator(async () => {})
+  static protected[(1)]() {
+    return Promise.resolve(1);
+  }
+  public'bar'() {
+    return Promise.resolve(2);
+  }
+  private['baz']() {
+    return Promise.resolve(3);
+  }
+}
+      `,
+      errors: [
+        { line: 4, column: 3, messageId },
+        { line: 7, column: 3, messageId },
+        { line: 10, column: 3, messageId },
+      ],
+      output: noFormat`
+class Test {
+  @decorator(async () => {})
+  static protected async [(1)]() {
+    return Promise.resolve(1);
+  }
+  public async 'bar'() {
+    return Promise.resolve(2);
+  }
+  private async ['baz']() {
+    return Promise.resolve(3);
   }
 }
       `,


### PR DESCRIPTION
- Fixer for `public"foo"() {}` now adds a space so it doesn't become `publicasync "foo"() {}`
- Fixer for `["computed"]() {}` now inserts async in the correct position instead of `[async "computed"]() {}`