### PR TITLE
docs: replace astexplorer.net links with playground

### DIFF
--- a/docs/development/architecture/ASTS.md
+++ b/docs/development/architecture/ASTS.md
@@ -41,9 +41,14 @@ ESLint uses an AST format known as **[`estree`]**.
 ESTree is more broadly used than just for ESLint -- it is the de facto community standard.
 ESLint's built-in parser that outputs an `estree`-shaped AST is also a separate package, called **[`espree`]**.
 
+## AST Playground
+
+The [TypeScript ESLint playground](https://typescript-eslint.io/play#showAST=es) contains an AST explorer that generates an interactive AST for any code entered into the playground.
+You can activate it under _Options_ > _AST Explorer_ on its left sidebar by selecting _ESTree_.
+
 :::note
 
-You can play more with various ASTs such as ESTree on [astexplorer.net] and read more details on their [Wikipedia article](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
+You can play more with various other ASTs on [astexplorer.net] and read more details on their [Wikipedia article](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
 
 :::
 

--- a/docs/development/architecture/PACKAGES.md
+++ b/docs/development/architecture/PACKAGES.md
@@ -32,7 +32,7 @@ ESTree is unoptimized and intended for "general purpose" use-cases of traversing
 See more on configuring custom parsers with ESLint on [ESLint's User Guide > Configuring > Plugins](https://eslint.org/docs/user-guide/configuring/plugins#specifying-parser).
 
 :::tip
-You can select `@typescript-eslint/parser` on [astexplorer.net](https://astexplorer.net)'s top-middle ⚙ dropdown that defaults to Acorn.
+You can select `@typescript-eslint/parser` on the [TypeScript ESLint playground](https://typescript-eslint.io/play#showAST=es)'s left sidebar under _Options_ > _AST Explorer_ by selecting _ESTree_.
 :::
 
 ## `@typescript-eslint/typescript-estree`

--- a/docs/linting/TROUBLESHOOTING.md
+++ b/docs/linting/TROUBLESHOOTING.md
@@ -67,7 +67,7 @@ See [#2041](https://github.com/typescript-eslint/typescript-eslint/issues/2041) 
 ESLint core contains the rule [`no-restricted-syntax`](https://eslint.org/docs/rules/no-restricted-syntax).
 This generic rule allows you to specify a [selector](https://eslint.org/docs/developer-guide/selectors) for the code you want to ban, along with a custom error message.
 
-You can use a tool like [AST Explorer](https://astexplorer.net/) to help in figuring out the structure of the AST that you want to ban.
+You can use an AST visualization tool such as [TypeScript ESLint playground](https://typescript-eslint.io/play#showAST=es) > _Options_ > _AST Explorer_ on its left sidebar by selecting _ESTree_ to help in figuring out the structure of the AST that you want to ban.
 
 For example, you can ban enums (or some variation of) using one of the following configs:
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4353
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Mentions the playground's AST option and changes links to surface with it enabled.