### PR TITLE
feat(utils): update eslint types

### DIFF
--- a/packages/utils/src/ts-eslint/ESLint.ts
+++ b/packages/utils/src/ts-eslint/ESLint.ts
@@ -140,11 +140,11 @@ namespace ESLint {
      * If a predicate function is present, the methods pass each lint message to the function, then use only the
      * lint messages for which the function returned true.
      */
-    fix?: boolean | ((message: LintMessage) => boolean);
+    fix?: boolean | ((message: ESLint.LintMessage) => boolean);
     /**
      * The types of the rules that the eslint.lintFiles() and eslint.lintText() methods use for autofix.
      */
-    fixTypes?: string[];
+    fixTypes?: ('directive' | 'problem' | 'suggestion' | 'layout')[] | null;
     /**
      * If false is present, the eslint.lintFiles() method doesn't interpret glob patterns.
      */
@@ -217,6 +217,11 @@ namespace ESLint {
      */
     errorCount: number;
     /**
+     * The number of fatal errors.
+     * @since 7.32.0
+     */
+    fatalErrorCount?: number;
+    /**
      * The absolute path to the file of this result. This is the string "<text>" if the file path is unknown (when you
      * didn't pass the options.filePath option to the eslint.lintText() method).
      */
@@ -232,7 +237,7 @@ namespace ESLint {
     /**
      * The array of LintMessage objects.
      */
-    messages: Linter.LintMessage[];
+    messages: ESLint.LintMessage[];
     /**
      * The source code of the file that was linted, with as many fixes applied as possible.
      */
@@ -242,6 +247,12 @@ namespace ESLint {
      * property exists.
      */
     source?: string;
+    /**
+     * The array of SuppressedLintMessage objects.
+     *
+     * @since 8.8.0
+     */
+    suppressedMessages?: SuppressedLintMessage[];
     /**
      * The information about the deprecated rules that were used to check this file.
      */
@@ -271,7 +282,7 @@ namespace ESLint {
     /**
      * The 1-based column number of the begin point of this message.
      */
-    column: number;
+    column: number | undefined;
     /**
      * The 1-based column number of the end point of this message. This property is undefined if this message
      * is not a range.
@@ -283,13 +294,18 @@ namespace ESLint {
      */
     endLine: number | undefined;
     /**
+     * `true` if this is a fatal error unrelated to a rule, like a parsing error.
+     * @since 7.24.0
+     */
+    fatal?: boolean | undefined;
+    /**
      * The EditInfo object of autofix. This property is undefined if this message is not fixable.
      */
     fix: EditInfo | undefined;
     /**
      * The 1-based line number of the begin point of this message.
      */
-    line: number;
+    line: number | undefined;
     /**
      * The error message
      */
@@ -308,7 +324,31 @@ namespace ESLint {
      * users such as editor integrations can choose one of them to fix the problem of this message. This property is
      * undefined if this message doesn't have any suggestions.
      */
-    suggestions: { desc: string; fix: EditInfo }[] | undefined;
+    suggestions:
+      | {
+          desc: string;
+          fix: EditInfo;
+        }[]
+      | undefined;
+  }
+
+  /**
+   * The SuppressedLintMessage value is the information of each suppressed linting error.
+   */
+  export interface SuppressedLintMessage extends ESLint.LintMessage {
+    /**
+     * The list of suppressions.
+     */
+    suppressions?: {
+      /**
+       * Right now, this is always `directive`
+       */
+      kind: string;
+      /**
+       * The free text description added after the `--` in the comment
+       */
+      justification: string;
+    }[];
   }
 
   /**
@@ -338,6 +378,11 @@ namespace ESLint {
      * The method to convert the LintResult objects to text
      */
     format(results: LintResult[]): string;
+    /**
+     * The method to asynchronously convert the LintResult objects to text.
+     * @since 8.4.0
+     */
+    format(results: LintResult[]): Promise<string>;
   }
 }
 

--- a/packages/utils/src/ts-eslint/ESLint.ts
+++ b/packages/utils/src/ts-eslint/ESLint.ts
@@ -375,14 +375,10 @@ namespace ESLint {
    */
   export interface Formatter {
     /**
-     * The method to convert the LintResult objects to text
+     * The method to convert the LintResult objects to text.
+     * Promise return supported since 8.4.0
      */
-    format(results: LintResult[]): string;
-    /**
-     * The method to asynchronously convert the LintResult objects to text.
-     * @since 8.4.0
-     */
-    format(results: LintResult[]): Promise<string>;
+    format(results: LintResult[]): string | Promise<string>;
   }
 }
 

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -221,7 +221,6 @@ interface RuleContext<
   /**
    * Returns the current working directory passed to Linter.
    * It is a path to a directory that should be considered as the current working directory.
-   * This was added in v6.6.0
    * @since 6.6.0
    */
   getCwd?(): string;
@@ -233,7 +232,6 @@ interface RuleContext<
 
   /**
    * Returns the full path of the file on disk without any code block information (unlike `getFilename()`).
-   * This was added in v7.28.0
    * @since 7.28.0
    */
   getPhysicalFilename?(): string;

--- a/packages/utils/src/ts-eslint/RuleTester.ts
+++ b/packages/utils/src/ts-eslint/RuleTester.ts
@@ -11,6 +11,7 @@ import {
 interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   /**
    * Name for the test case.
+   * @since 8.1.0
    */
   readonly name?: string;
   /**
@@ -47,6 +48,7 @@ interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   readonly settings?: Readonly<SharedConfigurationSettings>;
   /**
    * Run this case exclusively for debugging in supported test frameworks.
+   * @since 7.29.0
    */
   readonly only?: boolean;
 }

--- a/packages/utils/src/ts-eslint/SourceCode.ts
+++ b/packages/utils/src/ts-eslint/SourceCode.ts
@@ -288,7 +288,6 @@ declare class SourceCodeBase extends TokenStore {
    * Determines if two nodes or tokens have at least one whitespace character
    * between them. Order does not matter. Returns false if the given nodes or
    * tokens overlap.
-   * This was added in v6.7.0.
    * @since 6.7.0
    * @param first The first node or token to check between.
    * @param second The second node or token to check between.


### PR DESCRIPTION
This just updates eslint types to be in sync with the last few versions.
I just went through the [history on the nodejs api docs file](https://github.com/eslint/eslint/commits/f2c2d350425268efa4b78ee6e0a2df8860e0efad/docs/developer-guide/nodejs-api.md) and compared the commits to what we have.