### PR TITLE
fix(eslint-plugin): [no-shadow] fix static class method generics shadowing class generics

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow.test.ts
@@ -159,6 +159,19 @@ type Fn = (Foo: string) => typeof Foo;
       `,
       options: [{ ignoreFunctionTypeParameterNameValueShadow: false }],
     },
+    `
+export class Wrapper<Wrapped> {
+  private constructor(private readonly wrapped: Wrapped) {}
+
+  unwrap(): Wrapped {
+    return this.wrapped;
+  }
+
+  static create<Wrapped>(wrapped: Wrapped) {
+    return new Wrapper<Wrapped>(wrapped);
+  }
+}
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #2592

Unfortunately I think this is impossible to solve from the scope analysis side.. So I opted instead to just ignore it from the lint rule.