### PR TITLE
fix(eslint-plugin): [init-declarations] fix nested namespace

### DIFF
--- a/packages/eslint-plugin/src/rules/init-declarations.ts
+++ b/packages/eslint-plugin/src/rules/init-declarations.ts
@@ -35,11 +35,7 @@ export default createRule<Options, MessageIds>({
           if (node.declare) {
             return;
           }
-          if (
-            node.parent?.type === AST_NODE_TYPES.TSModuleBlock &&
-            node.parent.parent?.type === AST_NODE_TYPES.TSModuleDeclaration &&
-            node.parent.parent?.declare
-          ) {
+          if (isAncestorNamespaceDeclared(node)) {
             return;
           }
         }
@@ -47,5 +43,24 @@ export default createRule<Options, MessageIds>({
         rules['VariableDeclaration:exit'](node);
       },
     };
+
+    function isAncestorNamespaceDeclared(
+      node: TSESTree.VariableDeclaration,
+    ): boolean {
+      let ancestor = node.parent;
+
+      while (ancestor) {
+        if (
+          ancestor.type === AST_NODE_TYPES.TSModuleDeclaration &&
+          ancestor.declare
+        ) {
+          return true;
+        }
+
+        ancestor = ancestor.parent;
+      }
+
+      return false;
+    }
   },
 });

--- a/packages/eslint-plugin/tests/rules/init-declarations.test.ts
+++ b/packages/eslint-plugin/tests/rules/init-declarations.test.ts
@@ -341,6 +341,35 @@ namespace myLib {
       `,
       options: ['always'],
     },
+    {
+      code: `
+declare namespace myLib1 {
+  const foo: number;
+  namespace myLib2 {
+    let bar: string;
+    namespace myLib3 {
+      let baz: object;
+    }
+  }
+}
+      `,
+      options: ['always'],
+    },
+
+    {
+      code: `
+declare namespace myLib1 {
+  const foo: number;
+  namespace myLib2 {
+    let bar: string;
+    namespace myLib3 {
+      let baz: object;
+    }
+  }
+}
+      `,
+      options: ['never'],
+    },
   ],
   invalid: [
     // checking compatibility with base rule
@@ -720,6 +749,37 @@ namespace myLib {
         {
           messageId: 'notInitialized',
           data: { idName: 'numberOfGreetings' },
+          type: AST_NODE_TYPES.VariableDeclarator,
+        },
+      ],
+    },
+    {
+      code: `
+namespace myLib1 {
+  const foo: number;
+  namespace myLib2 {
+    let bar: string;
+    namespace myLib3 {
+      let baz: object;
+    }
+  }
+}
+      `,
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'initialized',
+          data: { idName: 'foo' },
+          type: AST_NODE_TYPES.VariableDeclarator,
+        },
+        {
+          messageId: 'initialized',
+          data: { idName: 'bar' },
+          type: AST_NODE_TYPES.VariableDeclarator,
+        },
+        {
+          messageId: 'initialized',
+          data: { idName: 'baz' },
           type: AST_NODE_TYPES.VariableDeclarator,
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4392
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
It doesn't error when the ancestor namespace is declared(`declare namespace myLib { }`)