### PR TITLE
fix(eslint-plugin): [member-delimiter-style] correct invalid fix for multiline with params on the same line

### DIFF
--- a/packages/eslint-plugin/src/rules/member-delimiter-style.ts
+++ b/packages/eslint-plugin/src/rules/member-delimiter-style.ts
@@ -142,6 +142,9 @@ export default util.createRule<Options, MessageIds>({
             },
             additionalProperties: false,
           },
+          multilineDetection: {
+            enum: ['brackets', 'last-member'],
+          },
         }),
         additionalProperties: false,
       },
@@ -157,6 +160,7 @@ export default util.createRule<Options, MessageIds>({
         delimiter: 'semi',
         requireLast: false,
       },
+      multilineDetection: 'brackets',
     },
   ],
   create(context, [options]) {

--- a/packages/eslint-plugin/src/rules/member-delimiter-style.ts
+++ b/packages/eslint-plugin/src/rules/member-delimiter-style.ts
@@ -2,6 +2,10 @@ import {
   TSESTree,
   AST_NODE_TYPES,
 } from '@typescript-eslint/experimental-utils';
+import {
+  RuleFix,
+  RuleFixer,
+} from '@typescript-eslint/experimental-utils/src/ts-eslint';
 import * as util from '../util';
 
 type Delimiter = 'comma' | 'none' | 'semi';
@@ -10,6 +14,9 @@ type Delimiter = 'comma' | 'none' | 'semi';
 type TypeOptions = {
   delimiter?: Delimiter;
   requireLast?: boolean;
+};
+type TypeOptionsWithType = TypeOptions & {
+  type: string;
 };
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type BaseOptions = {
@@ -21,7 +28,7 @@ type Config = BaseOptions & {
     typeLiteral?: BaseOptions;
     interface?: BaseOptions;
   };
-  multilineDetection?: 'brackets' | 'last-member';
+  multilineDetection?: string;
 };
 type Options = [Config];
 type MessageIds =
@@ -29,6 +36,18 @@ type MessageIds =
   | 'unexpectedSemi'
   | 'expectedComma'
   | 'expectedSemi';
+type LastTokenType = TSESTree.Token;
+
+interface MakeFixFunctionParams {
+  optsNone: boolean;
+  optsSemi: boolean;
+  lastToken: LastTokenType;
+  missingDelimiter: boolean;
+  lastTokenLine: string;
+  isSingleLine: boolean;
+}
+
+type MakeFixFunctionReturnType = ((fixer: RuleFixer) => RuleFix) | null;
 
 const definition = {
   type: 'object',
@@ -52,6 +71,47 @@ const definition = {
     },
   },
   additionalProperties: false,
+};
+
+const isLastTokenEndOfLine = (token: string, line: string): boolean => {
+  const positionInLine = line.indexOf(token);
+
+  return positionInLine === line.length - 1;
+};
+
+const makeFixFunction = ({
+  optsNone,
+  optsSemi,
+  lastToken,
+  missingDelimiter,
+  lastTokenLine,
+  isSingleLine,
+}: MakeFixFunctionParams): MakeFixFunctionReturnType => {
+  // if removing is the action but last token is not the end of the line
+  if (
+    optsNone &&
+    !isLastTokenEndOfLine(lastToken.value, lastTokenLine) &&
+    !isSingleLine
+  ) {
+    return null;
+  }
+
+  return (fixer: RuleFixer): RuleFix => {
+    if (optsNone) {
+      // remove the unneeded token
+      return fixer.remove(lastToken);
+    }
+
+    const token = optsSemi ? ';' : ',';
+
+    if (missingDelimiter) {
+      // add the missing delimiter
+      return fixer.insertTextAfter(lastToken, token);
+    }
+
+    // correct the current delimiter
+    return fixer.replaceText(lastToken, token);
+  };
 };
 
 export default util.createRule<Options, MessageIds>({
@@ -83,9 +143,6 @@ export default util.createRule<Options, MessageIds>({
             },
             additionalProperties: false,
           },
-          multilineDetection: {
-            enum: ['brackets', 'last-member'],
-          },
         }),
         additionalProperties: false,
       },
@@ -101,7 +158,6 @@ export default util.createRule<Options, MessageIds>({
         delimiter: 'semi',
         requireLast: false,
       },
-      multilineDetection: 'brackets',
     },
   ],
   create(context, [options]) {
@@ -127,7 +183,7 @@ export default util.createRule<Options, MessageIds>({
      */
     function checkLastToken(
       member: TSESTree.TypeElement,
-      opts: TypeOptions,
+      opts: TypeOptionsWithType,
       isLast: boolean,
     ): void {
       /**
@@ -147,9 +203,13 @@ export default util.createRule<Options, MessageIds>({
       const lastToken = sourceCode.getLastToken(member, {
         includeComments: false,
       });
+
       if (!lastToken) {
         return;
       }
+
+      const sourceCodeLines = sourceCode.getLines();
+      const lastTokenLine = sourceCodeLines[lastToken?.loc.start.line - 1];
 
       const optsSemi = getOption('semi');
       const optsComma = getOption('comma');
@@ -193,22 +253,14 @@ export default util.createRule<Options, MessageIds>({
             },
           },
           messageId,
-          fix(fixer) {
-            if (optsNone) {
-              // remove the unneeded token
-              return fixer.remove(lastToken);
-            }
-
-            const token = optsSemi ? ';' : ',';
-
-            if (missingDelimiter) {
-              // add the missing delimiter
-              return fixer.insertTextAfter(lastToken, token);
-            }
-
-            // correct the current delimiter
-            return fixer.replaceText(lastToken, token);
-          },
+          fix: makeFixFunction({
+            optsNone,
+            optsSemi,
+            lastToken,
+            missingDelimiter,
+            lastTokenLine,
+            isSingleLine: opts.type === 'single-line',
+          }),
         });
       }
     }
@@ -239,7 +291,9 @@ export default util.createRule<Options, MessageIds>({
         node.type === AST_NODE_TYPES.TSInterfaceBody
           ? interfaceOptions
           : typeLiteralOptions;
-      const opts = isSingleLine ? typeOpts.singleline : typeOpts.multiline;
+      const opts = isSingleLine
+        ? { ...typeOpts.singleline, type: 'single-line' }
+        : { ...typeOpts.multiline, type: 'multi-line' };
 
       members.forEach((member, index) => {
         checkLastToken(member, opts ?? {}, index === members.length - 1);

--- a/packages/eslint-plugin/src/rules/member-delimiter-style.ts
+++ b/packages/eslint-plugin/src/rules/member-delimiter-style.ts
@@ -1,11 +1,8 @@
 import {
+  TSESLint,
   TSESTree,
   AST_NODE_TYPES,
 } from '@typescript-eslint/experimental-utils';
-import {
-  RuleFix,
-  RuleFixer,
-} from '@typescript-eslint/experimental-utils/src/ts-eslint';
 import * as util from '../util';
 
 type Delimiter = 'comma' | 'none' | 'semi';
@@ -47,7 +44,9 @@ interface MakeFixFunctionParams {
   isSingleLine: boolean;
 }
 
-type MakeFixFunctionReturnType = ((fixer: RuleFixer) => RuleFix) | null;
+type MakeFixFunctionReturnType =
+  | ((fixer: TSESLint.RuleFixer) => TSESLint.RuleFix)
+  | null;
 
 const definition = {
   type: 'object',
@@ -96,7 +95,7 @@ const makeFixFunction = ({
     return null;
   }
 
-  return (fixer: RuleFixer): RuleFix => {
+  return (fixer: TSESLint.RuleFixer): TSESLint.RuleFix => {
     if (optsNone) {
       // remove the unneeded token
       return fixer.remove(lastToken);

--- a/packages/eslint-plugin/src/rules/member-delimiter-style.ts
+++ b/packages/eslint-plugin/src/rules/member-delimiter-style.ts
@@ -28,7 +28,7 @@ type Config = BaseOptions & {
     typeLiteral?: BaseOptions;
     interface?: BaseOptions;
   };
-  multilineDetection?: string;
+  multilineDetection?: 'last-member';
 };
 type Options = [Config];
 type MessageIds =

--- a/packages/eslint-plugin/src/rules/member-delimiter-style.ts
+++ b/packages/eslint-plugin/src/rules/member-delimiter-style.ts
@@ -25,7 +25,7 @@ type Config = BaseOptions & {
     typeLiteral?: BaseOptions;
     interface?: BaseOptions;
   };
-  multilineDetection?: 'last-member';
+  multilineDetection?: 'brackets' | 'last-member';
 };
 type Options = [Config];
 type MessageIds =

--- a/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
@@ -851,6 +851,24 @@ interface Foo {
     },
     {
       code: `
+type Test = {
+  a: {
+      one: 1
+  }; b: 2
+};
+      `,
+      output: null,
+      options: [{ multiline: { delimiter: 'none' } }],
+      errors: [
+        {
+          messageId: 'unexpectedSemi',
+          line: 5,
+          column: 5,
+        },
+      ],
+    },
+    {
+      code: `
 interface Foo {
     name: string
     age: number

--- a/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
@@ -705,6 +705,75 @@ type Bar = {
         },
       ],
     },
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+}};
+      `,
+      options: [
+        {
+          multilineDetection: 'last-member',
+        },
+      ],
+    },
+    `
+type Foo = {a: {
+  b: true;
+};};
+    `,
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+};};
+      `,
+      options: [
+        {
+          multilineDetection: 'brackets',
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {
+  a: {
+    b: true;
+  };
+};
+      `,
+      options: [
+        {
+          multilineDetection: 'last-member',
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+};};
+      `,
+      options: [
+        {
+          singleline: { delimiter: 'semi', requireLast: true },
+          multilineDetection: 'last-member',
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {
+
+};
+      `,
+      options: [
+        {
+          singleline: { delimiter: 'semi', requireLast: true },
+          multilineDetection: 'last-member',
+        },
+      ],
+    },
 
     {
       code: `
@@ -831,24 +900,6 @@ interface Foo {
           messageId: 'expectedSemi',
           line: 4,
           column: 16,
-        },
-      ],
-    },
-    {
-      code: `
-type Test = {
-  a: {
-      one: 1
-  }; b: 2
-};
-      `,
-      output: null,
-      options: [{ multiline: { delimiter: 'none' } }],
-      errors: [
-        {
-          messageId: 'unexpectedSemi',
-          line: 5,
-          column: 5,
         },
       ],
     },
@@ -3380,6 +3431,102 @@ type Foo = {
           messageId: 'expectedSemi',
           line: 1,
           column: 21,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+};};
+      `,
+      output: `
+type Foo = {a: {
+  b: true;
+}};
+      `,
+      options: [
+        {
+          multilineDetection: 'last-member',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'unexpectedSemi',
+          line: 4,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+}};
+      `,
+      output: `
+type Foo = {a: {
+  b: true;
+};};
+      `,
+      errors: [
+        {
+          messageId: 'expectedSemi',
+          line: 4,
+          column: 2,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {
+  a: {
+    b: true;
+  }
+};
+      `,
+      output: `
+type Foo = {
+  a: {
+    b: true;
+  };
+};
+      `,
+      options: [
+        {
+          multilineDetection: 'last-member',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'expectedSemi',
+          line: 5,
+          column: 4,
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = {a: {
+  b: true;
+}};
+      `,
+      output: `
+type Foo = {a: {
+  b: true;
+};};
+      `,
+      options: [
+        {
+          singleline: { delimiter: 'semi', requireLast: true },
+          multilineDetection: 'last-member',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'expectedSemi',
+          line: 4,
+          column: 2,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
@@ -705,75 +705,6 @@ type Bar = {
         },
       ],
     },
-    {
-      code: `
-type Foo = {a: {
-  b: true;
-}};
-      `,
-      options: [
-        {
-          multilineDetection: 'last-member',
-        },
-      ],
-    },
-    `
-type Foo = {a: {
-  b: true;
-};};
-    `,
-    {
-      code: `
-type Foo = {a: {
-  b: true;
-};};
-      `,
-      options: [
-        {
-          multilineDetection: 'brackets',
-        },
-      ],
-    },
-    {
-      code: `
-type Foo = {
-  a: {
-    b: true;
-  };
-};
-      `,
-      options: [
-        {
-          multilineDetection: 'last-member',
-        },
-      ],
-    },
-    {
-      code: `
-type Foo = {a: {
-  b: true;
-};};
-      `,
-      options: [
-        {
-          singleline: { delimiter: 'semi', requireLast: true },
-          multilineDetection: 'last-member',
-        },
-      ],
-    },
-    {
-      code: `
-type Foo = {
-
-};
-      `,
-      options: [
-        {
-          singleline: { delimiter: 'semi', requireLast: true },
-          multilineDetection: 'last-member',
-        },
-      ],
-    },
 
     {
       code: `
@@ -900,6 +831,24 @@ interface Foo {
           messageId: 'expectedSemi',
           line: 4,
           column: 16,
+        },
+      ],
+    },
+    {
+      code: `
+type Test = {
+  a: {
+      one: 1
+  }; b: 2
+};
+      `,
+      output: null,
+      options: [{ multiline: { delimiter: 'none' } }],
+      errors: [
+        {
+          messageId: 'unexpectedSemi',
+          line: 5,
+          column: 5,
         },
       ],
     },
@@ -3431,102 +3380,6 @@ type Foo = {
           messageId: 'expectedSemi',
           line: 1,
           column: 21,
-        },
-      ],
-    },
-    {
-      code: `
-type Foo = {a: {
-  b: true;
-};};
-      `,
-      output: `
-type Foo = {a: {
-  b: true;
-}};
-      `,
-      options: [
-        {
-          multilineDetection: 'last-member',
-        },
-      ],
-      errors: [
-        {
-          messageId: 'unexpectedSemi',
-          line: 4,
-          column: 3,
-        },
-      ],
-    },
-    {
-      code: `
-type Foo = {a: {
-  b: true;
-}};
-      `,
-      output: `
-type Foo = {a: {
-  b: true;
-};};
-      `,
-      errors: [
-        {
-          messageId: 'expectedSemi',
-          line: 4,
-          column: 2,
-        },
-      ],
-    },
-    {
-      code: `
-type Foo = {
-  a: {
-    b: true;
-  }
-};
-      `,
-      output: `
-type Foo = {
-  a: {
-    b: true;
-  };
-};
-      `,
-      options: [
-        {
-          multilineDetection: 'last-member',
-        },
-      ],
-      errors: [
-        {
-          messageId: 'expectedSemi',
-          line: 5,
-          column: 4,
-        },
-      ],
-    },
-    {
-      code: `
-type Foo = {a: {
-  b: true;
-}};
-      `,
-      output: `
-type Foo = {a: {
-  b: true;
-};};
-      `,
-      options: [
-        {
-          singleline: { delimiter: 'semi', requireLast: true },
-          multilineDetection: 'last-member',
-        },
-      ],
-      errors: [
-        {
-          messageId: 'expectedSemi',
-          line: 4,
-          column: 2,
         },
       ],
     },


### PR DESCRIPTION
Everything was explained here: https://github.com/typescript-eslint/typescript-eslint/issues/2982

The rule would produce invalid code when trying to fix it.

Fixes #2982 