### PR TITLE
docs: inline key parts of "getting started" in project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@
 
 ## Getting Started / Installation
 
+- **[You can find our full Getting Started docs here](./docs/getting-started/README.md)**
+- **[You can find our Linting FAQ / Troubleshooting docs here](./docs/getting-started/linting/FAQ.md)**
+
 tl;dr:
 
 ```
@@ -62,9 +65,6 @@ Or, if you like Airbnb's config, `npm i --save-dev eslint-config-airbnb-typescri
 +     'airbnb-typescript',
     ],
 ```
-
-- **[You can find more in our Getting Started docs here](./docs/getting-started/README.md)**
-- **[You can find our Linting FAQ / Troubleshooting docs here](./docs/getting-started/linting/FAQ.md)**
 
 The documentation below will give you an overview of what this project is, why it exists and how it works at a high level.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,37 @@
 
 ## Getting Started / Installation
 
-- **[You can find our Getting Started docs here](./docs/getting-started/README.md)**
+tl;dr:
+
+```
+$ npm i --save-dev eslint typescript @typescript-eslint/parser @typescript-eslint/eslint-plugin
+```
+
+A minimal `.eslintrc`:
+
+```js
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: [
+    '@typescript-eslint',
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+};
+```
+Or, if you like Airbnb's config, `npm i --save-dev eslint-config-airbnb-typescript` and extend from it:
+```diff
+    extends: [
+-     'eslint:recommended',
+-     'plugin:@typescript-eslint/recommended',
++     'airbnb-typescript',
+    ],
+```
+
+- **[You can find more in our Getting Started docs here](./docs/getting-started/README.md)**
 - **[You can find our Linting FAQ / Troubleshooting docs here](./docs/getting-started/linting/FAQ.md)**
 
 The documentation below will give you an overview of what this project is, why it exists and how it works at a high level.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ module.exports = {
   ],
 };
 ```
+
 Or, if you like Airbnb's config, `npm i --save-dev eslint-config-airbnb-typescript` and extend from it:
+
 ```diff
     extends: [
 -     'eslint:recommended',


### PR DESCRIPTION
Every time I start a new project, I have to google, click through three links, copy/paste twice, notice it's not working with airbnb, scroll down and copy/paste a few more things. I imagine the same is true of many folks. 

This gets the most important stuff up front, and preserves the existing link.