### PR TITLE
feat(experimental-utils): Include `getCwd()` in `RuleContext` type

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -212,6 +212,12 @@ interface RuleContext<
   getDeclaredVariables(node: TSESTree.Node): Scope.Variable[];
 
   /**
+   * returns the cwd passed to Linter.
+   * It is a path to a directory that should be considered as the current working directory.
+   */
+  getCwd(): string;
+
+  /**
    * Returns the filename associated with the source.
    */
   getFilename(): string;

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -212,10 +212,12 @@ interface RuleContext<
   getDeclaredVariables(node: TSESTree.Node): Scope.Variable[];
 
   /**
-   * returns the cwd passed to Linter.
+   * Returns the current working directory passed to Linter.
    * It is a path to a directory that should be considered as the current working directory.
+   * This was added in v6.6.0
+   * @since 6.6.0
    */
-  getCwd(): string;
+  getCwd?(): string;
 
   /**
    * Returns the filename associated with the source.


### PR DESCRIPTION
It's in https://eslint.org/docs/developer-guide/working-with-rules#the-context-object
