### PR TITLE
fix(experimental-utils): require fix in suggestions

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -112,11 +112,16 @@ interface RuleFixer {
   replaceTextRange(range: AST.Range, text: string): RuleFix;
 }
 
+interface SuggestionReportDescriptor<TMessageIds extends string>
+  extends Omit<ReportDescriptorBase<TMessageIds>, 'fix'> {
+  readonly fix: ReportFixFunction;
+}
+
 type ReportFixFunction = (
   fixer: RuleFixer,
 ) => null | RuleFix | readonly RuleFix[] | IterableIterator<RuleFix>;
 type ReportSuggestionArray<TMessageIds extends string> =
-  ReportDescriptorBase<TMessageIds>[];
+  SuggestionReportDescriptor<TMessageIds>[];
 
 interface ReportDescriptorBase<TMessageIds extends string> {
   /**


### PR DESCRIPTION
Fixes #3948 

Every suggestion _must_ have a fix function, it can't be left empty (nullish).

I did a similar fix in eslint's types recently. Really they should be aligned IMO but it seems they're already diverged anyway.