### PR TITLE
fix(visitor-keys): add missing import assertion keys

### DIFF
--- a/packages/visitor-keys/src/visitor-keys.ts
+++ b/packages/visitor-keys/src/visitor-keys.ts
@@ -19,9 +19,6 @@ const additionalKeys: AdditionalKeys = {
   // Stage 3 Import Assertions
   ImportAttribute: ['key', 'value'],
 
-  // ES2020
-  ImportExpression: ['source'],
-
   // Additional Properties.
   ArrayPattern: ['decorators', 'elements', 'typeAnnotation'],
   ArrowFunctionExpression: ['typeParameters', 'params', 'returnType', 'body'],
@@ -45,9 +42,13 @@ const additionalKeys: AdditionalKeys = {
     'implements',
     'body',
   ],
+  ExportAllDeclaration: ['exported', 'source', 'assertions'],
+  ExportNamedDeclaration: ['declaration', 'specifiers', 'source', 'assertions'],
   FunctionDeclaration: ['id', 'typeParameters', 'params', 'returnType', 'body'],
   FunctionExpression: ['id', 'typeParameters', 'params', 'returnType', 'body'],
   Identifier: ['decorators', 'typeAnnotation'],
+  ImportDeclaration: ['specifiers', 'source', 'assertions'],
+  ImportExpression: ['source', 'attributes'],
   MethodDefinition: ['decorators', 'key', 'value'],
   NewExpression: ['callee', 'typeParameters', 'arguments'],
   ObjectPattern: ['decorators', 'properties', 'typeAnnotation'],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4177
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md) were taken

## Overview

Add the missing key. This allows the rules to traverse the ImportAttribute.
