### PR TITLE
fix(typescript-estree): [ts 4.2] add support for import type equal declaration

### DIFF
--- a/packages/shared-fixtures/fixtures/typescript/basics/import-equal-type-declaration.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/import-equal-type-declaration.src.ts
@@ -1,0 +1,1 @@
+import type foo = require('bar');

--- a/packages/shared-fixtures/fixtures/typescript/basics/import-export-equal-type-declaration.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/import-export-equal-type-declaration.src.ts
@@ -1,0 +1,1 @@
+export import type foo = require('bar');

--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -1423,6 +1423,7 @@ export interface TSImportEqualsDeclaration extends BaseNode {
   type: AST_NODE_TYPES.TSImportEqualsDeclaration;
   id: Identifier;
   moduleReference: EntityName | TSExternalModuleReference;
+  importKind: 'type' | 'value';
   isExport: boolean;
 }
 

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@babel/code-frame": "^7.12.13",
-    "@babel/parser": "^7.13.4",
+    "@babel/parser": "^7.13.11",
     "@babel/types": "^7.13.0",
     "@types/babel__code-frame": "*",
     "@types/debug": "*",

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -2690,6 +2690,7 @@ export class Converter {
           type: AST_NODE_TYPES.TSImportEqualsDeclaration,
           id: this.convertChild(node.name),
           moduleReference: this.convertChild(node.moduleReference),
+          importKind: node.isTypeOnly ? 'type' : 'value',
           isExport: hasModifier(SyntaxKind.ExportKeyword, node),
         });
       }

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -395,6 +395,8 @@ tester.addFixturePatternConfig('typescript/basics', {
     'export-assignment',
     'import-equal-declaration',
     'import-export-equal-declaration',
+    'import-equal-type-declaration',
+    'import-export-equal-type-declaration',
     // babel treats declare and types as not a module
     'export-declare-const-named-enum',
     'export-declare-named-enum',

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
@@ -1929,7 +1929,11 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" e
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-equal-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-equal-type-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-export-equal-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-export-equal-type-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-type-default.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/import-equal-type-declaration.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/import-equal-type-declaration.src.ts.shot
@@ -1,32 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`typescript basics import-equal-declaration.src 1`] = `
+exports[`typescript basics import-equal-type-declaration.src 1`] = `
 Object {
   "body": Array [
     Object {
       "id": Object {
         "loc": Object {
           "end": Object {
-            "column": 10,
+            "column": 15,
             "line": 1,
           },
           "start": Object {
-            "column": 7,
+            "column": 12,
             "line": 1,
           },
         },
         "name": "foo",
         "range": Array [
-          7,
-          10,
+          12,
+          15,
         ],
         "type": "Identifier",
       },
-      "importKind": "value",
+      "importKind": "type",
       "isExport": false,
       "loc": Object {
         "end": Object {
-          "column": 28,
+          "column": 33,
           "line": 1,
         },
         "start": Object {
@@ -38,17 +38,17 @@ Object {
         "expression": Object {
           "loc": Object {
             "end": Object {
-              "column": 26,
+              "column": 31,
               "line": 1,
             },
             "start": Object {
-              "column": 21,
+              "column": 26,
               "line": 1,
             },
           },
           "range": Array [
-            21,
             26,
+            31,
           ],
           "raw": "'bar'",
           "type": "Literal",
@@ -56,23 +56,23 @@ Object {
         },
         "loc": Object {
           "end": Object {
-            "column": 27,
+            "column": 32,
             "line": 1,
           },
           "start": Object {
-            "column": 13,
+            "column": 18,
             "line": 1,
           },
         },
         "range": Array [
-          13,
-          27,
+          18,
+          32,
         ],
         "type": "TSExternalModuleReference",
       },
       "range": Array [
         0,
-        28,
+        33,
       ],
       "type": "TSImportEqualsDeclaration",
     },
@@ -90,7 +90,7 @@ Object {
   },
   "range": Array [
     0,
-    29,
+    34,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -115,7 +115,7 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 10,
+          "column": 11,
           "line": 1,
         },
         "start": Object {
@@ -125,7 +125,25 @@ Object {
       },
       "range": Array [
         7,
-        10,
+        11,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        12,
+        15,
       ],
       "type": "Identifier",
       "value": "foo",
@@ -133,17 +151,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 12,
+          "column": 17,
           "line": 1,
         },
         "start": Object {
-          "column": 11,
+          "column": 16,
           "line": 1,
         },
       },
       "range": Array [
-        11,
-        12,
+        16,
+        17,
       ],
       "type": "Punctuator",
       "value": "=",
@@ -151,17 +169,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 20,
+          "column": 25,
           "line": 1,
         },
         "start": Object {
-          "column": 13,
+          "column": 18,
           "line": 1,
         },
       },
       "range": Array [
-        13,
-        20,
+        18,
+        25,
       ],
       "type": "Identifier",
       "value": "require",
@@ -169,17 +187,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 21,
+          "column": 26,
           "line": 1,
         },
         "start": Object {
-          "column": 20,
+          "column": 25,
           "line": 1,
         },
       },
       "range": Array [
-        20,
-        21,
+        25,
+        26,
       ],
       "type": "Punctuator",
       "value": "(",
@@ -187,17 +205,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 26,
+          "column": 31,
           "line": 1,
         },
         "start": Object {
-          "column": 21,
+          "column": 26,
           "line": 1,
         },
       },
       "range": Array [
-        21,
         26,
+        31,
       ],
       "type": "String",
       "value": "'bar'",
@@ -205,17 +223,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 27,
+          "column": 32,
           "line": 1,
         },
         "start": Object {
-          "column": 26,
+          "column": 31,
           "line": 1,
         },
       },
       "range": Array [
-        26,
-        27,
+        31,
+        32,
       ],
       "type": "Punctuator",
       "value": ")",
@@ -223,17 +241,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 28,
+          "column": 33,
           "line": 1,
         },
         "start": Object {
-          "column": 27,
+          "column": 32,
           "line": 1,
         },
       },
       "range": Array [
-        27,
-        28,
+        32,
+        33,
       ],
       "type": "Punctuator",
       "value": ";",

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/import-export-equal-declaration.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/import-export-equal-declaration.src.ts.shot
@@ -22,6 +22,7 @@ Object {
         ],
         "type": "Identifier",
       },
+      "importKind": "value",
       "isExport": true,
       "loc": Object {
         "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/import-export-equal-type-declaration.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/import-export-equal-type-declaration.src.ts.shot
@@ -1,32 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`typescript basics import-equal-declaration.src 1`] = `
+exports[`typescript basics import-export-equal-type-declaration.src 1`] = `
 Object {
   "body": Array [
     Object {
       "id": Object {
         "loc": Object {
           "end": Object {
-            "column": 10,
+            "column": 22,
             "line": 1,
           },
           "start": Object {
-            "column": 7,
+            "column": 19,
             "line": 1,
           },
         },
         "name": "foo",
         "range": Array [
-          7,
-          10,
+          19,
+          22,
         ],
         "type": "Identifier",
       },
-      "importKind": "value",
-      "isExport": false,
+      "importKind": "type",
+      "isExport": true,
       "loc": Object {
         "end": Object {
-          "column": 28,
+          "column": 40,
           "line": 1,
         },
         "start": Object {
@@ -38,17 +38,17 @@ Object {
         "expression": Object {
           "loc": Object {
             "end": Object {
-              "column": 26,
+              "column": 38,
               "line": 1,
             },
             "start": Object {
-              "column": 21,
+              "column": 33,
               "line": 1,
             },
           },
           "range": Array [
-            21,
-            26,
+            33,
+            38,
           ],
           "raw": "'bar'",
           "type": "Literal",
@@ -56,23 +56,23 @@ Object {
         },
         "loc": Object {
           "end": Object {
-            "column": 27,
+            "column": 39,
             "line": 1,
           },
           "start": Object {
-            "column": 13,
+            "column": 25,
             "line": 1,
           },
         },
         "range": Array [
-          13,
-          27,
+          25,
+          39,
         ],
         "type": "TSExternalModuleReference",
       },
       "range": Array [
         0,
-        28,
+        40,
       ],
       "type": "TSImportEqualsDeclaration",
     },
@@ -90,7 +90,7 @@ Object {
   },
   "range": Array [
     0,
-    29,
+    41,
   ],
   "sourceType": "module",
   "tokens": Array [
@@ -110,12 +110,12 @@ Object {
         6,
       ],
       "type": "Keyword",
-      "value": "import",
+      "value": "export",
     },
     Object {
       "loc": Object {
         "end": Object {
-          "column": 10,
+          "column": 13,
           "line": 1,
         },
         "start": Object {
@@ -125,7 +125,43 @@ Object {
       },
       "range": Array [
         7,
-        10,
+        13,
+      ],
+      "type": "Keyword",
+      "value": "import",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 18,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        14,
+        18,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        19,
+        22,
       ],
       "type": "Identifier",
       "value": "foo",
@@ -133,17 +169,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 12,
+          "column": 24,
           "line": 1,
         },
         "start": Object {
-          "column": 11,
+          "column": 23,
           "line": 1,
         },
       },
       "range": Array [
-        11,
-        12,
+        23,
+        24,
       ],
       "type": "Punctuator",
       "value": "=",
@@ -151,17 +187,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 20,
+          "column": 32,
           "line": 1,
         },
         "start": Object {
-          "column": 13,
+          "column": 25,
           "line": 1,
         },
       },
       "range": Array [
-        13,
-        20,
+        25,
+        32,
       ],
       "type": "Identifier",
       "value": "require",
@@ -169,17 +205,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 21,
+          "column": 33,
           "line": 1,
         },
         "start": Object {
-          "column": 20,
+          "column": 32,
           "line": 1,
         },
       },
       "range": Array [
-        20,
-        21,
+        32,
+        33,
       ],
       "type": "Punctuator",
       "value": "(",
@@ -187,17 +223,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 26,
+          "column": 38,
           "line": 1,
         },
         "start": Object {
-          "column": 21,
+          "column": 33,
           "line": 1,
         },
       },
       "range": Array [
-        21,
-        26,
+        33,
+        38,
       ],
       "type": "String",
       "value": "'bar'",
@@ -205,17 +241,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 27,
+          "column": 39,
           "line": 1,
         },
         "start": Object {
-          "column": 26,
+          "column": 38,
           "line": 1,
         },
       },
       "range": Array [
-        26,
-        27,
+        38,
+        39,
       ],
       "type": "Punctuator",
       "value": ")",
@@ -223,17 +259,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 28,
+          "column": 40,
           "line": 1,
         },
         "start": Object {
-          "column": 27,
+          "column": 39,
           "line": 1,
         },
       },
       "range": Array [
-        27,
-        28,
+        39,
+        40,
       ],
       "type": "Punctuator",
       "value": ";",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,22 +16,22 @@
   dependencies:
     "@babel/highlight" "^7.12.13"
 
-"@babel/compat-data@^7.13.0":
-  version "7.13.6"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.6.tgz#11972d07db4c2317afdbf41d6feb3a730301ef4e"
-  integrity sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==
+"@babel/compat-data@^7.13.8":
+  version "7.13.11"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.13.11.tgz#9c8fe523c206979c9a81b1e12fe50c1254f1aa35"
+  integrity sha512-BwKEkO+2a67DcFeS3RLl0Z3Gs2OvdXewuWjc1Hfokhb5eQWP9YRYH1/+VrVZvql2CfjOiNGqSAFOYt4lsqTHzg==
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
-  version "7.13.1"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.1.tgz#7ddd027176debe40f13bb88bac0c21218c5b1ecf"
-  integrity sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.13.10.tgz#07de050bbd8193fcd8a3c27918c0890613a94559"
+  integrity sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.13.0"
-    "@babel/helper-compilation-targets" "^7.13.0"
+    "@babel/generator" "^7.13.9"
+    "@babel/helper-compilation-targets" "^7.13.10"
     "@babel/helper-module-transforms" "^7.13.0"
-    "@babel/helpers" "^7.13.0"
-    "@babel/parser" "^7.13.0"
+    "@babel/helpers" "^7.13.10"
+    "@babel/parser" "^7.13.10"
     "@babel/template" "^7.12.13"
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
@@ -40,27 +40,27 @@
     gensync "^1.0.0-beta.2"
     json5 "^2.1.2"
     lodash "^4.17.19"
-    semver "7.0.0"
+    semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.0.tgz#bd00d4394ca22f220390c56a0b5b85568ec1ec0c"
-  integrity sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==
+"@babel/generator@^7.13.0", "@babel/generator@^7.13.9":
+  version "7.13.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.13.9.tgz#3a7aa96f9efb8e2be42d38d80e2ceb4c64d8de39"
+  integrity sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==
   dependencies:
     "@babel/types" "^7.13.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-compilation-targets@^7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz#c9cf29b82a76fd637f0faa35544c4ace60a155a1"
-  integrity sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==
+"@babel/helper-compilation-targets@^7.13.10":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz#1310a1678cb8427c07a753750da4f8ce442bdd0c"
+  integrity sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==
   dependencies:
-    "@babel/compat-data" "^7.13.0"
+    "@babel/compat-data" "^7.13.8"
     "@babel/helper-validator-option" "^7.12.17"
     browserslist "^4.14.5"
-    semver "7.0.0"
+    semver "^6.3.0"
 
 "@babel/helper-function-name@^7.12.13":
   version "7.12.13"
@@ -153,28 +153,28 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
   integrity sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
 
-"@babel/helpers@^7.13.0":
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.13.0.tgz#7647ae57377b4f0408bf4f8a7af01c42e41badc0"
-  integrity sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==
+"@babel/helpers@^7.13.10":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.13.10.tgz#fd8e2ba7488533cdeac45cc158e9ebca5e3c7df8"
+  integrity sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==
   dependencies:
     "@babel/template" "^7.12.13"
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
-  integrity sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
+  integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.0", "@babel/parser@^7.13.4":
-  version "7.13.10"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.10.tgz#8f8f9bf7b3afa3eabd061f7a5bcdf4fec3c48409"
-  integrity sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.13.0", "@babel/parser@^7.13.10", "@babel/parser@^7.13.11":
+  version "7.13.11"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.11.tgz#f93ebfc99d21c1772afbbaa153f47e7ce2f50b88"
+  integrity sha512-PhuoqeHoO9fc4ffMEVk4qb/w/s2iOSWohvbHxLtxui0eBg3Lg5gN1U8wp1V1u61hOWkPQJJyJzGH6Y+grwkq8Q==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -261,9 +261,9 @@
     "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/runtime@^7.11.0", "@babel/runtime@^7.7.6":
-  version "7.13.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.6.tgz#86e0fad6cbb46a680e21c1aa4748717a058d345a"
-  integrity sha512-Y/DEVhSQ91u27rxq7D0EH/sewS6+x06p/MgO1VppbDHMzYXLZrAR5cFjCom78e9RUw1BQAq6qJg6fXc/ep7glA==
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2066,17 +2066,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.12.3:
-  version "6.12.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
-  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.12.4:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -2992,18 +2982,10 @@ contains-path@^0.1.0:
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
-conventional-changelog-angular@^5.0.11:
+conventional-changelog-angular@^5.0.11, conventional-changelog-angular@^5.0.3:
   version "5.0.12"
   resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz#c979b8b921cbfe26402eb3da5bbfda02d865a2b9"
   integrity sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==
-  dependencies:
-    compare-func "^2.0.0"
-    q "^1.5.1"
-
-conventional-changelog-angular@^5.0.3:
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz#99a3ca16e4a5305e0c2c2fae3ef74fd7631fc3fb"
-  integrity sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==
   dependencies:
     compare-func "^2.0.0"
     q "^1.5.1"
@@ -7793,11 +7775,6 @@ semver-compare@^1.0.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
-
-semver@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
-  integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
 semver@7.3.4, semver@7.x, semver@^7.2.1, semver@^7.3.2:
   version "7.3.4"


### PR DESCRIPTION
typescript 4.2 introduced new missing syntax: 

```ts
import type foo = require('bar');
export import type foo = require('bar');
```

AST addition

```js
TSImportEqualsDeclaration <: Node {
  importKind: 'type' | 'value';
}
```


fixes #3183, ref babel/babel#12962, microsoft/TypeScript#41573