### PR TITLE
fix(eslint-plugin): [space-infix-ops] correct PropertyDefinition with typeAnnotation

### DIFF
--- a/packages/eslint-plugin/src/rules/space-infix-ops.ts
+++ b/packages/eslint-plugin/src/rules/space-infix-ops.ts
@@ -124,8 +124,8 @@ export default util.createRule<Options, MessageIds>({
     function checkForPropertyDefinitionAssignmentSpace(
       node: TSESTree.PropertyDefinition,
     ): void {
-      const leftNode = sourceCode.getTokenByRangeStart(
-        node.typeAnnotation?.range[0] ?? node.range[0],
+      const leftNode = sourceCode.getLastToken(
+        node.typeAnnotation ?? node.key,
       )!;
       const rightNode = node.value
         ? sourceCode.getTokenByRangeStart(node.value.range[0])

--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -153,6 +153,20 @@ ruleTester.run('space-infix-ops', rule, {
     },
     {
       code: `
+        class Test {
+          value: { prop: string }[] = [];
+        }
+      `,
+    },
+    {
+      code: `
+        class Test {
+          value:{prop:string}[] = [];
+        }
+      `,
+    },
+    {
+      code: `
         type Test =
         | string
         | boolean;
@@ -469,6 +483,44 @@ ruleTester.run('space-infix-ops', rule, {
         {
           messageId: 'missingSpace',
           column: 33,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        class Test {
+          value: { prop: string }[]= [];
+        }
+      `,
+      output: `
+        class Test {
+          value: { prop: string }[] = [];
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 36,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        class Test {
+          value: { prop: string }[] =[];
+        }
+      `,
+      output: `
+        class Test {
+          value: { prop: string }[] = [];
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 37,
           line: 3,
         },
       ],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5109
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

correct seelcting last node of PropertyDefinition when `typeAnnotation` is present

regression fix for #5041 `/^[=|?|:]$/.test(token.value)`