### PR TITLE
fix(eslint-plugin): [consistent-type-definitions] correct fix for `export default`

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
@@ -122,6 +122,19 @@ export default util.createRule({
                     });
                   }
 
+                  if (
+                    node.parent?.type ===
+                    AST_NODE_TYPES.ExportDefaultDeclaration
+                  ) {
+                    fixes.push(
+                      fixer.removeRange([node.parent.range[0], node.range[0]]),
+                      fixer.insertTextAfter(
+                        node.body,
+                        `\nexport default ${node.id.name}`,
+                      ),
+                    );
+                  }
+
                   return fixes;
                 },
           });

--- a/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
@@ -1,5 +1,5 @@
 import rule from '../../src/rules/consistent-type-definitions';
-import { RuleTester, noFormat } from '../RuleTester';
+import { noFormat, RuleTester } from '../RuleTester';
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
@@ -278,6 +278,30 @@ declare global {
           messageId: 'typeOverInterface',
           line: 4,
           column: 15,
+        },
+      ],
+    },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/3894
+      code: `
+export default interface Test {
+  bar(): string;
+  foo(): number;
+}
+      `,
+      output: noFormat`
+type Test = {
+  bar(): string;
+  foo(): number;
+}
+export default Test
+      `,
+      options: ['type'],
+      errors: [
+        {
+          messageId: 'typeOverInterface',
+          line: 2,
+          column: 26,
         },
       ],
     },


### PR DESCRIPTION
Fixes #3894.