### PR TITLE
fix(parser): eliminate runtime TS dependency

### DIFF
--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -49,22 +49,22 @@ function getLib(compilerOptions: CompilerOptions): Lib[] {
     }, [] as Lib[]);
   }
 
-  const target = compilerOptions.target ?? ScriptTarget.ES5;
+  const target = compilerOptions.target ?? 1 /* ScriptTarget.ES5 */;
   // https://github.com/Microsoft/TypeScript/blob/59ad375234dc2efe38d8ee0ba58414474c1d5169/src/compiler/utilitiesPublic.ts#L13-L32
   switch (target) {
-    case ScriptTarget.ESNext:
+    case 99 /* ScriptTarget.ESNext */:
       return ['esnext.full'];
-    case ScriptTarget.ES2020:
+    case 7 /* ScriptTarget.ES2020 */:
       return ['es2020.full'];
-    case ScriptTarget.ES2019:
+    case 6 /* ScriptTarget.ES2019 */:
       return ['es2019.full'];
-    case ScriptTarget.ES2018:
+    case 5 /* ScriptTarget.ES2018 */:
       return ['es2018.full'];
-    case ScriptTarget.ES2017:
+    case 4 /* ScriptTarget.ES2017 */:
       return ['es2017.full'];
-    case ScriptTarget.ES2016:
+    case 3 /* ScriptTarget.ES2016 */:
       return ['es2016.full'];
-    case ScriptTarget.ES2015:
+    case 2 /* ScriptTarget.ES2015 */:
       return ['es6'];
     default:
       return ['lib'];


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

`@typescript-eslint/parser` declares an [optional peer dependency](https://github.com/typescript-eslint/typescript-eslint/pull/1327) on `typescript`, but [`dist/parser.js` calls `require("typescript")`](https://unpkg.com/browse/@typescript-eslint/parser@5.12.0/dist/parser.js).

It seems like the only runtime dependency is on `ScriptTarget`, and can be eliminated by inlining those 8 constants?

I ran into this because of [this issue](https://github.com/xojs/xo/issues/555#issuecomment-935062115) installing the `xo` package with npm <= 6, however I'm not sure npm is at fault, there:

npm (version 6) hoists `@typescript-eslint/parser` without hoisting `typescript`, because of a conflicting binary in `@tsd/typescript`. You can reproduce by running:
```sh
npm install @tsd/typescript xo@0.45
```
npm version 6:
- hoists `@typescript-eslint/parser` -> `node_modules/@typescript-eslint/parser`
- installs `typescript` -> `node_modules/xo/node_modules/typescript` (doesn't hoist, the `tsc` binary conflicts with `@tsd/typescript`)

Which leads to https://github.com/xojs/xo/issues/555: `Error: Failed to load parser '/home/runner/work/p-cancelable/p-cancelable/node_modules/@typescript-eslint/parser/dist/index.js' declared in 'BaseConfig': Cannot find module 'typescript'`

`xo` worked around this with [`bundledDependencies` on `@typescript-eslint/parser`](https://github.com/xojs/xo/pull/624/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R56) ... But with an optional peer dependency between `@typescript-eslint/parser` and `typescript`, is npm at fault for hoisting the former without the latter? I haven't confirmed what it does if `@typescript-eslint/parser` declared a stricter dependency.

My hope is that eliminating the runtime dependency would enable `xo` to unbundle its dependencies, decreasing the package size and fixing an issue with npm 7 that the workaround ([may have](https://github.com/xojs/xo/issues/651)) caused.