### PR TITLE
fix(eslint-plugin): [no-non-null-asserted-optional-chain] infinite loop problem

### DIFF
--- a/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
@@ -104,12 +104,13 @@ export default util.createRule({
         const node = child.parent as TSESTree.TSNonNullExpression;
 
         let current = child;
-        while (current) {
+        let isRight = true;
+        while (current && isRight) {
           switch (current.type) {
             case AST_NODE_TYPES.MemberExpression:
               if (current.optional) {
                 // found an optional chain! stop traversing
-                break;
+                isRight = false;
               }
 
               current = current.object;
@@ -118,7 +119,7 @@ export default util.createRule({
             case AST_NODE_TYPES.CallExpression:
               if (current.optional) {
                 // found an optional chain! stop traversing
-                break;
+                isRight = false;
               }
 
               current = current.callee;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #2521
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Prior to typescript 3.9, the code in the no-non-null-asserted-optional-chain rule had an infinite loop.
Causes the ESLint process to fail to end
```js
while (current) {
    switch (current.type) {
            case AST_NODE_TYPES.MemberExpression:
              if (current.optional) {
                // found an optional chain! stop traversing
                break;
              }

              current = current.object;
              continue;

            case AST_NODE_TYPES.CallExpression:
              if (current.optional) {
                // found an optional chain! stop traversing
                break;
              }

              current = current.callee;
              continue;

            default:
              // something that's not a ChainElement, which means this is not an optional chain we want to check
              return;
      }
}
```
