### PR TITLE
fix(eslint-plugin): [padding-line-between-statements] make function overloading is also processed

### DIFF
--- a/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
+++ b/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
@@ -803,7 +803,9 @@ export default util.createRule<Options, MessageIds>({
       ':statement': verify,
 
       SwitchCase: verifyThenEnterScope,
+      TSDeclareFunction: verifyThenEnterScope,
       'SwitchCase:exit': exitScope,
+      'TSDeclareFunction:exit': exitScope,
     };
   },
 });

--- a/packages/eslint-plugin/tests/rules/padding-line-between-statements.test.ts
+++ b/packages/eslint-plugin/tests/rules/padding-line-between-statements.test.ts
@@ -2799,6 +2799,20 @@ var a = 1
         { blankLine: 'always', prev: 'block-like', next: 'block-like' },
       ],
     },
+    {
+      code: 'export function foo(arg1: string): number;\nexport function foo(arg2: number) {\n return arg2;\n}',
+      options: [
+        { blankLine: 'always', prev: '*', next: 'block-like' },
+        { blankLine: 'never', prev: '*', next: 'export' },
+      ],
+    },
+    {
+      code: 'function foo(arg1: string): number;\nfunction foo(arg2: number) {\n return arg2;\n}',
+      options: [
+        { blankLine: 'always', prev: '*', next: 'block-like' },
+        { blankLine: 'never', prev: '*', next: 'function' },
+      ],
+    },
   ],
   invalid: [
     //----------------------------------------------------------------------
@@ -5100,6 +5114,20 @@ declare namespace Types {
         { messageId: 'expectedBlankLine' },
         { messageId: 'expectedBlankLine' },
       ],
+    },
+    {
+      code: 'export function foo(arg1: string): number;\nexport function foo(arg2: number) {\n return arg2;\n}',
+      output:
+        'export function foo(arg1: string): number;\n\nexport function foo(arg2: number) {\n return arg2;\n}',
+      options: [{ blankLine: 'always', prev: '*', next: 'block-like' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
+    },
+    {
+      code: 'function foo(arg1: string): number;\nfunction foo(arg2: number) {\n return arg2;\n}',
+      output:
+        'function foo(arg1: string): number;\n\nfunction foo(arg2: number) {\n return arg2;\n}',
+      options: [{ blankLine: 'always', prev: '*', next: 'block-like' }],
+      errors: [{ messageId: 'expectedBlankLine' }],
     },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4030
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
#### Problem
normal function overloading was not processed at all because `TSDeclareFunction` was not called at all. Cases such as below should have made error that there is a blank space expected
```
options: [{ blankLine: 'always', prev: '*', next: 'block-like' }],

function bar(arg: number): number;
function bar(arg: string | number) {
  return arg;
}
```

#### What I did
1. make `TSDeclareFunction` is also processed.
2. I added test case for already working export function overloading case

#### Context
I may be wrong because as I think more about it new approaches showing up but let's give it a shot

Issue provided 3 cases
```
options: [{ blankLine: 'always', prev: '*', next: 'block-like' }],

Case - 1 (error. Not expected)
export function bar(arg: number): number;
export function bar(arg: string | number) {
  return arg;
}

Case - 2 (no error, Expected)
function bar(arg: number): number;
function bar(arg: string | number) {
  return arg;
}

Case - 3 (no error, Expected)
class Foo {
  bar(arg: number): number;
  bar(arg: string | number) {
    return arg;
  }
}

```


* Case 1 is WAI, 
because `block-like`(curly brace at last token) and `*` are matched thus rule applies. To make this work like issue is saying, I think this option can override the option with `block-like`
```
options: [
  { blankLine: 'always', prev: '*', next: 'block-like' },
  { blankLine: 'never', prev: '*', next: 'export' }
]
``` 

* Case 2 should have errored.
But It wasn't because `TSDeclareFunction` was ignored for this rule. This PR fixes it. This option can be used to work as issuer intended
```
options: [
  { blankLine: 'always', prev: '*', next: 'block-like' },
  { blankLine: 'never', prev: '*', next: 'function' }
]
``` 

* Case 3 is not related to this rule?
I found this [`lines-between-class-members`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/lines-between-class-members.md) rule and it is the one that is taking care of the lines inside of class




