### PR TITLE
fix(eslint-plugin): ignore private identifiers in explicit-module-boundary-types

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -336,7 +336,10 @@ export default util.createRule<Options, MessageIds>({
           return;
 
         case AST_NODE_TYPES.PropertyDefinition:
-          if (node.accessibility === 'private') {
+          if (
+            node.accessibility === 'private' ||
+            node.key.type === AST_NODE_TYPES.PrivateIdentifier
+          ) {
             return;
           }
           return checkNode(node.value);
@@ -353,7 +356,10 @@ export default util.createRule<Options, MessageIds>({
 
         case AST_NODE_TYPES.MethodDefinition:
         case AST_NODE_TYPES.TSAbstractMethodDefinition:
-          if (node.accessibility === 'private') {
+          if (
+            node.accessibility === 'private' ||
+            node.key.type === AST_NODE_TYPES.PrivateIdentifier
+          ) {
             return;
           }
           return checkNode(node.value);

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -82,6 +82,16 @@ export class Test {
 }
       `,
     },
+    `
+export class PrivateProperty {
+  #property = () => null;
+}
+    `,
+    `
+export class PrivateMethod {
+  #method() {}
+}
+    `,
     {
       // https://github.com/typescript-eslint/typescript-eslint/issues/2150
       code: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1740
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

`PrivateIdentifier` key nodes indicate it's a `#`.