### PR TITLE
docs(website): fix tsconfig.eslint.json instead of .eslintrc.js in code snippet

### DIFF
--- a/docs/linting/MONOREPO.md
+++ b/docs/linting/MONOREPO.md
@@ -56,21 +56,22 @@ If you've only got one, you should inspect the `include` paths. If it doesn't in
 The former doesn't always work for everyone if they've got a complex build, as adding more paths (like test paths) to `include` could break the build.
 In those cases we suggest creating a new config called `tsconfig.eslint.json`, that looks something like this:
 
-```js title=".eslintrc.js"
-module.exports = {
+```jsonc title="tsconfig.eslint.json"
+{
   // extend your base config to share compilerOptions, etc
-  extends: './tsconfig.json',
-  compilerOptions: {
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
     // ensure that nobody can accidentally use this config for a build
-    noEmit: true,
+    "noEmit": true
   },
-  include: [
+  "include": [
     // whatever paths you intend to lint
-    'src',
-    'test',
-    'tools',
-  ],
-};
+    "src",
+    "test",
+    "tools"
+  ]
+}
+
 ```
 
 Ensure you update your `.eslintrc.js` to point at this new config file.

--- a/docs/linting/MONOREPO.md
+++ b/docs/linting/MONOREPO.md
@@ -71,7 +71,6 @@ In those cases we suggest creating a new config called `tsconfig.eslint.json`, t
     "tools"
   ]
 }
-
 ```
 
 Ensure you update your `.eslintrc.js` to point at this new config file.


### PR DESCRIPTION
## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [X] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Use tsconfig.eslint.json instead of .eslint.js in the code snippet at /docs/linting/monorepo

The paragraph mentions a `tsconfig.eslint.json` file but the example is a javascript snippet named `.eslintrc.js`

<img width="838" alt="Screen Shot 2021-12-06 at 13 05 16" src="https://user-images.githubusercontent.com/12036916/144906552-cac8e74c-2985-4793-a006-a3ddaf52e0f2.png">
