### PR TITLE
fix(eslint-plugin): crash in no-dupe-class-members (v5)

### DIFF
--- a/packages/eslint-plugin/src/rules/no-dupe-class-members.ts
+++ b/packages/eslint-plugin/src/rules/no-dupe-class-members.ts
@@ -27,15 +27,18 @@ export default util.createRule<Options, MessageIds>({
   create(context) {
     const rules = baseRule.create(context);
 
-    function wrapMemberDefinitionListener(
-      coreListener: (node: TSESTree.MethodDefinition) => void,
-    ): (node: TSESTree.MethodDefinition) => void {
-      return (node: TSESTree.MethodDefinition): void => {
+    function wrapMemberDefinitionListener<
+      N extends TSESTree.MethodDefinition | TSESTree.PropertyDefinition,
+    >(coreListener: (node: N) => void): (node: N) => void {
+      return (node: N): void => {
         if (node.computed) {
           return;
         }
 
-        if (node.value.type === AST_NODE_TYPES.TSEmptyBodyFunctionExpression) {
+        if (
+          node.value &&
+          node.value.type === AST_NODE_TYPES.TSEmptyBodyFunctionExpression
+        ) {
           return;
         }
 

--- a/packages/eslint-plugin/tests/rules/no-dupe-class-members.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-dupe-class-members.test.ts
@@ -172,5 +172,27 @@ class A {
         { line: 4, column: 3, messageId: 'unexpected', data: { name: 'foo' } },
       ],
     },
+    {
+      code: `
+class A {
+  foo;
+  foo = 42;
+}
+      `,
+      errors: [
+        { line: 4, column: 3, messageId: 'unexpected', data: { name: 'foo' } },
+      ],
+    },
+    {
+      code: `
+class A {
+  foo;
+  foo() {}
+}
+      `,
+      errors: [
+        { line: 4, column: 3, messageId: 'unexpected', data: { name: 'foo' } },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -234,7 +234,7 @@ declare module 'eslint/lib/rules/no-dupe-class-members' {
       MethodDefinition?: (node: TSESTree.MethodDefinition) => void;
       // for ESLint v8
       'MethodDefinition, PropertyDefinition'?: (
-        node: TSESTree.MethodDefinition /* | TSESTree.PropertyDefinition */,
+        node: TSESTree.MethodDefinition | TSESTree.PropertyDefinition,
       ) => void;
     }
   >;
@@ -646,7 +646,7 @@ declare module 'eslint/lib/rules/no-extra-semi' {
       MethodDefinition?: (node: TSESTree.MethodDefinition) => void;
       // for ESLint v8
       'MethodDefinition, PropertyDefinition'?: (
-        node: TSESTree.MethodDefinition /* | TSESTree.PropertyDefinition */,
+        node: TSESTree.MethodDefinition | TSESTree.PropertyDefinition,
       ) => void;
     }
   >;


### PR DESCRIPTION
*This PR is for version 5.*

I noticed that the `no-dupe-class-members` rule crashes with property definition that has no value due to my changes. This PR fixes it problem.