### PR TITLE
fix: update dependencies

### DIFF
--- a/packages/eslint-plugin-internal/package.json
+++ b/packages/eslint-plugin-internal/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@types/prettier": "*",
-    "@typescript-eslint/experimental-utils": "4.29.3",
+    "@typescript-eslint/experimental-utils": "^5.0.0-0",
     "prettier": "*"
   }
 }

--- a/packages/eslint-plugin-tslint/package.json
+++ b/packages/eslint-plugin-tslint/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "4.29.3",
+    "@typescript-eslint/experimental-utils": "^5.0.0-0",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
@@ -48,6 +48,6 @@
   },
   "devDependencies": {
     "@types/lodash": "*",
-    "@typescript-eslint/parser": "4.29.3"
+    "@typescript-eslint/parser": "^5.0.0-0"
   }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -44,8 +44,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "4.29.3",
-    "@typescript-eslint/scope-manager": "4.29.3",
+    "@typescript-eslint/experimental-utils": "^5.0.0-0",
+    "@typescript-eslint/scope-manager": "^5.0.0-0",
     "debug": "^4.3.1",
     "functional-red-black-tree": "^1.0.1",
     "regexpp": "^3.1.0",
@@ -62,7 +62,7 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^4.0.0",
+    "@typescript-eslint/parser": "^5.0.0-0",
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
   },
   "peerDependenciesMeta": {

--- a/packages/experimental-utils/package.json
+++ b/packages/experimental-utils/package.json
@@ -40,9 +40,9 @@
   },
   "dependencies": {
     "@types/json-schema": "^7.0.7",
-    "@typescript-eslint/scope-manager": "4.29.3",
-    "@typescript-eslint/types": "4.29.3",
-    "@typescript-eslint/typescript-estree": "4.29.3",
+    "@typescript-eslint/scope-manager": "^5.0.0-0",
+    "@typescript-eslint/types": "^5.0.0-0",
+    "@typescript-eslint/typescript-estree": "^5.0.0-0",
     "eslint-scope": "^5.1.1",
     "eslint-utils": "^3.0.0"
   },

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -44,14 +44,14 @@
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
   },
   "dependencies": {
-    "@typescript-eslint/scope-manager": "4.29.3",
-    "@typescript-eslint/types": "4.29.3",
-    "@typescript-eslint/typescript-estree": "4.29.3",
+    "@typescript-eslint/scope-manager": "^5.0.0-0",
+    "@typescript-eslint/types": "^5.0.0-0",
+    "@typescript-eslint/typescript-estree": "^5.0.0-0",
     "debug": "^4.3.1"
   },
   "devDependencies": {
     "@types/glob": "*",
-    "@typescript-eslint/experimental-utils": "4.29.3",
+    "@typescript-eslint/experimental-utils": "^5.0.0-0",
     "glob": "*",
     "typescript": "*"
   },

--- a/packages/scope-manager/package.json
+++ b/packages/scope-manager/package.json
@@ -39,12 +39,12 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@typescript-eslint/types": "4.29.3",
-    "@typescript-eslint/visitor-keys": "4.29.3"
+    "@typescript-eslint/types": "^5.0.0-0",
+    "@typescript-eslint/visitor-keys": "^5.0.0-0"
   },
   "devDependencies": {
     "@types/glob": "*",
-    "@typescript-eslint/typescript-estree": "4.29.3",
+    "@typescript-eslint/typescript-estree": "^5.0.0-0",
     "glob": "*",
     "jest-specific-snapshot": "*",
     "make-dir": "*",

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -41,8 +41,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@typescript-eslint/types": "4.29.3",
-    "@typescript-eslint/visitor-keys": "4.29.3",
+    "@typescript-eslint/types": "^5.0.0-0",
+    "@typescript-eslint/visitor-keys": "^5.0.0-0",
     "debug": "^4.3.1",
     "globby": "^11.0.3",
     "is-glob": "^4.0.1",
@@ -59,7 +59,7 @@
     "@types/is-glob": "*",
     "@types/semver": "*",
     "@types/tmp": "*",
-    "@typescript-eslint/shared-fixtures": "4.29.3",
+    "@typescript-eslint/shared-fixtures": "^5.0.0-0",
     "glob": "*",
     "jest-specific-snapshot": "*",
     "make-dir": "*",

--- a/packages/visitor-keys/package.json
+++ b/packages/visitor-keys/package.json
@@ -38,7 +38,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@typescript-eslint/types": "4.29.3",
+    "@typescript-eslint/types": "^5.0.0-0",
     "eslint-visitor-keys": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
When installing a v5 canary package, it still installs v4 dependencies 