### PR TITLE
feat(experimental-utils): extract `ast-utils`' `predicates`' helpers

### DIFF
--- a/packages/experimental-utils/src/ast-utils/helpers.ts
+++ b/packages/experimental-utils/src/ast-utils/helpers.ts
@@ -1,0 +1,37 @@
+import { AST_NODE_TYPES, TSESTree } from '../ts-estree';
+
+export const isNodeOfType =
+  <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) =>
+  (
+    node: TSESTree.Node | null | undefined,
+  ): node is TSESTree.Node & { type: NodeType } =>
+    node?.type === nodeType;
+
+export const isNodeOfTypes =
+  <NodeTypes extends readonly AST_NODE_TYPES[]>(nodeTypes: NodeTypes) =>
+  (
+    node: TSESTree.Node | null | undefined,
+  ): node is TSESTree.Node & { type: NodeTypes[number] } =>
+    !!node && nodeTypes.includes(node.type);
+
+type ObjectEntry<BaseType> = [keyof BaseType, BaseType[keyof BaseType]];
+type ObjectEntries<BaseType> = Array<ObjectEntry<BaseType>>;
+export const isNodeOfTypeWithConditions = <
+  NodeType extends AST_NODE_TYPES,
+  Conditions extends Partial<TSESTree.Node & { type: NodeType }>,
+>(
+  nodeType: NodeType,
+  conditions: Conditions,
+): ((
+  node: TSESTree.Node | null | undefined,
+) => node is TSESTree.Node & { type: NodeType } & Conditions) => {
+  const entries = Object.entries(conditions) as ObjectEntries<
+    TSESTree.Node & { type: NodeType }
+  >;
+
+  return (
+    node: TSESTree.Node | null | undefined,
+  ): node is TSESTree.Node & { type: NodeType } & Conditions =>
+    node?.type === nodeType &&
+    entries.every(([key, value]) => node[key] === value);
+};

--- a/packages/experimental-utils/src/ast-utils/predicates.ts
+++ b/packages/experimental-utils/src/ast-utils/predicates.ts
@@ -1,40 +1,10 @@
 import { AST_NODE_TYPES, AST_TOKEN_TYPES, TSESTree } from '../ts-estree';
 
-const isNodeOfType =
-  <NodeType extends AST_NODE_TYPES>(nodeType: NodeType) =>
-  (
-    node: TSESTree.Node | null | undefined,
-  ): node is TSESTree.Node & { type: NodeType } =>
-    node?.type === nodeType;
-
-const isNodeOfTypes =
-  <NodeTypes extends readonly AST_NODE_TYPES[]>(nodeTypes: NodeTypes) =>
-  (
-    node: TSESTree.Node | null | undefined,
-  ): node is TSESTree.Node & { type: NodeTypes[number] } =>
-    !!node && nodeTypes.includes(node.type);
-
-type ObjectEntry<BaseType> = [keyof BaseType, BaseType[keyof BaseType]];
-type ObjectEntries<BaseType> = Array<ObjectEntry<BaseType>>;
-const isNodeOfTypeWithConditions = <
-  NodeType extends AST_NODE_TYPES,
-  Conditions extends Partial<TSESTree.Node & { type: NodeType }>,
->(
-  nodeType: NodeType,
-  conditions: Conditions,
-): ((
-  node: TSESTree.Node | null | undefined,
-) => node is TSESTree.Node & { type: NodeType } & Conditions) => {
-  const entries = Object.entries(conditions) as ObjectEntries<
-    TSESTree.Node & { type: NodeType }
-  >;
-
-  return (
-    node: TSESTree.Node | null | undefined,
-  ): node is TSESTree.Node & { type: NodeType } & Conditions =>
-    node?.type === nodeType &&
-    entries.every(([key, value]) => node[key] === value);
-};
+import {
+  isNodeOfType,
+  isNodeOfTypes,
+  isNodeOfTypeWithConditions,
+} from './helpers';
 
 function isOptionalChainPunctuator(
   token: TSESTree.Token,


### PR DESCRIPTION
I'm extracting `isTokenOfTypeWithConditions` in #3977 and the `predicates` file would otherwise become really big