### PR TITLE
fix(eslint-plugin): [no-restricted-imports] fix crash when no options given

### DIFF
--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -1,14 +1,14 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
 import baseRule, {
-  ArrayOfStringOrObjectPatterns,
   ArrayOfStringOrObject,
+  ArrayOfStringOrObjectPatterns,
 } from 'eslint/lib/rules/no-restricted-imports';
 import ignore, { Ignore } from 'ignore';
 import {
-  InferOptionsTypeFromRule,
-  InferMessageIdsTypeFromRule,
   createRule,
   deepMerge,
+  InferMessageIdsTypeFromRule,
+  InferOptionsTypeFromRule,
 } from '../util';
 
 export type Options = InferOptionsTypeFromRule<typeof baseRule>;
@@ -118,6 +118,10 @@ export default createRule<Options, MessageIds>({
   create(context) {
     const rules = baseRule.create(context);
     const { options } = context;
+
+    if (options.length === 0) {
+      return {};
+    }
 
     const restrictedPaths = getRestrictedPaths(options);
     const allowedTypeImportPathNameSet: Set<string> = new Set();

--- a/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
@@ -8,6 +8,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-restricted-imports', rule, {
   valid: [
+    "import foo from 'foo';",
     {
       code: "import foo from 'foo';",
       options: ['import1', 'import2'],


### PR DESCRIPTION
Fixes #3933.