### PR TITLE
chore(experimental-utils): remove useless union types in `ast-utils`

### DIFF
--- a/packages/experimental-utils/src/ast-utils/eslint-utils/predicates.ts
+++ b/packages/experimental-utils/src/ast-utils/eslint-utils/predicates.ts
@@ -2,82 +2,80 @@ import * as eslintUtils from 'eslint-utils';
 import { TSESTree } from '../../ts-estree';
 
 const isArrowToken = eslintUtils.isArrowToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.PunctuatorToken & { value: '=>' };
 const isNotArrowToken = eslintUtils.isNotArrowToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => boolean;
 
 const isClosingBraceToken = eslintUtils.isClosingBraceToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.PunctuatorToken & { value: '}' };
 const isNotClosingBraceToken = eslintUtils.isNotClosingBraceToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => boolean;
 
 const isClosingBracketToken = eslintUtils.isClosingBracketToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.PunctuatorToken & { value: ']' };
 const isNotClosingBracketToken = eslintUtils.isNotClosingBracketToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => boolean;
 
 const isClosingParenToken = eslintUtils.isClosingParenToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.PunctuatorToken & { value: ')' };
 const isNotClosingParenToken = eslintUtils.isNotClosingParenToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => boolean;
 
 const isColonToken = eslintUtils.isColonToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.PunctuatorToken & { value: ':' };
 const isNotColonToken = eslintUtils.isNotColonToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => boolean;
 
 const isCommaToken = eslintUtils.isCommaToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.PunctuatorToken & { value: ',' };
 const isNotCommaToken = eslintUtils.isNotCommaToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => boolean;
 
 const isCommentToken = eslintUtils.isCommentToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.Comment;
-const isNotCommentToken = eslintUtils.isNotCommentToken as <
-  T extends TSESTree.Token | TSESTree.Comment
->(
-  token: T,
-) => token is Exclude<T, TSESTree.Comment>;
+const isNotCommentToken = eslintUtils.isNotCommentToken as (
+  token: TSESTree.Token,
+) => token is Exclude<TSESTree.Token, TSESTree.Comment>;
 
 const isOpeningBraceToken = eslintUtils.isOpeningBraceToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.PunctuatorToken & { value: '{' };
 const isNotOpeningBraceToken = eslintUtils.isNotOpeningBraceToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => boolean;
 
 const isOpeningBracketToken = eslintUtils.isOpeningBracketToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.PunctuatorToken & { value: '[' };
 const isNotOpeningBracketToken = eslintUtils.isNotOpeningBracketToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => boolean;
 
 const isOpeningParenToken = eslintUtils.isOpeningParenToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.PunctuatorToken & { value: '(' };
 const isNotOpeningParenToken = eslintUtils.isNotOpeningParenToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => boolean;
 
 const isSemicolonToken = eslintUtils.isSemicolonToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => token is TSESTree.PunctuatorToken & { value: ';' };
 const isNotSemicolonToken = eslintUtils.isNotSemicolonToken as (
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ) => boolean;
 
 export {

--- a/packages/experimental-utils/src/ast-utils/misc.ts
+++ b/packages/experimental-utils/src/ast-utils/misc.ts
@@ -6,8 +6,8 @@ const LINEBREAK_MATCHER = /\r\n|[\r\n\u2028\u2029]/;
  * Determines whether two adjacent tokens are on the same line
  */
 function isTokenOnSameLine(
-  left: TSESTree.Token | TSESTree.Comment,
-  right: TSESTree.Token | TSESTree.Comment,
+  left: TSESTree.Token,
+  right: TSESTree.Token,
 ): boolean {
   return left.loc.end.line === right.loc.start.line;
 }


### PR DESCRIPTION
`Comment` is a sub-type of `Token`

https://github.com/typescript-eslint/typescript-eslint/blob/02acc4f528c92efb4a7023ee3fa26413fd6180bb/packages/ast-spec/src/unions/Token.ts#L14-L26

---

Follow-up of #3289