### PR TITLE
feat(experimental-utils): remove `getComments` from `ESLint` `SourceCode` types

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/SourceCode.ts
+++ b/packages/experimental-utils/src/ts-eslint/SourceCode.ts
@@ -246,15 +246,6 @@ declare class SourceCodeBase extends TokenStore {
    */
   getAllComments(): TSESTree.Comment[];
   /**
-   * Gets all comments for the given node.
-   * @param node The AST node to get the comments for.
-   * @returns An object containing a leading and trailing array of comments indexed by their position.
-   */
-  getComments(node: TSESTree.Node): {
-    leading: TSESTree.Comment[];
-    trailing: TSESTree.Comment[];
-  };
-  /**
    * Converts a (line, column) pair into a range index.
    * @param loc A line/column location
    * @returns The range index of the location in the file.


### PR DESCRIPTION
Tackles a small part of #3738: the `getComments()` API is deprecated so we generally don't want to use it.

Ref: https://github.com/eslint/eslint/issues/14744, https://github.com/eslint/eslint/pull/14769