### PR TITLE
feat(eslint-plugin): [adjacent-overload-signatures] check BlockStatement nodes

### DIFF
--- a/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
+++ b/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
@@ -8,7 +8,8 @@ type RuleNode =
   | TSESTree.Program
   | TSESTree.TSModuleBlock
   | TSESTree.TSTypeLiteral
-  | TSESTree.TSInterfaceBody;
+  | TSESTree.TSInterfaceBody
+  | TSESTree.BlockStatement;
 type Member =
   | TSESTree.ClassElement
   | TSESTree.ProgramStatement
@@ -121,6 +122,7 @@ export default util.createRule({
         case AST_NODE_TYPES.Program:
         case AST_NODE_TYPES.TSModuleBlock:
         case AST_NODE_TYPES.TSInterfaceBody:
+        case AST_NODE_TYPES.BlockStatement:
           return node.body;
 
         case AST_NODE_TYPES.TSTypeLiteral:
@@ -172,6 +174,7 @@ export default util.createRule({
       TSModuleBlock: checkBodyForOverloadMethods,
       TSTypeLiteral: checkBodyForOverloadMethods,
       TSInterfaceBody: checkBodyForOverloadMethods,
+      BlockStatement: checkBodyForOverloadMethods,
     };
   },
 });

--- a/packages/eslint-plugin/tests/rules/adjacent-overload-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/adjacent-overload-signatures.test.ts
@@ -252,6 +252,21 @@ class Test {
   '#private'(arg: number): void {}
 }
     `,
+    // block statement
+    `
+function wrap() {
+  function foo(s: string);
+  function foo(n: number);
+  function foo(sn: string | number) {}
+}
+    `,
+    `
+if (true) {
+  function foo(s: string);
+  function foo(n: number);
+  function foo(sn: string | number) {}
+}
+    `,
   ],
   invalid: [
     {
@@ -259,8 +274,27 @@ class Test {
 function wrap() {
   function foo(s: string);
   function foo(n: number);
-  export type bar = number;
+  type bar = number;
   function foo(sn: string | number) {}
+}
+      `,
+      errors: [
+        {
+          messageId: 'adjacentSignature',
+          data: { name: 'foo' },
+          line: 6,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+if (true) {
+  function foo(s: string);
+  function foo(n: number);
+  let a = 1;
+  function foo(sn: string | number) {}
+  foo(a);
 }
       `,
       errors: [

--- a/packages/eslint-plugin/tests/rules/adjacent-overload-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/adjacent-overload-signatures.test.ts
@@ -256,6 +256,24 @@ class Test {
   invalid: [
     {
       code: `
+function wrap() {
+  function foo(s: string);
+  function foo(n: number);
+  export type bar = number;
+  function foo(sn: string | number) {}
+}
+      `,
+      errors: [
+        {
+          messageId: 'adjacentSignature',
+          data: { name: 'foo' },
+          line: 6,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
 export function foo(s: string);
 export function foo(n: number);
 export function bar(): void {}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Overloaded function declarations can also appear in BlockStatements and should be checked.