### PR TITLE
fix(eslint-plugin): [prefer-regexp-exec] check `RegExp` without flags

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
+++ b/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
@@ -84,6 +84,7 @@ export default createRule({
       ) {
         const [, flags] = node.arguments;
         return (
+          flags &&
           flags.type === AST_NODE_TYPES.Literal &&
           typeof flags.value === 'string' &&
           flags.value.includes('g')

--- a/packages/eslint-plugin/tests/rules/prefer-regexp-exec.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-regexp-exec.test.ts
@@ -233,5 +233,32 @@ function test(pattern: string) {
 }
       `,
     },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/3941
+      code: `
+function temp(text: string): void {
+  text.match(new RegExp(\`\${'hello'}\`));
+  text.match(new RegExp(\`\${'hello'.toString()}\`));
+}
+      `,
+      errors: [
+        {
+          messageId: 'regExpExecOverStringMatch',
+          line: 3,
+          column: 8,
+        },
+        {
+          messageId: 'regExpExecOverStringMatch',
+          line: 4,
+          column: 8,
+        },
+      ],
+      output: `
+function temp(text: string): void {
+  new RegExp(\`\${'hello'}\`).exec(text);
+  new RegExp(\`\${'hello'.toString()}\`).exec(text);
+}
+      `,
+    },
   ],
 });


### PR DESCRIPTION
Fixes #3941.