### PR TITLE
docs(eslint-plugin): clearer eslint-config example in no-magic-numbers rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-magic-numbers.md
+++ b/packages/eslint-plugin/docs/rules/no-magic-numbers.md
@@ -13,14 +13,18 @@ It adds support for:
 
 ```jsonc
 {
-  // note you must disable the base rule as it can report incorrect errors
-  "no-magic-numbers": "off",
-  "@typescript-eslint/no-magic-numbers": [
-    "error",
-    {
-      /* options */
-    }
-  ]
+  ...,
+  "rules: {
+    ...,
+    // note you must disable the base rule as it can report incorrect errors
+    "no-magic-numbers": "off",
+    "@typescript-eslint/no-magic-numbers": [
+      "error",
+      {
+        /* options */
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
Make the eslint-config example clearer for update no-magic-numbers

## PR Checklist

-   [N/A ] Addresses an existing issue: fixes #000
-   [N/A] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [Done] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

If you're not familiar with ESLint, it's not immediately clear where this object goes. I believe the addition of the "rules" context would cut down implementation time (it took me 5 mins or so to figure out).