### PR TITLE
feat(experimental-utils): expose ReferenceTracker.ESM

### DIFF
--- a/packages/experimental-utils/src/ast-utils/eslint-utils/ReferenceTracker.ts
+++ b/packages/experimental-utils/src/ast-utils/eslint-utils/ReferenceTracker.ts
@@ -7,6 +7,7 @@ const ReferenceTrackerREAD: unique symbol = eslintUtils.ReferenceTracker.READ;
 const ReferenceTrackerCALL: unique symbol = eslintUtils.ReferenceTracker.CALL;
 const ReferenceTrackerCONSTRUCT: unique symbol =
   eslintUtils.ReferenceTracker.CONSTRUCT;
+const ReferenceTrackerESM: unique symbol = eslintUtils.ReferenceTracker.ESM;
 
 interface ReferenceTracker {
   /**
@@ -59,12 +60,14 @@ interface ReferenceTrackerStatic {
   readonly READ: typeof ReferenceTrackerREAD;
   readonly CALL: typeof ReferenceTrackerCALL;
   readonly CONSTRUCT: typeof ReferenceTrackerCONSTRUCT;
+  readonly ESM: typeof ReferenceTrackerESM;
 }
 
 namespace ReferenceTracker {
   export type READ = ReferenceTrackerStatic['READ'];
   export type CALL = ReferenceTrackerStatic['CALL'];
   export type CONSTRUCT = ReferenceTrackerStatic['CONSTRUCT'];
+  export type ESM = ReferenceTrackerStatic['ESM'];
   export type ReferenceType = READ | CALL | CONSTRUCT;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export type TraceMap<T = any> = Record<string, TraceMapElement<T>>;
@@ -72,6 +75,7 @@ namespace ReferenceTracker {
     [ReferenceTrackerREAD]?: T;
     [ReferenceTrackerCALL]?: T;
     [ReferenceTrackerCONSTRUCT]?: T;
+    [ReferenceTrackerESM]?: true;
     [key: string]: TraceMapElement<T>;
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/experimental-utils/typings/eslint-utils.d.ts
+++ b/packages/experimental-utils/typings/eslint-utils.d.ts
@@ -35,6 +35,7 @@ declare module 'eslint-utils' {
     readonly READ: never;
     readonly CALL: never;
     readonly CONSTRUCT: never;
+    readonly ESM: never;
     new (): never;
   };
 }


### PR DESCRIPTION
Fixes #3527 

ReferenceTracker.ESM seems to be undocumented, but it marks a trace map as being an ES module. It is used only once that I can see, here: https://github.com/mysticatea/eslint-utils/blob/c3b1d38328dc3a5278b208a58186a0735315f58f/src/reference-tracker.js#L181

The code only checks if the trace map has they key, and does nothing with it's value. Therefore when adding it to the TraceMapElement type, I opted to type it as always `true`, if it's present. In theory something like `any` or `unknown` would work, but that wouldn't convey that it's just a flag; a type of `boolean` might lead to confusion if users think they can do `[ReferenceTracker.ESM]: false` and expect it to be disabled. 