### PR TITLE
feat: remove `meta.docs.category` from rules

### DIFF
--- a/packages/eslint-plugin-internal/src/rules/no-poorly-typed-ts-props.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-poorly-typed-ts-props.ts
@@ -37,7 +37,6 @@ export default createRule({
     docs: {
       description:
         "Enforces rules don't use TS API properties with known bad type definitions",
-      category: 'Possible Errors',
       recommended: 'error',
       suggestion: true,
       requiresTypeChecking: true,

--- a/packages/eslint-plugin-internal/src/rules/no-typescript-default-import.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-typescript-default-import.ts
@@ -22,7 +22,6 @@ export default createRule({
     docs: {
       description:
         "Enforces that packages rules don't do `import ts from 'typescript';`",
-      category: 'Possible Errors',
       recommended: 'error',
     },
     fixable: 'code',

--- a/packages/eslint-plugin-internal/src/rules/no-typescript-estree-import.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-typescript-estree-import.ts
@@ -16,7 +16,6 @@ export default createRule({
     type: 'problem',
     docs: {
       description: `Enforces that eslint-plugin rules don't require anything from ${TSESTREE_NAME} or ${TYPES_NAME}`,
-      category: 'Possible Errors',
       recommended: 'error',
     },
     fixable: 'code',

--- a/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
+++ b/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
@@ -108,7 +108,6 @@ export default createRule<Options, MessageIds>({
     type: 'problem',
     docs: {
       description: `Enforces that eslint-plugin test snippets are correctly formatted`,
-      category: 'Stylistic Issues',
       recommended: 'error',
     },
     fixable: 'code',

--- a/packages/eslint-plugin-internal/src/rules/prefer-ast-types-enum.ts
+++ b/packages/eslint-plugin-internal/src/rules/prefer-ast-types-enum.ts
@@ -14,7 +14,6 @@ export default createRule({
   meta: {
     type: 'problem',
     docs: {
-      category: 'Best Practices',
       recommended: 'error',
       description:
         'Ensures consistent usage of AST_NODE_TYPES & AST_TOKEN_TYPES enums.',

--- a/packages/eslint-plugin-tslint/src/rules/config.ts
+++ b/packages/eslint-plugin-tslint/src/rules/config.ts
@@ -63,8 +63,6 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         'Wraps a TSLint configuration and lints the whole source using TSLint',
-      // @ts-expect-error - We know this is a one off special category for this plugin
-      category: 'TSLint',
       recommended: false,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
+++ b/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
@@ -21,7 +21,6 @@ export default util.createRule({
     type: 'suggestion',
     docs: {
       description: 'Require that member overloads be consecutive',
-      category: 'Best Practices',
       recommended: 'error',
     },
     schema: [],

--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -92,7 +92,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Requires using either `T[]` or `Array<T>` for arrays',
-      category: 'Stylistic Issues',
       // too opinionated to be recommended
       recommended: false,
     },

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -7,7 +7,6 @@ export default util.createRule({
   meta: {
     docs: {
       description: 'Disallows awaiting a value that is not a Thenable',
-      category: 'Best Practices',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -22,7 +22,6 @@ export default util.createRule<[Options], MessageIds>({
     docs: {
       description:
         'Bans `@ts-<directive>` comments from being used or requires descriptions after directive',
-      category: 'Best Practices',
       recommended: 'error',
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/ban-tslint-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-tslint-comment.ts
@@ -20,7 +20,6 @@ export default util.createRule({
     type: 'suggestion',
     docs: {
       description: 'Bans `// tslint:<rule-flag>` comments from being used',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -124,7 +124,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Bans specific types from being used',
-      category: 'Best Practices',
       recommended: 'error',
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/brace-style.ts
+++ b/packages/eslint-plugin/src/rules/brace-style.ts
@@ -18,7 +18,6 @@ export default createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce consistent brace style for blocks',
-      category: 'Stylistic Issues',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -44,7 +44,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Ensures that literals on classes are exposed in a consistent style',
-      category: 'Best Practices',
       recommended: false,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/comma-dangle.ts
+++ b/packages/eslint-plugin/src/rules/comma-dangle.ts
@@ -45,7 +45,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Require or disallow trailing comma',
-      category: 'Stylistic Issues',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/comma-spacing.ts
+++ b/packages/eslint-plugin/src/rules/comma-spacing.ts
@@ -23,7 +23,6 @@ export default createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Enforces consistent spacing before and after commas',
-      category: 'Stylistic Issues',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -14,7 +14,6 @@ export default createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Enforce or disallow the use of the record type',
-      category: 'Stylistic Issues',
       // too opinionated to be recommended
       recommended: false,
     },

--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -25,7 +25,6 @@ export default util.createRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     docs: {
-      category: 'Best Practices',
       description: 'Enforces consistent usage of type assertions',
       recommended: false,
     },

--- a/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
@@ -13,7 +13,6 @@ export default util.createRule({
     docs: {
       description:
         'Consistent with type definition either `interface` or `type`',
-      category: 'Stylistic Issues',
       // too opinionated to be recommended
       recommended: false,
     },

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -56,7 +56,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Enforces consistent usage of type imports',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/default-param-last.ts
+++ b/packages/eslint-plugin/src/rules/default-param-last.ts
@@ -10,7 +10,6 @@ export default createRule({
     type: 'suggestion',
     docs: {
       description: 'Enforce default parameters to be last',
-      category: 'Best Practices',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/dot-notation.ts
+++ b/packages/eslint-plugin/src/rules/dot-notation.ts
@@ -20,7 +20,6 @@ export default createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'enforce dot notation whenever possible',
-      category: 'Best Practices',
       recommended: false,
       extendsBaseRule: true,
       requiresTypeChecking: true,

--- a/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
+++ b/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
@@ -26,7 +26,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Require explicit return types on functions and class methods',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
+++ b/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
@@ -36,7 +36,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Require explicit accessibility modifiers on class properties and methods',
-      category: 'Stylistic Issues',
       // too opinionated to be recommended
       recommended: false,
     },

--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -36,7 +36,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         "Require explicit return and argument types on exported functions' and classes' public class methods",
-      category: 'Stylistic Issues',
       recommended: 'warn',
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/func-call-spacing.ts
+++ b/packages/eslint-plugin/src/rules/func-call-spacing.ts
@@ -19,7 +19,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Require or disallow spacing between function identifiers and their invocations',
-      category: 'Stylistic Issues',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
+++ b/packages/eslint-plugin/src/rules/indent-new-do-not-use/index.ts
@@ -257,7 +257,6 @@ export default createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce consistent indentation.',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     fixable: 'whitespace',

--- a/packages/eslint-plugin/src/rules/indent.ts
+++ b/packages/eslint-plugin/src/rules/indent.ts
@@ -91,7 +91,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce consistent indentation',
-      category: 'Stylistic Issues',
       // too opinionated to be recommended
       recommended: false,
       extendsBaseRule: true,

--- a/packages/eslint-plugin/src/rules/init-declarations.ts
+++ b/packages/eslint-plugin/src/rules/init-declarations.ts
@@ -21,7 +21,6 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         'require or disallow initialization in variable declarations',
-      category: 'Variables',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/keyword-spacing.ts
+++ b/packages/eslint-plugin/src/rules/keyword-spacing.ts
@@ -13,7 +13,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforce consistent spacing before and after keywords',
-      category: 'Stylistic Issues',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/lines-between-class-members.ts
+++ b/packages/eslint-plugin/src/rules/lines-between-class-members.ts
@@ -28,7 +28,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Require or disallow an empty line between class members',
-      category: 'Stylistic Issues',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/member-delimiter-style.ts
+++ b/packages/eslint-plugin/src/rules/member-delimiter-style.ts
@@ -120,7 +120,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Require a specific member delimiter style for interfaces and type literals',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -423,7 +423,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Require a consistent member declaration order',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/method-signature-style.ts
+++ b/packages/eslint-plugin/src/rules/method-signature-style.ts
@@ -13,7 +13,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Enforces using a particular method signature syntax.',
-      category: 'Best Practices',
       recommended: false,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -55,7 +55,6 @@ export default util.createRule<Options, MessageIds>({
   name: 'naming-convention',
   meta: {
     docs: {
-      category: 'Variables',
       description:
         'Enforces naming conventions for everything across a codebase',
       recommended: false,

--- a/packages/eslint-plugin/src/rules/no-array-constructor.ts
+++ b/packages/eslint-plugin/src/rules/no-array-constructor.ts
@@ -10,7 +10,6 @@ export default util.createRule({
     type: 'suggestion',
     docs: {
       description: 'Disallow generic `Array` constructors',
-      category: 'Stylistic Issues',
       recommended: 'error',
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -25,7 +25,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Requires that `.toString()` is only called on objects which provide useful information when stringified',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-confusing-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-non-null-assertion.ts
@@ -13,7 +13,6 @@ export default util.createRule({
     docs: {
       description:
         'Disallow non-null assertion in locations that may be confusing',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -30,7 +30,6 @@ export default util.createRule<Options, MessageId>({
     docs: {
       description:
         'Requires expressions of type void to appear in statement position',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-dupe-class-members.ts
+++ b/packages/eslint-plugin/src/rules/no-dupe-class-members.ts
@@ -16,7 +16,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'problem',
     docs: {
       description: 'Disallow duplicate class members',
-      category: 'Possible Errors',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-duplicate-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-imports.ts
@@ -16,7 +16,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'problem',
     docs: {
       description: 'Disallow duplicate imports',
-      category: 'Best Practices',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-dynamic-delete.ts
+++ b/packages/eslint-plugin/src/rules/no-dynamic-delete.ts
@@ -10,7 +10,6 @@ export default util.createRule({
   name: 'no-dynamic-delete',
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow the delete operator with computed key expressions',
       recommended: false,
     },

--- a/packages/eslint-plugin/src/rules/no-empty-function.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-function.ts
@@ -45,7 +45,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Disallow empty functions',
-      category: 'Best Practices',
       recommended: 'error',
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -14,7 +14,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Disallow the declaration of empty interfaces',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: true,
     },

--- a/packages/eslint-plugin/src/rules/no-explicit-any.ts
+++ b/packages/eslint-plugin/src/rules/no-explicit-any.ts
@@ -19,7 +19,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Disallow usage of the `any` type',
-      category: 'Best Practices',
       recommended: 'warn',
       suggestion: true,
     },

--- a/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-non-null-assertion.ts
@@ -7,7 +7,6 @@ export default util.createRule({
     type: 'problem',
     docs: {
       description: 'Disallow extra non-null assertion',
-      category: 'Stylistic Issues',
       recommended: 'error',
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/no-extra-parens.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-parens.ts
@@ -20,7 +20,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Disallow unnecessary parentheses',
-      category: 'Possible Errors',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-extra-semi.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-semi.ts
@@ -12,7 +12,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Disallow unnecessary semicolons',
-      category: 'Possible Errors',
       recommended: 'error',
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-extraneous-class.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-class.ts
@@ -20,7 +20,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Forbids the use of classes as namespaces',
-      category: 'Best Practices',
       recommended: false,
     },
     schema: [

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -22,7 +22,6 @@ export default util.createRule<Options, MessageId>({
   meta: {
     docs: {
       description: 'Requires Promise-like values to be handled appropriately',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: true,
       requiresTypeChecking: true,

--- a/packages/eslint-plugin/src/rules/no-for-in-array.ts
+++ b/packages/eslint-plugin/src/rules/no-for-in-array.ts
@@ -6,7 +6,6 @@ export default util.createRule({
   meta: {
     docs: {
       description: 'Disallow iterating over an array with a for-in loop',
-      category: 'Best Practices',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-implicit-any-catch.ts
+++ b/packages/eslint-plugin/src/rules/no-implicit-any-catch.ts
@@ -20,7 +20,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Disallow usage of the implicit `any` type in catch clauses',
-      category: 'Best Practices',
       recommended: false,
       suggestion: true,
     },

--- a/packages/eslint-plugin/src/rules/no-implied-eval.ts
+++ b/packages/eslint-plugin/src/rules/no-implied-eval.ts
@@ -20,7 +20,6 @@ export default util.createRule({
   meta: {
     docs: {
       description: 'Disallow the use of `eval()`-like methods',
-      category: 'Best Practices',
       recommended: 'error',
       extendsBaseRule: true,
       requiresTypeChecking: true,

--- a/packages/eslint-plugin/src/rules/no-inferrable-types.ts
+++ b/packages/eslint-plugin/src/rules/no-inferrable-types.ts
@@ -19,7 +19,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean',
-      category: 'Best Practices',
       recommended: 'error',
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/no-invalid-this.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-this.ts
@@ -21,7 +21,6 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         'Disallow `this` keywords outside of classes or class-like objects',
-      category: 'Best Practices',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
@@ -23,7 +23,6 @@ export default util.createRule<[Options], MessageIds>({
     docs: {
       description:
         'Disallows usage of `void` type outside of generic or return types',
-      category: 'Best Practices',
       recommended: false,
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/no-loop-func.ts
+++ b/packages/eslint-plugin/src/rules/no-loop-func.ts
@@ -18,7 +18,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Disallow function declarations that contain unsafe references inside loop statements',
-      category: 'Best Practices',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-loss-of-precision.ts
+++ b/packages/eslint-plugin/src/rules/no-loss-of-precision.ts
@@ -15,7 +15,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'problem',
     docs: {
       description: 'Disallow literal numbers that lose precision',
-      category: 'Possible Errors',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-magic-numbers.ts
+++ b/packages/eslint-plugin/src/rules/no-magic-numbers.ts
@@ -20,7 +20,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Disallow magic numbers',
-      category: 'Best Practices',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-misused-new.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-new.ts
@@ -10,7 +10,6 @@ export default util.createRule({
     type: 'problem',
     docs: {
       description: 'Enforce valid definition of `new` and `constructor`',
-      category: 'Best Practices',
       recommended: 'error',
     },
     schema: [],

--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -20,7 +20,6 @@ export default util.createRule<Options, 'conditional' | 'voidReturn'>({
   meta: {
     docs: {
       description: 'Avoid using promises in places not designed to handle them',
-      category: 'Best Practices',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-namespace.ts
+++ b/packages/eslint-plugin/src/rules/no-namespace.ts
@@ -19,7 +19,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Disallow the use of custom TypeScript modules and namespaces',
-      category: 'Best Practices',
       recommended: 'error',
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
@@ -22,7 +22,6 @@ export default util.createRule({
     docs: {
       description:
         'Disallows using a non-null assertion after an optional chain expression',
-      category: 'Possible Errors',
       recommended: 'error',
       suggestion: true,
     },

--- a/packages/eslint-plugin/src/rules/no-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-assertion.ts
@@ -13,7 +13,6 @@ export default util.createRule<[], MessageIds>({
     docs: {
       description:
         'Disallows non-null assertions using the `!` postfix operator',
-      category: 'Stylistic Issues',
       recommended: 'warn',
       suggestion: true,
     },

--- a/packages/eslint-plugin/src/rules/no-parameter-properties.ts
+++ b/packages/eslint-plugin/src/rules/no-parameter-properties.ts
@@ -26,7 +26,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Disallow the use of parameter properties in class constructors',
-      category: 'Stylistic Issues',
       // too opinionated to be recommended
       recommended: false,
     },

--- a/packages/eslint-plugin/src/rules/no-redeclare.ts
+++ b/packages/eslint-plugin/src/rules/no-redeclare.ts
@@ -19,7 +19,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Disallow variable redeclaration',
-      category: 'Best Practices',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-require-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-require-imports.ts
@@ -7,7 +7,6 @@ export default util.createRule({
     type: 'problem',
     docs: {
       description: 'Disallows invocation of `require()`',
-      category: 'Best Practices',
       recommended: false,
     },
     schema: [],

--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -24,7 +24,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Disallow variable declarations from shadowing variables declared in the outer scope',
-      category: 'Variables',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-this-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-this-alias.ts
@@ -18,7 +18,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Disallow aliasing `this`',
-      category: 'Best Practices',
       recommended: 'error',
     },
     schema: [

--- a/packages/eslint-plugin/src/rules/no-throw-literal.ts
+++ b/packages/eslint-plugin/src/rules/no-throw-literal.ts
@@ -11,7 +11,6 @@ export default util.createRule({
     type: 'problem',
     docs: {
       description: 'Disallow throwing literals as exceptions',
-      category: 'Best Practices',
       recommended: false,
       extendsBaseRule: true,
       requiresTypeChecking: true,

--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -45,7 +45,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Disallow the use of type aliases',
-      category: 'Stylistic Issues',
       // too opinionated to be recommended
       recommended: false,
     },

--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -38,7 +38,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Flags unnecessary equality comparisons against boolean literals',
-      category: 'Stylistic Issues',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -90,7 +90,6 @@ export default createRule<Options, MessageId>({
     docs: {
       description:
         'Prevents conditionals where the type is always truthy or always falsy',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-unnecessary-qualifier.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-qualifier.ts
@@ -10,7 +10,6 @@ export default util.createRule({
   name: 'no-unnecessary-qualifier',
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Warns when a namespace qualifier is unnecessary',
       recommended: false,
       requiresTypeChecking: true,

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
@@ -22,7 +22,6 @@ export default util.createRule<[], MessageIds>({
     docs: {
       description:
         'Enforces that type arguments will not be used if not required',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -25,7 +25,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Warns if a type assertion does not change the type of an expression',
-      category: 'Best Practices',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts
@@ -32,7 +32,6 @@ export default util.createRule({
   name: 'no-unnecessary-type-constraint',
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallows unnecessary constraints on generic types',
       recommended: false,
       suggestion: true,

--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -138,7 +138,6 @@ export default util.createRule<[], MessageIds>({
     type: 'problem',
     docs: {
       description: 'Disallows calling an function with an any type value',
-      category: 'Possible Errors',
       // TODO - enable this with next breaking
       recommended: false,
       requiresTypeChecking: true,

--- a/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts
@@ -22,7 +22,6 @@ export default util.createRule({
     type: 'problem',
     docs: {
       description: 'Disallows assigning any to variables and properties',
-      category: 'Possible Errors',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -15,7 +15,6 @@ export default util.createRule<[], MessageIds>({
     type: 'problem',
     docs: {
       description: 'Disallows calling an any type value',
-      category: 'Possible Errors',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts
@@ -17,7 +17,6 @@ export default util.createRule({
     type: 'problem',
     docs: {
       description: 'Disallows member access on any typed variables',
-      category: 'Possible Errors',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-unsafe-return.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-return.ts
@@ -12,7 +12,6 @@ export default util.createRule({
     type: 'problem',
     docs: {
       description: 'Disallows returning any from a function',
-      category: 'Possible Errors',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/no-unused-expressions.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-expressions.ts
@@ -16,7 +16,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Disallow unused expressions',
-      category: 'Best Practices',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -37,7 +37,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'problem',
     docs: {
       description: 'Disallow unused variables',
-      category: 'Variables',
       recommended: 'warn',
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-use-before-define.ts
+++ b/packages/eslint-plugin/src/rules/no-use-before-define.ts
@@ -231,7 +231,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'problem',
     docs: {
       description: 'Disallow the use of variables before they are defined',
-      category: 'Variables',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-useless-constructor.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-constructor.ts
@@ -51,7 +51,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'problem',
     docs: {
       description: 'Disallow unnecessary constructors',
-      category: 'Best Practices',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/no-var-requires.ts
+++ b/packages/eslint-plugin/src/rules/no-var-requires.ts
@@ -14,7 +14,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Disallows the use of require statements except in import statements',
-      category: 'Best Practices',
       recommended: 'error',
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
+++ b/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
@@ -11,7 +11,6 @@ export default util.createRule({
   name: 'non-nullable-type-assertion-style',
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Prefers a non-null assertion over explicit type cast when possible',
       recommended: false,

--- a/packages/eslint-plugin/src/rules/object-curly-spacing.ts
+++ b/packages/eslint-plugin/src/rules/object-curly-spacing.ts
@@ -24,7 +24,6 @@ export default createRule<Options, MessageIds>({
     ...baseRule.meta,
     docs: {
       description: 'Enforce consistent spacing inside braces',
-      category: 'Stylistic Issues',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-as-const.ts
+++ b/packages/eslint-plugin/src/rules/prefer-as-const.ts
@@ -11,7 +11,6 @@ export default util.createRule({
     type: 'suggestion',
     docs: {
       description: 'Prefer usage of `as const` over literal type',
-      category: 'Best Practices',
       recommended: 'error',
       suggestion: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts
+++ b/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts
@@ -10,7 +10,6 @@ export default util.createRule<[], MessageIds>({
     type: 'suggestion',
     docs: {
       description: 'Prefer initializing each enums member value',
-      category: 'Best Practices',
       recommended: false,
       suggestion: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-for-of.ts
+++ b/packages/eslint-plugin/src/rules/prefer-for-of.ts
@@ -12,7 +12,6 @@ export default util.createRule({
     docs: {
       description:
         'Prefer a ‘for-of’ loop over a standard ‘for’ loop if the index is only used to access the array being iterated',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/prefer-function-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-function-type.ts
@@ -17,7 +17,6 @@ export default util.createRule({
     docs: {
       description:
         'Use function types instead of interfaces with call signatures',
-      category: 'Best Practices',
       recommended: false,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/prefer-includes.ts
+++ b/packages/eslint-plugin/src/rules/prefer-includes.ts
@@ -20,7 +20,6 @@ export default createRule({
     type: 'suggestion',
     docs: {
       description: 'Enforce `includes` method over `indexOf` method',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
+++ b/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
@@ -8,7 +8,6 @@ export default createRule({
     docs: {
       description:
         'Require that all enum members be literal values to prevent unintended enum member name shadow issues',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: false,
     },

--- a/packages/eslint-plugin/src/rules/prefer-namespace-keyword.ts
+++ b/packages/eslint-plugin/src/rules/prefer-namespace-keyword.ts
@@ -11,7 +11,6 @@ export default util.createRule({
     docs: {
       description:
         'Require the use of the `namespace` keyword instead of the `module` keyword to declare custom TypeScript modules',
-      category: 'Best Practices',
       recommended: 'error',
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -21,7 +21,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Enforce the usage of the nullish coalescing operator instead of logical chaining',
-      category: 'Best Practices',
       recommended: false,
       suggestion: true,
       requiresTypeChecking: true,

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -37,7 +37,6 @@ export default util.createRule({
     docs: {
       description:
         'Prefer using concise optional chain expressions instead of chained logical ands',
-      category: 'Best Practices',
       recommended: false,
       suggestion: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
@@ -19,7 +19,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Requires that function parameters are typed as readonly to prevent accidental mutation of inputs',
-      category: 'Possible Errors',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly.ts
@@ -28,7 +28,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         "Requires that private members are marked as `readonly` if they're never modified outside of the constructor",
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts
+++ b/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts
@@ -30,7 +30,6 @@ export default util.createRule({
   meta: {
     type: 'problem',
     docs: {
-      category: 'Best Practices',
       recommended: false,
       description:
         'Prefer using type parameter when calling `Array#reduce` instead of casting',

--- a/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
+++ b/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
@@ -29,7 +29,6 @@ export default createRule({
     docs: {
       description:
         'Enforce that `RegExp#exec` is used instead of `String#match` if no global flag is provided',
-      category: 'Best Practices',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-return-this-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-return-this-type.ts
@@ -22,7 +22,6 @@ export default createRule({
     docs: {
       description:
         'Enforce that `this` is used when only `this` type is returned',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -27,7 +27,6 @@ export default createRule({
     docs: {
       description:
         'Enforce the use of `String#startsWith` and `String#endsWith` instead of other equivalent methods of checking substrings',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
+++ b/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
@@ -16,7 +16,6 @@ export default util.createRule<[], MessageIds>({
     type: 'problem',
     docs: {
       description: 'Recommends using `@ts-expect-error` over `@ts-ignore`',
-      category: 'Best Practices',
       recommended: false,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -26,7 +26,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Requires any function or method that returns a Promise to be marked async',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/quotes.ts
+++ b/packages/eslint-plugin/src/rules/quotes.ts
@@ -17,7 +17,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Enforce the consistent use of either backticks, double, or single quotes',
-      category: 'Stylistic Issues',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
+++ b/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
@@ -21,7 +21,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Requires `Array#sort` calls to always provide a `compareFunction`',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/require-await.ts
+++ b/packages/eslint-plugin/src/rules/require-await.ts
@@ -25,7 +25,6 @@ export default util.createRule({
     type: 'suggestion',
     docs: {
       description: 'Disallow async functions which have no `await` expression',
-      category: 'Best Practices',
       recommended: 'error',
       requiresTypeChecking: true,
       extendsBaseRule: true,

--- a/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
+++ b/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
@@ -16,7 +16,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'When adding two variables, operands must both be of type number or of type string',
-      category: 'Best Practices',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
+++ b/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
@@ -22,7 +22,6 @@ export default util.createRule<Options, MessageId>({
     type: 'problem',
     docs: {
       description: 'Enforce template literal expressions to be of string type',
-      category: 'Best Practices',
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -22,7 +22,6 @@ export default util.createRule({
   meta: {
     docs: {
       description: 'Enforces consistent returning of awaited values',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
       extendsBaseRule: 'no-return-await',

--- a/packages/eslint-plugin/src/rules/semi.ts
+++ b/packages/eslint-plugin/src/rules/semi.ts
@@ -17,7 +17,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Require or disallow semicolons instead of ASI',
-      category: 'Stylistic Issues',
       // too opinionated to be recommended
       recommended: false,
       extendsBaseRule: true,

--- a/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
@@ -108,7 +108,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Enforces that members of a type union/intersection are sorted alphabetically',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/space-before-function-paren.ts
+++ b/packages/eslint-plugin/src/rules/space-before-function-paren.ts
@@ -23,7 +23,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Enforces consistent spacing before function parenthesis',
-      category: 'Stylistic Issues',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/space-infix-ops.ts
+++ b/packages/eslint-plugin/src/rules/space-infix-ops.ts
@@ -19,7 +19,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'This rule is aimed at ensuring there are spaces around infix operators.',
-      category: 'Stylistic Issues',
       recommended: false,
       extendsBaseRule: true,
     },

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -52,7 +52,6 @@ export default util.createRule<Options, MessageId>({
     hasSuggestions: true,
     docs: {
       description: 'Restricts the types allowed in boolean expressions',
-      category: 'Best Practices',
       recommended: false,
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -16,7 +16,6 @@ export default createRule({
     type: 'suggestion',
     docs: {
       description: 'Exhaustiveness checking in switch with union type',
-      category: 'Best Practices',
       recommended: false,
       suggestion: true,
       requiresTypeChecking: true,

--- a/packages/eslint-plugin/src/rules/triple-slash-reference.ts
+++ b/packages/eslint-plugin/src/rules/triple-slash-reference.ts
@@ -21,7 +21,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description:
         'Sets preference level for triple slash directives versus ES6-style import declarations',
-      category: 'Best Practices',
       recommended: 'error',
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
+++ b/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
@@ -114,7 +114,6 @@ export default util.createRule<Options, MessageIds>({
     type: 'layout',
     docs: {
       description: 'Require consistent spacing around type annotations',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     fixable: 'whitespace',

--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -24,7 +24,6 @@ export default util.createRule<[Options], MessageIds>({
   meta: {
     docs: {
       description: 'Requires type annotations to exist',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -128,7 +128,6 @@ export default util.createRule<Options, MessageIds>({
   name: 'unbound-method',
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Enforces unbound methods are called with their expected scope',
       recommended: 'error',

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -57,7 +57,6 @@ export default util.createRule({
     docs: {
       description:
         'Warns for any two overloads that could be unified into one by using a union or an optional/rest parameter',
-      category: 'Variables',
       // too opinionated to be recommended
       recommended: false,
     },

--- a/packages/eslint-plugin/tests/util/getWrappingFixer.test.ts
+++ b/packages/eslint-plugin/tests/util/getWrappingFixer.test.ts
@@ -10,7 +10,6 @@ const rule = createRule({
     fixable: 'code',
     docs: {
       description: 'Add void operator in random places for test purposes.',
-      category: 'Stylistic Issues',
       recommended: false,
     },
     messages: {

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -1,19 +1,11 @@
-import { JSONSchema4 } from '../json-schema';
-import { ParserServices, TSESTree } from '../ts-estree';
-import { AST } from './AST';
-import { Linter } from './Linter';
-import { Scope } from './Scope';
-import { SourceCode } from './SourceCode';
+import type { JSONSchema4 } from '../json-schema';
+import type { ParserServices, TSESTree } from '../ts-estree';
+import type { AST } from './AST';
+import type { Linter } from './Linter';
+import type { Scope } from './Scope';
+import type { SourceCode } from './SourceCode';
 
 interface RuleMetaDataDocs {
-  /**
-   * The general category the rule falls within
-   */
-  category:
-    | 'Best Practices'
-    | 'Stylistic Issues'
-    | 'Variables'
-    | 'Possible Errors';
   /**
    * Concise description of the rule
    */

--- a/packages/experimental-utils/tests/eslint-utils/RuleCreator.test.ts
+++ b/packages/experimental-utils/tests/eslint-utils/RuleCreator.test.ts
@@ -13,7 +13,6 @@ describe('RuleCreator', () => {
       meta: {
         docs: {
           description: 'some description',
-          category: 'Best Practices',
           recommended: 'error',
           requiresTypeChecking: true,
         },
@@ -31,7 +30,6 @@ describe('RuleCreator', () => {
     expect(rule.meta).toEqual({
       docs: {
         description: 'some description',
-        category: 'Best Practices',
         url: 'test/test',
         recommended: 'error',
         requiresTypeChecking: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4204,9 +4204,9 @@ eslint-visitor-keys@^3.0.0:
   integrity sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==
 
 eslint@^8.0.0-0:
-  version "8.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.0.0-beta.0.tgz#965fa5161b7cc93f1c82fb9c617a3814dc95ba38"
-  integrity sha512-Q5wCLXSpq+RIa9QBrmHApNCpgqjBU5aeQbVfeAuc9DyBIWzsdivbiirbCmYBrdoFWUoGSYCYWSIpqrS2une7jg==
+  version "8.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.0.0-beta.1.tgz#5cd74684dbcfd8abee08cc10de578294124539b5"
+  integrity sha512-+3EHhCIJHUXuksq6dUSe1Nv9+sdFaLfct6ZiWdFYrHU8u9tX6QQWGdKJQuQXUlUdhMMh6cchRFIQ7OqSAcyq7A==
   dependencies:
     "@eslint/eslintrc" "^1.0.0"
     "@humanwhocodes/config-array" "^0.6.0"


### PR DESCRIPTION
@bradzacher Not sure if wanted to remove it from all rules or only from the extended core rules, so went with the latter (for now).
Types will be less complex if we remove it on all rules though.

---

Part of #3738