### PR TITLE
fix(eslint-plugin): allow explicit any for no-unsafe-return

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-return.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-return.ts
@@ -91,6 +91,16 @@ export default util.createRule({
         functionType = checker.getTypeAtLocation(functionTSNode);
       }
 
+      // If there is an explicit type annotation *and* that type matches the actual
+      // function return type, we shouldn't complain (it's intentional, even if unsafe)
+      if (functionTSNode.type) {
+        for (const signature of functionType.getCallSignatures()) {
+          if (returnNodeType === signature.getReturnType()) {
+            return;
+          }
+        }
+      }
+
       if (anyType !== util.AnyType.Safe) {
         // Allow cases when the declared return type of the function is either unknown or unknown[]
         // and the function is returning any or any[].
@@ -140,13 +150,6 @@ export default util.createRule({
 
       for (const signature of functionType.getCallSignatures()) {
         const functionReturnType = signature.getReturnType();
-        if (returnNodeType === functionReturnType) {
-          // don't bother checking if they're the same
-          // either the function is explicitly declared to return the same type
-          // or there was no declaration, so the return type is implicit
-          return;
-        }
-
         const result = util.isUnsafeAssignment(
           returnNodeType,
           functionReturnType,

--- a/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
@@ -42,6 +42,18 @@ function foo() {
   return [];
 }
     `,
+    // explicit any return type is allowed, if you want to be unsafe like that
+    `
+function foo(): any {
+  return {} as any;
+}
+    `,
+    // explicit any array return type is allowed, if you want to be unsafe like that
+    `
+function foo(): any[] {
+  return [] as any[];
+}
+    `,
     // explicit any generic return type is allowed, if you want to be unsafe like that
     `
 function foo(): Set<any> {


### PR DESCRIPTION
Generally uses the same check that already existed for _some_ cases to make sure we don't give a complaint if the function's explicit return type matches its actual return type.

Fixes #3482.