### PR TITLE
fix(eslint-plugin): [no-implied-eval] handle bind on nested member expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-implied-eval.ts
+++ b/packages/eslint-plugin/src/rules/no-implied-eval.ts
@@ -99,6 +99,12 @@ export default util.createRule({
       return signatures.length > 0;
     }
 
+    function isBind(node: TSESTree.Node): boolean {
+      return node.type === AST_NODE_TYPES.MemberExpression
+        ? isBind(node.property)
+        : node.type === AST_NODE_TYPES.Identifier && node.name === 'bind';
+    }
+
     function isFunction(node: TSESTree.Node): boolean {
       switch (node.type) {
         case AST_NODE_TYPES.ArrowFunctionExpression:
@@ -112,11 +118,7 @@ export default util.createRule({
           return isFunctionType(node);
 
         case AST_NODE_TYPES.CallExpression:
-          return (
-            (node.callee.type === AST_NODE_TYPES.Identifier &&
-              node.callee.name === 'bind') ||
-            isFunctionType(node)
-          );
+          return isBind(node.callee) || isFunctionType(node);
 
         default:
           return false;

--- a/packages/eslint-plugin/tests/rules/no-implied-eval.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-implied-eval.test.ts
@@ -257,6 +257,26 @@ const bar = () => {};
 
 setTimeout(Math.radom() > 0.5 ? foo : bar, 0);
     `,
+    `
+class Foo {
+  func1() {}
+  func2(): void {
+    setTimeout(this.func1.bind(this), 1);
+  }
+}
+    `,
+    `
+class Foo {
+  private a = {
+    b: {
+      c: function () {},
+    },
+  };
+  funcw(): void {
+    setTimeout(this.a.b.c.bind(this), 1);
+  }
+}
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
Fixes https://github.com/typescript-eslint/typescript-eslint/issues/3582