### PR TITLE
Add attributes to rule docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/adjacent-overload-signatures.md
+++ b/packages/eslint-plugin/docs/rules/adjacent-overload-signatures.md
@@ -90,6 +90,6 @@ If you don't care about the general structure of the code, then you will not nee
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/adjacent-overload-signatures.md
+++ b/packages/eslint-plugin/docs/rules/adjacent-overload-signatures.md
@@ -87,3 +87,9 @@ If you don't care about the general structure of the code, then you will not nee
 ## Compatibility
 
 - TSLint: [adjacent-overload-signatures](https://palantir.github.io/tslint/rules/adjacent-overload-signatures/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/array-type.md
+++ b/packages/eslint-plugin/docs/rules/array-type.md
@@ -114,3 +114,9 @@ This matrix lists all possible option combinations and their expected results fo
 ## Related to
 
 - TSLint: [array-type](https://palantir.github.io/tslint/rules/array-type/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/array-type.md
+++ b/packages/eslint-plugin/docs/rules/array-type.md
@@ -118,5 +118,5 @@ This matrix lists all possible option combinations and their expected results fo
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/await-thenable.md
+++ b/packages/eslint-plugin/docs/rules/await-thenable.md
@@ -31,3 +31,9 @@ This is generally not preferred, but can sometimes be useful for visual consiste
 ## Related to
 
 - TSLint: ['await-promise'](https://palantir.github.io/tslint/rules/await-promise)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/await-thenable.md
+++ b/packages/eslint-plugin/docs/rules/await-thenable.md
@@ -34,6 +34,6 @@ This is generally not preferred, but can sometimes be useful for visual consiste
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/ban-ts-comment.md
+++ b/packages/eslint-plugin/docs/rules/ban-ts-comment.md
@@ -133,6 +133,6 @@ If you want to use all of the TypeScript directives.
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/ban-ts-comment.md
+++ b/packages/eslint-plugin/docs/rules/ban-ts-comment.md
@@ -130,3 +130,9 @@ If you want to use all of the TypeScript directives.
 ## Compatibility
 
 - TSLint: [ban-ts-ignore](https://palantir.github.io/tslint/rules/ban-ts-ignore/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/ban-tslint-comment.md
+++ b/packages/eslint-plugin/docs/rules/ban-tslint-comment.md
@@ -27,3 +27,9 @@ Examples of **correct** code for this rule:
 ## When Not To Use It
 
 If you are still using TSLint.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/ban-tslint-comment.md
+++ b/packages/eslint-plugin/docs/rules/ban-tslint-comment.md
@@ -31,5 +31,5 @@ If you are still using TSLint.
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -189,6 +189,6 @@ const curly2: Record<'a', string> = { a: 'string' };
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -186,3 +186,9 @@ const curly2: Record<'a', string> = { a: 'string' };
 ## Compatibility
 
 - TSLint: [ban-types](https://palantir.github.io/tslint/rules/ban-types/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/brace-style.md
+++ b/packages/eslint-plugin/docs/rules/brace-style.md
@@ -24,5 +24,5 @@ See [`eslint/brace-style` options](https://eslint.org/docs/rules/brace-style#opt
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/brace-style.md
+++ b/packages/eslint-plugin/docs/rules/brace-style.md
@@ -20,3 +20,9 @@ It adds support for `enum`, `interface`, `namespace` and `module` declarations.
 See [`eslint/brace-style` options](https://eslint.org/docs/rules/brace-style#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/brace-style.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/class-literal-property-style.md
+++ b/packages/eslint-plugin/docs/rules/class-literal-property-style.md
@@ -94,3 +94,9 @@ class Mx {
 
 When you have no strong preference, or do not wish to enforce a particular style
 for how literal values are exposed by your classes.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/class-literal-property-style.md
+++ b/packages/eslint-plugin/docs/rules/class-literal-property-style.md
@@ -98,5 +98,5 @@ for how literal values are exposed by your classes.
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/comma-dangle.md
+++ b/packages/eslint-plugin/docs/rules/comma-dangle.md
@@ -36,5 +36,5 @@ This rule has a string option and an object option.
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/comma-dangle.md
+++ b/packages/eslint-plugin/docs/rules/comma-dangle.md
@@ -32,3 +32,9 @@ This rule has a string option and an object option.
 - [See the other options allowed](https://github.com/eslint/eslint/blob/master/docs/rules/comma-dangle.md#options)
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/comma-dangle.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/comma-spacing.md
+++ b/packages/eslint-plugin/docs/rules/comma-spacing.md
@@ -20,3 +20,9 @@ It adds support for trailing comma in a types parameters list.
 See [`eslint/comma-spacing` options](https://eslint.org/docs/rules/comma-spacing#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/comma-spacing.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/comma-spacing.md
+++ b/packages/eslint-plugin/docs/rules/comma-spacing.md
@@ -24,5 +24,5 @@ See [`eslint/comma-spacing` options](https://eslint.org/docs/rules/comma-spacing
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md
+++ b/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md
@@ -65,3 +65,9 @@ type Foo = {
   [key: string]: unknown;
 };
 ```
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md
+++ b/packages/eslint-plugin/docs/rules/consistent-indexed-object-style.md
@@ -69,5 +69,5 @@ type Foo = {
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/consistent-type-assertions.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-assertions.md
@@ -92,3 +92,9 @@ If you do not want to enforce consistent type assertions.
 
 - TSLint: [no-angle-bracket-type-assertion](https://palantir.github.io/tslint/rules/no-angle-bracket-type-assertion/)
 - TSLint: [no-object-literal-type-assertion](https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
@@ -72,3 +72,9 @@ If you specifically want to use an interface or type literal for stylistic reaso
 ## Compatibility
 
 - TSLint: [interface-over-type-literal](https://palantir.github.io/tslint/rules/interface-over-type-literal/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
@@ -76,5 +76,5 @@ If you specifically want to use an interface or type literal for stylistic reaso
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -62,3 +62,9 @@ const x: import('Bar') = 1;
 
 - If you are not using TypeScript 3.8 (or greater), then you will not be able to use this rule, as type-only imports are not allowed.
 - If you specifically want to use both import kinds for stylistic reasons, you can disable this rule.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -66,5 +66,5 @@ const x: import('Bar') = 1;
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/default-param-last.md
+++ b/packages/eslint-plugin/docs/rules/default-param-last.md
@@ -54,3 +54,9 @@ class Foo {
 See [`eslint/default-param-last` options](https://eslint.org/docs/rules/default-param-last#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/default-param-last.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/dot-notation.md
+++ b/packages/eslint-plugin/docs/rules/dot-notation.md
@@ -81,3 +81,9 @@ x['hello'] = 123;
 If the TypeScript compiler option `noPropertyAccessFromIndexSignature` is set to `true`, then the above code is always allowed, even if `allowIndexSignaturePropertyAccess` is `false`.
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/dot-notation.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/dot-notation.md
+++ b/packages/eslint-plugin/docs/rules/dot-notation.md
@@ -85,5 +85,5 @@ If the TypeScript compiler option `noPropertyAccessFromIndexSignature` is set to
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -246,3 +246,9 @@ you will not need this rule.
 ## Further Reading
 
 - TypeScript [Functions](https://www.typescriptlang.org/docs/handbook/functions.html#function-types)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
+++ b/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
@@ -346,3 +346,9 @@ If you think defaulting to public is a good default, then you should consider us
 ## Compatibility
 
 - TSLint: [member-access](http://palantir.github.io/tslint/rules/member-access/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
+++ b/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
@@ -350,5 +350,5 @@ If you think defaulting to public is a good default, then you should consider us
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
@@ -267,3 +267,9 @@ If you wish to make sure all functions have explicit return types, as opposed to
 ## Further Reading
 
 - TypeScript [Functions](https://www.typescriptlang.org/docs/handbook/functions.html#function-types)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
@@ -270,6 +270,6 @@ If you wish to make sure all functions have explicit return types, as opposed to
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/func-call-spacing.md
+++ b/packages/eslint-plugin/docs/rules/func-call-spacing.md
@@ -20,3 +20,9 @@ It adds support for generic type parameters on function calls.
 See [`eslint/func-call-spacing` options](https://eslint.org/docs/rules/func-call-spacing#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/func-call-spacing.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/func-call-spacing.md
+++ b/packages/eslint-plugin/docs/rules/func-call-spacing.md
@@ -24,5 +24,5 @@ See [`eslint/func-call-spacing` options](https://eslint.org/docs/rules/func-call
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/indent.md
+++ b/packages/eslint-plugin/docs/rules/indent.md
@@ -22,3 +22,9 @@ It adds support for TypeScript nodes.
 See [`eslint/indent` options](https://eslint.org/docs/rules/indent#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/indent.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/indent.md
+++ b/packages/eslint-plugin/docs/rules/indent.md
@@ -26,5 +26,5 @@ See [`eslint/indent` options](https://eslint.org/docs/rules/indent#options).
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/init-declarations.md
+++ b/packages/eslint-plugin/docs/rules/init-declarations.md
@@ -20,3 +20,9 @@ It adds support for TypeScript's `declare` variables.
 See [`eslint/init-declarations` options](https://eslint.org/docs/rules/init-declarations#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/init-declarations.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/keyword-spacing.md
+++ b/packages/eslint-plugin/docs/rules/keyword-spacing.md
@@ -24,5 +24,5 @@ See [`eslint/keyword-spacing` options](https://eslint.org/docs/rules/keyword-spa
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/keyword-spacing.md
+++ b/packages/eslint-plugin/docs/rules/keyword-spacing.md
@@ -20,3 +20,9 @@ This version adds support for generic type parameters on function calls.
 See [`eslint/keyword-spacing` options](https://eslint.org/docs/rules/keyword-spacing#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/keyword-spacing.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/lines-between-class-members.md
+++ b/packages/eslint-plugin/docs/rules/lines-between-class-members.md
@@ -75,5 +75,5 @@ class foo {
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/lines-between-class-members.md
+++ b/packages/eslint-plugin/docs/rules/lines-between-class-members.md
@@ -71,3 +71,9 @@ class foo {
 ```
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/lines-between-class-members.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/member-delimiter-style.md
+++ b/packages/eslint-plugin/docs/rules/member-delimiter-style.md
@@ -203,5 +203,5 @@ If you don't care about enforcing a consistent member delimiter in interfaces an
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/member-delimiter-style.md
+++ b/packages/eslint-plugin/docs/rules/member-delimiter-style.md
@@ -199,3 +199,9 @@ type FooBar = { name: string; greet(): string }
 ## When Not To Use It
 
 If you don't care about enforcing a consistent member delimiter in interfaces and type literals, then you will not need this rule.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/member-ordering.md
+++ b/packages/eslint-plugin/docs/rules/member-ordering.md
@@ -865,3 +865,9 @@ If you don't care about the general structure of your classes and interfaces, th
 ## Compatibility
 
 - TSLint: [member-ordering](https://palantir.github.io/tslint/rules/member-ordering/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/method-signature-style.md
+++ b/packages/eslint-plugin/docs/rules/method-signature-style.md
@@ -92,3 +92,9 @@ type T2 = {
 ## When Not To Use It
 
 If you don't want to enforce a particular style for object/interface function types, and/or if you don't use `strictFunctionTypes`, then you don't need this rule.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/method-signature-style.md
+++ b/packages/eslint-plugin/docs/rules/method-signature-style.md
@@ -96,5 +96,5 @@ If you don't want to enforce a particular style for object/interface function ty
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/naming-convention.md
+++ b/packages/eslint-plugin/docs/rules/naming-convention.md
@@ -694,3 +694,9 @@ You can use the `destructured` modifier to match these names, and explicitly set
 ## When Not To Use It
 
 If you do not want to enforce naming conventions for anything.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/naming-convention.md
+++ b/packages/eslint-plugin/docs/rules/naming-convention.md
@@ -699,4 +699,4 @@ If you do not want to enforce naming conventions for anything.
 
 - [ ] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-array-constructor.md
+++ b/packages/eslint-plugin/docs/rules/no-array-constructor.md
@@ -41,3 +41,9 @@ new Array(someOtherArray.length);
 See [`eslint/no-array-constructor` options](https://eslint.org/docs/rules/no-array-constructor#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-array-constructor.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-array-constructor.md
+++ b/packages/eslint-plugin/docs/rules/no-array-constructor.md
@@ -44,6 +44,6 @@ See [`eslint/no-array-constructor` options](https://eslint.org/docs/rules/no-arr
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-base-to-string.md
+++ b/packages/eslint-plugin/docs/rules/no-base-to-string.md
@@ -90,4 +90,4 @@ If you don't mind `"[object Object]"` in your strings, then you will not need th
 
 - [ ] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-base-to-string.md
+++ b/packages/eslint-plugin/docs/rules/no-base-to-string.md
@@ -85,3 +85,9 @@ let text = `${value}`;
 If you don't mind `"[object Object]"` in your strings, then you will not need this rule.
 
 - [`Object.prototype.toString()` MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-confusing-non-null-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-confusing-non-null-assertion.md
@@ -48,5 +48,5 @@ If you don't care about this confusion, then you will not need this rule.
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-confusing-non-null-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-confusing-non-null-assertion.md
@@ -44,3 +44,9 @@ If you don't care about this confusion, then you will not need this rule.
 ## Further Reading
 
 - [`Issue: Easy misunderstanding: "! ==="`](https://github.com/microsoft/TypeScript/issues/37837) in [TypeScript repo](https://github.com/microsoft/TypeScript)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-confusing-void-expression.md
+++ b/packages/eslint-plugin/docs/rules/no-confusing-void-expression.md
@@ -151,5 +151,5 @@ Also, if you prefer concise coding style then also don't use it.
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-confusing-void-expression.md
+++ b/packages/eslint-plugin/docs/rules/no-confusing-void-expression.md
@@ -147,3 +147,9 @@ Also, if you prefer concise coding style then also don't use it.
 ## Related to
 
 - TSLint: ['no-void-expression'](https://palantir.github.io/tslint/rules/no-void-expression/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-dupe-class-members.md
+++ b/packages/eslint-plugin/docs/rules/no-dupe-class-members.md
@@ -20,3 +20,9 @@ It adds support for TypeScript's method overload definitions.
 See [`eslint/no-dupe-class-members` options](https://eslint.org/docs/rules/no-dupe-class-members#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-dupe-class-members.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-duplicate-imports.md
+++ b/packages/eslint-plugin/docs/rules/no-duplicate-imports.md
@@ -20,3 +20,9 @@ This version adds support for type-only import and export.
 See [`eslint/no-duplicate-imports` options](https://eslint.org/docs/rules/no-duplicate-imports#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-duplicate-imports.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-dynamic-delete.md
+++ b/packages/eslint-plugin/docs/rules/no-dynamic-delete.md
@@ -51,5 +51,5 @@ Even repeated minor performance slowdowns likely do not significantly affect you
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-dynamic-delete.md
+++ b/packages/eslint-plugin/docs/rules/no-dynamic-delete.md
@@ -47,3 +47,9 @@ Even repeated minor performance slowdowns likely do not significantly affect you
 ## Related to
 
 - TSLint: [no-dynamic-delete](https://palantir.github.io/tslint/rules/no-dynamic-delete)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-empty-function.md
+++ b/packages/eslint-plugin/docs/rules/no-empty-function.md
@@ -91,6 +91,6 @@ class Foo {
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-empty-function.md
+++ b/packages/eslint-plugin/docs/rules/no-empty-function.md
@@ -88,3 +88,9 @@ class Foo {
 ---
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-empty-function.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-empty-interface.md
+++ b/packages/eslint-plugin/docs/rules/no-empty-interface.md
@@ -62,3 +62,9 @@ If you don't care about having empty/meaningless interfaces, then you will not n
 ## Compatibility
 
 - TSLint: [no-empty-interface](https://palantir.github.io/tslint/rules/no-empty-interface/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-empty-interface.md
+++ b/packages/eslint-plugin/docs/rules/no-empty-interface.md
@@ -65,6 +65,6 @@ If you don't care about having empty/meaningless interfaces, then you will not n
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-explicit-any.md
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.md
@@ -182,6 +182,6 @@ and you want to be able to specify `any`.
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-explicit-any.md
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.md
@@ -179,3 +179,9 @@ and you want to be able to specify `any`.
 ## Compatibility
 
 - TSLint: [no-any](https://palantir.github.io/tslint/rules/no-any/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-extra-non-null-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-extra-non-null-assertion.md
@@ -50,6 +50,6 @@ function foo(bar?: { n: number }) {
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-extra-non-null-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-extra-non-null-assertion.md
@@ -47,3 +47,9 @@ function foo(bar?: { n: number }) {
   "@typescript-eslint/no-extra-non-null-assertion": ["error"]
 }
 ```
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-extra-parens.md
+++ b/packages/eslint-plugin/docs/rules/no-extra-parens.md
@@ -20,3 +20,9 @@ It adds support for TypeScript type assertions.
 See [`eslint/no-extra-parens` options](https://eslint.org/docs/rules/no-extra-parens#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-extra-parens.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-extra-parens.md
+++ b/packages/eslint-plugin/docs/rules/no-extra-parens.md
@@ -24,5 +24,5 @@ See [`eslint/no-extra-parens` options](https://eslint.org/docs/rules/no-extra-pa
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-extra-semi.md
+++ b/packages/eslint-plugin/docs/rules/no-extra-semi.md
@@ -20,3 +20,9 @@ It adds support for class properties.
 See [`eslint/no-extra-semi` options](https://eslint.org/docs/rules/no-extra-semi#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-extra-semi.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-extra-semi.md
+++ b/packages/eslint-plugin/docs/rules/no-extra-semi.md
@@ -23,6 +23,6 @@ See [`eslint/no-extra-semi` options](https://eslint.org/docs/rules/no-extra-semi
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-extraneous-class.md
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-class.md
@@ -78,3 +78,9 @@ team or if you use classes as namespaces.
 ## Compatibility
 
 [`no-unnecessary-class`](https://palantir.github.io/tslint/rules/no-unnecessary-class/) from TSLint
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-floating-promises.md
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.md
@@ -105,6 +105,6 @@ If you do not use Promise-like values in your codebase, or want to allow them to
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-floating-promises.md
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.md
@@ -102,3 +102,9 @@ If you do not use Promise-like values in your codebase, or want to allow them to
 ## Related to
 
 - TSLint: ['no-floating-promises'](https://palantir.github.io/tslint/rules/no-floating-promises/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-for-in-array.md
+++ b/packages/eslint-plugin/docs/rules/no-for-in-array.md
@@ -45,6 +45,6 @@ If you want to iterate through a loop using the indices in an array as strings, 
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-for-in-array.md
+++ b/packages/eslint-plugin/docs/rules/no-for-in-array.md
@@ -42,3 +42,9 @@ If you want to iterate through a loop using the indices in an array as strings, 
 ## Related to
 
 - TSLint: ['no-for-in-array'](https://palantir.github.io/tslint/rules/no-for-in-array/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md
+++ b/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md
@@ -74,3 +74,9 @@ If you are not using TypeScript 4.0 (or greater), then you will not be able to u
 ## Further Reading
 
 - [TypeScript 4.0 Beta Release Notes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0-beta/#unknown-on-catch)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md
+++ b/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md
@@ -78,5 +78,5 @@ If you are not using TypeScript 4.0 (or greater), then you will not be able to u
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-implied-eval.md
+++ b/packages/eslint-plugin/docs/rules/no-implied-eval.md
@@ -103,3 +103,9 @@ setTimeout(Foo.fn, 100);
 If you want to allow `new Function()` or `setTimeout()`, `setInterval()`, `setImmediate()` and `execScript()` with string arguments, then you can safely disable this rule.
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-implied-eval.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-implied-eval.md
+++ b/packages/eslint-plugin/docs/rules/no-implied-eval.md
@@ -106,6 +106,6 @@ If you want to allow `new Function()` or `setTimeout()`, `setInterval()`, `setIm
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-inferrable-types.md
+++ b/packages/eslint-plugin/docs/rules/no-inferrable-types.md
@@ -147,6 +147,6 @@ TSLint: [no-inferrable-types](https://palantir.github.io/tslint/rules/no-inferra
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-inferrable-types.md
+++ b/packages/eslint-plugin/docs/rules/no-inferrable-types.md
@@ -144,3 +144,9 @@ TypeScript [Inference](https://www.typescriptlang.org/docs/handbook/type-inferen
 ## Compatibility
 
 TSLint: [no-inferrable-types](https://palantir.github.io/tslint/rules/no-inferrable-types/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-invalid-this.md
+++ b/packages/eslint-plugin/docs/rules/no-invalid-this.md
@@ -24,3 +24,9 @@ See [`eslint/no-invalid-this` options](https://eslint.org/docs/rules/no-invalid-
 When you are indifferent as to how your variables are initialized.
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-invalid-this.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-invalid-void-type.md
+++ b/packages/eslint-plugin/docs/rules/no-invalid-void-type.md
@@ -124,3 +124,9 @@ or in invalid places, then you don't need this rule.
 ## Compatibility
 
 - TSLint: [invalid-void](https://palantir.github.io/tslint/rules/invalid-void/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-loop-func.md
+++ b/packages/eslint-plugin/docs/rules/no-loop-func.md
@@ -20,3 +20,9 @@ It adds support for TypeScript types.
 See [`eslint/no-loop-func` options](https://eslint.org/docs/rules/no-loop-func#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-loop-func.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-loss-of-precision.md
+++ b/packages/eslint-plugin/docs/rules/no-loss-of-precision.md
@@ -17,3 +17,9 @@ Note that this rule requires ESLint v7.
 ```
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-loss-of-precision.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-magic-numbers.md
+++ b/packages/eslint-plugin/docs/rules/no-magic-numbers.md
@@ -117,3 +117,9 @@ class Foo {
 ```
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-magic-numbers.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-meaningless-void-operator.md
+++ b/packages/eslint-plugin/docs/rules/no-meaningless-void-operator.md
@@ -48,3 +48,9 @@ This rule accepts a single object option with the following default configuratio
 ```
 
 - `checkNever: true` will suggest removing `void` when the argument has type `never`.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-meaningless-void-operator.md
+++ b/packages/eslint-plugin/docs/rules/no-meaningless-void-operator.md
@@ -52,5 +52,5 @@ This rule accepts a single object option with the following default configuratio
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-misused-new.md
+++ b/packages/eslint-plugin/docs/rules/no-misused-new.md
@@ -42,6 +42,6 @@ interface I {
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-misused-new.md
+++ b/packages/eslint-plugin/docs/rules/no-misused-new.md
@@ -39,3 +39,9 @@ interface I {
 ## Compatibility
 
 - TSLint: [no-misused-new](https://palantir.github.io/tslint/rules/no-misused-new/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-misused-promises.md
+++ b/packages/eslint-plugin/docs/rules/no-misused-promises.md
@@ -153,6 +153,6 @@ misuses of them outside of what the TypeScript compiler will check.
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-misused-promises.md
+++ b/packages/eslint-plugin/docs/rules/no-misused-promises.md
@@ -150,3 +150,9 @@ misuses of them outside of what the TypeScript compiler will check.
 ## Further Reading
 
 - [TypeScript void function assignability](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-are-functions-returning-non-void-assignable-to-function-returning-void)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-namespace.md
+++ b/packages/eslint-plugin/docs/rules/no-namespace.md
@@ -113,3 +113,9 @@ If you are using the ES2015 module syntax, then you will not need this rule.
 ## Compatibility
 
 - TSLint: [no-namespace](https://palantir.github.io/tslint/rules/no-namespace/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-namespace.md
+++ b/packages/eslint-plugin/docs/rules/no-namespace.md
@@ -116,6 +116,6 @@ If you are using the ES2015 module syntax, then you will not need this rule.
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-non-null-asserted-nullish-coalescing.md
+++ b/packages/eslint-plugin/docs/rules/no-non-null-asserted-nullish-coalescing.md
@@ -47,3 +47,9 @@ If you are not using TypeScript 3.7 (or greater), then you will not need to use 
 
 - [TypeScript 3.7 Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html)
 - [Nullish Coalescing Proposal](https://github.com/tc39/proposal-nullish-coalescing)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-non-null-asserted-optional-chain.md
+++ b/packages/eslint-plugin/docs/rules/no-non-null-asserted-optional-chain.md
@@ -46,3 +46,9 @@ If you are not using TypeScript 3.7 (or greater), then you will not need to use 
 
 - [TypeScript 3.7 Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html)
 - [Optional Chaining Proposal](https://github.com/tc39/proposal-optional-chaining/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-non-null-asserted-optional-chain.md
+++ b/packages/eslint-plugin/docs/rules/no-non-null-asserted-optional-chain.md
@@ -49,6 +49,6 @@ If you are not using TypeScript 3.7 (or greater), then you will not need to use 
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
@@ -36,6 +36,6 @@ If you don't care about strict null-checking, then you will not need this rule.
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-non-null-assertion.md
@@ -33,3 +33,9 @@ If you don't care about strict null-checking, then you will not need this rule.
 ## Further Reading
 
 - [`no-non-null-assertion`](https://palantir.github.io/tslint/rules/no-non-null-assertion/) in [TSLint](https://palantir.github.io/tslint/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-parameter-properties.md
+++ b/packages/eslint-plugin/docs/rules/no-parameter-properties.md
@@ -365,3 +365,9 @@ If you don't care about the using parameter properties in constructors, then you
 ## Compatibility
 
 - TSLint: [no-parameter-properties](https://palantir.github.io/tslint/rules/no-parameter-properties/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-redeclare.md
+++ b/packages/eslint-plugin/docs/rules/no-redeclare.md
@@ -78,3 +78,9 @@ const something = 2;
 ```
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-redeclare.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-require-imports.md
+++ b/packages/eslint-plugin/docs/rules/no-require-imports.md
@@ -32,3 +32,9 @@ If you don't care about TypeScript module syntax, then you will not need this ru
 ## Compatibility
 
 - TSLint: [no-require-imports](https://palantir.github.io/tslint/rules/no-require-imports/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-restricted-imports.md
+++ b/packages/eslint-plugin/docs/rules/no-restricted-imports.md
@@ -62,3 +62,9 @@ export { Foo } from 'import-foo';
 import baz from 'import-baz';
 export { Baz } from 'import-baz';
 ```
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-shadow.md
+++ b/packages/eslint-plugin/docs/rules/no-shadow.md
@@ -85,3 +85,9 @@ type Func = (test: string) => typeof test;
 ```
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-shadow.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-this-alias.md
+++ b/packages/eslint-plugin/docs/rules/no-this-alias.md
@@ -58,3 +58,9 @@ If you need to assign `this` to variables, you shouldn’t use this rule.
 ## Related to
 
 - TSLint: [`no-this-assignment`](https://palantir.github.io/tslint/rules/no-this-assignment/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-this-alias.md
+++ b/packages/eslint-plugin/docs/rules/no-this-alias.md
@@ -61,6 +61,6 @@ If you need to assign `this` to variables, you shouldn’t use this rule.
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-throw-literal.md
+++ b/packages/eslint-plugin/docs/rules/no-throw-literal.md
@@ -97,4 +97,4 @@ throw new CustomError();
 
 - [ ] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-throw-literal.md
+++ b/packages/eslint-plugin/docs/rules/no-throw-literal.md
@@ -92,3 +92,9 @@ throw new CustomError();
 ---
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-throw-literal.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-type-alias.md
+++ b/packages/eslint-plugin/docs/rules/no-type-alias.md
@@ -590,3 +590,9 @@ callback, etc. that would cause the code to be unreadable or impractical.
 ## Related to
 
 - TSLint: [interface-over-type-literal](https://palantir.github.io/tslint/rules/interface-over-type-literal/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
@@ -136,3 +136,9 @@ if (!(someNullCondition ?? true)) {
 ## Related to
 
 - TSLint: [no-boolean-literal-compare](https://palantir.github.io/tslint/rules/no-boolean-literal-compare)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md
@@ -140,5 +140,5 @@ if (!(someNullCondition ?? true)) {
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
@@ -105,3 +105,9 @@ The main downside to using this rule is the need for type information.
 - ESLint: [no-constant-condition](https://eslint.org/docs/rules/no-constant-condition) - `no-unnecessary-condition` is essentially a stronger version of `no-constant-condition`, but requires type information.
 
 - [strict-boolean-expressions](./strict-boolean-expressions.md) - a more opinionated version of `no-unnecessary-condition`. `strict-boolean-expressions` enforces a specific code style, while `no-unnecessary-condition` is about correctness.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
@@ -109,5 +109,5 @@ The main downside to using this rule is the need for type information.
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-qualifier.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-qualifier.md
@@ -81,5 +81,5 @@ If you don't care about having unneeded namespace or enum qualifiers, then you d
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-qualifier.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-qualifier.md
@@ -77,3 +77,9 @@ If you don't care about having unneeded namespace or enum qualifiers, then you d
 ## Further Reading
 
 - TSLint: [no-unnecessary-qualifier](https://palantir.github.io/tslint/rules/no-unnecessary-qualifier/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
@@ -51,3 +51,9 @@ class Impl implements I<string> {}
 ## Related to
 
 - TSLint: [use-default-type-parameter](https://palantir.github.io/tslint/rules/use-default-type-parameter)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
@@ -55,5 +55,5 @@ class Impl implements I<string> {}
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
@@ -74,6 +74,6 @@ If you don't care about having no-op type assertions in your code, then you can 
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
@@ -71,3 +71,9 @@ If you don't care about having no-op type assertions in your code, then you can 
 ## Related to
 
 - TSLint: [`no-unnecessary-type-assertion`](https://palantir.github.io/tslint/rules/no-unnecessary-type-assertion/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-constraint.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-constraint.md
@@ -53,3 +53,9 @@ function Quuz<T>() {}
 ## When Not To Use It
 
 If you don't care about the specific styles of your type constraints, or never use them in the first place, then you will not need this rule.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-constraint.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-constraint.md
@@ -57,5 +57,5 @@ If you don't care about the specific styles of your type constraints, or never u
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unsafe-argument.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-argument.md
@@ -72,4 +72,4 @@ foo(1 as any, new Set<any>(), [] as any[]);
 
 - [ ] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unsafe-argument.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-argument.md
@@ -67,3 +67,9 @@ foo(1 as any, new Set<any>(), [] as any[]);
 
 - [`no-explicit-any`](./no-explicit-any.md)
 - TSLint: [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unsafe-assignment.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-assignment.md
@@ -73,6 +73,6 @@ const x: Set<unknown> = y as Set<any>;
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unsafe-assignment.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-assignment.md
@@ -70,3 +70,9 @@ const x: Set<unknown> = y as Set<any>;
 
 - [`no-explicit-any`](./no-explicit-any.md)
 - TSLint: [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unsafe-call.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-call.md
@@ -49,6 +49,6 @@ String.raw`foo`;
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unsafe-call.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-call.md
@@ -46,3 +46,9 @@ String.raw`foo`;
 
 - [`no-explicit-any`](./no-explicit-any.md)
 - TSLint: [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unsafe-member-access.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-member-access.md
@@ -52,3 +52,9 @@ arr[idx++];
 
 - [`no-explicit-any`](./no-explicit-any.md)
 - TSLint: [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unsafe-member-access.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-member-access.md
@@ -55,6 +55,6 @@ arr[idx++];
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unsafe-return.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-return.md
@@ -87,3 +87,9 @@ function foo2(): unknown[] {
 
 - [`no-explicit-any`](./no-explicit-any.md)
 - TSLint: [`no-unsafe-any`](https://palantir.github.io/tslint/rules/no-unsafe-any/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unsafe-return.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-return.md
@@ -90,6 +90,6 @@ function foo2(): unknown[] {
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unused-expressions.md
+++ b/packages/eslint-plugin/docs/rules/no-unused-expressions.md
@@ -20,3 +20,9 @@ It adds support for optional call expressions `x?.()`, and directive in module d
 See [`eslint/no-unused-expressions` options](https://eslint.org/docs/rules/no-unused-expressions#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-unused-expressions.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unused-vars-experimental.md
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars-experimental.md
@@ -113,3 +113,9 @@ class Foo {
   }
 }
 ```
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unused-vars-experimental.md
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars-experimental.md
@@ -113,9 +113,3 @@ class Foo {
   }
 }
 ```
-
-## Attributes
-
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unused-vars.md
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars.md
@@ -23,6 +23,6 @@ See [`eslint/no-unused-vars` options](https://eslint.org/docs/rules/no-unused-va
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-unused-vars.md
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars.md
@@ -20,3 +20,9 @@ It adds support for TypeScript features, such as types.
 See [`eslint/no-unused-vars` options](https://eslint.org/docs/rules/no-unused-vars#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-unused-vars.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-use-before-define.md
+++ b/packages/eslint-plugin/docs/rules/no-use-before-define.md
@@ -102,3 +102,9 @@ enum Enum {}
 See [`eslint/no-use-before-define` options](https://eslint.org/docs/rules/no-use-before-define#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-use-before-define.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-useless-constructor.md
+++ b/packages/eslint-plugin/docs/rules/no-useless-constructor.md
@@ -24,3 +24,9 @@ It adds support for:
 See [`eslint/no-useless-constructor` options](https://eslint.org/docs/rules/no-useless-constructor#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-useless-constructor.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-var-requires.md
+++ b/packages/eslint-plugin/docs/rules/no-var-requires.md
@@ -27,3 +27,9 @@ If you don't care about TypeScript module syntax, then you will not need this ru
 ## Compatibility
 
 - TSLint: [no-var-requires](https://palantir.github.io/tslint/rules/no-var-requires/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/no-var-requires.md
+++ b/packages/eslint-plugin/docs/rules/no-var-requires.md
@@ -30,6 +30,6 @@ If you don't care about TypeScript module syntax, then you will not need this ru
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/non-nullable-type-assertion-style.md
+++ b/packages/eslint-plugin/docs/rules/non-nullable-type-assertion-style.md
@@ -29,5 +29,5 @@ If you don't mind having unnecessarily verbose type casts, you can avoid this ru
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/non-nullable-type-assertion-style.md
+++ b/packages/eslint-plugin/docs/rules/non-nullable-type-assertion-style.md
@@ -25,3 +25,9 @@ const alsoDefinitely = maybe!;
 ## When Not To Use It
 
 If you don't mind having unnecessarily verbose type casts, you can avoid this rule.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/object-curly-spacing.md
+++ b/packages/eslint-plugin/docs/rules/object-curly-spacing.md
@@ -24,5 +24,5 @@ See [`eslint/object-curly-spacing` options](https://eslint.org/docs/rules/object
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/object-curly-spacing.md
+++ b/packages/eslint-plugin/docs/rules/object-curly-spacing.md
@@ -20,3 +20,9 @@ It adds support for TypeScript's object types.
 See [`eslint/object-curly-spacing` options](https://eslint.org/docs/rules/object-curly-spacing#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/object-curly-spacing.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/padding-line-between-statements.md
+++ b/packages/eslint-plugin/docs/rules/padding-line-between-statements.md
@@ -50,5 +50,5 @@ See [`eslint/padding-line-between-statements` options](https://eslint.org/docs/r
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/padding-line-between-statements.md
+++ b/packages/eslint-plugin/docs/rules/padding-line-between-statements.md
@@ -46,3 +46,9 @@ See [`eslint/padding-line-between-statements` options](https://eslint.org/docs/r
 **Note** - In addition to options provided by ESLint, we have also added options for `interface` and `type`.
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/padding-line-between-statements.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-as-const.md
+++ b/packages/eslint-plugin/docs/rules/prefer-as-const.md
@@ -29,6 +29,6 @@ If you are using TypeScript < 3.4
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-as-const.md
+++ b/packages/eslint-plugin/docs/rules/prefer-as-const.md
@@ -26,3 +26,9 @@ let foo = { bar: 'baz' };
 ## When Not To Use It
 
 If you are using TypeScript < 3.4
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-enum-initializers.md
+++ b/packages/eslint-plugin/docs/rules/prefer-enum-initializers.md
@@ -68,3 +68,9 @@ enum Color {
 ## When Not To Use It
 
 If you don't care about `enum`s having implicit values you can safely disable this rule.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-for-of.md
+++ b/packages/eslint-plugin/docs/rules/prefer-for-of.md
@@ -39,3 +39,9 @@ If you transpile for browsers that do not support for-of loops, you may wish to 
 ## Related to
 
 - TSLint: ['prefer-for-of'](https://palantir.github.io/tslint/rules/prefer-for-of/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-function-type.md
+++ b/packages/eslint-plugin/docs/rules/prefer-function-type.md
@@ -79,3 +79,9 @@ If you specifically want to use an interface or type literal with a single call 
 ## Further Reading
 
 - TSLint: [`callable-types`](https://palantir.github.io/tslint/rules/callable-types/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-function-type.md
+++ b/packages/eslint-plugin/docs/rules/prefer-function-type.md
@@ -83,5 +83,5 @@ If you specifically want to use an interface or type literal with a single call 
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-includes.md
+++ b/packages/eslint-plugin/docs/rules/prefer-includes.md
@@ -71,3 +71,9 @@ There are no options.
 ## When Not To Use It
 
 If you don't want to suggest `includes`, you can safely turn this rule off.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-includes.md
+++ b/packages/eslint-plugin/docs/rules/prefer-includes.md
@@ -75,5 +75,5 @@ If you don't want to suggest `includes`, you can safely turn this rule off.
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-literal-enum-member.md
+++ b/packages/eslint-plugin/docs/rules/prefer-literal-enum-member.md
@@ -84,3 +84,9 @@ enum Foo {
 ## When Not To Use It
 
 If you want use anything other than simple literals as an enum value.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-namespace-keyword.md
+++ b/packages/eslint-plugin/docs/rules/prefer-namespace-keyword.md
@@ -23,6 +23,6 @@ If you are using the ES2015 module syntax, then you will not need this rule.
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-namespace-keyword.md
+++ b/packages/eslint-plugin/docs/rules/prefer-namespace-keyword.md
@@ -20,3 +20,9 @@ If you are using the ES2015 module syntax, then you will not need this rule.
 ## Compatibility
 
 - TSLint: [no-internal-module](https://palantir.github.io/tslint/rules/no-internal-module/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
@@ -139,3 +139,9 @@ If you are not using TypeScript 3.7 (or greater), then you will not be able to u
 
 - [TypeScript 3.7 Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html)
 - [Nullish Coalescing Operator Proposal](https://github.com/tc39/proposal-nullish-coalescing/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
@@ -144,4 +144,4 @@ If you are not using TypeScript 3.7 (or greater), then you will not be able to u
 
 - [ ] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-optional-chain.md
+++ b/packages/eslint-plugin/docs/rules/prefer-optional-chain.md
@@ -80,3 +80,9 @@ If you are not using TypeScript 3.7 (or greater), then you will not be able to u
 
 - [TypeScript 3.7 Release Notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html)
 - [Optional Chaining Proposal](https://github.com/tc39/proposal-optional-chaining/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
@@ -260,4 +260,4 @@ function foo(arg: MyType) {}
 
 - [ ] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
@@ -255,3 +255,9 @@ type MyType = {
 };
 function foo(arg: MyType) {}
 ```
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-readonly.md
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly.md
@@ -79,3 +79,9 @@ class Container {
 ## Related to
 
 - TSLint: ['prefer-readonly'](https://palantir.github.io/tslint/rules/prefer-readonly)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-readonly.md
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly.md
@@ -83,5 +83,5 @@ class Container {
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.md
+++ b/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.md
@@ -52,3 +52,9 @@ There are no options.
 ## When Not To Use It
 
 If you don't want to use typechecking in your linting, you can't use this rule.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.md
+++ b/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.md
@@ -56,5 +56,5 @@ If you don't want to use typechecking in your linting, you can't use this rule.
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-regexp-exec.md
+++ b/packages/eslint-plugin/docs/rules/prefer-regexp-exec.md
@@ -49,3 +49,9 @@ There are no options.
 ## When Not To Use It
 
 If you prefer consistent use of `String#match` for both, with `g` flag and without it, you can turn this rule off.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-regexp-exec.md
+++ b/packages/eslint-plugin/docs/rules/prefer-regexp-exec.md
@@ -52,6 +52,6 @@ If you prefer consistent use of `String#match` for both, with `g` flag and witho
 
 ## Attributes
 
-- [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-return-this-type.md
+++ b/packages/eslint-plugin/docs/rules/prefer-return-this-type.md
@@ -88,3 +88,9 @@ class Derived extends Base {
 ## When Not To Use It
 
 If you don't use method chaining or explicit return values, you can safely turn this rule off.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-return-this-type.md
+++ b/packages/eslint-plugin/docs/rules/prefer-return-this-type.md
@@ -92,5 +92,5 @@ If you don't use method chaining or explicit return values, you can safely turn 
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-string-starts-ends-with.md
+++ b/packages/eslint-plugin/docs/rules/prefer-string-starts-ends-with.md
@@ -56,5 +56,5 @@ If you don't mind that style, you can turn this rule off safely.
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-string-starts-ends-with.md
+++ b/packages/eslint-plugin/docs/rules/prefer-string-starts-ends-with.md
@@ -52,3 +52,9 @@ There are no options.
 ## When Not To Use It
 
 If you don't mind that style, you can turn this rule off safely.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.md
+++ b/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.md
@@ -63,3 +63,9 @@ If you are **NOT** using TypeScript 3.9 (or greater), then you will not be able 
 ## Further Reading
 
 - [Original Implementing PR](https://github.com/microsoft/TypeScript/pull/36014)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.md
+++ b/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.md
@@ -67,5 +67,5 @@ If you are **NOT** using TypeScript 3.9 (or greater), then you will not be able 
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/promise-function-async.md
+++ b/packages/eslint-plugin/docs/rules/promise-function-async.md
@@ -68,5 +68,5 @@ In addition, each of the following properties may be provided, and default to `t
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/promise-function-async.md
+++ b/packages/eslint-plugin/docs/rules/promise-function-async.md
@@ -64,3 +64,9 @@ In addition, each of the following properties may be provided, and default to `t
 ## Related To
 
 - TSLint: [promise-function-async](https://palantir.github.io/tslint/rules/promise-function-async)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/quotes.md
+++ b/packages/eslint-plugin/docs/rules/quotes.md
@@ -20,3 +20,9 @@ It adds support for TypeScript features which allow quoted names, but not backti
 See [`eslint/quotes` options](https://eslint.org/docs/rules/quotes#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/quotes.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/quotes.md
+++ b/packages/eslint-plugin/docs/rules/quotes.md
@@ -24,5 +24,5 @@ See [`eslint/quotes` options](https://eslint.org/docs/rules/quotes#options).
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
+++ b/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
@@ -83,3 +83,9 @@ const three = '3';
 ## When Not To Use It
 
 If you understand the language specification enough, you can turn this rule off safely.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
+++ b/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
@@ -88,4 +88,4 @@ If you understand the language specification enough, you can turn this rule off 
 
 - [ ] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/require-await.md
+++ b/packages/eslint-plugin/docs/rules/require-await.md
@@ -33,6 +33,6 @@ See [`eslint/require-await` options](https://eslint.org/docs/rules/require-await
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/require-await.md
+++ b/packages/eslint-plugin/docs/rules/require-await.md
@@ -30,3 +30,9 @@ const returnsPromise2 = () => returnsPromise1();
 See [`eslint/require-await` options](https://eslint.org/docs/rules/require-await#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/require-await.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
+++ b/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
@@ -56,3 +56,9 @@ bar += 'test';
 ## Compatibility
 
 - TSLint: [restrict-plus-operands](https://palantir.github.io/tslint/rules/restrict-plus-operands/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
+++ b/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
@@ -59,6 +59,6 @@ bar += 'test';
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/restrict-template-expressions.md
+++ b/packages/eslint-plugin/docs/rules/restrict-template-expressions.md
@@ -100,3 +100,9 @@ const msg1 = `arg = ${arg}`;
 const arg = /foo/;
 const msg1 = `arg = ${arg}`;
 ```
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/restrict-template-expressions.md
+++ b/packages/eslint-plugin/docs/rules/restrict-template-expressions.md
@@ -103,6 +103,6 @@ const msg1 = `arg = ${arg}`;
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/return-await.md
+++ b/packages/eslint-plugin/docs/rules/return-await.md
@@ -210,5 +210,5 @@ async function validNever3() {
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/return-await.md
+++ b/packages/eslint-plugin/docs/rules/return-await.md
@@ -206,3 +206,9 @@ async function validNever3() {
   return 'value';
 }
 ```
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/semi.md
+++ b/packages/eslint-plugin/docs/rules/semi.md
@@ -28,5 +28,5 @@ See [`eslint/semi` options](https://eslint.org/docs/rules/semi#options).
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/semi.md
+++ b/packages/eslint-plugin/docs/rules/semi.md
@@ -24,3 +24,9 @@ See also the [`@typescript-eslint/member-delimiter-style`](member-delimiter-styl
 See [`eslint/semi` options](https://eslint.org/docs/rules/semi#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/semi.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.md
+++ b/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.md
@@ -149,5 +149,5 @@ The ordering of groups is determined by this option.
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.md
+++ b/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.md
@@ -145,3 +145,9 @@ The ordering of groups is determined by this option.
 - `tuple` - Tuple types (`[A, B, C]`)
 - `union` - Union types (`A | B`)
 - `nullish` - `null` and `undefined`
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/space-before-function-paren.md
+++ b/packages/eslint-plugin/docs/rules/space-before-function-paren.md
@@ -24,5 +24,5 @@ See [`eslint/space-before-function-paren` options](https://eslint.org/docs/rules
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/space-before-function-paren.md
+++ b/packages/eslint-plugin/docs/rules/space-before-function-paren.md
@@ -20,3 +20,9 @@ It adds support for generic type parameters on function calls.
 See [`eslint/space-before-function-paren` options](https://eslint.org/docs/rules/space-before-function-paren#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/space-before-function-paren.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/space-infix-ops.md
+++ b/packages/eslint-plugin/docs/rules/space-infix-ops.md
@@ -24,3 +24,9 @@ enum MyEnum {
 See [`eslint/space-infix-ops` options](https://eslint.org/docs/rules/space-infix-ops#options).
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/space-infix-ops.md)</sup>
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/space-infix-ops.md
+++ b/packages/eslint-plugin/docs/rules/space-infix-ops.md
@@ -28,5 +28,5 @@ See [`eslint/space-infix-ops` options](https://eslint.org/docs/rules/space-infix
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
@@ -196,5 +196,5 @@ This rule provides following fixes and suggestions for particular types in boole
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
@@ -192,3 +192,9 @@ This rule provides following fixes and suggestions for particular types in boole
 - TSLint: [strict-boolean-expressions](https://palantir.github.io/tslint/rules/strict-boolean-expressions)
 
 - [no-unnecessary-condition](./no-unnecessary-condition.md) - Similar rule which reports always-truthy and always-falsy values in conditions
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.md
+++ b/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.md
@@ -106,4 +106,4 @@ If program doesn't have union types with many parts. Downside of this rule is th
 
 - [ ] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.md
+++ b/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.md
@@ -101,3 +101,9 @@ switch (day) {
 ## When Not To Use It
 
 If program doesn't have union types with many parts. Downside of this rule is the need for type information, so it's slower than regular rules.
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/triple-slash-reference.md
+++ b/packages/eslint-plugin/docs/rules/triple-slash-reference.md
@@ -57,6 +57,6 @@ If you want to use all flavors of triple slash reference directives.
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/triple-slash-reference.md
+++ b/packages/eslint-plugin/docs/rules/triple-slash-reference.md
@@ -54,3 +54,9 @@ If you want to use all flavors of triple slash reference directives.
 
 - TSLint: [no-reference](http://palantir.github.io/tslint/rules/no-reference/)
 - TSLint: [no-reference-import](https://palantir.github.io/tslint/rules/no-reference-import/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/type-annotation-spacing.md
+++ b/packages/eslint-plugin/docs/rules/type-annotation-spacing.md
@@ -293,5 +293,5 @@ If you don't want to enforce spacing for your type annotations, you can safely t
 ## Attributes
 
 - [ ] ✅ Recommended
-- [ ] 🔧 Fixable
+- [x] 🔧 Fixable
 - [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/type-annotation-spacing.md
+++ b/packages/eslint-plugin/docs/rules/type-annotation-spacing.md
@@ -289,3 +289,9 @@ If you don't want to enforce spacing for your type annotations, you can safely t
 ## Compatibility
 
 - TSLint: [`typedef-whitespace`](https://palantir.github.io/tslint/rules/typedef-whitespace/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/typedef.md
+++ b/packages/eslint-plugin/docs/rules/typedef.md
@@ -306,3 +306,9 @@ In general, if you do not consider the cost of writing unnecessary type annotati
 ## Compatibility
 
 - TSLint: [`typedef`](https://palantir.github.io/tslint/rules/typedef)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/unbound-method.md
+++ b/packages/eslint-plugin/docs/rules/unbound-method.md
@@ -115,6 +115,6 @@ If you're wanting to use `toBeCalled` and similar matches in `jest` tests, you c
 
 ## Attributes
 
-- [ ] ✅ Recommended
+- [x] ✅ Recommended
 - [ ] 🔧 Fixable
-- [ ] 💭 Requires type information
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/unbound-method.md
+++ b/packages/eslint-plugin/docs/rules/unbound-method.md
@@ -112,3 +112,9 @@ If you're wanting to use `toBeCalled` and similar matches in `jest` tests, you c
 ## Related To
 
 - TSLint: [no-unbound-method](https://palantir.github.io/tslint/rules/no-unbound-method/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information

--- a/packages/eslint-plugin/docs/rules/unified-signatures.md
+++ b/packages/eslint-plugin/docs/rules/unified-signatures.md
@@ -31,3 +31,9 @@ function f(x?: ...number[]): void;
 ## Related to
 
 - TSLint: [`unified-signatures`](https://palantir.github.io/tslint/rules/unified-signatures/)
+
+## Attributes
+
+- [ ] ✅ Recommended
+- [ ] 🔧 Fixable
+- [ ] 💭 Requires type information


### PR DESCRIPTION
Add attributes to rule docs (take from rule doc summary) for recommended, fixable, and requiring type information