### PR TITLE
feat(eslint-plugin): add support for valid number and bigint intersections in restrict-plus-operands rule

### DIFF
--- a/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
+++ b/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
@@ -88,7 +88,12 @@ export default util.createRule<Options, MessageIds>({
 
       if (type.isIntersection()) {
         const types = type.types.map(getBaseTypeOfLiteralType);
-        return types.some(value => value === 'string') ? 'string' : 'invalid';
+
+        if (types.some(value => value === 'string')) return 'string';
+        if (types.some(value => value === 'number')) return 'number';
+        if (types.some(value => value === 'bigint')) return 'bigint';
+
+        return 'invalid';
       }
 
       const stringType = typeChecker.typeToString(type);

--- a/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
+++ b/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
@@ -89,9 +89,17 @@ export default util.createRule<Options, MessageIds>({
       if (type.isIntersection()) {
         const types = type.types.map(getBaseTypeOfLiteralType);
 
-        if (types.some(value => value === 'string')) return 'string';
-        if (types.some(value => value === 'number')) return 'number';
-        if (types.some(value => value === 'bigint')) return 'bigint';
+        if (types.some(value => value === 'string')) {
+          return 'string';
+        }
+
+        if (types.some(value => value === 'number')) {
+          return 'number';
+        }
+
+        if (types.some(value => value === 'bigint')) {
+          return 'bigint';
+        }
 
         return 'invalid';
       }

--- a/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
@@ -604,12 +604,12 @@ function foo<T extends 1>(a: T) {
     {
       code: `
         declare const a: { a: 1 } & { b: 2 };
-        declare const b: number;
+        declare const b: string;
         const x = a + b;
       `,
       errors: [
         {
-          messageId: 'notNumbers',
+          messageId: 'notStrings',
           line: 4,
           column: 19,
         },
@@ -680,6 +680,20 @@ function foo<T extends 1>(a: T) {
       errors: [
         {
           messageId: 'notValidAnys',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: { a: 1 } & { b: 2 };
+        declare const b: number;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notNumbers',
           line: 4,
           column: 19,
         },
@@ -764,6 +778,20 @@ function foo<T extends 1>(a: T) {
       errors: [
         {
           messageId: 'notValidAnys',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: { a: 1 } & { b: 2 };
+        declare const b: bigint;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notBigInts',
           line: 4,
           column: 19,
         },

--- a/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
@@ -112,6 +112,46 @@ declare const b: string;
 const x = a + b;
     `,
     `
+declare const a: {} & number;
+declare const b: number;
+const x = a + b;
+    `,
+    `
+declare const a: unknown & number;
+declare const b: number;
+const x = a + b;
+    `,
+    `
+declare const a: number & number;
+declare const b: number;
+const x = a + b;
+    `,
+    `
+declare const a: 42 & number;
+declare const b: number;
+const x = a + b;
+    `,
+    `
+declare const a: {} & bigint;
+declare const b: bigint;
+const x = a + b;
+    `,
+    `
+declare const a: unknown & bigint;
+declare const b: bigint;
+const x = a + b;
+    `,
+    `
+declare const a: bigint & bigint;
+declare const b: bigint;
+const x = a + b;
+    `,
+    `
+declare const a: 42n & bigint;
+declare const b: bigint;
+const x = a + b;
+    `,
+    `
 function A(s: string) {
   return \`a\${s}b\` as const;
 }
@@ -564,12 +604,166 @@ function foo<T extends 1>(a: T) {
     {
       code: `
         declare const a: { a: 1 } & { b: 2 };
-        declare const b: string;
+        declare const b: number;
         const x = a + b;
       `,
       errors: [
         {
-          messageId: 'notStrings',
+          messageId: 'notNumbers',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: boolean & number;
+        declare const b: number;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notNumbers',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: symbol & number;
+        declare const b: number;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notNumbers',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: object & number;
+        declare const b: number;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notNumbers',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: never & number;
+        declare const b: number;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notNumbers',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: any & number;
+        declare const b: number;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notValidAnys',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: boolean & bigint;
+        declare const b: bigint;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notBigInts',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: number & bigint;
+        declare const b: bigint;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notBigInts',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: symbol & bigint;
+        declare const b: bigint;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notBigInts',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: object & bigint;
+        declare const b: bigint;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notBigInts',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: never & bigint;
+        declare const b: bigint;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notBigInts',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: any & bigint;
+        declare const b: bigint;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          messageId: 'notValidAnys',
           line: 4,
           column: 19,
         },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing issue: extends #2506
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR extends the functionality of #2628 to also support number intersections and bigint intersections. A real-world use case for this functionality would be the new reactivityTransfrom Vue macros: https://github.com/vuejs/eslint-plugin-vue/issues/1839

(also the code was mainly copied from PR #2628 and tweaked for numbers and bigints)