### PR TITLE
fix(experimental-utils): fix `eslint-utils`' negative predicates' return types

### DIFF
--- a/packages/experimental-utils/src/ast-utils/predicates.ts
+++ b/packages/experimental-utils/src/ast-utils/predicates.ts
@@ -5,7 +5,12 @@ function isOptionalChainPunctuator(
 ): token is TSESTree.PunctuatorToken & { value: '?.' } {
   return token.type === AST_TOKEN_TYPES.Punctuator && token.value === '?.';
 }
-function isNotOptionalChainPunctuator(token: TSESTree.Token): boolean {
+function isNotOptionalChainPunctuator(
+  token: TSESTree.Token,
+): token is Exclude<
+  TSESTree.Token,
+  TSESTree.PunctuatorToken & { value: '?.' }
+> {
   return !isOptionalChainPunctuator(token);
 }
 
@@ -14,7 +19,9 @@ function isNonNullAssertionPunctuator(
 ): token is TSESTree.PunctuatorToken & { value: '!' } {
   return token.type === AST_TOKEN_TYPES.Punctuator && token.value === '!';
 }
-function isNotNonNullAssertionPunctuator(token: TSESTree.Token): boolean {
+function isNotNonNullAssertionPunctuator(
+  token: TSESTree.Token,
+): token is Exclude<TSESTree.Token, TSESTree.PunctuatorToken & { value: '!' }> {
   return !isNonNullAssertionPunctuator(token);
 }
 


### PR DESCRIPTION
Just like it's done with `ast-utils`' `isNotCommentToken`

https://github.com/typescript-eslint/typescript-eslint/blob/d4f077473afb04f7c4d377dd87318749632b4404/packages/experimental-utils/src/ast-utils/eslint-utils/predicates.ts#L49-L51