### PR TITLE
fix(eslint-plugin): check optional chaining for floating promises

### DIFF
--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -65,7 +65,13 @@ export default util.createRule<Options, MessageId>({
           return;
         }
 
-        if (isUnhandledPromise(checker, node.expression)) {
+        let expression = node.expression;
+
+        if (expression.type === AST_NODE_TYPES.ChainExpression) {
+          expression = expression.expression;
+        }
+
+        if (isUnhandledPromise(checker, expression)) {
           if (options.ignoreVoid) {
             context.report({
               node,

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -335,6 +335,28 @@ async function test() {
   return returnsPromise();
 }
     `,
+    `
+const doSomething = async (
+  obj1: { a?: { b?: { c?: () => Promise<void> } } },
+  obj2: { a?: { b?: { c: () => Promise<void> } } },
+  obj3: { a?: { b: { c?: () => Promise<void> } } },
+  obj4: { a: { b: { c?: () => Promise<void> } } },
+  obj5: { a?: () => { b?: { c?: () => Promise<void> } } },
+  obj6?: { a: { b: { c?: () => Promise<void> } } },
+  callback?: () => Promise<void>,
+): Promise<void> => {
+  await obj1.a?.b?.c?.();
+  await obj2.a?.b?.c();
+  await obj3.a?.b.c?.();
+  await obj4.a.b.c?.();
+  await obj5.a?.().b?.c?.();
+  await obj6?.a.b.c?.();
+
+  return callback?.();
+};
+
+void doSomething();
+    `,
     // ignoreIIFE
     {
       code: `
@@ -410,6 +432,64 @@ async function test() {
         },
         {
           line: 6,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
+      code: `
+const doSomething = async (
+  obj1: { a?: { b?: { c?: () => Promise<void> } } },
+  obj2: { a?: { b?: { c: () => Promise<void> } } },
+  obj3: { a?: { b: { c?: () => Promise<void> } } },
+  obj4: { a: { b: { c?: () => Promise<void> } } },
+  obj5: { a?: () => { b?: { c?: () => Promise<void> } } },
+  obj6?: { a: { b: { c?: () => Promise<void> } } },
+  callback?: () => Promise<void>,
+): Promise<void> => {
+  obj1.a?.b?.c?.();
+  obj2.a?.b?.c();
+  obj3.a?.b.c?.();
+  obj4.a.b.c?.();
+  obj5.a?.().b?.c?.();
+  obj6?.a.b.c?.();
+
+  callback?.();
+};
+
+doSomething();
+      `,
+      errors: [
+        {
+          line: 11,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 12,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 13,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 14,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 15,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 16,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 18,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 21,
           messageId: 'floatingVoid',
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4095
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Changes `no-floating-promises` to "expand" optional chain so that it's expression is checked.
