### PR TITLE
fix(eslint-plugin): Skip missing 'rest' tuple type arguments in no-misused-promises

### DIFF
--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -564,7 +564,11 @@ function voidFunctionArguments(
             // Check each type in the tuple - for example, [boolean, () => void] would
             // add the index of the second tuple parameter to 'voidReturnIndices'
             const typeArgs = checker.getTypeArguments(type);
-            for (let i = index; i < node.arguments.length; i++) {
+            for (
+              let i = index;
+              i < node.arguments.length && i - index < typeArgs.length;
+              i++
+            ) {
               checkThenableOrVoidArgument(
                 checker,
                 node,

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -419,6 +419,14 @@ new TakeCallbacks(
   () => true,
 );
     `,
+    `
+function restTuple(...args: []): void;
+function restTuple(...args: [string]): void;
+function restTuple(..._args: string[]): void {}
+
+restTuple();
+restTuple('Hello');
+    `,
   ],
 
   invalid: [
@@ -1098,6 +1106,17 @@ new TakesVoidCb(
 );
       `,
       errors: [{ line: 11, messageId: 'voidReturnArgument' }],
+    },
+    {
+      code: `
+function restTuple(...args: []): void;
+function restTuple(...args: [boolean, () => void]): void;
+function restTuple(..._args: any[]): void {}
+
+restTuple();
+restTuple(true, () => Promise.resolve(1));
+      `,
+      errors: [{ line: 7, messageId: 'voidReturnArgument' }],
     },
   ],
 });


### PR DESCRIPTION
Fixes #5807

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #000
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview


When linting a function with a 'rest' tuple argument, we might have different numbers of arguments between signatures:

```
function foo(...args: []);
function foo(...args: [string]);
```

This PR makes no-misused-promises handle this code correctly, by ensuring that we only check an argument when we have a corresponding type parameter in the tuple type arguments.
