### PR TITLE
docs: remove TEMPLATE from website; fix CSS autoprefixer warning

### DIFF
--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -51,6 +51,7 @@ const config = {
         editUrl: `${githubUrl}/edit/main/packages/website/`,
         beforeDefaultRemarkPlugins,
         remarkPlugins,
+        exclude: ['TEMPLATE.md'],
       },
     ],
     [

--- a/packages/website/sidebars/sidebar.rules.js
+++ b/packages/website/sidebars/sidebar.rules.js
@@ -24,7 +24,11 @@ const paths = globby
     };
   })
   .filter(item => {
-    return item.name !== 'README' && !rules.some(a => a.name === item.name);
+    return (
+      item.name !== 'README' &&
+      item.name !== 'TEMPLATE' &&
+      !rules.some(a => a.name === item.name)
+    );
   });
 
 module.exports = {

--- a/packages/website/src/components/FinancialContributors.module.css
+++ b/packages/website/src/components/FinancialContributors.module.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  align-items: end;
+  align-items: flex-end;
   max-width: 800px;
   margin: 10px auto;
   padding: 0;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   ~~[ ] Addresses an existing issue: fixes #000~~
-   ~~[ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~~
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

1. This PR excludes TEMPLATE from the build entirely. Before it was listed in the sidebar's "deprecated" section which is definitely not correct; I think it doesn't make sense to put it anywhere in the website, so just removed it.
2. This PR removes a Webpack module warning:

```
ModuleWarning [Warning: Warning

(9:3) autoprefixer: end value has mixed support, consider using flex-end instead] undefined
[WARNING] {"moduleIdentifier":"node_modules/babel-loader/lib/index.js??ruleSet[1].rules[5].use[0]!packages/website/src/components/config/ConfigEditor.tsx","moduleName":"./src/components/config/ConfigEditor.tsx","loc":"1:925-930","message":"export 'parse' (imported as 'parse') was not found in 'json5' (possible exports: default)","compilerPath":"server"}
<w> [webpack.cache.PackFileCacheStrategy] Skipped not serializable cache item 'mini-css-extract-plugin node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[7].use[1]!node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[7].use[2]!packages/website/src/components/FinancialContributors.module.css|0|Compilation/modules|node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[7].use[1]!node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[7].use[2]!packages/website/src/components/FinancialContributors.module.css': No serializer registered for Warning
<w> while serializing webpack/lib/cache/PackFileCacheStrategy.PackContentItems -> webpack/lib/NormalModule -> Array { 1 items } -> webpack/lib/ModuleWarning -> Warning
```

Since the container is flex anyways, there should be no visual changes.