### PR TITLE
feat(utils): expose `ast-utils`' helpers

### DIFF
--- a/packages/utils/src/ast-utils/index.ts
+++ b/packages/utils/src/ast-utils/index.ts
@@ -1,3 +1,4 @@
+export * from './eslint-utils';
+export * from './helpers';
 export * from './misc';
 export * from './predicates';
-export * from './eslint-utils';


### PR DESCRIPTION
Currently we're using a copy of [`isNodeOfType`](https://github.com/typescript-eslint/typescript-eslint/blob/a2bd04865527cc9b172895caf380757fb214d4fb/packages/utils/src/ast-utils/helpers.ts#L6-L11) in `eslint-plugin-testing-library`.
https://github.com/testing-library/eslint-plugin-testing-library/blob/main/lib/node-utils/is-node-of-type.ts#L6-L11


As the extraction in this codebase was originally copied from `eslint-plugin-testing-library` (see #3677 & testing-library/eslint-plugin-testing-library#329), it seems logical to expose it here so other packages can use it whenever they want.