### PR TITLE
chore(website): [prefer-nullish-coalescing] explicit notice for strictNullChecks

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
@@ -11,6 +11,10 @@ Because the nullish coalescing operator _only_ coalesces when the original value
 
 This rule reports when an `||` operator can be safely replaced with a `??`.
 
+:::caution
+This rule will not work as expected if [`strictNullChecks`](https://www.typescriptlang.org/tsconfig#strictNullChecks) is not enabled.
+:::
+
 ## Options
 
 ### `ignoreTernaryTests`


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5748
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR adds a line to the `prefer-nullish-coalescing` docs letting the reader know the rule will not work as intended if `strict-null-checks` is not enabled.
