### PR TITLE
fix(eslint-plugin): [typedef] Support nested array destructuring with type annotation

### DIFF
--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -150,13 +150,14 @@ export default util.createRule<[Options], MessageIds>({
     }
 
     function isAncestorHasTypeAnnotation(
-      node: TSESTree.ObjectPattern,
+      node: TSESTree.ObjectPattern | TSESTree.ArrayPattern,
     ): boolean {
       let ancestor = node.parent;
 
       while (ancestor) {
         if (
-          ancestor.type === AST_NODE_TYPES.ObjectPattern &&
+          (ancestor.type === AST_NODE_TYPES.ObjectPattern ||
+            ancestor.type === AST_NODE_TYPES.ArrayPattern) &&
           ancestor.typeAnnotation
         ) {
           return true;
@@ -181,6 +182,7 @@ export default util.createRule<[Options], MessageIds>({
           if (
             !node.typeAnnotation &&
             !isForOfStatementContext(node) &&
+            !isAncestorHasTypeAnnotation(node) &&
             node.parent?.type !== AST_NODE_TYPES.AssignmentExpression
           ) {
             report(node);

--- a/packages/eslint-plugin/tests/rules/typedef.test.ts
+++ b/packages/eslint-plugin/tests/rules/typedef.test.ts
@@ -71,6 +71,32 @@ ruleTester.run('typedef', rule, {
       ],
     },
     {
+      code: 'const [[a]]: number[][] = [[1]];',
+      options: [
+        {
+          arrayDestructuring: true,
+        },
+      ],
+    },
+    {
+      code: 'const foo = ([{ bar }]: { bar: string }[]) => {};',
+      options: [
+        {
+          arrayDestructuring: true,
+          objectDestructuring: true,
+        },
+      ],
+    },
+    {
+      code: 'const foo = ([{ bar }]: [{ bar: string }]) => {};',
+      options: [
+        {
+          arrayDestructuring: true,
+          objectDestructuring: true,
+        },
+      ],
+    },
+    {
       code: 'const [a] = [1];',
       options: [
         {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #5233 
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Update the typedef rule to take into consideration the type annotation of ancestor nodes when destructuring nested arrays.
