### PR TITLE
feat(eslint-plugin): [keyword-spacing] Support spacing in import-type syntax

### DIFF
--- a/packages/eslint-plugin/tests/rules/keyword-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/keyword-spacing.test.ts
@@ -12,8 +12,8 @@ import { RuleTester } from '../RuleTester';
 // Helpers
 //------------------------------------------------------------------------------
 
-const BOTH = { before: true, after: true };
-const NEITHER = { before: false, after: false };
+const BOTH: Options[0] = { before: true, after: true };
+const NEITHER: Options[0] = { before: false, after: false };
 
 /**
  * Creates an option object to test an 'overrides' option.
@@ -114,6 +114,16 @@ ruleTester.run('keyword-spacing', rule, {
       options: [{ overrides: { as: {} } }],
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
+    // {
+    //   code: 'import type { foo } from "foo";',
+    //   options: [{ overrides: { as: {} } }],
+    //   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    // },
+    // {
+    //   code: 'import type * as Foo from \'foo\'',
+    //   options: [{ overrides: { as: {} } }],
+    //   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    // },
   ],
   invalid: [
     //----------------------------------------------------------------------
@@ -151,6 +161,34 @@ ruleTester.run('keyword-spacing', rule, {
       options: [{ overrides: { as: {} } }],
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
       errors: expectedAfter('as'),
+    },
+    {
+      code: 'import type{ foo } from "foo";',
+      output: 'import type { foo } from "foo";',
+      options: [{ after: true, before: true }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ messageId: 'expectedBefore', data: { value: '{' } }],
+    },
+    {
+      code: 'import type { foo } from"foo";',
+      output: 'import type{ foo } from"foo";',
+      options: [{ after: false, before: true }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ messageId: 'unexpectedBefore', data: { value: '{' } }],
+    },
+    {
+      code: 'import type* as foo from "foo";',
+      output: 'import type * as foo from "foo";',
+      options: [{ after: true, before: true }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ messageId: 'expectedBefore', data: { value: '*' } }],
+    },
+    {
+      code: 'import type * as foo from"foo";',
+      output: 'import type* as foo from"foo";',
+      options: [{ after: false, before: true }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+      errors: [{ messageId: 'unexpectedBefore', data: { value: '*' } }],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/keyword-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/keyword-spacing.test.ts
@@ -114,16 +114,16 @@ ruleTester.run('keyword-spacing', rule, {
       options: [{ overrides: { as: {} } }],
       parserOptions: { ecmaVersion: 6, sourceType: 'module' },
     },
-    // {
-    //   code: 'import type { foo } from "foo";',
-    //   options: [{ overrides: { as: {} } }],
-    //   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    // },
-    // {
-    //   code: 'import type * as Foo from \'foo\'',
-    //   options: [{ overrides: { as: {} } }],
-    //   parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-    // },
+    {
+      code: 'import type { foo } from "foo";',
+      options: [{ overrides: { as: {} } }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
+    {
+      code: "import type * as Foo from 'foo'",
+      options: [{ overrides: { as: {} } }],
+      parserOptions: { ecmaVersion: 6, sourceType: 'module' },
+    },
   ],
   invalid: [
     //----------------------------------------------------------------------

--- a/packages/eslint-plugin/tests/rules/keyword-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/keyword-spacing.test.ts
@@ -12,8 +12,8 @@ import { RuleTester } from '../RuleTester';
 // Helpers
 //------------------------------------------------------------------------------
 
-const BOTH: Options[0] = { before: true, after: true };
-const NEITHER: Options[0] = { before: false, after: false };
+const BOTH = { before: true, after: true };
+const NEITHER = { before: false, after: false };
 
 /**
  * Creates an option object to test an 'overrides' option.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5362
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Add a space between `type` token and `*` or `{` tokens when `after` option is true, and remove when `after` is false