### PR TITLE
fix(eslint-plugin): [prefer-optional-chain] handle binary expressions in negated or

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -407,6 +407,10 @@ export default util.createRule({
             propertyText = getMemberExpressionText(node.property);
             break;
 
+          case AST_NODE_TYPES.BinaryExpression:
+            propertyText = sourceCode.getText(node.property);
+            break;
+
           /* istanbul ignore next */
           default:
             throw new Error(

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -400,15 +400,12 @@ export default util.createRule({
 
           case AST_NODE_TYPES.Literal:
           case AST_NODE_TYPES.TemplateLiteral:
+          case AST_NODE_TYPES.BinaryExpression:
             propertyText = sourceCode.getText(node.property);
             break;
 
           case AST_NODE_TYPES.MemberExpression:
             propertyText = getMemberExpressionText(node.property);
-            break;
-
-          case AST_NODE_TYPES.BinaryExpression:
-            propertyText = sourceCode.getText(node.property);
             break;
 
           /* istanbul ignore next */

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain.test.ts
@@ -198,6 +198,8 @@ ruleTester.run('prefer-optional-chain', rule, {
     'foo && foo[bar as string] && foo[bar as string].baz;',
     'foo && foo[1 + 2] && foo[1 + 2].baz;',
     'foo && foo[typeof bar] && foo[typeof bar].baz;',
+    '!foo[1 + 1] || !foo[1 + 2];',
+    '!foo[1 + 1] || !foo[1 + 1].foo;',
     '!foo || !foo[bar as string] || !foo[bar as string].baz;',
     '!foo || !foo[1 + 2] || !foo[1 + 2].baz;',
     '!foo || !foo[typeof bar] || !foo[typeof bar].baz;',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5991
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I'm not sure why the default switch case is to throw instead of ignoring the code 😢 
~The issue was not yet triaged but I opened a PR just in case~