### PR TITLE
Switch to lightbulb emoji to denote rule suggestions

### DIFF
--- a/packages/website/src/components/RulesTable/index.tsx
+++ b/packages/website/src/components/RulesTable/index.tsx
@@ -36,7 +36,7 @@ function RuleRow({ rule }: { rule: RulesMeta[number] }): JSX.Element | null {
       </td>
       <td className={styles.attrCol}>
         {rule.fixable ? '🔧\n' : '\n'}
-        {rule.hasSuggestions ? '🛠' : ''}
+        {rule.hasSuggestions ? '💡' : ''}
       </td>
       <td className={styles.attrCol}>
         {rule.docs.requiresTypeChecking ? '💭' : ''}
@@ -168,7 +168,7 @@ export default function RulesTable({
         <RuleFilterCheckBox
           mode={showHasSuggestions}
           setMode={setShowHasSuggestion}
-          label="🛠 has suggestions"
+          label="💡 has suggestions"
         />
         <RuleFilterCheckBox
           mode={showTypeCheck}
@@ -181,7 +181,7 @@ export default function RulesTable({
           <tr>
             <th className={styles.ruleCol}>Rule</th>
             <th className={styles.attrCol}>✅{'\n'}🔒</th>
-            <th className={styles.attrCol}>🔧{'\n'}🛠</th>
+            <th className={styles.attrCol}>🔧{'\n'}💡</th>
             <th className={styles.attrCol}>💭</th>
           </tr>
         </thead>

--- a/packages/website/src/theme/MDXComponents/RuleAttributes.tsx
+++ b/packages/website/src/theme/MDXComponents/RuleAttributes.tsx
@@ -55,7 +55,7 @@ export function RuleAttributes({ name }: { name: string }): JSX.Element | null {
             </li>
             <li>
               <input type="checkbox" disabled checked={!!rule.hasSuggestions} />
-              🛠 Suggestion Fixer
+              💡 Suggestion Fixer
             </li>
           </ul>
         </li>


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The lightbulb 💡 emoji is the convention for denoting rules with emojis used by the official ESLint website as well as in many popular ESLint plugins. Examples (note: I am a maintainer on these plugins and have been working to standardize the lists of rules):
* https://eslint.org/docs/latest/rules/
* https://github.com/sindresorhus/eslint-plugin-unicorn#rules
* https://github.com/ember-cli/eslint-plugin-ember#-rules
* https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin#rules

The previous hammer and wrench 🛠 emoji for suggestable rules is too similar to the wrench 🔧 emoji for fixable rules, in my opinion. The lightbulb emoji better conveys the meaning of an "idea" or "suggestion".