### PR TITLE
chore(typescript-estree): use `SyntaxKind.LastPunctuation` as upper bound to determine `Punctuator` token type

### DIFF
--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -518,7 +518,7 @@ export function getTokenType(
 
   if (
     token.kind >= SyntaxKind.FirstPunctuation &&
-    token.kind <= SyntaxKind.LastBinaryOperator
+    token.kind <= SyntaxKind.LastPunctuation
   ) {
     return AST_TOKEN_TYPES.Punctuator;
   }


### PR DESCRIPTION
`SyntaxKind.LastBinaryOperator` & `SyntaxKind.LastPunctuation` have the same value (`77`)

https://github.com/microsoft/TypeScript/blob/663b19fe4a7c4d4ddaa61aedadd28da06acd27b6/lib/typescript.d.ts#L472
https://github.com/microsoft/TypeScript/blob/663b19fe4a7c4d4ddaa61aedadd28da06acd27b6/lib/typescript.d.ts#L462