### PR TITLE
chore(website): fix TSLint.md link casing in PACKAGES.md

### DIFF
--- a/docs/development/architecture/PACKAGES.md
+++ b/docs/development/architecture/PACKAGES.md
@@ -66,7 +66,7 @@ Any custom rules you write generally will be as well.
 [`@typescript-eslint/eslint-plugin-tslint`] is a separate ESLint plugin that allows running TSLint rules within ESLint to help you migrate from TSLint to ESLint.
 
 :::caution
-**TSLint is deprecated.** It is in your best interest to migrate off it. See [Linting > Troubleshooting & FAQs > What About TSLint?](../../linting/troubleshooting/TSLINT.md).
+**TSLint is deprecated.** It is in your best interest to migrate off it. See [Linting > Troubleshooting & FAQs > What About TSLint?](../../linting/troubleshooting/TSLint.md).
 :::
 
 [`@typescript-eslint/eslint-plugin-tslint`]: https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin-tslint


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5975
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Fixes the text's link casing to be the same as on disk.