### PR TITLE
chore: add fallback logic for getESLintCoreRule

### DIFF
--- a/packages/eslint-plugin/src/util/getESLintCoreRule.ts
+++ b/packages/eslint-plugin/src/util/getESLintCoreRule.ts
@@ -39,11 +39,19 @@ interface RuleMap {
 
 type RuleId = keyof RuleMap;
 
-const getESLintCoreRuleLegacy: <R extends RuleId>(ruleId: R) => RuleMap[R] = <R extends RuleId>(ruleId: R): RuleMap[R] => {
+const getESLintCoreRuleLegacy: <R extends RuleId>(ruleId: R) => RuleMap[R] = <
+  R extends RuleId,
+>(
+  ruleId: R,
+): RuleMap[R] => {
   return require(`eslint/lib/rules/${ruleId}`) as RuleMap[R];
 };
 
-const getESLintCoreRuleV8: <R extends RuleId>(ruleId: R) => RuleMap[R] = <R extends RuleId>(ruleId: R): RuleMap[R] => {
+const getESLintCoreRuleV8: <R extends RuleId>(ruleId: R) => RuleMap[R] = <
+  R extends RuleId,
+>(
+  ruleId: R,
+): RuleMap[R] => {
   try {
     return ESLintUtils.nullThrows(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -57,7 +65,9 @@ const getESLintCoreRuleV8: <R extends RuleId>(ruleId: R) => RuleMap[R] = <R exte
   }
 };
 
-export const getESLintCoreRule = isESLintV8 ? getESLintCoreRuleV8 : getESLintCoreRuleLegacy;
+export const getESLintCoreRule = isESLintV8
+  ? getESLintCoreRuleV8
+  : getESLintCoreRuleLegacy;
 
 export function maybeGetESLintCoreRule<R extends RuleId>(
   ruleId: R,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Because `@typescript-eslint/eslint-plugin` depends on `eslint/use-at-your-own-risk` which is not a stable export(should not be used generally),

but the legacy `eslint/lib/rules/${ruleId}` works.