### PR TITLE
Fixes incorrect "How to Use" for `no-restricted-imports` rule.

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-restricted-imports.md
+++ b/packages/eslint-plugin/docs/rules/no-restricted-imports.md
@@ -10,7 +10,7 @@ This rule extends the base [`eslint/no-restricted-imports`](https://eslint.org/d
 {
   // note you must disable the base rule as it can report incorrect errors
   "no-restricted-imports": "off",
-  "@typescript-eslint/no-restricted-imports": "off"
+  "@typescript-eslint/no-restricted-imports": ["error"]
 }
 ```
 


### PR DESCRIPTION
A simple doc change as the current config incorrectly turned the rule `off` instead of `error`.