### PR TITLE
chore: correct PR template and mention 'accepting prs'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@ Please fill out all fields below -- otherwise we may not be able to review your 
 ## PR Checklist
 
 -   [ ] Addresses an existing issue: fixes #000
+-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
 -   [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken
 
 ## Overview


### PR DESCRIPTION
Fixes #4044

Also adding a line for the new [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22) label.