### PR TITLE
chore(eslint-plugin): [no-loss-of-precision] fix spelling of `isSeparatedNumeric`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-loss-of-precision.ts
+++ b/packages/eslint-plugin/src/rules/no-loss-of-precision.ts
@@ -38,14 +38,14 @@ export default util.createRule<Options, MessageIds>({
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const rules = baseRule!.create(context);
 
-    function isSeperatedNumeric(node: TSESTree.Literal): boolean {
+    function isSeparatedNumeric(node: TSESTree.Literal): boolean {
       return typeof node.value === 'number' && node.raw.includes('_');
     }
     return {
       Literal(node: TSESTree.Literal): void {
         rules.Literal({
           ...node,
-          raw: isSeperatedNumeric(node) ? node.raw.replace(/_/g, '') : node.raw,
+          raw: isSeparatedNumeric(node) ? node.raw.replace(/_/g, '') : node.raw,
         } as never);
       },
     };


### PR DESCRIPTION
This commit fixes a typo in the name of the helper function `isSeparatedNumeric`.