### PR TITLE
feat(experimental-utils): add `only` property to `RuleTester` types

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -36,6 +36,10 @@ interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
    * Settings for the test case.
    */
   readonly settings?: Readonly<Record<string, unknown>>;
+  /**
+   * Run this case exclusively for debugging in supported test frameworks.
+   */
+  readonly only?: boolean;
 }
 
 interface SuggestionOutput<TMessageIds extends string> {


### PR DESCRIPTION
Was added in latest eslint: https://github.com/eslint/eslint/pull/14677 🎉 

(cc @SimenB in case you missed it - I'm so glad we finally have this 😍)