### PR TITLE
chore: unignore typescript and eslint from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,3 @@ updates:
       day: monday
     ignore:
       - dependency-name: cypress
-      - dependency-name: typescript
-      - dependency-name: eslint


### PR DESCRIPTION
<!-- Description of what is changed and how the code change does that. -->
Speaking with @JoshuaKGoldberg - we were thinking we wanted a way to help ensure we test against the latest stable version of our core deps.
We thought about creating a bespoke action to install the latest version and test.. then we realised we have that functionality in dependabot - though the deps were ignored in the config.

This unignores them so that we can get the auto update including a PR which runs the full CI.