### PR TITLE
feat(eslint-plugin): make 'ban-types' rule to allow 'object' in generics

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -22,6 +22,7 @@ type Options = {
         };
   };
   extendDefaults?: boolean;
+  allowObjectInGenerics?: boolean;
 };
 ```
 
@@ -36,6 +37,7 @@ The rule accepts a single object as options, with the following keys:
 - `extendDefaults` - if you're specifying custom `types`, you can set this to `true` to extend the default `types` configuration.
   - This is a convenience option to save you copying across the defaults when adding another type.
   - If this is `false`, the rule will _only_ use the types defined in your configuration.
+- `allowObjectInGenerics` - Allows `object` type usage in some special cases related to generics.
 
 Example configuration:
 
@@ -175,6 +177,8 @@ const func: () => number = () => 1;
 
 // use safer object types
 const lowerObj: Record<string, unknown> = {};
+// but you are allowed to use 'object' type in generic's conditionals
+interface Something<T extends object> {}
 
 const capitalObj1: number = 1;
 const capitalObj2: { a: string } = { a: 'string' };

--- a/packages/eslint-plugin/tests/rules/ban-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-types.test.ts
@@ -110,6 +110,8 @@ ruleTester.run('ban-types', rule, {
       ],
     },
     'let a: [];',
+    'interface A<T extends object> {}',
+    'type IsObject<T> = T extends object ? true : false;',
   ],
   invalid: [
     {
@@ -607,6 +609,52 @@ let bar: object = {};
           types: {
             '[]': '`[]` does only allow empty arrays.',
           },
+        },
+      ],
+    },
+    {
+      code: 'interface A<T extends object> {}',
+      errors: [
+        {
+          messageId: 'bannedTypeMessage',
+          data: {
+            name: 'object',
+            customMessage: '',
+          },
+          line: 1,
+          column: 23,
+        },
+      ],
+      options: [
+        {
+          types: {
+            object: null,
+          },
+          allowObjectInGenerics: false,
+          extendDefaults: false,
+        },
+      ],
+    },
+    {
+      code: 'type IsObject<T> = T extends object ? true : false;',
+      errors: [
+        {
+          messageId: 'bannedTypeMessage',
+          data: {
+            name: 'object',
+            customMessage: '',
+          },
+          line: 1,
+          column: 30,
+        },
+      ],
+      options: [
+        {
+          types: {
+            object: null,
+          },
+          allowObjectInGenerics: false,
+          extendDefaults: false,
         },
       ],
     },


### PR DESCRIPTION
**Problem:**
`ban-types` rule provides pretty nice defaul options. The only downside is `object` type handling: it has a bit different meaning in generics and cannot be equally replaced by alternatives:
```
type ObjectOf<T> = { [P in keyof T]: T[P] };
type IsObj_Broken<T> = T extends ObjectOf<T> ? true : false; // is found in one of issues on github
type IsObj_Record<T> = T extends Record<string, unknown> ? true : false;
type IsObj_Nice<T> = T extends object ? true : false;

// should be false:
IsObj_Broken<string> // => true
IsObj_Record<string> // => false
IsObj_Nice<string>   // => false

// should be false:
IsObj_Broken<10> // => true
IsObj_Record<10> // => false
IsObj_Nice<10>   // => false

// should be true:
interface I {};
IsObj_Broken<I> // => true
IsObj_Record<I> // => false
IsObj_Nice<I>   // => true
```

Clearly, there are generics-related cases when`ban-types` rule produces false-positives. There are several issues about it in github tracker.

**Current solution:**
There are 2 solutions suggested by `typescript-eslint` project:
1. modify rule options so it will not trigger on `object` type at all;
2. turn rule off using eslint disable comments whenever appropriate

I find both solutions unsatisfactory. I don't want to turn rule for `object` type because this is useful rule. In the same time I don't want to spam codebase with `eslint-disable-next-line` directives because
1. It makes easier in other cases to add even more disabling directives instead of thinking how to improve codebase. There are a lot of disabling directives. One more will not change much, right?
2. It makes totally legit code smell bad. We shouldn't use disabling directives in proper code.

**Proposed solution:**
Allow `object` type if it is used as constraint in generic parameters (both regular constraint and conditional types).

I also introduced new `allowObjectInGenerics` option for `ban-types` rule so user can switch to original behavior if they want (by setting it to `false`). IDK if it is needed tho.