### PR TITLE
test(eslint-plugin): add optional chaining cases for `await-thenable`

### DIFF
--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -176,6 +176,26 @@ async function test() {
   await bluebird;
 }
     `,
+    `
+const doSomething = async (
+  obj1: { a?: { b?: { c?: () => Promise<void> } } },
+  obj2: { a?: { b?: { c: () => Promise<void> } } },
+  obj3: { a?: { b: { c?: () => Promise<void> } } },
+  obj4: { a: { b: { c?: () => Promise<void> } } },
+  obj5: { a?: () => { b?: { c?: () => Promise<void> } } },
+  obj6?: { a: { b: { c?: () => Promise<void> } } },
+  callback?: () => Promise<void>,
+): Promise<void> => {
+  await obj1.a?.b?.c?.();
+  await obj2.a?.b?.c();
+  await obj3.a?.b.c?.();
+  await obj4.a.b.c?.();
+  await obj5.a?.().b?.c?.();
+  await obj6?.a.b.c?.();
+
+  await callback?.();
+};
+    `,
   ],
 
   invalid: [
@@ -224,6 +244,58 @@ async function test() {
       errors: [
         {
           line: 8,
+          messageId,
+        },
+      ],
+    },
+    {
+      code: `
+const doSomething = async (
+  obj1: { a?: { b?: { c?: () => void } } },
+  obj2: { a?: { b?: { c: () => void } } },
+  obj3: { a?: { b: { c?: () => void } } },
+  obj4: { a: { b: { c?: () => void } } },
+  obj5: { a?: () => { b?: { c?: () => void } } },
+  obj6?: { a: { b: { c?: () => void } } },
+  callback?: () => void,
+): Promise<void> => {
+  await obj1.a?.b?.c?.();
+  await obj2.a?.b?.c();
+  await obj3.a?.b.c?.();
+  await obj4.a.b.c?.();
+  await obj5.a?.().b?.c?.();
+  await obj6?.a.b.c?.();
+
+  await callback?.();
+};
+      `,
+      errors: [
+        {
+          line: 11,
+          messageId,
+        },
+        {
+          line: 12,
+          messageId,
+        },
+        {
+          line: 13,
+          messageId,
+        },
+        {
+          line: 14,
+          messageId,
+        },
+        {
+          line: 15,
+          messageId,
+        },
+        {
+          line: 16,
+          messageId,
+        },
+        {
+          line: 18,
           messageId,
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Added tests based on #4095 to confirm that `await-thenable` supports optional chaining and continues to do in future.