### PR TITLE
chore(website): add current version of typescript to playground dropdown

### DIFF
--- a/packages/website/src/components/OptionsSelector.tsx
+++ b/packages/website/src/components/OptionsSelector.tsx
@@ -90,10 +90,9 @@ function OptionsSelectorContent({
             name="ts"
             className="text--right"
             value={state.ts}
+            disabled={!tsVersions.length}
             onChange={updateTS}
-            options={((tsVersions.length && tsVersions) || [state.ts]).filter(
-              item => parseFloat(item) >= 3.3,
-            )}
+            options={(tsVersions.length && tsVersions) || [state.ts]}
           />
         </label>
         <label className={styles.optionLabel}>

--- a/packages/website/src/components/editor/useSandboxServices.ts
+++ b/packages/website/src/components/editor/useSandboxServices.ts
@@ -110,7 +110,14 @@ export const useSandboxServices = (
 
         const webLinter = new WebLinter(system, compilerOptions, lintUtils);
 
-        props.onLoaded(webLinter.ruleNames, sandboxInstance.supportedVersions);
+        props.onLoaded(
+          webLinter.ruleNames,
+          Array.from(
+            new Set([...sandboxInstance.supportedVersions, window.ts.version]),
+          )
+            .filter(item => parseFloat(item) >= 3.3)
+            .sort((a, b) => b.localeCompare(a)),
+        );
 
         setServices({
           main,

--- a/packages/website/src/components/inputs/Dropdown.tsx
+++ b/packages/website/src/components/inputs/Dropdown.tsx
@@ -13,6 +13,7 @@ export interface DropdownProps<T> {
   readonly value: T | undefined;
   readonly name: string;
   readonly className?: string;
+  readonly disabled?: boolean;
 }
 
 function Dropdown<T extends boolean | string | number>(
@@ -27,6 +28,7 @@ function Dropdown<T extends boolean | string | number>(
   return (
     <select
       name={props.name}
+      disabled={props.disabled}
       value={String(props.value)}
       className={clsx(styles.optionSelect, props.className)}
       onChange={(e): void => {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #5244
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

lock typescript version dropdown while playground is loading and add currently loaded ts version to dropdown
