### PR TITLE
feat: add RuleCreator.withoutDocs

### DIFF
--- a/packages/eslint-plugin/tests/docs.test.ts
+++ b/packages/eslint-plugin/tests/docs.test.ts
@@ -111,7 +111,7 @@ describe('Validating rule metadata', () => {
         // validate if rule name is same as url
         // there is no way to access this field but its used only in generation of docs url
         expect(
-          rule.meta.docs?.url.endsWith(`rules/${ruleName}.md`),
+          rule.meta.docs?.url?.endsWith(`rules/${ruleName}.md`),
         ).toBeTruthy();
       });
 

--- a/packages/experimental-utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/experimental-utils/src/eslint-utils/RuleCreator.ts
@@ -8,33 +8,61 @@ import {
 import { applyDefault } from './applyDefault';
 
 // we automatically add the url
-type CreateRuleMetaDocs = Omit<RuleMetaDataDocs, 'url'>;
-type CreateRuleMeta<TMessageIds extends string> = {
-  docs: CreateRuleMetaDocs;
+type NamedCreateRuleMetaDocs = Omit<RuleMetaDataDocs, 'url'>;
+type NamedCreateRuleMeta<TMessageIds extends string> = {
+  docs: NamedCreateRuleMetaDocs;
 } & Omit<RuleMetaData<TMessageIds>, 'docs'>;
 
+interface CreateAndOptions<
+  TOptions extends readonly unknown[],
+  TMessageIds extends string,
+  TRuleListener extends RuleListener,
+> {
+  create: (
+    context: Readonly<RuleContext<TMessageIds, TOptions>>,
+    optionsWithDefault: Readonly<TOptions>,
+  ) => TRuleListener;
+  defaultOptions: Readonly<TOptions>;
+}
+
+interface RuleWithMeta<
+  TOptions extends readonly unknown[],
+  TMessageIds extends string,
+  TRuleListener extends RuleListener,
+> extends CreateAndOptions<TOptions, TMessageIds, TRuleListener> {
+  meta: RuleMetaData<TMessageIds>;
+}
+
+interface RuleWithMetaAndName<
+  TOptions extends readonly unknown[],
+  TMessageIds extends string,
+  TRuleListener extends RuleListener,
+> extends CreateAndOptions<TOptions, TMessageIds, TRuleListener> {
+  meta: NamedCreateRuleMeta<TMessageIds>;
+  name: string;
+}
+
+/**
+ * Creates reusable function to create rules with default options and docs URLs.
+ *
+ * @param urlCreator Creates a documentation URL for a given rule name.
+ * @returns Function to create a rule with the docs URL format.
+ */
 function RuleCreator(urlCreator: (ruleName: string) => string) {
   // This function will get much easier to call when this is merged https://github.com/Microsoft/TypeScript/pull/26349
   // TODO - when the above PR lands; add type checking for the context.report `data` property
-  return function createRule<
+  return function createNamedRule<
     TOptions extends readonly unknown[],
     TMessageIds extends string,
     TRuleListener extends RuleListener = RuleListener,
   >({
     name,
     meta,
-    defaultOptions,
-    create,
-  }: Readonly<{
-    name: string;
-    meta: CreateRuleMeta<TMessageIds>;
-    defaultOptions: Readonly<TOptions>;
-    create: (
-      context: Readonly<RuleContext<TMessageIds, TOptions>>,
-      optionsWithDefault: Readonly<TOptions>,
-    ) => TRuleListener;
-  }>): RuleModule<TMessageIds, TOptions, TRuleListener> {
-    return {
+    ...rule
+  }: Readonly<
+    RuleWithMetaAndName<TOptions, TMessageIds, TRuleListener>
+  >): RuleModule<TMessageIds, TOptions, TRuleListener> {
+    return createRule<TOptions, TMessageIds, TRuleListener>({
       meta: {
         ...meta,
         docs: {
@@ -42,17 +70,41 @@ function RuleCreator(urlCreator: (ruleName: string) => string) {
           url: urlCreator(name),
         },
       },
-      create(
-        context: Readonly<RuleContext<TMessageIds, TOptions>>,
-      ): TRuleListener {
-        const optionsWithDefault = applyDefault(
-          defaultOptions,
-          context.options,
-        );
-        return create(context, optionsWithDefault);
-      },
-    };
+      ...rule,
+    });
   };
 }
+
+/**
+ * Creates a well-typed TSESLint custom ESLint rule without a docs URL.
+ *
+ * @returns Well-typed TSESLint custom ESLint rule.
+ * @remarks It is generally better to provide a docs URL function to RuleCreator.
+ */
+function createRule<
+  TOptions extends readonly unknown[],
+  TMessageIds extends string,
+  TRuleListener extends RuleListener = RuleListener,
+>({
+  create,
+  defaultOptions,
+  meta,
+}: Readonly<RuleWithMeta<TOptions, TMessageIds, TRuleListener>>): RuleModule<
+  TMessageIds,
+  TOptions,
+  TRuleListener
+> {
+  return {
+    meta,
+    create(
+      context: Readonly<RuleContext<TMessageIds, TOptions>>,
+    ): TRuleListener {
+      const optionsWithDefault = applyDefault(defaultOptions, context.options);
+      return create(context, optionsWithDefault);
+    },
+  };
+}
+
+RuleCreator.withoutDocs = createRule;
 
 export { RuleCreator };

--- a/packages/experimental-utils/src/ts-eslint/Rule.ts
+++ b/packages/experimental-utils/src/ts-eslint/Rule.ts
@@ -19,7 +19,7 @@ interface RuleMetaDataDocs {
   /**
    * The URL of the rule's docs
    */
-  url: string;
+  url?: string;
   /**
    * Specifies whether the rule can return suggestions.
    */


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4133
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

Allows this:

```ts
import { ESLintUtils } from '@typescript-eslint/experimental-utils';

const myRule = ESLintUtils.RuleCreator.withoutDocs({
  create(context) {
    // ...
  },
  meta: {
    // ...
  },
});
```

I'm not 100% attached to this particular API. I chose it because it forces people to import `RuleCreator` anyway and has a _"you're not documenting this"_ name.

Adds a bit of JSDoc around the two functions to help make them clear in IDEs.