### PR TITLE
fix(eslint-plugin): [no-restricted-imports] allow relative type imports with patterns configured

### DIFF
--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -146,9 +146,12 @@ export default createRule<Options, MessageIds>({
         typeof restrictedPattern === 'object' &&
         restrictedPattern.allowTypeImports
       ) {
-        // allowRelativePaths is true in the base rule
+        // Following how ignore is configured in the base rule
         allowedImportTypeMatchers.push(
-          ignore({ allowRelativePaths: true }).add(restrictedPattern.group),
+          ignore({
+            allowRelativePaths: true,
+            ignoreCase: !restrictedPattern.caseSensitive,
+          }).add(restrictedPattern.group),
         );
       }
     }

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -146,7 +146,10 @@ export default createRule<Options, MessageIds>({
         typeof restrictedPattern === 'object' &&
         restrictedPattern.allowTypeImports
       ) {
-        allowedImportTypeMatchers.push(ignore().add(restrictedPattern.group));
+        // allowRelativePaths is true in the base rule
+        allowedImportTypeMatchers.push(
+          ignore({ allowRelativePaths: true }).add(restrictedPattern.group),
+        );
       }
     }
     function isAllowedTypeImportPattern(importSource: string): boolean {

--- a/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
@@ -217,6 +217,20 @@ ruleTester.run('no-restricted-imports', rule, {
       code: "export * from 'foo';",
       options: ['import1'],
     },
+    {
+      code: "import type { MyType } from './types';",
+      options: [
+        {
+          patterns: [
+            {
+              group: ['fail'],
+              message: "Please do not load from 'fail'.",
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -905,6 +905,7 @@ declare module 'eslint/lib/rules/no-restricted-imports' {
       | {
           group: string[];
           message?: string;
+          caseSensitive?: boolean;
           // extended
           allowTypeImports?: boolean;
         }[];


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below -- otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4491 
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This is in line with how the ESLint base rule is configured:

https://github.com/eslint/eslint/blob/b6f2bd8879176cd774f253ba437963f2fa1c493d/lib/rules/no-restricted-imports.js#L163

I'm surprised that we never had the `caseSensitive` option in our typedef, so I added that as well.
