### PR TITLE
fix(eslint-plugin): [consistent-indexed-object-style] fix record mode fixer for generics with a default value

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -132,7 +132,7 @@ export default createRule<Options, MessageIds>({
 
           if ((node.typeParameters?.params ?? []).length > 0) {
             genericTypes = `<${node.typeParameters?.params
-              .map(p => p.name.name)
+              .map(p => sourceCode.getText(p))
               .join(', ')}>`;
           }
 

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -174,6 +174,19 @@ type Foo<A> = Record<string, A>;
       errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
     },
 
+    // Interface with generic parameter and default value
+    {
+      code: `
+interface Foo<A = any> {
+  [key: string]: A;
+}
+      `,
+      output: `
+type Foo<A = any> = Record<string, A>;
+      `,
+      errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
+    },
+
     // Interface with extends
     {
       code: `


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5279 
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Instead of just [mapping each typeParameter node to its name](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts#L135), map it to the complete node text to avoid stripping information.

### Before You File a Bug Report Please Confirm You Have Done The Following...

- [X] I have tried restarting my IDE and the issue persists.
- [X] I have updated to the latest version of the packages.
- [X] I have [searched for related issues](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+label%3Abug+label%3A%22package%3A+eslint-plugin%22) and found none that matched my issue.
- [X] I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.

### Playground Link

https://typescript-eslint.io/play/#ts=4.7.2&sourceType=module&code=JYOwLgpgTgZghgYwgAgGIHt0B4CCyC8ycIAngHzIDeAUMsgNoDWEJAXMgM5hSgDmAuuxwBuagF8gA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6MgeyeUuX0Ra1mAE0QAPRMNocARgCtEZOn0JJ0URNGgdokcGAC+IA0A&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA

### Repro Code

```typescript
interface Foo<A = any> {
  [key: string]: A;
}
```

### Expected Result

```ts
type Foo<A = any> = Record<string, A>;
```

### Actual Result

```ts
type Foo<A> = Record<string, A>;
```