### PR TITLE
docs(eslint-plugin) : Fix broken link in the readme

### DIFF
--- a/packages/eslint-plugin/docs/rules/README.md
+++ b/packages/eslint-plugin/docs/rules/README.md
@@ -9,7 +9,7 @@ slug: /
 `@typescript-eslint/eslint-plugin` comes with two rulesets you can extend from to pull in the recommended starting rules:
 
 - `'plugin:@typescript-eslint/recommended'`: recommended rules for code correctness that you can drop in without additional configuration.
-  See [Linting](https://typescript-eslint.io/docs/linting/linting) for more details.
+  See [Linting](https://typescript-eslint.io/docs/linting) for more details.
 - `'plugin:@typescript-eslint/recommended-requiring-type-checking'` additional recommended rules that require type information.
   See [Linting](https://typescript-eslint.io/docs/linting/type-linting) for more details.
 


### PR DESCRIPTION
Docs/Linting/Linting didn't exist. However there was a regular page called linting.

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [X] Addresses an existing issue: fixes #4593
-   [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [X] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

In Rules > Overview, in the first bullet point, "See [Linting](https://typescript-eslint.io/docs/linting/linting) for more details" has an incorrect link. This leads to a "Page Not Found" error.

I had changed the link from "https://typescript-eslint.io/docs/linting/linting" to "https://typescript-eslint.io/docs/linting" in order to fix the error. 