### PR TITLE
fix(eslint-plugin): [space-infix-ops] regression fix for conditional types

### DIFF
--- a/packages/eslint-plugin/src/rules/space-infix-ops.ts
+++ b/packages/eslint-plugin/src/rules/space-infix-ops.ts
@@ -183,18 +183,13 @@ export default util.createRule<Options, MessageIds>({
     }
 
     function checkForTypeConditional(node: TSESTree.TSConditionalType): void {
-      const extendsTypeNode = sourceCode.getTokenByRangeStart(
-        node.extendsType.range[0],
-      )!;
-      const trueTypeNode = sourceCode.getTokenByRangeStart(
-        node.trueType.range[0],
-      )!;
-      const falseTypeNode = sourceCode.getTokenByRangeStart(
-        node.falseType.range[0],
-      );
+      const extendsLastToken = sourceCode.getLastToken(node.extendsType)!;
+      const trueFirstToken = sourceCode.getFirstToken(node.trueType)!;
+      const trueLastToken = sourceCode.getLastToken(node.trueType)!;
+      const falseFirstToken = sourceCode.getFirstToken(node.falseType)!;
 
-      checkAndReportAssignmentSpace(node, extendsTypeNode, trueTypeNode);
-      checkAndReportAssignmentSpace(node, trueTypeNode, falseTypeNode);
+      checkAndReportAssignmentSpace(node, extendsLastToken, trueFirstToken);
+      checkAndReportAssignmentSpace(node, trueLastToken, falseFirstToken);
     }
 
     return {

--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -236,6 +236,15 @@ ruleTester.run('space-infix-ops', rule, {
       `,
     },
     {
+      code: 'type Baz<T> = T extends (bar: string) => void ? string : number',
+    },
+    {
+      code: 'type Foo<T> = T extends { bar: string } ? string : number',
+    },
+    {
+      code: 'type Baz<T> = T extends (bar: string) => void ? { x: string } : { y: string }',
+    },
+    {
       code: `
         interface Test {
           prop:


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5134 fixes #5133
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Additional regression fix for #5041 `/^[=|?|:]$/.test(token.value)`
