### PR TITLE
fix(experimental-utils): add missing signature for `isParenthesized`

### DIFF
--- a/packages/experimental-utils/src/ast-utils/eslint-utils/astUtilities.ts
+++ b/packages/experimental-utils/src/ast-utils/eslint-utils/astUtilities.ts
@@ -1,6 +1,6 @@
 import * as eslintUtils from 'eslint-utils';
-import { TSESTree } from '../../ts-estree';
 import * as TSESLint from '../../ts-eslint';
+import { TSESTree } from '../../ts-estree';
 
 /**
  * Get the proper location of a given function node to report.
@@ -101,19 +101,23 @@ const hasSideEffect = eslintUtils.hasSideEffect as (
   },
 ) => boolean;
 
-/**
- * Check whether a given node is parenthesized or not.
- * This function detects it correctly even if it's parenthesized by specific syntax.
- *
- * @see {@link https://eslint-utils.mysticatea.dev/api/ast-utils.html#isparenthesized}
- * @returns `true` if the node is parenthesized.
- * If `times` was given, it returns `true` only if the node is parenthesized the `times` times.
- * For example, `isParenthesized(2, node, sourceCode)` returns true for `((foo))`, but not for `(foo)`.
- */
-const isParenthesized = eslintUtils.isParenthesized as (
-  node: TSESTree.Node,
-  sourceCode: TSESLint.SourceCode,
-) => boolean;
+const isParenthesized = eslintUtils.isParenthesized as {
+  /**
+   * Check whether a given node is parenthesized or not.
+   * This function detects it correctly even if it's parenthesized by specific syntax.
+   *
+   * @see {@link https://eslint-utils.mysticatea.dev/api/ast-utils.html#isparenthesized}
+   * @returns `true` if the node is parenthesized.
+   * If `times` was given, it returns `true` only if the node is parenthesized the `times` times.
+   * For example, `isParenthesized(2, node, sourceCode)` returns true for `((foo))`, but not for `(foo)`.
+   */
+  (node: TSESTree.Node, sourceCode: TSESLint.SourceCode): boolean;
+  (
+    times: number,
+    node: TSESTree.Node,
+    sourceCode: TSESLint.SourceCode,
+  ): boolean;
+};
 
 export {
   getFunctionHeadLocation,


### PR DESCRIPTION
Fixes #3885.