### PR TITLE
feat(eslint-plugin): [no-type-alias] allowTemplateLiterals

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-type-alias.md
+++ b/packages/eslint-plugin/docs/rules/no-type-alias.md
@@ -92,6 +92,7 @@ or more of the following you may pass an object with the options set as follows:
 - `allowMappedTypes` set to `"always"` will allow you to use type aliases as mapping tools (Defaults to `"never"`)
 - `allowTupleTypes` set to `"always"` will allow you to use type aliases with tuples (Defaults to `"never"`)
 - `allowGenerics` set to `"always"` will allow you to use type aliases with generics (Defaults to `"never"`)
+- `allowTemplateLiterals` set to `"always"` will allow you to use type aliases with template literals (Defaults to `"never"`)
 
 ### `allowAliases`
 
@@ -598,6 +599,61 @@ type Foo = Readonly<Bar>;
 type Foo = Partial<Bar>;
 
 type Foo = Omit<Bar, 'a' | 'b'>;
+```
+
+### `allowTemplateLiterals`
+
+This applies to template literals.
+
+The setting accepts the following values:
+
+- `"always"` or `"never"` to active or deactivate the feature.
+- `"in-unions"`
+- `"in-intersections"`
+- `"in-unions-and-intersections"`
+
+Examples of **correct** code for the `{ "allowTemplateLiterals": "always" }` options:
+
+```ts
+type Foo = `foo-${number}`;
+```
+
+Examples of **incorrect** code for the `{ "allowTemplateLiterals": "in-unions" }` option:
+
+```ts
+type Foo = `foo-${number}`;
+```
+
+Examples of **correct** code for the `{ "allowTemplateLiterals": "in-unions" }` option:
+
+```ts
+type Foo = `a-${number}` | `b-${number}`;
+```
+
+Examples of **incorrect** code for the `{ "allowTemplateLiterals": "in-intersections" }` option:
+
+```ts
+type Foo = `a-${number}` | `b-${number}`;
+```
+
+Examples of **correct** code for the `{ "allowTemplateLiterals": "in-intersections" }` option:
+
+```ts
+type Foo = `a-${number}` & `b-${number}`;
+```
+
+Examples of **incorrect** code for the `{ "allowTemplateLiterals": "in-unions-and-intersections" }` option:
+
+```ts
+type Foo = `foo-${number}`;
+```
+
+Examples of **correct** code for the `{ "allowTemplateLiterals": "in-unions-and-intersections" }` option:
+
+```ts
+type Foo = `a-${number}` & `b-${number}`;
+
+type Foo = `a-${number}` | `b-${number}`;
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -29,6 +29,7 @@ type Options = [
     allowMappedTypes?: Values;
     allowTupleTypes?: Values;
     allowGenerics?: 'always' | 'never';
+    allowTemplateLiterals?: Values;
   },
 ];
 type MessageIds = 'noTypeAlias' | 'noCompositionAlias';
@@ -83,6 +84,9 @@ export default util.createRule<Options, MessageIds>({
           allowGenerics: {
             enum: ['always', 'never'],
           },
+          allowTemplateLiterals: {
+            enum: enumValues,
+          },
         },
         additionalProperties: false,
       },
@@ -98,6 +102,7 @@ export default util.createRule<Options, MessageIds>({
       allowMappedTypes: 'never',
       allowTupleTypes: 'never',
       allowGenerics: 'never',
+      allowTemplateLiterals: 'never',
     },
   ],
   create(
@@ -112,6 +117,7 @@ export default util.createRule<Options, MessageIds>({
         allowMappedTypes,
         allowTupleTypes,
         allowGenerics,
+        allowTemplateLiterals,
       },
     ],
   ) {
@@ -271,6 +277,13 @@ export default util.createRule<Options, MessageIds>({
       } else if (type.node.type === AST_NODE_TYPES.TSMappedType) {
         // mapped type
         checkAndReport(allowMappedTypes!, isTopLevel, type, 'Mapped types');
+      } else if (type.node.type === AST_NODE_TYPES.TSTemplateLiteralType) {
+        checkAndReport(
+          allowTemplateLiterals!,
+          isTopLevel,
+          type,
+          'Template literals',
+        );
       } else if (isValidTupleType(type)) {
         // tuple types
         checkAndReport(allowTupleTypes!, isTopLevel, type, 'Tuple Types');

--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -3461,5 +3461,242 @@ type Foo<T> = {
         },
       ],
     },
+    {
+      code: 'type Foo = `foo-${number}`;',
+      options: [{ allowTemplateLiterals: 'never' }],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'template literals',
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `foo-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-unions' }],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'template literals',
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `foo-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-intersections' }],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'template literals',
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `foo-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-unions-and-intersections' }],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'template literals',
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `foo-${number}`;',
+      options: [{ allowAliases: 'in-intersections' }],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'template literals',
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `foo-${number}`;',
+      options: [
+        { allowAliases: 'in-intersections', allowTemplateLiterals: 'never' },
+      ],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'template literals',
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `foo-${number}`;',
+      options: [
+        {
+          allowAliases: 'in-intersections',
+          allowTemplateLiterals: 'in-unions',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'template literals',
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `foo-${number}`;',
+      options: [
+        {
+          allowAliases: 'in-intersections',
+          allowTemplateLiterals: 'in-intersections',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'template literals',
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `foo-${number}`;',
+      options: [
+        {
+          allowAliases: 'in-unions',
+          allowTemplateLiterals: 'in-unions-and-intersections',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'noTypeAlias',
+          data: {
+            alias: 'template literals',
+          },
+          line: 1,
+          column: 12,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `a-${number}` | `b-${number}`;',
+      errors: [
+        {
+          messageId: 'noCompositionAlias',
+          data: {
+            typeName: 'Template literals',
+            compositionType: 'union',
+          },
+          line: 1,
+          column: 12,
+        },
+        {
+          messageId: 'noCompositionAlias',
+          data: {
+            typeName: 'Template literals',
+            compositionType: 'union',
+          },
+          line: 1,
+          column: 28,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `a-${number}` | `b-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-intersections' }],
+      errors: [
+        {
+          messageId: 'noCompositionAlias',
+          data: {
+            typeName: 'Template literals',
+            compositionType: 'union',
+          },
+          line: 1,
+          column: 12,
+        },
+        {
+          messageId: 'noCompositionAlias',
+          data: {
+            typeName: 'Template literals',
+            compositionType: 'union',
+          },
+          line: 1,
+          column: 28,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `a-${number}` & `b-${number}`;',
+      errors: [
+        {
+          messageId: 'noCompositionAlias',
+          data: {
+            typeName: 'Template literals',
+            compositionType: 'intersection',
+          },
+          line: 1,
+          column: 12,
+        },
+        {
+          messageId: 'noCompositionAlias',
+          data: {
+            typeName: 'Template literals',
+            compositionType: 'intersection',
+          },
+          line: 1,
+          column: 28,
+        },
+      ],
+    },
+    {
+      code: 'type Foo = `a-${number}` & `b-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-unions' }],
+      errors: [
+        {
+          messageId: 'noCompositionAlias',
+          data: {
+            typeName: 'Template literals',
+            compositionType: 'intersection',
+          },
+          line: 1,
+          column: 12,
+        },
+        {
+          messageId: 'noCompositionAlias',
+          data: {
+            typeName: 'Template literals',
+            compositionType: 'intersection',
+          },
+          line: 1,
+          column: 28,
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-type-alias.test.ts
@@ -132,66 +132,6 @@ ruleTester.run('no-type-alias', rule, {
       options: [{ allowAliases: 'in-unions-and-intersections' }],
     },
     {
-      code: 'type Foo = `a-${number}`;',
-      options: [{ allowAliases: 'always' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` | `b-${number}`;',
-      options: [{ allowAliases: 'always' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` | `b-${number}`;',
-      options: [{ allowAliases: 'in-unions-and-intersections' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` | `b-${number}`;',
-      options: [{ allowAliases: 'in-unions' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` | `b-${number}` | `c-${number}`;',
-      options: [{ allowAliases: 'always' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` | `b-${number}` | `c-${number}`;',
-      options: [{ allowAliases: 'in-unions-and-intersections' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` | `b-${number}` | `c-${number}`;',
-      options: [{ allowAliases: 'in-unions' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` & `b-${number}`;',
-      options: [{ allowAliases: 'always' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` & `b-${number}`;',
-      options: [{ allowAliases: 'in-unions-and-intersections' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` & `b-${number}`;',
-      options: [{ allowAliases: 'in-intersections' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` & `b-${number}` & `c-${number}`;',
-      options: [{ allowAliases: 'always' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` & `b-${number}` & `c-${number}`;',
-      options: [{ allowAliases: 'in-unions-and-intersections' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` & `b-${number}` & `c-${number}`;',
-      options: [{ allowAliases: 'in-intersections' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` | (`b-${number}` & `c-${number}`);',
-      options: [{ allowAliases: 'always' }],
-    },
-    {
-      code: 'type Foo = `a-${number}` | (`b-${number}` & `c-${number}`);',
-      options: [{ allowAliases: 'in-unions-and-intersections' }],
-    },
-    {
       code: 'type Foo = true;',
       options: [{ allowAliases: 'always' }],
     },
@@ -541,6 +481,66 @@ type KeyNames = keyof typeof SCALARS;
     {
       code: 'type Foo = Record<string, number>;',
       options: [{ allowGenerics: 'always' }],
+    },
+    {
+      code: 'type Foo = `a-${number}`;',
+      options: [{ allowTemplateLiterals: 'always' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` | `b-${number}`;',
+      options: [{ allowTemplateLiterals: 'always' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` | `b-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-unions-and-intersections' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` | `b-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-unions' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` | `b-${number}` | `c-${number}`;',
+      options: [{ allowTemplateLiterals: 'always' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` | `b-${number}` | `c-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-unions-and-intersections' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` | `b-${number}` | `c-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-unions' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` & `b-${number}`;',
+      options: [{ allowTemplateLiterals: 'always' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` & `b-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-unions-and-intersections' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` & `b-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-intersections' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` & `b-${number}` & `c-${number}`;',
+      options: [{ allowTemplateLiterals: 'always' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` & `b-${number}` & `c-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-unions-and-intersections' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` & `b-${number}` & `c-${number}`;',
+      options: [{ allowTemplateLiterals: 'in-intersections' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` | (`b-${number}` & `c-${number}`);',
+      options: [{ allowTemplateLiterals: 'always' }],
+    },
+    {
+      code: 'type Foo = `a-${number}` | (`b-${number}` & `c-${number}`);',
+      options: [{ allowTemplateLiterals: 'in-unions-and-intersections' }],
     },
   ],
   invalid: [
@@ -3406,7 +3406,7 @@ type Foo<T> = {
         {
           messageId: 'noTypeAlias',
           data: {
-            alias: 'aliases',
+            alias: 'template literals',
           },
           line: 1,
           column: 12,
@@ -3415,12 +3415,12 @@ type Foo<T> = {
     },
     {
       code: 'type Foo = `a-${number}` | `b-${number}`;',
-      options: [{ allowAliases: 'never' }],
+      options: [{ allowTemplateLiterals: 'never' }],
       errors: [
         {
           messageId: 'noCompositionAlias',
           data: {
-            typeName: 'Aliases',
+            typeName: 'Template literals',
             compositionType: 'union',
           },
           line: 1,
@@ -3429,7 +3429,7 @@ type Foo<T> = {
         {
           messageId: 'noCompositionAlias',
           data: {
-            typeName: 'Aliases',
+            typeName: 'Template literals',
             compositionType: 'union',
           },
           line: 1,
@@ -3439,12 +3439,12 @@ type Foo<T> = {
     },
     {
       code: 'type Foo = `a-${number}` & `b-${number}`;',
-      options: [{ allowAliases: 'never' }],
+      options: [{ allowTemplateLiterals: 'never' }],
       errors: [
         {
           messageId: 'noCompositionAlias',
           data: {
-            typeName: 'Aliases',
+            typeName: 'Template literals',
             compositionType: 'intersection',
           },
           line: 1,
@@ -3453,7 +3453,7 @@ type Foo<T> = {
         {
           messageId: 'noCompositionAlias',
           data: {
-            typeName: 'Aliases',
+            typeName: 'Template literals',
             compositionType: 'intersection',
           },
           line: 1,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #5095
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR adds a configuration option `allowTemplateLiterals` that users can utilize to regulate template literals.

### Fail

```typescript
// with allowTemplateLiterals: false (default)
type SlashCommand = `/${string}`
```

### Pass
```typescript
// with allowTemplateLiterals: true (default)
type SlashCommand = `/${string}`
```