### PR TITLE
docs: add a missing "

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -201,7 +201,7 @@ For example, by default it will ensure that a glob like `./**/tsconfig.json` wil
 Default `undefined`.
 
 This option allows you to provide one or more additional file extensions which should be considered in the TypeScript Program compilation.
-The default extensions are `.ts`, `.tsx`, `.js`, and `.jsx`. Add extensions starting with `.`, followed by the file extension. E.g. for a `.vue` file use `"extraFileExtensions: [".vue"]`.
+The default extensions are `.ts`, `.tsx`, `.js`, and `.jsx`. Add extensions starting with `.`, followed by the file extension. E.g. for a `.vue` file use `"extraFileExtensions": [".vue"]`.
 
 ### `parserOptions.warnOnUnsupportedTypeScriptVersion`
 


### PR DESCRIPTION
## PR Checklist

-   [ ] Addresses an existing issue: fixes #000 (NO ISSUE DUE TO SIZE)
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

The documentation is missing a `"` and I'm trying to fix it.

Happy to file an issue if you think it's worth it, but didn't want to add more noise.