### PR TITLE
fix(parser, types, typescript-estree, visitor-keys): public _ts3.4 for supporting lower version of typescript

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
+    "_ts3.4",
     "README.md",
     "LICENSE"
   ],

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "dist",
+    "_ts3.4",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
+    "_ts3.4",
     "README.md",
     "LICENSE"
   ],

--- a/packages/visitor-keys/package.json
+++ b/packages/visitor-keys/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "dist",
+    "_ts3.4",
     "package.json",
     "README.md",
     "LICENSE"


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5332
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

add _ts3.4 in package.json files field for parser, types, typescript-estree, visitor-keys
