### PR TITLE
fix: change ESLint rule creator doc URL base to website

### DIFF
--- a/packages/eslint-plugin-tslint/src/rules/config.ts
+++ b/packages/eslint-plugin-tslint/src/rules/config.ts
@@ -3,14 +3,10 @@ import memoize from 'lodash/memoize';
 import { Configuration, RuleSeverity } from 'tslint';
 import { CustomLinter } from '../custom-linter';
 
-// note - cannot migrate this to an import statement because it will make TSC copy the package.json to the dist folder
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const version: string = require('../../package.json');
-
 const createRule = ESLintUtils.RuleCreator(
-  () =>
-    `https://github.com/typescript-eslint/typescript-eslint/blob/v${version}/packages/eslint-plugin-tslint/README.md`,
+  () => 'https://typescript-eslint.io/docs/linting/',
 );
+
 export type RawRulesConfig = Record<
   string,
   | null


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4487
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview


Changed the url of the documentation from the github url to the website url.


<!-- Description of what is changed and how the code change does that. -->
