### PR TITLE
docs(eslint-plugin): add triple-slash-reference options schema and defaults

### DIFF
--- a/packages/eslint-plugin/docs/rules/triple-slash-reference.md
+++ b/packages/eslint-plugin/docs/rules/triple-slash-reference.md
@@ -44,6 +44,22 @@ import * as foo from 'foo';
 import foo = require('foo');
 ```
 
+## Options
+
+```ts
+type Options = {
+  lib?: 'always' | 'never';
+  path?: 'always' | 'never';
+  types?: 'always' | 'never' | 'prefer-import';
+};
+
+const defaultOptions: Options = {
+  lib: 'always',
+  path: 'never',
+  types: 'prefer-import',
+};
+```
+
 ## When To Use It
 
 If you want to ban use of one or all of the triple slash reference directives, or any time you might use triple-slash type reference directives and ES6 import declarations in the same file.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The [`triple-slash-reference` docs](https://typescript-eslint.io/rules/triple-slash-reference/) were missing the options schema and defaults, so I added that section from the [template](https://github.com/typescript-eslint/typescript-eslint/blob/1f60fae2a1fe06b886da92e4a3bb5ecc7df230bb/packages/eslint-plugin/docs/rules/TEMPLATE.md) based on the implementation's [schema](https://github.com/typescript-eslint/typescript-eslint/blob/1f60fae2a1fe06b886da92e4a3bb5ecc7df230bb/packages/eslint-plugin/src/rules/triple-slash-reference.ts#L30-L47) and [defaults](https://github.com/typescript-eslint/typescript-eslint/blob/1f60fae2a1fe06b886da92e4a3bb5ecc7df230bb/packages/eslint-plugin/src/rules/triple-slash-reference.ts#L48-L54).

I left the examples inside the Rule Details section alone to reduce scope, but I'm willing to give that a shot if the maintainers wish.