### PR TITLE
feat(eslint-plugin): [no-type-alias]: add allowGenerics option

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-type-alias.md
+++ b/packages/eslint-plugin/docs/rules/no-type-alias.md
@@ -89,7 +89,7 @@ or more of the following you may pass an object with the options set as follows:
 - `allowLiterals` set to `"always"` will allow you to use type aliases with literal objects (Defaults to `"never"`)
 - `allowMappedTypes` set to `"always"` will allow you to use type aliases as mapping tools (Defaults to `"never"`)
 - `allowTupleTypes` set to `"always"` will allow you to use type aliases with tuples (Defaults to `"never"`)
-- `allowedAliasNames` allows you to specify a list of alias names that the rule should ignore (Defaults to `[]`)
+- `allowGenerics` set to `"always"` will allow you to use type aliases with generics (Defaults to `"never"`)
 
 ### `allowAliases`
 
@@ -556,42 +556,26 @@ type Foo = [number] & [number, number];
 type Foo = [string] | [number];
 ```
 
-### `allowedAliasNames`
+### `allowGenerics`
 
-A string array of alias names that the rule should ignore.
+This applies to generic types, including TypeScript provided global utility types (`type Foo = Record<string, number>`).
 
-Use this option to avoid conflicts with other rules, for example:
+The setting accepts the following options:
 
-```ts
-/* eslint @typescript-eslint/consistent-indexed-object-style: "error" */
+- `"always"` or `"never"` to active or deactivate the feature.
 
-// error
-interface { [key: string]: number };
-
-// OK
-type Foo = Record<string, number>;
-```
+Examples of **correct** code for the `{ "allowGenerics": "always" }` options:
 
 ```ts
-/* eslint @typescript-eslint/no-type-alias: "error" */
+type Foo = Bar<string>;
 
-// error
 type Foo = Record<string, number>;
-```
 
-In the example above, the type alias is necessary to pass one rule, but triggers an error in another.
-To avoid a conflict such as this, you can tell the rule to ignore specific aliases such as `Record`.
+type Foo = Readonly<Bar>;
 
-Examples of **correct** code for the `{ "allowAliases": "never", "allowedAliasNames": ["Record"] }` options:
+type Foo = Partial<Bar>;
 
-```ts
-type Foo = Record<string, number>;
-```
-
-Examples of **incorrect** code for the `{ "allowAliases": "never", "allowedAliasNames": [] }` options:
-
-```ts
-type Foo = Record<string, number>;
+type Foo = Omit<Bar, 'a' | 'b'>;
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin/docs/rules/no-type-alias.md
+++ b/packages/eslint-plugin/docs/rules/no-type-alias.md
@@ -89,6 +89,7 @@ or more of the following you may pass an object with the options set as follows:
 - `allowLiterals` set to `"always"` will allow you to use type aliases with literal objects (Defaults to `"never"`)
 - `allowMappedTypes` set to `"always"` will allow you to use type aliases as mapping tools (Defaults to `"never"`)
 - `allowTupleTypes` set to `"always"` will allow you to use type aliases with tuples (Defaults to `"never"`)
+- `allowedAliasNames` allows you to specify a list of alias names that the rule should ignore (Defaults to `[]`)
 
 ### `allowAliases`
 
@@ -553,6 +554,44 @@ Examples of **correct** code for the `{ "allowLiterals": "in-unions-and-intersec
 type Foo = [number] & [number, number];
 
 type Foo = [string] | [number];
+```
+
+### `allowedAliasNames`
+
+A string array of alias names that the rule should ignore.
+
+Use this option to avoid conflicts with other rules, for example:
+
+```ts
+/* eslint @typescript-eslint/consistent-indexed-object-style: "error" */
+
+// error
+interface { [key: string]: number };
+
+// OK
+type Foo = Record<string, number>;
+```
+
+```ts
+/* eslint @typescript-eslint/no-type-alias: "error" */
+
+// error
+type Foo = Record<string, number>;
+```
+
+In the example above, the type alias is necessary to pass one rule, but triggers an error in another.
+To avoid a conflict such as this, you can tell the rule to ignore specific aliases such as `Record`.
+
+Examples of **correct** code for the `{ "allowAliases": "never", "allowedAliasNames": ["Record"] }` options:
+
+```ts
+type Foo = Record<string, number>;
+```
+
+Examples of **incorrect** code for the `{ "allowAliases": "never", "allowedAliasNames": [] }` options:
+
+```ts
+type Foo = Record<string, number>;
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -160,7 +160,7 @@ export default util.createRule<Options, MessageIds>({
     }
 
     /**
-     * Determines if the type is a  by the allowed flags.
+     * Determines if the alias name is in the list of allowed names.
      * @param node the kind of type alias being validated
      */
     function isAllowedAliasName(node: TSESTree.Node): boolean {

--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -209,10 +209,6 @@ export default util.createRule<Options, MessageIds>({
       return false;
     };
 
-    /**
-     * Determines if the alias name is in the list of allowed names.
-     * @param node the kind of type alias being validated
-     */
     const isValidGeneric = (type: TypeWithLabel): boolean => {
       return (
         type.node.type === AST_NODE_TYPES.TSTypeReference &&

--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -483,7 +483,7 @@ type KeyNames = keyof typeof SCALARS;
     },
     {
       code: 'type Foo = Record<string, number>;',
-      options: [{ allowedAliasNames: ['Record'] }],
+      options: [{ allowGenerics: 'always' }],
     },
   ],
   invalid: [
@@ -3335,12 +3335,11 @@ type Foo<T> = {
     },
     {
       code: 'type Foo = Record<string, number>;',
-      options: [{ allowedAliasNames: ['Other'] }],
       errors: [
         {
           messageId: 'noTypeAlias',
           data: {
-            alias: 'aliases',
+            alias: 'generics',
           },
           line: 1,
           column: 12,

--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -481,6 +481,10 @@ type KeyNames = keyof typeof SCALARS;
       code: 'type Foo = new (bar: number) => string | null;',
       options: [{ allowConstructors: 'always' }],
     },
+    {
+      code: 'type Foo = Record<string, number>;',
+      options: [{ allowedAliasNames: ['Record'] }],
+    },
   ],
   invalid: [
     {
@@ -3326,6 +3330,20 @@ type Foo<T> = {
           },
           line: 1,
           column: 29,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = Record<string, number>;',
+      options: [{ allowedAliasNames: ['Other'] }],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'aliases',
+          },
+          line: 1,
+          column: 12,
         },
       ],
     },


### PR DESCRIPTION
Fixes #3784

(⚠️ Note: an earlier version of this PR introduced an `allowedAliasNames: []` option which accepted an array of strings to ignore. This was later swapped to an `allowGenerics: 'always' | 'never'` option that permits/prevents _any_ `TSTypeReference` that has parameters)

This change adds an option to `no-type-alias` to allow generics to be ignored by the rule.

The new option is `allowGenerics`, and can be set to `"always"` or `"never"` (default is `"never"`), e.g.

```json
{
  "@typescript-eslint/no-type-alias": ["error", { "allowGenerics": "always" }]
}
```

As discussed in #3784, the main driver for this change is to avoid a conflict when using both `consistent-indexed-object-style` and `no-type-alias` with their default options.

Specifically to allow the following code to pass both rules:

```ts
type Foo = Record<string, number>;
```