### PR TITLE
[WIP] fix(eslint-plugin): member-ordering default configuration (#5452)

### DIFF
--- a/packages/eslint-plugin/docs/rules/member-ordering.md
+++ b/packages/eslint-plugin/docs/rules/member-ordering.md
@@ -23,7 +23,7 @@ interface Options {
 type OrderConfig = MemberType[] | SortedOrderConfig | 'never';
 
 interface SortedOrderConfig {
-  memberTypes?: MemberType[] | 'never';
+  memberTypes?: MemberType[] | 'never' | 'default';
   order: 'alphabetically' | 'alphabetically-case-insensitive' | 'as-written';
 }
 
@@ -41,7 +41,7 @@ You can configure `OrderConfig` options for:
 
 The `OrderConfig` settings for each kind of construct may configure sorting on one or both two levels:
 
-- **`memberTypes`**: organizing on member type groups such as methods vs. properties
+- **`memberTypes`**: organizing on member type groups such as methods vs. properties. If `'default'` - use a default member types.
 - **`order`**: organizing based on member names, such as alphabetically
 
 ### Groups

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -40,7 +40,7 @@ type Order =
   | 'as-written';
 
 interface SortedOrderConfig {
-  memberTypes?: MemberType[] | 'never';
+  memberTypes?: MemberType[] | 'never' | 'default';
   order: Order;
 }
 
@@ -60,6 +60,11 @@ export type Options = [
 const neverConfig: JSONSchema.JSONSchema4 = {
   type: 'string',
   enum: ['never'],
+};
+
+const defaultConfig: JSONSchema.JSONSchema4 = {
+  type: 'string',
+  enum: ['default'],
 };
 
 const arrayConfig = (memberTypes: MemberType[]): JSONSchema.JSONSchema4 => ({
@@ -83,7 +88,7 @@ const objectConfig = (memberTypes: MemberType[]): JSONSchema.JSONSchema4 => ({
   type: 'object',
   properties: {
     memberTypes: {
-      oneOf: [arrayConfig(memberTypes), neverConfig],
+      oneOf: [arrayConfig(memberTypes), neverConfig, defaultConfig],
     },
     order: {
       type: 'string',
@@ -689,6 +694,12 @@ export default util.createRule<Options, MessageIds>({
       } else {
         order = orderConfig.order;
         memberTypes = orderConfig.memberTypes;
+        if (memberTypes === 'never') {
+          return;
+        }
+        if (memberTypes === 'default') {
+          memberTypes = defaultOrder;
+        }
       }
 
       const hasAlphaSort = order?.startsWith('alphabetically');

--- a/packages/eslint-plugin/tests/rules/member-ordering.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering.test.ts
@@ -14,21 +14,46 @@ const grouped: TSESLint.RunTests<MessageIds, Options> = {
 // no accessibility === public
 interface Foo {
     [Z: string]: any;
+    F: string;
     A: string;
     B: string;
     C: string;
     D: string;
     E: string;
-    F: string;
     new();
+    L();
     G();
     H();
     I();
     J();
     K();
-    L();
 }
         `,
+    {
+      name: 'default member types with alphabetically order',
+      code: `
+          // no accessibility === public
+          interface Foo {
+              [Z: string]: any;
+              A: string;
+              B: string;
+              C: string;
+              D: string;
+              E: string;
+              F: string;
+              new();
+              G();
+              H();
+              I();
+              J();
+              K();
+              L();
+          }
+        `,
+      options: [
+        { default: { memberTypes: 'default', order: 'alphabetically' } },
+      ],
+    },
     {
       code: `
 // no accessibility === public
@@ -50,6 +75,28 @@ interface Foo {
 }
             `,
       options: [{ default: 'never' }],
+    },
+    {
+      code: `
+// no accessibility === public
+interface Foo {
+    A: string;
+    J();
+    K();
+    D: string;
+    E: string;
+    F: string;
+    new();
+    G();
+    H();
+    [Z: string]: any;
+    B: string;
+    C: string;
+    I();
+    L();
+}
+            `,
+      options: [{ default: { memberTypes: 'never', order: 'alphabetically' } }],
     },
     {
       code: `
@@ -1549,6 +1596,41 @@ interface Foo {
           line: 17,
           column: 5,
         },
+      ],
+    },
+    {
+      code: `
+// no accessibility === public
+interface Foo {
+    [Z: string]: any;
+    E: string;
+    F: string;
+    A: string;
+    B: string;
+    C: string;
+    D: string;
+    L();
+    G(); 
+    J();
+    H();
+    I();
+    K();
+    new();
+}
+            `,
+      errors: [
+        {
+          messageId: 'incorrectGroupOrder',
+          data: {
+            name: 'new',
+            rank: 'method',
+          },
+          line: 17,
+          column: 5,
+        },
+      ],
+      options: [
+        { default: { memberTypes: 'default', order: 'alphabetically' } },
       ],
     },
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5452
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken