### PR TITLE
feat(eslint-plugin): [object-curly-spacing] support MappedType

### DIFF
--- a/packages/eslint-plugin/src/rules/object-curly-spacing.ts
+++ b/packages/eslint-plugin/src/rules/object-curly-spacing.ts
@@ -63,7 +63,7 @@ export default createRule<Options, MessageIds>({
      * @param token The token to use for the report.
      */
     function reportNoBeginningSpace(
-      node: TSESTree.TSTypeLiteral,
+      node: TSESTree.TSMappedType | TSESTree.TSTypeLiteral,
       token: TSESTree.Token,
     ): void {
       const nextToken = context
@@ -89,7 +89,7 @@ export default createRule<Options, MessageIds>({
      * @param token The token to use for the report.
      */
     function reportNoEndingSpace(
-      node: TSESTree.TSTypeLiteral,
+      node: TSESTree.TSMappedType | TSESTree.TSTypeLiteral,
       token: TSESTree.Token,
     ): void {
       const previousToken = context
@@ -115,7 +115,7 @@ export default createRule<Options, MessageIds>({
      * @param token The token to use for the report.
      */
     function reportRequiredBeginningSpace(
-      node: TSESTree.TSTypeLiteral,
+      node: TSESTree.TSMappedType | TSESTree.TSTypeLiteral,
       token: TSESTree.Token,
     ): void {
       context.report({
@@ -137,7 +137,7 @@ export default createRule<Options, MessageIds>({
      * @param token The token to use for the report.
      */
     function reportRequiredEndingSpace(
-      node: TSESTree.TSTypeLiteral,
+      node: TSESTree.TSMappedType | TSESTree.TSTypeLiteral,
       token: TSESTree.Token,
     ): void {
       context.report({
@@ -162,7 +162,7 @@ export default createRule<Options, MessageIds>({
      * @param last The last token to check (should be closing brace)
      */
     function validateBraceSpacing(
-      node: TSESTree.TSTypeLiteral,
+      node: TSESTree.TSMappedType | TSESTree.TSTypeLiteral,
       first: TSESTree.Token,
       second: TSESTree.Token | TSESTree.Comment,
       penultimate: TSESTree.Token | TSESTree.Comment,
@@ -175,7 +175,10 @@ export default createRule<Options, MessageIds>({
 
         const openingCurlyBraceMustBeSpaced =
           options.arraysInObjectsException &&
-          secondType === AST_NODE_TYPES.TSIndexSignature
+          [
+            AST_NODE_TYPES.TSMappedType,
+            AST_NODE_TYPES.TSIndexSignature,
+          ].includes(secondType)
             ? !options.spaced
             : options.spaced;
 
@@ -197,15 +200,19 @@ export default createRule<Options, MessageIds>({
             isClosingBracketToken(penultimate)) ||
           (options.objectsInObjectsException &&
             isClosingBraceToken(penultimate));
-        const penultimateType =
-          shouldCheckPenultimate &&
-          sourceCode.getNodeByRangeIndex(penultimate.range[0])!.type;
+        const penultimateType = shouldCheckPenultimate
+          ? sourceCode.getNodeByRangeIndex(penultimate.range[0])!.type
+          : undefined;
 
         const closingCurlyBraceMustBeSpaced =
           (options.arraysInObjectsException &&
             penultimateType === AST_NODE_TYPES.TSTupleType) ||
           (options.objectsInObjectsException &&
-            penultimateType === AST_NODE_TYPES.TSTypeLiteral)
+            penultimateType !== undefined &&
+            [
+              AST_NODE_TYPES.TSMappedType,
+              AST_NODE_TYPES.TSTypeLiteral,
+            ].includes(penultimateType))
             ? !options.spaced
             : options.spaced;
 
@@ -246,6 +253,18 @@ export default createRule<Options, MessageIds>({
     const rules = baseRule.create(context);
     return {
       ...rules,
+      TSMappedType(node: TSESTree.TSMappedType): void {
+        const first = sourceCode.getFirstToken(node)!;
+        const last = sourceCode.getLastToken(node)!;
+        const second = sourceCode.getTokenAfter(first, {
+          includeComments: true,
+        })!;
+        const penultimate = sourceCode.getTokenBefore(last, {
+          includeComments: true,
+        })!;
+
+        validateBraceSpacing(node, first, second, penultimate, last);
+      },
       TSTypeLiteral(node: TSESTree.TSTypeLiteral): void {
         if (node.members.length === 0) {
           return;

--- a/packages/eslint-plugin/tests/rules/object-curly-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/object-curly-spacing.test.ts
@@ -570,6 +570,71 @@ ruleTester.run('object-curly-spacing', rule, {
       code: 'const x:{[key: string]: [number]}',
     },
 
+    // default - mapped types
+    {
+      code: "const x:{[k in 'union']: number}",
+    },
+    {
+      code: "const x:{ // line-comment\n[k in 'union']: number\n}",
+    },
+    {
+      code: "const x:{// line-comment\n[k in 'union']: number\n}",
+    },
+    {
+      code:
+        "const x:{/* inline-comment */[k in 'union']: number/* inline-comment */}",
+    },
+    {
+      code: "const x:{\n[k in 'union']: number\n}",
+    },
+    {
+      code: "const x:{[k in 'union']: {[k in 'union']: number}}",
+    },
+    {
+      code: "const x:{[k in 'union']: [number]}",
+    },
+    {
+      code: "const x:{[k in 'union']: value}",
+    },
+
+    // never - mapped types
+    {
+      code: "const x:{[k in 'union']: {[k in 'union']: number} }",
+      options: ['never', { objectsInObjects: true }],
+    },
+    {
+      code: "const x:{[k in 'union']: {[k in 'union']: number}}",
+      options: ['never', { objectsInObjects: false }],
+    },
+    {
+      code: "const x:{[k in 'union']: () => {[k in 'union']: number} }",
+      options: ['never', { objectsInObjects: true }],
+    },
+    {
+      code: "const x:{[k in 'union']: () => {[k in 'union']: number}}",
+      options: ['never', { objectsInObjects: false }],
+    },
+    {
+      code: "const x:{[k in 'union']: [ number ]}",
+      options: ['never', { arraysInObjects: false }],
+    },
+    {
+      code: "const x:{ [k in 'union']: value}",
+      options: ['never', { arraysInObjects: true }],
+    },
+    {
+      code: "const x:{[k in 'union']: value}",
+      options: ['never', { arraysInObjects: false }],
+    },
+    {
+      code: "const x:{ [k in 'union']: [number] }",
+      options: ['never', { arraysInObjects: true }],
+    },
+    {
+      code: "const x:{[k in 'union']: [number]}",
+      options: ['never', { arraysInObjects: false }],
+    },
+
     // never - object literal types
     {
       code: 'const x:{f: {g: number} }',
@@ -612,6 +677,69 @@ ruleTester.run('object-curly-spacing', rule, {
       options: ['never', { arraysInObjects: false }],
     },
 
+    // always - mapped types
+    {
+      code: "const x:{ [k in 'union']: number }",
+      options: ['always'],
+    },
+    {
+      code: "const x:{ // line-comment\n[k in 'union']: number\n}",
+      options: ['always'],
+    },
+    {
+      code:
+        "const x:{ /* inline-comment */ [k in 'union']: number /* inline-comment */ }",
+      options: ['always'],
+    },
+    {
+      code: "const x:{\n[k in 'union']: number\n}",
+      options: ['always'],
+    },
+    {
+      code: "const x:{ [k in 'union']: [number] }",
+      options: ['always'],
+    },
+
+    // always - mapped types - objectsInObjects
+    {
+      code: "const x:{ [k in 'union']: { [k in 'union']: number } }",
+      options: ['always', { objectsInObjects: true }],
+    },
+    {
+      code: "const x:{ [k in 'union']: { [k in 'union']: number }}",
+      options: ['always', { objectsInObjects: false }],
+    },
+    {
+      code: "const x:{ [k in 'union']: () => { [k in 'union']: number } }",
+      options: ['always', { objectsInObjects: true }],
+    },
+    {
+      code: "const x:{ [k in 'union']: () => { [k in 'union']: number }}",
+      options: ['always', { objectsInObjects: false }],
+    },
+
+    // always - mapped types - arraysInObjects
+    {
+      code: "type x = { [k in 'union']: number }",
+      options: ['always'],
+    },
+    {
+      code: "const x:{ [k in 'union']: [number] }",
+      options: ['always', { arraysInObjects: true }],
+    },
+    {
+      code: "const x:{ [k in 'union']: value }",
+      options: ['always', { arraysInObjects: true }],
+    },
+    {
+      code: "const x:{[k in 'union']: value }",
+      options: ['always', { arraysInObjects: false }],
+    },
+    {
+      code: "const x:{[k in 'union']: [number]}",
+      options: ['always', { arraysInObjects: false }],
+    },
+
     // always - object literal types
     {
       code: 'const x:{}',
@@ -642,7 +770,7 @@ ruleTester.run('object-curly-spacing', rule, {
       options: ['always'],
     },
 
-    // always - objectsInObjects
+    // always - literal types - objectsInObjects
     {
       code: 'const x:{ f: { g: number } }',
       options: ['always', { objectsInObjects: true }],
@@ -660,7 +788,7 @@ ruleTester.run('object-curly-spacing', rule, {
       options: ['always', { objectsInObjects: false }],
     },
 
-    // always - arraysInObjects
+    // always - literal types - arraysInObjects
     {
       code: 'const x:{ f: [number] }',
       options: ['always', { arraysInObjects: true }],
@@ -1912,6 +2040,7 @@ ruleTester.run('object-curly-spacing', rule, {
     },
 
     // object literal types
+    // never - literal types
     {
       code: 'type x = { f: number }',
       output: 'type x = {f: number}',
@@ -1930,6 +2059,7 @@ ruleTester.run('object-curly-spacing', rule, {
       output: 'type x = {f: number}',
       errors: [{ messageId: 'unexpectedSpaceBefore' }],
     },
+    // always - literal types
     {
       code: 'type x = {f: number}',
       output: 'type x = { f: number }',
@@ -1950,6 +2080,59 @@ ruleTester.run('object-curly-spacing', rule, {
       output: 'type x = { f: number }',
       options: ['always'],
       errors: [{ messageId: 'requireSpaceBefore' }],
+    },
+
+    // never - mapped types
+    {
+      code: "type x = { [k in 'union']: number }",
+      output: "type x = {[k in 'union']: number}",
+      errors: [
+        { messageId: 'unexpectedSpaceAfter' },
+        { messageId: 'unexpectedSpaceBefore' },
+      ],
+    },
+    {
+      code: "type x = { [k in 'union']: number}",
+      output: "type x = {[k in 'union']: number}",
+      errors: [{ messageId: 'unexpectedSpaceAfter' }],
+    },
+    {
+      code: "type x = {[k in 'union']: number }",
+      output: "type x = {[k in 'union']: number}",
+      errors: [{ messageId: 'unexpectedSpaceBefore' }],
+    },
+    // always - mapped types
+    {
+      code: "type x = {[k in 'union']: number}",
+      output: "type x = { [k in 'union']: number }",
+      options: ['always'],
+      errors: [
+        { messageId: 'requireSpaceAfter' },
+        { messageId: 'requireSpaceBefore' },
+      ],
+    },
+    {
+      code: "type x = {[k in 'union']: number }",
+      output: "type x = { [k in 'union']: number }",
+      options: ['always'],
+      errors: [{ messageId: 'requireSpaceAfter' }],
+    },
+    {
+      code: "type x = { [k in 'union']: number}",
+      output: "type x = { [k in 'union']: number }",
+      options: ['always'],
+      errors: [{ messageId: 'requireSpaceBefore' }],
+    },
+    // Mapped and literal types mix
+    {
+      code: "type x = { [k in 'union']: { [k: string]: number } }",
+      output: "type x = {[k in 'union']: {[k: string]: number}}",
+      errors: [
+        { messageId: 'unexpectedSpaceAfter' },
+        { messageId: 'unexpectedSpaceAfter' },
+        { messageId: 'unexpectedSpaceBefore' },
+        { messageId: 'unexpectedSpaceBefore' },
+      ],
     },
   ],
 });


### PR DESCRIPTION
The rule did support not `MappedType` (`var d: {[k in 'union']: any}`).

This PR adds tests and support.

This fixes #3175.