### PR TITLE
feat(eslint-plugin): [require-object-type-annotations] add rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/require-object-type-annotations.md
+++ b/packages/eslint-plugin/docs/rules/require-object-type-annotations.md
@@ -1,0 +1,11 @@
+---
+description: 'TODO'
+---
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/require-object-type-annotations** for documentation.
+
+## Rule Details
+
+## How to Use

--- a/packages/eslint-plugin/docs/rules/require-object-type-annotations.md
+++ b/packages/eslint-plugin/docs/rules/require-object-type-annotations.md
@@ -1,5 +1,5 @@
 ---
-description: 'TODO'
+description: 'Require type annotations for objects where there is no contextual type.'
 ---
 
 > 🛑 This file is source code, not the primary documentation location! 🛑

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -147,6 +147,7 @@ export = {
     '@typescript-eslint/require-array-sort-compare': 'error',
     'require-await': 'off',
     '@typescript-eslint/require-await': 'error',
+    '@typescript-eslint/require-object-type-annotations': 'error',
     '@typescript-eslint/restrict-plus-operands': 'error',
     '@typescript-eslint/restrict-template-expressions': 'error',
     'no-return-await': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -110,6 +110,7 @@ import promiseFunctionAsync from './promise-function-async';
 import quotes from './quotes';
 import requireArraySortCompare from './require-array-sort-compare';
 import requireAwait from './require-await';
+import requireObjectTypeAnnotations from './require-object-type-annotations';
 import restrictPlusOperands from './restrict-plus-operands';
 import restrictTemplateExpressions from './restrict-template-expressions';
 import returnAwait from './return-await';
@@ -239,6 +240,7 @@ export default {
   quotes: quotes,
   'require-array-sort-compare': requireArraySortCompare,
   'require-await': requireAwait,
+  'require-object-type-annotations': requireObjectTypeAnnotations,
   'restrict-plus-operands': restrictPlusOperands,
   'restrict-template-expressions': restrictTemplateExpressions,
   'return-await': returnAwait,

--- a/packages/eslint-plugin/src/rules/require-object-type-annotations.ts
+++ b/packages/eslint-plugin/src/rules/require-object-type-annotations.ts
@@ -1,4 +1,3 @@
-import type { TSESTree } from '@typescript-eslint/utils';
 import type { RuleListener } from '@typescript-eslint/utils/src/ts-eslint';
 import type * as ts from 'typescript';
 
@@ -21,36 +20,35 @@ export default util.createRule({
   },
   defaultOptions: [],
   create: (context): RuleListener => {
-    const listener = (esNode: TSESTree.ObjectExpression): void => {
-      const parserServices = util.getParserServices(context);
-      const checker = parserServices.program.getTypeChecker();
-
-      const tsNode: ts.ObjectLiteralExpression =
-        parserServices.esTreeNodeToTSNodeMap.get(esNode);
-
-      const type = checker.getTypeAtLocation(tsNode);
-
-      // Allow empty objects
-      if (type.getProperties().length === 0) {
-        return;
-      }
-
-      const contextualType = checker.getContextualType(tsNode);
-
-      if (
-        contextualType === undefined ||
-        // Needed to catch object passed as a function argument where the parameter type is generic,
-        // e.g. an identity function
-        contextualType?.getSymbol()?.name === '__object'
-      ) {
-        context.report({
-          node: esNode,
-          messageId: 'forbidden',
-        });
-      }
-    };
     return {
-      ObjectExpression: listener,
+      ObjectExpression: (esNode): void => {
+        const parserServices = util.getParserServices(context);
+        const checker = parserServices.program.getTypeChecker();
+
+        const tsNode: ts.ObjectLiteralExpression =
+          parserServices.esTreeNodeToTSNodeMap.get(esNode);
+
+        const type = checker.getTypeAtLocation(tsNode);
+
+        // Allow empty objects
+        if (type.getProperties().length === 0) {
+          return;
+        }
+
+        const contextualType = checker.getContextualType(tsNode);
+
+        if (
+          contextualType === undefined ||
+          // Needed to catch object passed as a function argument where the parameter type is generic,
+          // e.g. an identity function
+          contextualType?.getSymbol()?.name === '__object'
+        ) {
+          context.report({
+            node: esNode,
+            messageId: 'forbidden',
+          });
+        }
+      },
     };
   },
 });

--- a/packages/eslint-plugin/src/rules/require-object-type-annotations.ts
+++ b/packages/eslint-plugin/src/rules/require-object-type-annotations.ts
@@ -1,0 +1,55 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import type { RuleListener } from '@typescript-eslint/utils/src/ts-eslint';
+import type * as ts from 'typescript';
+
+import * as util from '../util';
+
+export default util.createRule({
+  name: 'require-object-type-annotations',
+  defaultOptions: [],
+  meta: {
+    docs: {
+      description: '',
+      requiresTypeChecking: true,
+      recommended: false,
+    },
+    messages: {
+      forbidden: 'Object is missing type annotation.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  create: (context): RuleListener => {
+    const listener = (esNode: TSESTree.ObjectExpression): void => {
+      const parserServices = util.getParserServices(context);
+      const checker = parserServices.program.getTypeChecker();
+
+      const tsNode: ts.ObjectLiteralExpression =
+        parserServices.esTreeNodeToTSNodeMap.get(esNode);
+
+      const type = checker.getTypeAtLocation(tsNode);
+
+      // Allow empty objects
+      if (type.getProperties().length === 0) {
+        return;
+      }
+
+      const contextualType = checker.getContextualType(tsNode);
+
+      if (
+        contextualType === undefined ||
+        // Needed to catch object passed as a function argument where the parameter type is generic,
+        // e.g. an identity function
+        contextualType?.getSymbol()?.name === '__object'
+      ) {
+        context.report({
+          node: esNode,
+          messageId: 'forbidden',
+        });
+      }
+    };
+    return {
+      ObjectExpression: listener,
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/require-object-type-annotations.ts
+++ b/packages/eslint-plugin/src/rules/require-object-type-annotations.ts
@@ -6,7 +6,6 @@ import * as util from '../util';
 
 export default util.createRule({
   name: 'require-object-type-annotations',
-  defaultOptions: [],
   meta: {
     docs: {
       description: '',
@@ -19,6 +18,7 @@ export default util.createRule({
     schema: [],
     type: 'problem',
   },
+  defaultOptions: [],
   create: (context): RuleListener => {
     const listener = (esNode: TSESTree.ObjectExpression): void => {
       const parserServices = util.getParserServices(context);

--- a/packages/eslint-plugin/src/rules/require-object-type-annotations.ts
+++ b/packages/eslint-plugin/src/rules/require-object-type-annotations.ts
@@ -8,7 +8,8 @@ export default util.createRule({
   name: 'require-object-type-annotations',
   meta: {
     docs: {
-      description: '',
+      description:
+        'Require type annotations for objects where there is no contextual type.',
       requiresTypeChecking: true,
       recommended: false,
     },

--- a/packages/eslint-plugin/src/rules/require-object-type-annotations.ts
+++ b/packages/eslint-plugin/src/rules/require-object-type-annotations.ts
@@ -20,11 +20,11 @@ export default util.createRule({
   },
   defaultOptions: [],
   create: (context): RuleListener => {
+    const parserServices = util.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
+
     return {
       ObjectExpression: (esNode): void => {
-        const parserServices = util.getParserServices(context);
-        const checker = parserServices.program.getTypeChecker();
-
         const tsNode: ts.ObjectLiteralExpression =
           parserServices.esTreeNodeToTSNodeMap.get(esNode);
 

--- a/packages/eslint-plugin/tests/rules/require-object-type-annotations.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-object-type-annotations.test.ts
@@ -1,0 +1,149 @@
+import rule from '../../src/rules/require-object-type-annotations';
+import { getFixturesRootDir, RuleTester } from '../RuleTester';
+
+const rootDir = getFixturesRootDir();
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: rootDir,
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('require-object-type-annotations', rule, {
+  valid: [
+    {
+      code: `
+        const x = {};
+      `,
+    },
+    {
+      code: `
+        const x: { prop: number } = { prop: 1 };
+      `,
+    },
+    {
+      code: `
+        const x: { [key: string]: any } = { prop: { prop: 1 } };
+      `,
+    },
+    {
+      code: `
+        const x: { [key: string]: unknown } = { prop: { prop: 1 } };
+      `,
+    },
+    {
+      code: `
+        const xs: Array<{ prop: number }> = [{ prop: 1 }];
+      `,
+    },
+    {
+      code: `
+        const fn: () => { prop: number } = () => ({ prop: 1 });
+      `,
+    },
+    {
+      code: `
+        const fn = (): { prop: number } => ({ prop: 1 });
+      `,
+    },
+    {
+      code: `
+        declare const f: (x: { prop: number }) => unknown;
+        f({ prop: 1 });
+      `,
+    },
+    {
+      code: `
+        declare const f: { g: (x: { prop: number }) => unknown };
+        f.g({ prop: 1 });
+      `,
+    },
+    {
+      code: `
+        declare const f: <T>(x: { [key: string]: T }) => T;
+        f({ prop: 1 });
+      `,
+    },
+    {
+      code: `
+        declare const mk: <T>() => (t: T) => unknown;
+        const f = mk<{ prop: number }>();
+        f({ prop: 1 });
+      `,
+    },
+    {
+      code: `
+        declare const f: (arg: () => { prop: number }) => unknown;
+        f(() => ({ prop: 1 }));
+      `,
+    },
+    {
+      code: `
+        interface Base {}
+
+        type MyType = Base & {
+          prop: string;
+        };
+
+        interface A extends MyType {}
+        interface B extends MyType {}
+
+        type Union = A | B;
+
+        declare const union: Union;
+        const v: MyType = { ...union };
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const x = { prop: 1 };
+      `,
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: `
+        const xs = [{ prop: 1 }];
+      `,
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: `
+        const fn = () => ({ prop: 1 });
+      `,
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: `
+        declare const f: <T>(x: T) => T;
+        f({ prop: 1 });
+      `,
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: `
+        declare const f: <T>(x: T) => T;
+        const x: { prop: number } = f({ prop: 1 });
+      `,
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: `
+        declare const f: <T extends { prop: number }>(x: T) => T;
+        f({ prop: 1 });
+      `,
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: `
+        declare const f: <T>(x: { [key: string]: T }) => T;
+        f({ prop: { prop: 1 } });
+      `,
+      errors: [{ messageId: 'forbidden' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/rules/require-object-type-annotations.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-object-type-annotations.test.ts
@@ -103,6 +103,11 @@ ruleTester.run('require-object-type-annotations', rule, {
         f({ prop: 1 });
       `,
     },
+    {
+      code: `
+        [1, 2, 3].map((id): { prop: number } => ({ prop: id }));
+      `,
+    },
   ],
   invalid: [
     {
@@ -148,6 +153,12 @@ ruleTester.run('require-object-type-annotations', rule, {
       code: `
         declare const f: <T>(x: { [key: string]: T }) => T;
         f({ prop: { prop: 1 } });
+      `,
+      errors: [{ messageId: 'forbidden' }],
+    },
+    {
+      code: `
+        [1, 2, 3].map(id => ({ prop: id }));
       `,
       errors: [{ messageId: 'forbidden' }],
     },

--- a/packages/eslint-plugin/tests/rules/require-object-type-annotations.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-object-type-annotations.test.ts
@@ -97,6 +97,12 @@ ruleTester.run('require-object-type-annotations', rule, {
         const v: MyType = { ...union };
       `,
     },
+    {
+      code: `
+        declare const f: (x: unknown) => unknown;
+        f({ prop: 1 });
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/require-object-type-annotations.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-object-type-annotations.test.ts
@@ -162,5 +162,16 @@ ruleTester.run('require-object-type-annotations', rule, {
       `,
       errors: [{ messageId: 'forbidden' }],
     },
+    {
+      code: `
+        declare function pipe<A, B>(a: A, ab: (a: A) => B): B;
+
+        declare const logName: (user: User) => void;
+        type User = { name: string };
+
+        pipe({ name: 'foo' }, logName);
+      `,
+      errors: [{ messageId: 'forbidden' }],
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/1467
   More context in https://github.com/typescript-eslint/typescript-eslint/issues/3408
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Problem

I've added this section to elaborate on the problem I described in https://github.com/typescript-eslint/typescript-eslint/issues/3408.

For object literals without type annotations, many TypeScript features don't work. Contrived example:

```ts
type User = { name: string; age: number };

const makeUser = () => ({ name: 'bob', age: 123 });
```

If you try to rename a property inside of the object literal (or vice versa, the property inside the type definition), it won't update the name of the corresponding property in the `User` type definition. This is because TypeScript does not understand that this object literal relates to the `User` type.

For the same reason, other language server features like "go to definition" and "find references" on object properties will also not work.

When a type is used in many places, this makes navigation and refactoring of the code much more difficult.

Furthermore, this can result in bugs:

```ts
type Config = { foo: string; bar?: string };

const config = { foo: 'yay', bar: 'woo' };
```

If we rename `bar` in the `Config` type, not only are the usages not automatically renamed but also we don't get a type error to say that we're now setting an invalid property in `config`. In this situation it's likely we won't realise there is a problem, and this would probably cause a bug:

```ts
type Config = { foo: string; barNEW?: string };

// ❌ No type error!
const config = { foo: 'yay', bar: 'woo' };
```

Another example:

```ts
type State = { foo: string; bar: string };

declare const state: State;
const newState = { ...state, bar: 'woo' };
```

Rename `bar` in the `State` type and we get:

```ts
type State = { foo: string; barNEW: string };

declare const state: State;
// ❌ No type error!
const newState = { ...state, bar: 'woo' };
```

See https://github.com/typescript-eslint/typescript-eslint/issues/3408 for a real world example of this.

### Note on debugging

VS Code makes it easy to identify when TypeScript understands the relationship between a value and its type because it will highlight all occurrences of a symbol when that symbol is selected:

All occurences of `myString` are highlighted:

<img src="https://user-images.githubusercontent.com/921609/143955693-435556d7-f40a-4a60-ac2b-ed902365137b.png" width="400" />

Only one occurence of `name` is highlighted:

<img src="https://user-images.githubusercontent.com/921609/143955799-2b89cf48-3fc1-44fc-aced-b2109aaad2b9.png" width="400" />
