### PR TITLE
fix(eslint-plugin): [explicit-module-boundary-types] fixes #2864 related to functions in nested object properties

### DIFF
--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -52,11 +52,12 @@ function isConstructorArgument(
 }
 
 /**
- * Checks if a node belongs to:
+ * Checks if a node is a property or a nested property of a typed object:
  * ```
  * const x: Foo = { prop: () => {} }
  * const x = { prop: () => {} } as Foo
  * const x = <Foo>{ prop: () => {} }
+ * const x: Foo = { bar: { prop: () => {} } }
  * ```
  */
 function isPropertyOfObjectWithType(
@@ -82,7 +83,8 @@ function isPropertyOfObjectWithType(
     isTypeAssertion(parent) ||
     isClassPropertyWithTypeAnnotation(parent) ||
     isVariableDeclaratorWithTypeAnnotation(parent) ||
-    isFunctionArgument(parent)
+    isFunctionArgument(parent) ||
+    isPropertyOfObjectWithType(parent)
   );
 }
 

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -160,6 +160,34 @@ const x: Foo = {
       `,
       options: [{ allowTypedFunctionExpressions: true }],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2864
+    {
+      filename: 'test.ts',
+      code: `
+const x = {
+  foo: { bar: () => {} },
+} as Foo;
+      `,
+      options: [{ allowTypedFunctionExpressions: true }],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+const x = <Foo>{
+  foo: { bar: () => {} },
+};
+      `,
+      options: [{ allowTypedFunctionExpressions: true }],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+const x: Foo = {
+  foo: { bar: () => {} },
+};
+      `,
+      options: [{ allowTypedFunctionExpressions: true }],
+    },
     // https://github.com/typescript-eslint/typescript-eslint/issues/484
     {
       filename: 'test.ts',

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -185,6 +185,34 @@ export const x: Foo = {
       `,
       options: [{ allowTypedFunctionExpressions: true }],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2864
+    {
+      filename: 'test.ts',
+      code: `
+export const x = {
+  foo: { bar: () => {} },
+} as Foo;
+      `,
+      options: [{ allowTypedFunctionExpressions: true }],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export const x = <Foo>{
+  foo: { bar: () => {} },
+};
+      `,
+      options: [{ allowTypedFunctionExpressions: true }],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export const x: Foo = {
+  foo: { bar: () => {} },
+};
+      `,
+      options: [{ allowTypedFunctionExpressions: true }],
+    },
     // https://github.com/typescript-eslint/typescript-eslint/issues/484
     {
       code: `


### PR DESCRIPTION
Fixes #2864

**Gist of it:**

`explicit-module-boundary-types` and `explicit-function-return-type` both have an option `allowTypedFunctionExpressions`.
It makes this code correct:
```ts
interface ObjectType {
  foo(): number;
}
export const obj: ObjectType = {
  foo: () => 1,
};
```

The issue is that the following code is not correct even with the option set to `true`:
```ts
interface ObjectType {
  foo: { bar: () => number }; 
}
export const obj: ObjectType = {
  foo: { bar: () => 1 },
};
```

My PR fixes the issue for both of these rules and adds relevant tests.

My fork can be used with npm/yarn using this, that's what I temporarily will do.
```
"@typescript-eslint/eslint-plugin": "https://gitpkg.now.sh/grumd/typescript-eslint/packages/eslint-plugin?build",
```