### PR TITLE
fix(eslint-plugin): [padding-line-between-statements] problems within namespaces not being reported

### DIFF
--- a/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
+++ b/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
@@ -723,10 +723,11 @@ export default util.createRule<Options, MessageIds>({
       if (
         !node.parent ||
         ![
-          AST_NODE_TYPES.SwitchStatement,
           AST_NODE_TYPES.BlockStatement,
           AST_NODE_TYPES.Program,
           AST_NODE_TYPES.SwitchCase,
+          AST_NODE_TYPES.SwitchStatement,
+          AST_NODE_TYPES.TSModuleBlock,
         ].includes(node.parent.type)
       ) {
         return;

--- a/packages/eslint-plugin/tests/rules/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin/tests/rules/padding-line-between-statements.test.ts
@@ -5056,5 +5056,45 @@ var a = 1
         { messageId: 'expectedBlankLine' },
       ],
     },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/3863
+      code: `
+declare namespace Types {
+  type Foo = string;
+  type Bar = string;
+  interface FooBar {
+    [key: string]: string;
+  }
+  interface BarBaz {
+    [key: string]: string;
+  }
+}
+      `,
+      output: `
+declare namespace Types {
+  type Foo = string;
+
+  type Bar = string;
+
+  interface FooBar {
+    [key: string]: string;
+  }
+
+  interface BarBaz {
+    [key: string]: string;
+  }
+}
+
+      `,
+      options: [
+        { blankLine: 'always', prev: '*', next: ['interface', 'type'] },
+      ],
+      errors: [
+        { messageId: 'expectedBlankLine' },
+        { messageId: 'expectedBlankLine' },
+        { messageId: 'expectedBlankLine' },
+        { messageId: 'expectedBlankLine' },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Fixes #3863.