### PR TITLE
chore(website): [a11y] Mark logo as decorative for assistive technologies

### DIFF
--- a/packages/website/docusaurusConfig.ts
+++ b/packages/website/docusaurusConfig.ts
@@ -69,7 +69,7 @@ const themeConfig: ThemeCommonConfig & AlgoliaThemeConfig = {
     title: 'TypeScript ESLint',
     // hideOnScroll: true,
     logo: {
-      alt: 'TypeScript ESLint logo',
+      alt: '',
       height: '32px',
       src: 'img/logo.svg',
       width: '32px',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue:
Fixes #5213
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

On the TypeScript ESLint Docusaurus site, the logo's alt text ("TypeScript ESLint logo") is cluttering the logo link's accessible name for assistive technologies. When screenreader users navigate to the logo link, they're told "link, TypeScript ESLint logo TypeScript ESLint," which is too cumbersome. Additionally, voice control users would need to recite that name to trigger the link.

This pull request uses a change to Docusaurus that arrived in v2 (facebook/docusaurus#7658) to supply an empty alt text for the logo image, marking it as decorative for assistive technologies. As a result, the link's accessible name is simply "link, TypeScript ESLint."

**DevTools showing empty alt for the image, and that the image is ignored in the accessibility tree:**
_(Note that Chrome DevTools shows `alt` when provided `alt=""`. This is expected)_
<img width="1610" alt="DevTools, showing empty alt for the image, and that the image is ignored in the accessibility tree" src="https://user-images.githubusercontent.com/18060369/187278951-81452ab2-2333-4bdc-a684-87c1943e913d.png">

**DevTools showing the logo link in the Accessibility tree, with the newly shortened name:**

<img width="1610" alt="DevTools showing the logo link in the Accessibility tree, with the newly shortened name" src="https://user-images.githubusercontent.com/18060369/187279343-d369f07e-5ca6-4602-851f-594c2570cfbc.png">

This can be verified with a screenreader — I'm happy to demonstrate if needed.
