### PR TITLE
docs(website): add community links to footer

### DIFF
--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -121,6 +121,34 @@ const config = {
           src: 'https://www.netlify.com/img/global/badges/netlify-dark.svg',
           href: 'https://www.netlify.com',
         },
+        links: [
+          {
+            title: 'Community',
+            items: [
+              {
+                label: 'Stack Overflow',
+                href: 'https://stackoverflow.com/questions/tagged/typescript-eslint',
+              },
+              {
+                label: 'Twitter',
+                href: 'https://twitter.com/tseslint',
+              },
+            ],
+          },
+          {
+            title: 'More',
+            items: [
+              {
+                label: 'GitHub',
+                href: 'https://github.com/typescript-eslint/typescript-eslint',
+              },
+              {
+                label: 'Report issue',
+                href: 'https://github.com/typescript-eslint/typescript-eslint/issues/new/choose',
+              },
+            ],
+          },
+        ],
         // style: 'primary',
         copyright: `Copyright © ${new Date().getFullYear()} TypeScript ESLint, Inc. Built with Docusaurus.`,
       },


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #000
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Add links to footer, 

as for UI, I'm not sure if we should wait for https://github.com/facebook/docusaurus/issues/6101 or just swizzle this component for now

![image](https://user-images.githubusercontent.com/625469/145740746-c51dd68e-34f3-471f-82d5-1a186926bb05.png)
