### PR TITLE
Parenthesise conditional types

### DIFF
--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -61,6 +61,7 @@ function typeNeedsParentheses(node: TSESTree.Node): boolean {
     case AST_NODE_TYPES.TSIntersectionType:
     case AST_NODE_TYPES.TSTypeOperator:
     case AST_NODE_TYPES.TSInferType:
+    case AST_NODE_TYPES.TSConditionalType:
       return true;
     case AST_NODE_TYPES.Identifier:
       return node.name === 'ReadonlyArray';


### PR DESCRIPTION
Conditional types aren't handled in the `array-type` rule when converting from generic syntax to array syntax

```tsx
type ClearError<T, U, V> = {
    values: ReadonlyArray<T extends string ? U : V>
    // GOES TO
    values: readonly T extends string ? U : V[] // ERRORS: Parsed as '(readonly T) extends ...` and so is invalid
}

type HiddenError<T, U, V> = {
    values: ReadonlyArray<[T] extends [string] ? U : V
    // GOES TO
    values: readonly [T] extends [string] ? U : V[] // VALID, changes types below
}

type Bar = HiddenError<number, "extends string", "does not extend string">
// BEFORE FIX - Bar = "does not extend string"
// AFTER FIX - Bar = "does not extend string"[]

type Baz = HiddenError<string, "extends string", "does not extend string">
// BEFORE FIX - Bar = "extends string"
// AFTER FIX - Bar = "does not extend string"[]
```

Conditional types being parenthesised resolves this issue

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
