### PR TITLE
chore: removed noUnused(Locals|Parameters) from tsconfig.base.json

### DIFF
--- a/packages/ast-spec/tests/PunctuatorTokenToText.type-test.ts
+++ b/packages/ast-spec/tests/PunctuatorTokenToText.type-test.ts
@@ -2,7 +2,6 @@ import type { PunctuationSyntaxKind } from 'typescript';
 
 import type { PunctuatorTokenToText } from '../src';
 
-// @ts-expect-error: purposely unused
 type _Test = {
   readonly [T in PunctuationSyntaxKind]: PunctuatorTokenToText[T];
   // If there are any PunctuationSyntaxKind members that don't have a

--- a/packages/ast-spec/tests/ast-node-types.type-test.ts
+++ b/packages/ast-spec/tests/ast-node-types.type-test.ts
@@ -9,7 +9,6 @@ type AllKeys = {
 
 type TakesString<T extends Record<string, string>> = T;
 
-// @ts-expect-error: purposely unused
 type _Test =
   // forcing the test onto a new line so it isn't covered by the expect error
   // If there are any enum members that don't have a corresponding TSESTree.Node, then this line will error with "Type 'string | number | symbol' is not assignable to type 'string'."

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,8 +9,6 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "pretty": true,
     "skipLibCheck": true,
     "sourceMap": true,


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #4871
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

As the issue suggests, has us use the ESLint rule only.
