### PR TITLE
fix(typescript-estree): fix decorator regression for pre TS4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "typescript": ">=3.3.1 <4.9.0"
   },
   "resolutions": {
-    "typescript": "4.8.2",
+    "typescript": "~4.8.2",
     "@types/node": "^17.0.31",
     "pretty-format": "^28.1.0",
     "//": "Pin jest to v28 across the repo",

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1056,15 +1056,11 @@ export class Converter {
 
         /**
          * Semantically, decorators are not allowed on variable declarations,
-         * but the TypeScript compiler will parse them and produce a valid AST,
-         * so we handle them here too.
+         * Pre 4.8 TS would include them in the AST, so we did as well.
+         * However as of 4.8 TS no longer includes it (as it is, well, invalid).
+         *
+         * So for consistency across versions, we no longer include it either.
          */
-        const decorators = getDecorators(node);
-        if (decorators) {
-          (result as any).decorators = decorators.map(el =>
-            this.convertChild(el),
-          );
-        }
 
         if (hasModifier(SyntaxKind.DeclareKeyword, node)) {
           result.declare = true;

--- a/packages/typescript-estree/src/getModifiers.ts
+++ b/packages/typescript-estree/src/getModifiers.ts
@@ -47,6 +47,6 @@ export function getDecorators(
 
   return (
     // eslint-disable-next-line deprecation/deprecation -- intentional fallback for older TS versions
-    node.modifiers?.filter(ts.isDecorator)
+    node.decorators?.filter(ts.isDecorator)
   );
 }

--- a/patches/typescript+4.8.2.patch
+++ b/patches/typescript+4.8.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/typescript/lib/typescript.d.ts b/node_modules/typescript/lib/typescript.d.ts
-index 0fd60ae..b3610b8 100644
+index 0fd60ae..8bce90e 100644
 --- a/node_modules/typescript/lib/typescript.d.ts
 +++ b/node_modules/typescript/lib/typescript.d.ts
 @@ -425,8 +425,8 @@ declare namespace ts {
@@ -40,3 +40,12 @@ index 0fd60ae..b3610b8 100644
      function canHaveDecorators(node: Node): node is HasDecorators;
  }
  declare namespace ts {
+@@ -7924,7 +7936,7 @@ declare namespace ts {
+          * const decorators = ts.canHaveDecorators(node) ? ts.getDecorators(node) : undefined;
+          * ```
+          */
+-        readonly decorators?: undefined;
++        readonly decorators?: NodeArray<Decorator> | undefined;
+         /**
+          * @deprecated `modifiers` has been removed from `Node` and moved to the `Node` subtypes that support them.
+          * Use `ts.canHaveModifiers()` to test whether a `Node` can have modifiers.

--- a/yarn.lock
+++ b/yarn.lock
@@ -14177,7 +14177,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*, typescript@4.8.2, "typescript@>=3.3.1 <4.9.0", typescript@^4.5.3, typescript@next, typescript@~4.7.4:
+typescript@*, "typescript@>=3.3.1 <4.9.0", typescript@^4.5.3, typescript@next, typescript@~4.7.4, typescript@~4.8.2:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
   integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5571
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
#5573 will add CI tests for this, so for now you'll have to trust me that this fixes things