### PR TITLE
docs(eslint-plugin): [comma-dangle] fix incorrect section heading

### DIFF
--- a/packages/eslint-plugin/docs/rules/comma-dangle.md
+++ b/packages/eslint-plugin/docs/rules/comma-dangle.md
@@ -9,7 +9,7 @@ It adds support for TypeScript syntax.
 
 See the [ESLint documentation](https://eslint.org/docs/rules/comma-dangle) for more details on the `comma-dangle` rule.
 
-## Rule Changes
+## How to Use
 
 ```jsonc
 {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The "How to Use" section of `comma-dangle` rule was incorrectly titled as "Rule Changes"

<img width="553" alt="image" src="https://user-images.githubusercontent.com/8225666/177688264-2c64c744-d7df-4132-920e-8501a6938af5.png">
