### PR TITLE
Add start and end properties to TemplateLiteral

### DIFF
--- a/packages/ast-spec/src/special/TemplateElement/spec.ts
+++ b/packages/ast-spec/src/special/TemplateElement/spec.ts
@@ -3,6 +3,8 @@ import type { BaseNode } from '../../base/BaseNode';
 
 export interface TemplateElement extends BaseNode {
   type: AST_NODE_TYPES.TemplateElement;
+  start: number;
+  end: number;
   value: {
     raw: string;
     cooked: string;


### PR DESCRIPTION
Using AST Explorer, I've found that `@babel/eslint-parser` has `start` and `end` properties on `TemplateLiteral`:

<img width="1439" alt="Screen Shot 2021-09-12 at 19 24 28" src="https://user-images.githubusercontent.com/1935696/132996926-bc62ea94-a024-45b7-bac0-15450f1670a3.png">

Source: https://astexplorer.net/#/gist/3e3ccd8555c4c6b4215fd7a5637aa0af/2fb6d4447a2643ba62e37cb72125a4119330737c

---

I'm kind of new to this whole AST thing in ESLint (and also writing ESLint plugins in general), so I could be totally wrong, but I wanted to add this naïve pull request here, in case this really was missing from the `typescript-eslint` package...