### PR TITLE
chore: update codecov/codecov-action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,9 +140,10 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./packages/**/coverage/lcov.info
+          files: packages/**/coverage/lcov.info
           flags: unittest
           name: codecov
+          verbose: true
 
   linting_and_style:
     name: Code style and lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,10 @@ jobs:
           CI: true
 
       - name: Publish code coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./packages/*/coverage/lcov.info
           flags: unittest
           name: codecov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./packages/*/coverage/lcov.info
+          files: ./packages/**/coverage/lcov.info
           flags: unittest
           name: codecov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,6 @@ jobs:
           files: packages/**/coverage/lcov.info
           flags: unittest
           name: codecov
-          verbose: true
 
   linting_and_style:
     name: Code style and lint


### PR DESCRIPTION
## Overview

https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1

> On February 1, 2022, this version will be fully sunset and no longer function
>
> Due to the deprecation of the underlying bash uploader, the Codecov GitHub Action has released v2 which will use the new uploader. You can learn more about our deprecation plan and the new uploader on our blog.
>
> We will be restricting any updates to the v1 Action to security updates and hotfixes.

This PR also fixes coverage report sent to codecov, we should not submit again coverage for all packages

https://app.codecov.io/gh/typescript-eslint/typescript-eslint/compare/4278/tree/packages

new: 
![image](https://user-images.githubusercontent.com/625469/145322845-5c3bee05-982d-4d12-a514-97bfe428d7db.png)

old:
![image](https://user-images.githubusercontent.com/625469/145322824-a6392938-a295-4a0b-8b18-b7b0a9eb6a18.png)