### PR TITLE
feat(eslint-plugin): [consistent-type-imports] support fixing to inline types

### DIFF
--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -41,7 +41,7 @@ const x: Bar = 1;
 This option defines the expected type modifier to be added when an import is detected as used only in the type position. Valid values for `fixStyle` are:
 
 - `separate-type-imports` will add the type keyword after the import keyword `import type { A } from '...'`. It is the default.
-- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names "TypeScript 4.5 documentation on type modifiers and import names").
+- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names 'TypeScript 4.5 documentation on type modifiers and import names').
 
 Examples of the fixer with `{ fixStyle: 'separate-type-imports' }`:
 

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -43,6 +43,8 @@ This option defines the expected type modifier to be added when an import is det
 - `separate-type-imports` will add the type keyword after the import keyword `import type { A } from '...'`. It is the default.
 - `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names 'TypeScript 4.5 documentation on type modifiers and import names').
 
+<!--tabs-->
+
 #### ❌ Incorrect
 
 ```ts
@@ -69,6 +71,8 @@ import type Bar from 'Bar';
 type T = Foo;
 const x: Bar = 1;
 ```
+
+<!--tabs-->
 
 ### `disallowTypeAnnotations`
 

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -41,7 +41,7 @@ const x: Bar = 1;
 This option defines the expected type modifier to be added when an import is detected as used only in the type position. Valid values for `fixStyle` are:
 
 - `separate-type-imports` will add the type keyword after the import keyword `import type { A } from '...'`. It is the default.
-- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names).
+- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names "TypeScript 4.5 documentation on type modifiers and import names").
 
 Examples of the fixer with `{ fixStyle: 'separate-type-imports' }`:
 

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -36,6 +36,49 @@ type T = Foo;
 const x: Bar = 1;
 ```
 
+### `fixStyle`
+
+This option defines the expected type modifier to be added when an import is detected as used only in the type position. Valid values for `fixStyle` are:
+
+- `separate-type-imports` will add the type keyword after the import `import type { A } from '...'`. It is default.
+- `inline-type-imports` will inline the type keyword. `import { type A } from '...'`.
+
+Examples of the fixer `{fixStyle: 'separate-type-imports'}`.
+
+```ts
+import { Foo } from 'Foo';
+import Bar from 'Bar';
+type T = Foo;
+const x: Bar = 1;
+```
+
+will fix to
+
+```ts
+import type { Foo } from 'Foo';
+import type Bar from 'Bar';
+type T = Foo;
+const x: Bar = 1;
+```
+
+Examples of the fixer `{fixStyle: 'inline-type-imports'}`.
+
+```ts
+import { Foo } from 'Foo';
+import Bar from 'Bar';
+type T = Foo;
+const x: Bar = 1;
+```
+
+will fix to
+
+```ts
+import { type Foo } from 'Foo';
+import type Bar from 'Bar';
+type T = Foo;
+const x: Bar = 1;
+```
+
 ### `disallowTypeAnnotations`
 
 If `true`, type imports in type annotations (`import()`) are not allowed.

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -43,7 +43,7 @@ This option defines the expected type modifier to be added when an import is det
 - `separate-type-imports` will add the type keyword after the import keyword `import type { A } from '...'`. It is the default.
 - `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names "TypeScript 4.5 release notes").
 
-Examples of the fixer `{fixStyle: 'separate-type-imports'}`.
+Examples of the fixer with `{ fixStyle: 'separate-type-imports' }`:
 
 ```ts
 import { Foo } from 'Foo';

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -43,7 +43,7 @@ This option defines the expected type modifier to be added when an import is det
 - `separate-type-imports` will add the type keyword after the import keyword `import type { A } from '...'`. It is the default.
 - `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names 'TypeScript 4.5 documentation on type modifiers and import names').
 
-Examples of the fixer with `{ fixStyle: 'separate-type-imports' }`:
+#### ❌ Incorrect
 
 ```ts
 import { Foo } from 'Foo';
@@ -52,7 +52,7 @@ type T = Foo;
 const x: Bar = 1;
 ```
 
-will fix to
+#### ✅ With `separate-type-imports`
 
 ```ts
 import type { Foo } from 'Foo';
@@ -61,16 +61,7 @@ type T = Foo;
 const x: Bar = 1;
 ```
 
-Examples of the fixer with `{ fixStyle: 'inline-type-imports' }`:
-
-```ts
-import { Foo } from 'Foo';
-import Bar from 'Bar';
-type T = Foo;
-const x: Bar = 1;
-```
-
-will fix to
+#### ✅ With `inline-type-imports`
 
 ```ts
 import { type Foo } from 'Foo';

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -61,7 +61,7 @@ type T = Foo;
 const x: Bar = 1;
 ```
 
-Examples of the fixer `{fixStyle: 'inline-type-imports'}`.
+Examples of the fixer with `{ fixStyle: 'inline-type-imports' }`:
 
 ```ts
 import { Foo } from 'Foo';

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -15,7 +15,7 @@ This allows transpilers to drop imports without knowing the types of the depende
 
 This option defines the expected import kind for type-only imports. Valid values for `prefer` are:
 
-- `type-imports` will enforce that you always use `import type Foo from '...'` except referenced by metadata of decorators. It is default.
+- `type-imports` will enforce that you always use `import type Foo from '...'` except referenced by metadata of decorators. It is the default.
 - `no-type-imports` will enforce that you always use `import Foo from '...'`.
 
 Examples of **correct** code with `{prefer: 'type-imports'}`, and **incorrect** code with `{prefer: 'no-type-imports'}`.
@@ -40,8 +40,8 @@ const x: Bar = 1;
 
 This option defines the expected type modifier to be added when an import is detected as used only in the type position. Valid values for `fixStyle` are:
 
-- `separate-type-imports` will add the type keyword after the import `import type { A } from '...'`. It is default.
-- `inline-type-imports` will inline the type keyword. `import { type A } from '...'`.
+- `separate-type-imports` will add the type keyword after the import keyword `import type { A } from '...'`. It is the default.
+- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in Typescript 4.5 and onwards. See [documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names) here.
 
 Examples of the fixer `{fixStyle: 'separate-type-imports'}`.
 

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -41,7 +41,7 @@ const x: Bar = 1;
 This option defines the expected type modifier to be added when an import is detected as used only in the type position. Valid values for `fixStyle` are:
 
 - `separate-type-imports` will add the type keyword after the import keyword `import type { A } from '...'`. It is the default.
-- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in Typescript 4.5 and onwards. See [documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names) here.
+- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names) here.
 
 Examples of the fixer `{fixStyle: 'separate-type-imports'}`.
 

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -41,7 +41,7 @@ const x: Bar = 1;
 This option defines the expected type modifier to be added when an import is detected as used only in the type position. Valid values for `fixStyle` are:
 
 - `separate-type-imports` will add the type keyword after the import keyword `import type { A } from '...'`. It is the default.
-- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names "TypeScript 4.5 release notes").
+- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names).
 
 Examples of the fixer with `{ fixStyle: 'separate-type-imports' }`:
 

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.md
@@ -41,7 +41,7 @@ const x: Bar = 1;
 This option defines the expected type modifier to be added when an import is detected as used only in the type position. Valid values for `fixStyle` are:
 
 - `separate-type-imports` will add the type keyword after the import keyword `import type { A } from '...'`. It is the default.
-- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names) here.
+- `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names "TypeScript 4.5 release notes").
 
 Examples of the fixer `{fixStyle: 'separate-type-imports'}`.
 

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -582,7 +582,6 @@ export default util.createRule<Options, MessageIds>({
       fixer: TSESLint.RuleFixer,
       typeSpecifiers: TSESTree.ImportSpecifier[],
     ): IterableIterator<TSESLint.RuleFix> {
-      // const existingSpecifiers = target.specifiers.map(spec => spec.local.name);
       for (const spec of typeSpecifiers) {
         const insertText = sourceCode.text.slice(...spec.range);
         yield fixer.replaceTextRange(spec.range, `type ${insertText}`);
@@ -687,7 +686,6 @@ export default util.createRule<Options, MessageIds>({
       const afterFixes: TSESLint.RuleFix[] = [];
       if (typeNamedSpecifiers.length) {
         if (sourceImports.typeOnlyNamedImport) {
-          // TODO: is this ever the case? Seems like this isn't called when the source import is import type ...
           const insertTypeNamedSpecifiers =
             fixInsertNamedSpecifiersInNamedSpecifierList(
               fixer,
@@ -792,7 +790,6 @@ export default util.createRule<Options, MessageIds>({
         }
       }
 
-      // we don't want to remove named specifiers if they can be inlined with a type modifier
       yield* fixesNamedSpecifiers.removeTypeNamedSpecifiers;
       yield* fixesRemoveTypeNamespaceSpecifier;
 
@@ -917,7 +914,6 @@ export default util.createRule<Options, MessageIds>({
       const afterFixes: TSESLint.RuleFix[] = [];
       if (valueNamedSpecifiers.length) {
         if (sourceImports.valueOnlyNamedImport) {
-          // TODO: The only use we have of this is for `isTypeImport` block.  Do we need this?
           const insertTypeNamedSpecifiers =
             fixInsertNamedSpecifiersInNamedSpecifierList(
               fixer,

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -72,7 +72,6 @@ export default util.createRule<Options, MessageIds>({
         'Type import {{typeImports}} is used by decorator metadata.',
       valueOverType: 'Use an `import` instead of an `import type`.',
       noImportTypeAnnotations: '`import()` type annotations are forbidden.',
-      inlineTypes: 'Type imports can be inlined.',
     },
     schema: [
       {

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -692,7 +692,6 @@ export default util.createRule<Options, MessageIds>({
           if (sourceImports.typeOnlyNamedImport.range[1] <= node.range[0]) {
             yield insertTypeNamedSpecifiers;
           } else {
-            // TODO: delay inserting b/c....
             afterFixes.push(insertTypeNamedSpecifiers);
           }
         } else {

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -51,8 +51,7 @@ type MessageIds =
   | 'valueOverType'
   | 'noImportTypeAnnotations'
   | 'someImportsInDecoMeta'
-  | 'aImportInDecoMeta'
-  | 'inlineTypes';
+  | 'aImportInDecoMeta';
 export default util.createRule<Options, MessageIds>({
   name: 'consistent-type-imports',
   meta: {

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -677,6 +677,15 @@ export default util.createRule<Options, MessageIds>({
           // import Type from 'foo'
           yield* fixInsertTypeSpecifierForImportDeclaration(fixer, node, true);
           return;
+        } else if (
+          fixStyle === 'inline-type-imports' &&
+          !report.typeSpecifiers.includes(defaultSpecifier) &&
+          namedSpecifiers.length > 0 &&
+          !namespaceSpecifier
+        ) {
+          // import {AValue, Type1, Type2} from 'foo'
+          yield* fixInlineTypeImportDeclaration(fixer, report, sourceImports);
+          return;
         }
       } else if (!namespaceSpecifier) {
         if (

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -625,27 +625,6 @@ export default util.createRule<Options, MessageIds>({
       for (const spec of typeSpecifiers) {
         const insertText = sourceCode.text.slice(...spec.range);
         yield fixer.replaceTextRange(spec.range, `type ${insertText}`);
-        // } else {
-        //   const closingBraceToken = util.nullThrows(
-        //     sourceCode.getFirstTokenBetween(
-        //       sourceCode.getFirstToken(target)!,
-        //       target.source,
-        //       util.isClosingBraceToken,
-        //     ),
-        //     util.NullThrowsReasons.MissingToken('}', target.type),
-        //   );
-        //   const before = sourceCode.getTokenBefore(closingBraceToken)!;
-        //   // imports might be on a new line or one one line.
-        //   // To insert multiple type imports, we need to take into account the index of specifiers as well
-        //   if (
-        //     i > 0 ||
-        //     (!util.isCommaToken(before) && !util.isOpeningBraceToken(before))
-        //   ) {
-        //     // import may not have a trailing comma.
-        //     yield fixer.insertTextAfter(before, `, type ${insertText}`);
-        //   } else {
-        //     yield fixer.insertTextAfter(before, `type ${insertText}`);
-        //   }
       }
     }
 
@@ -665,12 +644,6 @@ export default util.createRule<Options, MessageIds>({
         // add import named type specifiers to its value import
         // import { type A }
         //          ^^^^^^ insert
-        // or
-        // import A, { type A }
-        //         ^^^^^^^^^^^^ insert
-        // or
-        // import A, { C, type A }
-        //                ^^^^^^ insert
         const { namedSpecifiers: valueImportNamedSpecifiers } =
           classifySpecifier(sourceImports.valueImport);
         if (
@@ -682,36 +655,7 @@ export default util.createRule<Options, MessageIds>({
             sourceImports.valueImport,
             typeNamedSpecifiers,
           );
-          // } else {
-          //   const defaultSpecifier = sourceCode.getTokenAfter(
-          //     sourceCode.getFirstToken(sourceImports.valueImport)!,
-          //   );
-          //   if (defaultSpecifier && !util.isCommaToken(defaultSpecifier)) {
-          //     const insertText = typeNamedSpecifiers
-          //       .map(spec => {
-          //         const insertText = sourceCode.text.slice(...spec.range);
-          //         return `type ${insertText}`;
-          //       })
-          //       .join(', ');
-
-          //     yield fixer.insertTextAfter(
-          //       defaultSpecifier,
-          //       `, { ${insertText} }`,
-          //     );
-          //   }
         }
-
-        // if (node.importKind === 'type') {
-        //   // remove line + space leftover
-        //   yield fixer.remove(node);
-        //   const lastToken = sourceCode.getLastToken(node);
-        //   if (lastToken) {
-        //     yield fixer.replaceTextRange(
-        //       [lastToken.range[1], lastToken.range[1] + 1],
-        //       '',
-        //     );
-        //   }
-        // }
       }
     }
 

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -275,35 +275,17 @@ export default util.createRule<Options, MessageIds>({
                     report.unusedSpecifiers.length === 0 &&
                     report.node.importKind !== 'type'
                   ) {
-                    // import is all type-only, convert the entire import to `import type` or inline `import { type }`
-                    if (
-                      sourceImports.valueOnlyNamedImport &&
-                      fixStyle === 'inline-type-imports'
-                    ) {
-                      context.report({
-                        node: report.node,
-                        messageId: 'inlineTypes',
-                        *fix(fixer) {
-                          yield* fixInlineTypeImportDeclaration(
-                            fixer,
-                            report,
-                            sourceImports,
-                          );
-                        },
-                      });
-                    } else {
-                      context.report({
-                        node: report.node,
-                        messageId: 'typeOverValue',
-                        *fix(fixer) {
-                          yield* fixToTypeImportDeclaration(
-                            fixer,
-                            report,
-                            sourceImports,
-                          );
-                        },
-                      });
-                    }
+                    context.report({
+                      node: report.node,
+                      messageId: 'typeOverValue',
+                      *fix(fixer) {
+                        yield* fixToTypeImportDeclaration(
+                          fixer,
+                          report,
+                          sourceImports,
+                        );
+                      },
+                    });
                   } else {
                     const isTypeImport = report.node.importKind === 'type';
 

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -450,7 +450,6 @@ export default util.createRule<Options, MessageIds>({
           ),
           util.NullThrowsReasons.MissingToken('{', node.type),
         );
-        // TODO: why require default import as well?  What about import type { type1, type2 }?
         const commaToken = util.nullThrows(
           sourceCode.getTokenBefore(openingBraceToken, util.isCommaToken),
           util.NullThrowsReasons.MissingToken(',', node.type),

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -352,23 +352,6 @@ export default util.createRule<Options, MessageIds>({
                       },
                     });
                   }
-                  // else if (fixStyle === 'inline-type-imports') {
-                  //   // We may fix some specifiers or all specifiers to types
-                  //   // grab type imports and add to existing import if present.
-                  //   // import ValueImport, { type AType } from 'foo'
-                  //   //                       ^^^^ add
-                  //   context.report({
-                  //     node: report.node,
-                  //     messageId: 'inlineTypes',
-                  //     *fix(fixer) {
-                  //       yield* fixInlineTypeImportDeclaration(
-                  //         fixer,
-                  //         report,
-                  //         sourceImports,
-                  //       );
-                  //     },
-                  //   });
-                  // }
                 }
               }
             },
@@ -665,7 +648,8 @@ export default util.createRule<Options, MessageIds>({
           namedSpecifiers.length > 0 &&
           !namespaceSpecifier
         ) {
-          // import {AValue, Type1, Type2} from 'foo'
+          // if there is a default specifier but it isn't a type specifier, then just add the inline type modifier to the named specifiers
+          // import AValue, {BValue, Type1, Type2} from 'foo'
           yield* fixInlineTypeImportDeclaration(fixer, report, sourceImports);
           return;
         }
@@ -717,6 +701,7 @@ export default util.createRule<Options, MessageIds>({
             afterFixes.push(insertTypeNamedSpecifiers);
           }
         } else {
+          // The import is both default and named.  Insert named on new line because can't mix default type import and named type imports
           if (fixStyle === 'inline-type-imports') {
             yield fixer.insertTextBefore(
               node,

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -739,7 +739,10 @@ export default util.createRule<Options, MessageIds>({
             yield fixer.insertTextBefore(
               node,
               `import {${typeNamedSpecifiers
-                .map(spec => `type ${spec.local.name}`)
+                .map(spec => {
+                  const insertText = sourceCode.text.slice(...spec.range);
+                  return `type ${insertText}`;
+                })
                 .join(', ')}} from ${sourceCode.getText(node.source)};\n`,
             );
           } else {

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -2067,7 +2067,7 @@ type T = B;
 type U = C;
 type V = A;
       `,
-      output: noFormat`
+      output: `
 import {type B, type C} from 'foo';
 import type A from 'foo';
 type T = B;

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -1958,7 +1958,7 @@ const b = B;
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
-          messageId: 'inlineTypes',
+          messageId: 'aImportIsOnlyTypes',
           line: 2,
           column: 9,
         },
@@ -1978,7 +1978,7 @@ const b = B;
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
-          messageId: 'inlineTypes',
+          messageId: 'aImportIsOnlyTypes',
           line: 2,
           column: 9,
         },
@@ -2000,7 +2000,7 @@ const b = B;
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
-          messageId: 'inlineTypes',
+          messageId: 'someImportsAreOnlyTypes',
           line: 2,
           column: 9,
         },
@@ -2041,7 +2041,7 @@ const b = B;
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
-          messageId: 'inlineTypes',
+          messageId: 'aImportIsOnlyTypes',
           line: 2,
           column: 9,
         },
@@ -2059,7 +2059,7 @@ const b = B;
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
-          messageId: 'inlineTypes',
+          messageId: 'aImportIsOnlyTypes',
           line: 2,
           column: 9,
         },
@@ -2085,7 +2085,7 @@ let baz: D;
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
-          messageId: 'inlineTypes',
+          messageId: 'someImportsAreOnlyTypes',
           line: 2,
           column: 1,
         },
@@ -2109,7 +2109,7 @@ let baz: D;
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
-          messageId: 'inlineTypes',
+          messageId: 'aImportIsOnlyTypes',
           line: 2,
           column: 1,
         },

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -2013,7 +2013,7 @@ type T = B;
 type U = C;
 type V = A;
       `,
-      output: `
+      output: noFormat`
 import {type B, type C} from 'foo';
 import type A from 'foo';
 type T = B;

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -2090,7 +2090,7 @@ type T = B;
 type U = D;
 type V = A;
       `,
-      output: noFormat`
+      output: `
 import {type B, type C as D} from 'foo';
 import type A from 'foo';
 type T = B;

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -2014,13 +2014,13 @@ const b = B;
         type V = A;
       `,
       output: `
-        import type { B, C } from 'foo';
-import type A from 'foo';
+        import { type B, type C } from 'foo';
+        import type A from 'foo';
         type T = B;
         type U = C;
         type V = A;
       `,
-      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }], // fixStyle doesn't apply but just add to check
+      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
           messageId: 'typeOverValue',

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -1936,7 +1936,7 @@ const b = B;
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
-          messageId: 'inlineTypes',
+          messageId: 'typeOverValue',
           line: 2,
           column: 9,
         },

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -165,6 +165,15 @@ ruleTester.run('consistent-type-imports', rule, {
       `,
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
     },
+    {
+      code: `
+        import { B } from 'foo';
+        import type { A } from 'foo';
+        type T = A;
+        const b = B;
+      `,
+      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
+    },
     // exports
     `
       import Type from 'foo';
@@ -1902,14 +1911,14 @@ const b = B;
         let bar: B;
       `,
       output: `
-        import type { A, B } from 'foo';
+        import { type A, type B } from 'foo';
         let foo: A;
         let bar: B;
       `,
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
-          messageId: 'typeOverValue',
+          messageId: 'inlineTypes',
           line: 2,
           column: 9,
         },
@@ -2033,298 +2042,6 @@ import type { D } from 'deez';
 const foo: A = B();
 let bar: C;
 let baz: D;
-      `,
-      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 2,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `
-import { B } from 'foo';
-import type { A } from 'foo';
-const foo: A = B();
-      `,
-      output: `
-import { B, type A } from 'foo';
-const foo: A = B();
-      `,
-      options: [{ fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 3,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `
-import B, { C } from 'foo';
-import type { A } from 'foo';
-
-C();
-const foo: A = B();
-      `,
-      output: `
-import B, { C, type A } from 'foo';
-
-C();
-const foo: A = B();
-      `,
-      options: [{ fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 3,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `
-import B from 'foo';
-import type { A } from 'foo';
-
-const foo: A = B();
-      `,
-      output: `
-import B, { type A } from 'foo';
-
-const foo: A = B();
-      `,
-      options: [{ fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 3,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `
-import B, { Cat } from 'foo';
-import type { A } from 'foo';
-
-Cat();
-const foo: A = B();
-      `,
-      output: `
-import B, { Cat, type A } from 'foo';
-
-Cat();
-const foo: A = B();
-      `,
-      options: [{ fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 3,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: noFormat`
-import B from 'foo';
-import type { A, C } from 'foo';
-
-type IG = C;
-const foo: A = B();
-      `,
-      output: noFormat`
-import B, { type A, type C } from 'foo';
-
-type IG = C;
-const foo: A = B();
-      `,
-      options: [{ fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 3,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `
-import { B } from 'foo';
-import type { A, C } from 'foo';
-
-const foo: A = B();
-let bar: C;
-      `,
-      output: `
-import { B, type A, type C } from 'foo';
-
-const foo: A = B();
-let bar: C;
-      `,
-      options: [{ fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 3,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `
-import { B, type A } from 'foo';
-import type { C } from 'foo';
-const foo: A = B();
-let bar: C;
-      `,
-      output: `
-import { B, type A, type C } from 'foo';
-const foo: A = B();
-let bar: C;
-      `,
-      options: [{ fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 3,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `
-import { B } from 'foo';
-import type { C as A } from 'foo';
-
-let bar: A;
-let baz = B();
-      `,
-      output: `
-import { B, type C as A } from 'foo';
-
-let bar: A;
-let baz = B();
-      `,
-      options: [{ fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 3,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: noFormat`
-import type { C, Deez } from 'foo';
-import {
-  B,
-  A
-} from 'foo';
-
-let bar: C;
-let baz: Deez = B();
-A();
-      `,
-      output: noFormat`
-import {
-  B,
-  A, type C, type Deez
-} from 'foo';
-
-let bar: C;
-let baz: Deez = B();
-A();
-      `,
-      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 2,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: noFormat`
-import type { C, Deez } from 'foo';
-import {
-  B,
-  A,
-} from 'foo';
-
-let bar: C;
-let baz: Deez = B();
-A();
-      `,
-      output: noFormat`
-import {
-  B,
-  A,type C, type Deez
-} from 'foo';
-
-let bar: C;
-let baz: Deez = B();
-A();
-      `,
-      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 2,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `
-import type Deez from 'foo';
-import type { C } from 'foo';
-import { B, A } from 'foo';
-
-type Beez = C;
-let baz: Deez = B();
-A();
-      `,
-      output: `
-import type Deez from 'foo';
-import { B, A, type C } from 'foo';
-
-type Beez = C;
-let baz: Deez = B();
-A();
-      `,
-      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
-      errors: [
-        {
-          messageId: 'inlineTypes',
-          line: 3,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: `
-import type { C } from 'foo';
-import type Deez from 'foo';
-import { B, A } from 'foo';
-
-type Beez = C;
-let baz: Deez = B();
-A();
-      `,
-      output: `
-import type Deez from 'foo';
-import { B, A, type C } from 'foo';
-
-type Beez = C;
-let baz: Deez = B();
-A();
       `,
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -1986,46 +1986,46 @@ const b = B;
     },
     {
       code: `
-        import A, { B, C } from 'foo';
-        type T = B;
-        type U = C;
-        A();
+import A, { B, C } from 'foo';
+type T = B;
+type U = C;
+A();
       `,
       output: `
-        import A, { type B, type C } from 'foo';
-        type T = B;
-        type U = C;
-        A();
+import A, { type B, type C } from 'foo';
+type T = B;
+type U = C;
+A();
       `,
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
           messageId: 'someImportsAreOnlyTypes',
           line: 2,
-          column: 9,
+          column: 1,
         },
       ],
     },
     {
       code: `
-        import A, { B, C } from 'foo';
-        type T = B;
-        type U = C;
-        type V = A;
+import A, { B, C } from 'foo';
+type T = B;
+type U = C;
+type V = A;
       `,
       output: `
-        import { type B, type C } from 'foo';
-        import type A from 'foo';
-        type T = B;
-        type U = C;
-        type V = A;
+import {type B, type C} from 'foo';
+import type A from 'foo';
+type T = B;
+type U = C;
+type V = A;
       `,
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
       errors: [
         {
           messageId: 'typeOverValue',
           line: 2,
-          column: 9,
+          column: 1,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -157,6 +157,15 @@ ruleTester.run('consistent-type-imports', rule, {
     },
     {
       code: `
+        import { type B } from 'foo';
+        import type { A } from 'foo';
+        type T = A;
+        const b = B;
+      `,
+      options: [{ fixStyle: 'inline-type-imports' }],
+    },
+    {
+      code: `
         import { B, type C } from 'foo';
         import type A from 'baz';
         type T = A;
@@ -173,6 +182,15 @@ ruleTester.run('consistent-type-imports', rule, {
         const b = B;
       `,
       options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
+    },
+    {
+      code: `
+        import { B } from 'foo';
+        import { A } from 'foo';
+        type T = A;
+        const b = B;
+      `,
+      options: [{ prefer: 'no-type-imports', fixStyle: 'inline-type-imports' }],
     },
     // exports
     `

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -2031,6 +2031,29 @@ type V = A;
     },
     {
       code: `
+import A, { B, C as D } from 'foo';
+type T = B;
+type U = D;
+type V = A;
+      `,
+      output: noFormat`
+import {type B, type C as D} from 'foo';
+import type A from 'foo';
+type T = B;
+type U = D;
+type V = A;
+      `,
+      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
+      errors: [
+        {
+          messageId: 'typeOverValue',
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
         import { /* comment */ A, B } from 'foo';
         type T = A;
       `,

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -1986,6 +1986,60 @@ const b = B;
     },
     {
       code: `
+        import { A } from 'foo';
+        import { B } from 'foo';
+        type T = A;
+        type U = B;
+      `,
+      output: `
+        import { type A } from 'foo';
+        import { type B } from 'foo';
+        type T = A;
+        type U = B;
+      `,
+      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
+      errors: [
+        {
+          messageId: 'typeOverValue',
+          line: 2,
+          column: 9,
+        },
+        {
+          messageId: 'typeOverValue',
+          line: 3,
+          column: 9,
+        },
+      ],
+    },
+    {
+      code: `
+        import { A } from 'foo';
+        import B from 'foo';
+        type T = A;
+        type U = B;
+      `,
+      output: `
+        import { type A } from 'foo';
+        import type B from 'foo';
+        type T = A;
+        type U = B;
+      `,
+      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
+      errors: [
+        {
+          messageId: 'typeOverValue',
+          line: 2,
+          column: 9,
+        },
+        {
+          messageId: 'typeOverValue',
+          line: 3,
+          column: 9,
+        },
+      ],
+    },
+    {
+      code: `
 import A, { B, C } from 'foo';
 type T = B;
 type U = C;

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -1968,6 +1968,28 @@ const b = B;
     },
     {
       code: `
+        import A, { B, C } from 'foo';
+        type T = B;
+        type U = C;
+        A();
+      `,
+      output: `
+        import A, { type B, type C } from 'foo';
+        type T = B;
+        type U = C;
+        A();
+      `,
+      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
+      errors: [
+        {
+          messageId: 'inlineTypes',
+          line: 2,
+          column: 9,
+        },
+      ],
+    },
+    {
+      code: `
         import { /* comment */ A, B } from 'foo';
         type T = A;
       `,

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -1990,6 +1990,29 @@ const b = B;
     },
     {
       code: `
+        import A, { B, C } from 'foo';
+        type T = B;
+        type U = C;
+        type V = A;
+      `,
+      output: `
+        import type { B, C } from 'foo';
+import type A from 'foo';
+        type T = B;
+        type U = C;
+        type V = A;
+      `,
+      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }], // fixStyle doesn't apply but just add to check
+      errors: [
+        {
+          messageId: 'typeOverValue',
+          line: 2,
+          column: 9,
+        },
+      ],
+    },
+    {
+      code: `
         import { /* comment */ A, B } from 'foo';
         type T = A;
       `,


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #4338
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

This PR adds a configuration option `inline-type-imports` that users can utilize to inline their type imports.

Previously, as on Typescript 3.8, we had the ability to `import type`.  This import would be elided from the build deterministically.

```
import A, { CType } from 'foo';
import type { AType } from 'foo';
import { BType } from 'foo';
```

As of 4.5, we can inline that type, making it easier to manage top level imports.

```
import A, { tye CType } from 'foo';
import type { AType } from 'foo';
import { type BType } from 'foo';
```

The summation of the discussion and work is as follows.

1. fixes a **Type** import to **Inline Type** - https://github.com/import-js/eslint-plugin-import/pull/2473. 
2. (this PR) fixes a **Value** import to **Inline Type**
3. adds support for resolving duplicate **Type** imports to **Inline Types** to existing import source https://github.com/import-js/eslint-plugin-import/pull/2475