### PR TITLE
chore: deduplicate after renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,5 +15,6 @@
     }
   ],
   "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-  "stabilityDays": 3
+  "stabilityDays": 3,
+  "postUpdateOptions": ["yarnDedupeHighest"]
 }


### PR DESCRIPTION
## Overview

<!-- Description of what is changed and how the code change does that. -->
https://docs.renovatebot.com/configuration-options/#postupdateoptions

This will cause renovate bot to run `yarn-deplicate` after it does a bump.
This should help us keep the lockfile correct and the number of versions minimal