### PR TITLE
feat(eslint-plugin): [no-this-alias] report on assignment expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-this-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-this-alias.ts
@@ -51,13 +51,8 @@ export default util.createRule<Options, MessageIds>({
       "VariableDeclarator[init.type='ThisExpression'], AssignmentExpression[right.type='ThisExpression']"(
         node: TSESTree.VariableDeclarator | TSESTree.AssignmentExpression,
       ): void {
-        let id;
-
-        if (node.type === AST_NODE_TYPES.VariableDeclarator) {
-          id = node.id;
-        } else {
-          id = node.left;
-        }
+        const id =
+          node.type === AST_NODE_TYPES.VariableDeclarator ? node.id : node.left;
         if (allowDestructuring && id.type !== AST_NODE_TYPES.Identifier) {
           return;
         }

--- a/packages/eslint-plugin/src/rules/no-this-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-this-alias.ts
@@ -48,11 +48,16 @@ export default util.createRule<Options, MessageIds>({
   ],
   create(context, [{ allowDestructuring, allowedNames }]) {
     return {
-      "VariableDeclarator[init.type='ThisExpression']"(
-        node: TSESTree.VariableDeclarator,
+      "VariableDeclarator[init.type='ThisExpression'], AssignmentExpression[right.type='ThisExpression']"(
+        node: TSESTree.VariableDeclarator | TSESTree.AssignmentExpression,
       ): void {
-        const { id } = node;
+        let id;
 
+        if (node.type === AST_NODE_TYPES.VariableDeclarator) {
+          id = node.id;
+        } else {
+          id = node.left;
+        }
         if (allowDestructuring && id.type !== AST_NODE_TYPES.Identifier) {
           return;
         }

--- a/packages/eslint-plugin/tests/rules/no-this-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-this-alias.test.ts
@@ -67,6 +67,13 @@ declare module 'foo' {
       errors: [idError],
     },
     {
+      code: `
+let that;
+that = this;
+      `,
+      errors: [idError],
+    },
+    {
       code: 'const { props, state } = this;',
       options: [
         {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4690 
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The rule 'no-this-alias' had no logic of how to manage a reassignment of a variable already declared, it was only working in a variable declaration. This code adds an AssignmentExpression node to be handled and grabs the id of the Identifier of either AssigmentExpression or  VariableDeclarator.