### PR TITLE
fix(eslint-plugin) [array-type] --fix flag removes parentheses from type

### DIFF
--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -252,8 +252,7 @@ export default util.createRule<Options, MessageIds>({
         }
 
         const type = typeParams[0];
-        const typeParens =
-          !util.isParenthesized(type, sourceCode) && typeNeedsParentheses(type);
+        const typeParens = typeNeedsParentheses(type);
         const parentParens =
           readonlyPrefix &&
           node.parent?.type === AST_NODE_TYPES.TSArrayType &&

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -1983,6 +1983,61 @@ class Foo<T = Bar[][]> extends Bar<T, T[]> implements Baz<T[]> {
       `,
     );
     testOutput(
+      'array',
+      `
+interface WorkingArray {
+  outerProperty: Array<
+    { innerPropertyOne: string } & { innerPropertyTwo: string }
+  >;
+}
+
+interface BrokenArray {
+  outerProperty: Array<
+    ({ innerPropertyOne: string } & { innerPropertyTwo: string })
+  >;
+}
+      `,
+      `
+interface WorkingArray {
+  outerProperty: ({ innerPropertyOne: string } & { innerPropertyTwo: string })[];
+}
+
+interface BrokenArray {
+  outerProperty: ({ innerPropertyOne: string } & { innerPropertyTwo: string })[];
+}
+      `,
+    );
+    testOutput(
+      'array',
+      `
+type WorkingArray = {
+  outerProperty: Array<
+    { innerPropertyOne: string } & { innerPropertyTwo: string }
+  >;
+}
+
+type BrokenArray = {
+  outerProperty: Array<
+    ({ innerPropertyOne: string } & { innerPropertyTwo: string })
+  >;
+}
+      `,
+      `
+type WorkingArray = {
+  outerProperty: ({ innerPropertyOne: string } & { innerPropertyTwo: string })[];
+}
+
+type BrokenArray = {
+  outerProperty: ({ innerPropertyOne: string } & { innerPropertyTwo: string })[];
+}
+      `,
+    );
+    testOutput(
+      'array',
+      'const a: Array<(string|number)>;',
+      'const a: (string|number)[];',
+    );
+    testOutput(
       'array-simple',
       'let xx: Array<Array<number>> = [[1, 2], [3]];',
       'let xx: number[][] = [[1, 2], [3]];',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #5941
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Array type with intersection that has parentheses does not retain the parens. Remove an unnecessary check since the type node doesn't include parens.
