### PR TITLE
chore(website): fix playground

### DIFF
--- a/packages/website-eslint/rollup.config.js
+++ b/packages/website-eslint/rollup.config.js
@@ -36,6 +36,10 @@ module.exports = {
             /utils\/dist\/ts-eslint\/ESLint\.js/,
             // 'eslint/lib/shared/ajv.js',
             // 'eslint/lib/shared/runtime-info.js',
+            /ajv\/lib\/definition_schema\.js/,
+            /stream/,
+            /os/,
+            /fs/,
           ],
           target: './src/mock/empty.js',
         },
@@ -63,6 +67,14 @@ module.exports = {
           // semver simplified, solve issue with circular dependencies
           match: /semver$/u,
           target: './src/mock/semver.js',
+        },
+        {
+          match: /^globby$/u,
+          target: './src/mock/globby.js',
+        },
+        {
+          match: /^is-glob$/u,
+          target: './src/mock/is-glob.js',
         },
       ],
       replace: [

--- a/packages/website-eslint/src/mock/globby.js
+++ b/packages/website-eslint/src/mock/globby.js
@@ -1,0 +1,4 @@
+export function sync() {
+  // the website config is static and doesn't use glob config
+  return [];
+}

--- a/packages/website-eslint/src/mock/is-glob.js
+++ b/packages/website-eslint/src/mock/is-glob.js
@@ -1,0 +1,4 @@
+export default function isGlob() {
+  // the website config is static and doesn't use glob config
+  return false;
+}

--- a/packages/website-eslint/src/mock/semver.js
+++ b/packages/website-eslint/src/mock/semver.js
@@ -1,4 +1,7 @@
 import satisfies from 'semver/functions/satisfies';
 import major from 'semver/functions/major';
 
+// just in case someone adds a import * as semver usage
 export { satisfies, major };
+
+export default { satisfies, major };


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5572
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

There's a lot of unrelated changes in here - it took me a while to really nail down exactly what the problem was. I spent a chunk of time just figuring out how everything worked.

I still don't know *why* it occurred, but for some reason when we upgraded to TS4.8 the website-eslint build started including a dependency that required `os` and `stream` (nodejs modules). Because rollup can't bundle nodejs modules - it assumed they'd be provided later, which they weren't - leading to unresolved imports that (I think) monaco attempted to resolve by loading a script from the server.

Result of testing with this PR locally:
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/7462525/187597218-391588ac-1543-4b6c-83cc-a4af13ccce65.png">