### PR TITLE
fix(eslint-plugin): [consistent-type-assertions] enforce assertionStyle for `const` assertions

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -84,12 +84,12 @@ export default util.createRule<Options, MessageIds>({
     function reportIncorrectAssertionType(
       node: TSESTree.TSTypeAssertion | TSESTree.TSAsExpression,
     ): void {
+      const messageId = options.assertionStyle;
+
       // If this node is `as const`, then don't report an error.
-      if (isConst(node.typeAnnotation)) {
+      if (isConst(node.typeAnnotation) && messageId === 'never') {
         return;
       }
-
-      const messageId = options.assertionStyle;
 
       context.report({
         node,

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -5,18 +5,26 @@ const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
 });
 
-const ANGLE_BRACKET_TESTS = `
+const ANGLE_BRACKET_TESTS_EXCEPT_CONST_CASE = `
 const x = <Foo>new Generic<int>();
 const x = <A>b;
 const x = <readonly number[]>[1];
-const x = <a | b>('string');
+const x = <a | b>('string');`;
+
+const ANGLE_BRACKET_TESTS = `${ANGLE_BRACKET_TESTS_EXCEPT_CONST_CASE}
+const x = <const>{ key: 'value' };
 `;
-const AS_TESTS = `
+
+const AS_TESTS_EXCEPT_CONST_CASE = `
 const x = new Generic<int>() as Foo;
 const x = b as A;
 const x = [1] as readonly number[];
-const x = ('string') as a | b;
+const x = ('string') as a | b;`;
+
+const AS_TESTS = `${AS_TESTS_EXCEPT_CONST_CASE}
+const x = { key: 'value' } as const;
 `;
+
 const OBJECT_LITERAL_AS_CASTS = `
 const x = {} as Foo<int>;
 `;
@@ -189,7 +197,7 @@ ruleTester.run('consistent-type-assertions', rule, {
       ],
     }),
     ...batchedSingleLineTests({
-      code: AS_TESTS,
+      code: AS_TESTS_EXCEPT_CONST_CASE,
       options: [
         {
           assertionStyle: 'never',
@@ -219,7 +227,7 @@ ruleTester.run('consistent-type-assertions', rule, {
       ],
     }),
     ...batchedSingleLineTests({
-      code: ANGLE_BRACKET_TESTS,
+      code: ANGLE_BRACKET_TESTS_EXCEPT_CONST_CASE,
       options: [
         {
           assertionStyle: 'never',


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4684
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

- Enables the consistent-type-assertions rule enforces the assertionStyle (`as` and `angle-bracket`) for `const` too
