### PR TITLE
feat(eslint-plugin): [space-infix-ops] support for class properties and type aliases

### DIFF
--- a/packages/eslint-plugin/src/rules/space-infix-ops.ts
+++ b/packages/eslint-plugin/src/rules/space-infix-ops.ts
@@ -34,20 +34,11 @@ export default util.createRule<Options, MessageIds>({
     const rules = baseRule.create(context);
     const sourceCode = context.getSourceCode();
 
-    /**
-     * Check if it has an assignment char and report if it's faulty
-     * @param node The node to report
-     */
-    function checkForAssignmentSpace(node: TSESTree.TSEnumMember): void {
-      if (!node.initializer) {
-        return;
-      }
-
-      const leftNode = sourceCode.getTokenByRangeStart(node.id.range[0])!;
-      const rightNode = sourceCode.getTokenByRangeStart(
-        node.initializer.range[0],
-      )!;
-
+    function checkAndReportAssignmentSpace(
+      node: TSESTree.Node,
+      leftNode: TSESTree.Token,
+      rightNode?: TSESTree.Token | null,
+    ): void {
       if (!rightNode) {
         return;
       }
@@ -94,9 +85,44 @@ export default util.createRule<Options, MessageIds>({
       }
     }
 
+    /**
+     * Check if it has an assignment char and report if it's faulty
+     * @param node The node to report
+     */
+    function checkForEnumAssignmentSpace(node: TSESTree.TSEnumMember): void {
+      if (!node.initializer) {
+        return;
+      }
+
+      const leftNode = sourceCode.getTokenByRangeStart(node.id.range[0])!;
+      const rightNode = sourceCode.getTokenByRangeStart(
+        node.initializer.range[0],
+      )!;
+
+      checkAndReportAssignmentSpace(node, leftNode, rightNode);
+    }
+
+    /**
+     * Check if it has an assignment char and report if it's faulty
+     * @param node The node to report
+     */
+    function checkForClassPropertyAssignmentSpace(
+      node: TSESTree.ClassProperty,
+    ): void {
+      const leftNode = sourceCode.getTokenByRangeStart(
+        node.typeAnnotation?.range[0] ?? node.range[0],
+      )!;
+      const rightNode = node.value
+        ? sourceCode.getTokenByRangeStart(node.value.range[0])
+        : undefined;
+
+      checkAndReportAssignmentSpace(node, leftNode, rightNode);
+    }
+
     return {
       ...rules,
-      TSEnumMember: checkForAssignmentSpace,
+      TSEnumMember: checkForEnumAssignmentSpace,
+      ClassProperty: checkForClassPropertyAssignmentSpace,
     };
   },
 });

--- a/packages/eslint-plugin/src/rules/space-infix-ops.ts
+++ b/packages/eslint-plugin/src/rules/space-infix-ops.ts
@@ -119,10 +119,26 @@ export default util.createRule<Options, MessageIds>({
       checkAndReportAssignmentSpace(node, leftNode, rightNode);
     }
 
+    /**
+     * Check if it has an assignment char and report if it's faulty
+     * @param node The node to report
+     */
+    function checkForTypeAliasAssignmentSpace(
+      node: TSESTree.TSTypeAliasDeclaration,
+    ): void {
+      const leftNode = sourceCode.getTokenByRangeStart(node.id.range[0])!;
+      const rightNode = sourceCode.getTokenByRangeStart(
+        node.typeAnnotation.range[0],
+      );
+
+      checkAndReportAssignmentSpace(node, leftNode, rightNode);
+    }
+
     return {
       ...rules,
       TSEnumMember: checkForEnumAssignmentSpace,
       ClassProperty: checkForClassPropertyAssignmentSpace,
+      TSTypeAliasDeclaration: checkForTypeAliasAssignmentSpace,
     };
   },
 });

--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -33,6 +33,27 @@ ruleTester.run('space-infix-ops', rule, {
         }
       `,
     },
+    {
+      code: `
+        class Test {
+          public readonly value?: number;
+        }
+      `,
+    },
+    {
+      code: `
+        class Test {
+          public readonly value = 1;
+        }
+      `,
+    },
+    {
+      code: `
+        class Test {
+          private value:number = 1;
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -94,6 +115,44 @@ ruleTester.run('space-infix-ops', rule, {
         {
           messageId: 'missingSpace',
           column: 13,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        class Test {
+          public readonly value= 2;
+        }
+      `,
+      output: `
+        class Test {
+          public readonly value = 2;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 32,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        class Test {
+          public readonly value =2;
+        }
+      `,
+      output: `
+        class Test {
+          public readonly value = 2;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 33,
           line: 3,
         },
       ],

--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -54,6 +54,11 @@ ruleTester.run('space-infix-ops', rule, {
         }
       `,
     },
+    {
+      code: `
+        type Test = string | boolean;
+      `,
+    },
   ],
   invalid: [
     {
@@ -154,6 +159,36 @@ ruleTester.run('space-infix-ops', rule, {
           messageId: 'missingSpace',
           column: 33,
           line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        type Test= string | number;
+      `,
+      output: `
+        type Test = string | number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 18,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        type Test =string | number;
+      `,
+      output: `
+        type Test = string | number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 19,
+          line: 2,
         },
       ],
     },


### PR DESCRIPTION
Hey,

I've bumped into this issue after migrating to eslint. Nice work btw! We've used whitespace rule in tslint for certain formatting and this PR will bring feature parity closer to what was there before. I know it's about whitespace, but moving to prettier is just too much for our code base and the patterns we are used to. Maybe one day :) (plenty of things gets far less readable)

Fixes #1699 

A bit later I'll also have a look at #1606

EDIT:
2nd commit fixes first part of #1606 