### PR TITLE
feat(eslint-plugin): [no-unsafe-declaration-merging] switch to use scope analysis instead of type information

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unsafe-declaration-merging.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-declaration-merging.test.ts
@@ -80,23 +80,19 @@ class Foo {}
     },
     {
       code: `
-namespace Foo {
-  export interface Bar {}
-}
-namespace Foo {
-  export class Bar {}
-}
+class Foo {}
+interface Foo {}
       `,
       errors: [
         {
           messageId: 'unsafeMerging',
-          line: 3,
-          column: 20,
+          line: 2,
+          column: 7,
         },
         {
           messageId: 'unsafeMerging',
-          line: 6,
-          column: 16,
+          line: 3,
+          column: 11,
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5854
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Sorry to cut your lunch @yeonjuan and submit this before you - I wanted to try and get this in before the release so we release the rule on the right foot!