### PR TITLE
chore: fix replies.yml blank entry

### DIFF
--- a/.github/replies.yml
+++ b/.github/replies.yml
@@ -18,9 +18,6 @@ replies:
       If you need it sooner, please try the `canary` tag on NPM.
     name: Fix Has Been Merged
   - body: |
-
-    name:
-  - body: |
       With any issue opened in this project — it either has visible progress in the form of an attached PR, or it has no progress.\
       \
       We are a community-run project. The volunteer maintainers spend most of their time triaging issues and reviewing PRs. This means that most issues will not progress unless a member of the community steps up and champions it.\


### PR DESCRIPTION
## Overview

My [refined-save-replies extension](https://github.com/JoshuaKGoldberg/refined-saved-replies) bails out on parsing replies because of this one.