### PR TITLE
fix(eslint-plugin): [strict-boolean-expressions] account for truthy literals

### DIFF
--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -308,8 +308,13 @@ export default util.createRule<Options, MessageId>({
         return;
       }
 
+      // Known edge case: truthy primitives and nullish values are always valid boolean expressions
+      if (is('nullish', 'truthy string') || is('nullish', 'truthy number')) {
+        return;
+      }
+
       // string
-      if (is('string')) {
+      if (is('string') || is('truthy string')) {
         if (!options.allowString) {
           if (isLogicalNegationExpression(node.parent!)) {
             // if (!string)
@@ -458,7 +463,7 @@ export default util.createRule<Options, MessageId>({
       }
 
       // number
-      if (is('number')) {
+      if (is('number') || is('truthy number')) {
         if (!options.allowNumber) {
           if (isArrayLengthExpression(node, typeChecker, parserServices)) {
             if (isLogicalNegationExpression(node.parent!)) {
@@ -701,7 +706,9 @@ export default util.createRule<Options, MessageId>({
       | 'nullish'
       | 'boolean'
       | 'string'
+      | 'truthy string'
       | 'number'
+      | 'truthy number'
       | 'object'
       | 'any'
       | 'never';
@@ -731,21 +738,30 @@ export default util.createRule<Options, MessageId>({
         variantTypes.add('boolean');
       }
 
-      if (
-        types.some(type => tsutils.isTypeFlagSet(type, ts.TypeFlags.StringLike))
-      ) {
-        variantTypes.add('string');
+      const strings = types.filter(type =>
+        tsutils.isTypeFlagSet(type, ts.TypeFlags.StringLike),
+      );
+
+      if (strings.length) {
+        if (strings.some(type => type.isStringLiteral() && type.value !== '')) {
+          variantTypes.add('truthy string');
+        } else {
+          variantTypes.add('string');
+        }
       }
 
-      if (
-        types.some(type =>
-          tsutils.isTypeFlagSet(
-            type,
-            ts.TypeFlags.NumberLike | ts.TypeFlags.BigIntLike,
-          ),
-        )
-      ) {
-        variantTypes.add('number');
+      const numbers = types.filter(type =>
+        tsutils.isTypeFlagSet(
+          type,
+          ts.TypeFlags.NumberLike | ts.TypeFlags.BigIntLike,
+        ),
+      );
+      if (numbers.length) {
+        if (numbers.some(type => type.isNumberLiteral() && type.value !== 0)) {
+          variantTypes.add('truthy number');
+        } else {
+          variantTypes.add('number');
+        }
       }
 
       if (

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -309,7 +309,10 @@ export default util.createRule<Options, MessageId>({
       }
 
       // Known edge case: truthy primitives and nullish values are always valid boolean expressions
-      if (is('nullish', 'truthy string') || is('nullish', 'truthy number')) {
+      if (
+        (options.allowNumber && is('nullish', 'truthy number')) ||
+        (options.allowString && is('nullish', 'truthy string'))
+      ) {
         return;
       }
 

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -144,6 +144,21 @@ function f(arg: 'a' | 'b' | null) {
   if (arg) console.log(arg);
 }
     `,
+    {
+      code: `
+declare const x: 1 | null;
+declare const y: 1;
+if (x) {
+}
+if (y) {
+}
+      `,
+      options: [
+        {
+          allowNumber: true,
+        },
+      ],
+    },
     `
 function f(arg: 1 | null) {
   if (arg) console.log(arg);
@@ -154,6 +169,21 @@ function f(arg: 1 | 2 | null) {
   if (arg) console.log(arg);
 }
     `,
+    {
+      code: `
+declare const x: 'a' | null;
+declare const y: 'a';
+if (x) {
+}
+if (y) {
+}
+      `,
+      options: [
+        {
+          allowString: true,
+        },
+      ],
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -133,6 +133,27 @@ if (x) {
         tsconfigRootDir: path.join(rootPath, 'unstrict'),
       },
     },
+
+    `
+function f(arg: 'a' | null) {
+  if (arg) console.log(arg);
+}
+    `,
+    `
+function f(arg: 'a' | 'b' | null) {
+  if (arg) console.log(arg);
+}
+    `,
+    `
+function f(arg: 1 | null) {
+  if (arg) console.log(arg);
+}
+    `,
+    `
+function f(arg: 1 | 2 | null) {
+  if (arg) console.log(arg);
+}
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
Fixes #3115.

I hadn't seen this version of the code with phrases like `is('nullish', 'string')`. Very clever & readable! The code as-is does a _lot_ of loop iterations, but I guess that's fine because type unions are typically very small? 