### PR TITLE
docs(eslint-plugin): improve docs [parameter-properties]

### DIFF
--- a/packages/eslint-plugin/docs/rules/parameter-properties.md
+++ b/packages/eslint-plugin/docs/rules/parameter-properties.md
@@ -15,10 +15,10 @@ declare all properties in the class.
 This rule, in its default state, does not require any argument and would completely disallow the use of parameter properties.
 It may take an options object containing either or both of:
 
-- `"allows"`: allowing certain kinds of properties to be ignored
-- `"prefer"`: either `"class-properties"` _(default)_ or `"parameter-properties"`
+- `"allow"`: allowing certain kinds of properties to be ignored
+- `"prefer"`: either `"class-property"` _(default)_ or `"parameter-property"`
 
-### `"allows"`
+### `"allow"`
 
 If you would like to ignore certain kinds of properties then you may pass an object containing `"allows"` as an array of any of the following options:
 
@@ -46,10 +46,10 @@ For example, to ignore `public` properties:
 
 ### `"prefer"`
 
-By default, the rule prefers class properties (`"class-properties"`).
-You can switch it to instead preferring parameter properties with (`"parameter-properties"`).
+By default, the rule prefers class property (`"class-property"`).
+You can switch it to instead preferring parameter property with (`"parameter-property"`).
 
-In `"parameter-properties"` mode, the rule will issue a report when:
+In `"parameter-property"` mode, the rule will issue a report when:
 
 - A class property and constructor parameter have the same name and type
 - The constructor parameter is assigned to the class property at the beginning of the constructor


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #4878
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

I got this error when I first try this new rule by following the example on the document:
```
Configuration for rule "@typescript-eslint/parameter-properties" is invalid:
Value "parameter-properties" should be equal to one of the allowed values.
```
and here is my config:
```
"@typescript-eslint/parameter-properties": [
  "error",
  {
    "prefer": "parameter-properties"
  }
]
```
I checked the [source code](https://github.com/typescript-eslint/typescript-eslint/pull/4622/files#diff-a0997bb21a068d001530cb7d430c5c659e8ba9ac5d60c9b44eb4a11e98003572R59).
And found that the correct values of the `prefer` option should be: `class-property`, `parameter-property`.
However, the document shows `class-properties` and `parameter-properties`.

According to the schema of the [source code](https://github.com/typescript-eslint/typescript-eslint/pull/4622/files#diff-a0997bb21a068d001530cb7d430c5c659e8ba9ac5d60c9b44eb4a11e98003572R68), the `allows` option should be corrected to `allow` as well.