### PR TITLE
tests(ast-spec): make `PunctuatorTokenToText` more type-safe

### DIFF
--- a/packages/ast-spec/src/token/PunctuatorToken/PunctuatorTokenToText.ts
+++ b/packages/ast-spec/src/token/PunctuatorToken/PunctuatorTokenToText.ts
@@ -44,6 +44,8 @@ export interface PunctuatorTokenToText {
   [SyntaxKind.ColonToken]: ':';
   [SyntaxKind.AtToken]: '@';
   [SyntaxKind.QuestionQuestionToken]: '??';
+  [SyntaxKind.BacktickToken]: '`';
+  // [SyntaxKind.HashToken]: '#'; // new in PunctuationSyntaxKind in TS 4.4
   [SyntaxKind.EqualsToken]: '=';
   [SyntaxKind.PlusEqualsToken]: '+=';
   [SyntaxKind.MinusEqualsToken]: '-=';
@@ -56,8 +58,8 @@ export interface PunctuatorTokenToText {
   [SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken]: '>>>=';
   [SyntaxKind.AmpersandEqualsToken]: '&=';
   [SyntaxKind.BarEqualsToken]: '|=';
-  [SyntaxKind.BarBarEqualsToken]: '||=';
-  [SyntaxKind.AmpersandAmpersandEqualsToken]: '&&=';
-  [SyntaxKind.QuestionQuestionEqualsToken]: '??=';
+  [SyntaxKind.BarBarEqualsToken]: '||='; // included in PunctuationSyntaxKind in TS 4.4
+  [SyntaxKind.AmpersandAmpersandEqualsToken]: '&&='; // included in PunctuationSyntaxKind in TS 4.4
+  [SyntaxKind.QuestionQuestionEqualsToken]: '??='; // included in PunctuationSyntaxKind in TS 4.4
   [SyntaxKind.CaretEqualsToken]: '^=';
 }

--- a/packages/ast-spec/tests/PunctuatorTokenToText.test.ts
+++ b/packages/ast-spec/tests/PunctuatorTokenToText.test.ts
@@ -1,0 +1,11 @@
+import type { PunctuationSyntaxKind } from 'typescript';
+
+import type { PunctuatorTokenToText } from '../src';
+
+// @ts-expect-error: purposely unused
+type _Test = {
+  readonly [T in PunctuationSyntaxKind]: PunctuatorTokenToText[T];
+  // If there are any PunctuationSyntaxKind members that don't have a
+  // corresponding PunctuatorTokenToText, then this line will error with
+  // "Type 'T' cannot be used to index type 'PunctuatorTokenToText'."
+};


### PR DESCRIPTION
Follow-up of #3496

We should somehow test that all possible values of `PunctuationSyntaxKind` are definitely included.
If not, this should error out somehow.

I first tried doing
```ts
export const PunctuatorTokenToText: Record<PunctuationSyntaxKind, string> = {
  // ...
}
```
and this errored out (as expected) because `SyntaxKind.BacktickToken` isn't includes, but is included in `PunctuationSyntaxKind`.
Not including the type makes it also of type `string` again, which will fail #3461 & #3462.

This however made it a value instead of a type and had the implication that `SyntaxKind.BarBarEqualsToken`, `SyntaxKind.AmpersandAmpersandEqualsToken` & `SyntaxKind.QuestionQuestionEqualsToken` couldn't be added as they'll only be added to `PunctuationSyntaxKind` in TS 4.4 (they're currently included on `main`).

In TS 4.4 the new `SyntaxKind.HashToken` should also be included, so I think it would be nice to have it somehow error out if we don't include that when updating our TS version.

@bradzacher @JamesHenry Any idea how I can make this error out when some values aren't included or how I should write a test that can fail when a new value isn't included here?