### PR TITLE
chore(eslint-plugin): comma-spacing meta.type should be layout, not suggestion

### DIFF
--- a/packages/eslint-plugin/src/rules/comma-spacing.ts
+++ b/packages/eslint-plugin/src/rules/comma-spacing.ts
@@ -19,7 +19,7 @@ type MessageIds = 'unexpected' | 'missing';
 export default createRule<Options, MessageIds>({
   name: 'comma-spacing',
   meta: {
-    type: 'suggestion',
+    type: 'layout',
     docs: {
       description: 'Enforce consistent spacing before and after commas',
       recommended: false,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5706
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Found as part of #5696.