### PR TITLE
test(type-utils): add basic tests for isTypeReadonly

### DIFF
--- a/packages/type-utils/src/isTypeReadonly.ts
+++ b/packages/type-utils/src/isTypeReadonly.ts
@@ -243,7 +243,7 @@ function isTypeReadonlyRecurser(
 function isTypeReadonly(
   checker: ts.TypeChecker,
   type: ts.Type,
-  options: ReadonlynessOptions,
+  options: ReadonlynessOptions = readonlynessOptionsDefaults,
 ): boolean {
   return (
     isTypeReadonlyRecurser(checker, type, options, new Set()) ===

--- a/packages/type-utils/tests/isTypeReadonly.test.ts
+++ b/packages/type-utils/tests/isTypeReadonly.test.ts
@@ -1,0 +1,138 @@
+import * as ts from 'typescript';
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { parseForESLint } from '@typescript-eslint/parser';
+import {
+  isTypeReadonly,
+  type ReadonlynessOptions,
+} from '../src/isTypeReadonly';
+import path from 'path';
+
+describe('isTypeReadonly', () => {
+  const rootDir = path.join(__dirname, 'fixtures');
+
+  describe('TSTypeAliasDeclaration ', () => {
+    function getType(code: string): {
+      type: ts.Type;
+      checker: ts.TypeChecker;
+    } {
+      const { ast, services } = parseForESLint(code, {
+        project: './tsconfig.json',
+        filePath: path.join(rootDir, 'file.ts'),
+        tsconfigRootDir: rootDir,
+      });
+      const checker = services.program.getTypeChecker();
+      const esTreeNodeToTSNodeMap = services.esTreeNodeToTSNodeMap;
+
+      const declaration = ast.body[0] as TSESTree.TSTypeAliasDeclaration;
+      return {
+        type: checker.getTypeAtLocation(
+          esTreeNodeToTSNodeMap.get(declaration.id),
+        ),
+        checker,
+      };
+    }
+
+    function runTestForAliasDeclaration(
+      code: string,
+      options: ReadonlynessOptions | undefined,
+      expected: boolean,
+    ): void {
+      const { type, checker } = getType(code);
+
+      const result = isTypeReadonly(checker, type, options);
+      expect(result).toBe(expected);
+    }
+
+    describe('default options', () => {
+      const options = undefined;
+
+      function runTestIsReadonly(code: string): void {
+        runTestForAliasDeclaration(code, options, true);
+      }
+
+      function runTestIsNotReadonly(code: string): void {
+        runTestForAliasDeclaration(code, options, false);
+      }
+
+      describe('basics', () => {
+        describe('is readonly', () => {
+          const runTests = runTestIsReadonly;
+
+          // Record.
+          it.each([
+            ['type Test = { readonly bar: string; };'],
+            ['type Test = Readonly<{ bar: string; }>;'],
+          ])('handles fully readonly records', runTests);
+
+          // Array.
+          it.each([
+            ['type Test = Readonly<readonly string[]>;'],
+            ['type Test = Readonly<ReadonlyArray<string>>;'],
+          ])('handles fully readonly arrays', runTests);
+
+          // Array - special case.
+          // Note: Methods are mutable but arrays are treated special; hence no failure.
+          it.each([
+            ['type Test = readonly string[];'],
+            ['type Test = ReadonlyArray<string>;'],
+          ])('treats readonly arrays as fully readonly', runTests);
+
+          // Set and Map.
+          it.each([
+            ['type Test = Readonly<ReadonlySet<string>>;'],
+            ['type Test = Readonly<ReadonlyMap<string, string>>;'],
+          ])('handles fully readonly sets and maps', runTests);
+        });
+
+        describe('is not readonly', () => {
+          const runTests = runTestIsNotReadonly;
+
+          // Record.
+          it.each([
+            ['type Test = { foo: string; };'],
+            ['type Test = { foo: string; readonly bar: number; };'],
+          ])('handles non fully readonly records', runTests);
+
+          // Array.
+          it.each([['type Test = string[]'], ['type Test = Array<string>']])(
+            'handles non fully readonly arrays',
+            runTests,
+          );
+
+          // Set and Map.
+          // Note: Methods are mutable for ReadonlySet and ReadonlyMet; hence failure.
+          it.each([
+            ['type Test = Set<string>;'],
+            ['type Test = Map<string, string>;'],
+            ['type Test = ReadonlySet<string>;'],
+            ['type Test = ReadonlyMap<string, string>;'],
+          ])('handles non fully readonly sets and maps', runTests);
+        });
+      });
+    });
+
+    describe('treatMethodsAsReadonly', () => {
+      const options: ReadonlynessOptions = {
+        treatMethodsAsReadonly: true,
+      };
+
+      function runTestIsReadonly(code: string): void {
+        runTestForAliasDeclaration(code, options, true);
+      }
+
+      // function runTestIsNotReadonly(code: string): void {
+      //   runTestForAliasDeclaration(code, options, false);
+      // }
+
+      describe('is readonly', () => {
+        const runTests = runTestIsReadonly;
+
+        // Set and Map.
+        it.each([
+          ['type Test = ReadonlySet<string>;'],
+          ['type Test = ReadonlyMap<string, string>;'],
+        ])('handles non fully readonly sets and maps', runTests);
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing issue
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Add basic tests for `isTypeReadonly`.

Note: this PR is the base of #4417, #4419,#4421 and  #4429