### PR TITLE
fix(eslint-plugin): return-await now supports non async function that returns promises

### DIFF
--- a/packages/eslint-plugin/docs/rules/return-await.md
+++ b/packages/eslint-plugin/docs/rules/return-await.md
@@ -44,7 +44,13 @@ async function invalidInTryCatch1() {
   } catch (e) {}
 }
 
-async function invalidInTryCatch2() {
+function invalidInTryCatch2() {
+  try {
+    return Promise.resolve('try');
+  } catch (e) {}
+}
+
+async function invalidInTryCatch3() {
   try {
     throw new Error('error');
   } catch (e) {
@@ -52,7 +58,7 @@ async function invalidInTryCatch2() {
   }
 }
 
-async function invalidInTryCatch3() {
+async function invalidInTryCatch4() {
   try {
     throw new Error('error');
   } catch (e) {
@@ -62,7 +68,7 @@ async function invalidInTryCatch3() {
   }
 }
 
-async function invalidInTryCatch4() {
+async function invalidInTryCatch5() {
   try {
     throw new Error('error');
   } catch (e) {
@@ -72,11 +78,11 @@ async function invalidInTryCatch4() {
   }
 }
 
-async function invalidInTryCatch5() {
+async function invalidInTryCatch6() {
   return await Promise.resolve('try');
 }
 
-async function invalidInTryCatch6() {
+async function invalidInTryCatch7() {
   return await 'value';
 }
 ```

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -207,20 +207,6 @@ ruleTester.run('return-await', rule, {
       `,
     },
     {
-      options: ['always'],
-      code: `
-        declare function foo(): Promise<boolean>;
-
-        function bar(baz: boolean): Promise<boolean> | boolean {
-          if (baz) {
-            return true;
-          } else {
-            return foo();
-          }
-        }
-      `,
-    },
-    {
       code: `
         async function test(): Promise<string> {
           const res = await Promise.resolve('{}');
@@ -823,6 +809,127 @@ const buzz = async () => ((await foo()) ? 1 : await bar());
         },
         {
           line: 4,
+          messageId: 'requiredPromiseAwait',
+        },
+      ],
+    },
+    {
+      options: ['always'],
+      code: `
+        function test() {
+          return Promise.resolve(1);
+        }
+      `,
+      output: `
+        async function test() {
+          return await Promise.resolve(1);
+        }
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'requiredPromiseAwait',
+        },
+      ],
+    },
+    {
+      options: ['always'],
+      code: `
+        const test = () => {
+          return Promise.resolve(1);
+        };
+      `,
+      output: `
+        const test = async () => {
+          return await Promise.resolve(1);
+        };
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'requiredPromiseAwait',
+        },
+      ],
+    },
+    {
+      options: ['always'],
+      code: `
+        class Test {
+          private x() {
+            return Promise.resolve(1);
+          }
+        }
+      `,
+      output: `
+        class Test {
+          private async x() {
+            return await Promise.resolve(1);
+          }
+        }
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'requiredPromiseAwait',
+        },
+      ],
+    },
+    {
+      options: ['always'],
+      code: `
+        async function f(n: number) {
+          return n + 1;
+        }
+
+        async function g() {
+          const l = [1, 2, 3];
+          return await Promise.all(l.map(n => f(n)));
+        }
+      `,
+      output: `
+        async function f(n: number) {
+          return n + 1;
+        }
+
+        async function g() {
+          const l = [1, 2, 3];
+          return await Promise.all(l.map(async n => await f(n)));
+        }
+      `,
+      errors: [
+        {
+          line: 8,
+          messageId: 'requiredPromiseAwait',
+        },
+      ],
+    },
+    {
+      options: ['always'],
+      code: `
+        declare function foo(): Promise<boolean>;
+
+        function bar(baz: boolean): Promise<boolean> | boolean {
+          if (baz) {
+            return true;
+          } else {
+            return foo();
+          }
+        }
+      `,
+      output: `
+        declare function foo(): Promise<boolean>;
+
+        async function bar(baz: boolean): Promise<boolean> | boolean {
+          if (baz) {
+            return true;
+          } else {
+            return await foo();
+          }
+        }
+      `,
+      errors: [
+        {
+          line: 8,
           messageId: 'requiredPromiseAwait',
         },
       ],


### PR DESCRIPTION
Fixes #3331 
`return-await` will now work on non-async functions that return promises
e.g., with the option `in-try-catch`:
```
function x() {
    try {
        return Promise.resolve(1)
    catch(e) {}
}
```

will be fixed to:
```
async function x() {
    try {
        return await Promise.resolve(1)
    catch(e) {}
}
```