### PR TITLE
fix(eslint-plugin): [consistent-type-definitions] correct fixer with declare keyword

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
@@ -58,7 +58,7 @@ export default util.createRule({
               const typeNode = node.typeParameters ?? node.id;
               const fixes: TSESLint.RuleFix[] = [];
 
-              const firstToken = sourceCode.getFirstToken(node);
+              const firstToken = sourceCode.getTokenBefore(node.id);
               if (firstToken) {
                 fixes.push(fixer.replaceText(firstToken, 'interface'));
                 fixes.push(
@@ -98,7 +98,7 @@ export default util.createRule({
                   const typeNode = node.typeParameters ?? node.id;
                   const fixes: TSESLint.RuleFix[] = [];
 
-                  const firstToken = sourceCode.getFirstToken(node);
+                  const firstToken = sourceCode.getTokenBefore(node.id);
                   if (firstToken) {
                     fixes.push(fixer.replaceText(firstToken, 'type'));
                     fixes.push(

--- a/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
@@ -305,5 +305,51 @@ export default Test
         },
       ],
     },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/4333
+      code: `
+export declare type Test = {
+  foo: string;
+  bar: string;
+};
+      `,
+      output: `
+export declare interface Test {
+  foo: string;
+  bar: string;
+}
+      `,
+      options: ['interface'],
+      errors: [
+        {
+          messageId: 'interfaceOverType',
+          line: 2,
+          column: 21,
+        },
+      ],
+    },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/4333
+      code: `
+export declare interface Test {
+  foo: string;
+  bar: string;
+}
+      `,
+      output: noFormat`
+export declare type Test = {
+  foo: string;
+  bar: string;
+}
+      `,
+      options: ['type'],
+      errors: [
+        {
+          messageId: 'typeOverInterface',
+          line: 2,
+          column: 26,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION

## PR Checklist

-   [x] Addresses an existing issue: fixes #4333
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Fixer incorrectly changes declare keyword to interface
