### PR TITLE
fix(eslint-plugin): [no-restricted-imports] allow type import as long as there's one matching pattern

### DIFF
--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -157,7 +157,6 @@ export default createRule<Options, MessageIds>({
     }
     function isAllowedTypeImportPattern(importSource: string): boolean {
       return (
-        allowedImportTypeMatchers.length > 0 &&
         // As long as there's one matching pattern that allows type import
         allowedImportTypeMatchers.some(matcher => matcher.ignores(importSource))
       );

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -158,9 +158,8 @@ export default createRule<Options, MessageIds>({
     function isAllowedTypeImportPattern(importSource: string): boolean {
       return (
         allowedImportTypeMatchers.length > 0 &&
-        allowedImportTypeMatchers.every(matcher => {
-          return matcher.ignores(importSource);
-        })
+        // As long as there's one matching pattern that allows type import
+        allowedImportTypeMatchers.some(matcher => matcher.ignores(importSource))
       );
     }
 

--- a/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
@@ -231,6 +231,28 @@ ruleTester.run('no-restricted-imports', rule, {
         },
       ],
     },
+    {
+      code: `
+import type { foo } from 'import1/private/bar';
+import type { foo } from 'import2/private/bar';
+      `,
+      options: [
+        {
+          patterns: [
+            {
+              group: ['import1/private/*'],
+              message: 'usage of import1 private modules not allowed.',
+              allowTypeImports: true,
+            },
+            {
+              group: ['import2/private/*'],
+              message: 'usage of import2 private modules not allowed.',
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #4895 
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
    - No... but it clearly is a bug, so I'm pre-emptively sending the PR :D
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The problem with our current logic is that we require _every_ allowed import pattern to match a given path, but in practice, they can well be disjoint! With this change, we will be more permissive and allow type import as long as _one_ matcher matches.

This may lead to some false-negatives? For example, there are two matchers that both match a file, one with `allowTypeImports`, another without. Previously, we report an error; now we don't. To be fair, both seem like valid behaviors to me. We don't have existing test-cases covering that anyways, and it doesn't seem like we have this behavior specced in the docs, so I assume either is fine.
