### PR TITLE
docs(eslint-plugin): Mention `useUnknownInCatchVariables` in `no-implicit-any-catch`

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md
+++ b/packages/eslint-plugin/docs/rules/no-implicit-any-catch.md
@@ -4,7 +4,7 @@ TypeScript 4.0 added support for adding an explicit `any` or `unknown` type anno
 
 By default, TypeScript will type a catch clause variable as `any`, so explicitly annotating it as `unknown` can add a lot of safety to your codebase.
 
-The `noImplicitAny` flag in TypeScript does not cover this for backwards compatibility reasons.
+The `noImplicitAny` flag in TypeScript does not cover this for backwards compatibility reasons, however you can use `useUnknownInCatchVariables` (part of `strict`) instead of this rule.
 
 ## Rule Details
 


### PR DESCRIPTION
## PR Checklist

-   [ ] Addresses an existing issue
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

https://github.com/microsoft/TypeScript/pull/41013 added `useUnknownInCatchVariables` which implies `unknown` instead of `any`, meaning this rule is actually wrong when when that's enabled (because it's no longer "implicit any catch")