### PR TITLE
fix(parser): add ParseForESLintResult optionals

### DIFF
--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -21,9 +21,9 @@ interface ParseForESLintResult {
     tokens?: TSESTree.Token[];
     comments?: TSESTree.Comment[];
   };
-  services: ParserServices;
-  visitorKeys: typeof visitorKeys;
-  scopeManager: ScopeManager;
+  services?: ParserServices;
+  visitorKeys?: typeof visitorKeys;
+  scopeManager?: ScopeManager;
 }
 
 function validateBoolean(

--- a/packages/parser/tests/tools/test-utils.ts
+++ b/packages/parser/tests/tools/test-utils.ts
@@ -75,9 +75,9 @@ export function testServices(code: string, config: ParserOptions = {}): void {
 
   const services = parser.parseForESLint(code, config).services;
   expect(services).toBeDefined();
-  expect(services.program).toBeDefined();
-  expect(services.esTreeNodeToTSNodeMap).toBeDefined();
-  expect(services.tsNodeToESTreeNodeMap).toBeDefined();
+  expect(services!.program).toBeDefined();
+  expect(services!.esTreeNodeToTSNodeMap).toBeDefined();
+  expect(services!.tsNodeToESTreeNodeMap).toBeDefined();
 }
 
 export function formatSnapshotName(

--- a/packages/type-utils/tests/isTypeReadonly.test.ts
+++ b/packages/type-utils/tests/isTypeReadonly.test.ts
@@ -20,8 +20,8 @@ describe('isTypeReadonly', () => {
         filePath: path.join(rootDir, 'file.ts'),
         tsconfigRootDir: rootDir,
       });
-      const checker = services.program.getTypeChecker();
-      const esTreeNodeToTSNodeMap = services.esTreeNodeToTSNodeMap;
+      const checker = services!.program.getTypeChecker();
+      const esTreeNodeToTSNodeMap = services!.esTreeNodeToTSNodeMap;
 
       const declaration = ast.body[0] as TSESTree.TSTypeAliasDeclaration;
       return {

--- a/packages/type-utils/tests/isUnsafeAssignment.test.ts
+++ b/packages/type-utils/tests/isUnsafeAssignment.test.ts
@@ -18,8 +18,8 @@ describe('isUnsafeAssignment', () => {
       filePath: path.join(rootDir, 'file.ts'),
       tsconfigRootDir: rootDir,
     });
-    const checker = services.program.getTypeChecker();
-    const esTreeNodeToTSNodeMap = services.esTreeNodeToTSNodeMap;
+    const checker = services!.program.getTypeChecker();
+    const esTreeNodeToTSNodeMap = services!.esTreeNodeToTSNodeMap;
 
     const declaration = ast.body[0] as TSESTree.VariableDeclaration;
     const declarator = declaration.declarations[0];


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4728
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Added optionals to the `services`, `visitorKeys` and `scopeManager` parameters to the `ParseForESLintResult` interface according to [docs](https://eslint.org/docs/developer-guide/working-with-custom-parsers).