### PR TITLE
fix(eslint-plugin): [no-unsafe-*] special case handling for the empty map constructor with no generics

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -220,6 +220,9 @@ export default util.createRule<[], MessageIds>({
                     tupleType,
                     parameterType,
                     checker,
+                    // we can't pass the individual tuple members in here as this will most likely be a spread variable
+                    // not a spread array
+                    null,
                   );
                   if (result) {
                     context.report({
@@ -258,6 +261,7 @@ export default util.createRule<[], MessageIds>({
                 argumentType,
                 parameterType,
                 checker,
+                argument,
               );
               if (result) {
                 context.report({

--- a/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts
@@ -283,7 +283,12 @@ export default util.createRule({
         return false;
       }
 
-      const result = util.isUnsafeAssignment(senderType, receiverType, checker);
+      const result = util.isUnsafeAssignment(
+        senderType,
+        receiverType,
+        checker,
+        senderNode,
+      );
       if (!result) {
         return false;
       }

--- a/packages/eslint-plugin/src/rules/no-unsafe-return.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-return.ts
@@ -151,6 +151,7 @@ export default util.createRule({
           returnNodeType,
           functionReturnType,
           checker,
+          returnNode,
         );
         if (!result) {
           return;

--- a/packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts
@@ -85,6 +85,11 @@ foo('a', 'b', 1 as any);
 declare function toHaveBeenCalledWith<E extends any[]>(...params: E): void;
 toHaveBeenCalledWith(1 as any);
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2109
+    `
+declare function acceptsMap(arg: Map<string, string>): void;
+acceptsMap(new Map());
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-unsafe-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-assignment.test.ts
@@ -141,6 +141,8 @@ declare function Foo(props: { a: string }): never;
     'const x: unknown = y as any;',
     'const x: unknown[] = y as any[];',
     'const x: Set<unknown> = y as Set<any>;',
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2109
+    'const x: Map<string, string> = new Map();',
   ],
   invalid: [
     ...batchedSingleLineTests({

--- a/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
@@ -92,6 +92,12 @@ function foo(): Set<number> {
         return x as Set<any>;
       }
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2109
+    `
+      function test(): Map<string, string> {
+        return new Map();
+      }
+    `,
   ],
   invalid: [
     ...batchedSingleLineTests({

--- a/packages/eslint-plugin/tests/util/isUnsafeAssignment.test.ts
+++ b/packages/eslint-plugin/tests/util/isUnsafeAssignment.test.ts
@@ -10,7 +10,12 @@ describe('isUnsafeAssignment', () => {
 
   function getTypes(
     code: string,
-  ): { sender: ts.Type; receiver: ts.Type; checker: ts.TypeChecker } {
+  ): {
+    sender: ts.Type;
+    senderNode: TSESTree.Node;
+    receiver: ts.Type;
+    checker: ts.TypeChecker;
+  } {
     const { ast, services } = parseForESLint(code, {
       project: './tsconfig.json',
       filePath: path.join(rootDir, 'file.ts'),
@@ -28,6 +33,7 @@ describe('isUnsafeAssignment', () => {
       sender: checker.getTypeAtLocation(
         esTreeNodeToTSNodeMap.get(declarator.init!),
       ),
+      senderNode: declarator.init!,
       checker,
     };
   }
@@ -52,7 +58,7 @@ describe('isUnsafeAssignment', () => {
       );
 
       expectTypesAre(
-        isUnsafeAssignment(sender, receiver, checker),
+        isUnsafeAssignment(sender, receiver, checker, null),
         checker,
         'any',
         'string',
@@ -65,7 +71,7 @@ describe('isUnsafeAssignment', () => {
       );
 
       expectTypesAre(
-        isUnsafeAssignment(sender, receiver, checker),
+        isUnsafeAssignment(sender, receiver, checker, null),
         checker,
         'Set<any>',
         'Set<string>',
@@ -78,7 +84,7 @@ describe('isUnsafeAssignment', () => {
       );
 
       expectTypesAre(
-        isUnsafeAssignment(sender, receiver, checker),
+        isUnsafeAssignment(sender, receiver, checker, null),
         checker,
         'Map<string, any>',
         'Map<string, string>',
@@ -91,7 +97,7 @@ describe('isUnsafeAssignment', () => {
       );
 
       expectTypesAre(
-        isUnsafeAssignment(sender, receiver, checker),
+        isUnsafeAssignment(sender, receiver, checker, null),
         checker,
         'Set<any[]>',
         'Set<string[]>',
@@ -104,7 +110,7 @@ describe('isUnsafeAssignment', () => {
       );
 
       expectTypesAre(
-        isUnsafeAssignment(sender, receiver, checker),
+        isUnsafeAssignment(sender, receiver, checker, null),
         checker,
         'Set<Set<Set<any>>>',
         'Set<Set<Set<string>>>',
@@ -118,13 +124,13 @@ describe('isUnsafeAssignment', () => {
         'const test: string = "";',
       );
 
-      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+      expect(isUnsafeAssignment(sender, receiver, checker, null)).toBeFalsy();
     });
 
     it('non-any to a any', () => {
       const { sender, receiver, checker } = getTypes('const test: any = "";');
 
-      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+      expect(isUnsafeAssignment(sender, receiver, checker, null)).toBeFalsy();
     });
 
     it('non-any in a generic position to a non-any', () => {
@@ -132,7 +138,7 @@ describe('isUnsafeAssignment', () => {
         'const test: Set<string> = new Set<string>();',
       );
 
-      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+      expect(isUnsafeAssignment(sender, receiver, checker, null)).toBeFalsy();
     });
 
     it('non-any in a generic position to a non-any (multiple generics)', () => {
@@ -140,7 +146,7 @@ describe('isUnsafeAssignment', () => {
         'const test: Map<string, string> = new Map<string, string>();',
       );
 
-      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+      expect(isUnsafeAssignment(sender, receiver, checker, null)).toBeFalsy();
     });
 
     it('non-any[] in a generic position to a non-any[]', () => {
@@ -148,7 +154,7 @@ describe('isUnsafeAssignment', () => {
         'const test: Set<string[]> = new Set<string[]>();',
       );
 
-      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+      expect(isUnsafeAssignment(sender, receiver, checker, null)).toBeFalsy();
     });
 
     it('non-any in a generic position to a non-any (nested)', () => {
@@ -156,7 +162,7 @@ describe('isUnsafeAssignment', () => {
         'const test: Set<Set<Set<string>>> = new Set<Set<Set<string>>>();',
       );
 
-      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+      expect(isUnsafeAssignment(sender, receiver, checker, null)).toBeFalsy();
     });
 
     it('non-any in a generic position to a any (nested)', () => {
@@ -164,7 +170,7 @@ describe('isUnsafeAssignment', () => {
         'const test: Set<Set<Set<any>>> = new Set<Set<Set<string>>>();',
       );
 
-      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+      expect(isUnsafeAssignment(sender, receiver, checker, null)).toBeFalsy();
     });
 
     it('any to a unknown', () => {
@@ -172,7 +178,7 @@ describe('isUnsafeAssignment', () => {
         'const test: unknown = [] as any;',
       );
 
-      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+      expect(isUnsafeAssignment(sender, receiver, checker, null)).toBeFalsy();
     });
 
     it('any[] in a generic position to a unknown[]', () => {
@@ -180,7 +186,7 @@ describe('isUnsafeAssignment', () => {
         'const test: unknown[] = [] as any[]',
       );
 
-      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+      expect(isUnsafeAssignment(sender, receiver, checker, null)).toBeFalsy();
     });
 
     it('any in a generic position to a unknown (nested)', () => {
@@ -188,7 +194,18 @@ describe('isUnsafeAssignment', () => {
         'const test: Set<Set<Set<unknown>>> = new Set<Set<Set<any>>>();',
       );
 
-      expect(isUnsafeAssignment(sender, receiver, checker)).toBeFalsy();
+      expect(isUnsafeAssignment(sender, receiver, checker, null)).toBeFalsy();
+    });
+
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2109
+    it('special cases the empty map constructor with no generics', () => {
+      const { sender, senderNode, receiver, checker } = getTypes(
+        'const test: Map<string, string> = new Map();',
+      );
+
+      expect(
+        isUnsafeAssignment(sender, receiver, checker, senderNode),
+      ).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
Fixes #2109

Sucks that it had to be this way, but oh well.