### PR TITLE
chore(website): split extension rules in sidebar too

### DIFF
--- a/packages/website/sidebars/sidebar.rules.js
+++ b/packages/website/sidebars/sidebar.rules.js
@@ -13,14 +13,19 @@ const rules = Object.entries(plugin.rules).map(([name, rule]) => {
 const deprecatedRules = new Set(rules.filter(rule => rule.meta.deprecated));
 
 const formattingRules = new Set(
+  rules.filter(rule => !rule.meta.deprecated && rule.meta.type === 'layout'),
+);
+
+const extensionRules = new Set(
   rules.filter(
-    rule => !rule.meta.deprecated && rule.meta.fixable === 'whitespace',
+    rule => rule.meta.docs?.extendsBaseRule && !formattingRules.has(rule),
   ),
 );
 
-const emphasizedRules = rules.filter(
+const typescriptRules = rules.filter(
   rule =>
     !rule.meta.deprecated &&
+    !extensionRules.has(rule) &&
     !deprecatedRules.has(rule) &&
     !formattingRules.has(rule),
 );
@@ -63,14 +68,17 @@ module.exports = {
   someSidebar: [
     'README',
     {
-      ...createCategory('Rules', emphasizedRules, [
-        createCategory('Formatting Rules', Array.from(formattingRules)),
-        createCategory('Deprecated Rules', [
-          ...Array.from(deprecatedRules),
-          ...paths,
-        ]),
-      ]),
+      ...createCategory('TypeScript Rules', Array.from(typescriptRules)),
       collapsed: false,
     },
+    {
+      ...createCategory('Extension Rules', Array.from(extensionRules)),
+      collapsed: false,
+    },
+    createCategory('Formatting Rules', Array.from(formattingRules)),
+    createCategory('Deprecated Rules', [
+      ...Array.from(deprecatedRules),
+      ...paths,
+    ]),
   ],
 };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5707
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

The first two sections -_TypeScript Rules_ and _Extension Rules_- are uncollapsed by default:

<img width="309" alt="Screenshot of sidebar: Overview, TypeScript Rules, Extension Rules, Formatting Rules, Deprecated Rules" src="https://user-images.githubusercontent.com/3335181/193395492-27416dfc-1024-4643-8121-c5da4fb38fce.png">

