### PR TITLE
chore(website): simplify sponsor displays to just minimums

### DIFF
--- a/packages/website/data/sponsors.json
+++ b/packages/website/data/sponsors.json
@@ -12,7 +12,7 @@
     "image": "https://images.opencollective.com/nx/0efbe42/logo.png",
     "name": "Nx (by Nrwl)",
     "tier": "sponsor",
-    "totalDonations": 450000,
+    "totalDonations": 475000,
     "website": "https://nx.dev"
   },
   {
@@ -20,7 +20,7 @@
     "image": "https://images.opencollective.com/eslint/96b09dc/logo.png",
     "name": "ESLint",
     "tier": "sponsor",
-    "totalDonations": 155000,
+    "totalDonations": 170000,
     "website": "https://eslint.org/"
   },
   {
@@ -28,7 +28,7 @@
     "image": "https://images.opencollective.com/airbnb/d327d66/logo.png",
     "name": "Airbnb",
     "tier": "sponsor",
-    "totalDonations": 120800,
+    "totalDonations": 125800,
     "website": "https://www.airbnb.com/"
   },
   {
@@ -44,14 +44,14 @@
     "image": "https://images.opencollective.com/n8n/dca2f0c/logo.png",
     "name": "n8n.io - n8n GmbH",
     "tier": "sponsor",
-    "totalDonations": 95000,
+    "totalDonations": 100000,
     "website": "https://n8n.io"
   },
   {
     "id": "EY Doberman",
     "image": "https://images.opencollective.com/ey-doberman/b269462/logo.png",
     "name": "EY Doberman",
-    "tier": "sponsor",
+    "tier": "supporter",
     "totalDonations": 80400,
     "website": "https://doberman.co"
   },
@@ -59,24 +59,17 @@
     "id": "GitBook",
     "image": "https://images.opencollective.com/gitbook/d35a8e7/logo.png",
     "name": "GitBook",
-    "tier": "sponsor",
-    "totalDonations": 70000,
+    "tier": "supporter",
+    "totalDonations": 80000,
     "website": "https://www.gitbook.com"
   },
   {
     "id": "Codecademy",
     "image": "https://images.opencollective.com/codecademy/d56a48d/logo.png",
     "name": "Codecademy",
-    "tier": "sponsor",
-    "totalDonations": 60000,
-    "website": "https://codecademy.com"
-  },
-  {
-    "id": "GitHub",
-    "image": "https://images.opencollective.com/guest-f9980024/avatar.png",
-    "name": "GitHub",
     "tier": "supporter",
-    "totalDonations": 56674
+    "totalDonations": 70000,
+    "website": "https://codecademy.com"
   },
   {
     "id": "Future Processing",
@@ -98,7 +91,7 @@
     "id": "Whitebox",
     "image": "https://images.opencollective.com/whiteboxinc/ef0d11d/logo.png",
     "name": "Whitebox",
-    "tier": "supporter",
+    "tier": "contributor",
     "totalDonations": 40000,
     "website": "https://whitebox.com"
   },
@@ -106,7 +99,7 @@
     "id": "Monito",
     "image": "https://images.opencollective.com/monito/50fc878/logo.png",
     "name": "Monito",
-    "tier": "supporter",
+    "tier": "contributor",
     "totalDonations": 30000,
     "website": "https://www.monito.com"
   },
@@ -114,32 +107,33 @@
     "id": "revo.js",
     "image": "https://images.opencollective.com/revojsro/82623a7/logo.png",
     "name": "revo.js",
-    "tier": "supporter",
+    "tier": "contributor",
     "totalDonations": 23000,
     "website": "https://revojs.ro"
-  },
-  {
-    "id": "Ian MacLeod",
-    "image": "https://images.opencollective.com/nevir/35c52ef/avatar.png",
-    "name": "Ian MacLeod",
-    "tier": "supporter",
-    "totalDonations": 22000,
-    "website": "https://twitter.com/nevir"
   },
   {
     "id": "STORIS",
     "image": "https://images.opencollective.com/storis/dfb0e13/logo.png",
     "name": "STORIS",
-    "tier": "supporter",
-    "totalDonations": 21000,
+    "tier": "contributor",
+    "totalDonations": 22500,
     "website": "https://www.storis.com/"
   },
   {
-    "id": "Michael Ranciglio",
-    "image": "https://images.opencollective.com/michael-ranciglio/avatar.png",
-    "name": "Michael Ranciglio",
-    "tier": "supporter",
-    "totalDonations": 16500
+    "id": "Ian MacLeod",
+    "image": "https://images.opencollective.com/nevir/35c52ef/avatar.png",
+    "name": "Ian MacLeod",
+    "tier": "contributor",
+    "totalDonations": 22000,
+    "website": "https://twitter.com/nevir"
+  },
+  {
+    "id": "Sourcegraph",
+    "image": "https://images.opencollective.com/sourcegraph/8587b83/logo.png",
+    "name": "Sourcegraph",
+    "tier": "contributor",
+    "totalDonations": 20000,
+    "website": "https://about.sourcegraph.com"
   },
   {
     "id": "Joe Alden",
@@ -154,7 +148,7 @@
     "image": "https://images.opencollective.com/blacksheepcode/976d69a/avatar.png",
     "name": "David Johnston",
     "tier": "contributor",
-    "totalDonations": 13000,
+    "totalDonations": 13500,
     "website": "https://blacksheepcode.com"
   },
   {
@@ -174,89 +168,11 @@
     "website": "https://www.theguardian.com/"
   },
   {
-    "id": "Yuta Fukazawa",
-    "image": "https://images.opencollective.com/yuta-fukazawa/a337601/avatar.png",
-    "name": "Yuta Fukazawa",
-    "tier": "contributor",
-    "totalDonations": 10000
-  },
-  {
-    "id": "Sourcegraph",
-    "image": "https://images.opencollective.com/sourcegraph/8587b83/logo.png",
-    "name": "Sourcegraph",
-    "tier": "sponsor",
-    "totalDonations": 10000,
-    "website": "https://about.sourcegraph.com"
-  },
-  {
     "id": "Laserhub",
     "image": "https://images.opencollective.com/laserhub/bae6275/logo.png",
     "name": "Laserhub",
     "tier": "contributor",
     "totalDonations": 10000,
     "website": "https://laserhub.com/"
-  },
-  {
-    "id": "Tripwire, Inc.",
-    "image": "https://images.opencollective.com/tripwire/7599e30/logo.png",
-    "name": "Tripwire, Inc.",
-    "tier": "contributor",
-    "totalDonations": 8500,
-    "website": "https://tripwire.com"
-  },
-  {
-    "id": "Evil Martians",
-    "image": "https://images.opencollective.com/evilmartians/707ab4d/logo.png",
-    "name": "Evil Martians",
-    "tier": "contributor",
-    "totalDonations": 8000,
-    "website": "https://evilmartians.com/"
-  },
-  {
-    "id": "Balsa",
-    "image": "https://images.opencollective.com/balsa/77de498/logo.png",
-    "name": "Balsa",
-    "tier": "contributor",
-    "totalDonations": 8000,
-    "website": "https://balsa.com"
-  },
-  {
-    "id": "Jeffrey Rennie",
-    "image": "https://images.opencollective.com/jeffrey-rennie/avatar.png",
-    "name": "Jeffrey Rennie",
-    "tier": "contributor",
-    "totalDonations": 7500
-  },
-  {
-    "id": "Pete Gonzalez",
-    "image": "https://images.opencollective.com/octogonz/513f01a/avatar.png",
-    "name": "Pete Gonzalez",
-    "tier": "contributor",
-    "totalDonations": 5000,
-    "website": "https://github.com/octogonz"
-  },
-  {
-    "id": "Niklas Fiekas",
-    "image": "https://images.opencollective.com/niklas-fiekas/ffec4a8/avatar.png",
-    "name": "Niklas Fiekas",
-    "tier": "contributor",
-    "totalDonations": 5000,
-    "website": "https://backscattering.de"
-  },
-  {
-    "id": "Corellium",
-    "image": "https://images.opencollective.com/corellium/aa8c228/logo.png",
-    "name": "Corellium",
-    "tier": "contributor",
-    "totalDonations": 4800,
-    "website": "https://www.corellium.com"
-  },
-  {
-    "id": "Alexey Berezin",
-    "image": "https://images.opencollective.com/beraliv/034d971/avatar.png",
-    "name": "Alexey Berezin",
-    "tier": "contributor",
-    "totalDonations": 1500,
-    "website": "https://beraliv.dev"
   }
 ]

--- a/packages/website/src/components/FinancialContributors/Sponsor.tsx
+++ b/packages/website/src/components/FinancialContributors/Sponsor.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
 
 import { SponsorData, SponsorIncludeOptions } from './types';
+import styles from './styles.module.css';
 
 interface SponsorProps {
-  className?: string;
   include?: SponsorIncludeOptions;
   sponsor: SponsorData;
 }
 
-export function Sponsor({
-  className,
-  include = {},
-  sponsor,
-}: SponsorProps): JSX.Element {
+export function Sponsor({ include = {}, sponsor }: SponsorProps): JSX.Element {
   let children = <img alt={`${sponsor.name} logo`} src={sponsor.image} />;
 
   if (include.name) {
@@ -27,7 +23,7 @@ export function Sponsor({
   if (include.link) {
     children = (
       <a
-        className={className}
+        className={styles.sponsorLink}
         href={sponsor.website ?? undefined}
         title={sponsor.name}
         target="_blank"

--- a/packages/website/src/components/FinancialContributors/Sponsors/index.tsx
+++ b/packages/website/src/components/FinancialContributors/Sponsors/index.tsx
@@ -8,7 +8,6 @@ import { SponsorIncludeOptions } from '../types';
 
 interface SponsorsProps {
   className: string;
-  description: string;
   include?: SponsorIncludeOptions;
   expanded?: boolean;
   tier?: string;
@@ -17,7 +16,6 @@ interface SponsorsProps {
 
 export function Sponsors({
   className,
-  description,
   include,
   tier,
   title,
@@ -25,7 +23,6 @@ export function Sponsors({
   return (
     <div className={clsx(styles.tierArea, className)}>
       <h3>{title}</h3>
-      <p>{description}</p>
       <ul className={clsx(styles.sponsorsTier, styles[`tier-${tier}`])}>
         {sponsors
           .filter(sponsor => sponsor.tier === tier)

--- a/packages/website/src/components/FinancialContributors/Sponsors/styles.module.css
+++ b/packages/website/src/components/FinancialContributors/Sponsors/styles.module.css
@@ -9,7 +9,6 @@
   justify-content: center;
   align-items: flex-end;
   max-width: 800px;
-  margin: 10px auto;
   padding: 0;
 }
 
@@ -20,6 +19,7 @@
 }
 
 .sponsorsTier img {
+  display: block;
   margin: auto;
 }
 
@@ -30,29 +30,42 @@
 }
 
 .tier-sponsor {
-  gap: 16px;
+  gap: 32px 16px;
 }
 
 .tier-sponsor img {
   display: inline-block;
   max-height: 120px;
+  max-width: 120px;
   width: 120px;
 }
 
 .tier-supporter,
 .tier-contributor {
   align-items: center;
-  gap: 4px 16px;
+}
+
+.tier-supporter {
+  font-size: 0.95rem;
+  line-height: 1;
+  gap: 24px;
+  padding-top: 16px;
 }
 
 .tier-supporter img {
-  max-height: 60px;
-  width: 60px;
+  max-height: 75px;
+  max-width: 75px;
+  width: 75px;
+}
+
+.tier-contributor {
+  gap: 4px 24px;
 }
 
 .tier-contributor img {
-  max-height: 30px;
-  width: 30px;
+  max-height: 45px;
+  max-width: 45px;
+  width: 45px;
 }
 
 @media screen and (min-width: 700px) {

--- a/packages/website/src/components/FinancialContributors/index.tsx
+++ b/packages/website/src/components/FinancialContributors/index.tsx
@@ -15,32 +15,38 @@ export function FinancialContributors(): JSX.Element {
       <div className={styles.sponsorsContainer}>
         <Sponsors
           className={styles.tierSponsorArea}
-          description="Donors of $750 and/or a monthly amount of $100 or more."
           include={{ link: true, name: true }}
           tier="sponsor"
           title="Sponsors"
         />
         <Sponsors
           className={styles.tierSupporterArea}
-          description="Donors of $150 and/or a monthly amount of $10 or more."
           include={{ link: true }}
           tier="supporter"
           title="Gold Supporters"
         />
         <Sponsors
           className={styles.tierOtherArea}
-          description="Donors of $50 and/or a monthly amount of $3 or more."
           tier="contributor"
           title="Supporters"
         />
       </div>
-      <Link
-        className={clsx('button button--info button--outline', styles.become)}
-        to="https://opencollective.com/typescript-eslint/contribute"
-        target="_blank"
-      >
-        Become a financial contributor
-      </Link>
+      <div className={styles.linksArea}>
+        <Link
+          className={clsx('button button--primary', styles.become)}
+          to="https://opencollective.com/typescript-eslint/contribute"
+          target="_blank"
+        >
+          Become a financial contributor
+        </Link>
+        <Link
+          className="button button--info button--outline"
+          to="https://opencollective.com/typescript-eslint"
+          target="_blank"
+        >
+          See all financial contributors
+        </Link>
+      </div>
     </>
   );
 }

--- a/packages/website/src/components/FinancialContributors/index.tsx
+++ b/packages/website/src/components/FinancialContributors/index.tsx
@@ -17,7 +17,7 @@ export function FinancialContributors(): JSX.Element {
           className={styles.tierSponsorArea}
           include={{ link: true, name: true }}
           tier="sponsor"
-          title="Sponsors"
+          title="Platinum Sponsors"
         />
         <Sponsors
           className={styles.tierSupporterArea}
@@ -28,7 +28,7 @@ export function FinancialContributors(): JSX.Element {
         <Sponsors
           className={styles.tierOtherArea}
           tier="contributor"
-          title="Supporters"
+          title="Silver Supporters"
         />
       </div>
       <div className={styles.linksArea}>

--- a/packages/website/src/components/FinancialContributors/styles.module.css
+++ b/packages/website/src/components/FinancialContributors/styles.module.css
@@ -4,15 +4,22 @@
   gap: 8px;
 }
 
+.linksArea {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-direction: column;
+  margin: 48px 24px 24px;
+}
+
 .become {
-  margin: 8px 0 24px;
-  font-size: 1rem;
+  font-size: 1.25rem;
 }
 
 @media screen and (min-width: 1150px) {
   .sponsorsContainer {
     display: grid;
-    grid-template-columns: 55% 45%;
+    grid-template-columns: 50% 50%;
     margin: auto;
     max-width: 100%;
   }
@@ -33,5 +40,13 @@
 
   .tierOtherArea {
     grid-area: 2 / 2 / 3 / 3;
+  }
+
+  .sponsorLink {
+    display: flex;
+  }
+
+  .linksArea {
+    margin: 24px;
   }
 }

--- a/tools/generate-sponsors.ts
+++ b/tools/generate-sponsors.ts
@@ -99,19 +99,6 @@ interface MemberAccountAndTier extends MemberAccount {
 const excludedNames = new Set([
   'Guest', // Apparent anonymous donor equivalent without an avatar
   'Josh Goldberg', // Team member 💖
-
-  // These names *seem* to be spam websites, but we're not sure.
-  // If your name is mistakenly on this list, we're sorry; please let us know!
-  '420HUBS.COM',
-  'Deal Empire',
-  'Florian Studio',
-  'java',
-  'Loyalty Leo',
-  'Penalty.com',
-
-  // These names are of organizations we cannot in good conscience link to.
-  // If you disagree with a name on this list, please email a maintainer.
-  'Christian Healthcare Ministries', // #5440
 ]);
 
 async function requestGraphql<Data>(key: keyof typeof queries): Promise<Data> {
@@ -163,16 +150,16 @@ async function main(): Promise<void> {
         ...accountsById[name],
       };
       const totalDonations = totalDonationsById[name];
-      const slug = fromAccount.tier?.slug ?? 'contributor';
+      const website = fromAccount.website;
 
       return {
         id: name,
         image: fromAccount.imageUrl,
         name: fromAccount.name,
-        tier: getReportedTierSlug(slug, totalDonations),
+        tier: getReportedTierSlug(totalDonations, website),
         totalDonations,
         twitterHandle: fromAccount.twitterHandle,
-        website: fromAccount.website,
+        website,
       };
     })
     .filter(({ id, tier }) => {
@@ -209,30 +196,22 @@ async function stringifyObject(
   });
 }
 
-function getReportedTierSlug(slug: string, totalDonations: number): string {
-  // Sponsors: Donors of $750 and/or a monthly amount of $100 or more
-  if (
-    totalDonations >= 750_00 ||
-    (slug === 'sponsor' && totalDonations >= 100_00)
-  ) {
-    return 'sponsor';
+function getReportedTierSlug(
+  totalDonations: number,
+  website: string,
+): string | undefined {
+  if (!website) {
+    return undefined;
   }
 
-  // Gold Supporters: Donors of $150 and/or a monthly amount of $10 or more.
-  // We also only show gold supporters who have donated at least twice.
-  if (
-    totalDonations >= 150_00 ||
-    (slug === 'gold-supporter' && totalDonations >= 20_00)
-  ) {
+  if (totalDonations >= 1_000_00) {
+    return 'sponsor';
+  }
+  if (totalDonations >= 500_00) {
     return 'supporter';
   }
 
-  // Supporters: Donors of $50 and/or a monthly amount of $3 or more.
-  // We also only show supporters who have donated at least twice.
-  if (
-    totalDonations >= 50_00 ||
-    (slug === 'supporter' && totalDonations >= 6_00)
-  ) {
+  if (totalDonations >= 100_00) {
     return 'contributor';
   }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5475
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

As the issue describes:

* Removes the "monthly amount" option from the Financial Contributors list, and has it just go based on total donations
* Makes the tiers $100, $500, and $1000 (previous: $50, $150, $750)
* Adds a "see all financial contributors" link at the bottom

Re-running `yarn generate-sponsors` both applied those changes and updated sponsor amounts, since we haven't checked in an updated sponsors list in a week or so.

Gives the tiers nice rare metal based names to more clearly indicate that they're particularly money-generous sponsors.

![Screenshot of homepage sponsorship section with Platinum SPonsors, Gold Supporters, and Silver Supporters](https://user-images.githubusercontent.com/3335181/184563067-8f67a434-7c71-480a-a6dc-e90959ec4197.png)
