### PR TITLE
fix(eslint-plugin): [no-type-alias] consider `keyof` as an alias

### DIFF
--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -264,9 +264,10 @@ export default util.createRule<Options, MessageIds>({
         type.node.type.endsWith('Keyword') ||
         aliasTypes.has(type.node.type) ||
         (type.node.type === AST_NODE_TYPES.TSTypeOperator &&
-          type.node.operator === 'readonly' &&
-          type.node.typeAnnotation &&
-          aliasTypes.has(type.node.typeAnnotation.type))
+          (type.node.operator === 'keyof' ||
+            (type.node.operator === 'readonly' &&
+              type.node.typeAnnotation &&
+              aliasTypes.has(type.node.typeAnnotation.type))))
       ) {
         // alias / keyword
         checkAndReport(allowAliases!, isTopLevel, type, 'Aliases');

--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -395,6 +395,13 @@ export type ClassValue =
       options: [{ allowAliases: 'always' }],
     },
     {
+      code: `
+const WithAKey = { AKey: true };
+type KeyNames = keyof typeof SCALARS;
+      `,
+      options: [{ allowAliases: 'always' }],
+    },
+    {
       code: 'type Foo = typeof bar | typeof baz;',
       options: [{ allowAliases: 'in-unions' }],
     },


### PR DESCRIPTION
Fixes #3202.