### PR TITLE
chore(eslint-plugin): remove lodash from dependencies

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -48,7 +48,6 @@
     "@typescript-eslint/scope-manager": "4.26.0",
     "debug": "^4.3.1",
     "functional-red-black-tree": "^1.0.1",
-    "lodash": "^4.17.21",
     "regexpp": "^3.1.0",
     "semver": "^7.3.5",
     "tsutils": "^3.21.0"

--- a/packages/eslint-plugin/src/util/astUtils.ts
+++ b/packages/eslint-plugin/src/util/astUtils.ts
@@ -1,5 +1,5 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
-import escapeRegExp from 'lodash/escapeRegExp';
+import { escapeRegExp } from './escapeRegExp';
 
 // deeply re-export, for convenience
 export * from '@typescript-eslint/experimental-utils/dist/ast-utils';

--- a/packages/eslint-plugin/src/util/escapeRegExp.ts
+++ b/packages/eslint-plugin/src/util/escapeRegExp.ts
@@ -1,0 +1,12 @@
+/**
+ * Lodash <https://lodash.com/>
+ * Released under MIT license <https://lodash.com/license>
+ */
+const reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
+const reHasRegExpChar = RegExp(reRegExpChar.source);
+
+export function escapeRegExp(string = ''): string {
+  return string && reHasRegExpChar.test(string)
+    ? string.replace(reRegExpChar, '\\$&')
+    : string;
+}


### PR DESCRIPTION
It is not necessary to add a full lodash as a dependency just for escaping RegExp, right?