### PR TITLE
fix(eslint-plugin): [no-base-to-string] add missing apostrophe to message

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -27,7 +27,7 @@ export default util.createRule<Options, MessageIds>({
     },
     messages: {
       baseToString:
-        "'{{name}} {{certainty}} evaluate to '[object Object]' when stringified.",
+        "'{{name}}' {{certainty}} evaluate to '[object Object]' when stringified.",
     },
     schema: [
       {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5268
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

It's been like this for years. Oops.