### PR TITLE
fix(eslint-plugin): [no-magic-numbers] fix invalid schema merging

### DIFF
--- a/packages/eslint-plugin/src/rules/no-magic-numbers.ts
+++ b/packages/eslint-plugin/src/rules/no-magic-numbers.ts
@@ -9,7 +9,10 @@ type MessageIds = util.InferMessageIdsTypeFromRule<typeof baseRule>;
 
 // Extend base schema with additional property to ignore TS numeric literal types
 const schema = util.deepMerge(
-  { ...baseRule.meta.schema },
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- https://github.com/microsoft/TypeScript/issues/17002
+  Array.isArray(baseRule.meta.schema)
+    ? baseRule.meta.schema[0]
+    : baseRule.meta.schema,
   {
     properties: {
       ignoreNumericLiteralTypes: {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4515
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

`baseRule.meta.schema` is an array of object

![image](https://user-images.githubusercontent.com/22116465/152701487-f06b17c3-f53c-4cbd-9859-6d4ca13a54d0.png)

As a result, it merges in this:

![image](https://user-images.githubusercontent.com/22116465/152701637-e88594d2-89ad-45ac-8b71-c3847e6279e6.png)

According to the approach from `no-empty-function` rule, we use `Array.isArray` and return the first element, otherwise the object


