### PR TITLE
chore: removed pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn pre-push

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "lint": "cross-env NODE_OPTIONS=\"--max-old-space-size=16384\" eslint .",
     "postinstall": "yarn husky install && yarn build",
     "pre-commit": "yarn lint-staged",
-    "pre-push": "yarn check-format",
     "start": "nx run website:start",
     "test": "nx run-many --target=test --all --parallel",
     "test-integration": "yarn jest -c ./tests/integration/jest.config.js",


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5203
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Per the issue, commits still run Prettier on staged->committed files. We just no longer also run Prettier on _all_ files when pushing.
