### PR TITLE
fix(eslint-plugin): [padding-line-between-statements] TSModuleBlock should change scope

### DIFF
--- a/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
+++ b/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
@@ -763,9 +763,11 @@ export default util.createRule<Options, MessageIds>({
       Program: enterScope,
       BlockStatement: enterScope,
       SwitchStatement: enterScope,
+      TSModuleBlock: enterScope,
       'Program:exit': exitScope,
       'BlockStatement:exit': exitScope,
       'SwitchStatement:exit': exitScope,
+      'TSModuleBlock:exit': exitScope,
 
       ':statement': verify,
 

--- a/packages/eslint-plugin/tests/rules/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin/tests/rules/padding-line-between-statements.test.ts
@@ -5084,7 +5084,6 @@ declare namespace Types {
     [key: string]: string;
   }
 }
-
       `,
       options: [
         { blankLine: 'always', prev: '*', next: ['interface', 'type'] },

--- a/packages/eslint-plugin/tests/rules/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin/tests/rules/padding-line-between-statements.test.ts
@@ -5093,7 +5093,6 @@ declare namespace Types {
         { messageId: 'expectedBlankLine' },
         { messageId: 'expectedBlankLine' },
         { messageId: 'expectedBlankLine' },
-        { messageId: 'expectedBlankLine' },
       ],
     },
   ],


### PR DESCRIPTION
Updates the scope changes to include `TSModuleBlock`. This helps a `module` declaration be its own scope, thereby fixing false positives related to #3869