### PR TITLE
chore(website): fix border-shadow color in dark mode

### DIFF
--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -62,6 +62,8 @@ html[data-theme='dark']:root {
 
   --docsearch-muted-color: #aaa;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  --gray-border-shadow: var(--ifm-color-secondary-dark);
 }
 
 .header-github-link:hover {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5701
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

The thead shadow for the rules table in dark mode is much less aggressive now.

<img width="892" alt="Screenshot of the Rules table with a non-aggressive medium gray box shadow under the thead" src="https://user-images.githubusercontent.com/3335181/193394554-6e95a197-5249-4a75-bb0c-7f5dc306437f.png">
