### PR TITLE
fix(eslint-plugin): [no-empty-interface] disable autofix for declaration merging with class

### DIFF
--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -85,7 +85,7 @@ export default util.createRule<Options, MessageIds>({
               }
             }
 
-            // Not suggest if the interface declaration merged with class declarations.
+            // Checks if the interface declaration is merged with class declarations.
             const defs = scope.set.get(node.id.name)?.defs;
             if (
               defs?.some(

--- a/packages/eslint-plugin/tests/rules/no-empty-interface.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-empty-interface.test.ts
@@ -59,6 +59,26 @@ interface Bar extends Foo {}
     {
       code: `
 interface Foo {
+  props: string;
+}
+
+interface Bar extends Foo {}
+
+class Bar {}
+      `,
+      options: [{ allowSingleExtends: false }],
+      errors: [
+        {
+          messageId: 'noEmptyWithSuper',
+          line: 6,
+          column: 11,
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+interface Foo {
   name: string;
 }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5273
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
