### PR TITLE
chore: remove unsupported branch argument from update-sponsors

### DIFF
--- a/.github/workflows/update-sponsors.yml
+++ b/.github/workflows/update-sponsors.yml
@@ -1,7 +1,6 @@
 name: Update Sponsors Data
 
 on:
-  branch: main
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4370
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Turns out `schedule` (cron) in GHA doesn't support specifying the branch. https://github.com/typescript-eslint/typescript-eslint/actions/runs/1834719537

```
Error: .github#L1
Invalid type for `on`
```

Per https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule the commit SHA will be the last commit on the default branch.