### PR TITLE
fix(ast-spec): correct misnamed ExportNamedDeclaration AST type

### DIFF
--- a/packages/ast-spec/src/declaration/ExportNamedDeclaration/spec.ts
+++ b/packages/ast-spec/src/declaration/ExportNamedDeclaration/spec.ts
@@ -46,7 +46,7 @@ export interface ExportNamedDeclarationWithoutSourceWithMultiple
   extends ExportNamedDeclarationBase {
   // this will always be empty array
   assertions: ImportAttribute[];
-  declaration: NamedExportDeclarations;
+  declaration: null;
   source: null;
   specifiers: ExportSpecifier[];
 }
@@ -55,7 +55,7 @@ export interface ExportNamedDeclarationWithoutSourceWithSingle
   extends ExportNamedDeclarationBase {
   // this will always be empty array
   assertions: ImportAttribute[];
-  declaration: null;
+  declaration: NamedExportDeclarations;
   source: null;
   // this will always be empty array
   specifiers: ExportSpecifier[];


### PR DESCRIPTION
## Overview

<!-- Description of what is changed and how the code change does that. -->
The props were the correct sets - but they didn't match the names of the interfaces.