### PR TITLE
fix(type-utils): prevent stack overflow in `isTypeReadonly`

### DIFF
--- a/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
@@ -5,6 +5,7 @@ import type {
   InferMessageIdsTypeFromRule,
   InferOptionsTypeFromRule,
 } from '../../src/util';
+import { readonlynessOptionsDefaults } from '../../src/util';
 import { getFixturesRootDir, noFormat, RuleTester } from '../RuleTester';
 
 type MessageIds = InferMessageIdsTypeFromRule<typeof rule>;
@@ -359,6 +360,23 @@ ruleTester.run('prefer-readonly-parameter-types', rule, {
       options: [
         {
           ignoreInferredTypes: true,
+        },
+      ],
+    },
+    {
+      name: 'circular readonly types (Bug: #4476)',
+      code: `
+        interface Obj {
+          readonly [K: string]: Obj;
+        }
+        
+        function foo(event: Obj): void {}
+      `,
+      options: [
+        {
+          checkParameterProperties: true,
+          ignoreInferredTypes: false,
+          ...readonlynessOptionsDefaults,
         },
       ],
     },

--- a/packages/type-utils/src/isTypeReadonly.ts
+++ b/packages/type-utils/src/isTypeReadonly.ts
@@ -113,6 +113,10 @@ function isTypeReadonlyObject(
         return Readonlyness.Mutable;
       }
 
+      if (indexInfo.type === type) {
+        return Readonlyness.Readonly;
+      }
+
       return isTypeReadonlyRecurser(
         checker,
         indexInfo.type,

--- a/packages/type-utils/tests/isTypeReadonly.test.ts
+++ b/packages/type-utils/tests/isTypeReadonly.test.ts
@@ -134,6 +134,13 @@ describe('isTypeReadonly', () => {
           );
         });
 
+        describe('is readonly circular', () => {
+          const runTests = runTestIsReadonly;
+
+          it('handles circular readonly PropertySignature inside a readonly IndexSignature', () =>
+            runTests('interface Test { readonly [key: string]: Test };'));
+        });
+
         describe('is not readonly', () => {
           const runTests = runTestIsNotReadonly;
 
@@ -144,6 +151,13 @@ describe('isTypeReadonly', () => {
             'handles mutable PropertySignature inside a readonly IndexSignature',
             runTests,
           );
+        });
+
+        describe('is not readonly circular', () => {
+          const runTests = runTestIsNotReadonly;
+
+          it('handles circular mutable PropertySignature inside a readonly IndexSignature', () =>
+            runTests('interface Test { [key: string]: Test };'));
         });
       });
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #4476
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken