### PR TITLE
chore: bump @swc/core to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@nrwl/nx-cloud": "14.0.3",
     "@nrwl/tao": "14.1.4",
     "@nrwl/workspace": "14.1.4",
-    "@swc/core": "^1.2.181",
+    "@swc/core": "^1.3.1",
     "@swc/jest": "^0.2.21",
     "@types/babel__code-frame": "^7.0.3",
     "@types/debug": "^4.1.7",

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -1,12 +1,47 @@
 import debug from 'debug';
 import { join, resolve } from 'path';
 import * as parser from '../../src';
-import * as astConverter from '../../src/ast-converter';
 import { TSESTreeOptions } from '../../src/parser-options';
-import * as sharedParserUtils from '../../src/create-program/shared';
+import * as sharedParserUtilsModule from '../../src/create-program/shared';
 import { createSnapshotTestBlock } from '../../tools/test-utils';
+import * as astConverterModule from '../../src/ast-converter';
 
 const FIXTURES_DIR = join(__dirname, '../fixtures/simpleProject');
+
+// we can't spy on the exports of an ES module - so we instead have to mock the entire module
+jest.mock('../../src/ast-converter', () => {
+  const astConverterActual = jest.requireActual<typeof astConverterModule>(
+    '../../src/ast-converter',
+  );
+
+  return {
+    ...astConverterActual,
+    __esModule: true,
+    astConverter: jest.fn(astConverterActual.astConverter),
+  };
+});
+jest.mock('../../src/create-program/shared', () => {
+  const sharedActual = jest.requireActual<typeof sharedParserUtilsModule>(
+    '../../src/create-program/shared',
+  );
+
+  return {
+    ...sharedActual,
+    __esModule: true,
+    createDefaultCompilerOptionsFromExtra: jest.fn(
+      sharedActual.createDefaultCompilerOptionsFromExtra,
+    ),
+  };
+});
+
+const astConverterMock = jest.mocked(astConverterModule.astConverter);
+const createDefaultCompilerOptionsFromExtra = jest.mocked(
+  sharedParserUtilsModule.createDefaultCompilerOptionsFromExtra,
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('parseWithNodeMaps()', () => {
   describe('basic functionality', () => {
@@ -114,8 +149,6 @@ describe('parseWithNodeMaps()', () => {
 
   describe('loggerFn should be propagated to ast-converter', () => {
     it('output tokens, comments, locs, and ranges when called with those options', () => {
-      const spy = jest.spyOn(astConverter, 'astConverter');
-
       const loggerFn = jest.fn(() => {});
 
       parser.parseWithNodeMaps('let foo = bar;', {
@@ -126,8 +159,8 @@ describe('parseWithNodeMaps()', () => {
         loc: true,
       });
 
-      expect(spy).toHaveBeenCalled();
-      expect(spy.mock.calls[0][1]).toMatchObject({
+      expect(astConverterMock).toHaveBeenCalled();
+      expect(astConverterMock.mock.calls[0][1]).toMatchObject({
         code: 'let foo = bar;',
         comment: true,
         comments: [],
@@ -625,16 +658,11 @@ describe('parseAndGenerateServices', () => {
     });
 
     it('should turn on typescript debugger', () => {
-      const spy = jest.spyOn(
-        sharedParserUtils,
-        'createDefaultCompilerOptionsFromExtra',
-      );
-
       parser.parseAndGenerateServices('const x = 1;', {
         debugLevel: ['typescript'],
       });
-      expect(spy).toHaveBeenCalled();
-      expect(spy).toHaveReturnedWith(
+      expect(createDefaultCompilerOptionsFromExtra).toHaveBeenCalled();
+      expect(createDefaultCompilerOptionsFromExtra).toHaveReturnedWith(
         expect.objectContaining({
           extendedDiagnostics: true,
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3847,67 +3847,144 @@
   resolved "https://registry.yarnpkg.com/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.189.tgz#a8060c2ec7bd93bd9907c3059c44a832eda57b6d"
   integrity sha512-0kN3Le6QzFFz+Lc6a/tf/RkJXubWwWaHxF4c0bVm4AKIFf4nRlUCEqEkjdVaZvL92rpBMHaEEBuIIz3T8DqTTQ==
 
+"@swc/core-android-arm-eabi@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.1.tgz#2559b7a565a0a129ede27f15c86e744a021363a6"
+  integrity sha512-fZ6nTalHWYn1OHfU87yF8s24edgQ4COHydLlPcpU/pwSH90hCwy/fgna5PpUBw0rfzGBttX0/0yMorC7ZSar4Q==
+  dependencies:
+    "@swc/wasm" "1.2.122"
+
 "@swc/core-android-arm64@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-android-arm64/-/core-android-arm64-1.2.189.tgz#c9a7ebaecbef4488db3394e660dd5c2abfa5c173"
   integrity sha512-smsb+YkDw2OKwg66Z63E/G4NlFApDbsiOPmZXFZbtZbNBD9v+wnk6WVA//XR1bdUI9VbzNKlMPKJxQTE685QDw==
+
+"@swc/core-android-arm64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-android-arm64/-/core-android-arm64-1.3.1.tgz#b415f8e989d26b7634f68caccc0a9135cbda893f"
+  integrity sha512-aDrV22ajQ4NYOwxEWvipPpdhHaLqU5W1rxRap5N1KSetzwGIk6NMd31o6Jotoxf7tB8qtLlo5VyNok4adJRVYg==
+  dependencies:
+    "@swc/wasm" "1.2.130"
 
 "@swc/core-darwin-arm64@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.189.tgz#883098686504692218e88877b224e06db2a93c86"
   integrity sha512-OGjZRkTulKirJMLYbW9etb59lA9ueDXVwYRVD9SrNh8tRMTf0Nq+SUT/C3LVhBBGC4KSdWOzBAYbDTTdsnY++Q==
 
+"@swc/core-darwin-arm64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.1.tgz#386fadc4025ed2d51343a8abbc0dc0a301cc6b06"
+  integrity sha512-yom8pqaDhsncQaqp+NdXk1YEtWoqPrfsyKJP3RriTbUjXS/20q/WNfkkJjxUuaFZC6PH/MuvrLzD6Z6ZuZvLaA==
+
 "@swc/core-darwin-x64@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.2.189.tgz#38ba12dc3b07d96761dc895dd43e14ba3323129f"
   integrity sha512-BEcxnBHx51514Voe2dn/y1y5H9VNyw7Zpp9+mPekZqx5o/onPD5wZ1ZfAsPrA4UlvM3v16u6ITE/cLawJ/GdAQ==
+
+"@swc/core-darwin-x64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-darwin-x64/-/core-darwin-x64-1.3.1.tgz#65d438b696bc47e204f655b1654c138fe396d9df"
+  integrity sha512-Q2kH2i5pS0dvauOiRR4s7atH+Qrhe1LmiCv1D2U+AghZMfDcxi3DBTxrae/YqmDYm3GxHH3ZSAFHR3E0SeiSSg==
 
 "@swc/core-freebsd-x64@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.189.tgz#0cee19a1382ee97a7be2ea057cf48f5e08c66038"
   integrity sha512-B6g2NWeh2iw6WPOaM19Uj3VE4se6alT265kWibLUshjcofRfnYT1lNhhkrF1D0EVnpC8I96I/xXNQo4Am9z4zQ==
 
+"@swc/core-freebsd-x64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.1.tgz#c29c22984ebe94e89b614694d6572fba9769f758"
+  integrity sha512-f2a+rPGrhAICF+Du/nHWZlYzltX1/fWyt+v0IP+r0Zh4drgTrt5G3sMYrQVTjsKvI8R6tV2Q7BfYvDIQXwE1pw==
+  dependencies:
+    "@swc/wasm" "1.2.130"
+
 "@swc/core-linux-arm-gnueabihf@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.189.tgz#612010e31969387de6acde69d8250fd74f784be1"
   integrity sha512-6WhPG9pyN5AahQTVQk8MoN1I9Z/Ytfqizuie1wV7mW8FMNmMkiJvBekKtE6ftxu80Hqa34r86WfEwmJKm5MqYw==
+
+"@swc/core-linux-arm-gnueabihf@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.1.tgz#3d2f86ea5bc84bda9e458c5f249d36108fa29dd6"
+  integrity sha512-Q1zGHJMvAEkFdW7A2dthFrswf/HezhC2kOSoOmitz+KxWBZ0YSj8k9ImLYGFf7S8Vi0KVzLUaE1jCGK2oePx/A==
+  dependencies:
+    "@swc/wasm" "1.2.130"
 
 "@swc/core-linux-arm64-gnu@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.189.tgz#0fe98d1ca0a3441bfe4033fbe7fc19d87019f640"
   integrity sha512-frJTGnxsDe7h2d7BtnBivOdOJTtabkQIIZmHd4JHqafcoekI6teyveIax17axLyimvWl278yTo3hf7ePagD/eg==
 
+"@swc/core-linux-arm64-gnu@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.1.tgz#0bcbf91761fccf516f4ce6c4da7696177b9236d9"
+  integrity sha512-5OPkiU2A4Ijt2cRzi2FCGPkAC+wRvAb0TmUkL4Lj2PXPzM5RtEd2AoYmpQhV+YEOXO4XdnKwgBmdeiQV5K8eXA==
+
 "@swc/core-linux-arm64-musl@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.189.tgz#bb28e598e028745129e0eb9458184eb5b7efe685"
   integrity sha512-27K38LoZpME5lojDJIUNo7zdTDwAKLm0BMQ7HXWcYOyiDAekhSidI+SrBWxCfLzfuClhFu6/VE3E7j32VFJsiA==
+
+"@swc/core-linux-arm64-musl@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.1.tgz#078c0b0fabbe4bd361a81f4afce6017387c686c8"
+  integrity sha512-oTIeS7kEKSUrTxavYBEfqjqoIiHtbwSdgp/rrn2hz7CDG1B1imRHnsjwdh4YaYLsm8RcCH9+GABnHxJd3Nd6qg==
 
 "@swc/core-linux-x64-gnu@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.189.tgz#365073c3183e40080be900337987fcc4d2270fff"
   integrity sha512-Ha5oJKOyQm9w7+e+WdRm4ypijzEmglWZGtgBR6vV6ViqqHcTBAU4nG87ex7y7AS9p+Cbc6EOSR9X1qIB8KxtbA==
 
+"@swc/core-linux-x64-gnu@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.1.tgz#14b17a0cc580977c42efafecb1811ef59e3de1b5"
+  integrity sha512-gNojY1qIKksK9kNdY4pqrlUILTxfqSWtXjX0qV2mlxgwRpnOATJnMx585q09cOZnkN2/QB+33pXnT8z/wxuGzQ==
+
 "@swc/core-linux-x64-musl@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.189.tgz#1ce88e44952d0d4f525016c7841c1443f91de788"
   integrity sha512-/p5yXa9HEzpVEuE4ivkW1IvwyYu6fT+L2OvVEs5oXIba80F0Wjy7InWqaa83gwrdMH+bXV6loG8LzZUZu/lpjA==
+
+"@swc/core-linux-x64-musl@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.1.tgz#641f601051a7c21eb54570075df619acc6c5fd71"
+  integrity sha512-WXNagCsjul7U9uYYP1JkUUVtvqXRDDWjvdegqrtQ99/De+HoWr+fCPgvENgOsSwb0clPTBuiGm2PTnK6kDQ0Sw==
 
 "@swc/core-win32-arm64-msvc@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.189.tgz#2ad4d2aacd0032c1f8a859bba963207436a78769"
   integrity sha512-o/1ueM6/sifNjYnO6NMEXB895spVfJs5oQIPxQG9vJ/4zWLw8YmAx+u1xJY+XGyK6gnroHt7yPiS87qWdbeF6w==
 
+"@swc/core-win32-arm64-msvc@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.1.tgz#5a090bb3f70cd5fe0af83b5ca4204bf226ac925e"
+  integrity sha512-3LSDJtpYNgN4N/pd/YzHAWKaF2Y/1P9t83vHfPos77hQ+KzFaiyT7YIG1qfYy1AD8MGC28l2bJNH2gia3bcERA==
+  dependencies:
+    "@swc/wasm" "1.2.130"
+
 "@swc/core-win32-ia32-msvc@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.189.tgz#93dee76f59760b8eb516a2e55111fdeaf1e8c6c8"
   integrity sha512-YDwRkzykaf+dw5Z7u189cC/Tttkn2NVV84hrGL3LbVuh7wT5PaDhZs4Yz4unZQSlPV12olmZWgNr/i27h5wlpg==
+
+"@swc/core-win32-ia32-msvc@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.1.tgz#6a808a610e946013ffe4eb81d01b414eec93d636"
+  integrity sha512-0VfPVkQx7jV7k71tTQY5HchDrALWjrHF8AcaaCojXQpb9ftktLxaCUdTWlQ+Y958GkgG7QX+HEo95ImZ+cYRHQ==
+  dependencies:
+    "@swc/wasm" "1.2.130"
 
 "@swc/core-win32-x64-msvc@1.2.189":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.189.tgz#eeb127740952e3dd5cae2866c2da60346fed457b"
   integrity sha512-Nge8Z/ZkAp5p5No50yBDpBG7+ZYaVWGSuwtPj6OJe7orzvDCEm9GgcVE6J9GEjbclSWlCH8B8lUe17GaKRZHbg==
 
-"@swc/core@^1.2.119", "@swc/core@^1.2.173", "@swc/core@^1.2.181":
+"@swc/core-win32-x64-msvc@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.1.tgz#03410b2b76c2441856094e8cb514a19eb0109d1d"
+  integrity sha512-jSeqI8+1PGp+lHtyQCieDQxSszOF6UlA3bC2cmC9LAD84xcvsqpt0hsg3GFaw6RR7FsVjMNl/St6y1EEW0mm6Q==
+
+"@swc/core@^1.2.119", "@swc/core@^1.2.173":
   version "1.2.189"
   resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.2.189.tgz#8db88e809764e5b3b2be3fcac0da9d9d957e1056"
   integrity sha512-S5cKX4ECMSfW78DLFgnlilJZgjrFRYwPslrrwpLl3gpwh+Qo72/Mhn71u7G/5xXW+T/xW5GwPccHfCk+k72uUg==
@@ -3926,12 +4003,41 @@
     "@swc/core-win32-ia32-msvc" "1.2.189"
     "@swc/core-win32-x64-msvc" "1.2.189"
 
+"@swc/core@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.1.tgz#d81cb0d8af1b0e48e91ee328d41ccbbf21d532c0"
+  integrity sha512-ztB5N63UGLIOM60Vg+deHVigEnDAEAttiTQk4T91/i11SoOO65P9z8Bey01XFTxF0Alc2OJxkt8TBcq+n5mMYQ==
+  optionalDependencies:
+    "@swc/core-android-arm-eabi" "1.3.1"
+    "@swc/core-android-arm64" "1.3.1"
+    "@swc/core-darwin-arm64" "1.3.1"
+    "@swc/core-darwin-x64" "1.3.1"
+    "@swc/core-freebsd-x64" "1.3.1"
+    "@swc/core-linux-arm-gnueabihf" "1.3.1"
+    "@swc/core-linux-arm64-gnu" "1.3.1"
+    "@swc/core-linux-arm64-musl" "1.3.1"
+    "@swc/core-linux-x64-gnu" "1.3.1"
+    "@swc/core-linux-x64-musl" "1.3.1"
+    "@swc/core-win32-arm64-msvc" "1.3.1"
+    "@swc/core-win32-ia32-msvc" "1.3.1"
+    "@swc/core-win32-x64-msvc" "1.3.1"
+
 "@swc/jest@^0.2.21":
   version "0.2.22"
   resolved "https://registry.yarnpkg.com/@swc/jest/-/jest-0.2.22.tgz#70d02ac648c21a442016d7a0aa485577335a4c9a"
   integrity sha512-PIUIk9IdB1oAVfF9zNIfYoMBoEhahrrSvyryFANas7swC1cF0L5HR0f9X4qfet46oyCHCBtNcSpN0XJEOFIKlw==
   dependencies:
     "@jest/create-cache-key-function" "^27.4.2"
+
+"@swc/wasm@1.2.122":
+  version "1.2.122"
+  resolved "https://registry.yarnpkg.com/@swc/wasm/-/wasm-1.2.122.tgz#87a5e654b26a71b2e84b801f41e45f823b856639"
+  integrity sha512-sM1VCWQxmNhFtdxME+8UXNyPNhxNu7zdb6ikWpz0YKAQQFRGT5ThZgJrubEpah335SUToNg8pkdDF7ibVCjxbQ==
+
+"@swc/wasm@1.2.130":
+  version "1.2.130"
+  resolved "https://registry.yarnpkg.com/@swc/wasm/-/wasm-1.2.130.tgz#88ac26433335d1f957162a9a92f1450b73c176a0"
+  integrity sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
They fixed the regression they introduced which was preventing us from upgrading (https://github.com/swc-project/swc/issues/4851), but it looks like a newer version changed how things worked, so we can no longer spy on an ES6 module's exports.

This PR just converts those spies to be fully mocked modules to work around this and allow us to upgrade