### PR TITLE
docs(eslint-plugin): [unbound-method] reference eslint-plugin-jests extension rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/unbound-method.md
+++ b/packages/eslint-plugin/docs/rules/unbound-method.md
@@ -6,6 +6,8 @@ Class functions don't preserve the class scope when passed as standalone variabl
 
 If your function does not access `this`, [you can annotate it with `this: void`](https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function), or consider using an arrow function instead.
 
+If you're working with `jest`, you can use [`eslint-plugin-jest`'s version of this rule](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md) to lint your test files, which knows when it's ok to pass an unbound method to `expect` calls.
+
 ## Rule Details
 
 Examples of **incorrect** code for this rule
@@ -104,6 +106,8 @@ log();
 ## When Not To Use It
 
 If your code intentionally waits to bind methods after use, such as by passing a `scope: this` along with the method, you can disable this rule.
+
+If you're wanting to use `toBeCalled` and similar matches in `jest` tests, you can disable this rule for your test files in favor of [`eslint-plugin-jest`'s version of this rule](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md).
 
 ## Related To
 


### PR DESCRIPTION
Relates to #2951

-------

We've not had any complaints so far 🤷 