### PR TITLE
docs(eslint-plugin): [no-this-alias] `allowDestructuring` is `true` by default

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-this-alias.md
+++ b/packages/eslint-plugin/docs/rules/no-this-alias.md
@@ -44,7 +44,7 @@ You can pass an object option:
   "@typescript-eslint/no-this-alias": [
     "error",
     {
-      "allowDestructuring": true, // Allow `const { props, state } = this`; false by default
+      "allowDestructuring": false, // Disallow `const { props, state } = this`; true by default
       "allowedNames": ["self"] // Allow `const self = this`; `[]` by default
     }
   ]


### PR DESCRIPTION
ref: https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/rules/no-this-alias.ts#L49