### PR TITLE
chore(website): lower formatting rules in sidebar

### DIFF
--- a/packages/website/sidebars/sidebar.rules.js
+++ b/packages/website/sidebars/sidebar.rules.js
@@ -10,9 +10,20 @@ const rules = Object.entries(plugin.rules).map(([name, rule]) => {
   };
 });
 
-const notDeprecatedRules = rules.filter(rule => !rule.meta.deprecated);
+const deprecatedRules = new Set(rules.filter(rule => rule.meta.deprecated));
 
-const deprecatedRules = rules.filter(rule => rule.meta.deprecated);
+const formattingRules = new Set(
+  rules.filter(
+    rule => !rule.meta.deprecated && rule.meta.fixable === 'whitespace',
+  ),
+);
+
+const emphasizedRules = rules.filter(
+  rule =>
+    !rule.meta.deprecated &&
+    !deprecatedRules.has(rule) &&
+    !formattingRules.has(rule),
+);
 
 const paths = globby
   .sync('*.md', {
@@ -31,34 +42,35 @@ const paths = globby
     );
   });
 
+function createCategory(label, rules, additionalItems = []) {
+  const collapsed = !additionalItems.length;
+  return {
+    collapsed,
+    collapsible: collapsed,
+    items: [
+      ...rules.map(rule => {
+        return {
+          type: 'doc',
+          id: rule.name,
+          label: rule.name,
+        };
+      }),
+      ...additionalItems,
+    ],
+    label,
+    type: 'category',
+  };
+}
+
 module.exports = {
   someSidebar: [
     'README',
-    {
-      type: 'category',
-      label: 'Rules',
-      collapsible: true,
-      collapsed: false,
-      items: notDeprecatedRules.map(item => {
-        return {
-          type: 'doc',
-          id: item.name,
-          label: item.name,
-        };
-      }),
-    },
-    {
-      type: 'category',
-      label: 'Deprecated',
-      collapsible: true,
-      collapsed: false,
-      items: [...deprecatedRules, ...paths].map(item => {
-        return {
-          type: 'doc',
-          id: item.name,
-          label: item.name,
-        };
-      }),
-    },
+    createCategory('Rules', emphasizedRules, [
+      createCategory('Formatting Rules', Array.from(formattingRules)),
+      createCategory('Deprecated Rules', [
+        ...Array.from(deprecatedRules),
+        ...paths,
+      ]),
+    ]),
   ],
 };


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #5400
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Moves formatting and deprecated rules to sad little sub-categories at the bottom of the sidebar rules list.