### PR TITLE
fix(eslint-plugin): method-signature-style respect getter signature

### DIFF
--- a/packages/eslint-plugin/src/rules/method-signature-style.ts
+++ b/packages/eslint-plugin/src/rules/method-signature-style.ts
@@ -115,6 +115,10 @@ export default util.createRule<Options, MessageIds>({
     return {
       ...(mode === 'property' && {
         TSMethodSignature(methodNode): void {
+          if (methodNode.kind !== 'method') {
+            return;
+          }
+
           const parent = methodNode.parent;
           const members =
             parent?.type === AST_NODE_TYPES.TSInterfaceBody

--- a/packages/eslint-plugin/tests/rules/method-signature-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/method-signature-style.test.ts
@@ -32,10 +32,22 @@ interface Test {
   'f!': </* a */>(/* b */ x: any /* c */) => void;
 }
     `,
+    `
+interface Test {
+  get f(): number;
+}
+    `,
+    `
+interface Test {
+  set f(value: number): void;
+}
+    `,
     'type Test = { readonly f: (a: string) => number };',
     "type Test = { ['f']?: (a: boolean) => void };",
     'type Test = { readonly f?: <T>(a?: T) => T };',
     "type Test = { readonly ['f']?: <T>(a: T, b: T) => T };",
+    'type Test = { get f(): number };',
+    'type Test = { set f(value: number): void };',
     ...batchedSingleLineTests({
       options: ['method'],
       code: noFormat`
@@ -44,10 +56,14 @@ interface Test {
         interface Test { f<T>(a: T): T }
         interface Test { ['f']<T extends {}>(a: T, b: T): T }
         interface Test { 'f!'</* a */>(/* b */ x: any /* c */): void }
+        interface Test { get f(): number }
+        interface Test { set f(value: number): void }
         type Test = { readonly f(a: string): number }
         type Test = { ['f']?(a: boolean): void }
         type Test = { readonly f?<T>(a?: T): T }
         type Test = { readonly ['f']?<T>(a: T, b: T): T }
+        type Test = { get f(): number }
+        type Test = { set f(value: number): void }
       `,
     }),
   ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #4762
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Added a check to verify that the `TSMethodSignature` node is not a getter or setter by using the `kind` property.