### PR TITLE
fix: prefer-optional-chain.ts requiresTypeChecking

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -37,6 +37,7 @@ export default util.createRule({
         'Enforce using concise optional chain expressions instead of chained logical ands',
       recommended: 'strict',
       suggestion: true,
+      requiresTypeChecking: true,
     },
     hasSuggestions: true,
     messages: {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: related to #4820
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

This rule calls `util.getParserServices` so it's a `requiresTypeChecking`-rule