### PR TITLE
chore: bump primary node version for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - '**'
 
 env:
-  PRIMARY_NODE_VERSION: 12
+  PRIMARY_NODE_VERSION: 16
   NX_BRANCH: ${{ github.event.number }}
   NX_RUN_GROUP: ${{ github.run_id }}
   # Added the - at the end to function as a separator to improve readability in the PR comment from the Nx cloud app


### PR DESCRIPTION
our integration tests started failing because one of the packages bumped its engine reqs.

let's jump to the top-end of our current range to future proof us for a while
