### PR TITLE
fix(typescript-estree): support override modifier for parameter property

### DIFF
--- a/packages/ast-spec/src/parameter/TSParameterProperty/spec.ts
+++ b/packages/ast-spec/src/parameter/TSParameterProperty/spec.ts
@@ -12,6 +12,7 @@ export interface TSParameterProperty extends BaseNode {
   readonly?: boolean;
   static?: boolean;
   export?: boolean;
+  override?: boolean;
   parameter: AssignmentPattern | BindingName | RestElement;
   decorators?: Decorator[];
 }

--- a/packages/shared-fixtures/fixtures/typescript/basics/class-with-constructor-and-parameter-property-with-modifiers.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/class-with-constructor-and-parameter-property-with-modifiers.src.ts
@@ -1,0 +1,3 @@
+class SpecializedComponent extends SomeComponent {
+  constructor(protected override readonly param: string) {}
+}

--- a/packages/shared-fixtures/fixtures/typescript/basics/class-with-constructor-and-parameter-proptery-with-override-modifier.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/class-with-constructor-and-parameter-proptery-with-override-modifier.src.ts
@@ -1,0 +1,5 @@
+class SpecializedComponent extends SomeComponent {
+  constructor(override param: string) {
+      super();
+  }
+}

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1585,6 +1585,8 @@ export class Converter {
               hasModifier(SyntaxKind.ReadonlyKeyword, node) || undefined,
             static: hasModifier(SyntaxKind.StaticKeyword, node) || undefined,
             export: hasModifier(SyntaxKind.ExportKeyword, node) || undefined,
+            override:
+              hasModifier(SyntaxKind.OverrideKeyword, node) || undefined,
             parameter: result,
           });
         }

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -386,6 +386,11 @@ tester.addFixturePatternConfig('typescript/basics', {
      * This is intentional; babel is not checking types
      */
     'catch-clause-with-invalid-annotation',
+    /**
+     * [BABEL ERRORED, BUT TS-ESTREE DID NOT]
+     * SyntaxError: Unexpected token, expected ","
+     */
+    'class-with-constructor-and-parameter-property-with-modifiers',
   ],
   ignoreSourceType: [
     /**

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -391,6 +391,7 @@ tester.addFixturePatternConfig('typescript/basics', {
      * SyntaxError: Unexpected token, expected ","
      */
     'class-with-constructor-and-parameter-property-with-modifiers',
+    'class-with-constructor-and-parameter-proptery-with-override-modifier',
   ],
   ignoreSourceType: [
     /**

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
@@ -1748,6 +1748,8 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" e
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-parameter-property-with-modifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-parameter-proptery-with-override-modifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-return-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
@@ -1746,6 +1746,8 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" e
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-modifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-parameter-property-with-modifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-return-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-constructor-and-parameter-property-with-modifiers.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-constructor-and-parameter-property-with-modifiers.src.ts.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`typescript basics class-with-readonly-parameter-properties.src 1`] = `
+exports[`typescript basics class-with-constructor-and-parameter-property-with-modifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
@@ -21,16 +21,16 @@ Object {
               },
               "name": "constructor",
               "range": Array [
-                14,
-                25,
+                53,
+                64,
               ],
               "type": "Identifier",
             },
             "kind": "constructor",
             "loc": Object {
               "end": Object {
-                "column": 53,
-                "line": 3,
+                "column": 59,
+                "line": 2,
               },
               "start": Object {
                 "column": 2,
@@ -39,8 +39,8 @@ Object {
             },
             "override": false,
             "range": Array [
-              14,
-              107,
+              53,
+              110,
             ],
             "static": false,
             "type": "MethodDefinition",
@@ -50,17 +50,17 @@ Object {
                 "body": Array [],
                 "loc": Object {
                   "end": Object {
-                    "column": 53,
-                    "line": 3,
+                    "column": 59,
+                    "line": 2,
                   },
                   "start": Object {
-                    "column": 51,
-                    "line": 3,
+                    "column": 57,
+                    "line": 2,
                   },
                 },
                 "range": Array [
-                  105,
-                  107,
+                  108,
+                  110,
                 ],
                 "type": "BlockStatement",
               },
@@ -69,8 +69,8 @@ Object {
               "id": null,
               "loc": Object {
                 "end": Object {
-                  "column": 53,
-                  "line": 3,
+                  "column": 59,
+                  "line": 2,
                 },
                 "start": Object {
                   "column": 13,
@@ -79,11 +79,11 @@ Object {
               },
               "params": Array [
                 Object {
-                  "accessibility": undefined,
+                  "accessibility": "protected",
                   "export": undefined,
                   "loc": Object {
                     "end": Object {
-                      "column": 40,
+                      "column": 55,
                       "line": 2,
                     },
                     "start": Object {
@@ -91,172 +91,62 @@ Object {
                       "line": 2,
                     },
                   },
-                  "override": undefined,
+                  "override": true,
                   "parameter": Object {
                     "loc": Object {
                       "end": Object {
-                        "column": 40,
+                        "column": 55,
                         "line": 2,
                       },
                       "start": Object {
-                        "column": 23,
+                        "column": 42,
                         "line": 2,
                       },
                     },
-                    "name": "firstName",
+                    "name": "param",
                     "range": Array [
-                      35,
-                      52,
+                      93,
+                      106,
                     ],
                     "type": "Identifier",
                     "typeAnnotation": Object {
                       "loc": Object {
                         "end": Object {
-                          "column": 40,
+                          "column": 55,
                           "line": 2,
                         },
                         "start": Object {
-                          "column": 32,
+                          "column": 47,
                           "line": 2,
                         },
                       },
                       "range": Array [
-                        44,
-                        52,
+                        98,
+                        106,
                       ],
                       "type": "TSTypeAnnotation",
                       "typeAnnotation": Object {
                         "loc": Object {
                           "end": Object {
-                            "column": 40,
+                            "column": 55,
                             "line": 2,
                           },
                           "start": Object {
-                            "column": 34,
+                            "column": 49,
                             "line": 2,
                           },
                         },
                         "range": Array [
-                          46,
-                          52,
+                          100,
+                          106,
                         ],
                         "type": "TSStringKeyword",
                       },
                     },
                   },
                   "range": Array [
-                    26,
-                    52,
-                  ],
-                  "readonly": true,
-                  "static": undefined,
-                  "type": "TSParameterProperty",
-                },
-                Object {
-                  "accessibility": undefined,
-                  "export": undefined,
-                  "loc": Object {
-                    "end": Object {
-                      "column": 49,
-                      "line": 3,
-                    },
-                    "start": Object {
-                      "column": 14,
-                      "line": 3,
-                    },
-                  },
-                  "override": undefined,
-                  "parameter": Object {
-                    "left": Object {
-                      "loc": Object {
-                        "end": Object {
-                          "column": 39,
-                          "line": 3,
-                        },
-                        "start": Object {
-                          "column": 23,
-                          "line": 3,
-                        },
-                      },
-                      "name": "lastName",
-                      "range": Array [
-                        77,
-                        93,
-                      ],
-                      "type": "Identifier",
-                      "typeAnnotation": Object {
-                        "loc": Object {
-                          "end": Object {
-                            "column": 39,
-                            "line": 3,
-                          },
-                          "start": Object {
-                            "column": 31,
-                            "line": 3,
-                          },
-                        },
-                        "range": Array [
-                          85,
-                          93,
-                        ],
-                        "type": "TSTypeAnnotation",
-                        "typeAnnotation": Object {
-                          "loc": Object {
-                            "end": Object {
-                              "column": 39,
-                              "line": 3,
-                            },
-                            "start": Object {
-                              "column": 33,
-                              "line": 3,
-                            },
-                          },
-                          "range": Array [
-                            87,
-                            93,
-                          ],
-                          "type": "TSStringKeyword",
-                        },
-                      },
-                    },
-                    "loc": Object {
-                      "end": Object {
-                        "column": 49,
-                        "line": 3,
-                      },
-                      "start": Object {
-                        "column": 23,
-                        "line": 3,
-                      },
-                    },
-                    "range": Array [
-                      77,
-                      103,
-                    ],
-                    "right": Object {
-                      "loc": Object {
-                        "end": Object {
-                          "column": 49,
-                          "line": 3,
-                        },
-                        "start": Object {
-                          "column": 42,
-                          "line": 3,
-                        },
-                      },
-                      "range": Array [
-                        96,
-                        103,
-                      ],
-                      "raw": "'Smith'",
-                      "type": "Literal",
-                      "value": "Smith",
-                    },
-                    "type": "AssignmentPattern",
-                  },
-                  "range": Array [
-                    68,
-                    103,
+                    65,
+                    106,
                   ],
                   "readonly": true,
                   "static": undefined,
@@ -264,8 +154,8 @@ Object {
                 },
               ],
               "range": Array [
-                25,
-                107,
+                64,
+                110,
               ],
               "type": "FunctionExpression",
             },
@@ -274,23 +164,23 @@ Object {
         "loc": Object {
           "end": Object {
             "column": 1,
-            "line": 4,
+            "line": 3,
           },
           "start": Object {
-            "column": 10,
+            "column": 49,
             "line": 1,
           },
         },
         "range": Array [
-          10,
-          109,
+          49,
+          112,
         ],
         "type": "ClassBody",
       },
       "id": Object {
         "loc": Object {
           "end": Object {
-            "column": 9,
+            "column": 26,
             "line": 1,
           },
           "start": Object {
@@ -298,17 +188,17 @@ Object {
             "line": 1,
           },
         },
-        "name": "Foo",
+        "name": "SpecializedComponent",
         "range": Array [
           6,
-          9,
+          26,
         ],
         "type": "Identifier",
       },
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 4,
+          "line": 3,
         },
         "start": Object {
           "column": 0,
@@ -317,16 +207,33 @@ Object {
       },
       "range": Array [
         0,
-        109,
+        112,
       ],
-      "superClass": null,
+      "superClass": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 48,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 35,
+            "line": 1,
+          },
+        },
+        "name": "SomeComponent",
+        "range": Array [
+          35,
+          48,
+        ],
+        "type": "Identifier",
+      },
       "type": "ClassDeclaration",
     },
   ],
   "comments": Array [],
   "loc": Object {
     "end": Object {
-      "column": 1,
+      "column": 0,
       "line": 4,
     },
     "start": Object {
@@ -336,7 +243,7 @@ Object {
   },
   "range": Array [
     0,
-    109,
+    113,
   ],
   "sourceType": "script",
   "tokens": Array [
@@ -361,7 +268,7 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 9,
+          "column": 26,
           "line": 1,
         },
         "start": Object {
@@ -371,25 +278,61 @@ Object {
       },
       "range": Array [
         6,
-        9,
+        26,
       ],
       "type": "Identifier",
-      "value": "Foo",
+      "value": "SpecializedComponent",
     },
     Object {
       "loc": Object {
         "end": Object {
-          "column": 11,
+          "column": 34,
           "line": 1,
         },
         "start": Object {
-          "column": 10,
+          "column": 27,
           "line": 1,
         },
       },
       "range": Array [
-        10,
-        11,
+        27,
+        34,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 48,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        35,
+        48,
+      ],
+      "type": "Identifier",
+      "value": "SomeComponent",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 50,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        49,
+        50,
       ],
       "type": "Punctuator",
       "value": "{",
@@ -406,8 +349,8 @@ Object {
         },
       },
       "range": Array [
-        14,
-        25,
+        53,
+        64,
       ],
       "type": "Identifier",
       "value": "constructor",
@@ -424,8 +367,8 @@ Object {
         },
       },
       "range": Array [
-        25,
-        26,
+        64,
+        65,
       ],
       "type": "Punctuator",
       "value": "(",
@@ -433,7 +376,7 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 22,
+          "column": 23,
           "line": 2,
         },
         "start": Object {
@@ -442,11 +385,11 @@ Object {
         },
       },
       "range": Array [
-        26,
-        34,
+        65,
+        74,
       ],
-      "type": "Identifier",
-      "value": "readonly",
+      "type": "Keyword",
+      "value": "protected",
     },
     Object {
       "loc": Object {
@@ -455,52 +398,16 @@ Object {
           "line": 2,
         },
         "start": Object {
-          "column": 23,
+          "column": 24,
           "line": 2,
         },
       },
       "range": Array [
-        35,
-        44,
+        75,
+        83,
       ],
       "type": "Identifier",
-      "value": "firstName",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 33,
-          "line": 2,
-        },
-        "start": Object {
-          "column": 32,
-          "line": 2,
-        },
-      },
-      "range": Array [
-        44,
-        45,
-      ],
-      "type": "Punctuator",
-      "value": ":",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 40,
-          "line": 2,
-        },
-        "start": Object {
-          "column": 34,
-          "line": 2,
-        },
-      },
-      "range": Array [
-        46,
-        52,
-      ],
-      "type": "Identifier",
-      "value": "string",
+      "value": "override",
     },
     Object {
       "loc": Object {
@@ -509,31 +416,13 @@ Object {
           "line": 2,
         },
         "start": Object {
-          "column": 40,
+          "column": 33,
           "line": 2,
         },
       },
       "range": Array [
-        52,
-        53,
-      ],
-      "type": "Punctuator",
-      "value": ",",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 22,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 14,
-          "line": 3,
-        },
-      },
-      "range": Array [
-        68,
-        76,
+        84,
+        92,
       ],
       "type": "Identifier",
       "value": "readonly",
@@ -541,107 +430,71 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 31,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 23,
-          "line": 3,
-        },
-      },
-      "range": Array [
-        77,
-        85,
-      ],
-      "type": "Identifier",
-      "value": "lastName",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 32,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 31,
-          "line": 3,
-        },
-      },
-      "range": Array [
-        85,
-        86,
-      ],
-      "type": "Punctuator",
-      "value": ":",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 39,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 33,
-          "line": 3,
-        },
-      },
-      "range": Array [
-        87,
-        93,
-      ],
-      "type": "Identifier",
-      "value": "string",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 41,
-          "line": 3,
-        },
-        "start": Object {
-          "column": 40,
-          "line": 3,
-        },
-      },
-      "range": Array [
-        94,
-        95,
-      ],
-      "type": "Punctuator",
-      "value": "=",
-    },
-    Object {
-      "loc": Object {
-        "end": Object {
-          "column": 49,
-          "line": 3,
+          "column": 47,
+          "line": 2,
         },
         "start": Object {
           "column": 42,
-          "line": 3,
+          "line": 2,
         },
       },
       "range": Array [
-        96,
-        103,
+        93,
+        98,
       ],
-      "type": "String",
-      "value": "'Smith'",
+      "type": "Identifier",
+      "value": "param",
     },
     Object {
       "loc": Object {
         "end": Object {
-          "column": 50,
-          "line": 3,
+          "column": 48,
+          "line": 2,
         },
         "start": Object {
-          "column": 49,
-          "line": 3,
+          "column": 47,
+          "line": 2,
         },
       },
       "range": Array [
-        103,
-        104,
+        98,
+        99,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 55,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 49,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        100,
+        106,
+      ],
+      "type": "Identifier",
+      "value": "string",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 56,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 55,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        106,
+        107,
       ],
       "type": "Punctuator",
       "value": ")",
@@ -649,17 +502,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 52,
-          "line": 3,
+          "column": 58,
+          "line": 2,
         },
         "start": Object {
-          "column": 51,
-          "line": 3,
+          "column": 57,
+          "line": 2,
         },
       },
       "range": Array [
-        105,
-        106,
+        108,
+        109,
       ],
       "type": "Punctuator",
       "value": "{",
@@ -667,17 +520,17 @@ Object {
     Object {
       "loc": Object {
         "end": Object {
-          "column": 53,
-          "line": 3,
+          "column": 59,
+          "line": 2,
         },
         "start": Object {
-          "column": 52,
-          "line": 3,
+          "column": 58,
+          "line": 2,
         },
       },
       "range": Array [
-        106,
-        107,
+        109,
+        110,
       ],
       "type": "Punctuator",
       "value": "}",
@@ -686,16 +539,16 @@ Object {
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 4,
+          "line": 3,
         },
         "start": Object {
           "column": 0,
-          "line": 4,
+          "line": 3,
         },
       },
       "range": Array [
-        108,
-        109,
+        111,
+        112,
       ],
       "type": "Punctuator",
       "value": "}",

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-constructor-and-parameter-proptery-with-override-modifier.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-constructor-and-parameter-proptery-with-override-modifier.src.ts.shot
@@ -1,0 +1,649 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`typescript basics class-with-constructor-and-parameter-proptery-with-override-modifier.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "body": Object {
+        "body": Array [
+          Object {
+            "computed": false,
+            "key": Object {
+              "loc": Object {
+                "end": Object {
+                  "column": 13,
+                  "line": 2,
+                },
+                "start": Object {
+                  "column": 2,
+                  "line": 2,
+                },
+              },
+              "name": "constructor",
+              "range": Array [
+                53,
+                64,
+              ],
+              "type": "Identifier",
+            },
+            "kind": "constructor",
+            "loc": Object {
+              "end": Object {
+                "column": 3,
+                "line": 4,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 2,
+              },
+            },
+            "override": false,
+            "range": Array [
+              53,
+              109,
+            ],
+            "static": false,
+            "type": "MethodDefinition",
+            "value": Object {
+              "async": false,
+              "body": Object {
+                "body": Array [
+                  Object {
+                    "expression": Object {
+                      "arguments": Array [],
+                      "callee": Object {
+                        "loc": Object {
+                          "end": Object {
+                            "column": 11,
+                            "line": 3,
+                          },
+                          "start": Object {
+                            "column": 6,
+                            "line": 3,
+                          },
+                        },
+                        "range": Array [
+                          97,
+                          102,
+                        ],
+                        "type": "Super",
+                      },
+                      "loc": Object {
+                        "end": Object {
+                          "column": 13,
+                          "line": 3,
+                        },
+                        "start": Object {
+                          "column": 6,
+                          "line": 3,
+                        },
+                      },
+                      "optional": false,
+                      "range": Array [
+                        97,
+                        104,
+                      ],
+                      "type": "CallExpression",
+                    },
+                    "loc": Object {
+                      "end": Object {
+                        "column": 14,
+                        "line": 3,
+                      },
+                      "start": Object {
+                        "column": 6,
+                        "line": 3,
+                      },
+                    },
+                    "range": Array [
+                      97,
+                      105,
+                    ],
+                    "type": "ExpressionStatement",
+                  },
+                ],
+                "loc": Object {
+                  "end": Object {
+                    "column": 3,
+                    "line": 4,
+                  },
+                  "start": Object {
+                    "column": 38,
+                    "line": 2,
+                  },
+                },
+                "range": Array [
+                  89,
+                  109,
+                ],
+                "type": "BlockStatement",
+              },
+              "expression": false,
+              "generator": false,
+              "id": null,
+              "loc": Object {
+                "end": Object {
+                  "column": 3,
+                  "line": 4,
+                },
+                "start": Object {
+                  "column": 13,
+                  "line": 2,
+                },
+              },
+              "params": Array [
+                Object {
+                  "accessibility": undefined,
+                  "export": undefined,
+                  "loc": Object {
+                    "end": Object {
+                      "column": 36,
+                      "line": 2,
+                    },
+                    "start": Object {
+                      "column": 14,
+                      "line": 2,
+                    },
+                  },
+                  "override": true,
+                  "parameter": Object {
+                    "loc": Object {
+                      "end": Object {
+                        "column": 36,
+                        "line": 2,
+                      },
+                      "start": Object {
+                        "column": 23,
+                        "line": 2,
+                      },
+                    },
+                    "name": "param",
+                    "range": Array [
+                      74,
+                      87,
+                    ],
+                    "type": "Identifier",
+                    "typeAnnotation": Object {
+                      "loc": Object {
+                        "end": Object {
+                          "column": 36,
+                          "line": 2,
+                        },
+                        "start": Object {
+                          "column": 28,
+                          "line": 2,
+                        },
+                      },
+                      "range": Array [
+                        79,
+                        87,
+                      ],
+                      "type": "TSTypeAnnotation",
+                      "typeAnnotation": Object {
+                        "loc": Object {
+                          "end": Object {
+                            "column": 36,
+                            "line": 2,
+                          },
+                          "start": Object {
+                            "column": 30,
+                            "line": 2,
+                          },
+                        },
+                        "range": Array [
+                          81,
+                          87,
+                        ],
+                        "type": "TSStringKeyword",
+                      },
+                    },
+                  },
+                  "range": Array [
+                    65,
+                    87,
+                  ],
+                  "readonly": undefined,
+                  "static": undefined,
+                  "type": "TSParameterProperty",
+                },
+              ],
+              "range": Array [
+                64,
+                109,
+              ],
+              "type": "FunctionExpression",
+            },
+          },
+        ],
+        "loc": Object {
+          "end": Object {
+            "column": 1,
+            "line": 5,
+          },
+          "start": Object {
+            "column": 49,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          49,
+          111,
+        ],
+        "type": "ClassBody",
+      },
+      "id": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 26,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 6,
+            "line": 1,
+          },
+        },
+        "name": "SpecializedComponent",
+        "range": Array [
+          6,
+          26,
+        ],
+        "type": "Identifier",
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        111,
+      ],
+      "superClass": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 48,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 35,
+            "line": 1,
+          },
+        },
+        "name": "SomeComponent",
+        "range": Array [
+          35,
+          48,
+        ],
+        "type": "Identifier",
+      },
+      "type": "ClassDeclaration",
+    },
+  ],
+  "comments": Array [],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 6,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    112,
+  ],
+  "sourceType": "script",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 5,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        5,
+      ],
+      "type": "Keyword",
+      "value": "class",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 26,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        6,
+        26,
+      ],
+      "type": "Identifier",
+      "value": "SpecializedComponent",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 34,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        27,
+        34,
+      ],
+      "type": "Keyword",
+      "value": "extends",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 48,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        35,
+        48,
+      ],
+      "type": "Identifier",
+      "value": "SomeComponent",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 50,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        49,
+        50,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        53,
+        64,
+      ],
+      "type": "Identifier",
+      "value": "constructor",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        64,
+        65,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 22,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        65,
+        73,
+      ],
+      "type": "Identifier",
+      "value": "override",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 28,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        74,
+        79,
+      ],
+      "type": "Identifier",
+      "value": "param",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 29,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 28,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        79,
+        80,
+      ],
+      "type": "Punctuator",
+      "value": ":",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 36,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        81,
+        87,
+      ],
+      "type": "Identifier",
+      "value": "string",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 37,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 36,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        87,
+        88,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 39,
+          "line": 2,
+        },
+        "start": Object {
+          "column": 38,
+          "line": 2,
+        },
+      },
+      "range": Array [
+        89,
+        90,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 11,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        97,
+        102,
+      ],
+      "type": "Keyword",
+      "value": "super",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 12,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        102,
+        103,
+      ],
+      "type": "Punctuator",
+      "value": "(",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        103,
+        104,
+      ],
+      "type": "Punctuator",
+      "value": ")",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 14,
+          "line": 3,
+        },
+        "start": Object {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "range": Array [
+        104,
+        105,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 3,
+          "line": 4,
+        },
+        "start": Object {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "range": Array [
+        108,
+        109,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 5,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 5,
+        },
+      },
+      "range": Array [
+        110,
+        111,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+  ],
+  "type": "Program",
+}
+`;

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-export-parameter-properties.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-export-parameter-properties.src.ts.shot
@@ -91,6 +91,7 @@ Object {
                       "line": 2,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "loc": Object {
                       "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-private-parameter-properties.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-private-parameter-properties.src.ts.shot
@@ -91,6 +91,7 @@ Object {
                       "line": 2,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "loc": Object {
                       "end": Object {
@@ -164,6 +165,7 @@ Object {
                       "line": 3,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "loc": Object {
                       "end": Object {
@@ -237,6 +239,7 @@ Object {
                       "line": 4,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "left": Object {
                       "loc": Object {
@@ -346,6 +349,7 @@ Object {
                       "line": 5,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "left": Object {
                       "loc": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-protected-parameter-properties.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-protected-parameter-properties.src.ts.shot
@@ -91,6 +91,7 @@ Object {
                       "line": 2,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "loc": Object {
                       "end": Object {
@@ -164,6 +165,7 @@ Object {
                       "line": 3,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "loc": Object {
                       "end": Object {
@@ -237,6 +239,7 @@ Object {
                       "line": 4,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "left": Object {
                       "loc": Object {
@@ -346,6 +349,7 @@ Object {
                       "line": 5,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "left": Object {
                       "loc": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-public-parameter-properties.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-public-parameter-properties.src.ts.shot
@@ -91,6 +91,7 @@ Object {
                       "line": 2,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "loc": Object {
                       "end": Object {
@@ -164,6 +165,7 @@ Object {
                       "line": 3,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "loc": Object {
                       "end": Object {
@@ -237,6 +239,7 @@ Object {
                       "line": 4,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "left": Object {
                       "loc": Object {
@@ -346,6 +349,7 @@ Object {
                       "line": 5,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "left": Object {
                       "loc": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-static-parameter-properties.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/class-with-static-parameter-properties.src.ts.shot
@@ -91,6 +91,7 @@ Object {
                       "line": 2,
                     },
                   },
+                  "override": undefined,
                   "parameter": Object {
                     "loc": Object {
                       "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.src.ts.shot
@@ -31,6 +31,7 @@ Object {
                     "line": 2,
                   },
                 },
+                "override": undefined,
                 "parameter": Object {
                   "loc": Object {
                     "end": Object {
@@ -70,6 +71,7 @@ Object {
                     "line": 2,
                   },
                 },
+                "override": undefined,
                 "parameter": Object {
                   "loc": Object {
                     "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/namespaces-and-modules/nested-internal-module.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/namespaces-and-modules/nested-internal-module.src.ts.shot
@@ -189,6 +189,7 @@ Object {
                               "line": 5,
                             },
                           },
+                          "override": undefined,
                           "parameter": Object {
                             "loc": Object {
                               "end": Object {
@@ -262,6 +263,7 @@ Object {
                               "line": 5,
                             },
                           },
+                          "override": undefined,
                           "parameter": Object {
                             "loc": Object {
                               "end": Object {


### PR DESCRIPTION
ref: https://github.com/prettier/prettier/issues/11017

Support TS 4.3 `override` modifier for parameter properties.

[TS Playground Link](https://www.typescriptlang.org/play?#code/MYGwhgzhAEBC0G8BQ1XWAewHYQC4CcBXYXDfACgAd8NcBTEugE2nzrCexAE91sAzAJYBzAFyJoYcXnyCswgNzQARuKyEAtsrr5oAXwCUiFGj1IzSUJBgARaHQAe9LExjxkqTDgLFSFarQM9CzQGABuOrJMdKhsHFy8fFhCYhJS0DJyiipqmtq6hsZoGYSUOuReKQYKJmZmQA)