### PR TITLE
fix(website): Use extended base rule name from file's meta

### DIFF
--- a/packages/website/plugins/generated-rule-docs.ts
+++ b/packages/website/plugins/generated-rule-docs.ts
@@ -163,7 +163,7 @@ export const generatedRuleDocs: Plugin = () => {
             children: [
               {
                 type: 'inlineCode',
-                value: `eslint/${file.stem}`,
+                value: `eslint/${meta.docs.extendsBaseRule}`,
               },
               {
                 type: 'text',
@@ -171,7 +171,7 @@ export const generatedRuleDocs: Plugin = () => {
               },
             ],
             type: 'link',
-            url: `https://eslint.org/docs/rules/${file.stem}#options`,
+            url: `https://eslint.org/docs/rules/${meta.docs.extendsBaseRule}#options`,
           },
           {
             type: 'text',
@@ -187,7 +187,7 @@ export const generatedRuleDocs: Plugin = () => {
         meta: 'title=".eslintrc.cjs"',
         value: `module.exports = {
   // Note: you must disable the base rule as it can report incorrect errors
-  "${file.stem}": "off",
+  "${meta.docs.extendsBaseRule}": "off",
   "@typescript-eslint/${file.stem}": "${optionLevel}"
 };`,
       } as mdast.Code);
@@ -294,7 +294,7 @@ export const generatedRuleDocs: Plugin = () => {
           {
             type: 'link',
             title: null,
-            url: `https://github.com/eslint/eslint/blob/main/docs/rules/${file.stem}.md`,
+            url: `https://github.com/eslint/eslint/blob/main/docs/rules/${meta.docs.extendsBaseRule}.md`,
             children: [
               {
                 type: 'text',


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

The name of the rules from typescript-eslint and eslint may differ (for example `return-await` rule in typescript-eslint and `no-return-await` rule in eslint) and the information specified in `How to Use` and some links on the page become broken and lead to the 404 page of the eslint site.