### PR TITLE
fix(experimental-utils): expand `RuleTester` config properties

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/RuleTester.ts
+++ b/packages/experimental-utils/src/ts-eslint/RuleTester.ts
@@ -1,6 +1,7 @@
 import { RuleTester as ESLintRuleTester } from 'eslint';
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '../ts-estree';
 import { ParserOptions } from './ParserOptions';
+import { Linter } from './Linter';
 import { RuleCreateFunction, RuleModule } from './Rule';
 
 interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
@@ -121,7 +122,7 @@ interface RunTests<
   readonly valid: readonly (ValidTestCase<TOptions> | string)[];
   readonly invalid: readonly InvalidTestCase<TMessageIds, TOptions>[];
 }
-interface RuleTesterConfig {
+interface RuleTesterConfig extends Linter.Config {
   // should be require.resolve(parserPackageName)
   readonly parser: string;
   readonly parserOptions?: Readonly<ParserOptions>;


### PR DESCRIPTION
From [the docs](https://eslint.org/docs/developer-guide/nodejs-api#ruletester):

> The RuleTester constructor accepts an optional object argument, which can be used to specify defaults for your test cases. For example, if all of your test cases use ES2015, you can set it as a default:

Have configured that this is supported & usable for e.g. setting `settings`:

```
const ruleTester = new TSESLint.RuleTester({
  parser: resolveFrom(require.resolve('eslint'), 'espree'),
  parserOptions: {
    ecmaVersion: 2015,
  },
  settings: { hookNames: ['beforeAll', 'beforeEach', 'afterAll', 'afterEach'] },
});
```
