### PR TITLE
fix(eslint-plugin): [sort-type-union-intersection-members] Wrap the constructorType in parentheses

### DIFF
--- a/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
@@ -85,7 +85,10 @@ function getGroup(node: TSESTree.TypeNode): Group {
 }
 
 function requiresParentheses(node: TSESTree.TypeNode): boolean {
-  return node.type === AST_NODE_TYPES.TSFunctionType;
+  return (
+    node.type === AST_NODE_TYPES.TSFunctionType ||
+    node.type === AST_NODE_TYPES.TSConstructorType
+  );
 }
 
 export type Options = [

--- a/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
@@ -272,6 +272,15 @@ type T =
         },
       ],
     },
+    {
+      code: `type Expected = (new (x: number) => boolean) ${operator} string;`,
+      output: `type Expected = string ${operator} (new (x: number) => boolean);`,
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+        },
+      ],
+    },
   ];
 };
 


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4581
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview
The constructorType is now also enclosed in parentheses.
<!-- Description of what is changed and how the code change does that. -->
