### PR TITLE
fix(eslint-plugin): [no-base-to-string] ignore Error, URL, and URLSearchParams by default

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -48,7 +48,7 @@ export default util.createRule<Options, MessageIds>({
   },
   defaultOptions: [
     {
-      ignoredTypeNames: ['RegExp'],
+      ignoredTypeNames: ['Error', 'RegExp', 'URL', 'URLSearchParams'],
     },
   ],
   create(context, [option]) {

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -113,6 +113,9 @@ tag\`\${{}}\`;
         return \`\${v}\`;
       }
     `,
+    "'' += new Error();",
+    "'' += new URL();",
+    "'' += new URLSearchParams();",
   ],
   invalid: [
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4999
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Adds built-in types that have `toString()` overrides not mentioned by TypeScript to the default `ignoredTypeNames` object.