### PR TITLE
feat: raise tsconfig target to ES2021

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,8 +13,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2017",
-    "lib": ["es2017"],
+    "target": "ES2021",
+    "lib": ["ES2021"],
     "paths": {}
   }
 }


### PR DESCRIPTION
BREAKING CHANGE:
Updates the internal TSConfig target to ES2021.

Fixes #5980.

I didn't see any other production files to update this in. All the other `tsconfig.json` files present are test fixtures. Let me know if we should update those too.

Potential breaking change targeting v6 (#5886).