### PR TITLE
fix: missing placeholders in violation messages for `no-unnecessary-type-constraint` and `no-unsafe-argument` (and enable `eslint-plugin/recommended` rules internally)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
+    'plugin:eslint-plugin/recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
   ],
@@ -194,7 +195,7 @@ module.exports = {
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
-        'eslint-plugin/no-identical-tests': 'error',
+        'eslint-plugin/consistent-output': 'off',
         'jest/no-disabled-tests': 'warn',
         'jest/no-focused-tests': 'error',
         'jest/no-alias-methods': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -195,7 +195,7 @@ module.exports = {
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
-        'eslint-plugin/consistent-output': 'off',
+        'eslint-plugin/consistent-output': 'off', // Might eventually be removed from `eslint-plugin/recommended`: https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/284
         'jest/no-disabled-tests': 'warn',
         'jest/no-focused-tests': 'error',
         'jest/no-alias-methods': 'error',

--- a/packages/eslint-plugin-internal/src/rules/no-poorly-typed-ts-props.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-poorly-typed-ts-props.ts
@@ -35,7 +35,6 @@ export default createRule({
       description:
         "Enforces rules don't use TS API properties with known bad type definitions",
       recommended: 'error',
-      suggestion: true,
       requiresTypeChecking: true,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -1,3 +1,7 @@
+/* eslint-disable eslint-comments/no-use */
+/* eslint eslint-plugin/no-unused-message-ids:"off" -- rule has false positives due to our usage of an external helper function */
+/* eslint-enable eslint-comments/no-use */
+
 import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { PatternVisitor } from '@typescript-eslint/scope-manager';
 import type { ScriptTarget } from 'typescript';

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -1,5 +1,5 @@
 /* eslint-disable eslint-comments/no-use */
-/* eslint eslint-plugin/no-unused-message-ids:"off" -- rule has false positives due to our usage of an external helper function */
+/* eslint eslint-plugin/no-unused-message-ids:"off" -- https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/283 */
 /* eslint-enable eslint-comments/no-use */
 
 import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';

--- a/packages/eslint-plugin/src/rules/no-duplicate-enum-values.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-enum-values.ts
@@ -9,7 +9,7 @@ export default util.createRule({
       description: 'Disallow duplicate enum member values',
       recommended: 'strict',
     },
-    hasSuggestions: true,
+    hasSuggestions: false,
     messages: {
       duplicateValue: 'Duplicate enum member value {{value}}.',
     },

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -15,10 +15,9 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description: 'Disallow the declaration of empty interfaces',
       recommended: 'error',
-      suggestion: true,
     },
     fixable: 'code',
-    hasSuggestions: true,
+    hasSuggestions: true, // eslint-disable-line eslint-plugin/require-meta-has-suggestions -- https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/272
     messages: {
       noEmpty: 'An empty interface is equivalent to `{}`.',
       noEmptyWithSuper:

--- a/packages/eslint-plugin/src/rules/no-explicit-any.ts
+++ b/packages/eslint-plugin/src/rules/no-explicit-any.ts
@@ -16,10 +16,9 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description: 'Disallow the `any` type',
       recommended: 'warn',
-      suggestion: true,
     },
     fixable: 'code',
-    hasSuggestions: true,
+    hasSuggestions: true, // eslint-disable-line eslint-plugin/require-meta-has-suggestions -- https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/281
     messages: {
       unexpectedAny: 'Unexpected any. Specify a different type.',
       suggestUnknown:

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -20,7 +20,6 @@ export default util.createRule<Options, MessageId>({
       description:
         'Require Promise-like statements to be handled appropriately',
       recommended: 'error',
-      suggestion: true,
       requiresTypeChecking: true,
     },
     hasSuggestions: true,

--- a/packages/eslint-plugin/src/rules/no-implicit-any-catch.ts
+++ b/packages/eslint-plugin/src/rules/no-implicit-any-catch.ts
@@ -19,7 +19,6 @@ export default util.createRule<Options, MessageIds>({
     docs: {
       description: 'Disallow usage of the implicit `any` type in catch clauses',
       recommended: false,
-      suggestion: true,
     },
     fixable: 'code',
     hasSuggestions: true,

--- a/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
+++ b/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
@@ -20,7 +20,6 @@ export default util.createRule<
       description:
         'Disallow the `void` operator except when used to discard a value',
       recommended: 'strict',
-      suggestion: true,
       requiresTypeChecking: true,
     },
     fixable: 'code',

--- a/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
@@ -19,7 +19,6 @@ export default util.createRule({
       description:
         'Disallow non-null assertions after an optional chain expression',
       recommended: 'error',
-      suggestion: true,
     },
     hasSuggestions: true,
     messages: {

--- a/packages/eslint-plugin/src/rules/no-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-assertion.ts
@@ -11,7 +11,6 @@ export default util.createRule<[], MessageIds>({
       description:
         'Disallow non-null assertions using the `!` postfix operator',
       recommended: 'warn',
-      suggestion: true,
     },
     hasSuggestions: true,
     messages: {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts
@@ -31,7 +31,6 @@ export default util.createRule({
     docs: {
       description: 'Disallow unnecessary constraints on generic types',
       recommended: 'error',
-      suggestion: true,
     },
     hasSuggestions: true,
     messages: {
@@ -89,6 +88,9 @@ export default util.createRule({
           suggest: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: {
+                constraint,
+              },
               fix(fixer): TSESLint.RuleFix | null {
                 return fixer.replaceTextRange(
                   [node.name.range[1], node.constraint.range[1]],

--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -142,7 +142,7 @@ export default util.createRule<[], MessageIds>({
       unsafeArgument:
         'Unsafe argument of type `{{sender}}` assigned to a parameter of type `{{receiver}}`.',
       unsafeTupleSpread:
-        'Unsafe spread of a tuple type. The {{index}} element is of type `{{sender}}` and is assigned to a parameter of type `{{reciever}}`.',
+        'Unsafe spread of a tuple type. The argument is of type `{{sender}}` and is assigned to a parameter of type `{{receiver}}`.',
       unsafeArraySpread: 'Unsafe spread of an `any` array type.',
       unsafeSpread: 'Unsafe spread of an `any` type.',
     },

--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -1,3 +1,7 @@
+/* eslint-disable eslint-comments/no-use */
+/* eslint eslint-plugin/no-unused-message-ids:"off" -- disabled because the rule doesn't understand our helper function checkCall() */
+/* eslint-enable eslint-comments/no-use */
+
 import { TSESTree } from '@typescript-eslint/utils';
 import * as tsutils from 'tsutils';
 import * as util from '../util';

--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -1,5 +1,5 @@
 /* eslint-disable eslint-comments/no-use */
-/* eslint eslint-plugin/no-unused-message-ids:"off" -- disabled because the rule doesn't understand our helper function checkCall() */
+/* eslint eslint-plugin/no-unused-message-ids:"off" -- https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/282 */
 /* eslint-enable eslint-comments/no-use */
 
 import { TSESTree } from '@typescript-eslint/utils';

--- a/packages/eslint-plugin/src/rules/no-useless-empty-export.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-empty-export.ts
@@ -28,10 +28,9 @@ export default util.createRule({
       description:
         "Disallow empty exports that don't change anything in a module file",
       recommended: false,
-      suggestion: true,
     },
     fixable: 'code',
-    hasSuggestions: true,
+    hasSuggestions: false,
     messages: {
       uselessExport: 'Empty export does nothing and can be removed.',
     },

--- a/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
+++ b/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
@@ -11,7 +11,6 @@ export default util.createRule({
       description: 'Enforce non-null assertions over explicit type casts',
       recommended: 'strict',
       requiresTypeChecking: true,
-      suggestion: true,
     },
     fixable: 'code',
     messages: {

--- a/packages/eslint-plugin/src/rules/object-curly-spacing.ts
+++ b/packages/eslint-plugin/src/rules/object-curly-spacing.ts
@@ -20,6 +20,7 @@ export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
 
 export default createRule<Options, MessageIds>({
   name: 'object-curly-spacing',
+  // eslint-disable-next-line eslint-plugin/prefer-message-ids,eslint-plugin/require-meta-type,eslint-plugin/require-meta-schema,eslint-plugin/require-meta-fixable -- all in base rule
   meta: {
     ...baseRule.meta,
     docs: {

--- a/packages/eslint-plugin/src/rules/object-curly-spacing.ts
+++ b/packages/eslint-plugin/src/rules/object-curly-spacing.ts
@@ -20,7 +20,7 @@ export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
 
 export default createRule<Options, MessageIds>({
   name: 'object-curly-spacing',
-  // eslint-disable-next-line eslint-plugin/prefer-message-ids,eslint-plugin/require-meta-type,eslint-plugin/require-meta-schema,eslint-plugin/require-meta-fixable -- all in base rule
+  // eslint-disable-next-line eslint-plugin/prefer-message-ids,eslint-plugin/require-meta-type,eslint-plugin/require-meta-schema,eslint-plugin/require-meta-fixable -- all in base rule - https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/274
   meta: {
     ...baseRule.meta,
     docs: {

--- a/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
+++ b/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
@@ -592,7 +592,7 @@ export default util.createRule<Options, MessageIds>({
       extendsBaseRule: true,
     },
     fixable: 'whitespace',
-    hasSuggestions: true,
+    hasSuggestions: false,
     schema: {
       definitions: {
         paddingType: {

--- a/packages/eslint-plugin/src/rules/prefer-as-const.ts
+++ b/packages/eslint-plugin/src/rules/prefer-as-const.ts
@@ -8,7 +8,6 @@ export default util.createRule({
     docs: {
       description: 'Enforce the use of `as const` over literal type',
       recommended: 'error',
-      suggestion: true,
     },
     fixable: 'code',
     hasSuggestions: true,

--- a/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts
+++ b/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts
@@ -11,7 +11,6 @@ export default util.createRule<[], MessageIds>({
       description:
         'Require each enum member value to be explicitly initialized',
       recommended: false,
-      suggestion: true,
     },
     hasSuggestions: true,
     messages: {

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -28,7 +28,6 @@ export default util.createRule<Options, MessageIds>({
       description:
         'Enforce using the nullish coalescing operator instead of logical chaining',
       recommended: 'strict',
-      suggestion: true,
       requiresTypeChecking: true,
     },
     hasSuggestions: true,

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -36,7 +36,6 @@ export default util.createRule({
       description:
         'Enforce using concise optional chain expressions instead of chained logical ands',
       recommended: 'strict',
-      suggestion: true,
     },
     hasSuggestions: true,
     messages: {

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -25,7 +25,7 @@ export default util.createRule({
       extendsBaseRule: 'no-return-await',
     },
     fixable: 'code',
-    hasSuggestions: true,
+    hasSuggestions: true, // eslint-disable-line eslint-plugin/require-meta-has-suggestions -- https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/272
     type: 'problem',
     messages: {
       nonPromiseAwait:

--- a/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
@@ -110,7 +110,7 @@ export default util.createRule<Options, MessageIds>({
       recommended: false,
     },
     fixable: 'code',
-    hasSuggestions: true,
+    hasSuggestions: true, // eslint-disable-line eslint-plugin/require-meta-has-suggestions -- https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/272
     messages: {
       notSorted: '{{type}} type members must be sorted.',
       notSortedNamed: '{{type}} type {{name}} members must be sorted.',

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -18,7 +18,6 @@ export default createRule({
       description:
         'Require switch-case statements to be exhaustive with union type',
       recommended: false,
-      suggestion: true,
       requiresTypeChecking: true,
     },
     hasSuggestions: true,

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -194,11 +194,7 @@ interface B extends A {
   [index: number]: unknown;
 }
       `,
-      output: `
-interface B extends A {
-  [index: number]: unknown;
-}
-      `,
+      output: null,
       errors: [{ messageId: 'preferRecord', line: 2, column: 1 }],
     },
     // Readonly interface with generic parameter

--- a/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
@@ -368,11 +368,7 @@ export class XXXX {
           line: 3,
         },
       ],
-      output: `
-export class XXXX {
-  public constructor(readonly value: string) {}
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -383,11 +379,7 @@ export class WithParameterProperty {
       `,
       options: [{ accessibility: 'explicit' }],
       errors: [{ messageId: 'missingAccessibility' }],
-      output: `
-export class WithParameterProperty {
-  public constructor(readonly value: string) {}
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -406,11 +398,7 @@ export class XXXX {
         },
       ],
       errors: [{ messageId: 'missingAccessibility' }],
-      output: `
-export class XXXX {
-  public constructor(readonly samosa: string) {}
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -426,11 +414,7 @@ class Test {
         },
       ],
       errors: [{ messageId: 'missingAccessibility' }],
-      output: `
-class Test {
-  public constructor(readonly foo: string) {}
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -453,14 +437,7 @@ class Test {
           column: 3,
         },
       ],
-      output: `
-class Test {
-  x: number;
-  public getX() {
-    return this.x;
-  }
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -483,14 +460,7 @@ class Test {
           column: 3,
         },
       ],
-      output: `
-class Test {
-  private x: number;
-  getX() {
-    return this.x;
-  }
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -522,14 +492,7 @@ class Test {
           column: 3,
         },
       ],
-      output: `
-class Test {
-  x?: number;
-  getX?() {
-    return this.x;
-  }
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -658,20 +621,7 @@ class Test {
         },
       ],
       options: [{ overrides: { constructors: 'no-public' } }],
-      output: `
-class Test {
-  private x: number;
-  constructor(x: number) {
-    this.x = x;
-  }
-  get internalValue() {
-    return this.x;
-  }
-  set internalValue(value: number) {
-    this.x = value;
-  }
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -706,20 +656,7 @@ class Test {
           column: 3,
         },
       ],
-      output: `
-class Test {
-  private x: number;
-  constructor(x: number) {
-    this.x = x;
-  }
-  get internalValue() {
-    return this.x;
-  }
-  set internalValue(value: number) {
-    this.x = value;
-  }
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -743,14 +680,7 @@ class Test {
           overrides: { parameterProperties: 'no-public' },
         },
       ],
-      output: `
-class Test {
-  constructor(public x: number) {}
-  public foo(): string {
-    return 'foo';
-  }
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -766,11 +696,7 @@ class Test {
           column: 3,
         },
       ],
-      output: `
-class Test {
-  constructor(public x: number) {}
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -818,11 +744,7 @@ class Test {
           column: 3,
         },
       ],
-      output: `
-class Test {
-  x = 2;
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',
@@ -866,11 +788,7 @@ class Test {
           column: 3,
         },
       ],
-      output: `
-class Test {
-  constructor(public ...x: any[]) {}
-}
-      `,
+      output: null,
     },
     {
       filename: 'test.ts',

--- a/packages/eslint-plugin/tests/rules/no-dynamic-delete.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-dynamic-delete.test.ts
@@ -68,10 +68,7 @@ const container: { [i: string]: 0 } = {};
 delete container['aa' + 'b'];
       `,
       errors: [{ messageId: 'dynamicDelete' }],
-      output: `
-const container: { [i: string]: 0 } = {};
-delete container['aa' + 'b'];
-      `,
+      output: null,
     },
     {
       code: `
@@ -90,10 +87,7 @@ const container: { [i: string]: 0 } = {};
 delete container[-Infinity];
       `,
       errors: [{ messageId: 'dynamicDelete' }],
-      output: `
-const container: { [i: string]: 0 } = {};
-delete container[-Infinity];
-      `,
+      output: null,
     },
     {
       code: `
@@ -101,10 +95,7 @@ const container: { [i: string]: 0 } = {};
 delete container[+Infinity];
       `,
       errors: [{ messageId: 'dynamicDelete' }],
-      output: `
-const container: { [i: string]: 0 } = {};
-delete container[+Infinity];
-      `,
+      output: null,
     },
     {
       code: `
@@ -112,10 +103,7 @@ const container: { [i: string]: 0 } = {};
 delete container[NaN];
       `,
       errors: [{ messageId: 'dynamicDelete' }],
-      output: `
-const container: { [i: string]: 0 } = {};
-delete container[NaN];
-      `,
+      output: null,
     },
     {
       code: `
@@ -135,11 +123,7 @@ const name = 'name';
 delete container[name];
       `,
       errors: [{ messageId: 'dynamicDelete' }],
-      output: `
-const container: { [i: string]: 0 } = {};
-const name = 'name';
-delete container[name];
-      `,
+      output: null,
     },
     {
       code: `
@@ -147,11 +131,7 @@ const container: { [i: string]: 0 } = {};
 const getName = () => 'aaa';
 delete container[getName()];
       `,
-      output: `
-const container: { [i: string]: 0 } = {};
-const getName = () => 'aaa';
-delete container[getName()];
-      `,
+      output: null,
       errors: [{ messageId: 'dynamicDelete' }],
     },
     {
@@ -160,11 +140,7 @@ const container: { [i: string]: 0 } = {};
 const name = { foo: { bar: 'bar' } };
 delete container[name.foo.bar];
       `,
-      output: `
-const container: { [i: string]: 0 } = {};
-const name = { foo: { bar: 'bar' } };
-delete container[name.foo.bar];
-      `,
+      output: null,
       errors: [{ messageId: 'dynamicDelete' }],
     },
   ],

--- a/packages/eslint-plugin/tests/rules/no-empty-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-interface.test.ts
@@ -184,12 +184,7 @@ declare module FooBar {
         },
       ],
       // output matches input because a suggestion was made
-      output: `
-declare module FooBar {
-  type Baz = typeof baz;
-  export interface Bar extends Baz {}
-}
-      `.trimRight(),
+      output: null,
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-constraint.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-constraint.test.ts
@@ -39,6 +39,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: 'function data<T>() {}',
             },
           ],
@@ -57,6 +58,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: 'function data<T, U>() {}',
             },
           ],
@@ -75,6 +77,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: 'function data<T, U>() {}',
             },
           ],
@@ -93,6 +96,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: 'function data<T, U extends T>() {}',
             },
           ],
@@ -111,6 +115,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: noFormat`const data = <T,>() => {};`,
             },
           ],
@@ -130,6 +135,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: noFormat`const data = <T,>() => {};`,
             },
           ],
@@ -149,6 +155,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: noFormat`const data = <T, >() => {};`,
             },
           ],
@@ -168,6 +175,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: noFormat`const data = <T ,>() => {};`,
             },
           ],
@@ -187,6 +195,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: noFormat`const data = <T , >() => {};`,
             },
           ],
@@ -206,6 +215,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: 'const data = <T = unknown>() => {};',
             },
           ],
@@ -225,6 +235,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: noFormat`const data = <T, U extends any>() => {};`,
             },
           ],
@@ -238,6 +249,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: noFormat`const data = <T extends any, U>() => {};`,
             },
           ],
@@ -257,6 +269,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'unknown' },
               output: 'function data<T>() {}',
             },
           ],
@@ -275,6 +288,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'any' },
               output: 'const data = <T>() => {};',
             },
           ],
@@ -293,6 +307,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'unknown' },
               output: 'const data = <T>() => {};',
             },
           ],
@@ -311,6 +326,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'unknown' },
               output: 'class Data<T> {}',
             },
           ],
@@ -329,6 +345,7 @@ function data<T extends TODO>() {}
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'unknown' },
               output: 'const Data = class<T> {};',
             },
           ],
@@ -351,6 +368,7 @@ class Data {
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'unknown' },
               output: `
 class Data {
   member<T>() {}
@@ -377,6 +395,7 @@ const Data = class {
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'unknown' },
               output: `
 const Data = class {
   member<T>() {}
@@ -399,6 +418,7 @@ const Data = class {
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'unknown' },
               output: 'interface Data<T> {}',
             },
           ],
@@ -417,6 +437,7 @@ const Data = class {
           suggestions: [
             {
               messageId: 'removeUnnecessaryConstraint',
+              data: { constraint: 'unknown' },
               output: 'type Data<T> = {};',
             },
           ],

--- a/packages/eslint-plugin/tests/rules/prefer-as-const.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-as-const.test.ts
@@ -114,7 +114,7 @@ ruleTester.run('prefer-as-const', rule, {
     },
     {
       code: "let []: 'bar' = 'bar';",
-      output: "let []: 'bar' = 'bar';",
+      output: null,
       errors: [
         {
           messageId: 'variableConstAssertion',
@@ -125,7 +125,7 @@ ruleTester.run('prefer-as-const', rule, {
     },
     {
       code: "let foo: 'bar' = 'bar';",
-      output: "let foo: 'bar' = 'bar';",
+      output: null,
       errors: [
         {
           messageId: 'variableConstAssertion',
@@ -142,7 +142,7 @@ ruleTester.run('prefer-as-const', rule, {
     },
     {
       code: 'let foo: 2 = 2;',
-      output: 'let foo: 2 = 2;',
+      output: null,
       errors: [
         {
           messageId: 'variableConstAssertion',
@@ -218,11 +218,7 @@ class foo {
   bar: 'baz' = 'baz';
 }
       `.trimRight(),
-      output: `
-class foo {
-  bar: 'baz' = 'baz';
-}
-      `.trimRight(),
+      output: null,
       errors: [
         {
           messageId: 'variableConstAssertion',
@@ -247,11 +243,7 @@ class foo {
   bar: 2 = 2;
 }
       `.trimRight(),
-      output: `
-class foo {
-  bar: 2 = 2;
-}
-      `.trimRight(),
+      output: null,
       errors: [
         {
           messageId: 'variableConstAssertion',

--- a/packages/eslint-plugin/tests/rules/prefer-function-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-function-type.test.ts
@@ -82,12 +82,7 @@ export default interface Foo {
           },
         },
       ],
-      output: `
-export default interface Foo {
-  /** comment */
-  (): string;
-}
-      `,
+      output: null,
     },
     {
       code: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5460 fixes #5461
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Fixes bugs caught by the [eslint-plugin/no-missing-placeholders](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/no-missing-placeholders.md) and [eslint-plugin/no-unused-placeholders](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/no-unused-placeholders.md) rules:
1. #5460
2. #5461

Enables the `recommended` config from [eslint-plugin-eslint-plugin](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin) which catches mistakes and enforces best practices in eslint plugins. Note that I have been actively making fixes to eslint-plugin-eslint-plugin to eliminate any false positives with its rules.

If desired, I can extract these bug fixes into separate PRs to go in ahead of the rest of the eslint-plugin-eslint-plugin additions.



