### PR TITLE
docs(eslint-plugin): fix typo in prefer-readonly-parameter-types

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.md
@@ -191,7 +191,7 @@ Examples of code for this rule with `{ignoreInferredTypes: true}`:
 ```ts
 import { acceptsCallback, CallbackOptions } from 'external-dependency';
 
-acceceptsCallback((options: CallbackOptions) => {});
+acceptsCallback((options: CallbackOptions) => {});
 ```
 
 <details>
@@ -214,7 +214,7 @@ export const acceptsCallback: AcceptsCallback;
 ```ts
 import { acceptsCallback } from 'external-dependency';
 
-acceceptsCallback(options => {});
+acceptsCallback(options => {});
 ```
 
 <details>


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

This only fixes the typo error `acceceptsCallback` => `acceptsCallback` in prefer-readonly-parameter-types
