### PR TITLE
feat(type-utils): make isTypeReadonly's options param optional

### DIFF
--- a/packages/type-utils/src/isTypeReadonly.ts
+++ b/packages/type-utils/src/isTypeReadonly.ts
@@ -243,7 +243,7 @@ function isTypeReadonlyRecurser(
 function isTypeReadonly(
   checker: ts.TypeChecker,
   type: ts.Type,
-  options: ReadonlynessOptions,
+  options: ReadonlynessOptions = readonlynessOptionsDefaults,
 ): boolean {
   return (
     isTypeReadonlyRecurser(checker, type, options, new Set()) ===


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4410
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Use the default options as the default param.