### PR TITLE
fix(scope-manager): allow visiting of constraint in infer type

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,6 +16,7 @@ packages/ast-spec/src/*/*/fixtures/_error_/*/fixture.ts
 
 # Syntax not yet supported
 packages/scope-manager/tests/fixtures/type-declaration/type-query-with-parameters.ts
+packages/scope-manager/tests/fixtures/type-declaration/infer-type-constraint.ts
 
 # Ignore CHANGELOG.md files to avoid issues with automated release job
 CHANGELOG.md

--- a/packages/scope-manager/src/referencer/TypeVisitor.ts
+++ b/packages/scope-manager/src/referencer/TypeVisitor.ts
@@ -167,6 +167,8 @@ class TypeVisitor extends Visitor {
       typeParameter.name,
       new TypeDefinition(typeParameter.name, typeParameter),
     );
+
+    this.visit(typeParameter.constraint);
   }
 
   protected TSInterfaceDeclaration(

--- a/packages/scope-manager/tests/fixtures/type-declaration/infer-type-constraint.ts
+++ b/packages/scope-manager/tests/fixtures/type-declaration/infer-type-constraint.ts
@@ -1,0 +1,2 @@
+type X = string | number;
+type Id<T> = T extends { id: infer Id extends X } ? Id : never;

--- a/packages/scope-manager/tests/fixtures/type-declaration/infer-type-constraint.ts.shot
+++ b/packages/scope-manager/tests/fixtures/type-declaration/infer-type-constraint.ts.shot
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`type-declaration type-constrain 1`] = `
+ScopeManager {
+  variables: Array [
+    ImplicitGlobalConstTypeVariable,
+    Variable$2 {
+      defs: Array [
+        TypeDefinition$1 {
+          name: Identifier<"X">,
+          node: TSTypeAliasDeclaration$1,
+        },
+      ],
+      name: "X",
+      references: Array [
+        Reference$2 {
+          identifier: Identifier<"X">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$2,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$3 {
+      defs: Array [
+        TypeDefinition$2 {
+          name: Identifier<"Id">,
+          node: TSTypeAliasDeclaration$2,
+        },
+      ],
+      name: "Id",
+      references: Array [],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$4 {
+      defs: Array [
+        TypeDefinition$3 {
+          name: Identifier<"T">,
+          node: TSTypeParameter$3,
+        },
+      ],
+      name: "T",
+      references: Array [
+        Reference$1 {
+          identifier: Identifier<"T">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$4,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+    Variable$5 {
+      defs: Array [
+        TypeDefinition$4 {
+          name: Identifier<"Id">,
+          node: TSTypeParameter$4,
+        },
+      ],
+      name: "Id",
+      references: Array [
+        Reference$3 {
+          identifier: Identifier<"Id">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$5,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+  ],
+  scopes: Array [
+    GlobalScope$1 {
+      block: Program$5,
+      isStrict: false,
+      references: Array [],
+      set: Map {
+        "const" => ImplicitGlobalConstTypeVariable,
+        "X" => Variable$2,
+        "Id" => Variable$3,
+      },
+      type: "global",
+      upper: null,
+      variables: Array [
+        ImplicitGlobalConstTypeVariable,
+        Variable$2,
+        Variable$3,
+      ],
+    },
+    TypeScope$2 {
+      block: TSTypeAliasDeclaration$2,
+      isStrict: true,
+      references: Array [],
+      set: Map {
+        "T" => Variable$4,
+      },
+      type: "type",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$4,
+      ],
+    },
+    ConditionalTypeScope$3 {
+      block: TSConditionalType$6,
+      isStrict: true,
+      references: Array [
+        Reference$1,
+        Reference$2,
+        Reference$3,
+      ],
+      set: Map {
+        "Id" => Variable$5,
+      },
+      type: "conditionalType",
+      upper: TypeScope$2,
+      variables: Array [
+        Variable$5,
+      ],
+    },
+  ],
+}
+`;

--- a/packages/scope-manager/tests/fixtures/type-declaration/infer-type-constraint.ts.shot
+++ b/packages/scope-manager/tests/fixtures/type-declaration/infer-type-constraint.ts.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`type-declaration type-constrain 1`] = `
+exports[`type-declaration infer-type-constraint 1`] = `
 ScopeManager {
   variables: Array [
     ImplicitGlobalConstTypeVariable,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #5330
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Add visiting of `constraint` in `infer` type
