### PR TITLE
fix: [TS4.7] allow visiting of typeParameters in TSTypeQuery

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,9 @@ packages/eslint-plugin/src/configs/*.json
 CONTRIBUTORS.md
 packages/ast-spec/src/*/*/fixtures/_error_/*/fixture.ts
 
+# Syntax not yet supported
+packages/scope-manager/tests/fixtures/type-declaration/type-query-with-parameters.ts
+
 # Ignore CHANGELOG.md files to avoid issues with automated release job
 CHANGELOG.md
 

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -739,6 +739,17 @@ export function foo() {
   return new Promise<Foo>();
 }
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/5152
+    {
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
+      code: `
+function foo<T>(value: T): T {
+  return { value };
+}
+export type Foo<T> = typeof foo<T>;
+      `,
+      only: true,
+    },
     // https://github.com/typescript-eslint/typescript-eslint/issues/2331
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -741,14 +741,12 @@ export function foo() {
     `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/5152
     {
-      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
-      code: `
+      code: noFormat`
 function foo<T>(value: T): T {
   return { value };
 }
 export type Foo<T> = typeof foo<T>;
       `,
-      only: true,
     },
     // https://github.com/typescript-eslint/typescript-eslint/issues/2331
     {

--- a/packages/scope-manager/src/referencer/TypeVisitor.ts
+++ b/packages/scope-manager/src/referencer/TypeVisitor.ts
@@ -265,6 +265,7 @@ class TypeVisitor extends Visitor {
       }
       this.#referencer.currentScope().referenceValue(expr);
     }
+    this.visit(node.typeParameters);
   }
 
   protected TSTypeAnnotation(node: TSESTree.TSTypeAnnotation): void {

--- a/packages/scope-manager/tests/fixtures.test.ts
+++ b/packages/scope-manager/tests/fixtures.test.ts
@@ -13,7 +13,9 @@ const ONLY = [].join(path.sep);
 const FIXTURES_DIR = path.resolve(__dirname, 'fixtures');
 
 const fixtures = glob
-  .sync(`${FIXTURES_DIR}/**/*.{js,ts,jsx,tsx}`, {
+  .sync('**/*.{js,ts,jsx,tsx}', {
+    cwd: FIXTURES_DIR,
+    absolute: true,
     ignore: ['fixtures.test.ts'],
   })
   .map(absolute => {

--- a/packages/scope-manager/tests/fixtures/type-declaration/type-query-with-parameters.ts
+++ b/packages/scope-manager/tests/fixtures/type-declaration/type-query-with-parameters.ts
@@ -1,0 +1,5 @@
+function foo<T>(y: T) {
+  return { y };
+}
+
+export type Foo<T> = typeof foo<T>;

--- a/packages/scope-manager/tests/fixtures/type-declaration/type-query-with-parameters.ts.shot
+++ b/packages/scope-manager/tests/fixtures/type-declaration/type-query-with-parameters.ts.shot
@@ -1,0 +1,167 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`type-declaration type-query-with-parameters 1`] = `
+ScopeManager {
+  variables: Array [
+    ImplicitGlobalConstTypeVariable,
+    Variable$2 {
+      defs: Array [
+        FunctionNameDefinition$1 {
+          name: Identifier<"foo">,
+          node: FunctionDeclaration$1,
+        },
+      ],
+      name: "foo",
+      references: Array [
+        Reference$3 {
+          identifier: Identifier<"foo">,
+          isRead: true,
+          isTypeReference: false,
+          isValueReference: true,
+          isWrite: false,
+          resolved: Variable$2,
+        },
+      ],
+      isValueVariable: true,
+      isTypeVariable: false,
+    },
+    Variable$3 {
+      defs: Array [],
+      name: "arguments",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+    Variable$4 {
+      defs: Array [
+        ParameterDefinition$2 {
+          name: Identifier<"y">,
+          node: FunctionDeclaration$1,
+        },
+      ],
+      name: "y",
+      references: Array [
+        Reference$2 {
+          identifier: Identifier<"y">,
+          isRead: true,
+          isTypeReference: false,
+          isValueReference: true,
+          isWrite: false,
+          resolved: Variable$4,
+        },
+      ],
+      isValueVariable: true,
+      isTypeVariable: false,
+    },
+    Variable$5 {
+      defs: Array [
+        TypeDefinition$3 {
+          name: Identifier<"T">,
+          node: TSTypeParameter$2,
+        },
+      ],
+      name: "T",
+      references: Array [
+        Reference$1 {
+          identifier: Identifier<"T">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$5,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$6 {
+      defs: Array [
+        TypeDefinition$4 {
+          name: Identifier<"Foo">,
+          node: TSTypeAliasDeclaration$3,
+        },
+      ],
+      name: "Foo",
+      references: Array [],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$7 {
+      defs: Array [
+        TypeDefinition$5 {
+          name: Identifier<"T">,
+          node: TSTypeParameter$4,
+        },
+      ],
+      name: "T",
+      references: Array [
+        Reference$4 {
+          identifier: Identifier<"T">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$7,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+  ],
+  scopes: Array [
+    GlobalScope$1 {
+      block: Program$5,
+      isStrict: false,
+      references: Array [],
+      set: Map {
+        "const" => ImplicitGlobalConstTypeVariable,
+        "foo" => Variable$2,
+        "Foo" => Variable$6,
+      },
+      type: "global",
+      upper: null,
+      variables: Array [
+        ImplicitGlobalConstTypeVariable,
+        Variable$2,
+        Variable$6,
+      ],
+    },
+    FunctionScope$2 {
+      block: FunctionDeclaration$1,
+      isStrict: false,
+      references: Array [
+        Reference$1,
+        Reference$2,
+      ],
+      set: Map {
+        "arguments" => Variable$3,
+        "y" => Variable$4,
+        "T" => Variable$5,
+      },
+      type: "function",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$3,
+        Variable$4,
+        Variable$5,
+      ],
+    },
+    TypeScope$3 {
+      block: TSTypeAliasDeclaration$3,
+      isStrict: true,
+      references: Array [
+        Reference$3,
+        Reference$4,
+      ],
+      set: Map {
+        "T" => Variable$7,
+      },
+      type: "type",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$7,
+      ],
+    },
+  ],
+}
+`;

--- a/packages/visitor-keys/src/visitor-keys.ts
+++ b/packages/visitor-keys/src/visitor-keys.ts
@@ -142,7 +142,7 @@ const additionalKeys: AdditionalKeys = {
   TSTypeParameterDeclaration: ['params'],
   TSTypeParameterInstantiation: ['params'],
   TSTypePredicate: ['typeAnnotation', 'parameterName'],
-  TSTypeQuery: ['exprName'],
+  TSTypeQuery: ['exprName', 'typeParameters'],
   TSTypeReference: ['typeName', 'typeParameters'],
   TSUndefinedKeyword: [],
   TSUnionType: ['types'],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5152
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

add visiting of `typeParameters` in `TSTypeQuery`

prettier is not supporting this syntax yet

missing changes for #5067