### PR TITLE
fix(eslint-plugin): [lines-between-class-members] fix `exceptAfterOverload` for abstract methods

### DIFF
--- a/packages/eslint-plugin/src/rules/lines-between-class-members.ts
+++ b/packages/eslint-plugin/src/rules/lines-between-class-members.ts
@@ -51,7 +51,8 @@ export default util.createRule<Options, MessageIds>({
 
     function isOverload(node: TSESTree.Node): boolean {
       return (
-        node.type === AST_NODE_TYPES.MethodDefinition &&
+        (node.type === AST_NODE_TYPES.TSAbstractMethodDefinition ||
+          node.type === AST_NODE_TYPES.MethodDefinition) &&
         node.value.type === AST_NODE_TYPES.TSEmptyBodyFunctionExpression
       );
     }

--- a/packages/eslint-plugin/tests/rules/lines-between-class-members.test.ts
+++ b/packages/eslint-plugin/tests/rules/lines-between-class-members.test.ts
@@ -120,6 +120,15 @@ qux() { }
         { exceptAfterOverload: true, exceptAfterSingleLine: true },
       ],
     },
+    {
+      code: `
+abstract class foo {
+abstract bar(a: string): void;
+abstract bar(a: string, b: string): void;
+};
+      `,
+      options: ['always'],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #3942.