### PR TITLE
docs: update links to point to correct pages

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,7 +15,7 @@ The more relevant information you can include, the faster we can find the issue 
 
 - [ ] I have tried restarting my IDE and the issue persists.
 - [ ] I have updated to the latest version of the packages.
-- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md) and my problem is not listed.
+- [ ] I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
 
 **Repro**
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,8 +3,8 @@ contact_links:
   -
     name: FAQ
     about: Please check out our FAQ before filing new issues
-    url: https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md
+    url: https://typescript-eslint.io/docs/linting/troubleshooting
   -
     name: Getting Started Guide
     about: If you're looking for help setting up check out our getting started guide
-    url: https://github.com/typescript-eslint/typescript-eslint/tree/main/docs/getting-started
+    url: https://typescript-eslint.io/docs/

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -14,7 +14,7 @@ The more relevant information you can include, the faster we can find the issue 
 -->
 
 - [ ] I have looked on [typescript-eslint.io](https://typescript-eslint.io).
-- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md) and my problem is not listed.
+- [ ] I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
 
 ## Suggested Changes
 

--- a/.github/ISSUE_TEMPLATE/eslint-plugin-tslint.md
+++ b/.github/ISSUE_TEMPLATE/eslint-plugin-tslint.md
@@ -23,7 +23,7 @@ If you have a problem with a specific lint rule, please back out and select the 
 
 - [ ] I have tried restarting my IDE and the issue persists.
 - [ ] I have updated to the latest version of the packages.
-- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md) and my problem is not listed.
+- [ ] I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
 
 **Repro**
 

--- a/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.md
+++ b/.github/ISSUE_TEMPLATE/eslint-plugin-typescript.md
@@ -28,7 +28,7 @@ Are you opening an issue because the rule you're trying to use is not found?
 
 - [ ] I have tried restarting my IDE and the issue persists.
 - [ ] I have updated to the latest version of the packages.
-- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md) and my problem is not listed.
+- [ ] I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
 
 **Repro**
 

--- a/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
+++ b/.github/ISSUE_TEMPLATE/typescript-eslint-parser.md
@@ -24,7 +24,7 @@ If you have a problem with a specific lint rule, please back out and select the 
 
 - [ ] I have tried restarting my IDE and the issue persists.
 - [ ] I have updated to the latest version of the packages.
-- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md) and my problem is not listed.
+- [ ] I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
 
 **Repro**
 

--- a/.github/ISSUE_TEMPLATE/typescript-eslint-scope-manager.md
+++ b/.github/ISSUE_TEMPLATE/typescript-eslint-scope-manager.md
@@ -24,7 +24,7 @@ If you have a problem with the parser, please back out and select the `@typescri
 
 - [ ] I have tried restarting my IDE and the issue persists.
 - [ ] I have updated to the latest version of the packages.
-- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md) and my problem is not listed.
+- [ ] I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
 
 **Repro**
 

--- a/.github/ISSUE_TEMPLATE/typescript-eslint-utils.md
+++ b/.github/ISSUE_TEMPLATE/typescript-eslint-utils.md
@@ -24,7 +24,7 @@ If you have a problem with the parser, please back out and select the `@typescri
 
 - [ ] I have tried restarting my IDE and the issue persists.
 - [ ] I have updated to the latest version of the packages.
-- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md) and my problem is not listed.
+- [ ] I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
 
 **Repro**
 

--- a/.github/ISSUE_TEMPLATE/typescript-estree.md
+++ b/.github/ISSUE_TEMPLATE/typescript-estree.md
@@ -23,7 +23,7 @@ If you have a problem with a specific lint rule, please back out and select the 
 
 - [ ] I have tried restarting my IDE and the issue persists.
 - [ ] I have updated to the latest version of the packages.
-- [ ] I have [read the FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md) and my problem is not listed.
+- [ ] I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
 
 **Repro**
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -10,7 +10,7 @@
 
 ## Getting Started
 
-- **[You can find our Getting Started docs here](https://typescript-eslint.io/docs/linting/linting)**
+- **[You can find our Getting Started docs here](https://typescript-eslint.io/docs/linting)**
 - **[You can find our FAQ / Troubleshooting docs here](https://typescript-eslint.io/docs/linting/troubleshooting)**
 
 These docs walk you through setting up ESLint, this plugin, and our parser. If you know what you're doing and just want to quick start, read on...

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -10,7 +10,7 @@
 
 ## Getting Started
 
-**[You can find our Getting Started docs here](../../docs/linting/README.md)**
+**[You can find our Getting Started docs here](https://typescript-eslint.io/docs/linting)**
 
 These docs walk you through setting up ESLint, this parser, and our plugin. If you know what you're doing and just want to quick start, read on...
 

--- a/packages/scope-manager/README.md
+++ b/packages/scope-manager/README.md
@@ -14,7 +14,7 @@ You probably don't want to use it directly.
 
 ## Getting Started
 
-**[You can find our Getting Started docs here](../../docs/linting/README.md)**
+**[You can find our Getting Started docs here](https://typescript-eslint.io/docs/linting)**
 
 ## Installation
 

--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -10,7 +10,7 @@
 
 ## Getting Started
 
-**[You can find our Getting Started docs here](../../docs/linting/README.md)**
+**[You can find our Getting Started docs here](https://typescript-eslint.io/docs/linting)**
 
 ## About
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4316
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Update links to correctly point into `troubleshooting` and `getting started` pages
