### PR TITLE
fix(ast-spec): correct `AwaitExpression.argument` type

### DIFF
--- a/packages/ast-spec/src/expression/AwaitExpression/spec.ts
+++ b/packages/ast-spec/src/expression/AwaitExpression/spec.ts
@@ -1,14 +1,8 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
-import type { LeftHandSideExpression } from '../../unions/LeftHandSideExpression';
-import type { UnaryExpression } from '../UnaryExpression/spec';
-import type { UpdateExpression } from '../UpdateExpression/spec';
+import type { Expression } from '../../unions/Expression';
 
 export interface AwaitExpression extends BaseNode {
   type: AST_NODE_TYPES.AwaitExpression;
-  argument:
-    | AwaitExpression
-    | LeftHandSideExpression
-    | UnaryExpression
-    | UpdateExpression;
+  argument: Expression;
 }

--- a/packages/ast-spec/src/unions/LeftHandSideExpression.ts
+++ b/packages/ast-spec/src/unions/LeftHandSideExpression.ts
@@ -9,7 +9,7 @@ import type { JSXFragment } from '../expression/JSXFragment/spec';
 import type { MemberExpression } from '../expression/MemberExpression/spec';
 import type { MetaProperty } from '../expression/MetaProperty/spec';
 import type { ObjectExpression } from '../expression/ObjectExpression/spec';
-import type { SequenceExpression } from '../expression/spec';
+import type { ImportExpression, SequenceExpression } from '../expression/spec';
 import type { Super } from '../expression/Super/spec';
 import type { TaggedTemplateExpression } from '../expression/TaggedTemplateExpression/spec';
 import type { ThisExpression } from '../expression/ThisExpression/spec';
@@ -28,6 +28,7 @@ export type LeftHandSideExpression =
   | ClassExpression
   | FunctionExpression
   | Identifier
+  | ImportExpression
   | JSXElement
   | JSXFragment
   | LiteralExpression

--- a/packages/ast-spec/src/unions/LeftHandSideExpression.ts
+++ b/packages/ast-spec/src/unions/LeftHandSideExpression.ts
@@ -9,7 +9,7 @@ import type { JSXFragment } from '../expression/JSXFragment/spec';
 import type { MemberExpression } from '../expression/MemberExpression/spec';
 import type { MetaProperty } from '../expression/MetaProperty/spec';
 import type { ObjectExpression } from '../expression/ObjectExpression/spec';
-import type { ImportExpression, SequenceExpression } from '../expression/spec';
+import type { SequenceExpression } from '../expression/spec';
 import type { Super } from '../expression/Super/spec';
 import type { TaggedTemplateExpression } from '../expression/TaggedTemplateExpression/spec';
 import type { ThisExpression } from '../expression/ThisExpression/spec';
@@ -28,7 +28,6 @@ export type LeftHandSideExpression =
   | ClassExpression
   | FunctionExpression
   | Identifier
-  | ImportExpression
   | JSXElement
   | JSXFragment
   | LiteralExpression


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #4877
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

ImportExpression is added to [LeftHandSideExpression](https://github.com/typescript-eslint/typescript-eslint/blob/f79ae9b58e82f4fddef640a34a1d7ff92b763e65/packages/ast-spec/src/unions/LeftHandSideExpression.ts#L23).
