### PR TITLE
docs: remove node_modules from .eslintignore

### DIFF
--- a/docs/linting/README.md
+++ b/docs/linting/README.md
@@ -56,8 +56,6 @@ This file will tell ESLint which files and folders it should never lint.
 Add the following lines to the file:
 
 ```ignore title=".eslintignore"
-# don't ever lint node_modules
-node_modules
 # don't lint build output (make sure it's set to your correct build folder name)
 dist
 ```


### PR DESCRIPTION
I found this in the documentation of ESLint (https://eslint.org/docs/user-guide/configuring/ignoring-code):

```
In addition to any patterns in the .eslintignore file, ESLint always follows a couple of implicit ignore rules even if the --no-ignore flag is passed. The implicit rules are as follows:
- node_modules/ is ignored.
- dot-files (except for .eslintrc.*), as well as dot-folders and their contents, are ignored.
```

Maybe it's confusing to the person reading the documentation?

I couldn't find an issue for this change, sorry.