### PR TITLE
feat(eslint-plugin): allowMixins option for explicit-function-return-type and explicit-module-boundary-types

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -81,6 +81,8 @@ type Options = {
   allowDirectConstAssertionInArrowFunctions?: boolean;
   // if true, concise arrow functions that start with the void keyword will not be checked
   allowConciseArrowFunctionExpressionsStartingWithVoid?: boolean;
+  // if true, functions immediately returning a class definition will not be checked
+  allowMixins?: boolean;
   /**
    * An array of function/method names that will not have their arguments or their return values checked.
    */
@@ -93,6 +95,7 @@ const defaults = {
   allowHigherOrderFunctions: true,
   allowDirectConstAssertionInArrowFunctions: true,
   allowConciseArrowFunctionExpressionsStartingWithVoid: false,
+  allowMixins: false,
   allowedNames: [],
 };
 ```
@@ -269,6 +272,54 @@ const log = (message: string) => {
 
 ```ts
 var log = (message: string) => void console.log(message);
+```
+
+### `allowMixins`
+
+Examples of code for this rule with `{ allowMixins: true }`:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+function fn(supertype: Constructor<Object>) {
+  return new (class extends supertype {})();
+}
+
+function fn(supertype: Constructor<Object>) {}
+
+var fn = () => {};
+```
+
+#### ✅ Correct
+
+```ts
+type Constructor<T> = abstract new (...args: any) => T;
+
+function M1(supertype: Constructor<Object>) {
+  return class extends supertype {};
+}
+
+const M2 = (supertype: Constructor<Object>) => class extends supertype {};
+
+const M3 = (supertype: Constructor<Object>) => {
+  return class extends supertype {};
+};
+
+const M4 = function (supertype: Constructor<Object>) {
+  return class extends supertype {};
+};
+
+function M5(supertype: Constructor<Object>) {
+  class Response extends supertype {}
+  return Response;
+}
+
+const M6 = (supertype: Constructor<Object>) => {
+  class Response extends supertype {}
+  return Response;
+};
 ```
 
 ### `allowedNames`

--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
@@ -101,6 +101,11 @@ type Options = {
    * rather than on the function arguments/return value directly.
    */
   allowTypedFunctionExpressions?: boolean;
+
+  /*
+   * if true, functions immediately returning a class definition will not be checked
+   */
+  allowMixins: boolean;
 };
 
 const defaults = {
@@ -109,6 +114,7 @@ const defaults = {
   allowedNames: [],
   allowHigherOrderFunctions: true,
   allowTypedFunctionExpressions: true,
+  allowMixins: false,
 };
 ```
 
@@ -279,6 +285,55 @@ export let objectPropCast = <ObjectType>{
 
 type FooType = (bar: string) => void;
 export const foo: FooType = bar => {};
+```
+
+### `allowMixins`
+
+Examples of code for this rule with `{ allowMixins: true }`:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+export function fn(supertype: Constructor<Object>) {
+  return new (class extends supertype {})();
+}
+
+export function fn(supertype: Constructor<Object>) {}
+
+export var fn = () => {};
+```
+
+#### ✅ Correct
+
+```ts
+type Constructor<T> = abstract new (...args: any) => T;
+
+export function M1(supertype: Constructor<Object>) {
+  return class extends supertype {};
+}
+
+export const M2 = (supertype: Constructor<Object>) =>
+  class extends supertype {};
+
+export const M3 = (supertype: Constructor<Object>) => {
+  return class extends supertype {};
+};
+
+export const M4 = function (supertype: Constructor<Object>) {
+  return class extends supertype {};
+};
+
+export function M5(supertype: Constructor<Object>) {
+  class Response extends supertype {}
+  return Response;
+}
+
+export const M6 = (supertype: Constructor<Object>) => {
+  class Response extends supertype {}
+  return Response;
+};
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
+++ b/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
@@ -142,7 +142,7 @@ export default util.createRule<Options, MessageIds>({
         return false;
       }
 
-      return doesImmediatelyReturnClassExpression(node);
+      return doesImmediatelyReturnClassExpression(node.body);
     }
 
     return {
@@ -159,11 +159,7 @@ export default util.createRule<Options, MessageIds>({
           return;
         }
 
-        if (isAllowedName(node)) {
-          return;
-        }
-
-        if (isAllowedMixin(node)) {
+        if (isAllowedName(node) || isAllowedMixin(node)) {
           return;
         }
 
@@ -184,11 +180,7 @@ export default util.createRule<Options, MessageIds>({
         );
       },
       FunctionDeclaration(node): void {
-        if (isAllowedName(node)) {
-          return;
-        }
-
-        if (isAllowedMixin(node)) {
+        if (isAllowedName(node) || isAllowedMixin(node)) {
           return;
         }
 

--- a/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
+++ b/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
@@ -138,7 +138,9 @@ export default util.createRule<Options, MessageIds>({
         | TSESTree.FunctionExpression
         | TSESTree.FunctionDeclaration,
     ): boolean {
-      if (!options.allowMixins) return false;
+      if (!options.allowMixins) {
+        return false;
+      }
 
       return doesImmediatelyReturnClassExpression(node);
     }

--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -274,7 +274,7 @@ export default util.createRule<Options, MessageIds>({
         return false;
       }
 
-      return doesImmediatelyReturnClassExpression(node);
+      return doesImmediatelyReturnClassExpression(node.body);
     }
 
     function isExportedHigherOrderFunction(node: FunctionNode): boolean {

--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -141,12 +141,9 @@ function doesImmediatelyReturnFunctionExpression({
  * function fn() { return function() { ... } }
  * ```
  */
-function doesImmediatelyReturnClassExpression({ body }: FunctionNode): boolean {
-  // Should always have a body; really checking just in case
-  /* istanbul ignore if */ if (!body) {
-    return false;
-  }
-
+function doesImmediatelyReturnClassExpression(
+  body: TSESTree.BlockStatement | TSESTree.Expression,
+): boolean {
   // Check if body is a class expression
   if (body.type === AST_NODE_TYPES.ClassExpression) {
     return true;

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -555,6 +555,91 @@ const x: Bar<Foo> = arg1 => arg2 => arg1 + arg2;
         },
       ],
     },
+
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+function M(supertype: Constructor<Object>) {
+  return class extends supertype {};
+}
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+const M = (supertype: Constructor<Object>) => class extends supertype {};
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+const M = (supertype: Constructor<Object>) => {
+  return class extends supertype {};
+};
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+const M = function (supertype: Constructor<Object>) {
+  return class extends supertype {};
+};
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+function M(supertype: Constructor<Object>) {
+  class Response extends supertype {}
+  return Response;
+}
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+const M = (supertype: Constructor<Object>) => {
+  class Response extends supertype {}
+  return Response;
+};
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -1411,6 +1496,114 @@ class Foo {
           endLine: 4,
           column: 3,
           endColumn: 18,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+function M(supertype: Constructor<Object>) {
+  return class extends supertype {};
+}
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 1,
+          endColumn: 43,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+const M = (supertype: Constructor<Object>) => class extends supertype {};
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 11,
+          endColumn: 46,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+const M = (supertype: Constructor<Object>) => {
+  return class extends supertype {};
+};
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 11,
+          endColumn: 46,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+const M = function (supertype: Constructor<Object>) {
+  return class extends supertype {};
+};
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 11,
+          endColumn: 52,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+function M(supertype: Constructor<Object>) {
+  class Response extends supertype {}
+  return Response;
+}
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 1,
+          endColumn: 43,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+type Constructor<T> = abstract new (...args: any) => T;
+const M = (supertype: Constructor<Object>) => {
+  class Response extends supertype {}
+  return Response;
+};
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 11,
+          endColumn: 46,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -1607,5 +1607,69 @@ const M = (supertype: Constructor<Object>) => {
         },
       ],
     },
+    {
+      filename: 'test.ts',
+      code: `
+function M() {
+  return [1, 2, 3];
+}
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          endLine: 2,
+          column: 1,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+const M = () => [1, 2, 3];
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          endLine: 2,
+          column: 11,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+const M = function () {
+  return [1, 2, 3];
+};
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          endLine: 2,
+          column: 11,
+          endColumn: 22,
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -741,6 +741,90 @@ export const a: Foo = {
   f: (x: boolean) => x,
 };
     `,
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export function M(supertype: Constructor<Object>) {
+  return class extends supertype {};
+}
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export const M = (supertype: Constructor<Object>) => class extends supertype {};
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export const M = (supertype: Constructor<Object>) => {
+  return class extends supertype {};
+};
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export const M = function (supertype: Constructor<Object>) {
+  return class extends supertype {};
+};
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export function M(supertype: Constructor<Object>) {
+  class Response extends supertype {}
+  return Response;
+}
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export const M = (supertype: Constructor<Object>) => {
+  class Response extends supertype {}
+  return Response;
+};
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -1899,6 +1983,114 @@ export const foo = {
           endLine: 6,
           column: 3,
           endColumn: 10,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export function M(supertype: Constructor<Object>) {
+  return class extends supertype {};
+}
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 8,
+          endColumn: 50,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export const M = (supertype: Constructor<Object>) => class extends supertype {};
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 18,
+          endColumn: 53,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export const M = (supertype: Constructor<Object>) => {
+  return class extends supertype {};
+};
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 18,
+          endColumn: 53,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export const M = function (supertype: Constructor<Object>) {
+  return class extends supertype {};
+};
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 18,
+          endColumn: 59,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export function M(supertype: Constructor<Object>) {
+  class Response extends supertype {}
+  return Response;
+}
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 8,
+          endColumn: 50,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export type Constructor<T> = abstract new (...args: any) => T;
+export const M = (supertype: Constructor<Object>) => {
+  class Response extends supertype {}
+  return Response;
+};
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 18,
+          endColumn: 53,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -2094,5 +2094,69 @@ export const M = (supertype: Constructor<Object>) => {
         },
       ],
     },
+    {
+      filename: 'test.ts',
+      code: `
+export function M() {
+  return [1, 2, 3];
+}
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          endLine: 2,
+          column: 8,
+          endColumn: 20,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export const M = () => [1, 2, 3];
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          endLine: 2,
+          column: 18,
+          endColumn: 23,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+export const M = function () {
+  return [1, 2, 3];
+};
+      `,
+      options: [
+        {
+          allowMixins: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          endLine: 2,
+          column: 18,
+          endColumn: 29,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2035
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Hi Dev Team!

I created this PR that should fix #2035, providing an option to skip required explicit types for the TypeScript Mixin pattern. The "Mixin" definition was loosely interpreted as "a function that returns a newly declared class". I made sure to allow both arrow and function definitions and only admitted functions that immediately define a class (although I am allowing returning named classes in blocks of two sentences to allow mixins that return an abstract class).

I've added tests to cover the new cases and updated the markdowns just in case I was supposed to.

This is my first PR to this project, so please let me know if something is amiss.