### PR TITLE
feat: allow user to provide TS program instance in parser options

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -64,6 +64,8 @@ interface ParserOptions {
   tsconfigRootDir?: string;
   extraFileExtensions?: string[];
   warnOnUnsupportedTypeScriptVersion?: boolean;
+
+  program?: import('typescript').Program;
 }
 ```
 
@@ -210,6 +212,14 @@ This option allows you to toggle the warning that the parser will give you if yo
 Default `false`.
 
 This option allows you to request that when the `project` setting is specified, files will be allowed when not included in the projects defined by the provided `tsconfig.json` files. **Using this option will incur significant performance costs. This option is primarily included for backwards-compatibility.** See the **`project`** section above for more information.
+
+### `parserOptions.program`
+
+Default `undefined`.
+
+This option allows you to programmatically provide an instance of a TypeScript Program object that will provide type information to rules.
+This will override any program that would have been computed from `parserOptions.project` or `parserOptions.createDefaultProgram`.
+All linted files must be part of the provided program.
 
 ## Supported TypeScript Version
 

--- a/packages/parser/tests/lib/services.ts
+++ b/packages/parser/tests/lib/services.ts
@@ -4,6 +4,7 @@ import glob from 'glob';
 import { ParserOptions } from '../../src/parser';
 import {
   createSnapshotTestBlock,
+  createTSProgram,
   formatSnapshotName,
   testServices,
 } from '../tools/test-utils';
@@ -30,15 +31,17 @@ function createConfig(filename: string): ParserOptions {
 //------------------------------------------------------------------------------
 
 describe('services', () => {
+  const program = createTSProgram(path.resolve(FIXTURES_DIR, 'tsconfig.json'));
   testFiles.forEach(filename => {
     const code = fs.readFileSync(path.join(FIXTURES_DIR, filename), 'utf8');
     const config = createConfig(filename);
-    it(
-      formatSnapshotName(filename, FIXTURES_DIR, '.ts'),
-      createSnapshotTestBlock(code, config),
-    );
-    it(`${formatSnapshotName(filename, FIXTURES_DIR, '.ts')} services`, () => {
+    const snapshotName = formatSnapshotName(filename, FIXTURES_DIR, '.ts');
+    it(snapshotName, createSnapshotTestBlock(code, config));
+    it(`${snapshotName} services`, () => {
       testServices(code, config);
+    });
+    it(`${snapshotName} services with provided program`, () => {
+      testServices(code, { ...config, program });
     });
   });
 });

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -48,5 +48,8 @@
         "_ts3.4/*"
       ]
     }
+  },
+  "devDependencies": {
+    "typescript": ">=2.6.0"
   }
 }

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -1,4 +1,5 @@
 import { Lib } from './lib';
+import { Program } from 'typescript';
 
 type DebugLevel = boolean | ('typescript-eslint' | 'eslint' | 'typescript')[];
 
@@ -41,6 +42,7 @@ interface ParserOptions {
   extraFileExtensions?: string[];
   filePath?: string;
   loc?: boolean;
+  program?: Program;
   project?: string | string[];
   projectFolderIgnoreList?: (string | RegExp)[];
   range?: boolean;

--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -209,6 +209,13 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
   tsconfigRootDir?: string;
 
   /**
+   * Instance of a TypeScript Program object to be used for type information.
+   * This overrides any program or programs that would have been computed from the `project` option.
+   * All linted files must be part of the provided program.
+   */
+  program?: import('typescript').Program;
+
+  /**
    ***************************************************************************************
    * IT IS RECOMMENDED THAT YOU DO NOT USE THIS OPTION, AS IT CAUSES PERFORMANCE ISSUES. *
    ***************************************************************************************

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -64,6 +64,9 @@
     "jest-specific-snapshot": "*",
     "make-dir": "*",
     "tmp": "^0.2.1",
+    "typescript": "^4.3.2"
+  },
+  "peerDependencies": {
     "typescript": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/typescript-estree/src/create-program/createProjectProgram.ts
+++ b/packages/typescript-estree/src/create-program/createProjectProgram.ts
@@ -3,18 +3,11 @@ import path from 'path';
 import { getProgramsForProjects } from './createWatchProgram';
 import { firstDefined } from '../node-utils';
 import { Extra } from '../parser-options';
-import { ASTAndProgram } from './shared';
+import { ASTAndProgram, getAstFromProgram } from './shared';
 
 const log = debug('typescript-eslint:typescript-estree:createProjectProgram');
 
 const DEFAULT_EXTRA_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
-
-function getExtension(fileName: string | undefined): string | null {
-  if (!fileName) {
-    return null;
-  }
-  return fileName.endsWith('.d.ts') ? '.d.ts' : path.extname(fileName);
-}
 
 /**
  * @param code The code of the file being linted
@@ -31,18 +24,7 @@ function createProjectProgram(
 
   const astAndProgram = firstDefined(
     getProgramsForProjects(code, extra.filePath, extra),
-    currentProgram => {
-      const ast = currentProgram.getSourceFile(extra.filePath);
-
-      // working around https://github.com/typescript-eslint/typescript-eslint/issues/1573
-      const expectedExt = getExtension(extra.filePath);
-      const returnedExt = getExtension(ast?.fileName);
-      if (expectedExt !== returnedExt) {
-        return;
-      }
-
-      return ast && { ast, program: currentProgram };
-    },
+    currentProgram => getAstFromProgram(currentProgram, extra),
   );
 
   if (!astAndProgram && !createDefaultProgram) {

--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import * as ts from 'typescript';
+import { Program } from 'typescript';
 import { Extra } from '../parser-options';
 
 interface ASTAndProgram {
@@ -93,6 +94,29 @@ function getScriptKind(
   }
 }
 
+function getExtension(fileName: string | undefined): string | null {
+  if (!fileName) {
+    return null;
+  }
+  return fileName.endsWith('.d.ts') ? '.d.ts' : path.extname(fileName);
+}
+
+function getAstFromProgram(
+  currentProgram: Program,
+  extra: Extra,
+): ASTAndProgram | undefined {
+  const ast = currentProgram.getSourceFile(extra.filePath);
+
+  // working around https://github.com/typescript-eslint/typescript-eslint/issues/1573
+  const expectedExt = getExtension(extra.filePath);
+  const returnedExt = getExtension(ast?.fileName);
+  if (expectedExt !== returnedExt) {
+    return undefined;
+  }
+
+  return ast && { ast, program: currentProgram };
+}
+
 export {
   ASTAndProgram,
   canonicalDirname,
@@ -101,4 +125,5 @@ export {
   ensureAbsolutePath,
   getCanonicalFileName,
   getScriptKind,
+  getAstFromProgram,
 };

--- a/packages/typescript-estree/src/create-program/useProvidedProgram.ts
+++ b/packages/typescript-estree/src/create-program/useProvidedProgram.ts
@@ -1,0 +1,28 @@
+import debug from 'debug';
+import { Program } from 'typescript';
+import { Extra } from '../parser-options';
+import { ASTAndProgram, getAstFromProgram } from './shared';
+
+const log = debug('typescript-eslint:typescript-estree:useProvidedProgram');
+
+function useProvidedProgram(
+  programInstance: Program,
+  extra: Extra,
+): ASTAndProgram | undefined {
+  log('Retrieving ast for %s from provided program instance', extra.filePath);
+
+  const astAndProgram = getAstFromProgram(programInstance, extra);
+
+  if (!astAndProgram) {
+    const errorLines = [
+      '"parserOptions.program" has been provided for @typescript-eslint/parser.',
+      `The file was not found in the provided program instance: ${extra.filePath}`,
+    ];
+
+    throw new Error(errorLines.join('\n'));
+  }
+
+  return astAndProgram;
+}
+
+export { useProvidedProgram };

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -20,6 +20,7 @@ export interface Extra {
   loc: boolean;
   log: (message: string) => void;
   preserveNodeMaps?: boolean;
+  program: null | Program;
   projects: CanonicalPath[];
   range: boolean;
   strict: boolean;
@@ -168,6 +169,12 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
    * The absolute path to the root directory for all provided `project`s.
    */
   tsconfigRootDir?: string;
+
+  /**
+   * TypeScript program instance to be used in place of a project built and managed by this library.
+   * Intended for use by CI scenarios only.
+   */
+  program?: Program;
 
   /**
    ***************************************************************************************

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -171,8 +171,9 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
   tsconfigRootDir?: string;
 
   /**
-   * TypeScript program instance to be used in place of a project built and managed by this library.
-   * Intended for use by CI scenarios only.
+   * Instance of a TypeScript Program object to be used for type information.
+   * This overrides any program or programs that would have been computed from the `project` option.
+   * All linted files must be part of the provided program.
    */
   program?: Program;
 

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -276,7 +276,7 @@ function applyParserOptionsToExtra(options: TSESTreeOptions): void {
     );
   }
 
-  if (extra.program !== null) {
+  if (extra.program === null) {
     // providing a program overrides project resolution
     const projectFolderIgnoreList = (
       options.projectFolderIgnoreList ?? ['**/node_modules/**']

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -18,6 +18,8 @@ import {
   ensureAbsolutePath,
   getCanonicalFileName,
 } from './create-program/shared';
+import { Program } from 'typescript';
+import { useProvidedProgram } from './create-program/useProvidedProgram';
 
 const log = debug('typescript-eslint:typescript-estree:parser');
 
@@ -61,10 +63,12 @@ function enforceString(code: unknown): string {
  */
 function getProgramAndAST(
   code: string,
+  programInstance: Program | null,
   shouldProvideParserServices: boolean,
   shouldCreateDefaultProgram: boolean,
 ): ASTAndProgram {
   return (
+    (programInstance && useProvidedProgram(programInstance, extra)) ||
     (shouldProvideParserServices &&
       createProjectProgram(code, shouldCreateDefaultProgram, extra)) ||
     (shouldProvideParserServices &&
@@ -105,6 +109,7 @@ function resetExtra(): void {
     loc: false,
     log: console.log, // eslint-disable-line no-console
     preserveNodeMaps: true,
+    program: null,
     projects: [],
     range: false,
     strict: false,
@@ -264,22 +269,32 @@ function applyParserOptionsToExtra(options: TSESTreeOptions): void {
   // NOTE - ensureAbsolutePath relies upon having the correct tsconfigRootDir in extra
   extra.filePath = ensureAbsolutePath(extra.filePath, extra);
 
-  const projectFolderIgnoreList = (
-    options.projectFolderIgnoreList ?? ['**/node_modules/**']
-  )
-    .reduce<string[]>((acc, folder) => {
-      if (typeof folder === 'string') {
-        acc.push(folder);
-      }
-      return acc;
-    }, [])
-    // prefix with a ! for not match glob
-    .map(folder => (folder.startsWith('!') ? folder : `!${folder}`));
-  // NOTE - prepareAndTransformProjects relies upon having the correct tsconfigRootDir in extra
-  extra.projects = prepareAndTransformProjects(
-    options.project,
-    projectFolderIgnoreList,
-  );
+  if (typeof options.program === 'object') {
+    extra.program = options.program;
+    log(
+      'parserOptions.program was provided, so parserOptions.project will be ignored.',
+    );
+  }
+
+  if (extra.program !== null) {
+    // providing a program overrides project resolution
+    const projectFolderIgnoreList = (
+      options.projectFolderIgnoreList ?? ['**/node_modules/**']
+    )
+      .reduce<string[]>((acc, folder) => {
+        if (typeof folder === 'string') {
+          acc.push(folder);
+        }
+        return acc;
+      }, [])
+      // prefix with a ! for not match glob
+      .map(folder => (folder.startsWith('!') ? folder : `!${folder}`));
+    // NOTE - prepareAndTransformProjects relies upon having the correct tsconfigRootDir in extra
+    extra.projects = prepareAndTransformProjects(
+      options.project,
+      projectFolderIgnoreList,
+    );
+  }
 
   if (
     Array.isArray(options.extraFileExtensions) &&
@@ -453,6 +468,7 @@ function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
     extra.projects && extra.projects.length > 0;
   const { ast, program } = getProgramAndAST(
     code,
+    extra.program,
     shouldProvideParserServices,
     extra.createDefaultProgram,
   )!;

--- a/packages/typescript-estree/tests/lib/__snapshots__/semanticInfo.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semanticInfo.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`semanticInfo file not in provided program instance 1`] = `
+"\\"parserOptions.program\\" has been provided for @typescript-eslint/parser.
+The file was not found in the provided program instance: C:\\\\Repos\\\\typescript-eslint\\\\packages\\\\typescript-estree\\\\tests\\\\fixtures\\\\semanticInfo\\\\non-existent-file.ts"
+`;
+
 exports[`semanticInfo fixtures/export-file.src 1`] = `
 Object {
   "body": Array [

--- a/packages/typescript-estree/tests/lib/__snapshots__/semanticInfo.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semanticInfo.test.ts.snap
@@ -1,10 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`semanticInfo file not in provided program instance 1`] = `
-"\\"parserOptions.program\\" has been provided for @typescript-eslint/parser.
-The file was not found in the provided program instance: C:\\\\Repos\\\\typescript-eslint\\\\packages\\\\typescript-estree\\\\tests\\\\fixtures\\\\semanticInfo\\\\non-existent-file.ts"
-`;
-
 exports[`semanticInfo fixtures/export-file.src 1`] = `
 Object {
   "body": Array [

--- a/packages/typescript-estree/tests/lib/semanticInfo.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo.test.ts
@@ -316,7 +316,12 @@ describe('semanticInfo', () => {
     };
     expect(() =>
       parseAndGenerateServices('const foo = 5;', optionsProjectString),
-    ).toThrowErrorMatchingSnapshot();
+    ).toThrow(
+      `The file was not found in the provided program instance: ${path.resolve(
+        FIXTURES_DIR,
+        filename,
+      )}`,
+    );
   });
 });
 

--- a/packages/typescript-estree/tests/lib/semanticInfo.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo.test.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from 'fs';
+import * as fs from 'fs';
 import glob from 'glob';
-import { extname, join, resolve } from 'path';
+import * as path from 'path';
 import * as ts from 'typescript';
 import { TSESTreeOptions } from '../../src/parser-options';
 import {
@@ -30,7 +30,7 @@ function createOptions(fileName: string): TSESTreeOptions & { cwd?: string } {
     useJSXTextNode: false,
     errorOnUnknownASTType: true,
     filePath: fileName,
-    tsconfigRootDir: join(process.cwd(), FIXTURES_DIR),
+    tsconfigRootDir: path.join(process.cwd(), FIXTURES_DIR),
     project: `./tsconfig.json`,
     loggerFn: false,
   };
@@ -42,9 +42,9 @@ beforeEach(() => clearCaches());
 describe('semanticInfo', () => {
   // test all AST snapshots
   testFiles.forEach(filename => {
-    const code = readFileSync(join(FIXTURES_DIR, filename), 'utf8');
+    const code = fs.readFileSync(path.join(FIXTURES_DIR, filename), 'utf8');
     it(
-      formatSnapshotName(filename, FIXTURES_DIR, extname(filename)),
+      formatSnapshotName(filename, FIXTURES_DIR, path.extname(filename)),
       createSnapshotTestBlock(
         code,
         createOptions(filename),
@@ -55,7 +55,7 @@ describe('semanticInfo', () => {
 
   it(`should cache the created ts.program`, () => {
     const filename = testFiles[0];
-    const code = readFileSync(join(FIXTURES_DIR, filename), 'utf8');
+    const code = fs.readFileSync(path.join(FIXTURES_DIR, filename), 'utf8');
     const options = createOptions(filename);
     const optionsProjectString = {
       ...options,
@@ -70,7 +70,7 @@ describe('semanticInfo', () => {
 
   it(`should handle "project": "./tsconfig.json" and "project": ["./tsconfig.json"] the same`, () => {
     const filename = testFiles[0];
-    const code = readFileSync(join(FIXTURES_DIR, filename), 'utf8');
+    const code = fs.readFileSync(path.join(FIXTURES_DIR, filename), 'utf8');
     const options = createOptions(filename);
     const optionsProjectString = {
       ...options,
@@ -87,7 +87,7 @@ describe('semanticInfo', () => {
 
   it(`should resolve absolute and relative tsconfig paths the same`, () => {
     const filename = testFiles[0];
-    const code = readFileSync(join(FIXTURES_DIR, filename), 'utf8');
+    const code = fs.readFileSync(path.join(FIXTURES_DIR, filename), 'utf8');
     const options = createOptions(filename);
     const optionsAbsolutePath = {
       ...options,
@@ -119,9 +119,9 @@ describe('semanticInfo', () => {
 
   // case-specific tests
   it('isolated-file tests', () => {
-    const fileName = resolve(FIXTURES_DIR, 'isolated-file.src.ts');
+    const fileName = path.resolve(FIXTURES_DIR, 'isolated-file.src.ts');
     const parseResult = parseCodeAndGenerateServices(
-      readFileSync(fileName, 'utf8'),
+      fs.readFileSync(fileName, 'utf8'),
       createOptions(fileName),
     );
 
@@ -129,9 +129,9 @@ describe('semanticInfo', () => {
   });
 
   it('isolated-vue-file tests', () => {
-    const fileName = resolve(FIXTURES_DIR, 'extra-file-extension.vue');
+    const fileName = path.resolve(FIXTURES_DIR, 'extra-file-extension.vue');
     const parseResult = parseCodeAndGenerateServices(
-      readFileSync(fileName, 'utf8'),
+      fs.readFileSync(fileName, 'utf8'),
       {
         ...createOptions(fileName),
         extraFileExtensions: ['.vue'],
@@ -142,9 +142,12 @@ describe('semanticInfo', () => {
   });
 
   it('non-existent-estree-nodes tests', () => {
-    const fileName = resolve(FIXTURES_DIR, 'non-existent-estree-nodes.src.ts');
+    const fileName = path.resolve(
+      FIXTURES_DIR,
+      'non-existent-estree-nodes.src.ts',
+    );
     const parseResult = parseCodeAndGenerateServices(
-      readFileSync(fileName, 'utf8'),
+      fs.readFileSync(fileName, 'utf8'),
       createOptions(fileName),
     );
 
@@ -166,9 +169,9 @@ describe('semanticInfo', () => {
   });
 
   it('imported-file tests', () => {
-    const fileName = resolve(FIXTURES_DIR, 'import-file.src.ts');
+    const fileName = path.resolve(FIXTURES_DIR, 'import-file.src.ts');
     const parseResult = parseCodeAndGenerateServices(
-      readFileSync(fileName, 'utf8'),
+      fs.readFileSync(fileName, 'utf8'),
       createOptions(fileName),
     );
 
@@ -242,20 +245,26 @@ describe('semanticInfo', () => {
   });
 
   it('non-existent project file', () => {
-    const fileName = resolve(FIXTURES_DIR, 'isolated-file.src.ts');
+    const fileName = path.resolve(FIXTURES_DIR, 'isolated-file.src.ts');
     const badConfig = createOptions(fileName);
     badConfig.project = './tsconfigs.json';
     expect(() =>
-      parseCodeAndGenerateServices(readFileSync(fileName, 'utf8'), badConfig),
+      parseCodeAndGenerateServices(
+        fs.readFileSync(fileName, 'utf8'),
+        badConfig,
+      ),
     ).toThrow(/Cannot read file .+tsconfigs\.json'/);
   });
 
   it('fail to read project file', () => {
-    const fileName = resolve(FIXTURES_DIR, 'isolated-file.src.ts');
+    const fileName = path.resolve(FIXTURES_DIR, 'isolated-file.src.ts');
     const badConfig = createOptions(fileName);
     badConfig.project = '.';
     expect(() =>
-      parseCodeAndGenerateServices(readFileSync(fileName, 'utf8'), badConfig),
+      parseCodeAndGenerateServices(
+        fs.readFileSync(fileName, 'utf8'),
+        badConfig,
+      ),
     ).toThrow(
       // case insensitive because unix based systems are case insensitive
       /Cannot read file .+semanticInfo'./i,
@@ -263,11 +272,14 @@ describe('semanticInfo', () => {
   });
 
   it('malformed project file', () => {
-    const fileName = resolve(FIXTURES_DIR, 'isolated-file.src.ts');
+    const fileName = path.resolve(FIXTURES_DIR, 'isolated-file.src.ts');
     const badConfig = createOptions(fileName);
     badConfig.project = './badTSConfig/tsconfig.json';
     expect(() =>
-      parseCodeAndGenerateServices(readFileSync(fileName, 'utf8'), badConfig),
+      parseCodeAndGenerateServices(
+        fs.readFileSync(fileName, 'utf8'),
+        badConfig,
+      ),
     ).toThrowErrorMatchingSnapshot();
   });
 
@@ -278,6 +290,33 @@ describe('semanticInfo', () => {
     });
 
     expect(parseResult.services.program).toBeDefined();
+  });
+
+  it(`provided program instance is returned in result`, () => {
+    const filename = testFiles[0];
+    const program = createTSProgram(path.join(FIXTURES_DIR, 'tsconfig.json'));
+    const code = fs.readFileSync(path.join(FIXTURES_DIR, filename), 'utf8');
+    const options = createOptions(filename);
+    const optionsProjectString = {
+      ...options,
+      program: program,
+      project: './tsconfig.json',
+    };
+    const parseResult = parseAndGenerateServices(code, optionsProjectString);
+    expect(parseResult.services.program).toBe(program);
+  });
+
+  it('file not in provided program instance', () => {
+    const filename = 'non-existent-file.ts';
+    const program = createTSProgram(path.join(FIXTURES_DIR, 'tsconfig.json'));
+    const options = createOptions(filename);
+    const optionsProjectString = {
+      ...options,
+      program: program,
+    };
+    expect(() =>
+      parseAndGenerateServices('const foo = 5;', optionsProjectString),
+    ).toThrowErrorMatchingSnapshot();
   });
 });
 
@@ -340,4 +379,27 @@ function checkNumberArrayType(checker: ts.TypeChecker, tsNode: ts.Node): void {
   const typeArguments = checker.getTypeArguments(nodeType as ts.TypeReference);
   expect(typeArguments).toHaveLength(1);
   expect(typeArguments[0].flags).toBe(ts.TypeFlags.Number);
+}
+
+function createTSProgram(configFile: string): ts.Program {
+  const projectDirectory = path.dirname(configFile);
+  const config = ts.readConfigFile(configFile, ts.sys.readFile);
+  expect(config.error).toBeUndefined();
+  const parseConfigHost: ts.ParseConfigHost = {
+    fileExists: fs.existsSync,
+    readDirectory: ts.sys.readDirectory,
+    readFile: file => fs.readFileSync(file, 'utf8'),
+    useCaseSensitiveFileNames: true,
+  };
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    parseConfigHost,
+    path.resolve(projectDirectory),
+    { noEmit: true },
+  );
+  expect(parsed.errors).toHaveLength(0);
+  const host = ts.createCompilerHost(parsed.options, true);
+  const program = ts.createProgram(parsed.fileNames, parsed.options, host);
+
+  return program;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8878,7 +8878,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*, typescript@4.3.2, "typescript@>=3.3.1 <4.4.0", typescript@^4.1.0-dev.20201026, typescript@~4.2.4:
+typescript@*, typescript@4.3.2, typescript@>=2.6.0, "typescript@>=3.3.1 <4.4.0", typescript@^4.1.0-dev.20201026, typescript@~4.2.4:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
   integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==


### PR DESCRIPTION
`typescript-estree` has complex handling for constructing and managing TS program instances in order to provide type info for semantic rules. However, for one-off invocations on large codebases (e.g., in CI), this functionality isn't valuable, and the overhead is substantial.

Here, we introduce a new parser option `program` that allows users to programmatically provide their own TS program instance that will be used in rules for type info. This is based on [TSLint's functionality](https://github.com/palantir/tslint/blob/285fc1db18d1fd24680d6a2282c6445abf1566ee/src/linter.ts#L121).

In this initial implementation, we only allow for a single program to be provided. However, this could be augmented in the future to support multiple programs.

Fixes https://github.com/typescript-eslint/typescript-eslint/issues/1442