### PR TITLE
chore: allow publishing canary versions

### DIFF
--- a/.github/actions/prepare-install/action.yml
+++ b/.github/actions/prepare-install/action.yml
@@ -4,6 +4,10 @@ inputs:
   node-version:
     description: "The node version to setup"
     required: true
+  registry-url:
+    description: "Define registry-url"
+    required: false
+
 # outputs: - no outputs
 
 runs:
@@ -17,6 +21,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
+        registry-url: ${{ inputs.registry-url }}
 
     - name: Get yarn cache directory path
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,7 @@ jobs:
         uses: ./.github/actions/prepare-install
         with:
           node-version: ${{ env.PRIMARY_NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
       - name: Build
         uses: ./.github/actions/prepare-build
 


### PR DESCRIPTION
## Overview

Correct issue with credentials not being setup in `publish_canary_version` action after changes to #4959

> Please note that you need to set the `registry-url` to `https://registry.npmjs.org/` in setup-node to properly configure your credentials.

https://github.com/actions/setup-node/blob/bacd6b4b3ac3127b28a1e1920c23bf1c2cadbb85/src/main.ts#L42-L46

```ts
    const registryUrl: string = core.getInput('registry-url');
    const alwaysAuth: string = core.getInput('always-auth');
    if (registryUrl) {
      auth.configAuthentication(registryUrl, alwaysAuth);
    }
```

https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry