### PR TITLE
fix(eslint-plugin): [space-infix-ops] regression fix for type aliases

### DIFF
--- a/packages/eslint-plugin/src/rules/space-infix-ops.ts
+++ b/packages/eslint-plugin/src/rules/space-infix-ops.ts
@@ -174,10 +174,8 @@ export default util.createRule<Options, MessageIds>({
     function checkForTypeAliasAssignment(
       node: TSESTree.TSTypeAliasDeclaration,
     ): void {
-      const leftNode = sourceCode.getTokenByRangeStart(node.id.range[0])!;
-      const rightNode = sourceCode.getTokenByRangeStart(
-        node.typeAnnotation.range[0],
-      );
+      const leftNode = sourceCode.getLastToken(node.typeParameters ?? node.id)!;
+      const rightNode = sourceCode.getFirstToken(node.typeAnnotation);
 
       checkAndReportAssignmentSpace(node, leftNode, rightNode);
     }

--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -245,6 +245,9 @@ ruleTester.run('space-infix-ops', rule, {
       code: 'type Baz<T> = T extends (bar: string) => void ? { x: string } : { y: string }',
     },
     {
+      code: 'type Foo<T extends (...args: any[]) => any> = T;',
+    },
+    {
       code: `
         interface Test {
           prop:


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5137
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Additional regression fix for #5041 `/^[=|?|:]$/.test(token.value)`
