### PR TITLE
chore: don't renovate `nx` or `@nrwl/workspace` for now

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,8 @@
     '@nrwl/jest',
     '@nrwl/nx-cloud',
     '@nrwl/tao',
+    '@nrwl/workspace',
+    'nx',
   ],
   ignorePaths: [
     // integration test package.json's should never be updated as they're purposely fixed tests


### PR DESCRIPTION
## Overview

#5797 is working on automation here, which is when we can remove `@nrwl/workspace`.
I'm adding because renovate raised #5837, #5838, #5842, #5843