### PR TITLE
fix(eslint-plugin): [no-duplicate-imports] remove unnecessary type checking for `node.source`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-duplicate-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-imports.ts
@@ -54,16 +54,6 @@ export default util.createRule<Options, MessageIds>({
       });
     }
 
-    function isStringLiteral(
-      node: TSESTree.Node | null,
-    ): node is TSESTree.StringLiteral {
-      return (
-        !!node &&
-        node.type === AST_NODE_TYPES.Literal &&
-        typeof node.value === 'string'
-      );
-    }
-
     function isAllMemberImport(node: TSESTree.ImportDeclaration): boolean {
       return node.specifiers.every(
         specifier => specifier.type === AST_NODE_TYPES.ImportSpecifier,
@@ -71,7 +61,7 @@ export default util.createRule<Options, MessageIds>({
     }
 
     function checkTypeImport(node: TSESTree.ImportDeclaration): void {
-      if (isStringLiteral(node.source)) {
+      if (node.source) {
         const value = node.source.value;
         const isMemberImport = isAllMemberImport(node);
         if (
@@ -96,7 +86,7 @@ export default util.createRule<Options, MessageIds>({
     function checkTypeExport(
       node: TSESTree.ExportNamedDeclaration | TSESTree.ExportAllDeclaration,
     ): void {
-      if (isStringLiteral(node.source)) {
+      if (node.source) {
         const value = node.source.value;
         if (typeExports.has(value)) {
           report('exportType', node, value);


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Since v5.x, `source` of `ExportNamedDeclaration`, `ExportAllDeclaration` and `ImportDeclaration` is always `StringLiteral`.
