### PR TITLE
fix: move generatedRuleDocs to beforeDefaultRemarkPlugins

### DIFF
--- a/packages/website/docusaurusConfig.ts
+++ b/packages/website/docusaurusConfig.ts
@@ -23,8 +23,11 @@ const presetClassicOptions: PresetClassicOptions = {
     sidebarPath: require.resolve('./sidebars/sidebar.rules.js'),
     routeBasePath: 'rules',
     editUrl: `${githubUrl}/edit/main/packages/website/`,
-    beforeDefaultRemarkPlugins,
-    remarkPlugins: [...remarkPlugins, [generatedRuleDocs, {}]],
+    beforeDefaultRemarkPlugins: [
+      ...beforeDefaultRemarkPlugins,
+      [generatedRuleDocs, {}],
+    ],
+    remarkPlugins,
     exclude: ['TEMPLATE.md'],
     breadcrumbs: false,
   },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #5425
-   [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
