### PR TITLE
fix(eslint-plugin): add hasSuggestions to no-meaningless-void-operator

### DIFF
--- a/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
+++ b/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
@@ -28,6 +28,7 @@ export default util.createRule<
       requiresTypeChecking: true,
     },
     fixable: 'code',
+    hasSuggestions: true,
     messages: {
       meaninglessVoidOperator:
         "void operator shouldn't be used on {{type}}; it should convey that a return value is being ignored",


### PR DESCRIPTION
*This PR is for version 5.*

This PR adds `meta.hasSuggestions` to the new rule.