### PR TITLE
docs(eslint-plugin): typo in `member-ordering` rule documentation

### DIFF
--- a/packages/eslint-plugin/docs/rules/member-ordering.md
+++ b/packages/eslint-plugin/docs/rules/member-ordering.md
@@ -40,7 +40,7 @@ You can configure `OrderConfig` options for:
 
 The `OrderConfig` settings for each kind of construct may configure sorting on one or both two levels:
 
-- **`memberType`**: organizing on member type groups such as methods vs. properties
+- **`memberTypes`**: organizing on member type groups such as methods vs. properties
 - **`order`**: organizing based on member names, such as alphabetically
 
 ### Groups


### PR DESCRIPTION
## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Just a typo – seems like `memberTypes` is missing an `s` in documentation of `member-ordering` rule.
