### PR TITLE
fix(eslint-plugin): update code to use estree range instead of ts pos/end 

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -171,8 +171,8 @@ export default util.createRule<Options, MessageIds>({
             messageId: 'unnecessaryAssertion',
             fix(fixer) {
               return fixer.removeRange([
-                originalNode.expression.end,
-                originalNode.end,
+                node.expression.range[1],
+                node.range[1],
               ]);
             },
           });
@@ -217,8 +217,8 @@ export default util.createRule<Options, MessageIds>({
                 messageId: 'contextuallyUnnecessary',
                 fix(fixer) {
                   return fixer.removeRange([
-                    originalNode.expression.end,
-                    originalNode.end,
+                    node.expression.range[1],
+                    node.range[1],
                   ]);
                 },
               });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4723
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Use location data from estree instead of typescript, this change fixes fixer when,

This issue is present in any parser that modifies location data of estree nodes, eg. mdx, vue
