### PR TITLE
fix(eslint-plugin): [member-ordering] order literal names correctly in

### DIFF
--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -271,6 +271,31 @@ function getNodeType(node: Member): string | null {
 }
 
 /**
+ * Gets the raw string value of a member's name
+ */
+function getMemberRawName(
+  member:
+    | TSESTree.MethodDefinition
+    | TSESTree.TSMethodSignature
+    | TSESTree.TSAbstractMethodDefinition
+    | TSESTree.PropertyDefinition
+    | TSESTree.TSAbstractPropertyDefinition
+    | TSESTree.Property
+    | TSESTree.TSPropertySignature,
+  sourceCode: TSESLint.SourceCode,
+): string {
+  const { name, type } = util.getNameFromMember(member, sourceCode);
+
+  if (type === util.MemberNameType.Quoted) {
+    return name.substr(1, name.length - 2);
+  }
+  if (type === util.MemberNameType.Private) {
+    return name.substr(1);
+  }
+  return name;
+}
+
+/**
  * Gets the member name based on the member type.
  *
  * @param node the node to be evaluated.
@@ -285,12 +310,12 @@ function getMemberName(
     case AST_NODE_TYPES.TSMethodSignature:
     case AST_NODE_TYPES.TSAbstractPropertyDefinition:
     case AST_NODE_TYPES.PropertyDefinition:
-      return util.getNameFromMember(node, sourceCode).name;
+      return getMemberRawName(node, sourceCode);
     case AST_NODE_TYPES.TSAbstractMethodDefinition:
     case AST_NODE_TYPES.MethodDefinition:
       return node.kind === 'constructor'
         ? 'constructor'
-        : util.getNameFromMember(node, sourceCode).name;
+        : getMemberRawName(node, sourceCode);
     case AST_NODE_TYPES.TSConstructSignatureDeclaration:
       return 'new';
     case AST_NODE_TYPES.TSCallSignatureDeclaration:

--- a/packages/eslint-plugin/tests/rules/member-ordering-alphabetically-order.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering-alphabetically-order.test.ts
@@ -50,6 +50,18 @@ interface Foo {
       options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
     },
 
+    // default option + interface + literal properties
+    {
+      code: `
+interface Foo {
+  a : Foo;
+  'b.c' : Foo;
+  "b.d" : Foo;
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+    },
+
     // default option + type literal + multiple types
     {
       code: `
@@ -84,6 +96,18 @@ type Foo = {
 }
             `,
       options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
+    },
+
+    // default option + type + literal properties
+    {
+      code: `
+type Foo = {
+  a : Foo;
+  'b.c' : Foo;
+  "b.d" : Foo;
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
     },
 
     // default option + class + multiple types
@@ -221,6 +245,34 @@ interface Foo {
       ],
     },
 
+    // default option + interface + literal properties
+    {
+      code: `
+interface Foo {
+  "b.d" : Foo;
+  'b.c' : Foo;
+  a : Foo;
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b.c',
+            beforeMember: 'b.d',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b.c',
+          },
+        },
+      ],
+    },
+
     // default option + interface + wrong order (multiple)
     {
       code: `
@@ -274,6 +326,34 @@ type Foo = {
           data: {
             member: 'call',
             beforeMember: 'new',
+          },
+        },
+      ],
+    },
+
+    // default option + type + literal properties
+    {
+      code: `
+type Foo = {
+  "b.d" : Foo;
+  'b.c' : Foo;
+  a : Foo;
+}
+            `,
+      options: [{ default: { order: 'alphabetically' } }],
+      errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b.c',
+            beforeMember: 'b.d',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b.c',
           },
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing issue: fixes #4051
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

Updated the sorting algorithm to consider the raw string values of identifiers.