### PR TITLE
fix(eslint-plugin): allow unnecessary constraint in JSX arrow functions with default.

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-constraint.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-constraint.md
@@ -54,6 +54,9 @@ class Baz<T> {
 const Quux = <T>() => {};
 
 function Quuz<T>() {}
+
+const JSXWorkaround = <T,>() => {};
+const JSXWorkaround2 = <T extends unknown = unknown>() => {};
 ```
 
 ## Options

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts
@@ -64,8 +64,10 @@ export default util.createRule({
       inArrowFunction: boolean,
     ): void => {
       const constraint = unnecessaryConstraints.get(node.constraint.type);
+      const hasDefaultInJsxArrowFn =
+        inArrowFunction && inJsx && node.default !== undefined;
 
-      if (constraint) {
+      if (constraint && !hasDefaultInJsxArrowFn) {
         context.report({
           data: {
             constraint,

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-constraint.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-constraint.test.ts
@@ -25,6 +25,15 @@ function data<T extends TODO>() {}
     'const data = <T, U>() => {};',
     'const data = <T extends number>() => {};',
     'const data = <T extends number | string>() => {};',
+    // https://github.com/typescript-eslint/typescript-eslint/issues/4062
+    {
+      code: 'const data = <T extends unknown = string>() => {};',
+      filename: 'react.tsx',
+    },
+    {
+      code: noFormat`const data = <T,>() => {};`,
+      filename: 'react.tsx',
+    },
   ],
   invalid: [
     {
@@ -225,6 +234,20 @@ const Data = class {
         },
       ],
       output: 'type Data<T> = {};',
+    },
+    // Regression test for fix for https://github.com/typescript-eslint/typescript-eslint/issues/4062
+    {
+      code: 'const data = <T extends unknown = string>() => {};',
+      errors: [
+        {
+          data: { constraint: 'unknown', name: 'T' },
+          messageId: 'unnecessaryConstraint',
+          endColumn: 41,
+          column: 15,
+          line: 1,
+        },
+      ],
+      output: 'const data = <T = string>() => {};',
     },
   ],
 });


### PR DESCRIPTION
In JSX arrow functions, unnecessary constraints are sometimes a necessary workaround, in particular when dealing with default values. This rule change allows that.

I marked this as a "fix" because I consider the issue a regression introduced when this rule was added to the recommended rules.

## PR Checklist

-   [x] Addresses an existing issue: fixes #4062
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

I tried implementing the rule change that @bradzacher suggested in #4062, allowing these:

1. `const a = <T,>() => {};`
2. `const b = <T extends unknown = unknown>() => {};`

Looking at the code, 1 already was allowed. I added another test case for it to make it more explicit.

I implemented 2 by adding a check to the rule, `inArrowFunction && inJsx && node.default !== undefined;`.

Another option would be changing the selector to `ArrowFunctionExpression > TSTypeParameterDeclaration > TSTypeParameter[constraint]:not([default])`, but that would also apply to non-JSX files. I think limiting this edge case to JSX files makes sense.

I also added both 1 and 2 as "good" examples to the rule documentation.

