### PR TITLE
docs(eslint-plugin): change createRule usage to point to website

### DIFF
--- a/packages/eslint-plugin/src/util/createRule.ts
+++ b/packages/eslint-plugin/src/util/createRule.ts
@@ -1,10 +1,5 @@
 import { ESLintUtils } from '@typescript-eslint/experimental-utils';
 
-// note - cannot migrate this to an import statement because it will make TSC copy the package.json to the dist folder
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-const version: string = require('../../package.json').version;
-
 export const createRule = ESLintUtils.RuleCreator(
-  name =>
-    `https://github.com/typescript-eslint/typescript-eslint/blob/v${version}/packages/eslint-plugin/docs/rules/${name}.md`,
+  name => `https://typescript-eslint.io/rules/${name}`,
 );

--- a/packages/eslint-plugin/tests/docs.test.ts
+++ b/packages/eslint-plugin/tests/docs.test.ts
@@ -118,9 +118,9 @@ describe('Validating rule metadata', () => {
       it('`name` field in rule must match the filename', () => {
         // validate if rule name is same as url
         // there is no way to access this field but its used only in generation of docs url
-        expect(
-          rule.meta.docs?.url?.endsWith(`rules/${ruleName}.md`),
-        ).toBeTruthy();
+        expect(rule.meta.docs?.url).toBe(
+          `https://typescript-eslint.io/rules/${ruleName}`,
+        );
       });
 
       it('`requiresTypeChecking` should be set if the rule uses type information', () => {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4368
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Changes the link in most rules' `createRule` usage to point to the general website instead of version-specific GitHub markdown files.