### PR TITLE
feat(eslint-plugin): [explicit-module-boundary-types] add checking property definition on `allowedNames` option

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -232,7 +232,8 @@ export default util.createRule<Options, MessageIds>({
       } else if (
         node.type === AST_NODE_TYPES.MethodDefinition ||
         node.type === AST_NODE_TYPES.TSAbstractMethodDefinition ||
-        (node.type === AST_NODE_TYPES.Property && node.method)
+        (node.type === AST_NODE_TYPES.Property && node.method) ||
+        node.type === AST_NODE_TYPES.PropertyDefinition
       ) {
         if (
           node.key.type === AST_NODE_TYPES.Literal &&

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -390,11 +390,15 @@ export class Test {
   ['prop']() {}
   [\`prop\`]() {}
   [\`\${v}\`](): void {}
+
+  foo = () => {
+    bar: 5;
+  };
 }
       `,
       options: [
         {
-          allowedNames: ['prop', 'method'],
+          allowedNames: ['prop', 'method', 'foo'],
         },
       ],
     },
@@ -1187,6 +1191,7 @@ export class Test {
     return;
   }
   arrow = (): string => 'arrow';
+  foo = () => 'bar';
 }
       `,
       options: [
@@ -1201,6 +1206,13 @@ export class Test {
           endLine: 8,
           column: 3,
           endColumn: 11,
+        },
+        {
+          messageId: 'missingReturnType',
+          line: 12,
+          endLine: 12,
+          column: 9,
+          endColumn: 14,
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4463
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Now, it also covers the case with property definition