### PR TITLE
feat(eslint-plugin): [prefer-for-of] report forEach

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-for-of.md
+++ b/packages/eslint-plugin/docs/rules/prefer-for-of.md
@@ -1,5 +1,5 @@
 ---
-description: 'Enforce the use of `for-of` loop over the standard `for` loop where possible.'
+description: 'Enforce the use of `for-of` loop over the standard `for` loop and `forEach` where possible'
 ---
 
 > 🛑 This file is source code, not the primary documentation location! 🛑
@@ -44,16 +44,41 @@ for (let i = 0; i < arr.length; i++) {
 
 ## Options
 
-```jsonc
-// .eslintrc.json
-{
-  "rules": {
-    "@typescript-eslint/prefer-for-of": "warn"
-  }
-}
+The rule accepts an options object with the following properties:
+
+```ts
+type Options = {
+  checkForEach: boolean;
+};
+
+const defaults = {
+  checkForEach: false,
+};
 ```
 
-This rule is not configurable.
+### `checkForEach`
+
+A boolean to specify if `for of` should be preferred to `forEach`. `false` by default.
+
+Examples of **incorrect** code for the `{ "checkForEach": true }` option:
+
+```ts
+/*eslint @typescript-eslint/prefer-for-of: ["error", { "ignoreRestArgs": true }]*/
+
+bar.forEach(item => {
+  console.log(item);
+});
+```
+
+Examples of **correct** code for the `{ "checkForEach": true }` option:
+
+```ts
+/*eslint @typescript-eslint/prefer-for-of: ["error", { "checkForEach": true }]*/
+
+bar.forEach((item, index) => {
+  console.log(item, index);
+});
+```
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/docs/rules/prefer-for-of.md
+++ b/packages/eslint-plugin/docs/rules/prefer-for-of.md
@@ -1,5 +1,5 @@
 ---
-description: 'Enforce the use of `for-of` loop over the standard `for` loop and `forEach` where possible'
+description: 'Enforce the use of `for-of` loop over the standard `for` loop and `forEach` where possible'.
 ---
 
 > 🛑 This file is source code, not the primary documentation location! 🛑

--- a/packages/eslint-plugin/src/rules/prefer-for-of.ts
+++ b/packages/eslint-plugin/src/rules/prefer-for-of.ts
@@ -16,10 +16,20 @@ export default util.createRule({
       preferForOfToForEach:
         'Expected a `for-of` loop instead of a `forEach` loop with this simple iteration.',
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          checkForEach: {
+            type: 'boolean',
+          },
+        },
+      },
+    ],
   },
-  defaultOptions: [],
-  create(context) {
+  defaultOptions: [{ checkForEach: false }],
+  create(context, [{ checkForEach }]) {
     function isSingleVariableDeclaration(
       node: TSESTree.Node | null,
     ): node is TSESTree.VariableDeclaration {
@@ -183,6 +193,7 @@ export default util.createRule({
     return {
       CallExpression(node): void {
         if (
+          checkForEach &&
           // forEach call
           node.callee.type === AST_NODE_TYPES.MemberExpression &&
           node.callee.property.type === AST_NODE_TYPES.Identifier &&

--- a/packages/eslint-plugin/src/rules/prefer-for-of.ts
+++ b/packages/eslint-plugin/src/rules/prefer-for-of.ts
@@ -7,12 +7,14 @@ export default util.createRule({
     type: 'suggestion',
     docs: {
       description:
-        'Enforce the use of `for-of` loop over the standard `for` loop where possible',
+        'Enforce the use of `for-of` loop over the standard `for` loop and `forEach` where possible',
       recommended: 'strict',
     },
     messages: {
       preferForOf:
         'Expected a `for-of` loop instead of a `for` loop with this simple iteration.',
+      preferForOfToForEach:
+        'Expected a `for-of` loop instead of a `forEach` loop with this simple iteration.',
     },
     schema: [],
   },

--- a/packages/eslint-plugin/src/rules/prefer-for-of.ts
+++ b/packages/eslint-plugin/src/rules/prefer-for-of.ts
@@ -179,6 +179,26 @@ export default util.createRule({
     }
 
     return {
+      CallExpression(node): void {
+        if (
+          // forEach call
+          node.callee.type === AST_NODE_TYPES.MemberExpression &&
+          node.callee.property.type === AST_NODE_TYPES.Identifier &&
+          node.callee.property.name === 'forEach' &&
+          // only being called with one arg, aka we're not passing a `this` param
+          node.arguments.length === 1 &&
+          (node.arguments[0].type === AST_NODE_TYPES.FunctionExpression ||
+            node.arguments[0].type ===
+              AST_NODE_TYPES.ArrowFunctionExpression) &&
+          // function expression with one param
+          node.arguments[0].params.length === 1
+        ) {
+          context.report({
+            node,
+            messageId: 'preferForOf',
+          });
+        }
+      },
       'ForStatement:exit'(node: TSESTree.ForStatement): void {
         if (!isSingleVariableDeclaration(node.init)) {
           return;

--- a/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
@@ -130,6 +130,29 @@ for (var r of arr) {
 }
     `,
     `
+arr.forEach((item, index) => {
+  console.log(item, index);
+});
+    `,
+    `
+arr.forEach(item => {
+  console.log(item);
+}, _this);
+    `,
+    `
+arr.forEach(function (item, index) {
+  console.log(item, index);
+});
+    `,
+    `
+arr.forEach(function (item, index) {
+  console.log(item, index);
+}, _this);
+    `,
+    `
+arr.forEach(func);
+    `,
+    `
 for (let x = 0; x < arr.length; x++) {
   let y = arr[x + 1];
 }
@@ -344,6 +367,30 @@ for (let i = 0; i < arr.length; i++) {
 for (let i = 0; i < arr.length; i++) {
   [obj[arr[i]]] = [1];
 }
+      `,
+      errors: [
+        {
+          messageId: 'preferForOf',
+        },
+      ],
+    },
+    {
+      code: `
+arr.forEach(item => {
+  console.log(item);
+});
+      `,
+      errors: [
+        {
+          messageId: 'preferForOf',
+        },
+      ],
+    },
+    {
+      code: `
+arr.forEach(function (item) {
+  console.log(item);
+});
       `,
       errors: [
         {

--- a/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
@@ -382,7 +382,7 @@ arr.forEach(item => {
       `,
       errors: [
         {
-          messageId: 'preferForOf',
+          messageId: 'preferForOfToForEach',
         },
       ],
     },
@@ -394,7 +394,7 @@ arr.forEach(function (item) {
       `,
       errors: [
         {
-          messageId: 'preferForOf',
+          messageId: 'preferForOfToForEach',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
@@ -380,6 +380,7 @@ arr.forEach(item => {
   console.log(item);
 });
       `,
+      options: [{ checkForEach: true }],
       errors: [
         {
           messageId: 'preferForOfToForEach',
@@ -392,6 +393,7 @@ arr.forEach(function (item) {
   console.log(item);
 });
       `,
+      options: [{ checkForEach: true }],
       errors: [
         {
           messageId: 'preferForOfToForEach',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/702
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

After this change we check for `.forEach` calls and report if they don't use the array index. We only check function expressions and check the type that we're calling `.forEach` on, so there may be falls positives unless we want to introduce some type checking.
