### PR TITLE
feat(eslint-plugin): [no-unnecessary-condition] adds error when comparing to `never`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -319,6 +319,13 @@ export default createRule<Options, MessageId>({
         context.report({ node, messageId: 'literalBooleanExpression' });
         return;
       }
+      if (
+        isTypeFlagSet(leftType, ts.TypeFlags.Never) ||
+        isTypeFlagSet(rightType, ts.TypeFlags.Never)
+      ) {
+        context.report({ node, messageId: 'never' });
+        return;
+      }
       // Workaround for https://github.com/microsoft/TypeScript/issues/37160
       if (isStrictNullChecks) {
         const UNDEFINED = ts.TypeFlags.Undefined;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1488,6 +1488,17 @@ if (!speech) {
     },
     {
       code: `
+function compareNever(x: never) {
+  if (x === 'a') {
+  }
+  if ('a' === x) {
+  }
+}
+      `,
+      errors: [ruleError(3, 7, 'never'), ruleError(5, 7, 'never')],
+    },
+    {
+      code: `
 declare const x: string[] | null;
 if (x) {
 }


### PR DESCRIPTION
I'm aware this will likely wait until a major version update to go in, but flags an error when doing binary operations comparing against `never` on either side.  

For example, this code compiles:

```ts
function handleCases(kind: "A" | "B") {
    if(kind === "A") { 
        // do something
    } else if (kind === "B") {
       // do something else
    } else if (kind === "oops") {  
        // no error, TS is okay comparing "oops" and `never`
    }
}
```