### PR TITLE
feat(eslint-plugin): [prefer-readonly-parameter-types] add option treatMethodsAsReadonly

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
@@ -130,6 +130,7 @@ interface Options {
 const defaultOptions: Options = {
   checkParameterProperties: true,
   ignoreInferredTypes: false,
+  treatMethodsAsReadonly: false,
 };
 ```
 
@@ -214,3 +215,43 @@ export const acceptsCallback: AcceptsCallback;
 ```
 
 </details>
+
+### `treatMethodsAsReadonly`
+
+This option allows you to treat all mutable methods as though they were readonly. This may be desirable in when you are never reassigning methods.
+
+Examples of **incorrect** code for this rule with `{treatMethodsAsReadonly: false}`:
+
+```ts
+type MyType = {
+  readonly prop: string;
+  method(): string; // note: this method is mutable
+};
+function foo(arg: MyType) {}
+```
+
+Examples of **correct** code for this rule with `{treatMethodsAsReadonly: false}`:
+
+```ts
+type MyType = Readonly<{
+  prop: string;
+  method(): string;
+}>;
+function foo(arg: MyType) {}
+
+type MyOtherType = {
+  readonly prop: string;
+  readonly method: () => string;
+};
+function bar(arg: MyOtherType) {}
+```
+
+Examples of **correct** code for this rule with `{treatMethodsAsReadonly: true}`:
+
+```ts
+type MyType = {
+  readonly prop: string;
+  method(): string; // note: this method is mutable
+};
+function foo(arg: MyType) {}
+```

--- a/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
@@ -154,6 +154,74 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
       }
       function foo(arg: Readonly<Foo>) {}
     `,
+    // immutable methods
+    `
+      type MyType = Readonly<{
+        prop: string;
+        method(): string;
+      }>;
+      function foo(arg: MyType) {}
+    `,
+    `
+      type MyType = {
+        readonly prop: string;
+        readonly method: () => string;
+      };
+      function bar(arg: MyType) {}
+    `,
+    // methods treated as readonly
+    {
+      code: `
+        type MyType = {
+          readonly prop: string;
+          method(): string;
+        };
+        function foo(arg: MyType) {}
+      `,
+      options: [
+        {
+          treatMethodsAsReadonly: true,
+        },
+      ],
+    },
+    {
+      code: `
+        class Foo {
+          method() {}
+        }
+        function foo(arg: Foo) {}
+      `,
+      options: [
+        {
+          treatMethodsAsReadonly: true,
+        },
+      ],
+    },
+    {
+      code: `
+        interface Foo {
+          method(): void;
+        }
+        function foo(arg: Foo) {}
+      `,
+      options: [
+        {
+          treatMethodsAsReadonly: true,
+        },
+      ],
+    },
+    // ReadonlySet and ReadonlyMap are seen as readonly when methods are treated as readonly
+    {
+      code: `
+        function foo(arg: ReadonlySet<string>) {}
+        function bar(arg: ReadonlyMap<string, string>) {}
+      `,
+      options: [
+        {
+          treatMethodsAsReadonly: true,
+        },
+      ],
+    },
 
     // parameter properties should work fine
     {
@@ -712,6 +780,24 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
           line: 10,
           column: 43,
           endColumn: 67,
+        },
+      ],
+    },
+    // Mutable methods.
+    {
+      code: `
+        type MyType = {
+          readonly prop: string;
+          method(): string;
+        };
+        function foo(arg: MyType) {}
+      `,
+      errors: [
+        {
+          messageId: 'shouldBeReadonly',
+          line: 6,
+          column: 22,
+          endColumn: 33,
         },
       ],
     },


### PR DESCRIPTION
fix #1758