### PR TITLE
docs: clarify PR template to refer to an open issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Otherwise we may not be able to review your PR.
 
 ## PR Checklist
 
--   [ ] Addresses an existing issue: fixes #000
+-   [ ] Addresses an existing open issue: fixes #000
 -   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
 -   [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #4010
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

I am again clarifying the PR template.