### PR TITLE
chore(website): fix Options heading level for no-empty-interface docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-empty-interface.md
+++ b/packages/eslint-plugin/docs/rules/no-empty-interface.md
@@ -48,7 +48,7 @@ interface Baz extends Foo, Bar {}
 
 <!--/tabs-->
 
-### Options
+## Options
 
 This rule accepts a single object option with the following default configuration:
 

--- a/packages/eslint-plugin/tests/docs.test.ts
+++ b/packages/eslint-plugin/tests/docs.test.ts
@@ -26,11 +26,15 @@ function tokenIs<Type extends TokenType>(
   return token.type === type;
 }
 
-function tokenIsH2(token: marked.Token): token is marked.Tokens.Heading {
+function tokenIsHeading(token: marked.Token): token is marked.Tokens.Heading {
+  return tokenIs(token, 'heading');
+}
+
+function tokenIsH2(
+  token: marked.Token,
+): token is marked.Tokens.Heading & { depth: 2 } {
   return (
-    tokenIs(token, 'heading') &&
-    token.depth === 2 &&
-    !/[a-z]+: /.test(token.text)
+    tokenIsHeading(token) && token.depth === 2 && !/[a-z]+: /.test(token.text)
   );
 }
 
@@ -92,6 +96,23 @@ describe('Validating rule docs', () => {
         headers.forEach(header =>
           expect(header.text).toBe(titleCase(header.text)),
         );
+      });
+
+      const importantHeadings = new Set([
+        'How to Use',
+        'Options',
+        'Related To',
+        'When Not To Use It',
+      ]);
+
+      test('important headings must be h2s', () => {
+        const headers = tokens.filter(tokenIsHeading);
+
+        for (const header of headers) {
+          if (importantHeadings.has(header.raw.replace(/#/g, '').trim())) {
+            expect(header.depth).toBe(2);
+          }
+        }
       });
     });
   }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5869
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

The _Options_ heading in https://typescript-eslint.io/rules/no-empty-interface was an h3 (`###`), not h2 (`##`) as expected by `generated-rule-docs.ts`. This fixes it to be an h2 and adds a unit test for known headings.
