### PR TITLE
fix(eslint-plugin): [no-floating-promises] Make the error msg more descriptive

### DIFF
--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -28,9 +28,9 @@ export default util.createRule<Options, MessageId>({
     },
     hasSuggestions: true,
     messages: {
-      floating: 'Promises must be handled appropriately.',
+      floating: 'Expressions of type Promise must end with a call to .catch or a call to .then with a rejection handler',
       floatingVoid:
-        'Promises must be handled appropriately' +
+        'Expressions of type Promise must end with a call to .catch or a call to .then with a rejection handler' +
         ' or explicitly marked as ignored with the `void` operator.',
       floatingFixVoid: 'Add void operator to ignore.',
     },


### PR DESCRIPTION
## WHY

The existing error msg for `no-floating-promises` could use a bit more clarity

```Promises must be handled appropriately.```

## WHAT

Make the no-floating-promises error msg more descriptive

Update the error msg to 

```Expressions of type Promise must end with a call to .catch or a call to .then with a rejection handler```

and in case void is ignored

```Expressions of type Promise must end with a call to .catch or a call to .then with a rejection handler or explicitly marked as ignored with the `void` operator.```