### PR TITLE
fix(utils): add missing dependency on `@types/semver`

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@types/json-schema": "^7.0.9",
+    "@types/semver": "^7.3.12",
     "@typescript-eslint/scope-manager": "5.40.0",
     "@typescript-eslint/types": "5.40.0",
     "@typescript-eslint/typescript-estree": "5.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4237,7 +4237,7 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@types/semver@*", "@types/semver@^7.3.9":
+"@types/semver@*", "@types/semver@^7.3.12", "@types/semver@^7.3.9":
   version "7.3.12"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.12.tgz#920447fdd78d76b19de0438b7f60df3c4a80bf1c"
   integrity sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

#5750 added a dependency on `semver` to the `@typescript-eslint/utils` package. This implicitly depended on `@types/semver` which is provided by the top-level workspace package.json file but not `@typescript-eslint/utils` itself. This caused my application to break.

My application imports some types from this package:

```ts
import type { TSESLint, JSONSchema } from '@typescript-eslint/utils';
```

And the breakage occurred during:
* https://github.com/bmish/eslint-doc-generator/pull/111
* https://github.com/bmish/eslint-doc-generator/pull/113

While running:

```
> tsc

Error: node_modules/@typescript-eslint/utils/dist/eslint-utils/rule-tester/dependencyConstraints.d.ts(1,25):
error TS7016: Could not find a declaration file for module 'semver'.
'/home/runner/work/eslint-doc-generator/eslint-doc-generator/node_modules/@typescript-eslint/utils/node_modules/semver/index.js' implicitly has an 'any' type.
```

I have fixed the issue by adding the missing dependency.

In this PR or as a follow-up, we should also remove `@types/semver` from the top-level package.json which doesn't need it, and instead ensure it's defined as an explicit dependency in each package that uses it.
