### PR TITLE
chore(eslint-plugin): fix missing periods in rule messages

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -19,7 +19,7 @@ export default createRule<Options, MessageIds>({
       recommended: false,
     },
     messages: {
-      preferRecord: 'A record is preferred over an index signature',
+      preferRecord: 'A record is preferred over an index signature.',
       preferIndexSignature: 'An index signature is preferred over a record.',
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -61,13 +61,14 @@ export default util.createRule<Options, MessageIds>({
     },
     messages: {
       typeOverValue:
-        'All imports in the declaration are only used as types. Use `import type`',
-      someImportsAreOnlyTypes: 'Imports {{typeImports}} are only used as types',
-      aImportIsOnlyTypes: 'Import {{typeImports}} is only used as types',
+        'All imports in the declaration are only used as types. Use `import type`.',
+      someImportsAreOnlyTypes:
+        'Imports {{typeImports}} are only used as types.',
+      aImportIsOnlyTypes: 'Import {{typeImports}} is only used as types.',
       someImportsInDecoMeta:
-        'Type imports {{typeImports}} are used by decorator metadata',
+        'Type imports {{typeImports}} are used by decorator metadata.',
       aImportInDecoMeta:
-        'Type import {{typeImports}} is used by decorator metadata',
+        'Type import {{typeImports}} is used by decorator metadata.',
       valueOverType: 'Use an `import` instead of an `import type`.',
       noImportTypeAnnotations: '`import()` type annotations are forbidden.',
     },

--- a/packages/eslint-plugin/src/rules/no-confusing-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-non-null-assertion.ts
@@ -19,14 +19,14 @@ export default util.createRule({
     fixable: 'code',
     messages: {
       confusingEqual:
-        'Confusing combinations of non-null assertion and equal test like "a! == b", which looks very similar to not equal "a !== b"',
+        'Confusing combinations of non-null assertion and equal test like "a! == b", which looks very similar to not equal "a !== b".',
       confusingAssign:
-        'Confusing combinations of non-null assertion and equal test like "a! = b", which looks very similar to not equal "a != b"',
-      notNeedInEqualTest: 'Unnecessary non-null assertion (!) in equal test',
+        'Confusing combinations of non-null assertion and equal test like "a! = b", which looks very similar to not equal "a != b".',
+      notNeedInEqualTest: 'Unnecessary non-null assertion (!) in equal test.',
       notNeedInAssign:
-        'Unnecessary non-null assertion (!) in assignment left hand',
+        'Unnecessary non-null assertion (!) in assignment left hand.',
       wrapUpLeft:
-        'Wrap up left hand to avoid putting non-null assertion "!" and "=" together',
+        'Wrap up left hand to avoid putting non-null assertion "!" and "=" together.',
     },
     schema: [],
   },

--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -57,7 +57,7 @@ export default util.createRule<Options, MessageId>({
       invalidVoidExprReturnWrapVoid:
         'Void expressions returned from a function ' +
         'must be marked explicitly with the `void` operator.',
-      voidExprWrapVoid: 'Mark with an explicit `void` operator',
+      voidExprWrapVoid: 'Mark with an explicit `void` operator.',
     },
     schema: [
       {

--- a/packages/eslint-plugin/src/rules/no-duplicate-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-imports.ts
@@ -21,10 +21,10 @@ export default util.createRule<Options, MessageIds>({
     schema: baseRule.meta.schema,
     messages: {
       ...baseRule.meta.messages,
-      importType: '{{module}} type import is duplicated',
-      importTypeAs: '{{module}} type import is duplicated as type export',
-      exportType: '{{module}} type export is duplicated',
-      exportTypeAs: '{{module}} type export is duplicated as type import',
+      importType: '{{module}} type import is duplicated.',
+      importTypeAs: '{{module}} type import is duplicated as type export.',
+      exportType: '{{module}} type export is duplicated.',
+      exportTypeAs: '{{module}} type export is duplicated as type import.',
     },
   },
   defaultOptions: [

--- a/packages/eslint-plugin/src/rules/no-implicit-any-catch.ts
+++ b/packages/eslint-plugin/src/rules/no-implicit-any-catch.ts
@@ -26,8 +26,8 @@ export default util.createRule<Options, MessageIds>({
     },
     fixable: 'code',
     messages: {
-      implicitAnyInCatch: 'Implicit any in catch clause',
-      explicitAnyInCatch: 'Explicit any in catch clause',
+      implicitAnyInCatch: 'Implicit any in catch clause.',
+      explicitAnyInCatch: 'Explicit any in catch clause.',
       suggestExplicitUnknown:
         'Use `unknown` instead, this will force you to explicitly, and safely assert the type is correct.',
     },

--- a/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
@@ -28,14 +28,14 @@ export default util.createRule<[Options], MessageIds>({
     },
     messages: {
       invalidVoidForGeneric:
-        '{{ generic }} may not have void as a type variable',
+        '{{ generic }} may not have void as a type variable.',
       invalidVoidNotReturnOrGeneric:
-        'void is only valid as a return type or generic type variable',
-      invalidVoidNotReturn: 'void is only valid as a return type',
+        'void is only valid as a return type or generic type variable.',
+      invalidVoidNotReturn: 'void is only valid as a return type.',
       invalidVoidNotReturnOrThisParam:
-        'void is only valid as return type or type of `this` parameter',
+        'void is only valid as return type or type of `this` parameter.',
       invalidVoidNotReturnOrThisParamOrGeneric:
-        'void is only valid as a return type or generic type variable or the type of a `this` parameter',
+        'void is only valid as a return type or generic type variable or the type of a `this` parameter.',
     },
     schema: [
       {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -121,11 +121,11 @@ export default createRule<Options, MessageId>({
       alwaysNullish:
         'Unnecessary conditional, left-hand side of `??` operator is always `null` or `undefined`.',
       literalBooleanExpression:
-        'Unnecessary conditional, both sides of the expression are literal values',
+        'Unnecessary conditional, both sides of the expression are literal values.',
       noOverlapBooleanExpression:
-        'Unnecessary conditional, the types have no overlap',
-      never: 'Unnecessary conditional, value is `never`',
-      neverOptionalChain: 'Unnecessary optional chain on a non-nullish value',
+        'Unnecessary conditional, the types have no overlap.',
+      never: 'Unnecessary conditional, value is `never`.',
+      neverOptionalChain: 'Unnecessary optional chain on a non-nullish value.',
       noStrictNullCheck:
         'This rule requires the `strictNullChecks` compiler option to be turned on to function correctly.',
     },

--- a/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts
+++ b/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts
@@ -16,7 +16,7 @@ export default util.createRule<[], MessageIds>({
     },
     messages: {
       defineInitializer:
-        "The value of the member '{{ name }}' should be explicitly defined",
+        "The value of the member '{{ name }}' should be explicitly defined.",
       defineInitializerSuggestion:
         'Can be fixed to {{ name }} = {{ suggested }}',
     },

--- a/packages/eslint-plugin/src/rules/prefer-return-this-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-return-this-type.ts
@@ -27,7 +27,7 @@ export default createRule({
       requiresTypeChecking: true,
     },
     messages: {
-      useThisType: 'use `this` type instead.',
+      useThisType: 'Use `this` type instead.',
     },
     schema: [],
     fixable: 'code',


### PR DESCRIPTION
Revisiting #1935 a year later – some rule messages are missing a period at the end, and there is one instance of a message beginning with a lowercase letter.