### PR TITLE
feat(eslint-plugin): [no-throw-literal] add options to to disallow `any`/`unknown`

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-throw-literal.md
+++ b/packages/eslint-plugin/docs/rules/no-throw-literal.md
@@ -3,7 +3,7 @@
 It is considered good practice to only `throw` the `Error` object itself or an object using the `Error` object as base objects for user-defined exceptions.
 The fundamental benefit of `Error` objects is that they automatically keep track of where they were built and originated.
 
-This rule restricts what can be thrown as an exception. When it was first created, it only prevented literals from being thrown (hence the name), but it has now been expanded to only allow expressions which have a possibility of being an `Error` object.
+This rule restricts what can be thrown as an exception. When it was first created, it only prevented literals from being thrown (hence the name), but it has now been expanded to only allow expressions which have a possibility of being an `Error` object. With the `allowThrowingAny` and `allowThrowingUnknown`, it can be configured to only allow throwing values which are guaranteed to be an instance of `Error`.
 
 ## Rule Details
 
@@ -90,6 +90,20 @@ throw new CustomError();
   // note you must disable the base rule as it can report incorrect errors
   "no-throw-literal": "off",
   "@typescript-eslint/no-throw-literal": ["error"]
+}
+```
+
+### Options
+
+```jsonc
+{
+  "@typescript-eslint/no-throw-literal": [
+    "error",
+    {
+      "allowThrowingAny": true, // Default is to allow throwing values of type any
+      "allowThrowingUnknown": true // Default is to allow throwing values of type unknown
+    }
+  ]
 }
 ```
 

--- a/packages/eslint-plugin/tests/rules/no-throw-literal.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-throw-literal.test.ts
@@ -438,7 +438,7 @@ throw foo as string;
 function fun(value: any) {
   throw value;
 }
-          `,
+      `,
       errors: [
         {
           messageId: 'object',
@@ -455,7 +455,7 @@ function fun(value: any) {
 function fun(value: unknown) {
   throw value;
 }
-          `,
+      `,
       errors: [
         {
           messageId: 'object',

--- a/packages/eslint-plugin/tests/rules/no-throw-literal.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-throw-literal.test.ts
@@ -123,6 +123,16 @@ throw nullishError || new Error();
 declare const nullishError: Error | undefined;
 throw nullishError ? nullishError : new Error();
     `,
+    `
+function fun(value: any) {
+  throw value;
+}
+    `,
+    `
+function fun(value: unknown) {
+  throw value;
+}
+    `,
   ],
   invalid: [
     {
@@ -422,6 +432,40 @@ declare const foo: Error | string;
 throw foo as string;
       `,
       errors: [{ messageId: 'object' }],
+    },
+    {
+      code: `
+function fun(value: any) {
+  throw value;
+}
+          `,
+      errors: [
+        {
+          messageId: 'object',
+        },
+      ],
+      options: [
+        {
+          allowThrowingAny: false,
+        },
+      ],
+    },
+    {
+      code: `
+function fun(value: unknown) {
+  throw value;
+}
+          `,
+      errors: [
+        {
+          messageId: 'object',
+        },
+      ],
+      options: [
+        {
+          allowThrowingUnknown: false,
+        },
+      ],
     },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/4206
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR adds the following options to `@typescript-eslint/no-throw-literal`:
```jsonc
{
  "allowThrowingAny": true, // Default is to allow throwing values of type any
  "allowThrowingUnknown": true // Default is to allow throwing values of type unknown
}
```

When enabled, these rules result in an error being generated from code such as:
```typescript
function fun(value: any) {
  throw value;
}

function fun(value: unknown) {
  throw value;
}
```

This is useful when using this rule to prevent the `throw`ing of values that aren't instances of `Error` - because values of type `any` and `unknown` are not necessarily instances of `Error`.

The default values have the same behaviour as the current code.