### PR TITLE
chore: add test coverage data to nx test caches

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -32,7 +32,7 @@
       "dependsOn": ["^build"]
     },
     "test": {
-      "outputs": ["packages/*/coverage"]
+      "outputs": ["{projectRoot}/coverage"]
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -30,6 +30,9 @@
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"]
+    },
+    "test": {
+      "outputs": ["packages/*/coverage"]
     }
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5832
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Per the #5382, adds the coverage directory to nx output cache for `test` commands. This should get coverage data uploaded to the cache restored in `main` branch runs.