### PR TITLE
chore(eslint-plugin): remove useless union types

### DIFF
--- a/packages/eslint-plugin/src/rules/comma-spacing.ts
+++ b/packages/eslint-plugin/src/rules/comma-spacing.ts
@@ -108,8 +108,8 @@ export default createRule<Options, MessageIds>({
      */
     function validateCommaSpacing(
       commaToken: TSESTree.PunctuatorToken,
-      prevToken: TSESTree.Token | TSESTree.Comment | null,
-      nextToken: TSESTree.Token | TSESTree.Comment | null,
+      prevToken: TSESTree.Token | null,
+      nextToken: TSESTree.Token | null,
     ): void {
       if (
         prevToken &&

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -31,13 +31,13 @@ interface ReportValueImport {
 }
 
 function isImportToken(
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ): token is TSESTree.KeywordToken & { value: 'import' } {
   return token.type === AST_TOKEN_TYPES.Keyword && token.value === 'import';
 }
 
 function isTypeToken(
-  token: TSESTree.Token | TSESTree.Comment,
+  token: TSESTree.Token,
 ): token is TSESTree.IdentifierToken & { value: 'type' } {
   return token.type === AST_TOKEN_TYPES.Identifier && token.value === 'type';
 }

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/BinarySearchTree.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/BinarySearchTree.ts
@@ -4,10 +4,9 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import createTree from 'functional-red-black-tree';
 
-export type TokenOrComment = TSESTree.Token | TSESTree.Comment;
 export interface TreeValue {
   offset: number;
-  from: TokenOrComment | null;
+  from: TSESTree.Token | null;
   force: boolean;
 }
 

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/OffsetStorage.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/OffsetStorage.ts
@@ -2,11 +2,7 @@
 // License: https://github.com/eslint/eslint/blob/48700fc8408f394887cdedd071b22b757700fdcb/LICENSE
 
 import { TSESTree } from '@typescript-eslint/experimental-utils';
-import {
-  BinarySearchTree,
-  TokenOrComment,
-  TreeValue,
-} from './BinarySearchTree';
+import { BinarySearchTree, TreeValue } from './BinarySearchTree';
 import { TokenInfo } from './TokenInfo';
 
 /**
@@ -17,9 +13,9 @@ export class OffsetStorage {
   private readonly indentSize: number;
   private readonly indentType: string;
   private readonly tree: BinarySearchTree;
-  private readonly lockedFirstTokens: WeakMap<TokenOrComment, TokenOrComment>;
-  private readonly desiredIndentCache: WeakMap<TokenOrComment, string>;
-  private readonly ignoredTokens: WeakSet<TokenOrComment>;
+  private readonly lockedFirstTokens: WeakMap<TSESTree.Token, TSESTree.Token>;
+  private readonly desiredIndentCache: WeakMap<TSESTree.Token, string>;
+  private readonly ignoredTokens: WeakSet<TSESTree.Token>;
   /**
    * @param tokenInfo a TokenInfo instance
    * @param indentSize The desired size of each indentation level
@@ -38,7 +34,7 @@ export class OffsetStorage {
     this.ignoredTokens = new WeakSet();
   }
 
-  private getOffsetDescriptor(token: TokenOrComment): TreeValue {
+  private getOffsetDescriptor(token: TSESTree.Token): TreeValue {
     return this.tree.findLe(token.range[0]).value;
   }
 
@@ -50,8 +46,8 @@ export class OffsetStorage {
    * @param offsetToken The second token, whose offset should be matched to the first token
    */
   public matchOffsetOf(
-    baseToken: TokenOrComment,
-    offsetToken: TokenOrComment,
+    baseToken: TSESTree.Token,
+    offsetToken: TSESTree.Token,
   ): void {
     /*
      * lockedFirstTokens is a map from a token whose indentation is controlled by the "first" option to
@@ -120,8 +116,8 @@ export class OffsetStorage {
    * @param offset The desired indent level
    */
   public setDesiredOffset(
-    token: TokenOrComment,
-    fromToken: TokenOrComment | null,
+    token: TSESTree.Token,
+    fromToken: TSESTree.Token | null,
     offset: number,
   ): void {
     this.setDesiredOffsets(token.range, fromToken, offset);
@@ -154,7 +150,7 @@ export class OffsetStorage {
    */
   public setDesiredOffsets(
     range: [number, number],
-    fromToken: TokenOrComment | null,
+    fromToken: TSESTree.Token | null,
     offset = 0,
     force = false,
   ): void {
@@ -212,7 +208,7 @@ export class OffsetStorage {
    * Gets the desired indent of a token
    * @returns The desired indent of the token
    */
-  public getDesiredIndent(token: TokenOrComment): string {
+  public getDesiredIndent(token: TSESTree.Token): string {
     if (!this.desiredIndentCache.has(token)) {
       if (this.ignoredTokens.has(token)) {
         /*
@@ -263,7 +259,7 @@ export class OffsetStorage {
   /**
    * Ignores a token, preventing it from being reported.
    */
-  ignoreToken(token: TokenOrComment): void {
+  ignoreToken(token: TSESTree.Token): void {
     if (this.tokenInfo.isFirstTokenOfLine(token)) {
       this.ignoredTokens.add(token);
     }

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/TokenInfo.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/TokenInfo.ts
@@ -2,7 +2,6 @@
 // License: https://github.com/eslint/eslint/blob/48700fc8408f394887cdedd071b22b757700fdcb/LICENSE
 
 import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
-import { TokenOrComment } from './BinarySearchTree';
 
 /**
  * A helper class to get token-based info related to indentation
@@ -37,8 +36,8 @@ export class TokenInfo {
    * @returns The first token on the given line
    */
   public getFirstTokenOfLine(
-    token: TokenOrComment | TSESTree.Node,
-  ): TokenOrComment {
+    token: TSESTree.Token | TSESTree.Node,
+  ): TSESTree.Token {
     return this.firstTokensByLineNumber.get(token.loc.start.line)!;
   }
 
@@ -46,7 +45,7 @@ export class TokenInfo {
    * Determines whether a token is the first token in its line
    * @returns `true` if the token is the first on its line
    */
-  public isFirstTokenOfLine(token: TokenOrComment): boolean {
+  public isFirstTokenOfLine(token: TSESTree.Token): boolean {
     return this.getFirstTokenOfLine(token) === token;
   }
 
@@ -55,7 +54,7 @@ export class TokenInfo {
    * @param token Token to examine. This should be the first token on its line.
    * @returns The indentation characters that precede the token
    */
-  public getTokenIndent(token: TokenOrComment): string {
+  public getTokenIndent(token: TSESTree.Token): string {
     return this.sourceCode.text.slice(
       token.range[0] - token.loc.start.column,
       token.range[0],

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
@@ -1666,7 +1666,7 @@ export default createRule<Options, MessageIds>({
               commentMap.get(tokenBefore) ?? tokenBefore,
             );
           },
-          new WeakMap<TokenOrComment, TSESTree.Token>(),
+          new WeakMap<TSESTree.Token, TSESTree.Token>(),
         );
 
         sourceCode.lines.forEach((_, lineIndex) => {

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
@@ -9,7 +9,6 @@ import {
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 
-import { TokenOrComment } from './BinarySearchTree';
 import { OffsetStorage } from './OffsetStorage';
 import { TokenInfo } from './TokenInfo';
 import {
@@ -474,7 +473,7 @@ export default createRule<Options, MessageIds>({
      * @param token Token violating the indent rule
      * @param neededIndent Expected indentation string
      */
-    function report(token: TokenOrComment, neededIndent: string): void {
+    function report(token: TSESTree.Token, neededIndent: string): void {
       const actualIndent = Array.from(tokenInfo.getTokenIndent(token));
       const numSpaces = actualIndent.filter(char => char === ' ').length;
       const numTabs = actualIndent.filter(char => char === '\t').length;
@@ -503,7 +502,7 @@ export default createRule<Options, MessageIds>({
      * @returns `true` if the token's indentation is correct
      */
     function validateTokenIndent(
-      token: TokenOrComment,
+      token: TSESTree.Token,
       desiredIndent: string,
     ): boolean {
       const indentation = tokenInfo.getTokenIndent(token);
@@ -1653,20 +1652,20 @@ export default createRule<Options, MessageIds>({
         addParensIndent(sourceCode.ast.tokens);
 
         /*
-         * Create a Map from (tokenOrComment) => (precedingToken).
+         * Create a Map from (token) => (precedingToken).
          * This is necessary because sourceCode.getTokenBefore does not handle a comment as an argument correctly.
          */
         const precedingTokens = sourceCode.ast.comments.reduce(
           (commentMap, comment) => {
-            const tokenOrCommentBefore = sourceCode.getTokenBefore(comment, {
+            const tokenBefore = sourceCode.getTokenBefore(comment, {
               includeComments: true,
             })!;
 
             return commentMap.set(
               comment,
-              commentMap.has(tokenOrCommentBefore)
-                ? commentMap.get(tokenOrCommentBefore)
-                : tokenOrCommentBefore,
+              commentMap.has(tokenBefore)
+                ? commentMap.get(tokenBefore)
+                : tokenBefore,
             );
           },
           new WeakMap(),

--- a/packages/eslint-plugin/src/rules/object-curly-spacing.ts
+++ b/packages/eslint-plugin/src/rules/object-curly-spacing.ts
@@ -164,8 +164,8 @@ export default createRule<Options, MessageIds>({
     function validateBraceSpacing(
       node: TSESTree.TSMappedType | TSESTree.TSTypeLiteral,
       first: TSESTree.Token,
-      second: TSESTree.Token | TSESTree.Comment,
-      penultimate: TSESTree.Token | TSESTree.Comment,
+      second: TSESTree.Token,
+      penultimate: TSESTree.Token,
       last: TSESTree.Token,
     ): void {
       if (isTokenOnSameLine(first, second)) {


### PR DESCRIPTION
`Comment` is a sub-type of `Token`

https://github.com/typescript-eslint/typescript-eslint/blob/02acc4f528c92efb4a7023ee3fa26413fd6180bb/packages/ast-spec/src/unions/Token.ts#L14-L26

---

Follow-up of #3289