### PR TITLE
docs(eslint-plugin): corrected no-unsupported-browser-code in roadmap as unimplemented

### DIFF
--- a/packages/eslint-plugin/ROADMAP.md
+++ b/packages/eslint-plugin/ROADMAP.md
@@ -299,7 +299,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 | `no-document-write`                 | 🌓  | Use [`no-restricted-syntax`][no-restricted-syntax] |
 | `no-exec-script`                    | 🌓  | Use [`no-restricted-syntax`][no-restricted-syntax] |
 | `no-jquery-raw-elements`            | 🛑  | N/A                                                |
-| `no-unsupported-browser-code`       | 🔌  | [`eslint-plugin-compat`][plugin:compat]            |
+| `no-unsupported-browser-code`       | 🛑  | N/A                                                |
 | `react-this-binding-issue`          | 🛑  | N/A                                                |
 | `react-tsx-curly-spacing`           | 🔌  | [`react/jsx-curly-spacing`]                        |
 | `react-unused-props-and-state`      | 🌓  | [`react/no-unused-state`]                          |


### PR DESCRIPTION
Noticed in https://github.com/typescript-eslint/tslint-to-eslint-config/issues/892: despite its name, the rule is about letting developers explicitly mark certain areas of code as specific to a browser.