### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -299,10 +299,10 @@ function getMemberRawName(
   const { name, type } = util.getNameFromMember(member, sourceCode);
 
   if (type === util.MemberNameType.Quoted) {
-    return name.substr(1, name.length - 2);
+    return name.slice(1, -1);
   }
   if (type === util.MemberNameType.Private) {
-    return name.substr(1);
+    return name.slice(1);
   }
   return name;
 }

--- a/packages/typescript-estree/src/convert-comments.ts
+++ b/packages/typescript-estree/src/convert-comments.ts
@@ -36,7 +36,7 @@ export function convertComments(
             range[1] - textStart - 2;
       comments.push({
         type,
-        value: code.substr(textStart, textEnd),
+        value: code.slice(textStart, textStart + textEnd),
         range,
         loc,
       });

--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -57,7 +57,7 @@ const correctPathCasing = useCaseSensitiveFileNames
 function getCanonicalFileName(filePath: string): CanonicalPath {
   let normalized = path.normalize(filePath);
   if (normalized.endsWith(path.sep)) {
-    normalized = normalized.substr(0, normalized.length - 1);
+    normalized = normalized.slice(0, -1);
   }
   return correctPathCasing(normalized) as CanonicalPath;
 }

--- a/packages/website-eslint/src/mock/path.js
+++ b/packages/website-eslint/src/mock/path.js
@@ -95,7 +95,7 @@ export function resolve() {
 // posix version
 export function normalize(path) {
   let isPathAbsolute = isAbsolute(path),
-    trailingSlash = substr(path, -1) === '/';
+    trailingSlash = path.endsWith('/');
 
   // Normalize the path
   path = normalizeArray(
@@ -136,8 +136,8 @@ export function join() {
 // path.relative(from, to)
 // posix version
 export function relative(from, to) {
-  from = resolve(from).substr(1);
-  to = resolve(to).substr(1);
+  from = resolve(from).slice(1);
+  to = resolve(to).slice(1);
 
   function trim(arr) {
     let start = 0;
@@ -191,7 +191,7 @@ export function dirname(path) {
 
   if (dir) {
     // It has a dirname, strip trailing slash
-    dir = dir.substr(0, dir.length - 1);
+    dir = dir.slice(0, -1);
   }
 
   return root + dir;
@@ -200,8 +200,8 @@ export function dirname(path) {
 export function basename(path, ext) {
   let f = splitPath(path)[2];
   // TODO: make this comparison case-insensitive on windows?
-  if (ext && f.substr(-1 * ext.length) === ext) {
-    f = f.substr(0, f.length - ext.length);
+  if (ext && f.slice(-1 * ext.length) === ext) {
+    f = f.slice(0, f.length - ext.length);
   }
   return f;
 }
@@ -231,14 +231,3 @@ function filter(xs, f) {
   }
   return res;
 }
-
-// String.prototype.substr - negative index don't work in IE8
-const substr =
-  'ab'.substr(-1) === 'b'
-    ? function (str, start, len) {
-        return str.substr(start, len);
-      }
-    : function (str, start, len) {
-        if (start < 0) start = str.length + start;
-        return str.substr(start, len);
-      };


### PR DESCRIPTION
## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
