### PR TITLE
feat(experimental-utils): add literal types to `global` option

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/Linter.ts
+++ b/packages/experimental-utils/src/ts-eslint/Linter.ts
@@ -119,6 +119,8 @@ namespace Linter {
   export type RuleEntry = RuleLevel | RuleLevelAndOptions;
   export type RulesRecord = Partial<Record<string, RuleEntry>>;
 
+  export type GlobalVariableOption = 'readonly' | 'writable' | 'off' | boolean;
+
   // https://github.com/eslint/eslint/blob/v6.8.0/conf/config-schema.js
   interface BaseConfig {
     $schema?: string;
@@ -133,7 +135,7 @@ namespace Linter {
     /**
      * The global variable settings.
      */
-    globals?: { [name: string]: boolean };
+    globals?: { [name: string]: GlobalVariableOption };
     /**
      * The flag that disables directive comments.
      */


### PR DESCRIPTION
In addition to boolean values, the string values below are allowed in `globals` field of `BaseConfig`.

- "readable"
- "readonly"
- "writeable"
- "writable"
- "off"

> Globals can be disabled with the string "off". For example, in an environment where most ES2015 globals are available but Promise is unavailable, you might use this config:

> For historical reasons, the boolean value false and the string value "readable" are equivalent to "readonly". Similarly, the boolean value true and the string value "writeable" are equivalent to "writable". However, the use of older values is deprecated.

https://eslint.org/docs/user-guide/configuring/language-options#using-configuration-files-1