### PR TITLE
fix(utils): support immutable arrays in `ReportFixFunction`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-explicit-any.ts
+++ b/packages/eslint-plugin/src/rules/no-explicit-any.ts
@@ -1,9 +1,9 @@
 import {
-  TSESTree,
   AST_NODE_TYPES,
+  TSESLint,
+  TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import * as util from '../util';
-import { TSESLint } from '@typescript-eslint/experimental-utils';
 
 export type Options = [
   {
@@ -199,8 +199,8 @@ export default util.createRule<Options, MessageIds>({
         };
 
         if (fixToUnknown) {
-          fixOrSuggest.fix = (fixer =>
-            fixer.replaceText(node, 'unknown')) as TSESLint.ReportFixFunction;
+          fixOrSuggest.fix = (fixer): TSESLint.RuleFix =>
+            fixer.replaceText(node, 'unknown');
         }
 
         context.report({

--- a/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts
+++ b/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts
@@ -1,6 +1,5 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 import * as util from '../util';
-import { TSESLint } from '@typescript-eslint/experimental-utils';
 
 type MessageIds = 'defineInitializer' | 'defineInitializerSuggestion';
 

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -114,7 +114,7 @@ interface RuleFixer {
 
 type ReportFixFunction = (
   fixer: RuleFixer,
-) => null | RuleFix | RuleFix[] | IterableIterator<RuleFix>;
+) => null | RuleFix | readonly RuleFix[] | IterableIterator<RuleFix>;
 type ReportSuggestionArray<TMessageIds extends string> =
   ReportDescriptorBase<TMessageIds>[];
 


### PR DESCRIPTION
Fixes #3829.