### PR TITLE
fix(eslint-plugin): [no-misused-promises] factor thenable returning function overload signatures

### DIFF
--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -398,8 +398,8 @@ function voidFunctionParams(
   const voidReturnIndices = new Set<number>();
   const type = checker.getTypeAtLocation(node.expression);
 
-  // TODO(file bug on TypeScript): checker.getResolvedSignature prefers a () => void over a () => Promise<void>
-  // See https://github.com/typescript-eslint/typescript-eslint/issues/4609 (todo: comment in PR)
+  // We can't use checker.getResolvedSignature because it prefers an early '() => void' over a later '() => Promise<void>'
+  // See https://github.com/microsoft/TypeScript/issues/48077
 
   for (const subType of tsutils.unionTypeParts(type)) {
     // Standard function calls and `new` have two different types of signatures

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -276,6 +276,34 @@ declare const it: ItLike;
 it('', async () => {});
       `,
     },
+    {
+      code: `
+interface ItLike {
+  (name: string, callback: () => void): void;
+}
+interface ItLike {
+  (name: string, callback: () => Promise<void>): void;
+}
+
+declare const it: ItLike;
+
+it('', async () => {});
+      `,
+    },
+    {
+      code: `
+interface ItLike {
+  (name: string, callback: () => Promise<void>): void;
+}
+interface ItLike {
+  (name: string, callback: () => void): void;
+}
+
+declare const it: ItLike;
+
+it('', async () => {});
+      `,
+    },
   ],
 
   invalid: [
@@ -725,6 +753,46 @@ it('', async () => {});
       errors: [
         {
           line: 9,
+          messageId: 'voidReturnArgument',
+        },
+      ],
+    },
+    {
+      code: `
+interface ItLike {
+  (name: string, callback: () => number): void;
+}
+interface ItLike {
+  (name: string, callback: () => void): void;
+}
+
+declare const it: ItLike;
+
+it('', async () => {});
+      `,
+      errors: [
+        {
+          line: 11,
+          messageId: 'voidReturnArgument',
+        },
+      ],
+    },
+    {
+      code: `
+interface ItLike {
+  (name: string, callback: () => void): void;
+}
+interface ItLike {
+  (name: string, callback: () => number): void;
+}
+
+declare const it: ItLike;
+
+it('', async () => {});
+      `,
+      errors: [
+        {
+          line: 11,
           messageId: 'voidReturnArgument',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -252,6 +252,30 @@ const Component: any = () => null;
       `,
       filename: 'react.tsx',
     },
+    {
+      code: `
+interface ItLike {
+  (name: string, callback: () => Promise<void>): void;
+  (name: string, callback: () => void): void;
+}
+
+declare const it: ItLike;
+
+it('', async () => {});
+      `,
+    },
+    {
+      code: `
+interface ItLike {
+  (name: string, callback: () => void): void;
+  (name: string, callback: () => Promise<void>): void;
+}
+
+declare const it: ItLike;
+
+it('', async () => {});
+      `,
+    },
   ],
 
   invalid: [
@@ -684,6 +708,24 @@ const Component = (obj: O) => null;
         {
           line: 7,
           messageId: 'voidReturnAttribute',
+        },
+      ],
+    },
+    {
+      code: `
+interface ItLike {
+  (name: string, callback: () => number): void;
+  (name: string, callback: () => void): void;
+}
+
+declare const it: ItLike;
+
+it('', async () => {});
+      `,
+      errors: [
+        {
+          line: 9,
+          messageId: 'voidReturnArgument',
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4609
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Previously the rule checked for any function overload signature that had a `void`-returning function for each parameter. Those parameters were then considered unsafe for thenable-returning functions.

In an ideal world we would use the type checker's `getResolvedSignature` API to grab the specific type signature used for the call instead. However, TypeScript selects the first matching signature, causing it to select one with the `() => void`  parameter before the `() => Promise<void>` parameter is seen. https://github.com/microsoft/TypeScript/issues/48077

Instead, now we no longer consider any parameter index unsafe if a signature can have a thenable-returning function for it. 😞 