### PR TITLE
fix(typescript-estree): changed `updateCachedFileList` to always use `program.getRootFileNames`

### DIFF
--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -120,13 +120,10 @@ function createHash(content: string): string {
 function updateCachedFileList(
   tsconfigPath: CanonicalPath,
   program: ts.Program,
-  extra: Extra,
 ): Set<CanonicalPath> {
-  const fileList = extra.EXPERIMENTAL_useSourceOfProjectReferenceRedirect
-    ? new Set(
-        program.getSourceFiles().map(sf => getCanonicalFileName(sf.fileName)),
-      )
-    : new Set(program.getRootFileNames().map(f => getCanonicalFileName(f)));
+  const fileList = new Set(
+    program.getRootFileNames().map(f => getCanonicalFileName(f)),
+  );
   programFileListCache.set(tsconfigPath, fileList);
   return fileList;
 }
@@ -173,7 +170,7 @@ function getProgramsForProjects(
     let updatedProgram: ts.Program | null = null;
     if (!fileList) {
       updatedProgram = existingWatch.getProgram().getProgram();
-      fileList = updateCachedFileList(tsconfigPath, updatedProgram, extra);
+      fileList = updateCachedFileList(tsconfigPath, updatedProgram);
     }
 
     if (fileList.has(filePath)) {
@@ -214,11 +211,7 @@ function getProgramsForProjects(
       updatedProgram.getTypeChecker();
 
       // cache and check the file list
-      const fileList = updateCachedFileList(
-        tsconfigPath,
-        updatedProgram,
-        extra,
-      );
+      const fileList = updateCachedFileList(tsconfigPath, updatedProgram);
       if (fileList.has(filePath)) {
         log('Found updated program for file. %s', filePath);
         // we can return early because we know this program contains the file
@@ -237,7 +230,7 @@ function getProgramsForProjects(
     program.getTypeChecker();
 
     // cache and check the file list
-    const fileList = updateCachedFileList(tsconfigPath, program, extra);
+    const fileList = updateCachedFileList(tsconfigPath, program);
     if (fileList.has(filePath)) {
       log('Found program for file. %s', filePath);
       // we can return early because we know this program contains the file


### PR DESCRIPTION
Fixes #4026.

(This is a tentative fix that I've only really tested on some basic projects, so I'll admit I don't fully understand the implications of this change on more complex projects).

I had trouble seeing why `updateCachedFileList` would use `program.getSourceFiles` when using the flag `EXPERIMENTAL_useSourceOfProjectReferenceRedirect`. My rationale being that there would never be any need to lint anything besides what `program.getRootFileNames` provides, since any referenced projects (and files therein) would presumably be linted themselves at some other stage in the process anyway.

See the above mentioned issue for more details.