### PR TITLE
chore: mention needing an issue for a PR in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ Please refrain from commenting on `master` commits. Commit comments are not sear
 
 ## Pull Requests
 
+> With the exception of extremely minor documentation typos, **only send pull requests that resolve open issues**.
+
 Anyone is free to help us build and maintain this project. If you see an issue that needs working on because it's important to you, comment on the issue to help make sure that nobody else works on it at the same time, and then start working.
 
 Developing in this repo is easy:


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4010 _(-ish)_
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

#4066 was sent in without an attached issue. Time to make the docs more explicit?
