### PR TITLE
test: update @babel/parser to update ignored fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@babel/code-frame": "^7.12.13",
-    "@babel/parser": "^7.14.4",
+    "@babel/parser": "^7.14.6",
     "@babel/types": "^7.14.4",
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -386,12 +386,6 @@ tester.addFixturePatternConfig('typescript/basics', {
      * This is intentional; babel is not checking types
      */
     'catch-clause-with-invalid-annotation',
-    /**
-     * [BABEL ERRORED, BUT TS-ESTREE DID NOT]
-     * SyntaxError: Unexpected token, expected ","
-     */
-    'class-with-constructor-and-parameter-property-with-modifiers',
-    'class-with-constructor-and-parameter-proptery-with-override-modifier',
   ],
   ignoreSourceType: [
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,7 +169,12 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@*", "@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.14.2", "@babel/parser@^7.14.3", "@babel/parser@^7.14.4", "@babel/parser@^7.7.2":
+"@babel/parser@*", "@babel/parser@^7.14.6":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.6.tgz#d85cc68ca3cac84eae384c06f032921f5227f4b2"
+  integrity sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.14.2", "@babel/parser@^7.14.3", "@babel/parser@^7.7.2":
   version "7.14.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.4.tgz#a5c560d6db6cd8e6ed342368dea8039232cbab18"
   integrity sha512-ArliyUsWDUqEGfWcmzpGUzNfLxTdTp6WU4IuP6QFSp9gGfWS6boxFCkJSJ/L4+RG8z/FnIU3WxCk6hPL9SSWeA==


### PR DESCRIPTION
@babel/parser 7.14.6 supports override modifiers for parameter property.
I'm not sure if this is the correct diff for yarn.lock.

Ref: https://github.com/babel/babel/blob/main/CHANGELOG.md#v7146-2021-06-14