### PR TITLE
feat(typescript-estree): allow providing code as a ts.SourceFile

### DIFF
--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -14,7 +14,7 @@ import {
   visitorKeys,
 } from '@typescript-eslint/typescript-estree';
 import debug from 'debug';
-import type { CompilerOptions } from 'typescript';
+import type * as ts from 'typescript';
 import { ScriptTarget } from 'typescript';
 
 const log = debug('typescript-eslint:parser:parser');
@@ -41,7 +41,7 @@ function validateBoolean(
 }
 
 const LIB_FILENAME_REGEX = /lib\.(.+)\.d\.[cm]?ts$/;
-function getLib(compilerOptions: CompilerOptions): Lib[] {
+function getLib(compilerOptions: ts.CompilerOptions): Lib[] {
   if (compilerOptions.lib) {
     return compilerOptions.lib.reduce((acc, lib) => {
       const match = LIB_FILENAME_REGEX.exec(lib.toLowerCase());
@@ -76,14 +76,14 @@ function getLib(compilerOptions: CompilerOptions): Lib[] {
 }
 
 function parse(
-  code: string,
+  code: string | ts.SourceFile,
   options?: ParserOptions,
 ): ParseForESLintResult['ast'] {
   return parseForESLint(code, options).ast;
 }
 
 function parseForESLint(
-  code: string,
+  code: string | ts.SourceFile,
   options?: ParserOptions | null,
 ): ParseForESLintResult {
   if (!options || typeof options !== 'object') {

--- a/packages/typescript-estree/src/ast-converter.ts
+++ b/packages/typescript-estree/src/ast-converter.ts
@@ -63,7 +63,7 @@ export function astConverter(
    * Optionally convert and include all comments in the AST
    */
   if (parseSettings.comment) {
-    estree.comments = convertComments(ast, parseSettings.code);
+    estree.comments = convertComments(ast, parseSettings.codeFullText);
   }
 
   const astMaps = instance.getASTMaps();

--- a/packages/typescript-estree/src/create-program/createDefaultProgram.ts
+++ b/packages/typescript-estree/src/create-program/createDefaultProgram.ts
@@ -53,7 +53,7 @@ function createDefaultProgram(
   const oldReadFile = compilerHost.readFile;
   compilerHost.readFile = (fileName: string): string | undefined =>
     path.normalize(fileName) === path.normalize(parseSettings.filePath)
-      ? parseSettings.code
+      ? parseSettings.codeFullText
       : oldReadFile(fileName);
 
   const program = ts.createProgram(

--- a/packages/typescript-estree/src/create-program/createIsolatedProgram.ts
+++ b/packages/typescript-estree/src/create-program/createIsolatedProgram.ts
@@ -43,7 +43,7 @@ function createIsolatedProgram(parseSettings: ParseSettings): ASTAndProgram {
     getSourceFile(filename: string) {
       return ts.createSourceFile(
         filename,
-        parseSettings.code,
+        parseSettings.codeFullText,
         ts.ScriptTarget.Latest,
         /* setParentNodes */ true,
         getScriptKind(parseSettings.filePath, parseSettings.jsx),

--- a/packages/typescript-estree/src/create-program/createSourceFile.ts
+++ b/packages/typescript-estree/src/create-program/createSourceFile.ts
@@ -2,6 +2,7 @@ import debug from 'debug';
 import * as ts from 'typescript';
 
 import type { ParseSettings } from '../parseSettings';
+import { isSourceFile } from '../source-files';
 import { getScriptKind } from './getScriptKind';
 
 const log = debug('typescript-eslint:typescript-estree:createSourceFile');
@@ -13,13 +14,15 @@ function createSourceFile(parseSettings: ParseSettings): ts.SourceFile {
     parseSettings.filePath,
   );
 
-  return ts.createSourceFile(
-    parseSettings.filePath,
-    parseSettings.code,
-    ts.ScriptTarget.Latest,
-    /* setParentNodes */ true,
-    getScriptKind(parseSettings.filePath, parseSettings.jsx),
-  );
+  return isSourceFile(parseSettings.code)
+    ? parseSettings.code
+    : ts.createSourceFile(
+        parseSettings.filePath,
+        parseSettings.codeFullText,
+        ts.ScriptTarget.Latest,
+        /* setParentNodes */ true,
+        getScriptKind(parseSettings.filePath, parseSettings.jsx),
+      );
 }
 
 export { createSourceFile };

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -4,6 +4,7 @@ import semver from 'semver';
 import * as ts from 'typescript';
 
 import type { ParseSettings } from '../parseSettings';
+import { getCodeText } from '../source-files';
 import type { CanonicalPath } from './shared';
 import {
   canonicalDirname,
@@ -90,7 +91,10 @@ function saveWatchCallback(
 /**
  * Holds information about the file currently being linted
  */
-const currentLintOperationState: { code: string; filePath: CanonicalPath } = {
+const currentLintOperationState: {
+  code: string | ts.SourceFile;
+  filePath: CanonicalPath;
+} = {
   code: '',
   filePath: '' as CanonicalPath,
 };
@@ -148,7 +152,7 @@ function getProgramsForProjects(parseSettings: ParseSettings): ts.Program[] {
 
   // Update file version if necessary
   const fileWatchCallbacks = fileWatchCallbackTrackingMap.get(filePath);
-  const codeHash = createHash(parseSettings.code);
+  const codeHash = createHash(getCodeText(parseSettings.code));
   if (
     parsedFilesSeenHash.get(filePath) !== codeHash &&
     fileWatchCallbacks &&
@@ -281,7 +285,7 @@ function createWatchProgram(
     const filePath = getCanonicalFileName(filePathIn);
     const fileContent =
       filePath === currentLintOperationState.filePath
-        ? currentLintOperationState.code
+        ? getCodeText(currentLintOperationState.code)
         : oldReadFile(filePath, encoding);
     if (fileContent !== undefined) {
       parsedFilesSeenHash.set(filePath, createHash(fileContent));

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -1,6 +1,7 @@
 import debug from 'debug';
 import { sync as globSync } from 'globby';
 import isGlob from 'is-glob';
+import type * as ts from 'typescript';
 
 import type { CanonicalPath } from '../create-program/shared';
 import {
@@ -8,6 +9,7 @@ import {
   getCanonicalFileName,
 } from '../create-program/shared';
 import type { TSESTreeOptions } from '../parser-options';
+import { isSourceFile } from '../source-files';
 import type { MutableParseSettings } from './index';
 import { inferSingleRun } from './inferSingleRun';
 import { warnAboutTSVersion } from './warnAboutTSVersion';
@@ -17,15 +19,17 @@ const log = debug(
 );
 
 export function createParseSettings(
-  code: string,
+  code: string | ts.SourceFile,
   options: Partial<TSESTreeOptions> = {},
 ): MutableParseSettings {
+  const codeFullText = enforceCodeString(code);
   const tsconfigRootDir =
     typeof options.tsconfigRootDir === 'string'
       ? options.tsconfigRootDir
       : process.cwd();
   const parseSettings: MutableParseSettings = {
-    code: enforceString(code),
+    code,
+    codeFullText,
     comment: options.comment === true,
     comments: [],
     createDefaultProgram: options.createDefaultProgram === true,
@@ -125,12 +129,12 @@ export function createParseSettings(
 /**
  * Ensures source code is a string.
  */
-function enforceString(code: unknown): string {
-  if (typeof code !== 'string') {
-    return String(code);
-  }
-
-  return code;
+function enforceCodeString(code: unknown): string {
+  return isSourceFile(code)
+    ? code.getFullText(code)
+    : typeof code === 'string'
+    ? code
+    : String(code);
 }
 
 /**

--- a/packages/typescript-estree/src/parseSettings/index.ts
+++ b/packages/typescript-estree/src/parseSettings/index.ts
@@ -10,9 +10,14 @@ type DebugModule = 'typescript-eslint' | 'eslint' | 'typescript';
  */
 export interface MutableParseSettings {
   /**
-   * Code of the file being parsed.
+   * Code of the file being parsed, or raw source file containing it.
    */
-  code: string;
+  code: string | ts.SourceFile;
+
+  /**
+   * Full text of the file being parsed.
+   */
+  codeFullText: string;
 
   /**
    * Whether the `comment` parse option is enabled.

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -75,7 +75,7 @@ function parse<T extends TSESTreeOptions = TSESTreeOptions>(
 }
 
 function parseWithNodeMapsInternal<T extends TSESTreeOptions = TSESTreeOptions>(
-  code: string,
+  code: string | ts.SourceFile,
   options: T | undefined,
   shouldPreserveNodeMaps: boolean,
 ): ParseWithNodeMapsResult<T> {
@@ -128,7 +128,7 @@ function clearParseAndGenerateServicesCalls(): void {
 }
 
 function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
-  code: string,
+  code: string | ts.SourceFile,
   options: T,
 ): ParseAndGenerateServicesResult<T> {
   /**

--- a/packages/typescript-estree/src/source-files.ts
+++ b/packages/typescript-estree/src/source-files.ts
@@ -1,0 +1,14 @@
+import * as ts from 'typescript';
+
+export function isSourceFile(code: unknown): code is ts.SourceFile {
+  return (
+    typeof code !== 'string' &&
+    (code as Partial<ts.SourceFile> | undefined)?.kind ===
+      ts.SyntaxKind.SourceFile &&
+    !!(code as Partial<ts.SourceFile>).getFullText
+  );
+}
+
+export function getCodeText(code: string | ts.SourceFile): string {
+  return isSourceFile(code) ? code.getFullText(code) : code;
+}

--- a/packages/typescript-estree/src/source-files.ts
+++ b/packages/typescript-estree/src/source-files.ts
@@ -1,11 +1,14 @@
 import * as ts from 'typescript';
 
 export function isSourceFile(code: unknown): code is ts.SourceFile {
+  if (typeof code !== 'object' || code == null) {
+    return false;
+  }
+
+  const maybeSourceFile = code as Partial<ts.SourceFile>;
   return (
-    typeof code !== 'string' &&
-    (code as Partial<ts.SourceFile> | undefined)?.kind ===
-      ts.SyntaxKind.SourceFile &&
-    !!(code as Partial<ts.SourceFile>).getFullText
+    maybeSourceFile.kind === ts.SyntaxKind.SourceFile &&
+    typeof maybeSourceFile.getFullText === 'function'
   );
 }
 

--- a/packages/typescript-estree/tests/lib/source-files.test.ts
+++ b/packages/typescript-estree/tests/lib/source-files.test.ts
@@ -1,0 +1,18 @@
+import * as ts from 'typescript';
+
+import { isSourceFile } from '../../src/source-files';
+
+describe('isSourceFile', () => {
+  it.each([null, undefined, {}, { getFullText: (): string => '', text: '' }])(
+    `returns false when given %j`,
+    input => {
+      expect(isSourceFile(input)).toBe(false);
+    },
+  );
+
+  it('returns true when given a real source file', () => {
+    const input = ts.createSourceFile('test.ts', '', ts.ScriptTarget.ESNext);
+
+    expect(isSourceFile(input)).toBe(true);
+  });
+});

--- a/packages/typescript-estree/tests/lib/source-files.test.ts
+++ b/packages/typescript-estree/tests/lib/source-files.test.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 
-import { isSourceFile } from '../../src/source-files';
+import { getCodeText, isSourceFile } from '../../src/source-files';
 
 describe('isSourceFile', () => {
   it.each([null, undefined, {}, { getFullText: (): string => '', text: '' }])(
@@ -14,5 +14,24 @@ describe('isSourceFile', () => {
     const input = ts.createSourceFile('test.ts', '', ts.ScriptTarget.ESNext);
 
     expect(isSourceFile(input)).toBe(true);
+  });
+});
+
+describe('getCodeText', () => {
+  it('returns the code when code is provided as a string', () => {
+    const code = '// Hello world';
+
+    expect(getCodeText(code)).toBe(code);
+  });
+
+  it('returns the code when code is provided as a source file', () => {
+    const code = '// Hello world';
+    const sourceFile = ts.createSourceFile(
+      'test.ts',
+      code,
+      ts.ScriptTarget.ESNext,
+    );
+
+    expect(getCodeText(sourceFile)).toBe(code);
   });
 });

--- a/packages/website/src/components/linter/config.ts
+++ b/packages/website/src/components/linter/config.ts
@@ -2,6 +2,7 @@ import type { ParseSettings } from '@typescript-eslint/typescript-estree/dist/pa
 
 export const parseSettings: ParseSettings = {
   code: '',
+  codeFullText: '',
   comment: true,
   comments: [],
   createDefaultProgram: false,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #774
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Changes several function parameters from `code: string` to `code: string | ts.SourceFile`. Folks should now be able to pass in a source file directly, instead of the text of a file that we then have to redundantly reparse.

Targeting the `v6` branch even though this arguably isn't really a breaking change. Since this is such a core API, I'd want it to be able to benefit from the v6 testing process too.