### PR TITLE
chore(website): fix RuleTester alias in Rollup

### DIFF
--- a/packages/website-eslint/rollup.config.js
+++ b/packages/website-eslint/rollup.config.js
@@ -27,7 +27,7 @@ module.exports = {
           match: [
             /eslint\/lib\/(rule-tester|eslint|cli-engine|init)\//u,
             /eslint\/lib\/cli\.js$/,
-            /utils\/dist\/eslint-utils\/RuleTester\.js$/,
+            /utils\/dist\/eslint-utils\/rule-tester\/RuleTester\.js$/,
             /utils\/dist\/ts-eslint\/CLIEngine\.js$/,
             /utils\/dist\/ts-eslint\/RuleTester\.js$/,
             /typescript-estree\/dist\/create-program\/createWatchProgram\.js/,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5771
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Corrects the alias path for `RuleTester` in the Rollup config, as it was updated in #5750.