### PR TITLE
chore: enable `eslint-plugin/require-meta-docs-description` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -257,6 +257,11 @@ module.exports = {
         './packages/eslint-plugin/src/rules/**/*.ts',
       ],
       rules: {
+        'eslint-plugin/require-meta-docs-description': [
+          'error',
+          { pattern: '^(Enforce|Require|Disallow) .+[^. ]$' },
+        ],
+
         // specifically for rules - default exports makes the tooling easier
         'import/no-default-export': 'off',
       },

--- a/packages/eslint-plugin-internal/src/rules/no-poorly-typed-ts-props.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-poorly-typed-ts-props.ts
@@ -35,7 +35,7 @@ export default createRule({
     type: 'problem',
     docs: {
       description:
-        "Enforces rules don't use TS API properties with known bad type definitions",
+        "Enforce that rules don't use TS API properties with known bad type definitions",
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin-internal/src/rules/no-typescript-default-import.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-typescript-default-import.ts
@@ -20,7 +20,7 @@ export default createRule({
     type: 'problem',
     docs: {
       description:
-        "Enforces that packages rules don't do `import ts from 'typescript';`",
+        "Enforce that packages rules don't do `import ts from 'typescript';`",
       recommended: 'error',
     },
     fixable: 'code',

--- a/packages/eslint-plugin-internal/src/rules/no-typescript-estree-import.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-typescript-estree-import.ts
@@ -15,7 +15,7 @@ export default createRule({
   meta: {
     type: 'problem',
     docs: {
-      description: `Enforces that eslint-plugin rules don't require anything from ${TSESTREE_NAME} or ${TYPES_NAME}`,
+      description: `Enforce that eslint-plugin rules don't require anything from ${TSESTREE_NAME} or ${TYPES_NAME}`,
       recommended: 'error',
     },
     fixable: 'code',

--- a/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
+++ b/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
@@ -107,7 +107,7 @@ export default createRule<Options, MessageIds>({
   meta: {
     type: 'problem',
     docs: {
-      description: `Enforces that eslint-plugin test snippets are correctly formatted`,
+      description: `Enforce that eslint-plugin test snippets are correctly formatted`,
       recommended: 'error',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin-internal/src/rules/prefer-ast-types-enum.ts
+++ b/packages/eslint-plugin-internal/src/rules/prefer-ast-types-enum.ts
@@ -15,7 +15,7 @@ export default createRule({
     docs: {
       recommended: 'error',
       description:
-        'Ensures consistent usage of `AST_NODE_TYPES`, `AST_TOKEN_TYPES` and `DefinitionType` enums.',
+        'Enforce consistent usage of `AST_NODE_TYPES`, `AST_TOKEN_TYPES` and `DefinitionType` enums',
     },
     messages: {
       preferEnum: 'Prefer {{ enumName }}.{{ literal }} over raw literal',

--- a/packages/eslint-plugin-tslint/src/rules/config.ts
+++ b/packages/eslint-plugin-tslint/src/rules/config.ts
@@ -64,7 +64,7 @@ export default createRule<Options, MessageIds>({
   meta: {
     docs: {
       description:
-        'Wraps a TSLint configuration and lints the whole source using TSLint',
+        'Wraps a TSLint configuration and lints the whole source using TSLint', // eslint-disable-line eslint-plugin/require-meta-docs-description
       recommended: false,
     },
     fixable: 'code',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Enable this optional rule for rule source files internally: https://github.com/eslint-community/eslint-plugin-eslint-plugin/blob/main/docs/rules/require-meta-docs-description.md


Same change in ESLint recently: https://github.com/eslint/eslint/pull/16529