### PR TITLE
chore: add issue template to propose new rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.yml
+++ b/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.yml
@@ -1,0 +1,38 @@
+name: Rule proposal
+description: Propose a new rule for the '@typescript-eslint/eslint-plugin' package
+labels:
+  - 'enhancement: new base rule extension'
+  - 'package: eslint-plugin'
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a new issue:
+        - Look for existing [open or closed rule proposals](https://github.com/typescript-eslint/typescript-eslint/issues?q=label%3A%22enhancement%3A+new+base+rule+extension%22)
+        - Look for [existing rules](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin)
+        - Ensure that the rule you want to propose is related to types. If not, consider looking into [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn)
+- type: textarea
+    attributes:
+      label: Description
+      description: Explain here why this rule would be beneficial
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Fail
+      description: Specify an example of code that should be detected
+      value: |
+        ```ts
+        var replace = 'me';
+        ```
+  - type: input
+    attributes:
+      label: Pass
+      description: Specify an example of code that would be accepted in its place
+      value: |
+        ```ts
+        const replace = 'me';
+        ```
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.yml
+++ b/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.yml
@@ -1,8 +1,9 @@
 name: Rule proposal
-description: Propose a new rule for the '@typescript-eslint/eslint-plugin' package
+description: "Propose a new rule for the '@typescript-eslint/eslint-plugin' package"
+title: "Rule proposal: "
 labels:
-  - 'enhancement: new base rule extension'
-  - 'package: eslint-plugin'
+  - "enhancement: new base rule extension"
+  - "package: eslint-plugin"
   - triage
 body:
   - type: markdown
@@ -12,13 +13,15 @@ body:
         - Look for existing [open or closed rule proposals](https://github.com/typescript-eslint/typescript-eslint/issues?q=label%3A%22enhancement%3A+new+base+rule+extension%22)
         - Look for [existing rules](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin)
         - Ensure that the rule you want to propose is related to types. If not, consider looking into [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn)
-- type: textarea
+  - type: textarea
+    validations:
+      required: true
     attributes:
       label: Description
       description: Explain here why this rule would be beneficial
+  - type: textarea
     validations:
       required: true
-  - type: textarea
     attributes:
       label: Fail
       description: Specify an example of code that should be detected
@@ -26,7 +29,9 @@ body:
         ```ts
         var replace = 'me';
         ```
-  - type: input
+  - type: textarea
+    validations:
+      required: true
     attributes:
       label: Pass
       description: Specify an example of code that would be accepted in its place
@@ -34,5 +39,3 @@ body:
         ```ts
         const replace = 'me';
         ```
-    validations:
-      required: true


### PR DESCRIPTION
The current template for the plugin is centered around bug reporting: https://github.com/typescript-eslint/typescript-eslint/issues/new?assignees=&labels=package%3A+eslint-plugin%2C+triage&template=eslint-plugin-typescript.md&title=%5Brulename%5D+issue+title

## Live demo

https://github.com/fregante/sandbox/issues/new?assignees=&labels=enhancement%3A+new+base+rule+extension%2Cpackage%3A+eslint-plugin%2Ctriage&template=a.yml&title=Rule+proposal%3A+

## Example issue created with this form

https://github.com/typescript-eslint/typescript-eslint/issues/3926


## Screenshot


<img width="953"  src="https://user-images.githubusercontent.com/1402241/134773424-4c7b555a-5ef8-4077-9e1c-531be905ae95.png">


