### PR TITLE
fix(scope-manager): correct handling for class static blocks

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -1018,6 +1018,27 @@ export class TestClass {
       `,
       parserOptions: withMetaParserOptions,
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/5577
+    `
+function foo() {}
+
+export class Foo {
+  constructor() {
+    foo();
+  }
+}
+    `,
+    `
+function foo() {}
+
+export class Foo {
+  static {}
+
+  constructor() {
+    foo();
+  }
+}
+    `,
   ],
 
   invalid: [

--- a/packages/scope-manager/src/referencer/ClassVisitor.ts
+++ b/packages/scope-manager/src/referencer/ClassVisitor.ts
@@ -322,10 +322,6 @@ class ClassVisitor extends Visitor {
     this.visitType(node);
   }
 
-  protected visitStaticBlock(node: TSESTree.StaticBlock): void {
-    this.#referencer.scopeManager.nestClassStaticBlockScope(node);
-  }
-
   /////////////////////
   // Visit selectors //
   /////////////////////
@@ -365,7 +361,11 @@ class ClassVisitor extends Visitor {
   }
 
   protected StaticBlock(node: TSESTree.StaticBlock): void {
-    this.visitStaticBlock(node);
+    this.#referencer.scopeManager.nestClassStaticBlockScope(node);
+
+    node.body.forEach(b => this.visit(b));
+
+    this.#referencer.close(node);
   }
 }
 

--- a/packages/scope-manager/tests/fixtures/class/declaration/static-external-ref.ts
+++ b/packages/scope-manager/tests/fixtures/class/declaration/static-external-ref.ts
@@ -1,0 +1,7 @@
+function f() {}
+
+class A {
+  static {
+    f();
+  }
+}

--- a/packages/scope-manager/tests/fixtures/class/declaration/static-external-ref.ts.shot
+++ b/packages/scope-manager/tests/fixtures/class/declaration/static-external-ref.ts.shot
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`class declaration static-external-ref 1`] = `
+ScopeManager {
+  variables: Array [
+    ImplicitGlobalConstTypeVariable,
+    Variable$2 {
+      defs: Array [
+        FunctionNameDefinition$1 {
+          name: Identifier<"f">,
+          node: FunctionDeclaration$1,
+        },
+      ],
+      name: "f",
+      references: Array [
+        Reference$1 {
+          identifier: Identifier<"f">,
+          isRead: true,
+          isTypeReference: false,
+          isValueReference: true,
+          isWrite: false,
+          resolved: Variable$2,
+        },
+      ],
+      isValueVariable: true,
+      isTypeVariable: false,
+    },
+    Variable$3 {
+      defs: Array [],
+      name: "arguments",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+    Variable$4 {
+      defs: Array [
+        ClassNameDefinition$2 {
+          name: Identifier<"A">,
+          node: ClassDeclaration$2,
+        },
+      ],
+      name: "A",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+    Variable$5 {
+      defs: Array [
+        ClassNameDefinition$3 {
+          name: Identifier<"A">,
+          node: ClassDeclaration$2,
+        },
+      ],
+      name: "A",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+  ],
+  scopes: Array [
+    GlobalScope$1 {
+      block: Program$3,
+      isStrict: false,
+      references: Array [],
+      set: Map {
+        "const" => ImplicitGlobalConstTypeVariable,
+        "f" => Variable$2,
+        "A" => Variable$4,
+      },
+      type: "global",
+      upper: null,
+      variables: Array [
+        ImplicitGlobalConstTypeVariable,
+        Variable$2,
+        Variable$4,
+      ],
+    },
+    FunctionScope$2 {
+      block: FunctionDeclaration$1,
+      isStrict: false,
+      references: Array [],
+      set: Map {
+        "arguments" => Variable$3,
+      },
+      type: "function",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$3,
+      ],
+    },
+    ClassScope$3 {
+      block: ClassDeclaration$2,
+      isStrict: true,
+      references: Array [],
+      set: Map {
+        "A" => Variable$5,
+      },
+      type: "class",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$5,
+      ],
+    },
+    ClassStaticBlockScope$4 {
+      block: StaticBlock$4,
+      isStrict: true,
+      references: Array [
+        Reference$1,
+      ],
+      set: Map {},
+      type: "class-static-block",
+      upper: ClassScope$3,
+      variables: Array [],
+    },
+  ],
+}
+`;

--- a/packages/scope-manager/tests/fixtures/class/declaration/static-with-constructor.ts
+++ b/packages/scope-manager/tests/fixtures/class/declaration/static-with-constructor.ts
@@ -1,0 +1,10 @@
+// https://github.com/typescript-eslint/typescript-eslint/issues/5577
+function f() {}
+
+class A {
+  static {}
+
+  constructor() {
+    f();
+  }
+}

--- a/packages/scope-manager/tests/fixtures/class/declaration/static-with-constructor.ts.shot
+++ b/packages/scope-manager/tests/fixtures/class/declaration/static-with-constructor.ts.shot
@@ -1,0 +1,137 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`class declaration static-with-constructor 1`] = `
+ScopeManager {
+  variables: Array [
+    ImplicitGlobalConstTypeVariable,
+    Variable$2 {
+      defs: Array [
+        FunctionNameDefinition$1 {
+          name: Identifier<"f">,
+          node: FunctionDeclaration$1,
+        },
+      ],
+      name: "f",
+      references: Array [
+        Reference$1 {
+          identifier: Identifier<"f">,
+          isRead: true,
+          isTypeReference: false,
+          isValueReference: true,
+          isWrite: false,
+          resolved: Variable$2,
+        },
+      ],
+      isValueVariable: true,
+      isTypeVariable: false,
+    },
+    Variable$3 {
+      defs: Array [],
+      name: "arguments",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+    Variable$4 {
+      defs: Array [
+        ClassNameDefinition$2 {
+          name: Identifier<"A">,
+          node: ClassDeclaration$2,
+        },
+      ],
+      name: "A",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+    Variable$5 {
+      defs: Array [
+        ClassNameDefinition$3 {
+          name: Identifier<"A">,
+          node: ClassDeclaration$2,
+        },
+      ],
+      name: "A",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+    Variable$6 {
+      defs: Array [],
+      name: "arguments",
+      references: Array [],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+  ],
+  scopes: Array [
+    GlobalScope$1 {
+      block: Program$3,
+      isStrict: false,
+      references: Array [],
+      set: Map {
+        "const" => ImplicitGlobalConstTypeVariable,
+        "f" => Variable$2,
+        "A" => Variable$4,
+      },
+      type: "global",
+      upper: null,
+      variables: Array [
+        ImplicitGlobalConstTypeVariable,
+        Variable$2,
+        Variable$4,
+      ],
+    },
+    FunctionScope$2 {
+      block: FunctionDeclaration$1,
+      isStrict: false,
+      references: Array [],
+      set: Map {
+        "arguments" => Variable$3,
+      },
+      type: "function",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$3,
+      ],
+    },
+    ClassScope$3 {
+      block: ClassDeclaration$2,
+      isStrict: true,
+      references: Array [],
+      set: Map {
+        "A" => Variable$5,
+      },
+      type: "class",
+      upper: GlobalScope$1,
+      variables: Array [
+        Variable$5,
+      ],
+    },
+    ClassStaticBlockScope$4 {
+      block: StaticBlock$4,
+      isStrict: true,
+      references: Array [],
+      set: Map {},
+      type: "class-static-block",
+      upper: ClassScope$3,
+      variables: Array [],
+    },
+    FunctionScope$5 {
+      block: FunctionExpression$5,
+      isStrict: true,
+      references: Array [
+        Reference$1,
+      ],
+      set: Map {
+        "arguments" => Variable$6,
+      },
+      type: "function",
+      upper: ClassScope$3,
+      variables: Array [
+        Variable$6,
+      ],
+    },
+  ],
+}
+`;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5577
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I wasn't paying anywhere near enough attention when reviewing #5489.
That PR did not actually properly implement scope analysis.
It created a scope but never closed it - meaning if you had a static block it'd leave a dangling scope which breaks things.
Also it never actually visited the static block's children.

This PR closes off the scope and visits the children, fixing the problem