### PR TITLE
fix(eslint-plugin): [no-shadow] allow enum variables matching scope variables

### DIFF
--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -79,6 +79,13 @@ export default util.createRule<Options, MessageIds>({
     }
 
     /**
+     * Check if the variable is in an enum scope.
+     */
+    function isEnum(scope: TSESLint.Scope.Variable): boolean {
+      return scope.scope.type === ScopeType.tsEnum;
+    }
+
+    /**
      * Check if variable is a `this` parameter.
      */
     function isThisParam(variable: TSESLint.Scope.Variable): boolean {
@@ -360,6 +367,11 @@ export default util.createRule<Options, MessageIds>({
       for (const variable of variables) {
         // ignore "arguments"
         if (variable.identifiers.length === 0) {
+          continue;
+        }
+
+        // enum values require literals and cannot be shadowed
+        if (isEnum(variable)) {
           continue;
         }
 

--- a/packages/eslint-plugin/tests/rules/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow.test.ts
@@ -11,6 +11,14 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-shadow TS tests', rule, {
   valid: [
+    // enums
+    `
+let foo;
+
+enum Bar {
+  foo = 1,
+}
+    `,
     // nested conditional types
     `
 export type ArrayInput<Func> = Func extends (arg0: Array<infer T>) => any


### PR DESCRIPTION
Enum values only accept literals. This means they don’t shadow the scope if an enum variable happens to be the same name as a variable in the scope.