### PR TITLE
fix(eslint-plugin): false-positive/negative with array index in no-unnecessary-condition

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -279,7 +279,7 @@ export default createRule<Options, MessageId>({
           !(
             node.type === AST_NODE_TYPES.ChainExpression &&
             node.expression.type !== AST_NODE_TYPES.TSNonNullExpression &&
-            optionChainContainsArrayIndex(node.expression)
+            optionChainContainsOptionArrayIndex(node.expression)
           )
         ) {
           messageId = 'neverNullish';
@@ -483,19 +483,19 @@ export default createRule<Options, MessageId>({
     //    ?.x // type is {y: "z"}
     //    ?.y // This access is considered "unnecessary" according to the types
     //  ```
-    function optionChainContainsArrayIndex(
+    function optionChainContainsOptionArrayIndex(
       node: TSESTree.MemberExpression | TSESTree.CallExpression,
     ): boolean {
       const lhsNode =
         node.type === AST_NODE_TYPES.CallExpression ? node.callee : node.object;
-      if (isArrayIndexExpression(lhsNode)) {
+      if (node.optional && isArrayIndexExpression(lhsNode)) {
         return true;
       }
       if (
         lhsNode.type === AST_NODE_TYPES.MemberExpression ||
         lhsNode.type === AST_NODE_TYPES.CallExpression
       ) {
-        return optionChainContainsArrayIndex(lhsNode);
+        return optionChainContainsOptionArrayIndex(lhsNode);
       }
       return false;
     }
@@ -590,7 +590,7 @@ export default createRule<Options, MessageId>({
       // Since typescript array index signature types don't represent the
       //  possibility of out-of-bounds access, if we're indexing into an array
       //  just skip the check, to avoid false positives
-      if (optionChainContainsArrayIndex(node)) {
+      if (optionChainContainsOptionArrayIndex(node)) {
         return;
       }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -274,7 +274,14 @@ export default createRule<Options, MessageId>({
         // Since typescript array index signature types don't represent the
         //  possibility of out-of-bounds access, if we're indexing into an array
         //  just skip the check, to avoid false positives
-        if (!isArrayIndexExpression(node)) {
+        if (
+          !isArrayIndexExpression(node) &&
+          !(
+            node.type === AST_NODE_TYPES.ChainExpression &&
+            node.expression.type !== AST_NODE_TYPES.TSNonNullExpression &&
+            optionChainContainsArrayIndex(node.expression)
+          )
+        ) {
           messageId = 'neverNullish';
         }
       } else if (isAlwaysNullish(type)) {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -261,12 +261,6 @@ export default createRule<Options, MessageId>({
     }
 
     function checkNodeForNullish(node: TSESTree.Expression): void {
-      // Since typescript array index signature types don't represent the
-      //  possibility of out-of-bounds access, if we're indexing into an array
-      //  just skip the check, to avoid false positives
-      if (isArrayIndexExpression(node)) {
-        return;
-      }
       const type = getNodeType(node);
       // Conditional is always necessary if it involves `any` or `unknown`
       if (isTypeAnyType(type) || isTypeUnknownType(type)) {
@@ -277,7 +271,12 @@ export default createRule<Options, MessageId>({
       if (isTypeFlagSet(type, ts.TypeFlags.Never)) {
         messageId = 'never';
       } else if (!isPossiblyNullish(type)) {
-        messageId = 'neverNullish';
+        // Since typescript array index signature types don't represent the
+        //  possibility of out-of-bounds access, if we're indexing into an array
+        //  just skip the check, to avoid false positives
+        if (!isArrayIndexExpression(node)) {
+          messageId = 'neverNullish';
+        }
       } else if (isAlwaysNullish(type)) {
         messageId = 'alwaysNullish';
       }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1337,6 +1337,17 @@ foo?.fooOrBar.baz?.qux;
     },
     {
       code: `
+declare const x: { a: { b: number } }[];
+x[0].a?.b;
+      `,
+      output: `
+declare const x: { a: { b: number } }[];
+x[0].a.b;
+      `,
+      errors: [ruleError(3, 7, 'neverOptionalChain')],
+    },
+    {
+      code: `
 type Foo = { [key: string]: string; foo: 'foo'; bar: 'bar' } | null;
 type Key = 'bar' | 'foo';
 declare const foo: Foo;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -765,6 +765,14 @@ function test(a: null) {
     },
     {
       code: `
+function test(a: null[]) {
+  return a[0] ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 10, 'alwaysNullish')],
+    },
+    {
+      code: `
 function test(a: never) {
   return a ?? 'default';
 }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -316,6 +316,11 @@ returnsArr?.()[42]?.toUpperCase();
 declare const arr: string[][];
 arr[x] ?? [];
     `,
+    // nullish + optional array index
+    `
+declare const arr: { foo: number }[];
+const bar = arr[42]?.foo ?? 0;
+    `,
     // Doesn't check the right-hand side of a logical expression
     //  in a non-conditional context
     {
@@ -751,6 +756,15 @@ function test(a: string) {
       code: `
 function test(a: string | false) {
   return a ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 10, 'neverNullish')],
+    },
+    // nullish + array index without optional chaining
+    {
+      code: `
+function test(a: { foo: string }[]) {
+  return a[0].foo ?? 'default';
 }
       `,
       errors: [ruleError(3, 10, 'neverNullish')],


### PR DESCRIPTION
This PR fixes several false-positive/negatives in no-unnecessary-condition.
- False-positive at nullish coalescing after array index access: `arr[42]?.foo ?? 0`
- False-negative at `arr[42] ?? 0` where `arr[42]` is always nullish or never.
- False-negative at `arr[0].foo?.bar` where `foo` is not nullable.