### PR TITLE
chore(ast-spec): remove useless union type from `LeftHandSideExpression`

### DIFF
--- a/packages/ast-spec/src/unions/LeftHandSideExpression.ts
+++ b/packages/ast-spec/src/unions/LeftHandSideExpression.ts
@@ -11,7 +11,6 @@ import type { MetaProperty } from '../expression/MetaProperty/spec';
 import type { ObjectExpression } from '../expression/ObjectExpression/spec';
 import type { Super } from '../expression/Super/spec';
 import type { TaggedTemplateExpression } from '../expression/TaggedTemplateExpression/spec';
-import type { TemplateLiteral } from '../expression/TemplateLiteral/spec';
 import type { ThisExpression } from '../expression/ThisExpression/spec';
 import type { TSAsExpression } from '../expression/TSAsExpression/spec';
 import type { TSNonNullExpression } from '../expression/TSNonNullExpression/spec';
@@ -37,7 +36,6 @@ export type LeftHandSideExpression =
   | ObjectPattern
   | Super
   | TaggedTemplateExpression
-  | TemplateLiteral
   | ThisExpression
   | TSAsExpression
   | TSNonNullExpression


### PR DESCRIPTION
Remove `TemplateLiteral` from `LeftHandSideExpression` as `TemplateLiteral` is a sub-type of `LiteralExpression`, which is a sub-type of `LeftHandSideExpression`

https://github.com/typescript-eslint/typescript-eslint/blob/02acc4f528c92efb4a7023ee3fa26413fd6180bb/packages/ast-spec/src/unions/LiteralExpression.ts#L4

https://github.com/typescript-eslint/typescript-eslint/blob/02acc4f528c92efb4a7023ee3fa26413fd6180bb/packages/ast-spec/src/unions/LeftHandSideExpression.ts#L23-L44