### PR TITLE
[no-unused-vars] Consider decorated declarations to be in use

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -30,6 +30,11 @@ import { ClassDecoratorFactory } from 'decorators';
 export class Foo {}
     `,
     `
+import { ClassDecoratorFactory } from 'decorators';
+@ClassDecoratorFactory()
+class Foo {}
+    `,
+    `
 import { ClassDecorator } from 'decorators';
 @ClassDecorator
 export class Foo {}


### PR DESCRIPTION
I want to consider anything that has a decorator in my project to be used and not fail the `no-unused-vars` rule. I tried to implement this myself but didn't get much further than the test.

I figured I'd ask if you'd consider a pull request like this before going further. Any pointers would also be appreciated on how I can achieve this.