### PR TITLE
fix(typescript-estree): type-only regression for consumers not yet on TS 4.5

### DIFF
--- a/packages/typescript-estree/src/ts-estree/ts-nodes.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-nodes.ts
@@ -8,6 +8,8 @@ declare module 'typescript' {
   export interface TemplateLiteralTypeNode extends ts.Node {}
   export interface PrivateIdentifier extends ts.Node {}
   export interface ClassStaticBlockDeclaration extends ts.Node {}
+  export interface AssertClause extends ts.Node {}
+  export interface AssertEntry extends ts.Node {}
   /* eslint-enable @typescript-eslint/no-empty-interface */
 }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4164
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I tested with typesript `4.4` variations and got another error so I added `AssertClause` aside from mentioned issue's `AssertEntry`(Maybe I did it with wrong local setting?)
![스크린샷 2021-12-07 오후 10 03 02](https://user-images.githubusercontent.com/15892571/145038305-22713dc7-f2f0-4db4-a5bf-0807fd92d543.png)

