### PR TITLE
Update strict-boolean-expressions.md Nullable number as wrong 'undefined' type.

### DIFF
--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
@@ -29,7 +29,7 @@ Examples of code for this rule:
 
 ```ts
 // nullable numbers are considered unsafe by default
-let num: number | undefined = 0;
+let num: number | null = 0;
 if (num) {
   console.log('num is defined');
 }
@@ -67,7 +67,7 @@ const Component = () => {
 };
 
 // nullable values should be checked explicitly against null or undefined
-let num: number | undefined = 0;
+let num: number | null = 0;
 if (num != null) {
   console.log('num is defined');
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5587
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Nullable number as wrong 'undefined' type.

`let num: number | undefined = 0;` should be `let num: number | null = 0;`


