### PR TITLE
fix(eslint-plugin): [non-nullable-type-assertion-style] false-positive with non-nullish `as` assertions and types

### DIFF
--- a/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
+++ b/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
@@ -57,6 +57,10 @@ export default util.createRule({
           type.flags !== ts.TypeFlags.Undefined,
       );
 
+      if (nonNullishOriginalTypes.length === originalTypes.length) {
+        return false;
+      }
+
       for (const assertedType of assertedTypes) {
         if (!nonNullishOriginalTypes.includes(assertedType)) {
           return false;
@@ -67,10 +71,6 @@ export default util.createRule({
         if (!assertedTypes.includes(originalType)) {
           return false;
         }
-      }
-
-      if (assertedTypes.length === originalTypes.length) {
-        return false;
       }
 
       return true;

--- a/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
+++ b/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
@@ -69,6 +69,10 @@ export default util.createRule({
         }
       }
 
+      if (assertedTypes.length === originalTypes.length) {
+        return false;
+      }
+
       return true;
     };
 

--- a/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
@@ -54,6 +54,13 @@ const y = x as NonNullable<T>;
     `
 const foo = [] as const;
     `,
+    `
+const x = 1 as 1;
+    `,
+    `
+declare function foo<T = any>(): T;
+const bar = foo() as number;
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
Fixes #3938.

As suggested there, a simple array length assertion did the trick. I added two regression test cases for this check.