### PR TITLE
fix(eslint-plugin): [typedef] support nested object destructuring with type annotation

### DIFF
--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -149,6 +149,25 @@ export default util.createRule<[Options], MessageIds>({
       );
     }
 
+    function isAncestorHasTypeAnnotation(
+      node: TSESTree.ObjectPattern,
+    ): boolean {
+      let ancestor = node.parent;
+
+      while (ancestor) {
+        if (
+          ancestor.type === AST_NODE_TYPES.ObjectPattern &&
+          ancestor.typeAnnotation
+        ) {
+          return true;
+        }
+
+        ancestor = ancestor.parent;
+      }
+
+      return false;
+    }
+
     return {
       ...(arrayDestructuring && {
         ArrayPattern(node): void {
@@ -193,7 +212,11 @@ export default util.createRule<[Options], MessageIds>({
       }),
       ...(objectDestructuring && {
         ObjectPattern(node): void {
-          if (!node.typeAnnotation && !isForOfStatementContext(node)) {
+          if (
+            !node.typeAnnotation &&
+            !isForOfStatementContext(node) &&
+            !isAncestorHasTypeAnnotation(node)
+          ) {
             report(node);
           }
         },

--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -201,6 +201,26 @@ ruleTester.run('typedef', rule, {
         },
       ],
     },
+    {
+      code: `
+        const {
+          id,
+          details: {
+            name: {
+              first,
+              middle,
+              last,
+              forTest: { moreNested },
+            },
+          },
+        }: User = getUser();
+      `,
+      options: [
+        {
+          objectDestructuring: true,
+        },
+      ],
+    },
     // Function parameters
     'function receivesNumber(a: number): void {}',
     'function receivesStrings(a: string, b: string): void {}',
@@ -507,6 +527,44 @@ class ClassName {
       code: 'const { a, b } = { a: 1, b: 2 };',
       errors: [
         {
+          messageId: 'expectedTypedef',
+        },
+      ],
+      options: [
+        {
+          objectDestructuring: true,
+        },
+      ],
+    },
+    {
+      code: `
+        const {
+          id,
+          details: {
+            name: {
+              first,
+              middle,
+              last,
+              forTest: { moreNested },
+            },
+          },
+        } = getUser();
+      `,
+      errors: [
+        {
+          data: { name: 'first' },
+          messageId: 'expectedTypedef',
+        },
+        {
+          data: { name: 'middle' },
+          messageId: 'expectedTypedef',
+        },
+        {
+          data: { name: 'last' },
+          messageId: 'expectedTypedef',
+        },
+        {
+          data: { name: 'moreNested' },
           messageId: 'expectedTypedef',
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4505
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
It finds if top level has object has type annotation