### PR TITLE
feat(eslint-plugin): [dot-notation] optionally allow square bracket notation where an index signature exists in conjunction with `noPropertyAccessFromIndexSignature`

### DIFF
--- a/packages/eslint-plugin/docs/rules/dot-notation.md
+++ b/packages/eslint-plugin/docs/rules/dot-notation.md
@@ -3,7 +3,10 @@
 ## Rule Details
 
 This rule extends the base [`eslint/dot-notation`](https://eslint.org/docs/rules/dot-notation) rule.
-It adds support for optionally ignoring computed `private` member access.
+It adds:
+
+- Support for optionally ignoring computed `private` and/or `protected` member access.
+- Compatibility with TypeScript's `noPropertyAccessFromIndexSignature` option.
 
 ## How to use
 
@@ -24,13 +27,17 @@ This rule adds the following options:
 interface Options extends BaseDotNotationOptions {
   allowPrivateClassPropertyAccess?: boolean;
   allowProtectedClassPropertyAccess?: boolean;
+  allowIndexSignaturePropertyAccess?: boolean;
 }
 const defaultOptions: Options = {
   ...baseDotNotationDefaultOptions,
   allowPrivateClassPropertyAccess: false,
   allowProtectedClassPropertyAccess: false,
+  allowIndexSignaturePropertyAccess: false,
 };
 ```
+
+If the TypeScript compiler option `noPropertyAccessFromIndexSignature` is set to `true`, then this rule always allows the use of square bracket notation to access properties of types that have a `string` index signature, even if `allowIndexSignaturePropertyAccess` is `false`.
 
 ### `allowPrivateClassPropertyAccess`
 
@@ -57,5 +64,20 @@ class X {
 const x = new X();
 x['protected_prop'] = 123;
 ```
+
+### `allowIndexSignaturePropertyAccess`
+
+Example of correct code when `allowIndexSignaturePropertyAccess` is set to `true`
+
+```ts
+class X {
+  [key: string]: number;
+}
+
+const x = new X();
+x['hello'] = 123;
+```
+
+If the TypeScript compiler option `noPropertyAccessFromIndexSignature` is set to `true`, then the above code is always allowed, even if `allowIndexSignaturePropertyAccess` is `false`.
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/dot-notation.md)</sup>

--- a/packages/eslint-plugin/tests/rules/dot-notation.test.ts
+++ b/packages/eslint-plugin/tests/rules/dot-notation.test.ts
@@ -87,6 +87,18 @@ x['protected_prop'] = 123;
       `,
       options: [{ allowProtectedClassPropertyAccess: true }],
     },
+    {
+      code: `
+class X {
+  prop: string;
+  [key: string]: number;
+}
+
+const x = new X();
+x['hello'] = 3;
+      `,
+      options: [{ allowIndexSignaturePropertyAccess: true }],
+    },
   ],
   invalid: [
     {
@@ -286,6 +298,28 @@ const x = new X();
 x.protected_prop = 123;
       `,
       errors: [{ messageId: 'useDot' }],
+    },
+    {
+      code: `
+class X {
+  prop: string;
+  [key: string]: number;
+}
+
+const x = new X();
+x['prop'] = 'hello';
+      `,
+      options: [{ allowIndexSignaturePropertyAccess: true }],
+      errors: [{ messageId: 'useDot' }],
+      output: `
+class X {
+  prop: string;
+  [key: string]: number;
+}
+
+const x = new X();
+x.prop = 'hello';
+      `,
     },
   ],
 });

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -713,6 +713,7 @@ declare module 'eslint/lib/rules/dot-notation' {
         allowPattern?: string;
         allowPrivateClassPropertyAccess?: boolean;
         allowProtectedClassPropertyAccess?: boolean;
+        allowIndexSignaturePropertyAccess?: boolean;
       },
     ],
     {


### PR DESCRIPTION
Fixes #3104.

This PR modifies the `dot-notation` rule to add a new option named `allowIndexSignaturePropertyAccess`.

When this option is set to `true`, `dot-notation` allows the use of square bracket notation if there is a corresponding index signature defined on the type that is being dereferenced. For example:

```typescript
class X {
    property: string;
    [key: string]: number;
}

const x = new X();
x["hello"] = 123; // Allowed if `allowIndexSignaturePropertyAccess: true`
x["property"] = "hello"; // Still disallowed, should use dot-notation.
```

If the TypeScript compiler option `noPropertyAccessFromIndexSignature` is set to `true`, then the `dot-notation` rule always behaves as if `allowIndexSignaturePropertyAccess` is set to `true`. The motivation for this behaviour is that `noPropertyAccessFromIndexSignature` causes the TypeScript compiler to *require* the use of square bracket notation, so typescript-eslint conflicts with the compiler if it disallows square bracket notation in this case. See #3104.