### PR TITLE
docs(eslint-plugin): Fix `consistent-type-definitions` README with correct usage of type

### DIFF
--- a/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-definitions.md
@@ -59,7 +59,7 @@ interface T {
 }
 ```
 
-Examples of **correct** code with `interface` option.
+Examples of **correct** code with `type` option.
 
 ```ts
 type T = { x: number };


### PR DESCRIPTION
Fix consistent-type-definitions README with correct usage of `type`, as of right now, the README conflicts with itself.