### PR TITLE
fix(eslint-plugin): no-floating-promises - support chain expression

### DIFF
--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -149,6 +149,7 @@ export default util.createRule<Options, MessageId>({
         );
       } else if (
         node.type === AST_NODE_TYPES.MemberExpression ||
+        node.type === AST_NODE_TYPES.ChainExpression ||
         node.type === AST_NODE_TYPES.Identifier ||
         node.type === AST_NODE_TYPES.NewExpression
       ) {

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -317,24 +317,6 @@ async function test() {
   return promise;
 }
     `,
-
-    // optional chaining
-    `
-async function test() {
-  declare const returnsPromise: () => Promise<void> | null;
-  await returnsPromise?.();
-  returnsPromise()?.then(
-    () => {},
-    () => {},
-  );
-  returnsPromise()
-    ?.then(() => {})
-    ?.catch(() => {});
-  returnsPromise()?.catch(() => {});
-  returnsPromise()?.finally(() => {});
-  return returnsPromise();
-}
-    `,
     // ignoreIIFE
     {
       code: `
@@ -892,6 +874,21 @@ async function test() {
         },
         {
           line: 7,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
+      // optional chaining
+      code: `
+        async function test() {
+          declare const returnsPromise: () => Promise<void> | null;
+          returnsPromise?.();
+        }
+      `,
+      errors: [
+        {
+          line: 4,
           messageId: 'floatingVoid',
         },
       ],


### PR DESCRIPTION
I can't see a reason why chain expressions aren't supported - `await undefined` is a no-op, and other than that they behave like member expressions