### PR TITLE
chore(website): multiple fixes to rule docs generation

### DIFF
--- a/packages/website/plugins/generated-rule-docs.ts
+++ b/packages/website/plugins/generated-rule-docs.ts
@@ -27,10 +27,12 @@ const generatedRuleDocs: Plugin = () => {
     parent.children.unshift({
       children: [
         {
-          children: docs.description.split(/`(.+?)`/).map((v, i) => ({
-            type: i % 2 === 0 ? 'text' : 'inlineCode',
-            value: v,
-          })),
+          children: docs.description
+            .split(/`(.+?)`/)
+            .map((value, index, array) => ({
+              type: index % 2 === 0 ? 'text' : 'inlineCode',
+              value: index === array.length - 1 ? `${value}.` : value,
+            })),
           type: 'paragraph',
         },
       ],

--- a/packages/website/plugins/generated-rule-docs.ts
+++ b/packages/website/plugins/generated-rule-docs.ts
@@ -18,18 +18,19 @@ const generatedRuleDocs: Plugin = () => {
     const parent = root as unist.Parent;
 
     // 1. Remove the " 🛑 This file is source code, not the primary documentation location! 🛑"
-    parent.children.splice(3, 1);
+    parent.children.splice(
+      parent.children.findIndex(v => v.type === 'blockquote'),
+      1,
+    );
 
     // 2. Add a description of the rule at the top of the file
     parent.children.unshift({
       children: [
         {
-          children: [
-            {
-              type: 'text',
-              value: `${docs.description}.`,
-            },
-          ],
+          children: docs.description.split(/`(.+?)`/).map((v, i) => ({
+            type: i % 2 === 0 ? 'text' : 'inlineCode',
+            value: v,
+          })),
           type: 'paragraph',
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

1. Allows interpolating inline code
2. Reliably removes the notice; currently some rules don't have their notice removed, for some reason... (e.g. https://typescript-eslint.io/rules/comma-dangle)