### PR TITLE
feat(website): open issue with rule name if only one rule is enabled

### DIFF
--- a/packages/website/src/components/lib/markdown.ts
+++ b/packages/website/src/components/lib/markdown.ts
@@ -50,7 +50,7 @@ export function createMarkdown(state: ConfigModel): string {
 }
 
 export function createMarkdownParams(state: ConfigModel): string {
-  const { rules = {} } = parseESLintRC(state.eslintrc);
+  const { rules } = parseESLintRC(state.eslintrc);
   const ruleKeys = Object.keys(rules);
 
   const onlyRuleName =

--- a/packages/website/src/components/lib/markdown.ts
+++ b/packages/website/src/components/lib/markdown.ts
@@ -1,3 +1,4 @@
+import { parseESLintRC } from '../config/utils';
 import type { ConfigModel } from '../types';
 
 export function createSummary(
@@ -49,10 +50,18 @@ export function createMarkdown(state: ConfigModel): string {
 }
 
 export function createMarkdownParams(state: ConfigModel): string {
+  const { rules = {} } = parseESLintRC(state.eslintrc);
+  const ruleKeys = Object.keys(rules);
+
+  const onlyRuleName =
+    ruleKeys.length === 1
+      ? ruleKeys[0].replace('@typescript-eslint/', '')
+      : 'rule name here';
+
   const params = {
     labels: 'bug,package: eslint-plugin,triage',
     template: '1-bug-report-plugin.yaml',
-    title: 'Bug: [rule name here] <short description of the issue>',
+    title: `Bug: [${onlyRuleName}] <short description of the issue>`,
     'playground-link': document.location.toString(),
     'repro-code': state.code,
     'eslint-config': `module.exports = ${state.eslintrc ?? '{}'}`,


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5056
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Nice little feature so most well-isolated issue reporters won't have to manually edit the issue name.