### PR TITLE
fix(eslint-plugin): [array-type] in fixer add missing parens for constructor types #4756

### DIFF
--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -61,6 +61,7 @@ function typeNeedsParentheses(node: TSESTree.Node): boolean {
     case AST_NODE_TYPES.TSIntersectionType:
     case AST_NODE_TYPES.TSTypeOperator:
     case AST_NODE_TYPES.TSInferType:
+    case AST_NODE_TYPES.TSConstructorType:
       return true;
     case AST_NODE_TYPES.Identifier:
       return node.name === 'ReadonlyArray';

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -1885,6 +1885,36 @@ interface FooInterface {
         },
       ],
     },
+    {
+      code: 'const foo: Array<new (...args: any[]) => void> = [];',
+      output: 'const foo: (new (...args: any[]) => void)[] = [];',
+      options: [{ default: 'array' }],
+      errors: [
+        {
+          messageId: 'errorStringArray',
+          data: { className: 'Array', readonlyPrefix: '', type: 'T' },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'const foo: ReadonlyArray<new (...args: any[]) => void> = [];',
+      output: 'const foo: readonly (new (...args: any[]) => void)[] = [];',
+      options: [{ default: 'array' }],
+      errors: [
+        {
+          messageId: 'errorStringArray',
+          data: {
+            className: 'ReadonlyArray',
+            readonlyPrefix: 'readonly ',
+            type: 'T',
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
   ],
 });
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #4756
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

add missing parens to fixer of rule `array-type` for `TSConstructorType` nodes