### PR TITLE
chore: added missing implicit dependency on types to eslint-plugin

### DIFF
--- a/packages/eslint-plugin/project.json
+++ b/packages/eslint-plugin/project.json
@@ -1,5 +1,5 @@
 {
   "root": "packages/eslint-plugin",
   "type": "library",
-  "implicitDependencies": []
+  "implicitDependencies": ["@typescript-eslint/types"]
 }

--- a/packages/eslint-plugin/project.json
+++ b/packages/eslint-plugin/project.json
@@ -1,5 +1,5 @@
 {
   "root": "packages/eslint-plugin",
   "type": "library",
-  "implicitDependencies": ["@typescript-eslint/types"]
+  "implicitDependencies": []
 }

--- a/packages/types/tools/copy-ast-spec.ts
+++ b/packages/types/tools/copy-ast-spec.ts
@@ -56,4 +56,7 @@ async function main(): Promise<void> {
   ]);
 }
 
-void main();
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/typescript-estree/project.json
+++ b/packages/typescript-estree/project.json
@@ -1,5 +1,5 @@
 {
   "root": "packages/typescript-estree",
   "type": "library",
-  "implicitDependencies": []
+  "implicitDependencies": ["@typescript-eslint/types"]
 }


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4335
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Adds `"@typescript-eslint/types"` under `implicitDependencies` for the `eslint-plugin` package so that `npx nx build website` knows to build types and therefore copy `ast-spec.ts`.

Also adds a `console.error` in case the `copy-ast-spec` code throws for whatever reason.