### PR TITLE
feat(experimental-utils): add default [] for RuleModule TOptions generic

### DIFF
--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -429,7 +429,7 @@ interface RuleListener {
 
 interface RuleModule<
   TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  TOptions extends readonly unknown[] = [],
   // for extending base rules
   TRuleListener extends RuleListener = RuleListener,
 > {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4134
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

Allow `TOptions` to default to `[]` so there's less overhead in setting up rules. Related to https://github.com/typescript-eslint/typescript-eslint/pull/4124.
