### PR TITLE
docs: fix typo in link

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-type-alias.md
+++ b/packages/eslint-plugin/docs/rules/no-type-alias.md
@@ -591,7 +591,7 @@ callback, etc. that would cause the code to be unreadable or impractical.
 
 ## Further Reading
 
-- [Advance Types](https://www.typescriptlang.org/docs/handbook/advanced-types.html)
+- [Advanced Types](https://www.typescriptlang.org/docs/handbook/advanced-types.html)
 
 ## Related To
 


### PR DESCRIPTION
## PR Checklist

-   [] Addresses an existing open issue: fixes #000
-   [] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

There was obviously no issue for this, but caught my eye. I assume that the correct form is "Advanced Types" instead of "Advance Types".

No change in code, only docs.

(And btw, big thanks for this comprehensive documentation)