### PR TITLE
fix(typescript-estree): ensure --fix works with singleRun mode

### DIFF
--- a/packages/typescript-estree/src/index.ts
+++ b/packages/typescript-estree/src/index.ts
@@ -1,4 +1,12 @@
-export * from './parser';
+export {
+  AST,
+  parse,
+  parseAndGenerateServices,
+  parseWithNodeMaps,
+  ParseAndGenerateServicesResult,
+  ParseWithNodeMapsResult,
+  clearProgramCache,
+} from './parser';
 export { ParserServices, TSESTreeOptions } from './parser-options';
 export { simpleTraverse } from './simple-traverse';
 export * from './ts-estree';

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -496,6 +496,12 @@ function parseWithNodeMaps<T extends TSESTreeOptions = TSESTreeOptions>(
   return parseWithNodeMapsInternal(code, options, true);
 }
 
+let parseAndGenerateServicesCalls: { [fileName: string]: number } = {};
+// Privately exported utility intented for use in typescript-eslint unit tests only
+function ɵclearParseAndGenerateServicesCalls(): void {
+  parseAndGenerateServicesCalls = {};
+}
+
 function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
   code: string,
   options: T,
@@ -566,12 +572,43 @@ function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
    */
   const shouldProvideParserServices =
     extra.programs != null || (extra.projects && extra.projects.length > 0);
-  const { ast, program } = getProgramAndAST(
-    code,
-    extra.programs,
-    shouldProvideParserServices,
-    extra.createDefaultProgram,
-  )!;
+
+  /**
+   * If we are in singleRun mode but the parseAndGenerateServices() function has been called more than once for the current file,
+   * it must mean that we are in the middle of an ESLint automated fix cycle (in which parsing can be performed up to an additional
+   * 10 times in order to apply all possible fixes for the file).
+   *
+   * In this scenario we cannot rely upon the singleRun AOT compiled programs because the SourceFiles will not contain the source
+   * with the latest fixes applied. Therefore we fallback to creating the quickest possible isolated program from the updated source.
+   */
+  let ast: ts.SourceFile;
+  let program: ts.Program;
+
+  if (extra.singleRun && options.filePath) {
+    parseAndGenerateServicesCalls[options.filePath] =
+      parseAndGenerateServicesCalls[options.filePath] || 0;
+    parseAndGenerateServicesCalls[options.filePath] =
+      parseAndGenerateServicesCalls[options.filePath] + 1;
+  }
+
+  if (
+    extra.singleRun &&
+    options.filePath &&
+    parseAndGenerateServicesCalls[options.filePath] > 1
+  ) {
+    const isolatedAstAndProgram = createIsolatedProgram(code, extra);
+    ast = isolatedAstAndProgram.ast;
+    program = isolatedAstAndProgram.program;
+  } else {
+    const astAndProgram = getProgramAndAST(
+      code,
+      extra.programs,
+      shouldProvideParserServices,
+      extra.createDefaultProgram,
+    )!;
+    ast = astAndProgram.ast;
+    program = astAndProgram.program;
+  }
 
   /**
    * Convert the TypeScript AST to an ESTree-compatible one, and optionally preserve
@@ -614,4 +651,5 @@ export {
   ParseAndGenerateServicesResult,
   ParseWithNodeMapsResult,
   clearProgramCache,
+  ɵclearParseAndGenerateServicesCalls,
 };

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -498,7 +498,7 @@ function parseWithNodeMaps<T extends TSESTreeOptions = TSESTreeOptions>(
 
 let parseAndGenerateServicesCalls: { [fileName: string]: number } = {};
 // Privately exported utility intended for use in typescript-eslint unit tests only
-function ɵclearParseAndGenerateServicesCalls(): void {
+function clearParseAndGenerateServicesCalls(): void {
   parseAndGenerateServicesCalls = {};
 }
 
@@ -586,9 +586,7 @@ function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
 
   if (extra.singleRun && options.filePath) {
     parseAndGenerateServicesCalls[options.filePath] =
-      parseAndGenerateServicesCalls[options.filePath] || 0;
-    parseAndGenerateServicesCalls[options.filePath] =
-      parseAndGenerateServicesCalls[options.filePath] + 1;
+      (parseAndGenerateServicesCalls[options.filePath] || 0) + 1;
   }
 
   if (
@@ -651,5 +649,5 @@ export {
   ParseAndGenerateServicesResult,
   ParseWithNodeMapsResult,
   clearProgramCache,
-  ɵclearParseAndGenerateServicesCalls,
+  clearParseAndGenerateServicesCalls,
 };

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -497,7 +497,7 @@ function parseWithNodeMaps<T extends TSESTreeOptions = TSESTreeOptions>(
 }
 
 let parseAndGenerateServicesCalls: { [fileName: string]: number } = {};
-// Privately exported utility intented for use in typescript-eslint unit tests only
+// Privately exported utility intended for use in typescript-eslint unit tests only
 function ɵclearParseAndGenerateServicesCalls(): void {
   parseAndGenerateServicesCalls = {};
 }

--- a/packages/typescript-estree/tests/lib/semanticInfo-singleRun.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo-singleRun.test.ts
@@ -1,6 +1,10 @@
 import glob from 'glob';
 import * as path from 'path';
-import { clearProgramCache, parseAndGenerateServices } from '../../src';
+import {
+  clearProgramCache,
+  parseAndGenerateServices,
+  ɵclearParseAndGenerateServicesCalls,
+} from '../../src';
 import { getCanonicalFileName } from '../../src/create-program/shared';
 
 const mockProgram = {
@@ -91,6 +95,8 @@ describe('semanticInfo - singleRun', () => {
     clearProgramCache();
     // ensure invocations of mock are clean for each test
     (createProgramFromConfigFile as jest.Mock).mockClear();
+    // Do not track invocations per file across tests
+    ɵclearParseAndGenerateServicesCalls();
   });
 
   it('should not create any programs ahead of time by default when there is no way to infer singleRun=true', () => {

--- a/packages/typescript-estree/tests/lib/semanticInfo-singleRun.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo-singleRun.test.ts
@@ -3,8 +3,8 @@ import * as path from 'path';
 import {
   clearProgramCache,
   parseAndGenerateServices,
-  ɵclearParseAndGenerateServicesCalls as clearParseAndGenerateServicesCalls,
-} from '../../src';
+  clearParseAndGenerateServicesCalls,
+} from '../../src/parser';
 import { getCanonicalFileName } from '../../src/create-program/shared';
 
 const mockProgram = {

--- a/packages/typescript-estree/tests/lib/semanticInfo-singleRun.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo-singleRun.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import {
   clearProgramCache,
   parseAndGenerateServices,
-  ɵclearParseAndGenerateServicesCalls,
+  ɵclearParseAndGenerateServicesCalls as clearParseAndGenerateServicesCalls,
 } from '../../src';
 import { getCanonicalFileName } from '../../src/create-program/shared';
 
@@ -96,7 +96,7 @@ describe('semanticInfo - singleRun', () => {
     // ensure invocations of mock are clean for each test
     (createProgramFromConfigFile as jest.Mock).mockClear();
     // Do not track invocations per file across tests
-    ɵclearParseAndGenerateServicesCalls();
+    clearParseAndGenerateServicesCalls();
   });
 
   it('should not create any programs ahead of time by default when there is no way to infer singleRun=true', () => {


### PR DESCRIPTION
I realise this isn't the most sophisticated fix (and we can improve this further in the future by adding support for the catch-all builder program as we discussed as part of the long-term solution to `createDefaultProgram`) but for now this at least makes singleRun mode usable with `--fix` and in my basic testing locally it still yields a speed up over the same invocation without singleRun mode enabled.

Fixes #3626