### PR TITLE
chore: add auto-canary release for v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v6
   pull_request:
     branches:
       - '**'
@@ -247,5 +248,30 @@ jobs:
 
       - name: Publish all packages to npm
         run: npx lerna publish --loglevel=verbose --canary --exact --force-publish --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish_canary_version_v6:
+    name: Publish the next major version code as a canary version
+    runs-on: ubuntu-latest
+    needs: [integration_tests, lint_with_build, lint_without_build, unit_tests]
+    if: github.ref == 'refs/heads/v${major}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install
+        uses: ./.github/actions/prepare-install
+        with:
+          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Build
+        uses: ./.github/actions/prepare-build
+
+      # Fetch all history for all tags and branches in this job because lerna needs it
+      - run: |
+          git fetch --prune --unshallow
+
+      - name: Publish all packages to npm
+        run: npx lerna publish premajor --loglevel=verbose --canary --exact --force-publish --yes --dist-tag rc-v${major}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: start on #5037
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Akin to #3776 but for v6, and roughly following the guide in #5874.

Things I changed from the guide based on the old PR:
* Made this branch+PR first, rather than all in one `v6`
* Added to `push: branches:` list on top of `ci.yml`
* Additions to Step 2:
    * Change the name
    * Change the description
* Additions to Step 3:
    * Naming convention for initial commit / PR
