### PR TITLE
fix(eslint-plugin): [restrict-plus-operands] consider template literal types as strings

### DIFF
--- a/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
+++ b/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
@@ -57,7 +57,10 @@ export default util.createRule<Options, MessageIds>({
       if (type.isNumberLiteral()) {
         return 'number';
       }
-      if (type.isStringLiteral()) {
+      if (
+        type.isStringLiteral() ||
+        util.isTypeFlagSet(type, ts.TypeFlags.TemplateLiteral)
+      ) {
         return 'string';
       }
       // is BigIntLiteral

--- a/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
@@ -111,6 +111,12 @@ declare const a: 'string literal' & string;
 declare const b: string;
 const x = a + b;
     `,
+    `
+function A(s: string) {
+  return \`a\${s}b\` as const;
+}
+const b = A('') + '!';
+    `,
     {
       code: `
 let foo: number = 0;


### PR DESCRIPTION
Fixes #3220.