### PR TITLE
feat(eslint-plugin): Add BigInt object type to default ban-types list

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -105,6 +105,10 @@ const defaultTypes = {
     message: 'Use symbol instead',
     fixWith: 'symbol',
   },
+  BigInt: {
+    message: 'Use bigint instead',
+    fixWith: 'bigint',
+  },
 
   Function: {
     message: [
@@ -149,6 +153,7 @@ const str: String = 'foo';
 const bool: Boolean = true;
 const num: Number = 1;
 const symb: Symbol = Symbol('foo');
+const bigInt: BigInt = 1n;
 
 // use a proper function type
 const func: Function = () => 1;
@@ -169,6 +174,7 @@ const str: string = 'foo';
 const bool: boolean = true;
 const num: number = 1;
 const symb: symbol = Symbol('foo');
+const bigInt: bigint = 1n;
 
 // use a proper function type
 const func: () => number = () => 1;

--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -66,6 +66,10 @@ const defaultTypes: Types = {
     message: 'Use symbol instead',
     fixWith: 'symbol',
   },
+  BigInt: {
+    message: 'Use bigint instead',
+    fixWith: 'bigint',
+  },
 
   Function: {
     message: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] ~Addresses an existing open issue: fixes #000~ No issues have been created about this feature
-   [x] ~That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~ No issues have been created about this feature
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The pull request title says it all: to add `BigInt` type to the default list of banned types, given that `bigint` is a primitive type (just like `boolean`, `string`, `number`, and `symbol`).

The `ban-types` rule source code and the rule documentation have been changed.
