### PR TITLE
docs(eslint-plugin): fix incorrect quote

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
@@ -70,4 +70,4 @@ If you don't care about having no-op type assertions in your code, then you can 
 
 ## Related to
 
-- TSLint: ['no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/)
+- TSLint: [`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/)


### PR DESCRIPTION
**Before**:
<img width="445" alt="Captura de Tela 2021-08-29 às 01 27 29" src="https://user-images.githubusercontent.com/11965907/131238434-0babd760-3d09-4001-8929-741077c7fb64.png">

**After**:
<img width="379" alt="Captura de Tela 2021-08-29 às 01 28 57" src="https://user-images.githubusercontent.com/11965907/131238444-08d31a87-c453-47c7-8dc4-706bfc10a919.png">