### PR TITLE
fix(eslint-plugin): always ignore assignments in no-unnecessary-type-assertion

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -151,6 +151,10 @@ export default util.createRule<Options, MessageIds>({
               },
             });
           }
+          // for all other = assignments we ignore non-null checks
+          // this is because non-null assertions can change the type-flow of the code
+          // so whilst they might be unnecessary for the assignment - they are necessary
+          // for following code
           return;
         }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -137,19 +137,20 @@ export default util.createRule<Options, MessageIds>({
       TSNonNullExpression(node): void {
         if (
           node.parent?.type === AST_NODE_TYPES.AssignmentExpression &&
-          node.parent?.operator === '=' &&
-          node.parent.left === node
+          node.parent.operator === '='
         ) {
-          context.report({
-            node,
-            messageId: 'contextuallyUnnecessary',
-            fix(fixer) {
-              return fixer.removeRange([
-                node.expression.range[1],
-                node.range[1],
-              ]);
-            },
-          });
+          if (node.parent.left === node) {
+            context.report({
+              node,
+              messageId: 'contextuallyUnnecessary',
+              fix(fixer) {
+                return fixer.removeRange([
+                  node.expression.range[1],
+                  node.range[1],
+                ]);
+              },
+            });
+          }
           return;
         }
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -202,6 +202,12 @@ let a: { b?: string } | undefined;
 a!.b = '';
       `,
     },
+    `
+let value: number | undefined;
+let values: number[] = [];
+
+value = values.pop()!;
+    `,
   ],
 
   invalid: [
@@ -477,14 +483,10 @@ y! = 0;
       output: `
 let x: number | undefined;
 let y: number | undefined;
-y = x;
+y = x!;
 y = 0;
       `,
       errors: [
-        {
-          messageId: 'contextuallyUnnecessary',
-          line: 4,
-        },
         {
           messageId: 'contextuallyUnnecessary',
           line: 5,


### PR DESCRIPTION
Fixes #3187.

Since TypeScript is smart about inferring types for variable assignments, I think it's reasonable to always exclude the right-hand-side of assignment expressions. 