### PR TITLE
chore(eslint-plugin): [no-floating-promises] Make the error msg more descriptive

### DIFF
--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -31,7 +31,7 @@ export default util.createRule<Options, MessageId>({
       floating:
         'Promises must be awaited, end with a call to .catch, or end with a call to .then with a rejection handler.',
       floatingVoid:
-        'Promises must be awaited, end with a call to .catch, or end with a call to .then with a rejection handler' +
+        'Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler' +
         ' or be explicitly marked as ignored with the `void` operator.',
       floatingFixVoid: 'Add void operator to ignore.',
     },


### PR DESCRIPTION
## WHY

The existing error msg for `no-floating-promises` could use a bit more clarity

```Promises must be handled appropriately.```

ref: https://stackoverflow.com/questions/43980188/what-could-this-be-about-tslint-error-promises-must-be-handled-appropriately?answertab=votes#tab-top

## WHAT

Make the no-floating-promises error msg more descriptive

Update the error msg to 

```Expressions of type Promise must end with a call to .catch or a call to .then with a rejection handler.```

and in case that void is ignored

```Expressions of type Promise must end with a call to .catch or a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator.```