### PR TITLE
fix(website): correct dark mode color regression

### DIFF
--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -19,7 +19,6 @@ html:root {
   --ifm-code-font-size: 95%;
   --ifm-color-info: var(--ifm-color-primary-dark);
   --ifm-link-color: var(--ifm-color-primary-dark);
-  --ifm-link-color: var(--ifm-color-primary-dark);
 
   --code-line-decoration: rgba(53, 120, 229, 0.1);
   --code-editor-bg: #ffffff;
@@ -27,7 +26,7 @@ html:root {
   --docsearch-muted-color: #666;
 }
 
-html[data-theme='dark'] {
+html[data-theme='dark']:root {
   --ifm-color-feedback-background: #f0f8ff;
   --ifm-color-primary: #4e89e8;
   --ifm-color-primary-dark: #144697;
@@ -40,7 +39,6 @@ html[data-theme='dark'] {
   --ifm-code-background: rgb(40, 42, 54);
   --ifm-code-color: rgb(248, 248, 242);
   --ifm-color-info: var(--ifm-color-primary-light);
-  --ifm-link-color: var(--ifm-color-primary-light);
   --ifm-link-color: var(--ifm-color-primary-light);
   --ifm-menu-color-active: var(--ifm-color-primary-light);
   --ifm-navbar-link-hover-color: var(--ifm-color-primary-light);


### PR DESCRIPTION
## Overview

i noticed that dark mode colors are not workign correctly after changes done in #4362

`html:root` has higher priority than `html[data-theme='dark']` and it looks that dark mode overrides are no longer working correctly

![image](https://user-images.githubusercontent.com/625469/161148619-1cf7fcd2-bfe0-40a3-9de8-513bacd7e702.png)

and this should be 

![image](https://user-images.githubusercontent.com/625469/161148640-bb261307-3563-456e-94e8-624710478be8.png)

-----------

before fix:

![image](https://user-images.githubusercontent.com/625469/161149472-196efa33-f90c-497d-af44-ce131386566b.png)

after fix:

![image](https://user-images.githubusercontent.com/625469/161149507-f49a23ed-e57a-40af-a019-77a64401b100.png)
