### PR TITLE
docs: explain why there is not a "typescriptLocation" option

### DIFF
--- a/docs/linting/TROUBLESHOOTING.md
+++ b/docs/linting/TROUBLESHOOTING.md
@@ -213,3 +213,16 @@ However this involves a _lot_ of computations across every single token in a fil
 Across a large codebase, these can add up, and severely impact performance.
 
 We recommend not using this rule, and instead using a tool like [`prettier`](https://www.npmjs.com/package/prettier) to enforce a standardized formatting.
+
+## How can I specify a TypeScript version / `parserOptions.typescriptLocation`?
+
+You can't, and you don't want to.
+
+You should use the same version of TypeScript for linting as the rest of your project.
+TypeScript versions often have slight differences in edge cases that can cause contradictory information between typescript-eslint rules and editor information.
+For example:
+
+- `@typescript-eslint/strict-boolean-expressions` might be operating with TypeScript version _X_ and think a variable is `string[] | undefined`
+- TypeScript itself might be on version _X+1-beta_ and think the variable is `string[]`
+
+See [this issue comment](https://github.com/typescript-eslint/typescript-eslint/issues/4102#issuecomment-963265514) for more details.

--- a/docs/linting/TROUBLESHOOTING.md
+++ b/docs/linting/TROUBLESHOOTING.md
@@ -153,6 +153,19 @@ If you see more than one version installed, then you will have to either use [ya
 
 **The best course of action in this case is to wait until your dependency releases a new version with support for our latest versions.**
 
+## How can I specify a TypeScript version / `parserOptions.typescriptLocation`?
+
+You can't, and you don't want to.
+
+You should use the same version of TypeScript for linting as the rest of your project.
+TypeScript versions often have slight differences in edge cases that can cause contradictory information between typescript-eslint rules and editor information.
+For example:
+
+- `@typescript-eslint/strict-boolean-expressions` might be operating with TypeScript version _X_ and think a variable is `string[] | undefined`
+- TypeScript itself might be on version _X+1-beta_ and think the variable is `string[]`
+
+See [this issue comment](https://github.com/typescript-eslint/typescript-eslint/issues/4102#issuecomment-963265514) for more details.
+
 ## My linting feels really slow
 
 As mentioned in the [type-aware linting doc](./TYPED_LINTING.md), if you're using type-aware linting, your lint times should be roughly the same as your build times.
@@ -213,16 +226,3 @@ However this involves a _lot_ of computations across every single token in a fil
 Across a large codebase, these can add up, and severely impact performance.
 
 We recommend not using this rule, and instead using a tool like [`prettier`](https://www.npmjs.com/package/prettier) to enforce a standardized formatting.
-
-## How can I specify a TypeScript version / `parserOptions.typescriptLocation`?
-
-You can't, and you don't want to.
-
-You should use the same version of TypeScript for linting as the rest of your project.
-TypeScript versions often have slight differences in edge cases that can cause contradictory information between typescript-eslint rules and editor information.
-For example:
-
-- `@typescript-eslint/strict-boolean-expressions` might be operating with TypeScript version _X_ and think a variable is `string[] | undefined`
-- TypeScript itself might be on version _X+1-beta_ and think the variable is `string[]`
-
-See [this issue comment](https://github.com/typescript-eslint/typescript-eslint/issues/4102#issuecomment-963265514) for more details.


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4102
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Mentions the high-level version conflicts and links to the deeper technical explanation.