### PR TITLE
fix(typescript-estree): allow providing more one than one existing program in config

### DIFF
--- a/packages/typescript-estree/src/create-program/useProvidedPrograms.ts
+++ b/packages/typescript-estree/src/create-program/useProvidedPrograms.ts
@@ -11,15 +11,23 @@ import {
 
 const log = debug('typescript-eslint:typescript-estree:useProvidedProgram');
 
-function useProvidedProgram(
-  programInstance: ts.Program,
+function useProvidedPrograms(
+  programInstances: ts.Program[],
   extra: Extra,
 ): ASTAndProgram | undefined {
-  log('Retrieving ast for %s from provided program instance', extra.filePath);
+  log(
+    'Retrieving ast for %s from provided program instance(s)',
+    extra.filePath,
+  );
 
-  programInstance.getTypeChecker(); // ensure parent pointers are set in source files
-
-  const astAndProgram = getAstFromProgram(programInstance, extra);
+  let astAndProgram: ASTAndProgram | undefined;
+  for (const programInstance of programInstances) {
+    astAndProgram = getAstFromProgram(programInstance, extra);
+    // Stop at the first applicable program instance
+    if (astAndProgram) {
+      break;
+    }
+  }
 
   if (!astAndProgram) {
     const relativeFilePath = path.relative(
@@ -28,11 +36,13 @@ function useProvidedProgram(
     );
     const errorLines = [
       '"parserOptions.program" has been provided for @typescript-eslint/parser.',
-      `The file was not found in the provided program instance: ${relativeFilePath}`,
+      `The file was not found in any of the provided program instance(s): ${relativeFilePath}`,
     ];
 
     throw new Error(errorLines.join('\n'));
   }
+
+  astAndProgram.program.getTypeChecker(); // ensure parent pointers are set in source files
 
   return astAndProgram;
 }
@@ -84,4 +94,4 @@ function formatDiagnostics(diagnostics: ts.Diagnostic[]): string | undefined {
   });
 }
 
-export { useProvidedProgram, createProgramFromConfigFile };
+export { useProvidedPrograms, createProgramFromConfigFile };

--- a/packages/typescript-estree/src/index.ts
+++ b/packages/typescript-estree/src/index.ts
@@ -3,7 +3,7 @@ export { ParserServices, TSESTreeOptions } from './parser-options';
 export { simpleTraverse } from './simple-traverse';
 export * from './ts-estree';
 export { clearCaches } from './create-program/createWatchProgram';
-export { createProgramFromConfigFile as createProgram } from './create-program/useProvidedProgram';
+export { createProgramFromConfigFile as createProgram } from './create-program/useProvidedPrograms';
 
 // re-export for backwards-compat
 export { visitorKeys } from '@typescript-eslint/visitor-keys';

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -20,7 +20,7 @@ export interface Extra {
   loc: boolean;
   log: (message: string) => void;
   preserveNodeMaps?: boolean;
-  program: null | Program;
+  programs: null | Program[];
   projects: CanonicalPath[];
   range: boolean;
   strict: boolean;
@@ -171,11 +171,11 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
   tsconfigRootDir?: string;
 
   /**
-   * Instance of a TypeScript Program object to be used for type information.
+   * An array of one or more instances of TypeScript Program objects to be used for type information.
    * This overrides any program or programs that would have been computed from the `project` option.
-   * All linted files must be part of the provided program.
+   * All linted files must be part of the provided program(s).
    */
-  program?: Program;
+  programs?: Program[];
 
   /**
    ***************************************************************************************


### PR DESCRIPTION
The `program` (singular) option was only merged yesterday and had not yet been released (other than auto canaries).