### PR TITLE
docs(eslint-plugin): [member-ordering] correct options type

### DIFF
--- a/packages/eslint-plugin/docs/rules/member-ordering.md
+++ b/packages/eslint-plugin/docs/rules/member-ordering.md
@@ -25,24 +25,20 @@ These options allow to specify how to group the members and sort their groups.
 - Sort members within groups: Use `memberTypes` and `order`
 
 ```ts
-type TypeOptions<T> =
-  | {
-    memberTypes: Array<T> | 'never',
-    order?: 'alphabetically' | 'alphabetically-case-insensitive' | 'as-written',
-  }
-  | {
-    order: 'alphabetically' | 'alphabetically-case-insensitive' | 'as-written',
-  };
+type SortedOrderConfig = {
+  memberTypes?: MemberType[] | 'never';
+  order: 'alphabetically' | 'alphabetically-case-insensitive' | 'as-written';
+};
 
-{
-  default?: TypeOptions<MemberTypes>,
+type OrderConfig = MemberType[] | SortedOrderConfig | 'never';
 
-  classes?: TypeOptions<MemberTypes>,
-  classExpressions?: TypeOptions<MemberTypes>,
-
-  interfaces?: TypeOptions<'signature' | 'field' | 'method' | 'constructor'>,
-  typeLiterals?: TypeOptions<'signature' | 'field' | 'method' | 'constructor'>,
-}
+type Options = {
+  default?: OrderConfig;
+  classes?: OrderConfig;
+  classExpressions?: OrderConfig;
+  interfaces?: OrderConfig;
+  typeLiterals?: OrderConfig;
+};
 ```
 
 See below for the possible definitions of `MemberType`.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Corrected member-ordering options type on the readme.
