### PR TITLE
chore: remove naming convention todo from eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,9 +74,6 @@ module.exports = {
       { varsIgnorePattern: '^_', argsIgnorePattern: '^_' },
     ],
 
-    // TODO - enable this
-    '@typescript-eslint/naming-convention': 'off',
-
     //
     // Internal repo rules
     //


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #3278
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

I tried enabling it but there are a ton of AST-specific names such as `TSQuery` that don't match with it. We've lived this long without it and have a pretty informed maintainer team. 🤷 