### PR TITLE
fix(experimental-utils): fix types for eslint-utils

### DIFF
--- a/packages/experimental-utils/src/ast-utils/eslint-utils/ReferenceTracker.ts
+++ b/packages/experimental-utils/src/ast-utils/eslint-utils/ReferenceTracker.ts
@@ -83,7 +83,7 @@ namespace ReferenceTracker {
     node: TSESTree.Node;
     path: readonly string[];
     type: ReferenceType;
-    entry: T;
+    info: T;
   }
 }
 

--- a/packages/experimental-utils/src/ast-utils/eslint-utils/astUtilities.ts
+++ b/packages/experimental-utils/src/ast-utils/eslint-utils/astUtilities.ts
@@ -25,6 +25,7 @@ const getFunctionNameWithKind = eslintUtils.getFunctionNameWithKind as (
     | TSESTree.FunctionDeclaration
     | TSESTree.FunctionExpression
     | TSESTree.ArrowFunctionExpression,
+  sourceCode?: TSESLint.SourceCode,
 ) => string;
 
 /**
@@ -38,7 +39,8 @@ const getPropertyName = eslintUtils.getPropertyName as (
   node:
     | TSESTree.MemberExpression
     | TSESTree.Property
-    | TSESTree.MethodDefinition,
+    | TSESTree.MethodDefinition
+    | TSESTree.PropertyDefinition,
   initialScope?: TSESLint.Scope.Scope,
 ) => string | null;
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4159
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Fixed typings for `ReferenceTracker`, `getFunctionNameWithKind` and `getPropertyName`, re-exported from `eslint-utils`.
