### PR TITLE
docs(eslint-plugin): mention constructor privacy limitation on no-useless-constructor

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-useless-constructor.md
+++ b/packages/eslint-plugin/docs/rules/no-useless-constructor.md
@@ -29,6 +29,11 @@ Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/main/
 
 </sup>
 
+## Caveat
+
+This lint rule will report on constructors whose sole purpose is to change visibility of a parent constructor.
+See [discussion on this rule's lack of type information](https://github.com/typescript-eslint/typescript-eslint/issues/3820#issuecomment-917821240) for context.
+
 ## Attributes
 
 - [ ] ✅ Recommended


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #3820
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Adds a `## Caveat` heading in the rule docs file.