### PR TITLE
fix(eslint-plugin): [non-nullable-type-assertion-style] fix false positive when asserting to a generic type that might be nullish

### DIFF
--- a/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
+++ b/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
@@ -17,7 +17,7 @@ export default util.createRule({
     fixable: 'code',
     messages: {
       preferNonNullAssertion:
-        'Use a ! assertion to more succintly remove null and undefined from the type.',
+        'Use a ! assertion to more succinctly remove null and undefined from the type.',
     },
     schema: [],
     type: 'suggestion',

--- a/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
+++ b/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
@@ -43,14 +43,31 @@ export default util.createRule({
       return tsutils.unionTypeParts(type);
     };
 
+    const couldBeNullish = (type: ts.Type): boolean => {
+      if (type.flags & ts.TypeFlags.TypeParameter) {
+        const constraint = type.getConstraint();
+        return constraint == null || couldBeNullish(constraint);
+      } else if (tsutils.isUnionType(type)) {
+        for (const part of type.types) {
+          if (couldBeNullish(part)) {
+            return true;
+          }
+        }
+        return false;
+      } else {
+        return (
+          (type.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) !== 0
+        );
+      }
+    };
+
     const sameTypeWithoutNullish = (
       assertedTypes: ts.Type[],
       originalTypes: ts.Type[],
     ): boolean => {
       const nonNullishOriginalTypes = originalTypes.filter(
         type =>
-          type.flags !== ts.TypeFlags.Null &&
-          type.flags !== ts.TypeFlags.Undefined,
+          (type.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) === 0,
       );
 
       if (nonNullishOriginalTypes.length === originalTypes.length) {
@@ -58,7 +75,10 @@ export default util.createRule({
       }
 
       for (const assertedType of assertedTypes) {
-        if (!nonNullishOriginalTypes.includes(assertedType)) {
+        if (
+          couldBeNullish(assertedType) ||
+          !nonNullishOriginalTypes.includes(assertedType)
+        ) {
           return false;
         }
       }

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.noUncheckedIndexedAccess.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.noUncheckedIndexedAccess.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true
+  }
+}

--- a/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
@@ -83,6 +83,13 @@ function first<T extends string | null | undefined>(
   return array.length > 0 ? (array[0] as T) : null;
 }
     `,
+    `
+type A = 'a' | 'A';
+type B = 'b' | 'B';
+function first<T extends A | B | null>(array: ArrayLike<T>): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
@@ -71,6 +71,18 @@ function first<T extends string | null>(array: ArrayLike<T>): T | null {
   return array.length > 0 ? (array[0] as T) : null;
 }
     `,
+    `
+function first<T extends string | undefined>(array: ArrayLike<T>): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
+    `,
+    `
+function first<T extends string | null | undefined>(
+  array: ArrayLike<T>,
+): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
@@ -7,7 +7,7 @@ const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
     tsconfigRootDir: rootDir,
-    project: './tsconfig.json',
+    project: './tsconfig.noUncheckedIndexedAccess.json',
   },
   parser: '@typescript-eslint/parser',
 });
@@ -60,6 +60,16 @@ const x = 1 as 1;
     `
 declare function foo<T = any>(): T;
 const bar = foo() as number;
+    `,
+    `
+function first<T>(array: ArrayLike<T>): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
+    `,
+    `
+function first<T extends string | null>(array: ArrayLike<T>): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
     `,
   ],
 
@@ -197,6 +207,27 @@ type T = string | null | undefined;
 declare const x: T;
 
 const y = x!;
+      `,
+    },
+    {
+      code: `
+function first<T extends string | number>(array: ArrayLike<T>): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
+      `,
+      errors: [
+        {
+          column: 30,
+          line: 3,
+          messageId: 'preferNonNullAssertion',
+        },
+      ],
+      // Output is not expected to match required formatting due to excess parentheses
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
+      output: `
+function first<T extends string | number>(array: ArrayLike<T>): T | null {
+  return array.length > 0 ? (array[0]!) : null;
+}
       `,
     },
   ],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4512
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Consider the following code:

```typescript
function first<T>(array: ArrayLike<T>): T | null {
    return array.length > 0 ? (array[0] as T) : null;
}
```

When compiling with `noUncheckedIndexedAccess`, the type assertion `array[0] as T` is required because the original type of `array[0]` is `T | undefined`.

However, non-nullable-type-assertion-style complains about the cast, suggesting that it should be `array[0]!` instead. This is not correct because the type parameter `T` might itself be nullish. `array[0]!` is equivalent to `array[0] as NonNullable<T>`, which is not the same as `array[0] as T`.

To see the issue more clearly, consider the following slightly more contrived example:

```typescript
function first<T extends string | null>(array: ArrayLike<T>): T | null {
    return array.length > 0 ? (array[0] as T) : null;
}
```

non-nullable-type-assertion-style complains about this code too, but here the problem is more obvious. Clearly the type assertion `array[0] as T` is not equivalent to `array[0]!` because the type parameter `T` has a constraint that explicitly allows the type to be `null`.

This PR loosens non-nullable-type-assertion-style so that in addition to the type assertions it already allows, it will also allow type assertions providing both of the following conditions are true:

1. The asserted type contains a type parameter.
2. The type parameter has no constraint or, if the type parameter has a constraint, then the constraint itself includes nullish types or other type parameters that would meet these conditions.