### PR TITLE
fix(eslint-plugin): [explicit-member-accessibility] private fields cannot have accessibility modifiers

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
+++ b/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
@@ -214,6 +214,10 @@ export default util.createRule<Options, MessageIds>({
         | TSESTree.PropertyDefinition
         | TSESTree.TSAbstractPropertyDefinition,
     ): void {
+      if (propertyDefinition.key.type === AST_NODE_TYPES.PrivateIdentifier) {
+        return;
+      }
+
       const nodeType = 'class property';
 
       const { name: propertyName } = util.getNameFromMember(

--- a/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
@@ -342,7 +342,7 @@ class Test {
   #bar() {}
 }
       `,
-      options: [{ accessibility: 'no-public' }],
+      options: [{ accessibility: 'explicit' }],
     },
   ],
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1666
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Private fields, like methods, cannot have accessibility modifiers, and so they shouldnt be required by this rule. To fix this I took the fix that was already done for private methods (#3808) and applied it to private fields too. 