### PR TITLE
fix: code container hiding navigation menu

### DIFF
--- a/packages/website/data/sponsors.json
+++ b/packages/website/data/sponsors.json
@@ -12,7 +12,7 @@
     "description": "LIVE PAIN FREE",
     "id": "x8k03rey-d5agmq5m-z9b6lbwo-z7j4nxv9",
     "image": "https://images.opencollective.com/my-sports-injury-ltd/518c583/logo.png",
-    "name": "My Sports Injury Ltd",
+    "name": "MySportsInjury",
     "slug": "my-sports-injury-ltd",
     "tier": "supporter",
     "website": "https://www.mysportsinjury.co.uk"

--- a/packages/website/src/components/Playground.module.css
+++ b/packages/website/src/components/Playground.module.css
@@ -39,5 +39,5 @@
   width: 100%;
   height: calc(100% - var(--ifm-navbar-height));
   top: var(--ifm-navbar-height);
-  z-index: 100;
+  z-index: calc(var(--ifm-z-index-fixed) - 1);
 }

--- a/packages/website/src/components/Playground.module.css
+++ b/packages/website/src/components/Playground.module.css
@@ -39,5 +39,5 @@
   width: 100%;
   height: calc(100% - var(--ifm-navbar-height));
   top: var(--ifm-navbar-height);
-  z-index: var(--ifm-z-index-fixed);
+  z-index: 100;
 }


### PR DESCRIPTION

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview
<img width="986" alt="issue" src="https://user-images.githubusercontent.com/4947384/159300290-5abea02b-f40f-465b-82a9-f8009d45e6d8.png">

Code container is hiding side navigation menu in a smaller window. The issue is due same z-index values for both code container and navigation menu. Now code container is pushed down by lowering the z-index value.

No issue template for creating issues for the website. So directly raising PR without opening an issue.