### PR TITLE
feat: Support `'latest'` as `ecmaVersion`

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -53,7 +53,7 @@ interface ParserOptions {
     jsx?: boolean;
     globalReturn?: boolean;
   };
-  ecmaVersion?: number;
+  ecmaVersion?: number | 'latest';
 
   jsxPragma?: string | null;
   jsxFragmentName?: string | null;
@@ -97,12 +97,13 @@ This options allows you to tell the parser if you want to allow global `return` 
 
 Default `2018`.
 
-Accepts any valid ECMAScript version number:
+Accepts any valid ECMAScript version number or `'latest'`:
 
-- A version: es3, es5, es6, es7, es8, es9, es10, es11, ..., or
-- A year: es2015, es2016, es2017, es2018, es2019, es2020, ...
+- A version: es3, es5, es6, es7, es8, es9, es10, es11, es12, es13, ..., or
+- A year: es2015, es2016, es2017, es2018, es2019, es2020, es2021, es2022, ..., or
+- `'latest'`
 
-The value **must** be a number - so do not include the `es` prefix.
+When it's a version or a year, the value **must** be a number - so do not include the `es` prefix.
 
 Specifies the version of ECMAScript syntax you want to use. This is used by the parser to determine how to perform scope analysis, and it affects the default
 

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -102,7 +102,7 @@ function parseForESLint(
     jsx: validateBoolean(options.ecmaFeatures.jsx),
   });
   const analyzeOptions: AnalyzeOptions = {
-    ecmaVersion: options.ecmaVersion,
+    ecmaVersion: options.ecmaVersion === 'latest' ? 1e8 : options.ecmaVersion,
     globalReturn: options.ecmaFeatures.globalReturn,
     jsxPragma: options.jsxPragma,
     jsxFragmentName: options.jsxFragmentName,

--- a/packages/parser/tests/lib/parser.ts
+++ b/packages/parser/tests/lib/parser.ts
@@ -18,6 +18,11 @@ describe('parser', () => {
     expect(() => parseForESLint(code, null)).not.toThrow();
   });
 
+  it("parseForESLint() should work if options.ecmaVersion is `'latest'`", () => {
+    const code = 'const valid = true;';
+    expect(() => parseForESLint(code, { ecmaVersion: 'latest' })).not.toThrow();
+  });
+
   it('parseAndGenerateServices() should be called with options', () => {
     const code = 'const valid = true;';
     const spy = jest.spyOn(typescriptESTree, 'parseAndGenerateServices');

--- a/packages/scope-manager/README.md
+++ b/packages/scope-manager/README.md
@@ -40,7 +40,7 @@ interface AnalyzeOptions {
    * Which ECMAScript version is considered.
    * Defaults to `2018`.
    */
-  ecmaVersion?: EcmaVersion;
+  ecmaVersion?: EcmaVersion | 1e8;
 
   /**
    * Whether the whole script is executed under node.js environment.

--- a/packages/scope-manager/README.md
+++ b/packages/scope-manager/README.md
@@ -39,6 +39,7 @@ interface AnalyzeOptions {
   /**
    * Which ECMAScript version is considered.
    * Defaults to `2018`.
+   * `'latest'` is converted to 1e8 at parser.
    */
   ecmaVersion?: EcmaVersion | 1e8;
 

--- a/packages/scope-manager/src/analyze.ts
+++ b/packages/scope-manager/src/analyze.ts
@@ -17,8 +17,9 @@ interface AnalyzeOptions {
   /**
    * Which ECMAScript version is considered.
    * Defaults to `2018`.
+   * `'latest'` is converted to 1e8 at parser.
    */
-  ecmaVersion?: EcmaVersion;
+  ecmaVersion?: EcmaVersion | 1e8;
 
   /**
    * Whether the whole script is executed under node.js environment.
@@ -81,7 +82,11 @@ const DEFAULT_OPTIONS: Required<AnalyzeOptions> = {
   emitDecoratorMetadata: false,
 };
 
-function mapEcmaVersion(version: EcmaVersion | undefined): Lib {
+/**
+ * Convert ecmaVersion to lib.
+ * `'latest'` is converted to 1e8 at parser.
+ */
+function mapEcmaVersion(version: EcmaVersion | 1e8 | undefined): Lib {
   if (version == null || version === 3 || version === 5) {
     return 'es5';
   }

--- a/packages/scope-manager/tests/eslint-scope/map-ecma-version.test.ts
+++ b/packages/scope-manager/tests/eslint-scope/map-ecma-version.test.ts
@@ -31,6 +31,11 @@ describe('ecma version mapping', () => {
   it("should map to 'es2018' when undefined", () => {
     expectMapping(undefined, 'es2018');
   });
+
+  it("should map to 'esnext' when 'latest'", () => {
+    // `'latest'` is converted to 1e8 at parser.
+    expectMapping(1e8, 'esnext');
+  });
 });
 
 const fakeNode = {} as unknown as TSESTree.Node;

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -12,12 +12,16 @@ type EcmaVersion =
   | 9
   | 10
   | 11
+  | 12
+  | 13
   | 2015
   | 2016
   | 2017
   | 2018
   | 2019
-  | 2020;
+  | 2020
+  | 2021
+  | 2022;
 
 type SourceType = 'script' | 'module';
 
@@ -26,7 +30,7 @@ interface ParserOptions {
     globalReturn?: boolean;
     jsx?: boolean;
   };
-  ecmaVersion?: EcmaVersion;
+  ecmaVersion?: EcmaVersion | 'latest';
 
   // scope-manager specific
   jsxPragma?: string | null;


### PR DESCRIPTION
Done: https://github.com/typescript-eslint/typescript-eslint/issues/3857