### PR TITLE
feat(experimental-utils): use mergable interface for `settings` property

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/Linter.ts
+++ b/packages/experimental-utils/src/ts-eslint/Linter.ts
@@ -3,7 +3,12 @@
 import { Linter as ESLintLinter } from 'eslint';
 import { TSESTree, ParserServices } from '../ts-estree';
 import { ParserOptions as TSParserOptions } from './ParserOptions';
-import { RuleCreateFunction, RuleFix, RuleModule } from './Rule';
+import {
+  RuleCreateFunction,
+  RuleFix,
+  RuleModule,
+  SharedConfigurationSettings,
+} from './Rule';
 import { Scope } from './Scope';
 import { SourceCode } from './SourceCode';
 
@@ -164,7 +169,7 @@ namespace Linter {
     /**
      * The shared settings.
      */
-    settings?: { [name: string]: unknown };
+    settings?: SharedConfigurationSettings;
   }
 
   export interface ConfigOverride extends BaseConfig {

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -165,6 +165,14 @@ type ReportDescriptor<TMessageIds extends string> =
   ReportDescriptorWithSuggestion<TMessageIds> &
     (ReportDescriptorNodeOptionalLoc | ReportDescriptorLocOnly);
 
+/**
+ * Plugins can add their settings using declaration
+ * merging against this interface.
+ */
+interface SharedConfigurationSettings {
+  [name: string]: unknown;
+}
+
 interface RuleContext<
   TMessageIds extends string,
   TOptions extends readonly unknown[],
@@ -194,7 +202,7 @@ interface RuleContext<
    * The shared settings from configuration.
    * We do not have any shared settings in this plugin.
    */
-  settings: Record<string, unknown>;
+  settings: SharedConfigurationSettings;
 
   /**
    * Returns an array of the ancestors of the currently-traversed node, starting at
@@ -452,4 +460,5 @@ export {
   RuleMetaData,
   RuleMetaDataDocs,
   RuleModule,
+  SharedConfigurationSettings,
 };

--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -2,7 +2,11 @@ import { RuleTester as ESLintRuleTester } from 'eslint';
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '../ts-estree';
 import { ParserOptions } from './ParserOptions';
 import { Linter } from './Linter';
-import { RuleCreateFunction, RuleModule } from './Rule';
+import {
+  RuleCreateFunction,
+  RuleModule,
+  SharedConfigurationSettings,
+} from './Rule';
 
 interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   /**
@@ -36,7 +40,7 @@ interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   /**
    * Settings for the test case.
    */
-  readonly settings?: Readonly<Record<string, unknown>>;
+  readonly settings?: Readonly<SharedConfigurationSettings>;
   /**
    * Run this case exclusively for debugging in supported test frameworks.
    */


### PR DESCRIPTION
This lets us do declaration merging to define settings at the plugin level e.g.

```
interface ESLintPluginJestSettings {
  describeBlocks: readonly string[];
  hookNames: readonly string[];
}

declare module '@typescript-eslint/experimental-utils/dist/ts-eslint/Rule' {
  export interface SharedConfigurationSettings
    extends ESLintPluginJestSettings {}
}
```