### PR TITLE
chore(experimental-utils): remove useless union types in `ts-eslint`

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -148,7 +148,7 @@ interface ReportDescriptorNodeOptionalLoc {
   /**
    * The Node or AST Token which the report is being attached to
    */
-  readonly node: TSESTree.Node | TSESTree.Comment | TSESTree.Token;
+  readonly node: TSESTree.Node | TSESTree.Token;
   /**
    * An override of the location of the report
    */

--- a/packages/experimental-utils/src/ts-eslint/SourceCode.ts
+++ b/packages/experimental-utils/src/ts-eslint/SourceCode.ts
@@ -55,8 +55,8 @@ declare class TokenStore {
    * @returns An object representing the token.
    */
   getFirstTokenBetween<T extends SourceCode.CursorWithSkipOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.Token,
+    right: TSESTree.Node | TSESTree.Token,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T> | null;
   /**
@@ -77,8 +77,8 @@ declare class TokenStore {
    * @returns Tokens between left and right.
    */
   getFirstTokensBetween<T extends SourceCode.CursorWithCountOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.Token,
+    right: TSESTree.Node | TSESTree.Token,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T>[];
   /**
@@ -99,8 +99,8 @@ declare class TokenStore {
    * @returns An object representing the token.
    */
   getLastTokenBetween<T extends SourceCode.CursorWithSkipOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.Token,
+    right: TSESTree.Node | TSESTree.Token,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T> | null;
   /**
@@ -121,8 +121,8 @@ declare class TokenStore {
    * @returns Tokens between left and right.
    */
   getLastTokensBetween<T extends SourceCode.CursorWithCountOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.Token,
+    right: TSESTree.Node | TSESTree.Token,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T>[];
   /**
@@ -132,7 +132,7 @@ declare class TokenStore {
    * @returns An object representing the token.
    */
   getTokenAfter<T extends SourceCode.CursorWithSkipOptions>(
-    node: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    node: TSESTree.Node | TSESTree.Token,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T> | null;
   /**
@@ -142,7 +142,7 @@ declare class TokenStore {
    * @returns An object representing the token.
    */
   getTokenBefore<T extends SourceCode.CursorWithSkipOptions>(
-    node: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    node: TSESTree.Node | TSESTree.Token,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T> | null;
   /**
@@ -184,7 +184,7 @@ declare class TokenStore {
    * @returns Tokens.
    */
   getTokensAfter<T extends SourceCode.CursorWithCountOptions>(
-    node: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    node: TSESTree.Node | TSESTree.Token,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T>[];
   /**
@@ -194,7 +194,7 @@ declare class TokenStore {
    * @returns Tokens.
    */
   getTokensBefore<T extends SourceCode.CursorWithCountOptions>(
-    node: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    node: TSESTree.Node | TSESTree.Token,
     options?: T,
   ): SourceCode.ReturnTypeFromOptions<T>[];
   /**
@@ -205,8 +205,8 @@ declare class TokenStore {
    * @returns Tokens between left and right.
    */
   getTokensBetween<T extends SourceCode.CursorWithCountOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.Token,
+    right: TSESTree.Node | TSESTree.Token,
     padding?: T,
   ): SourceCode.ReturnTypeFromOptions<T>[];
   /**
@@ -217,8 +217,8 @@ declare class TokenStore {
    * @returns Tokens between left and right.
    */
   getTokensBetween<T extends SourceCode.CursorWithCountOptions>(
-    left: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
-    right: TSESTree.Node | TSESTree.Token | TSESTree.Comment,
+    left: TSESTree.Node | TSESTree.Token,
+    right: TSESTree.Node | TSESTree.Token,
     padding?: number,
   ): SourceCode.ReturnTypeFromOptions<T>[];
 }
@@ -303,8 +303,8 @@ declare class SourceCodeBase extends TokenStore {
    * @returns True if there is a whitespace character between any of the tokens found between the two given nodes or tokens.
    */
   isSpaceBetween?(
-    first: TSESTree.Token | TSESTree.Comment | TSESTree.Node,
-    second: TSESTree.Token | TSESTree.Comment | TSESTree.Node,
+    first: TSESTree.Token | TSESTree.Node,
+    second: TSESTree.Token | TSESTree.Node,
   ): boolean;
   /**
    * Determines if two nodes or tokens have at least one whitespace character
@@ -342,8 +342,10 @@ declare class SourceCodeBase extends TokenStore {
   text: string;
   /**
    * All of the tokens and comments in the AST.
+   *
+   * TODO: rename to 'tokens'
    */
-  tokensAndComments: (TSESTree.Comment | TSESTree.Token)[];
+  tokensAndComments: TSESTree.Token[];
   /**
    * The visitor keys to traverse AST.
    */
@@ -394,9 +396,7 @@ namespace SourceCode {
     [nodeType: string]: string[];
   }
 
-  export type FilterPredicate = (
-    tokenOrComment: TSESTree.Token | TSESTree.Comment,
-  ) => boolean;
+  export type FilterPredicate = (token: TSESTree.Token) => boolean;
 
   export type ReturnTypeFromOptions<T> = T extends { includeComments: true }
     ? TSESTree.Token


### PR DESCRIPTION
`Comment` is a sub-type of `Token`

https://github.com/typescript-eslint/typescript-eslint/blob/02acc4f528c92efb4a7023ee3fa26413fd6180bb/packages/ast-spec/src/unions/Token.ts#L14-L26

---

Follow-up of #3289