### PR TITLE
fix(eslint-plugin): [no-confusing-void-expression] support optional chaining

### DIFF
--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -268,6 +268,11 @@ export default util.createRule<Options, MessageId>({
         }
       }
 
+      if (parent.type === AST_NODE_TYPES.ChainExpression) {
+        // e.g. `console?.log('foo')`
+        return findInvalidAncestor(parent);
+      }
+
       // any other parent is invalid
       return parent;
     }

--- a/packages/eslint-plugin/tests/rules/no-confusing-void-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-confusing-void-expression.test.ts
@@ -22,11 +22,12 @@ ruleTester.run('no-confusing-void-expression', rule, {
   valid: [
     ...batchedSingleLineTests<Options>({
       code: `
-        () => Math.random();
         console.log('foo');
+        () => Math.random();
         foo && console.log(foo);
         foo || console.log(foo);
         foo ? console.log(true) : console.log(false);
+        console?.log?.('foo');
       `,
     }),
 
@@ -69,6 +70,7 @@ ruleTester.run('no-confusing-void-expression', rule, {
         (console.log('foo') && true) || false;
         (cond && console.log('ok')) || console.log('error');
         !console.log('foo');
+        const x = console?.log?.('foo');
       `,
       errors: [
         { line: 2, column: 11, messageId: 'invalidVoidExpr' },
@@ -80,6 +82,7 @@ ruleTester.run('no-confusing-void-expression', rule, {
         { line: 8, column: 10, messageId: 'invalidVoidExpr' },
         { line: 9, column: 18, messageId: 'invalidVoidExpr' },
         { line: 10, column: 10, messageId: 'invalidVoidExpr' },
+        { line: 11, column: 19, messageId: 'invalidVoidExpr' },
       ],
     }),
 

--- a/packages/eslint-plugin/tests/rules/no-confusing-void-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-confusing-void-expression.test.ts
@@ -22,12 +22,12 @@ ruleTester.run('no-confusing-void-expression', rule, {
   valid: [
     ...batchedSingleLineTests<Options>({
       code: `
-        console.log('foo');
         () => Math.random();
+        console.log('foo');
         foo && console.log(foo);
         foo || console.log(foo);
         foo ? console.log(true) : console.log(false);
-        console?.log?.('foo');
+        console?.log('foo');
       `,
     }),
 
@@ -62,6 +62,7 @@ ruleTester.run('no-confusing-void-expression', rule, {
     ...batchedSingleLineTests<MessageId, Options>({
       code: `
         const x = console.log('foo');
+        const x = console?.log('foo');
         console.error(console.log('foo'));
         [console.log('foo')];
         ({ x: console.log('foo') });
@@ -70,19 +71,18 @@ ruleTester.run('no-confusing-void-expression', rule, {
         (console.log('foo') && true) || false;
         (cond && console.log('ok')) || console.log('error');
         !console.log('foo');
-        const x = console?.log?.('foo');
       `,
       errors: [
         { line: 2, column: 11, messageId: 'invalidVoidExpr' },
-        { line: 3, column: 23, messageId: 'invalidVoidExpr' },
-        { line: 4, column: 10, messageId: 'invalidVoidExpr' },
-        { line: 5, column: 15, messageId: 'invalidVoidExpr' },
-        { line: 6, column: 14, messageId: 'invalidVoidExpr' },
-        { line: 7, column: 9, messageId: 'invalidVoidExpr' },
-        { line: 8, column: 10, messageId: 'invalidVoidExpr' },
-        { line: 9, column: 18, messageId: 'invalidVoidExpr' },
-        { line: 10, column: 10, messageId: 'invalidVoidExpr' },
-        { line: 11, column: 19, messageId: 'invalidVoidExpr' },
+        { line: 3, column: 19, messageId: 'invalidVoidExpr' },
+        { line: 4, column: 23, messageId: 'invalidVoidExpr' },
+        { line: 5, column: 10, messageId: 'invalidVoidExpr' },
+        { line: 6, column: 15, messageId: 'invalidVoidExpr' },
+        { line: 7, column: 14, messageId: 'invalidVoidExpr' },
+        { line: 8, column: 9, messageId: 'invalidVoidExpr' },
+        { line: 9, column: 10, messageId: 'invalidVoidExpr' },
+        { line: 10, column: 18, messageId: 'invalidVoidExpr' },
+        { line: 11, column: 10, messageId: 'invalidVoidExpr' },
       ],
     }),
 


### PR DESCRIPTION
Fixes: #3454 