### PR TITLE
fix(eslint-plugin): [ban-types] Suggest using `object` to mean "any object"

### DIFF
--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -84,14 +84,15 @@ const defaultTypes: Types = {
   Object: {
     message: [
       'The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.',
-      '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
+      '- If you want a type meaning "any object", you probably want `object` instead.',
       '- If you want a type meaning "any value", you probably want `unknown` instead.',
     ].join('\n'),
   },
+  
   '{}': {
     message: [
       '`{}` actually means "any non-nullish value".',
-      '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
+      '- If you want a type meaning "any object", you probably want `object` instead.',
       '- If you want a type meaning "any value", you probably want `unknown` instead.',
       '- If you want a type meaning "empty object", you probably want `Record<string, never>` instead.',
     ].join('\n'),


### PR DESCRIPTION
People vexed by
```ts
declare let j: unknown;
let m = { ...(j as {}) };
```
being banned by `ban-types`'s default of disallowing `{}` have resorted to using

```ts
let m = { ...(j as never) };
```
which TS 4.7 flags as an error, for good reason. The alternatives suggested by this rule are all inappropriate for the situation:
```ts
// Doesn't fix anything
let m2 = { ...(j as unknown) };

// Adds undesirable index signature to result type
let m3 = { ...(j as Record<string, never>) };

// Adds undesirable index signature to result type
let m4 = { ...(j as Record<string, unknown>) };
```
The "correct" fix is
```ts
let m = { ...(j as object) };
```

Now that `object` has been shipping in TS for several years, this seems like a safe suggestion in lieu of `Record`'s messy side effects

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
