### PR TITLE
chore(ast-spec): remove useless union type from `TSUnaryExpression`

### DIFF
--- a/packages/ast-spec/src/unions/TSUnaryExpression.ts
+++ b/packages/ast-spec/src/unions/TSUnaryExpression.ts
@@ -1,5 +1,4 @@
 import type { AwaitExpression } from '../expression/AwaitExpression/spec';
-import type { TSTypeAssertion } from '../expression/TSTypeAssertion/spec';
 import type { UnaryExpression } from '../expression/UnaryExpression/spec';
 import type { UpdateExpression } from '../expression/UpdateExpression/spec';
 import type { LeftHandSideExpression } from './LeftHandSideExpression';
@@ -8,6 +7,5 @@ import type { LeftHandSideExpression } from './LeftHandSideExpression';
 export type TSUnaryExpression =
   | AwaitExpression
   | LeftHandSideExpression
-  | TSTypeAssertion
   | UnaryExpression
   | UpdateExpression;


### PR DESCRIPTION
`TSTypeAssertion` is a sub-type of `LeftHandSideExpression`

https://github.com/typescript-eslint/typescript-eslint/blob/02acc4f528c92efb4a7023ee3fa26413fd6180bb/packages/ast-spec/src/unions/LeftHandSideExpression.ts#L23-L44