### PR TITLE
docs: Fix links to getting started in README.md

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -10,7 +10,7 @@
 
 ## Getting Started
 
-- **[You can find our Getting Started docs here](https://typescript-eslint.io/docs/linting)**
+- **[You can find our Getting Started docs here](https://typescript-eslint.io/docs)**
 - **[You can find our FAQ / Troubleshooting docs here](https://typescript-eslint.io/docs/linting/troubleshooting)**
 
 These docs walk you through setting up ESLint, this plugin, and our parser. If you know what you're doing and just want to quick start, read on...

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -10,7 +10,7 @@
 
 ## Getting Started
 
-**[You can find our Getting Started docs here](https://typescript-eslint.io/docs/linting)**
+**[You can find our Getting Started docs here](https://typescript-eslint.io/docs)**
 
 These docs walk you through setting up ESLint, this parser, and our plugin. If you know what you're doing and just want to quick start, read on...
 

--- a/packages/scope-manager/README.md
+++ b/packages/scope-manager/README.md
@@ -14,7 +14,7 @@ You probably don't want to use it directly.
 
 ## Getting Started
 
-**[You can find our Getting Started docs here](https://typescript-eslint.io/docs/linting)**
+**[You can find our Getting Started docs here](https://typescript-eslint.io/docs)**
 
 ## Installation
 

--- a/packages/typescript-estree/README.md
+++ b/packages/typescript-estree/README.md
@@ -10,7 +10,7 @@
 
 ## Getting Started
 
-**[You can find our Getting Started docs here](https://typescript-eslint.io/docs/linting)**
+**[You can find our Getting Started docs here](https://typescript-eslint.io/docs)**
 
 ## About
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5545
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Update readme files to new getting started page
