### PR TITLE
feat(parser): add `parserOptions.emitDecoratorMetadata`

### DIFF
--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -67,6 +67,8 @@ interface ParserOptions {
 
   program?: import('typescript').Program;
   moduleResolver?: string;
+
+  emitDecoratorMetadata?: boolean;
 }
 ```
 
@@ -245,6 +247,12 @@ interface ModuleResolver {
 [Refer to the TypeScript Wiki for an example on how to write the `resolveModuleNames` function](https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#customizing-module-resolution).
 
 Note that if you pass custom programs via `options.programs` this option will not have any effect over them (you can simply add the custom resolution on them directly).
+
+### `parserOptions.emitDecoratorMetadata`
+
+Default `undefined`.
+
+This option allow you to tell parser to act as if `emitDecoratorMetadata: true` is set in `tsconfig.json`, but without [type-aware linting](https://typescript-eslint.io/docs/linting/type-linting). In other words, you don't have to specify `parserOptions.project` in this case, making the linting process faster.
 
 ## Utilities
 

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -132,6 +132,7 @@ function parseForESLint(
   const { ast, services } = parseAndGenerateServices(code, parserOptions);
   ast.sourceType = options.sourceType;
 
+  let emitDecoratorMetadata = options.emitDecoratorMetadata === true;
   if (services.hasFullTypeInformation) {
     // automatically apply the options configured for the program
     const compilerOptions = services.program.getCompilerOptions();
@@ -165,9 +166,12 @@ function parseForESLint(
       }
     }
     if (compilerOptions.emitDecoratorMetadata === true) {
-      analyzeOptions.emitDecoratorMetadata =
-        compilerOptions.emitDecoratorMetadata;
+      emitDecoratorMetadata = true;
     }
+  }
+
+  if (emitDecoratorMetadata) {
+    analyzeOptions.emitDecoratorMetadata = true;
   }
 
   const scopeManager = analyze(ast, analyzeOptions);

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -37,6 +37,9 @@ interface ParserOptions {
   jsxFragmentName?: string | null;
   lib?: Lib[];
 
+  // use emitDecoratorMetadata without specifying parserOptions.project
+  emitDecoratorMetadata?: boolean;
+
   // typescript-estree specific
   comment?: boolean;
   debugLevel?: DebugLevel;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4608
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

`emitDecoratorMetadata` is added to `ParserOptions` as an optional param

The parser first try to use `compilerOptions.emitDecoratorMetadata` as it did before.

If `parserOptions.project` is set, then `parserOptions.emitDecoratorMetadata` is used.
