### PR TITLE
chore: add label-commenter bot for formatting issues

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,0 +1,16 @@
+comment:
+  footer: Please do not respond to this message. Thanks! 💖
+  header: 🤖 Beep boop, hello!
+
+labels:
+  - name: formatting
+    labeled:
+      issue:
+        body: |
+          I'm the ⚡ TypeScript ESLint Formatting Bot ⚡, and I'm popping in automatically to advertise that we **strongly recommend against using ESLint rules for formatting purposes**.
+
+          * [ESLint core has not accepted new stylistic rules for years](https://eslint.org/blog/2020/05/changes-to-rules-policies#what-are-the-changes)
+          * Formatting rules are inherently difficult to maintain and will not catch many edge cases _(todo: docs link pending #4907)_
+          * Dedicated formatting tools such as [Prettier](https://prettier.io) are much faster, more stable, and more comprehensive than ESLint can ever be for formatting.
+
+          This message is automated and serves only as a reminder. We will still triage your issue and, as long as it only involves fixing existing formatting rules, do not plan on automatically closing it.

--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -9,8 +9,6 @@ labels:
         body: |
           I'm the ⚡ TypeScript ESLint Formatting Bot ⚡, and I'm popping in automatically to advertise that we **strongly recommend against using ESLint rules for formatting purposes**.
 
-          * [ESLint core has not accepted new stylistic rules for years](https://eslint.org/blog/2020/05/changes-to-rules-policies#what-are-the-changes)
-          * Formatting rules are inherently difficult to maintain and will not catch many edge cases _(todo: docs link pending #4907)_
-          * Dedicated formatting tools such as [Prettier](https://prettier.io) are much faster, more stable, and more comprehensive than ESLint can ever be for formatting.
+          See our **[What About Formatting? docs page](https://typescript-eslint.io/docs/linting/troubleshooting/formatting)** for more info.
 
           This message is automated and serves only as a reminder. We will still triage your issue and, as long as it only involves fixing existing formatting rules, do not plan on automatically closing it.

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,0 +1,18 @@
+name: Label Commenter
+
+on:
+  issues:
+    types: [labeled]
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: peaceiris/actions-label-commenter@v1


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5111
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Uses the simple featured action bot that adds a comment when a label is added.

Example issue comment: https://github.com/JoshuaKGoldberg/typescript-eslint/issues/140#issuecomment-1166353923

Requires the changes described in https://github.com/JoshuaKGoldberg/typescript-eslint/pull/141, which is blocked on https://github.com/typescript-eslint/typescript-eslint/pull/5248.