### PR TITLE
feat: bump minimum supported TS version to 4.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,22 +51,36 @@ The latest version under the `canary` tag **(latest commit to `main`)** is:
 
 ### Supported TypeScript Version
 
-**The version range of TypeScript currently supported by this parser is `>=3.3.1 <4.9.0`.**
+**The version range of TypeScript currently supported by this parser is `>=4.2.0 <4.9.0`.**
 
-These versions are what we test against.
+Note that we mirror [DefinitelyTyped's version support window](https://github.com/DefinitelyTyped/DefinitelyTyped/#support-window) - meaning we only support versions of TypeScript less than 2 years old.
 
-We will always endeavor to support the latest stable version of TypeScript.
-Sometimes, but not always, changes in TypeScript will not require breaking changes in this project, and so we are able to support more than one version of TypeScript.
-In some cases, we may even be able to support additional pre-releases (i.e. betas and release candidates) of TypeScript, but only if doing so does not require us to compromise on support for the latest stable version.
+You may find that our tooling works on older TypeScript versions however we provide no guarantees and **_we will not accept issues against unsupported versions_**.
+
+#### Supporting New TypeScript Releases
+
+With each new TypeScript release we file an issue to track the changes in the new version. The issue should always be pinned, and you can also [find the issues by searching for issues tagged with "New TypeScript Version"](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+label%3A%22New+TypeScript+Version%22+sort%3Acreated-desc). If the issue is open, we do not have official support yet - please be patient.
+
+In terms of what versions we support:
+
+- We do not support the `beta` releases.
+- We _generally_ do not officially support the `rc` releases.
+- We endeavour to support the latest stable TypeScript versions as soon as possible after the release.
+
+Generally we will begin working on supporting the next release when the `rc` version is released.
+
+#### Version Warning Logs
 
 Note that our packages have an open `peerDependency` requirement in order to allow for experimentation on newer/beta versions of TypeScript.
 
-If you use a non-supported version of TypeScript, the parser will log a warning to the console.
+However if you use a non-supported version of TypeScript, the parser will log a warning to the console.
 If you want to disable this warning, you can configure this in your `parserOptions`. See: [`@typescript-eslint/parser`](./packages/parser/) and [`@typescript-eslint/typescript-estree`](./packages/typescript-estree/).
 
 **Please ensure that you are using a supported version before submitting any issues/bug reports.**
 
 ### Supported ESLint Version
+
+We endeavour to support the latest stable ESLint versions as soon as possible after the release.
 
 See the value of `eslint` declared in `@typescript-eslint/eslint-plugin`'s [package.json](./packages/eslint-plugin/package.json).
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In terms of what versions we support:
 
 - We do not support the `beta` releases.
 - We _generally_ do not officially support the `rc` releases.
-- We endeavour to support the latest stable TypeScript versions as soon as possible after the release.
+- We endeavor to support the latest stable TypeScript versions as soon as possible after the release.
 
 Generally we will begin working on supporting the next release when the `rc` version is released.
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "tmp": "^0.2.1",
     "ts-node": "^10.7.0",
     "tslint": "^6.1.3",
-    "typescript": ">=3.3.1 <4.9.0"
+    "typescript": ">=4.2.4 <4.9.0"
   },
   "resolutions": {
     "typescript": "~4.8.3",

--- a/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
@@ -1,5 +1,4 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import * as util from '../util';
 

--- a/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-asserted-optional-chain.ts
@@ -1,17 +1,7 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
-import * as semver from 'semver';
-import * as ts from 'typescript';
 
 import * as util from '../util';
-
-const is3dot9 = semver.satisfies(
-  ts.version,
-  `>= 3.9.0 || >= 3.9.1-rc || >= 3.9.0-beta`,
-  {
-    includePrerelease: true,
-  },
-);
 
 export default util.createRule({
   name: 'no-non-null-asserted-optional-chain',
@@ -32,16 +22,7 @@ export default util.createRule({
   },
   defaultOptions: [],
   create(context) {
-    // TS3.9 made a breaking change to how non-null works with optional chains.
-    // Pre-3.9,  `x?.y!.z` means `(x?.y).z` - i.e. it essentially scrubbed the optionality from the chain
-    // Post-3.9, `x?.y!.z` means `x?.y!.z`  - i.e. it just asserts that the property `y` is non-null, not the result of `x?.y`.
-    // This means that for > 3.9, x?.y!.z is valid!
-    //
-    // NOTE: these cases are still invalid for 3.9:
-    // - x?.y.z!
-    // - (x?.y)!.z
-
-    const baseSelectors = {
+    return {
       // non-nulling a wrapped chain will scrub all nulls introduced by the chain
       // (x?.y)!
       // (x?.())!
@@ -74,63 +55,6 @@ export default util.createRule({
       'ChainExpression > TSNonNullExpression'(
         node: TSESTree.TSNonNullExpression,
       ): void {
-        context.report({
-          node,
-          messageId: 'noNonNullOptionalChain',
-          // use a suggestion instead of a fixer, because this can obviously break type checks
-          suggest: [
-            {
-              messageId: 'suggestRemovingNonNull',
-              fix(fixer): TSESLint.RuleFix {
-                return fixer.removeRange([node.range[1] - 1, node.range[1]]);
-              },
-            },
-          ],
-        });
-      },
-    };
-
-    if (is3dot9) {
-      return baseSelectors;
-    }
-
-    return {
-      ...baseSelectors,
-      [[
-        // > :not(ChainExpression) because that case is handled by a previous selector
-        'MemberExpression > TSNonNullExpression.object > :not(ChainExpression)',
-        'CallExpression > TSNonNullExpression.callee > :not(ChainExpression)',
-      ].join(', ')](child: TSESTree.Node): void {
-        // selector guarantees this assertion
-        const node = child.parent as TSESTree.TSNonNullExpression;
-
-        let current = child;
-        while (current) {
-          switch (current.type) {
-            case AST_NODE_TYPES.MemberExpression:
-              if (current.optional) {
-                // found an optional chain! stop traversing
-                break;
-              }
-
-              current = current.object;
-              continue;
-
-            case AST_NODE_TYPES.CallExpression:
-              if (current.optional) {
-                // found an optional chain! stop traversing
-                break;
-              }
-
-              current = current.callee;
-              continue;
-
-            default:
-              // something that's not a ChainElement, which means this is not an optional chain we want to check
-              return;
-          }
-        }
-
         context.report({
           node,
           messageId: 'noNonNullOptionalChain',

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts
@@ -1,7 +1,5 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
-import * as semver from 'semver';
-import * as ts from 'typescript';
 
 import * as util from '../util';
 
@@ -12,20 +10,6 @@ type TypeParameterWithConstraint = MakeRequired<
   TSESTree.TSTypeParameter,
   'constraint'
 >;
-
-const is3dot5 = semver.satisfies(
-  ts.version,
-  `>= 3.5.0 || >= 3.5.1-rc || >= 3.5.0-beta`,
-  {
-    includePrerelease: true,
-  },
-);
-
-const is3dot9 =
-  is3dot5 &&
-  semver.satisfies(ts.version, `>= 3.9.0 || >= 3.9.1-rc || >= 3.9.0-beta`, {
-    includePrerelease: true,
-  });
 
 export default util.createRule({
   name: 'no-unnecessary-type-constraint',
@@ -46,19 +30,13 @@ export default util.createRule({
   },
   defaultOptions: [],
   create(context) {
-    if (!is3dot5) {
-      return {};
-    }
-
     // In theory, we could use the type checker for more advanced constraint types...
     // ...but in practice, these types are rare, and likely not worth requiring type info.
     // https://github.com/typescript-eslint/typescript-eslint/pull/2516#discussion_r495731858
-    const unnecessaryConstraints = is3dot9
-      ? new Map([
-          [AST_NODE_TYPES.TSAnyKeyword, 'any'],
-          [AST_NODE_TYPES.TSUnknownKeyword, 'unknown'],
-        ])
-      : new Map([[AST_NODE_TYPES.TSUnknownKeyword, 'unknown']]);
+    const unnecessaryConstraints = new Map([
+      [AST_NODE_TYPES.TSAnyKeyword, 'any'],
+      [AST_NODE_TYPES.TSUnknownKeyword, 'unknown'],
+    ]);
 
     const inJsx = context.getFilename().toLowerCase().endsWith('tsx');
     const source = context.getSourceCode();

--- a/packages/eslint-plugin/tests/rules/no-non-null-asserted-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-non-null-asserted-optional-chain.test.ts
@@ -17,7 +17,6 @@ ruleTester.run('no-non-null-asserted-optional-chain', rule, {
     'foo?.bar();',
     '(foo?.bar).baz!;',
     '(foo?.bar()).baz!;',
-    // Valid as of 3.9
     'foo?.bar!.baz;',
     'foo?.bar!();',
     "foo?.['bar']!.baz;",

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -33,7 +33,6 @@ import type {
 import type { SemanticOrSyntacticError } from './semantic-or-syntactic-errors';
 import type { TSESTree, TSESTreeToTSNode, TSNode } from './ts-estree';
 import { AST_NODE_TYPES } from './ts-estree';
-import { typescriptVersionIsAtLeast } from './version-check';
 
 const SyntaxKind = ts.SyntaxKind;
 
@@ -2151,13 +2150,6 @@ export class Converter {
         });
 
       case SyntaxKind.NullKeyword: {
-        if (!typescriptVersionIsAtLeast['4.0'] && this.inTypeMode) {
-          // 4.0 started nesting null types inside a LiteralType node, but we still need to support pre-4.0
-          return this.createNode<TSESTree.TSNullKeyword>(node, {
-            type: AST_NODE_TYPES.TSNullKeyword,
-          });
-        }
-
         return this.createNode<TSESTree.NullLiteral>(node, {
           type: AST_NODE_TYPES.Literal,
           value: null,
@@ -2769,10 +2761,7 @@ export class Converter {
         });
       }
       case SyntaxKind.LiteralType: {
-        if (
-          typescriptVersionIsAtLeast['4.0'] &&
-          node.literal.kind === SyntaxKind.NullKeyword
-        ) {
+        if (node.literal.kind === SyntaxKind.NullKeyword) {
           // 4.0 started nesting null types inside a LiteralType node
           // but our AST is designed around the old way of null being a keyword
           return this.createNode<TSESTree.TSNullKeyword>(

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -1,6 +1,5 @@
 import debug from 'debug';
 import fs from 'fs';
-import semver from 'semver';
 import * as ts from 'typescript';
 
 import type { ParseSettings } from '../parseSettings';
@@ -249,10 +248,6 @@ function getProgramsForProjects(parseSettings: ParseSettings): ts.Program[] {
   return results;
 }
 
-const isRunningNoTimeoutFix = semver.satisfies(ts.version, '>=3.9.0-beta', {
-  includePrerelease: true,
-});
-
 function createWatchProgram(
   tsconfigPath: string,
   parseSettings: ParseSettings,
@@ -363,34 +358,9 @@ function createWatchProgram(
 
   // Since we don't want to asynchronously update program we want to disable timeout methods
   // So any changes in the program will be delayed and updated when getProgram is called on watch
-  let callback: (() => void) | undefined;
-  if (isRunningNoTimeoutFix) {
-    watchCompilerHost.setTimeout = undefined;
-    watchCompilerHost.clearTimeout = undefined;
-  } else {
-    log('Running without timeout fix');
-    // But because of https://github.com/microsoft/TypeScript/pull/37308 we cannot just set it to undefined
-    // instead save it and call before getProgram is called
-    watchCompilerHost.setTimeout = (cb, _ms, ...args: unknown[]): unknown => {
-      callback = cb.bind(/*this*/ undefined, ...args);
-      return callback;
-    };
-    watchCompilerHost.clearTimeout = (): void => {
-      callback = undefined;
-    };
-  }
-  const watch = ts.createWatchProgram(watchCompilerHost);
-  if (!isRunningNoTimeoutFix) {
-    const originalGetProgram = watch.getProgram;
-    watch.getProgram = (): ts.BuilderProgram => {
-      if (callback) {
-        callback();
-      }
-      callback = undefined;
-      return originalGetProgram.call(watch);
-    };
-  }
-  return watch;
+  watchCompilerHost.setTimeout = undefined;
+  watchCompilerHost.clearTimeout = undefined;
+  return ts.createWatchProgram(watchCompilerHost);
 }
 
 function hasTSConfigChanged(tsconfigPath: CanonicalPath): boolean {

--- a/packages/typescript-estree/src/parseSettings/warnAboutTSVersion.ts
+++ b/packages/typescript-estree/src/parseSettings/warnAboutTSVersion.ts
@@ -6,7 +6,7 @@ import type { ParseSettings } from './index';
  * This needs to be kept in sync with the top-level README.md in the
  * typescript-eslint monorepo
  */
-const SUPPORTED_TYPESCRIPT_VERSIONS = '>=3.3.1 <4.9.0';
+const SUPPORTED_TYPESCRIPT_VERSIONS = '>=4.2.4 <4.9.0';
 
 /*
  * The semver package will ignore prerelease ranges, and we don't want to explicitly document every one

--- a/packages/typescript-estree/src/version-check.ts
+++ b/packages/typescript-estree/src/version-check.ts
@@ -12,11 +12,7 @@ function semverCheck(version: string): boolean {
 }
 
 const versions = [
-  '3.7',
-  '3.8',
-  '3.9',
-  '4.0',
-  '4.1',
+  //
   '4.2',
   '4.3',
   '4.4',
@@ -24,6 +20,8 @@ const versions = [
   '4.6',
   '4.7',
   '4.8',
+  '4.9',
+  '5.0',
 ] as const;
 type Versions = typeof versions extends ArrayLike<infer U> ? U : never;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13622,7 +13622,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*, "typescript@>=3.3.1 <4.9.0", "typescript@^3 || ^4", typescript@next, typescript@~4.8.3, typescript@~4.8.4:
+typescript@*, "typescript@>=4.2.4 <4.9.0", "typescript@^3 || ^4", typescript@next, typescript@~4.8.3, typescript@~4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==


### PR DESCRIPTION
BREAKING CHANGE:
Bumps the minimum supported range and removes handling for old versions

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5914, fixes #2521, closes #5367
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
DT hasn't bumped to 4.2 yet, but it's only just ticked to november, so I'd expect them to do it soon - likely before we do the major release.

This PR:
- updates docs to clarify our version support windows
- bumps the ranges around the place
- removes no-longer-necessary checks for now outdated versions