### PR TITLE
docs(eslint-plugin): [consistent-type-definitions] fix a typo

### DIFF
--- a/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
@@ -59,7 +59,7 @@ interface T {
 }
 ```
 
-Examples of **correct** code with `type` option.
+Examples of **correct** code with `interface` option.
 
 ```ts
 type T = { x: number };


### PR DESCRIPTION
Seems like the `interface` option was intended