### PR TITLE
fix(eslint-plugin): [no-unnecessary-boolean-literal-compare] incorrect fix when condition is reversed

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -186,7 +186,7 @@ export default util.createRule<Options, MessageIds>({
           range:
             expression.range[0] < against.range[0]
               ? [expression.range[1], against.range[1]]
-              : [against.range[1], expression.range[1]],
+              : [against.range[0], expression.range[0]],
         };
       }
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
@@ -224,5 +224,39 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
         }
       `,
     },
+    {
+      code: `
+        declare const varBoolean: boolean;
+        if (false !== varBoolean) {
+        }
+      `,
+      errors: [
+        {
+          messageId: 'negated',
+        },
+      ],
+      output: `
+        declare const varBoolean: boolean;
+        if (varBoolean) {
+        }
+      `,
+    },
+    {
+      code: `
+        declare const varBoolean: boolean;
+        if (true !== varBoolean) {
+        }
+      `,
+      errors: [
+        {
+          messageId: 'negated',
+        },
+      ],
+      output: `
+        declare const varBoolean: boolean;
+        if (!varBoolean) {
+        }
+      `,
+    },
   ],
 });


### PR DESCRIPTION
Fixes #3442
Before this PR no-unnecessary-boolean-literal-compare fix would change
```
if (true === var) {
   ...
}
```
to
```
if (true) {
   ...
}
```
instead of 
```
if (var) {
   ...
}
```

This PR intends to fix this issue.