### PR TITLE
docs(eslint-plugin): [naming-convention] clarify literal regex notation vs. argument to RegExp

### DIFF
--- a/packages/eslint-plugin/docs/rules/naming-convention.md
+++ b/packages/eslint-plugin/docs/rules/naming-convention.md
@@ -110,7 +110,7 @@ This can be useful if you want to enforce no particular format for a specific se
 The `custom` option defines a custom regex that the identifier must (or must not) match. This option allows you to have a bit more finer-grained control over identifiers, letting you ban (or force) certain patterns and substrings.
 Accepts an object with the following properties:
 
-- `regex` - accepts a regular expression (anything accepted into `new RegExp(regex)`).
+- `regex` - a string that is then passed into RegExp to create a new regular expression: `new RegExp(regex)`
 - `match` - true if the identifier _must_ match the `regex`, false if the identifier _must not_ match the `regex`.
 
 ### `filter`
@@ -121,7 +121,7 @@ You can use this to include or exclude specific identifiers from specific config
 
 Accepts an object with the following properties:
 
-- `regex` - accepts a regular expression (anything accepted into `new RegExp(regex)`).
+- `regex` - a string that is then passed into RegExp to create a new regular expression: `new RegExp(regex)`
 - `match` - true if the identifier _must_ match the `regex`, false if the identifier _must not_ match the `regex`.
 
 Alternatively, `filter` accepts a regular expression (anything accepted into `new RegExp(filter)`). In this case, it's treated as if you had passed an object with the regex and `match: true`.


### PR DESCRIPTION
Hi, I was working with naming-convention recently. I was trying to remove an object prop `___typename` from a rule. From the documentation  at the time it wasn't entirely clear (to me) what the `regex` property should take:

`let re = "/ab+c/i";` // literal notation
`let re = "ab+c"`  // something to be passed into [RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)

This is important because for example `new RegExp('/typename/') === '//typename//'` and not `"/typename/"`

Also, I think that the args that RegExp is taking changes slightly in ES6? 

I've proposed a small docs change.

Thanks!