### PR TITLE
feat(eslint-plugin): [space-infix-ops] Add support for Union and intersection of type declarations

### DIFF
--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -136,6 +136,28 @@ ruleTester.run('space-infix-ops', rule, {
         }
       `,
     },
+    {
+      code: `
+        const x: string & number;
+      `,
+    },
+    {
+      code: `
+        class Test {
+           value: string & number;
+        }
+      `,
+    },
+    {
+      code: `
+        function foo<T extends string & number>() {}
+      `,
+    },
+    {
+      code: `
+        function bar(): string & number {}
+      `,
+    },
   ],
   invalid: [
     {
@@ -486,6 +508,228 @@ ruleTester.run('space-infix-ops', rule, {
           messageId: 'missingSpace',
           column: 13,
           line: 4,
+        },
+      ],
+    },
+    {
+      code: `
+        const x: string &number;
+      `,
+      output: `
+        const x: string & number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 25,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        const x: string& number;
+      `,
+      output: `
+        const x: string & number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 24,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        const x: string| number;
+      `,
+      output: `
+        const x: string | number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 24,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        class Test {
+          value: string |number;
+        }
+      `,
+      output: `
+        class Test {
+          value: string | number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 25,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        class Test {
+          value: string& number;
+        }
+      `,
+      output: `
+        class Test {
+          value: string & number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 24,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        class Test {
+          value: string| number;
+        }
+      `,
+      output: `
+        class Test {
+          value: string | number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 24,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        function foo<T extends string &number>() {}
+      `,
+      output: `
+        function foo<T extends string & number>() {}
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 39,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        function foo<T extends string& number>() {}
+      `,
+      output: `
+        function foo<T extends string & number>() {}
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 38,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        function foo<T extends string |number>() {}
+      `,
+      output: `
+        function foo<T extends string | number>() {}
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 39,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        function foo<T extends string| number>() {}
+      `,
+      output: `
+        function foo<T extends string | number>() {}
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 38,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        function bar(): string &number {}
+      `,
+      output: `
+        function bar(): string & number {}
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 32,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        function bar(): string& number {}
+      `,
+      output: `
+        function bar(): string & number {}
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 31,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        function bar(): string |number {}
+      `,
+      output: `
+        function bar(): string | number {}
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 32,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        function bar(): string| number {}
+      `,
+      output: `
+        function bar(): string | number {}
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 31,
+          line: 2,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -56,7 +56,84 @@ ruleTester.run('space-infix-ops', rule, {
     },
     {
       code: `
+        type Test = string;
+      `,
+    },
+    {
+      code: `
         type Test = string | boolean;
+      `,
+    },
+    {
+      code: `
+        type Test = string & boolean;
+      `,
+    },
+    {
+      code: `
+        class Test {
+          private value:number | string = 1;
+        }
+      `,
+    },
+    {
+      code: `
+        class Test {
+          private value:number & string = 1;
+        }
+      `,
+    },
+    {
+      code: `
+        type Test =
+        | string
+        | boolean;
+      `,
+    },
+    {
+      code: `
+        type Test =
+        & string
+        & boolean;
+      `,
+    },
+    {
+      code: `
+        interface Test {
+          prop:
+            & string
+            & boolean;
+        }
+      `,
+    },
+    {
+      code: `
+        interface Test {
+          prop:
+            | string
+            | boolean;
+        }
+      `,
+    },
+    {
+      code: `
+        interface Test {
+          props: string;
+        }
+      `,
+    },
+    {
+      code: `
+        interface Test {
+          props: string | boolean;
+        }
+      `,
+    },
+    {
+      code: `
+        interface Test {
+          props: string & boolean;
+        }
       `,
     },
   ],
@@ -189,6 +266,226 @@ ruleTester.run('space-infix-ops', rule, {
           messageId: 'missingSpace',
           column: 19,
           line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        type Test = string| number;
+      `,
+      output: `
+        type Test = string | number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 27,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        type Test = string |number;
+      `,
+      output: `
+        type Test = string | number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 28,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        type Test = string &number;
+      `,
+      output: `
+        type Test = string & number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 28,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        type Test = string& number;
+      `,
+      output: `
+        type Test = string & number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 27,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        type Test =
+        |string
+        | number;
+      `,
+      output: `
+        type Test =
+        | string
+        | number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 9,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        type Test =
+        &string
+        & number;
+      `,
+      output: `
+        type Test =
+        & string
+        & number;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 9,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        interface Test {
+          prop: string| number;
+        }
+      `,
+      output: `
+        interface Test {
+          prop: string | number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 23,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        interface Test {
+          prop: string |number;
+        }
+      `,
+      output: `
+        interface Test {
+          prop: string | number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 24,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        interface Test {
+          prop: string &number;
+        }
+      `,
+      output: `
+        interface Test {
+          prop: string & number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 24,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        interface Test {
+          prop: string& number;
+        }
+      `,
+      output: `
+        interface Test {
+          prop: string & number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 23,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        interface Test {
+          prop:
+            |string
+            | number;
+        }
+      `,
+      output: `
+        interface Test {
+          prop:
+            | string
+            | number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 13,
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: `
+        interface Test {
+          prop:
+            &string
+            & number;
+        }
+      `,
+      output: `
+        interface Test {
+          prop:
+            & string
+            & number;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 13,
+          line: 4,
         },
       ],
     },


### PR DESCRIPTION
Second PR so maybe i'm missing something. I added support for Union and Intersection of interface and type declarations.
There is the yarn.lock that was updated and don't understand why, i can remove it if it not support to be there