### PR TITLE
feat(ast-spec): specify `LogicalExpression`'s `operator` type

### DIFF
--- a/packages/ast-spec/src/expression/LogicalExpression/spec.ts
+++ b/packages/ast-spec/src/expression/LogicalExpression/spec.ts
@@ -3,4 +3,5 @@ import type { BinaryExpressionBase } from '../../base/BinaryExpressionBase';
 
 export interface LogicalExpression extends BinaryExpressionBase {
   type: AST_NODE_TYPES.LogicalExpression;
+  operator: '??' | '&&' | '||';
 }


### PR DESCRIPTION
Just like #3496 is doing for `PunctuatorToken`'s `value` type