### PR TITLE
chore: enable no-floating-promises internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,7 +63,6 @@ module.exports = {
     ],
 
     // TODO - enable these new recommended rules
-    '@typescript-eslint/no-floating-promises': 'off',
     '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unsafe-call': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',

--- a/tools/generate-contributors.ts
+++ b/tools/generate-contributors.ts
@@ -114,4 +114,7 @@ async function main(): Promise<void> {
   fs.writeFileSync(rcPath, JSON.stringify(allContributorsConfig, null, 2));
 }
 
-main();
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Starts on #3278.

This was the only rule with very few violations: only one.