### PR TITLE
docs: use new Algolia infrastructure credentials

### DIFF
--- a/packages/website/docusaurusConfig.ts
+++ b/packages/website/docusaurusConfig.ts
@@ -55,8 +55,8 @@ const pluginContentDocsOptions: PluginContentDocsOptions = {
 
 const themeConfig: ThemeCommonConfig & AlgoliaThemeConfig = {
   algolia: {
-    appId: 'BH4D9OD16A',
-    apiKey: '1ad6b47d4e742c4c0653877b5511c602',
+    appId: 'N1HUB2TU6A',
+    apiKey: '74d42ed10d0f7b327d74d774570035c7',
     indexName: 'typescript-eslint',
   },
   metadata: [


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5008
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Update the Algolia DocSearch credentials to leverage [the new infrastructure](https://docsearch.algolia.com/docs/migrating-from-legacy/#scraper).

The daily crawls on the legacy infra (`BH4D9OD16A`) have been stopped months ago, which make the search results outdated and not benefiting of the improvements made on our crawler since then.