### PR TITLE
docs: align colors of code block

### DIFF
--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -1,9 +1,6 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const lightCodeTheme = require('prism-react-renderer/themes/github');
-const darkCodeTheme = require('prism-react-renderer/themes/dracula');
-
 const remarkPlugins = [
   [require('@docusaurus/remark-plugin-npm2yarn'), { sync: true }],
 ];
@@ -157,8 +154,10 @@ const config = {
         copyright: `Copyright © ${new Date().getFullYear()} TypeScript ESLint, Inc. Built with Docusaurus.`,
       },
       prism: {
-        theme: lightCodeTheme,
-        darkTheme: darkCodeTheme,
+        theme: {
+          plain: {},
+          styles: [],
+        },
         additionalLanguages: ['ignore'],
       },
       tableOfContents: {

--- a/packages/website/src/components/ast/ASTViewer.module.css
+++ b/packages/website/src/components/ast/ASTViewer.module.css
@@ -43,39 +43,39 @@
 }
 
 .tokenName {
-  color: #2aa198;
+  color: var(--token-color-class-name);
 }
 
 .propName {
-  color: #b58900;
+  color: var(--token-color-property);
 }
 
 .propNumber {
-  color: #268bd2;
+  color: var(--token-color-number);
 }
 
 .propEmpty {
-  color: var(--ifm-color-emphasis-400);
+  color: var(--token-color-comment);
 }
 
 .propRegExp {
-  color: #b58900;
+  color: var(--token-color-regexp);
 }
 
 .propClass {
-  color: #b58900;
+  color: var(--token-color-class-name);
 }
 
 .propBoolean {
-  color: #b58900;
+  color: var(--token-color-boolean);
 }
 
 .propString {
-  color: #15aa15;
+  color: var(--token-color-string);
 }
 
 .hidden {
-  color: var(--ifm-color-emphasis-400);
+  color: var(--token-color-comment);
   max-width: 40%;
   overflow: hidden;
   display: inline-block;

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -5,6 +5,8 @@
  * work well for content-centric websites.
  */
 
+@import './prism.css';
+
 /* You can override the default Infima variables here. */
 :root {
   --ifm-color-primary: #3578e5;

--- a/packages/website/src/css/prism.css
+++ b/packages/website/src/css/prism.css
@@ -22,7 +22,7 @@
 
   --token-color-inserted: #36acaa;
   --token-color-deleted: #d73a49;
-  --token-color-unchanged: #82827d;
+  --token-color-unchanged: #a7a9a8;
 
   --token-color-highlight: rgba(193, 222, 241, 0.2);
 }
@@ -50,7 +50,7 @@ html[data-theme='dark'] {
   --token-color-boolean: #569cd6;
 
   --token-color-inserted: #50fa7b;
-  --token-color-deleted: #ff5555;
+  --token-color-deleted: #f55;
   --token-color-unchanged: #a6a6a6;
 
   --token-color-highlight: rgba(247, 235, 198, 0.2);

--- a/packages/website/src/css/prism.css
+++ b/packages/website/src/css/prism.css
@@ -11,8 +11,6 @@
   --token-color-number: #098658;
   --token-color-keyword: #0000ff;
   --token-color-function: #000000;
-  --token-color-inserted: #36acaa;
-  --token-color-deleted: #d73a49;
   --token-color-important: #e90;
   --token-color-class-name: #2b91af;
   --token-color-selector: #800000;
@@ -20,6 +18,10 @@
   --token-color-property: #ff0000;
   --token-color-builtin: #0000ff;
   --token-color-boolean: #0000ff;
+
+  --token-color-inserted: #36acaa;
+  --token-color-deleted: #d73a49;
+  --token-color-unchanged: #82827d;
 
   --token-color-highlight: rgba(193, 222, 241, 0.2);
 }
@@ -36,9 +38,7 @@ html[data-theme='dark'] {
   --token-color-symbol: #b5cea8;
   --token-color-number: #b5cea8;
   --token-color-keyword: #569cd6;
-  --token-color-function: #569cd6;
-  --token-color-inserted: #50fa7b;
-  --token-color-deleted: #ff5555;
+  --token-color-function: #f8f8f2;
   --token-color-important: #569cd6;
   --token-color-class-name: #4ec9b0;
   --token-color-selector: #d7ba7d;
@@ -46,6 +46,10 @@ html[data-theme='dark'] {
   --token-color-property: #ce9178;
   --token-color-builtin: #569cd6;
   --token-color-boolean: #569cd6;
+
+  --token-color-inserted: #50fa7b;
+  --token-color-deleted: #ff5555;
+  --token-color-unchanged: #a6a6a6;
 
   --token-color-highlight: rgba(247, 235, 198, 0.2);
 }
@@ -114,6 +118,10 @@ div[class*='codeBlockContainer'] pre {
 
 .token.deleted {
   color: var(--token-color-deleted);
+}
+
+.token.unchanged {
+  color: var(--token-color-unchanged);
 }
 
 .token.important {

--- a/packages/website/src/css/prism.css
+++ b/packages/website/src/css/prism.css
@@ -1,0 +1,160 @@
+:root {
+  --token-color: #393a34;
+  --token-background: #f6f8fa;
+  --token-border: var(--ifm-color-emphasis-300);
+
+  --token-color-comment: #999988;
+  --token-color-doctype: #008000;
+  --token-color-string: #a31515;
+  --token-color-operator: #393a34;
+  --token-color-symbol: #36acaa;
+  --token-color-number: #098658;
+  --token-color-keyword: #0000ff;
+  --token-color-function: #000000;
+  --token-color-inserted: #36acaa;
+  --token-color-deleted: #d73a49;
+  --token-color-important: #e90;
+  --token-color-class-name: #2b91af;
+  --token-color-selector: #800000;
+  --token-color-regexp: #800000;
+  --token-color-property: #ff0000;
+  --token-color-builtin: #0000ff;
+  --token-color-boolean: #0000ff;
+
+  --token-color-highlight: rgba(193, 222, 241, 0.2);
+}
+
+html[data-theme='dark'] {
+  --token-color: #f8f8f2;
+  --token-background: var(--ifm-background-surface-color);
+  --token-border: #414458;
+
+  --token-color-comment: #737373;
+  --token-color-doctype: #6a9955;
+  --token-color-string: #6a9955;
+  --token-color-operator: #d4d4d4;
+  --token-color-symbol: #b5cea8;
+  --token-color-number: #b5cea8;
+  --token-color-keyword: #569cd6;
+  --token-color-function: #569cd6;
+  --token-color-inserted: #50fa7b;
+  --token-color-deleted: #ff5555;
+  --token-color-important: #569cd6;
+  --token-color-class-name: #4ec9b0;
+  --token-color-selector: #d7ba7d;
+  --token-color-regexp: #d7ba7d;
+  --token-color-property: #ce9178;
+  --token-color-builtin: #569cd6;
+  --token-color-boolean: #569cd6;
+
+  --token-color-highlight: rgba(247, 235, 198, 0.2);
+}
+
+div[class*='codeBlockContainer'],
+div[class*='codeBlockContainer'] pre {
+  color: var(--token-color);
+  background-color: var(--token-background);
+  --ifm-color-emphasis-300: var(--token-border);
+}
+
+.token.comment {
+  color: var(--token-color-comment);
+  font-style: italic;
+}
+
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: var(--token-color-doctype);
+  font-style: italic;
+}
+
+.token.namespace {
+  opacity: 0.7;
+}
+
+.token.string,
+.token.char {
+  color: var(--token-color-string);
+}
+
+.token.punctuation,
+.token.operator {
+  color: var(--token-color-operator);
+}
+
+.token.number {
+  color: var(--token-color-number);
+}
+
+.token.boolean {
+  color: var(--token-color-boolean);
+}
+
+.token.url,
+.token.symbol,
+.token.variable,
+.token.constant {
+  color: var(--token-color-symbol);
+}
+
+.token.inserted {
+  color: var(--token-color-inserted);
+}
+
+.token.atrule,
+.token.keyword,
+.token.attr-value {
+  color: var(--token-color-keyword);
+}
+
+.token.function {
+  color: var(--token-color-function);
+}
+
+.token.deleted {
+  color: var(--token-color-deleted);
+}
+
+.token.important {
+  color: var(--token-color-important);
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+
+.token.italic {
+  font-style: italic;
+}
+
+.token.class-name,
+.token.maybe-class-name {
+  color: var(--token-color-class-name);
+}
+
+.token.tag,
+.token.selector {
+  color: var(--token-color-selector);
+}
+
+.token.builtin {
+  color: var(--token-color-builtin);
+}
+
+.token.regex {
+  color: var(--token-color-regexp);
+}
+
+.token.attr-name,
+.token.property,
+.token.entity {
+  color: var(--token-color-property);
+}
+
+.line-highlight.line-highlight {
+  background: var(--token-color-highlight);
+  box-shadow: inset 5px 0 0 var(--token-color-highlight);
+  z-index: 0;
+}

--- a/packages/website/src/css/prism.css
+++ b/packages/website/src/css/prism.css
@@ -10,7 +10,8 @@
   --token-color-symbol: #36acaa;
   --token-color-number: #098658;
   --token-color-keyword: #0000ff;
-  --token-color-function: #000000;
+  --token-color-function: #569cd6;
+  --token-color-function-variable: #000000;
   --token-color-important: #e90;
   --token-color-class-name: #2b91af;
   --token-color-selector: #800000;
@@ -38,7 +39,8 @@ html[data-theme='dark'] {
   --token-color-symbol: #b5cea8;
   --token-color-number: #b5cea8;
   --token-color-keyword: #569cd6;
-  --token-color-function: #f8f8f2;
+  --token-color-function: #98b6ce;
+  --token-color-function-variable: #f8f8f2;
   --token-color-important: #569cd6;
   --token-color-class-name: #4ec9b0;
   --token-color-selector: #d7ba7d;
@@ -114,6 +116,10 @@ div[class*='codeBlockContainer'] pre {
 
 .token.function {
   color: var(--token-color-function);
+}
+
+.token.function-variable {
+  color: var(--token-color-function-variable);
 }
 
 .token.deleted {


### PR DESCRIPTION
## Overview

This PR aligns colors used in various code blocks on website, as for palette I used colors use theme in playground

this change fixes blinking of code blocks in dark mode.

----------------------

dark mode code blocks do look different now:

## old:
![image](https://user-images.githubusercontent.com/625469/146610190-7db7e45c-c160-4386-83ab-b0513b754b64.png)
![image](https://user-images.githubusercontent.com/625469/146610273-ee3eaec7-99a5-4e6f-9729-17212b8ec4a2.png)


new:
![image](https://user-images.githubusercontent.com/625469/146610212-735b8db9-9bf4-4a1c-85e9-8c74a9516012.png)
![image](https://user-images.githubusercontent.com/625469/146610332-c03dec5f-0dc2-4edb-ab11-319c1ccecbdc.png)

