### PR TITLE
fix(eslint-plugin): [explicit-member-accessibility] report `TSAbstractPropertyDefinition` and `TSAbstractMethodDefinition` properly

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
+++ b/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
@@ -1,8 +1,8 @@
 import {
   AST_NODE_TYPES,
-  TSESTree,
   AST_TOKEN_TYPES,
   TSESLint,
+  TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import * as util from '../util';
 
@@ -96,13 +96,13 @@ export default util.createRule<Options, MessageIds>({
       fix: TSESLint.ReportFixFunction | null = null,
     ): void {
       context.report({
-        node: node,
-        messageId: messageId,
+        node,
+        messageId,
         data: {
           type: nodeType,
           name: nodeName,
         },
-        fix: fix,
+        fix,
       });
     }
 
@@ -170,6 +170,8 @@ export default util.createRule<Options, MessageIds>({
       node:
         | TSESTree.MethodDefinition
         | TSESTree.PropertyDefinition
+        | TSESTree.TSAbstractMethodDefinition
+        | TSESTree.TSAbstractPropertyDefinition
         | TSESTree.TSParameterProperty,
     ): TSESLint.ReportFixFunction {
       return function (fixer: TSESLint.RuleFixer): TSESLint.RuleFix {
@@ -208,7 +210,9 @@ export default util.createRule<Options, MessageIds>({
      * @param propertyDefinition The node representing a PropertyDefinition.
      */
     function checkPropertyAccessibilityModifier(
-      propertyDefinition: TSESTree.PropertyDefinition,
+      propertyDefinition:
+        | TSESTree.PropertyDefinition
+        | TSESTree.TSAbstractPropertyDefinition,
     ): void {
       const nodeType = 'class property';
 
@@ -285,9 +289,11 @@ export default util.createRule<Options, MessageIds>({
     }
 
     return {
+      'MethodDefinition, TSAbstractMethodDefinition':
+        checkMethodAccessibilityModifier,
+      'PropertyDefinition, TSAbstractPropertyDefinition':
+        checkPropertyAccessibilityModifier,
       TSParameterProperty: checkParameterPropertyAccessibilityModifier,
-      PropertyDefinition: checkPropertyAccessibilityModifier,
-      MethodDefinition: checkMethodAccessibilityModifier,
     };
   },
 });

--- a/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
@@ -1,5 +1,5 @@
 import rule from '../../src/rules/explicit-member-accessibility';
-import { RuleTester, noFormat } from '../RuleTester';
+import { noFormat, RuleTester } from '../RuleTester';
 
 const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
@@ -1138,6 +1138,87 @@ class Test {
   'foo foo' = 2;
   'bar'() {}
   'bar bar'() {}
+}
+      `,
+    },
+    {
+      code: `
+abstract class SomeClass {
+  abstract method(): string;
+}
+      `,
+      options: [{ accessibility: 'explicit' }],
+      errors: [
+        {
+          messageId: 'missingAccessibility',
+          line: 3,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+abstract class SomeClass {
+  public abstract method(): string;
+}
+      `,
+      options: [
+        {
+          accessibility: 'no-public',
+          overrides: { parameterProperties: 'no-public' },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'unwantedPublicAccessibility',
+          line: 3,
+          column: 3,
+        },
+      ],
+      output: `
+abstract class SomeClass {
+  abstract method(): string;
+}
+      `,
+    },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/3835
+      code: `
+abstract class SomeClass {
+  abstract x: string;
+}
+      `,
+      options: [{ accessibility: 'explicit' }],
+      errors: [
+        {
+          messageId: 'missingAccessibility',
+          line: 3,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+abstract class SomeClass {
+  public abstract x: string;
+}
+      `,
+      options: [
+        {
+          accessibility: 'no-public',
+          overrides: { parameterProperties: 'no-public' },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'unwantedPublicAccessibility',
+          line: 3,
+          column: 3,
+        },
+      ],
+      output: `
+abstract class SomeClass {
+  abstract x: string;
 }
       `,
     },


### PR DESCRIPTION
Fixes #3835.