### PR TITLE
feat(eslint-plugin): [type-annotation-spacing] add allowExtraSpaces option

### DIFF
--- a/packages/eslint-plugin/docs/rules/type-annotation-spacing.md
+++ b/packages/eslint-plugin/docs/rules/type-annotation-spacing.md
@@ -44,6 +44,8 @@ This rule has an object option:
 - `"after": true`, (default) requires a space after the colon/arrow.
 - `"after": false`, disallows spaces after the colon/arrow.
 - `"overrides"`, overrides the default options for type annotations with `colon` (e.g. `const foo: string`) and function types with `arrow` (e.g. `type Foo = () => {}`). Additionally allows granular overrides for `variable` (`const foo: string`),`parameter` (`function foo(bar: string) {...}`),`property` (`interface Foo { bar: string }`) and `returnType` (`function foo(): string {...}`) annotations.
+- `"allowExtraSpaces": false`, (default) disallows more than one whitespace
+- `"allowExtraSpaces": true`, allows more than one whitespace
 
 ### defaults
 
@@ -297,6 +299,39 @@ class Foo {
 }
 
 type Foo = () => {};
+```
+
+### allowExtraSpaces
+
+Examples of code for this rule with `{ "before": true, "after": true, allowExtraSpaces: false }` options:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+<!-- prettier-ignore -->
+```ts
+let foo    :    string = "bar";
+
+function foo()    :    string {}
+
+class Foo {
+    name    :     string;
+}
+```
+
+#### ✅ Correct
+
+<!-- prettier-ignore -->
+```ts
+let foo : string = "bar";
+
+function foo() : string {}
+
+class Foo {
+    name : string;
+}
+
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/type-annotation-spacing.test.ts
@@ -1181,6 +1181,30 @@ interface Foo {
     },
     // https://github.com/typescript-eslint/typescript-eslint/issues/1663
     'type ConstructorFn = new (...args: any[]) => any;',
+    {
+      code: `
+class Foo {
+    bar      :Bar;
+    }
+      `,
+      options: [{ before: true, after: false, allowExtraSpaces: true }],
+    },
+    {
+      code: `
+class Foo {
+    bar:        Bar;
+    }
+      `,
+      options: [{ before: false, after: true, allowExtraSpaces: true }],
+    },
+    {
+      code: `
+class Foo {
+    bar      :       Bar;
+    }
+      `,
+      options: [{ before: true, after: true, allowExtraSpaces: true }],
+    },
   ],
   invalid: [
     {
@@ -3793,6 +3817,75 @@ type Foo = {
           },
           line: 5,
           column: 59,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+    bar      :Bar;
+}
+      `,
+      options: [{ before: true, after: false }],
+      output: `
+class Foo {
+    bar :Bar;
+}
+      `,
+      errors: [
+        {
+          messageId: 'extraSpaceBefore',
+          data: { type: ':' },
+          line: 3,
+          column: 14,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+    bar:        Bar;
+}
+      `,
+      options: [{ before: false, after: true }],
+      output: `
+class Foo {
+    bar: Bar;
+}
+      `,
+      errors: [
+        {
+          messageId: 'extraSpaceAfter',
+          data: { type: ':' },
+          line: 3,
+          column: 8,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+    bar      :        Bar;
+}
+      `,
+      options: [{ before: true, after: true }],
+      output: `
+class Foo {
+    bar : Bar;
+}
+      `,
+      errors: [
+        {
+          messageId: 'extraSpaceAfter',
+          data: { type: ':' },
+          line: 3,
+          column: 14,
+        },
+        {
+          messageId: 'extraSpaceBefore',
+          data: { type: ':' },
+          line: 3,
+          column: 14,
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1001
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I looked at the code because it seems like a good starter for a fixer part. I didn't know there was some stale PR https://github.com/typescript-eslint/typescript-eslint/pull/1013  Anyway, since I tweaked some code, I just made this PR. I made this to option so that It doesn't conflict with current behavior.