### PR TITLE
docs(eslint-plugin): fix no-throw-literal options type

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-throw-literal.md
+++ b/packages/eslint-plugin/docs/rules/no-throw-literal.md
@@ -94,7 +94,7 @@ throw new CustomError();
 This rule adds the following options:
 
 ```ts
-interface Options extends BaseNoShadowOptions {
+interface Options {
   /**
    * Whether to always allow throwing values typed as `any`.
    */
@@ -107,7 +107,6 @@ interface Options extends BaseNoShadowOptions {
 }
 
 const defaultOptions: Options = {
-  ...baseNoShadowDefaultOptions,
   allowThrowingAny: false,
   allowThrowingUnknown: false,
 };


### PR DESCRIPTION
[#5386](https://github.com/typescript-eslint/typescript-eslint/pull/5386/files#diff-9181ab0ae5422d5141e0ec2940c8730c5b367547acacbf5033ac3b3260bab8b7) changed the docs for the no-throw-literal options to show them extending from the no-shadow options. In fact, the base no-throw-literal rule does not have any options, so this PR removes the references to the base options.