### PR TITLE
feat(utils): add `RuleTester` API for top-level dependency constraints

### DIFF
--- a/packages/utils/src/eslint-utils/rule-tester/RuleTester.ts
+++ b/packages/utils/src/eslint-utils/rule-tester/RuleTester.ts
@@ -146,7 +146,7 @@ class RuleTester extends BaseRuleTester.RuleTester {
         };
         (this.staticThis.describe as DescribeWithSkip).skip(name, () => {
           this.staticThis.it(
-            'All test skipped due to unsatisfied constructor dependency constraints',
+            'All tests skipped due to unsatisfied constructor dependency constraints',
             () => {},
           );
         });
@@ -154,7 +154,7 @@ class RuleTester extends BaseRuleTester.RuleTester {
         // otherwise just declare an empty test
         this.staticThis.describe(name, () => {
           this.staticThis.it(
-            'All test skipped due to unsatisfied constructor dependency constraints',
+            'All tests skipped due to unsatisfied constructor dependency constraints',
             () => {
               // some frameworks error if there are no assertions
               assert.equal(true, true);

--- a/packages/utils/src/eslint-utils/rule-tester/RuleTester.ts
+++ b/packages/utils/src/eslint-utils/rule-tester/RuleTester.ts
@@ -55,7 +55,12 @@ function isDescribeWithSkip(
 ): value is RuleTesterTestFrameworkFunction & {
   skip: RuleTesterTestFrameworkFunction;
 } {
-  return 'skip' in describe && typeof describe.skip === 'function';
+  return (
+    typeof value === 'object' &&
+    value != null &&
+    'skip' in value &&
+    typeof (value as Record<string, unknown>).skip === 'function'
+  );
 }
 
 class RuleTester extends BaseRuleTester.RuleTester {

--- a/packages/utils/src/ts-eslint/RuleTester.ts
+++ b/packages/utils/src/ts-eslint/RuleTester.ts
@@ -169,7 +169,8 @@ declare class RuleTesterBase {
    * @param text a string describing the rule
    * @param callback the test callback
    */
-  static describe?: RuleTesterTestFrameworkFunction;
+  static get describe(): RuleTesterTestFrameworkFunction;
+  static set describe(value: RuleTesterTestFrameworkFunction | undefined);
 
   /**
    * If you supply a value to this property, the rule tester will call this instead of using the version defined on
@@ -177,7 +178,8 @@ declare class RuleTesterBase {
    * @param text a string describing the test case
    * @param callback the test callback
    */
-  static it?: RuleTesterTestFrameworkFunction;
+  static get it(): RuleTesterTestFrameworkFunction;
+  static set it(value: RuleTesterTestFrameworkFunction | undefined);
 
   /**
    * If you supply a value to this property, the rule tester will call this instead of using the version defined on
@@ -185,7 +187,8 @@ declare class RuleTesterBase {
    * @param text a string describing the test case
    * @param callback the test callback
    */
-  static itOnly?: RuleTesterTestFrameworkFunction;
+  static get itOnly(): RuleTesterTestFrameworkFunction;
+  static set itOnly(value: RuleTesterTestFrameworkFunction | undefined);
 
   /**
    * Define a rule for one particular run of tests.

--- a/packages/utils/src/ts-eslint/RuleTester.ts
+++ b/packages/utils/src/ts-eslint/RuleTester.ts
@@ -125,6 +125,10 @@ interface TestCaseError<TMessageIds extends string> {
   // readonly message?: string | RegExp;
 }
 
+/**
+ * @param text a string describing the rule
+ * @param callback the test callback
+ */
 type RuleTesterTestFrameworkFunction = (
   text: string,
   callback: () => void,
@@ -166,8 +170,6 @@ declare class RuleTesterBase {
   /**
    * If you supply a value to this property, the rule tester will call this instead of using the version defined on
    * the global namespace.
-   * @param text a string describing the rule
-   * @param callback the test callback
    */
   static get describe(): RuleTesterTestFrameworkFunction;
   static set describe(value: RuleTesterTestFrameworkFunction | undefined);
@@ -175,8 +177,6 @@ declare class RuleTesterBase {
   /**
    * If you supply a value to this property, the rule tester will call this instead of using the version defined on
    * the global namespace.
-   * @param text a string describing the test case
-   * @param callback the test callback
    */
   static get it(): RuleTesterTestFrameworkFunction;
   static set it(value: RuleTesterTestFrameworkFunction | undefined);
@@ -184,16 +184,12 @@ declare class RuleTesterBase {
   /**
    * If you supply a value to this property, the rule tester will call this instead of using the version defined on
    * the global namespace.
-   * @param text a string describing the test case
-   * @param callback the test callback
    */
   static get itOnly(): RuleTesterTestFrameworkFunction;
   static set itOnly(value: RuleTesterTestFrameworkFunction | undefined);
 
   /**
    * Define a rule for one particular run of tests.
-   * @param name The name of the rule to define.
-   * @param rule The rule definition.
    */
   defineRule<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
     name: string,

--- a/packages/utils/tests/eslint-utils/rule-tester/RuleTester.test.ts
+++ b/packages/utils/tests/eslint-utils/rule-tester/RuleTester.test.ts
@@ -750,7 +750,7 @@ describe('RuleTester', () => {
         mockedDescribe.mock.lastCall?.[1]();
         expect(mockedIt.mock.lastCall).toMatchInlineSnapshot(`
           [
-            "All test skipped due to unsatisfied constructor dependency constraints",
+            "All tests skipped due to unsatisfied constructor dependency constraints",
             [Function],
           ]
         `);

--- a/packages/utils/tests/eslint-utils/rule-tester/RuleTester.test.ts
+++ b/packages/utils/tests/eslint-utils/rule-tester/RuleTester.test.ts
@@ -739,15 +739,17 @@ describe('RuleTester', () => {
           ],
         });
 
-        expect(mockedDescribe.mock.lastCall).toMatchInlineSnapshot(`
+        // trigger the describe block
+        expect(mockedDescribe.mock.calls.length).toBeGreaterThanOrEqual(1);
+        mockedDescribe.mock.lastCall?.[1]();
+        expect(mockedDescribe.mock.calls).toMatchInlineSnapshot(`
           [
-            "my-rule",
-            [Function],
+            [
+              "my-rule",
+              [Function],
+            ],
           ]
         `);
-
-        // trigger the describe block
-        mockedDescribe.mock.lastCall?.[1]();
         expect(mockedIt.mock.lastCall).toMatchInlineSnapshot(`
           [
             "All tests skipped due to unsatisfied constructor dependency constraints",
@@ -777,6 +779,27 @@ describe('RuleTester', () => {
             },
           ],
         });
+
+        // trigger the describe block
+        expect(mockedDescribe.mock.calls.length).toBeGreaterThanOrEqual(1);
+        mockedDescribe.mock.lastCall?.[1]();
+        expect(mockedDescribe.mock.calls).toMatchInlineSnapshot(`
+          [
+            [
+              "my-rule",
+              [Function],
+            ],
+            [
+              "valid",
+              [Function],
+            ],
+            [
+              "invalid",
+              [Function],
+            ],
+          ]
+        `);
+        // expect(mockedIt.mock.lastCall).toMatchInlineSnapshot(`undefined`);
       });
     });
   });

--- a/packages/utils/tests/eslint-utils/rule-tester/RuleTester.test.ts
+++ b/packages/utils/tests/eslint-utils/rule-tester/RuleTester.test.ts
@@ -73,8 +73,8 @@ RuleTester.itOnly = jest.fn();
 /* eslint-enable jest/prefer-spy-on */
 
 const mockedAfterAll = jest.mocked(RuleTester.afterAll);
-const _mockedDescribe = jest.mocked(RuleTester.describe);
-const _mockedIt = jest.mocked(RuleTester.it);
+const mockedDescribe = jest.mocked(RuleTester.describe);
+const mockedIt = jest.mocked(RuleTester.it);
 const _mockedItOnly = jest.mocked(RuleTester.itOnly);
 const runSpy = jest.spyOn(BaseRuleTester.prototype, 'run');
 const mockedParserClearCaches = jest.mocked(parser.clearCaches);
@@ -714,6 +714,70 @@ describe('RuleTester', () => {
           ],
         }
       `);
+    });
+
+    describe('constructor constraints', () => {
+      it('skips all tests if a constructor constraint is not satisifed', () => {
+        const ruleTester = new RuleTester({
+          parser: '@typescript-eslint/parser',
+          dependencyConstraints: {
+            'totally-real-dependency': '999',
+          },
+        });
+
+        ruleTester.run('my-rule', NOOP_RULE, {
+          invalid: [
+            {
+              code: 'failing - major',
+              errors: [],
+            },
+          ],
+          valid: [
+            {
+              code: 'passing - major',
+            },
+          ],
+        });
+
+        expect(mockedDescribe.mock.lastCall).toMatchInlineSnapshot(`
+          [
+            "my-rule",
+            [Function],
+          ]
+        `);
+
+        // trigger the describe block
+        mockedDescribe.mock.lastCall?.[1]();
+        expect(mockedIt.mock.lastCall).toMatchInlineSnapshot(`
+          [
+            "All test skipped due to unsatisfied constructor dependency constraints",
+            [Function],
+          ]
+        `);
+      });
+
+      it('does not skip all tests if a constructor constraint is satisifed', () => {
+        const ruleTester = new RuleTester({
+          parser: '@typescript-eslint/parser',
+          dependencyConstraints: {
+            'totally-real-dependency': '10',
+          },
+        });
+
+        ruleTester.run('my-rule', NOOP_RULE, {
+          invalid: [
+            {
+              code: 'valid',
+              errors: [],
+            },
+          ],
+          valid: [
+            {
+              code: 'valid',
+            },
+          ],
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Overview

<!-- Description of what is changed and how the code change does that. -->
As I continued working on #5573, I realised that there are some plugin rules that won't ever work on old versions of TS.
For example `consistent-type-imports` hard requires at least TS 4.1 as that was the first version where the required syntax was added.

This PR adds a new API to the rule tester that allows you to list a set of dependency constraints for all tests in the rule tester constructor. If the constraints don't pass then absolutely no tests are run.