### PR TITLE
chore(eslint-plugin): [prefer-optional-chain] fix incorrect syntax in documentation

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-optional-chain.md
+++ b/packages/eslint-plugin/docs/rules/prefer-optional-chain.md
@@ -61,8 +61,8 @@ foo && foo.a && foo.a.b && foo.a.b.c;
 foo && foo['a'] && foo['a'].b && foo['a'].b.c;
 foo && foo.a && foo.a.b && foo.a.b.method && foo.a.b.method();
 
-(((foo || {}).a || {}).b {}).c;
-(((foo || {})['a'] || {}).b {}).c;
+(((foo || {}).a || {}).b || {}).c;
+(((foo || {})['a'] || {}).b || {}).c;
 
 // this rule also supports converting chained strict nullish checks:
 foo &&


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Fixes invalid syntax.

```js
> (((foo || {}).a || {}).b {}).c;
(((foo || {}).a || {}).b {}).c;
                         ^

Uncaught SyntaxError: Unexpected token '{'
```

Now has become:

```js
> (((foo || {}).a || {}).b || {}).c;
undefined
```