### PR TITLE
feat(eslint-plugin): remove `object` from `ban-types`' default types

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -75,8 +75,6 @@ The default options provide a set of "best practices", intended to provide safet
 - Avoid the `Object` and `{}` types, as they mean "any non-nullish value".
   - This is a point of confusion for many developers, who think it means "any object type".
   - See [this comment for more information](https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-675156492).
-- Avoid the `object` type, as it is currently hard to use due to not being able to assert that keys exist.
-  - See [microsoft/TypeScript#21732](https://github.com/microsoft/TypeScript/issues/21732).
 
 **_Important note:_** the default options suggest using `Record<string, unknown>`; this was a stylistic decision, as the built-in `Record` type is considered to look cleaner.
 
@@ -126,12 +124,6 @@ const defaultTypes = {
       '- If you want a type meaning "any value", you probably want `unknown` instead.',
     ].join('\n'),
   },
-  object: {
-    message: [
-      'The `object` type is currently hard to use ([see this issue](https://github.com/microsoft/TypeScript/issues/21732)).',
-      'Consider using `Record<string, unknown>` instead, as it allows you to more easily inspect and use the keys.',
-    ].join('\n'),
-  },
 };
 ```
 
@@ -152,8 +144,6 @@ const symb: Symbol = Symbol('foo');
 const func: Function = () => 1;
 
 // use safer object types
-const lowerObj: object = {};
-
 const capitalObj1: Object = 1;
 const capitalObj2: Object = { a: 'string' };
 
@@ -174,7 +164,7 @@ const symb: symbol = Symbol('foo');
 const func: () => number = () => 1;
 
 // use safer object types
-const lowerObj: Record<string, unknown> = {};
+const lowerObj: object = {};
 
 const capitalObj1: number = 1;
 const capitalObj2: { a: string } = { a: 'string' };
@@ -185,4 +175,4 @@ const curly2: Record<'a', string> = { a: 'string' };
 
 ## Compatibility
 
-- TSLint: [ban-types](https://palantir.github.io/tslint/rules/ban-types/)
+- TSLint: [ban-types](https://palantir.github.io/tslint/rules/ban-types)

--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -96,12 +96,6 @@ const defaultTypes: Types = {
       '- If you want a type meaning "empty object", you probably want `Record<string, never>` instead.',
     ].join('\n'),
   },
-  object: {
-    message: [
-      'The `object` type is currently hard to use ([see this issue](https://github.com/microsoft/TypeScript/issues/21732)).',
-      'Consider using `Record<string, unknown>` instead, as it allows you to more easily inspect and use the keys.',
-    ].join('\n'),
-  },
 };
 
 export const TYPE_KEYWORDS = {


### PR DESCRIPTION
BREAKING CHANGE: `ban-types` no longer reports `object` by default

---

Part of #3738
Part of #3746