### PR TITLE
fix(types): remove leftovers from removal of useJSXTextNode

### DIFF
--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -98,7 +98,6 @@ function parseForESLint(
 
   const parserOptions: TSESTreeOptions = {};
   Object.assign(parserOptions, options, {
-    useJSXTextNode: validateBoolean(options.useJSXTextNode, true),
     jsx: validateBoolean(options.ecmaFeatures.jsx),
   });
   const analyzeOptions: AnalyzeOptions = {

--- a/packages/parser/tests/lib/parser.ts
+++ b/packages/parser/tests/lib/parser.ts
@@ -40,7 +40,6 @@ describe('parser', () => {
       // ts-estree specific
       filePath: 'isolated-file.src.ts',
       project: 'tsconfig.json',
-      useJSXTextNode: false,
       errorOnUnknownASTType: false,
       errorOnTypeScriptSyntacticAndSemanticIssues: false,
       tsconfigRootDir: 'tests/fixtures/services',
@@ -62,7 +61,6 @@ describe('parser', () => {
       ecmaFeatures: {},
       jsx: false,
       sourceType: 'script',
-      useJSXTextNode: true,
       warnOnUnsupportedTypeScriptVersion: true,
     });
     spy.mockClear();
@@ -71,7 +69,6 @@ describe('parser', () => {
       ecmaFeatures: {},
       jsx: false,
       sourceType: 'script',
-      useJSXTextNode: true,
       loggerFn: false,
       warnOnUnsupportedTypeScriptVersion: false,
     });
@@ -98,7 +95,6 @@ describe('parser', () => {
       // ts-estree specific
       filePath: 'isolated-file.src.ts',
       project: 'tsconfig.json',
-      useJSXTextNode: false,
       errorOnUnknownASTType: false,
       errorOnTypeScriptSyntacticAndSemanticIssues: false,
       tsconfigRootDir: 'tests/fixtures/services',

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -56,7 +56,6 @@ interface ParserOptions {
   sourceType?: SourceType;
   tokens?: boolean;
   tsconfigRootDir?: string;
-  useJSXTextNode?: boolean;
   warnOnUnsupportedTypeScriptVersion?: boolean;
   moduleResolver?: string;
 }

--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -455,8 +455,8 @@ tester.addFixturePatternConfig('typescript/expressions', {
   fileType: 'ts',
   ignore: [
     /**
-     * Produced AST is different
-     * TODO: investigate in more details
+     * Babel produces incorrect structure for TSInstantiationExpression and optional ChainExpression
+     * @see https://github.com/babel/babel/issues/14613
      */
     'instantiation-expression',
   ],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: related to changes done in #3109 and released with 5.0.0
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

this option is no longer available / working since v5.0.0 release but looks that not all references has been removed for it
