### PR TITLE
feat(ast-spec): bring `Node` objects in line with ESTree

### DIFF
--- a/packages/ast-spec/src/base/NodeOrTokenData.ts
+++ b/packages/ast-spec/src/base/NodeOrTokenData.ts
@@ -4,6 +4,9 @@ import type { SourceLocation } from './SourceLocation';
 export interface NodeOrTokenData {
   /**
    * The source location information of the node.
+   *
+   * The loc property is defined as nullable by ESTree, but ESLint requires this property.
+   *
    * @see {SourceLocation}
    */
   loc: SourceLocation;

--- a/packages/ast-spec/src/base/Position.ts
+++ b/packages/ast-spec/src/base/Position.ts
@@ -1,4 +1,4 @@
-export interface LineAndColumnData {
+export interface Position {
   /**
    * Line number (1-indexed)
    */

--- a/packages/ast-spec/src/base/SourceLocation.ts
+++ b/packages/ast-spec/src/base/SourceLocation.ts
@@ -1,12 +1,12 @@
-import type { LineAndColumnData } from './LineAndColumnData';
+import type { Position } from './Position';
 
 export interface SourceLocation {
   /**
    * The position of the first character of the parsed source region
    */
-  start: LineAndColumnData;
+  start: Position;
   /**
    * The position of the first character after the parsed source region
    */
-  end: LineAndColumnData;
+  end: Position;
 }

--- a/packages/ast-spec/src/index.ts
+++ b/packages/ast-spec/src/index.ts
@@ -1,7 +1,7 @@
 export * from './base/Accessibility';
 export * from './base/BaseNode'; // this is exported so that the `types` package can merge the decl and add the `parent` property
-export * from './base/LineAndColumnData';
 export * from './base/OptionalRangeAndLoc';
+export * from './base/Position';
 export * from './base/Range';
 export * from './base/SourceLocation';
 

--- a/packages/eslint-plugin/src/util/getFunctionHeadLoc.ts
+++ b/packages/eslint-plugin/src/util/getFunctionHeadLoc.ts
@@ -31,7 +31,7 @@ export function getFunctionHeadLoc(
   node: FunctionNode,
   sourceCode: TSESLint.SourceCode,
 ): TSESTree.SourceLocation {
-  function getLocStart(): TSESTree.LineAndColumnData {
+  function getLocStart(): TSESTree.Position {
     if (node.parent && node.parent.type === AST_NODE_TYPES.MethodDefinition) {
       // return the start location for class method
 
@@ -58,7 +58,7 @@ export function getFunctionHeadLoc(
     return node.loc.start;
   }
 
-  function getLocEnd(): TSESTree.LineAndColumnData {
+  function getLocEnd(): TSESTree.Position {
     if (node.type === AST_NODE_TYPES.ArrowFunctionExpression) {
       // find the end location for arrow function expression
       return sourceCode.getTokenBefore(

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -149,13 +149,13 @@ interface ReportDescriptorNodeOptionalLoc {
    */
   readonly loc?:
     | Readonly<TSESTree.SourceLocation>
-    | Readonly<TSESTree.LineAndColumnData>;
+    | Readonly<TSESTree.Position>;
 }
 interface ReportDescriptorLocOnly {
   /**
    * An override of the location of the report
    */
-  loc: Readonly<TSESTree.SourceLocation> | Readonly<TSESTree.LineAndColumnData>;
+  loc: Readonly<TSESTree.SourceLocation> | Readonly<TSESTree.Position>;
 }
 type ReportDescriptor<TMessageIds extends string> =
   ReportDescriptorWithSuggestion<TMessageIds> &

--- a/packages/experimental-utils/src/ts-eslint/SourceCode.ts
+++ b/packages/experimental-utils/src/ts-eslint/SourceCode.ts
@@ -250,7 +250,7 @@ declare class SourceCodeBase extends TokenStore {
    * @param loc A line/column location
    * @returns The range index of the location in the file.
    */
-  getIndexFromLoc(location: TSESTree.LineAndColumnData): number;
+  getIndexFromLoc(location: TSESTree.Position): number;
   /**
    * Gets the entire source text split into an array of lines.
    * @returns The source text as an array of lines.
@@ -261,7 +261,7 @@ declare class SourceCodeBase extends TokenStore {
    * @param index The index of a character in a file
    * @returns A {line, column} location object with a 0-indexed column
    */
-  getLocFromIndex(index: number): TSESTree.LineAndColumnData;
+  getLocFromIndex(index: number): TSESTree.Position;
   /**
    * Gets the deepest node containing a range index.
    * @param index Range index of the desired node.

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -161,7 +161,7 @@ export function getBinaryExpressionType<T extends ts.SyntaxKind>(
 export function getLineAndCharacterFor(
   pos: number,
   ast: ts.SourceFile,
-): TSESTree.LineAndColumnData {
+): TSESTree.Position {
   const loc = ast.getLineAndCharacterOfPosition(pos);
   return {
     line: loc.line + 1,

--- a/packages/typescript-estree/tests/ast-alignment/parse.ts
+++ b/packages/typescript-estree/tests/ast-alignment/parse.ts
@@ -105,7 +105,7 @@ export function parse(
         );
     }
   } catch (error: any) {
-    const loc = error.loc as TSESTree.LineAndColumnData | undefined;
+    const loc = error.loc as TSESTree.Position | undefined;
     if (loc) {
       error.codeFrame = codeFrameColumns(
         text,


### PR DESCRIPTION
https://github.com/estree/estree/blob/master/es5.md#node-objects
https://eslint.org/docs/developer-guide/working-with-custom-parsers#the-ast-specification

---

BREAKING CHANGE: `LineAndColumnData` is renamed to `Position`