### PR TITLE
docs(eslint-plugin): [sort-type-union-intersection-members] fix link to new rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.md
+++ b/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.md
@@ -8,7 +8,7 @@ description: 'Enforce members of a type union/intersection to be sorted alphabet
 
 :::danger Deprecated
 
-This rule has been renamed to [`sort-type-union-intersection-members`](./sort-type-union-intersection-members.md).
+This rule has been renamed to [`sort-type-constituents`](./sort-type-constituents.md).
 :::
 
 Sorting union (`|`) and intersection (`&`) types can help:


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/5963
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview
Replaces the incorrect link that currently links to the rule itself with the link to the rule that replaced it.
