### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-arguments] Use Symbol to check for the same type

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
@@ -290,5 +290,32 @@ function bar<T = F<string>>() {}
 bar();
       `,
     },
+    {
+      code: `
+type DefaultE = { foo: string };
+type T<E = DefaultE> = { box: E };
+type G = T<DefaultE>;
+declare module 'bar' {
+  type DefaultE = { somethingElse: true };
+  type G = T<DefaultE>;
+}
+      `,
+      errors: [
+        {
+          line: 4,
+          column: 12,
+          messageId: 'unnecessaryTypeParameter',
+        },
+      ],
+      output: `
+type DefaultE = { foo: string };
+type T<E = DefaultE> = { box: E };
+type G = T;
+declare module 'bar' {
+  type DefaultE = { somethingElse: true };
+  type G = T<DefaultE>;
+}
+      `,
+    },
   ],
 });


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4489
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Instead of using text to check if the type is the same, it is now checked by symbol.
If there is no symbol, it is checked by typeFlag.
Typescript doesn't provide an api for handling type relationships, does it?