### PR TITLE
chore: add --changedSince to CI test runs on other Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,8 +250,13 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Print debug Git info
+        run: |
+          git remote -v
+          git log
+
       - name: Fetch commits after base SHA
-        run: git log main.. --pretty="%H" | xargs -n1 git fetch origin ${{ github.event.pull_request.base.sha }}
+        run: git log ${{ github.event.pull_request.base.sha }}.. --pretty="%H" | xargs -n1 git fetch origin
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,8 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,32 +278,32 @@ jobs:
           yarn build --exclude website
 
       - name: Run unit tests for typescript-estree
-        run: npx nx test @typescript-eslint/typescript-estree --changedSince=${{ github.event.pull_request.base.sha }}
+        run: npx nx test @typescript-eslint/typescript-estree
         env:
           CI: true
 
       - name: Run unit tests for visitor-keys
-        run: npx nx test @typescript-eslint/visitor-keys --changedSince=${{ github.event.pull_request.base.sha }}
+        run: npx nx test @typescript-eslint/visitor-keys
         env:
           CI: true
 
       - name: Run unit tests for scope-manager
-        run: npx nx test @typescript-eslint/scope-manager --changedSince=${{ github.event.pull_request.base.sha }}
+        run: npx nx test @typescript-eslint/scope-manager
         env:
           CI: true
 
       - name: Run unit tests for utils
-        run: npx nx test @typescript-eslint/utils --changedSince=${{ github.event.pull_request.base.sha }}
+        run: npx nx test @typescript-eslint/utils
         env:
           CI: true
 
       - name: Run unit tests for type-utils
-        run: npx nx test @typescript-eslint/type-utils --changedSince=${{ github.event.pull_request.base.sha }}
+        run: npx nx test @typescript-eslint/type-utils
         env:
           CI: true
 
       - name: Run unit tests for parser
-        run: npx nx test @typescript-eslint/parser --changedSince=${{ github.event.pull_request.base.sha }}
+        run: npx nx test @typescript-eslint/parser
         env:
           CI: true
 
@@ -313,7 +313,7 @@ jobs:
           CI: true
 
       - name: Run unit tests for eslint-plugin-tslint
-        run: npx nx test @typescript-eslint/eslint-plugin-tslint --changedSince=${{ github.event.pull_request.base.sha }}
+        run: npx nx test @typescript-eslint/eslint-plugin-tslint
         env:
           CI: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,14 @@ jobs:
       # Added the - at the end to function as a separator to improve readability in the PR comment from the Nx cloud app
       NX_CLOUD_ENV_NAME: 'Node ${{ matrix.node-version }} -'
     steps:
+      - name: Populate base SHA in local history
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.base.sha }}
+
       - uses: actions/checkout@v3
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -269,42 +276,42 @@ jobs:
           yarn build --exclude website
 
       - name: Run unit tests for typescript-estree
-        run: npx nx test @typescript-eslint/typescript-estree
+        run: npx nx test @typescript-eslint/typescript-estree --changedSince=${{ github.event.pull_request.base.sha }}
         env:
           CI: true
 
       - name: Run unit tests for visitor-keys
-        run: npx nx test @typescript-eslint/visitor-keys
+        run: npx nx test @typescript-eslint/visitor-keys --changedSince=${{ github.event.pull_request.base.sha }}
         env:
           CI: true
 
       - name: Run unit tests for scope-manager
-        run: npx nx test @typescript-eslint/scope-manager
+        run: npx nx test @typescript-eslint/scope-manager --changedSince=${{ github.event.pull_request.base.sha }}
         env:
           CI: true
 
       - name: Run unit tests for utils
-        run: npx nx test @typescript-eslint/utils
+        run: npx nx test @typescript-eslint/utils --changedSince=${{ github.event.pull_request.base.sha }}
         env:
           CI: true
 
       - name: Run unit tests for type-utils
-        run: npx nx test @typescript-eslint/type-utils
+        run: npx nx test @typescript-eslint/type-utils --changedSince=${{ github.event.pull_request.base.sha }}
         env:
           CI: true
 
       - name: Run unit tests for parser
-        run: npx nx test @typescript-eslint/parser
+        run: npx nx test @typescript-eslint/parser --changedSince=${{ github.event.pull_request.base.sha }}
         env:
           CI: true
 
       - name: Run unit tests for eslint-plugin
-        run: npx nx test @typescript-eslint/eslint-plugin
+        run: npx nx test @typescript-eslint/eslint-plugin --changedSince=${{ github.event.pull_request.base.sha }}
         env:
           CI: true
 
       - name: Run unit tests for eslint-plugin-tslint
-        run: npx nx test @typescript-eslint/eslint-plugin-tslint
+        run: npx nx test @typescript-eslint/eslint-plugin-tslint --changedSince=${{ github.event.pull_request.base.sha }}
         env:
           CI: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,8 +255,8 @@ jobs:
           git remote -v
           git log
 
-      - name: Fetch commits after base SHA
-        run: git log ${{ github.event.pull_request.base.sha }}.. --pretty="%H" | xargs -n1 git fetch origin
+      - name: Pull commits after base SHA
+        run: git log ${{ github.event.pull_request.base.sha }}.. --pretty="%H" | xargs -n1 git pull origin
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,12 @@ jobs:
       # Added the - at the end to function as a separator to improve readability in the PR comment from the Nx cloud app
       NX_CLOUD_ENV_NAME: 'Node ${{ matrix.node-version }} -'
     steps:
+      - name: Populate base SHA in local history
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.base.sha }}
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,15 +240,12 @@ jobs:
       # Added the - at the end to function as a separator to improve readability in the PR comment from the Nx cloud app
       NX_CLOUD_ENV_NAME: 'Node ${{ matrix.node-version }} -'
     steps:
-      - name: Populate base SHA in local history
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 1
-          ref: ${{ github.event.pull_request.base.sha }}
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+
+      - name: Fetch commits after base SHA
+        run: git log main.. --pretty="%H" | xargs -n1 git fetch origin ${{ github.event.pull_request.base.sha }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -4,6 +4,7 @@ import { RuleTester } from '../RuleTester';
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
+// comment for CI change :)
 
 const ruleTester = new RuleTester({ parser: '@typescript-eslint/parser' });
 

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1,11 +1,6 @@
 import rule from '../../src/rules/unified-signatures';
 import { RuleTester } from '../RuleTester';
 
-//------------------------------------------------------------------------------
-// Tests
-//------------------------------------------------------------------------------
-// comment for CI change :)
-
 const ruleTester = new RuleTester({ parser: '@typescript-eslint/parser' });
 
 ruleTester.run('unified-signatures', rule, {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4660
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Uses [Jest's `--changedSince`](https://jestjs.io/docs/cli#--changedsince) against the target branch in a PR to cut down on the number of unnecessary tests run on other Node.js versions. This means we'll get reports of unit test failures in `eslint-plugin` a minute or two sooner!

Doesn't use this in the primary Node.js version because the test coverage report still needs to include all files.

Not that I think this is reachable, but if the `${{ github.event.pull_request.base.sha }}` variable is blank/empty then all tests will be run.