### PR TITLE
feat(typescript-estree): support type-only module specifiers

### DIFF
--- a/packages/ast-spec/src/special/ExportSpecifier/spec.ts
+++ b/packages/ast-spec/src/special/ExportSpecifier/spec.ts
@@ -1,9 +1,11 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
+import type { ExportKind } from '../../declaration/ExportAndImportKind';
 import type { Identifier } from '../../expression/Identifier/spec';
 
 export interface ExportSpecifier extends BaseNode {
   type: AST_NODE_TYPES.ExportSpecifier;
   local: Identifier;
   exported: Identifier;
+  exportKind: ExportKind;
 }

--- a/packages/ast-spec/src/special/ImportSpecifier/spec.ts
+++ b/packages/ast-spec/src/special/ImportSpecifier/spec.ts
@@ -1,9 +1,11 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
+import type { ImportKind } from '../../declaration/ExportAndImportKind';
 import type { Identifier } from '../../expression/Identifier/spec';
 
 export interface ImportSpecifier extends BaseNode {
   type: AST_NODE_TYPES.ImportSpecifier;
   local: Identifier;
   imported: Identifier;
+  importKind: ImportKind;
 }

--- a/packages/shared-fixtures/fixtures/typescript/basics/type-only-export-specifiers.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/type-only-export-specifiers.src.ts
@@ -1,0 +1,1 @@
+export { type A, type B } from "mod";

--- a/packages/shared-fixtures/fixtures/typescript/basics/type-only-import-specifiers.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/type-only-import-specifiers.src.ts
@@ -1,0 +1,1 @@
+import { type A, type B } from "mod";

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1793,6 +1793,7 @@ export class Converter {
           type: AST_NODE_TYPES.ImportSpecifier,
           local: this.convertChild(node.name),
           imported: this.convertChild(node.propertyName ?? node.name),
+          importKind: node.isTypeOnly ? 'type' : 'value',
         });
 
       case SyntaxKind.ImportClause: {
@@ -1841,6 +1842,7 @@ export class Converter {
           type: AST_NODE_TYPES.ExportSpecifier,
           local: this.convertChild(node.propertyName ?? node.name),
           exported: this.convertChild(node.name),
+          exportKind: node.isTypeOnly ? 'type' : 'value',
         });
 
       case SyntaxKind.ExportAssignment:

--- a/packages/typescript-estree/tests/ast-alignment/utils.ts
+++ b/packages/typescript-estree/tests/ast-alignment/utils.ts
@@ -263,18 +263,6 @@ export function preprocessBabylonAST(ast: File): any {
         Object.keys(node).forEach(key => delete node[key]);
         Object.assign(node, typeAnnotation);
       },
-      /**
-       * @see https://github.com/babel/babel/pull/13802
-       */
-      ImportSpecifier(node) {
-        delete node.importKind;
-      },
-      /**
-       * @see https://github.com/babel/babel/pull/13802
-       */
-      ExportSpecifier(node) {
-        delete node.exportKind;
-      },
       /*
        * Babel's AST has no `assertions` property if there are no assertions.
        */

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
@@ -2126,6 +2126,10 @@ exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" e
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-import-type-with-type-parameters-in-type-reference.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-only-export-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-only-import-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-parameters-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
 exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-parameters-comments-heritage.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-default.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-default.src.js.shot
@@ -42,6 +42,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-named-as-default.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-named-as-default.src.js.shot
@@ -42,6 +42,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-named-as-specifier.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-named-as-specifier.src.js.shot
@@ -42,6 +42,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-named-as-specifiers.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-named-as-specifiers.src.js.shot
@@ -42,6 +42,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {
@@ -95,6 +96,7 @@ Object {
           "type": "ExportSpecifier",
         },
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-specifier.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-specifier.src.js.shot
@@ -42,6 +42,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-specifiers.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-from-specifiers.src.js.shot
@@ -42,6 +42,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {
@@ -95,6 +96,7 @@ Object {
           "type": "ExportSpecifier",
         },
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-as-default.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-as-default.src.js.shot
@@ -24,6 +24,7 @@ Object {
       "source": null,
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-as-specifier.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-as-specifier.src.js.shot
@@ -24,6 +24,7 @@ Object {
       "source": null,
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-as-specifiers.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-as-specifiers.src.js.shot
@@ -24,6 +24,7 @@ Object {
       "source": null,
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {
@@ -77,6 +78,7 @@ Object {
           "type": "ExportSpecifier",
         },
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-specifier.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-specifier.src.js.shot
@@ -24,6 +24,7 @@ Object {
       "source": null,
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-specifiers-comma.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-specifiers-comma.src.js.shot
@@ -24,6 +24,7 @@ Object {
       "source": null,
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {
@@ -77,6 +78,7 @@ Object {
           "type": "ExportSpecifier",
         },
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-specifiers.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/export-named-specifiers.src.js.shot
@@ -24,6 +24,7 @@ Object {
       "source": null,
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {
@@ -77,6 +78,7 @@ Object {
           "type": "ExportSpecifier",
         },
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/import-default-and-named-specifiers.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/import-default-and-named-specifiers.src.js.shot
@@ -76,6 +76,7 @@ Object {
           "type": "ImportDefaultSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/import-default-as.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/import-default-as.src.js.shot
@@ -41,6 +41,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/import-named-as-specifier.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/import-named-as-specifier.src.js.shot
@@ -41,6 +41,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/import-named-as-specifiers.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/import-named-as-specifiers.src.js.shot
@@ -41,6 +41,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -94,6 +95,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/import-named-specifier.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/import-named-specifier.src.js.shot
@@ -41,6 +41,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/import-named-specifiers-comma.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/import-named-specifiers-comma.src.js.shot
@@ -41,6 +41,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -94,6 +95,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/import-named-specifiers.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/import-named-specifiers.src.js.shot
@@ -41,6 +41,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -94,6 +95,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/import-null-as-nil.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/import-null-as-nil.src.js.shot
@@ -41,6 +41,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/javascript/modules/invalid-export-named-default.src.js.shot
+++ b/packages/typescript-estree/tests/snapshots/javascript/modules/invalid-export-named-default.src.js.shot
@@ -24,6 +24,7 @@ Object {
       "source": null,
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/export-type-as.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/export-type-as.src.ts.shot
@@ -24,6 +24,7 @@ Object {
       "source": null,
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/export-type-from-as.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/export-type-from-as.src.ts.shot
@@ -42,6 +42,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/export-type-from.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/export-type-from.src.ts.shot
@@ -42,6 +42,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/export-type.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/export-type.src.ts.shot
@@ -24,6 +24,7 @@ Object {
       "source": null,
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/export-with-import-assertions.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/export-with-import-assertions.src.ts.shot
@@ -97,6 +97,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "exportKind": "value",
           "exported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/import-type-error.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/import-type-error.src.ts.shot
@@ -76,6 +76,7 @@ Object {
           "type": "ImportDefaultSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/import-type-named-as.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/import-type-named-as.src.ts.shot
@@ -41,6 +41,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/import-type-named.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/import-type-named.src.ts.shot
@@ -41,6 +41,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -94,6 +95,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/keyword-variables.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/keyword-variables.src.ts.shot
@@ -2354,6 +2354,7 @@ Object {
       },
       "specifiers": Array [
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2407,6 +2408,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2460,6 +2462,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2513,6 +2516,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2566,6 +2570,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2619,6 +2624,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2672,6 +2678,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2725,6 +2732,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2778,6 +2786,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2831,6 +2840,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2884,6 +2894,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2937,6 +2948,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -2990,6 +3002,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3043,6 +3056,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3096,6 +3110,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3149,6 +3164,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3202,6 +3218,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3255,6 +3272,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3308,6 +3326,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3361,6 +3380,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3414,6 +3434,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3467,6 +3488,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3520,6 +3542,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3573,6 +3596,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3626,6 +3650,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3679,6 +3704,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3732,6 +3758,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3785,6 +3812,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3838,6 +3866,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3891,6 +3920,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {
@@ -3944,6 +3974,7 @@ Object {
           "type": "ImportSpecifier",
         },
         Object {
+          "importKind": "value",
           "imported": Object {
             "loc": Object {
               "end": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/type-only-export-specifiers.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/type-only-export-specifiers.src.ts.shot
@@ -1,0 +1,373 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`typescript basics type-only-export-specifiers.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "declaration": null,
+      "exportKind": "value",
+      "loc": Object {
+        "end": Object {
+          "column": 37,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        37,
+      ],
+      "source": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 36,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 31,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          31,
+          36,
+        ],
+        "raw": "\\"mod\\"",
+        "type": "Literal",
+        "value": "mod",
+      },
+      "specifiers": Array [
+        Object {
+          "exportKind": "type",
+          "exported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 14,
+                "line": 1,
+              },
+            },
+            "name": "A",
+            "range": Array [
+              14,
+              15,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 9,
+              "line": 1,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 14,
+                "line": 1,
+              },
+            },
+            "name": "A",
+            "range": Array [
+              14,
+              15,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            9,
+            15,
+          ],
+          "type": "ExportSpecifier",
+        },
+        Object {
+          "exportKind": "type",
+          "exported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 23,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 22,
+                "line": 1,
+              },
+            },
+            "name": "B",
+            "range": Array [
+              22,
+              23,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 23,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 17,
+              "line": 1,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 23,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 22,
+                "line": 1,
+              },
+            },
+            "name": "B",
+            "range": Array [
+              22,
+              23,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            17,
+            23,
+          ],
+          "type": "ExportSpecifier",
+        },
+      ],
+      "type": "ExportNamedDeclaration",
+    },
+  ],
+  "comments": Array [],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    38,
+  ],
+  "sourceType": "module",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        6,
+      ],
+      "type": "Keyword",
+      "value": "export",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        7,
+        8,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        13,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        14,
+        15,
+      ],
+      "type": "Identifier",
+      "value": "A",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        15,
+        16,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        17,
+        21,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        22,
+        23,
+      ],
+      "type": "Identifier",
+      "value": "B",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        24,
+        25,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 30,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        26,
+        30,
+      ],
+      "type": "Identifier",
+      "value": "from",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 36,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        31,
+        36,
+      ],
+      "type": "String",
+      "value": "\\"mod\\"",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 37,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        36,
+        37,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/type-only-export-specifiers.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/type-only-export-specifiers.src.ts.shot
@@ -4,6 +4,7 @@ exports[`typescript basics type-only-export-specifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
+      "assertions": Array [],
       "declaration": null,
       "exportKind": "value",
       "loc": Object {

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/type-only-import-specifiers.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/type-only-import-specifiers.src.ts.shot
@@ -1,0 +1,372 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`typescript basics type-only-import-specifiers.src 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "importKind": "value",
+      "loc": Object {
+        "end": Object {
+          "column": 37,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        37,
+      ],
+      "source": Object {
+        "loc": Object {
+          "end": Object {
+            "column": 36,
+            "line": 1,
+          },
+          "start": Object {
+            "column": 31,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          31,
+          36,
+        ],
+        "raw": "\\"mod\\"",
+        "type": "Literal",
+        "value": "mod",
+      },
+      "specifiers": Array [
+        Object {
+          "importKind": "type",
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 14,
+                "line": 1,
+              },
+            },
+            "name": "A",
+            "range": Array [
+              14,
+              15,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 9,
+              "line": 1,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 14,
+                "line": 1,
+              },
+            },
+            "name": "A",
+            "range": Array [
+              14,
+              15,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            9,
+            15,
+          ],
+          "type": "ImportSpecifier",
+        },
+        Object {
+          "importKind": "type",
+          "imported": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 23,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 22,
+                "line": 1,
+              },
+            },
+            "name": "B",
+            "range": Array [
+              22,
+              23,
+            ],
+            "type": "Identifier",
+          },
+          "loc": Object {
+            "end": Object {
+              "column": 23,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 17,
+              "line": 1,
+            },
+          },
+          "local": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 23,
+                "line": 1,
+              },
+              "start": Object {
+                "column": 22,
+                "line": 1,
+              },
+            },
+            "name": "B",
+            "range": Array [
+              22,
+              23,
+            ],
+            "type": "Identifier",
+          },
+          "range": Array [
+            17,
+            23,
+          ],
+          "type": "ImportSpecifier",
+        },
+      ],
+      "type": "ImportDeclaration",
+    },
+  ],
+  "comments": Array [],
+  "loc": Object {
+    "end": Object {
+      "column": 0,
+      "line": 2,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  "range": Array [
+    0,
+    38,
+  ],
+  "sourceType": "module",
+  "tokens": Array [
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 6,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        6,
+      ],
+      "type": "Keyword",
+      "value": "import",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        7,
+        8,
+      ],
+      "type": "Punctuator",
+      "value": "{",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 13,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        9,
+        13,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        14,
+        15,
+      ],
+      "type": "Identifier",
+      "value": "A",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 16,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        15,
+        16,
+      ],
+      "type": "Punctuator",
+      "value": ",",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 21,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        17,
+        21,
+      ],
+      "type": "Identifier",
+      "value": "type",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 23,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        22,
+        23,
+      ],
+      "type": "Identifier",
+      "value": "B",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 25,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        24,
+        25,
+      ],
+      "type": "Punctuator",
+      "value": "}",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 30,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        26,
+        30,
+      ],
+      "type": "Identifier",
+      "value": "from",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 36,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        31,
+        36,
+      ],
+      "type": "String",
+      "value": "\\"mod\\"",
+    },
+    Object {
+      "loc": Object {
+        "end": Object {
+          "column": 37,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        36,
+        37,
+      ],
+      "type": "Punctuator",
+      "value": ";",
+    },
+  ],
+  "type": "Program",
+}
+`;

--- a/packages/typescript-estree/tests/snapshots/typescript/basics/type-only-import-specifiers.src.ts.shot
+++ b/packages/typescript-estree/tests/snapshots/typescript/basics/type-only-import-specifiers.src.ts.shot
@@ -4,6 +4,7 @@ exports[`typescript basics type-only-import-specifiers.src 1`] = `
 Object {
   "body": Array [
     Object {
+      "assertions": Array [],
       "importKind": "value",
       "loc": Object {
         "end": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,7 +285,12 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@*", "@babel/parser@^7.1.0", "@babel/parser@^7.12.16", "@babel/parser@^7.12.7", "@babel/parser@^7.16.0", "@babel/parser@^7.16.2", "@babel/parser@^7.7.2":
+"@babel/parser@*", "@babel/parser@^7.1.0", "@babel/parser@^7.16.0", "@babel/parser@^7.7.2":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.0.tgz#cf147d7ada0a3655e79bf4b08ee846f00a00a295"
+  integrity sha512-TEHWXf0xxpi9wKVyBCmRcSSDjbJ/cl6LUdlbYUHEaNQUJGhreJbZrXT6sR4+fZLxVUJqNRB4KyOvjuy/D9009A==
+
+"@babel/parser@^7.12.16", "@babel/parser@^7.12.7", "@babel/parser@^7.16.2":
   version "7.16.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.2.tgz#3723cd5c8d8773eef96ce57ea1d9b7faaccd12ac"
   integrity sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: #3950
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Adds support for type-only module specifiers.

Based on #4073
