### PR TITLE
docs: use consistent auto-fixable rule emoji

### DIFF
--- a/packages/website/src/theme/MDXComponents/RuleAttributes.tsx
+++ b/packages/website/src/theme/MDXComponents/RuleAttributes.tsx
@@ -62,7 +62,7 @@ export function RuleAttributes({ name }: { name: string }): React.ReactNode {
           .
         </>
       ),
-      emoji: '🛠',
+      emoji: '🔧',
     });
   }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The typescript rules [index](https://typescript-eslint.io/rules/) uses the wrench 🔧 emoji for auto-fixable rules, as do MANY other ESLint plugins (including many that use [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator)):
* [eslint-plugin-ava](https://github.com/avajs/eslint-plugin-ava#rules)
* [eslint-plugin-ember](https://github.com/ember-cli/eslint-plugin-ember#-rules)
* [eslint-plugin-eslint-plugin](https://github.com/eslint-community/eslint-plugin-eslint-plugin#rules)
* [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import#rules)
* [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#supported-rules)
* [eslint-plugin-promise](https://github.com/eslint-community/eslint-plugin-promise#rules)
* [eslint-plugin-qunit](https://github.com/platinumazure/eslint-plugin-qunit#rules)
* [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#list-of-supported-rules)
* [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn#rules)

However, the typescript rule doc notice was using an inconsistent emoji 🛠 for the same intended auto-fixable meaning. I am fixing that inconsistency.