### PR TITLE
fix(typescript-estree): don't allow single-run unless we're in type-aware linting mode

### DIFF
--- a/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
+++ b/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
@@ -15,6 +15,16 @@ import type { TSESTreeOptions } from '../parser-options';
  * @returns Whether this is part of a single run, rather than a long-running process.
  */
 export function inferSingleRun(options: TSESTreeOptions | undefined): boolean {
+  if (
+    // single-run implies type-aware linting - no projects means we can't be in single-run mode
+    options?.project == null ||
+    // programs passed via options means the user should be managing the programs, so we shouldn't
+    // be creating our own single-run programs accidentally
+    options?.programs != null
+  ) {
+    return false;
+  }
+
   // Allow users to explicitly inform us of their intent to perform a single run (or not) with TSESTREE_SINGLE_RUN
   if (process.env.TSESTREE_SINGLE_RUN === 'false') {
     return false;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5880
    - fixes https://github.com/import-js/eslint-plugin-import/issues/2496
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

This was an absolute doozy to debug!

`eslint-plugin-import` does its own out-of-band parsing for some of its lint rules (like `import/no-cycle` or `import/namespace`). It does this by reusing the config originally passed to ESLint for the currently linted file - namely the `parser` and `parserOptions` config items.

This parsing is always forced to be in non-type-aware mode thanks to some hard-coding I added to their tooling way way back (https://github.com/import-js/eslint-plugin-import/blob/c3d14cb920bdc6d277134973d37364db22c3a8b8/utils/parse.js#L79-L84). This was necessary for performance and because they often parse files not covered by a tsconfig (like `node_modules` files).

Back to the issue at hand. When we added the single-run optimisation, we had to add a fallback state for when you do `eslint --fix` - a state where we would fall out of the optimised path to handle the changed, fixed file contents with a dynamic program. The logic is simple - it just increments a counter if we're doing single-run linting, and if that counter is `> 1`, then we use the slow path:
https://github.com/typescript-eslint/typescript-eslint/blob/2ee81df5a365d82ef4b3dfc124d4ec39c7bcb725/packages/typescript-estree/src/parser.ts#L185-L203
This slow path uses a (slightly dodgy) "isolated" program for the file that's light-weight, slightly incorrect, but relatively fast to create (faster than rebuilding the programs for the tsconfig from the ground up!). Using a "dodgy" program is okay because the fixed file's contents won't ever influence the types of any other file in the workspace (by definition fixers must be safe and not break the build!).

So what is the bug?
Due to `eslint-plugin-import`'s out-of-band parsing it is possible for a file to be parsed multiple times with the second time being the eslint parse. This is an issue because unfortunately `inferSingleRun` didn't consider the case where we aren't doing type-aware linting for a file. So the bug would be:
1) lint file A
1) parse file A
    1) create a single-run program for the tsconfig
1) `eslint-plugin-import` sees A depends on B -> out-of-band parse B
    1) `parseAndGenerateServicesCalls[B] = 1`
1) lint file B
1) parse file B
    1) `parseAndGenerateServicesCalls[B] = 2`
    1) `parseSettings.singleRun === true && parseAndGenerateServicesCalls[B] > 1`, so create an isolated program for that file and use that instead of the true program for the file from (2,i)

The fix is simple - ensure we can never enter single run mode unless we're doing type-aware linting!

I don't know a good way to test this, but I confirmed that this fixes the problem by patching this change into the repro repos provided in both issues and it fixed the bug!