### PR TITLE
chore(website): include labels in the report-an-issue button

### DIFF
--- a/packages/website/src/components/lib/markdown.ts
+++ b/packages/website/src/components/lib/markdown.ts
@@ -50,6 +50,7 @@ export function createMarkdown(state: ConfigModel): string {
 
 export function createMarkdownParams(state: ConfigModel): string {
   const params = {
+    labels: 'bug,package eslint-plugin,triage',
     template: '1-bug-report-plugin.yaml',
     title: 'Bug: [rule name here] <short description of the issue>',
     'playground-link': document.location.toString(),

--- a/packages/website/src/components/lib/markdown.ts
+++ b/packages/website/src/components/lib/markdown.ts
@@ -50,7 +50,7 @@ export function createMarkdown(state: ConfigModel): string {
 
 export function createMarkdownParams(state: ConfigModel): string {
   const params = {
-    labels: 'bug,package eslint-plugin,triage',
+    labels: 'bug,package: eslint-plugin,triage',
     template: '1-bug-report-plugin.yaml',
     title: 'Bug: [rule name here] <short description of the issue>',
     'playground-link': document.location.toString(),


### PR DESCRIPTION
I was wrong [when I originally told armano to remove these](https://github.com/typescript-eslint/typescript-eslint/pull/4916#discussion_r870862218).
It appears that GH uses the issue form config to power the initial link from the issue chooser, and then completely ignores the config after that 😢 
So without this param, the issue is filled without any tags at all!!!
