### PR TITLE
fix(eslint-plugin): [member-delimiter-style] autofixer result is not as expected when comments after the delimiter with option `delimiter: 'none'`

### DIFF
--- a/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-delimiter-style.test.ts
@@ -3586,5 +3586,41 @@ type Foo = {
         },
       ],
     },
+    {
+      code: `
+type Foo = {
+  a: true; /** something */ /** some
+  thing */ b: true; /** something */ c: false; // something
+}
+      `,
+      output: `
+type Foo = {
+  a: true /** something */ /** some
+  thing */ b: true; /** something */ c: false // something
+}
+      `,
+      options: [
+        {
+          multiline: { delimiter: 'none' },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'unexpectedSemi',
+          line: 3,
+          column: 11,
+        },
+        {
+          messageId: 'unexpectedSemi',
+          line: 4,
+          column: 20,
+        },
+        {
+          messageId: 'unexpectedSemi',
+          line: 4,
+          column: 47,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #5028
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
