### PR TITLE
feat(eslint-plugin): [comma-dangle] align schema with ESLint v8

### DIFF
--- a/packages/eslint-plugin/src/rules/comma-dangle.ts
+++ b/packages/eslint-plugin/src/rules/comma-dangle.ts
@@ -80,6 +80,7 @@ export default util.createRule<Options, MessageIds>({
           ],
         },
       ],
+      additionalProperties: false,
     },
     fixable: 'code',
     messages: baseRule.meta.messages,


### PR DESCRIPTION
Continues #3738 by matching the rule's to the new ESLint value. Just on echange: adding an `additionalProperties: false`.

Refs: https://github.com/eslint/eslint/issues/13739, https://github.com/eslint/eslint/pull/14030