### PR TITLE
docs(website): fix `node` to `originalNode` in type checking example

### DIFF
--- a/docs/development/CUSTOM_RULES.md
+++ b/docs/development/CUSTOM_RULES.md
@@ -240,7 +240,7 @@ export const rule: eslint.Rule.RuleModule = {
         const originalNode = parserServices.esTreeNodeToTSNodeMap.get(
           node.right,
         );
-        const nodeType = checker.getTypeAtLocation(node);
+        const nodeType = checker.getTypeAtLocation(originalNode);
 
         // 3. Check the TS node type using the TypeScript APIs
         if (tsutils.isTypeFlagSet(nodeType, ts.TypeFlags.EnumLike)) {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #000
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Correct the example in the type checking section. The type that `checker.getTypeAtLocation` accepts is a TS Node not a ES Node. 
