### PR TITLE
feat(utils): remove obsolete `meta.docs.suggestion` rule type

### DIFF
--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -23,10 +23,6 @@ interface RuleMetaDataDocs {
    */
   url?: string;
   /**
-   * Specifies whether the rule can return suggestions.
-   */
-  suggestion?: boolean;
-  /**
    * Does the rule require us to create a full TypeScript Program in order for it
    * to type-check code. This is only used for documentation purposes.
    */


### PR DESCRIPTION
BREAKING CHANGE:
Removes `meta.docs.suggestion` property

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
`meta.docs.suggestion` was replaced by `meta.hasSuggestions` as of ESLint v8: https://github.com/eslint/eslint/pull/14573

The old property was never used for anything, while the presence of the new property is [enforced](https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0#suggestions) by ESLint when a rule provides suggestions.

It's confusing to leave the old, redundant property in place, so I have removed it here.

We can remove the old type as a breaking change in the upcoming v6 release.