### PR TITLE
feat(eslint-plugin): [prefer-readonly-parameter-types] Added option `utilityTypeSufficient` which makes `Readonly<>` sufficient to satisfy the rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
@@ -125,11 +125,13 @@ interface Foo {
 interface Options {
   checkParameterProperties?: boolean;
   ignoreInferredTypes?: boolean;
+  utilityTypeSufficient?: boolean;
 }
 
 const defaultOptions: Options = {
   checkParameterProperties: true,
   ignoreInferredTypes: false,
+  utilityTypeSufficient: false,
   treatMethodsAsReadonly: false,
 };
 ```
@@ -215,6 +217,30 @@ export const acceptsCallback: AcceptsCallback;
 ```
 
 </details>
+
+### `utilityTypeSufficient`
+
+This option makes it so that any parameter using the utility type `Readonly<>` passes the this rule. Beware that this does not guarantee deep immutability, however, it simplifies the usage of this rule.
+
+Examples of **incorrect** code for this rule with `{utilityTypeSufficient: true}`:
+
+```ts
+interface T {
+  prop: { subProp: string };
+}
+
+function foo(arg: T): void {}
+```
+
+Examples of **correct** code for this rule with `{utilityTypeSufficient: true}`:
+
+```ts
+interface T {
+  prop: { subProp: string };
+}
+
+function foo(arg: Readonly<T>): void {}
+```
 
 ### `treatMethodsAsReadonly`
 

--- a/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
@@ -335,7 +335,11 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
     },
     {
       code: `
-        function foo(arg: Readonly<Element>) {}
+        interface T {
+          prop: { subProp: string };
+        }
+
+        function foo(arg: Readonly<T>): void {}
       `,
       options: [
         {
@@ -795,7 +799,11 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
     },
     {
       code: `
-        function foo(arg: Readonly<Element>) {}
+        interface T {
+          prop: { subProp: string };
+        }
+
+        function foo(arg: Readonly<T>): void {}
       `,
       options: [
         {
@@ -805,15 +813,19 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
       errors: [
         {
           messageId: 'shouldBeReadonly',
-          line: 2,
+          line: 6,
           column: 27,
-          endColumn: 44,
+          endColumn: 38,
         },
       ],
     },
     {
       code: `
-        function foo(arg: Element) {}
+        interface T {
+          prop: { subProp: string };
+        }
+
+        function foo(arg: T): void {}
       `,
       options: [
         {
@@ -823,9 +835,9 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
       errors: [
         {
           messageId: 'shouldBeReadonly',
-          line: 2,
+          line: 6,
           column: 27,
-          endColumn: 34,
+          endColumn: 38,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
@@ -814,7 +814,7 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
         {
           messageId: 'shouldBeReadonly',
           line: 6,
-          column: 27,
+          column: 22,
           endColumn: 38,
         },
       ],
@@ -836,8 +836,8 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
         {
           messageId: 'shouldBeReadonly',
           line: 6,
-          column: 27,
-          endColumn: 38,
+          column: 22,
+          endColumn: 28,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
@@ -333,6 +333,16 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
         },
       ],
     },
+    {
+      code: `
+        function foo(arg: Readonly<Element>) {}
+      `,
+      options: [
+        {
+          utilityTypeSufficient: true,
+        },
+      ],
+    },
   ],
   invalid: [
     // arrays
@@ -780,6 +790,42 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
           line: 10,
           column: 43,
           endColumn: 67,
+        },
+      ],
+    },
+    {
+      code: `
+        function foo(arg: Readonly<Element>) {}
+      `,
+      options: [
+        {
+          utilityTypeSufficient: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'shouldBeReadonly',
+          line: 2,
+          column: 27,
+          endColumn: 44,
+        },
+      ],
+    },
+    {
+      code: `
+        function foo(arg: Element) {}
+      `,
+      options: [
+        {
+          utilityTypeSufficient: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'shouldBeReadonly',
+          line: 2,
+          column: 27,
+          endColumn: 34,
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4061 
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview
Added the option `utilityTypeSufficient` to the rule `prefer-readonly-parameter-types` which makes it so that `Readonly<>` is enough to satisfy the rule. Turning this option on is a sort of a compromise as it makes it not so strict, but much easier to use.

This could "solve" #2699.
