### PR TITLE
chore(ast-spec): remove useless union type from `AwaitExpression`'s `argument`

### DIFF
--- a/packages/ast-spec/src/expression/AwaitExpression/spec.ts
+++ b/packages/ast-spec/src/expression/AwaitExpression/spec.ts
@@ -1,7 +1,6 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
 import type { LeftHandSideExpression } from '../../unions/LeftHandSideExpression';
-import type { TSTypeAssertion } from '../TSTypeAssertion/spec';
 import type { UnaryExpression } from '../UnaryExpression/spec';
 import type { UpdateExpression } from '../UpdateExpression/spec';
 
@@ -10,7 +9,6 @@ export interface AwaitExpression extends BaseNode {
   argument:
     | AwaitExpression
     | LeftHandSideExpression
-    | TSTypeAssertion
     | UnaryExpression
     | UpdateExpression;
 }


### PR DESCRIPTION
`TSTypeAssertion` is a sub-type of `LeftHandSideExpression`

https://github.com/typescript-eslint/typescript-eslint/blob/02acc4f528c92efb4a7023ee3fa26413fd6180bb/packages/ast-spec/src/unions/LeftHandSideExpression.ts#L23-L44