### PR TITLE
fix(eslint-plugin): [no-uinnecessary-type-arguments] fix comparison of types

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
@@ -38,6 +38,22 @@ export default util.createRule<[], MessageIds>({
     const parserServices = util.getParserServices(context);
     const checker = parserServices.program.getTypeChecker();
 
+    function getTypeForComparison(type: ts.Type): {
+      type: ts.Type;
+      typeArguments: readonly ts.Type[];
+    } {
+      if (util.isTypeReferenceType(type)) {
+        return {
+          type: type.target,
+          typeArguments: util.getTypeArguments(type, checker),
+        };
+      }
+      return {
+        type,
+        typeArguments: [],
+      };
+    }
+
     function checkTSArgsAndParameters(
       esParameters: TSESTree.TSTypeParameterInstantiation,
       typeParameters: readonly ts.TypeParameterDeclaration[],
@@ -49,19 +65,30 @@ export default util.createRule<[], MessageIds>({
       if (!param?.default) {
         return;
       }
+
       // TODO: would like checker.areTypesEquivalent. https://github.com/Microsoft/TypeScript/issues/13502
       const defaultType = checker.getTypeAtLocation(param.default);
       const argTsNode = parserServices.esTreeNodeToTSNodeMap.get(arg);
       const argType = checker.getTypeAtLocation(argTsNode);
-      if (!argType.aliasSymbol && !defaultType.aliasSymbol) {
-        if (argType.flags !== defaultType.flags) {
+      // this check should handle some of the most simple cases of like strings, numbers, etc
+      if (defaultType !== argType) {
+        // For more complex types (like aliases to generic object types) - TS won't always create a
+        // global shared type object for the type - so we need to resort to manually comparing the
+        // reference type and the passed type arguments.
+        // Also - in case there are aliases - we need to resolve them before we do checks
+        const defaultTypeResolved = getTypeForComparison(defaultType);
+        const argTypeResolved = getTypeForComparison(argType);
+        if (
+          // ensure the resolved type AND all the parameters are the same
+          defaultTypeResolved.type !== argTypeResolved.type ||
+          defaultTypeResolved.typeArguments.length !==
+            argTypeResolved.typeArguments.length ||
+          defaultTypeResolved.typeArguments.some(
+            (t, i) => t !== argTypeResolved.typeArguments[i],
+          )
+        ) {
           return;
         }
-      } else if (
-        argType.aliasSymbol !== defaultType.aliasSymbol ||
-        argType.aliasTypeArguments !== defaultType.aliasTypeArguments
-      ) {
-        return;
       }
 
       context.report({

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
@@ -132,6 +132,19 @@ import { F } from './missing';
 function bar<T = F>() {}
 bar<F<number>>();
     `,
+    `
+type A<T = Element> = T;
+type B = A<HTMLInputElement>;
+    `,
+    `
+type A<T = Map<string, string>> = T;
+type B = A<Map<string, number>>;
+    `,
+    `
+type A = Map<string, string>;
+type B<T = A> = T;
+type C2 = B<Map<string, number>>;
+    `,
   ],
   invalid: [
     {
@@ -315,6 +328,102 @@ declare module 'bar' {
   type DefaultE = { somethingElse: true };
   type G = T<DefaultE>;
 }
+      `,
+    },
+    {
+      code: `
+type A<T = Map<string, string>> = T;
+type B = A<Map<string, string>>;
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'unnecessaryTypeParameter',
+        },
+      ],
+      output: `
+type A<T = Map<string, string>> = T;
+type B = A;
+      `,
+    },
+    {
+      code: `
+type A = Map<string, string>;
+type B<T = A> = T;
+type C = B<A>;
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'unnecessaryTypeParameter',
+        },
+      ],
+      output: `
+type A = Map<string, string>;
+type B<T = A> = T;
+type C = B;
+      `,
+    },
+    {
+      code: `
+type A = Map<string, string>;
+type B<T = A> = T;
+type C = B<Map<string, string>>;
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'unnecessaryTypeParameter',
+        },
+      ],
+      output: `
+type A = Map<string, string>;
+type B<T = A> = T;
+type C = B;
+      `,
+    },
+    {
+      code: `
+type A = Map<string, string>;
+type B = Map<string, string>;
+type C<T = A> = T;
+type D = C<B>;
+      `,
+      errors: [
+        {
+          line: 5,
+          messageId: 'unnecessaryTypeParameter',
+        },
+      ],
+      output: `
+type A = Map<string, string>;
+type B = Map<string, string>;
+type C<T = A> = T;
+type D = C;
+      `,
+    },
+    {
+      code: `
+type A = Map<string, string>;
+type B = A;
+type C = Map<string, string>;
+type D = C;
+type E<T = B> = T;
+type F = E<D>;
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'unnecessaryTypeParameter',
+        },
+      ],
+      output: `
+type A = Map<string, string>;
+type B = A;
+type C = Map<string, string>;
+type D = C;
+type E<T = B> = T;
+type F = E;
       `,
     },
   ],

--- a/packages/type-utils/src/predicates.ts
+++ b/packages/type-utils/src/predicates.ts
@@ -54,6 +54,24 @@ export function isTypeUnknownType(type: ts.Type): boolean {
   return isTypeFlagSet(type, ts.TypeFlags.Unknown);
 }
 
+// https://github.com/microsoft/TypeScript/blob/42aa18bf442c4df147e30deaf27261a41cbdc617/src/compiler/types.ts#L5157
+const Nullable = ts.TypeFlags.Undefined | ts.TypeFlags.Null;
+// https://github.com/microsoft/TypeScript/blob/42aa18bf442c4df147e30deaf27261a41cbdc617/src/compiler/types.ts#L5187
+const ObjectFlagsType =
+  ts.TypeFlags.Any |
+  Nullable |
+  ts.TypeFlags.Never |
+  ts.TypeFlags.Object |
+  ts.TypeFlags.Union |
+  ts.TypeFlags.Intersection;
+export function isTypeReferenceType(type: ts.Type): type is ts.TypeReference {
+  if ((type.flags & ObjectFlagsType) === 0) {
+    return false;
+  }
+  const objectTypeFlags = (type as ts.ObjectType).objectFlags;
+  return (objectTypeFlags & ts.ObjectFlags.Reference) !== 0;
+}
+
 /**
  * @returns true if the type is `any`
  */


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4554
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
The old logic (introduced in #4543) only handled a subset of cases and caused false-positives.
We probably should have asked for more test cases on the PR to help validate? 🤷  Hindsight is 20:20.

This new logic should cover more cases by comparing the types to a tighter degree.
No doubt there will still be some false-positives here, but without the proper type relationship API we're making it up as we go...!