### PR TITLE
fix(eslint-plugin): [space-infix-ops] support for optional property without type

### DIFF
--- a/packages/eslint-plugin/src/rules/space-infix-ops.ts
+++ b/packages/eslint-plugin/src/rules/space-infix-ops.ts
@@ -36,13 +36,9 @@ export default util.createRule<Options, MessageIds>({
     const rules = baseRule.create(context);
     const sourceCode = context.getSourceCode();
 
-    const report = (
-      node: TSESTree.Node | TSESTree.Token,
-      operator: TSESTree.Token,
-    ): void => {
+    function report(operator: TSESTree.Token): void {
       context.report({
-        node: node,
-        loc: operator.loc,
+        node: operator,
         messageId: 'missingSpace',
         data: {
           operator: operator.value,
@@ -65,7 +61,7 @@ export default util.createRule<Options, MessageIds>({
           return fixer.replaceText(operator, fixString);
         },
       });
-    };
+    }
 
     function isSpaceChar(token: TSESTree.Token): boolean {
       return (
@@ -74,7 +70,6 @@ export default util.createRule<Options, MessageIds>({
     }
 
     function checkAndReportAssignmentSpace(
-      node: TSESTree.Node,
       leftNode: TSESTree.Token | TSESTree.Node | null,
       rightNode?: TSESTree.Token | TSESTree.Node | null,
     ): void {
@@ -95,7 +90,7 @@ export default util.createRule<Options, MessageIds>({
         !sourceCode.isSpaceBetween!(prev, operator) ||
         !sourceCode.isSpaceBetween!(operator, next)
       ) {
-        report(node, operator);
+        report(operator);
       }
     }
 
@@ -104,7 +99,7 @@ export default util.createRule<Options, MessageIds>({
      * @param node The node to report
      */
     function checkForEnumAssignmentSpace(node: TSESTree.TSEnumMember): void {
-      checkAndReportAssignmentSpace(node, node.id, node.initializer);
+      checkAndReportAssignmentSpace(node.id, node.initializer);
     }
 
     /**
@@ -119,7 +114,7 @@ export default util.createRule<Options, MessageIds>({
           ? sourceCode.getTokenAfter(node.key)
           : node.typeAnnotation ?? node.key;
 
-      checkAndReportAssignmentSpace(node, leftNode, node.value);
+      checkAndReportAssignmentSpace(leftNode, node.value);
     }
 
     /**
@@ -149,7 +144,7 @@ export default util.createRule<Options, MessageIds>({
             !sourceCode.isSpaceBetween!(prev!, operator) ||
             !sourceCode.isSpaceBetween!(operator, next!)
           ) {
-            report(typeAnnotation, operator);
+            report(operator);
           }
         }
       });
@@ -163,15 +158,14 @@ export default util.createRule<Options, MessageIds>({
       node: TSESTree.TSTypeAliasDeclaration,
     ): void {
       checkAndReportAssignmentSpace(
-        node,
         node.typeParameters ?? node.id,
         node.typeAnnotation,
       );
     }
 
     function checkForTypeConditional(node: TSESTree.TSConditionalType): void {
-      checkAndReportAssignmentSpace(node, node.extendsType, node.trueType);
-      checkAndReportAssignmentSpace(node, node.trueType, node.falseType);
+      checkAndReportAssignmentSpace(node.extendsType, node.trueType);
+      checkAndReportAssignmentSpace(node.trueType, node.falseType);
     }
 
     return {

--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -1018,6 +1018,36 @@ ruleTester.run('space-infix-ops', rule, {
     },
     {
       code: `
+        type Test=|string|(((() => void)))|string;
+      `,
+      output: `
+        type Test = | string | (((() => void))) | string;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 18,
+          line: 2,
+        },
+        {
+          messageId: 'missingSpace',
+          column: 19,
+          line: 2,
+        },
+        {
+          messageId: 'missingSpace',
+          column: 26,
+          line: 2,
+        },
+        {
+          messageId: 'missingSpace',
+          column: 43,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
         type Test=(string&number)|string|(((() => void)));
       `,
       output: `

--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -167,6 +167,20 @@ ruleTester.run('space-infix-ops', rule, {
     },
     {
       code: `
+        class Test {
+           value: string & number;
+        }
+      `,
+    },
+    {
+      code: `
+        class Test {
+          optional? = false;
+        }
+      `,
+    },
+    {
+      code: `
         type Test =
         | string
         | boolean;
@@ -377,13 +391,6 @@ ruleTester.run('space-infix-ops', rule, {
     {
       code: `
         const x: string & (((() => void)));
-      `,
-    },
-    {
-      code: `
-        class Test {
-           value: string & number;
-        }
       `,
     },
     {
@@ -1857,6 +1864,25 @@ ruleTester.run('space-infix-ops', rule, {
         {
           messageId: 'missingSpace',
           column: 24,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+        class Test {
+          optional?= false;
+        }
+      `,
+      output: `
+        class Test {
+          optional? = false;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 20,
           line: 3,
         },
       ],

--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -993,6 +993,61 @@ ruleTester.run('space-infix-ops', rule, {
     },
     {
       code: `
+        type Test = |string|(((() => void)))|string;
+      `,
+      output: `
+        type Test = | string | (((() => void))) | string;
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 21,
+          line: 2,
+        },
+        {
+          messageId: 'missingSpace',
+          column: 28,
+          line: 2,
+        },
+        {
+          messageId: 'missingSpace',
+          column: 45,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+        type Test=(string&number)|string|(((() => void)));
+      `,
+      output: `
+        type Test = (string & number) | string | (((() => void)));
+      `,
+      errors: [
+        {
+          messageId: 'missingSpace',
+          column: 18,
+          line: 2,
+        },
+        {
+          messageId: 'missingSpace',
+          column: 26,
+          line: 2,
+        },
+        {
+          messageId: 'missingSpace',
+          column: 34,
+          line: 2,
+        },
+        {
+          messageId: 'missingSpace',
+          column: 41,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
         type Test =
         &string
         & number;

--- a/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
+++ b/packages/eslint-plugin/tests/rules/space-infix-ops.test.ts
@@ -1021,7 +1021,7 @@ ruleTester.run('space-infix-ops', rule, {
         type Test=|string|(((() => void)))|string;
       `,
       output: `
-        type Test = | string | (((() => void))) | string;
+        type Test = |string | (((() => void))) | string;
       `,
       errors: [
         {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5154
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Additional regression fix for #5041 `/^[=|?|:]$/.test(token.value)`

```
class Example {
  optional? = false;
}
```

---------------

Optimizations:
- reduce amount of computations needed to find tokens (we can use nodes as they contain proper information's about range)

