### PR TITLE
fix(typescript-estree): don't consider a cached program unless it's specified in the current `parserOptions.project` config

### DIFF
--- a/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
@@ -1,14 +1,11 @@
-import path from 'path';
-
 import rule from '../../src/rules/non-nullable-type-assertion-style';
-import { RuleTester } from '../RuleTester';
+import { getFixturesRootDir, RuleTester } from '../RuleTester';
 
-const rootDir = path.resolve(__dirname, '../fixtures/');
 const ruleTester = new RuleTester({
   parserOptions: {
     sourceType: 'module',
-    tsconfigRootDir: rootDir,
-    project: './tsconfig.noUncheckedIndexedAccess.json',
+    tsconfigRootDir: getFixturesRootDir(),
+    project: './tsconfig.json',
   },
   parser: '@typescript-eslint/parser',
 });
@@ -61,35 +58,6 @@ const x = 1 as 1;
     `
 declare function foo<T = any>(): T;
 const bar = foo() as number;
-    `,
-    `
-function first<T>(array: ArrayLike<T>): T | null {
-  return array.length > 0 ? (array[0] as T) : null;
-}
-    `,
-    `
-function first<T extends string | null>(array: ArrayLike<T>): T | null {
-  return array.length > 0 ? (array[0] as T) : null;
-}
-    `,
-    `
-function first<T extends string | undefined>(array: ArrayLike<T>): T | null {
-  return array.length > 0 ? (array[0] as T) : null;
-}
-    `,
-    `
-function first<T extends string | null | undefined>(
-  array: ArrayLike<T>,
-): T | null {
-  return array.length > 0 ? (array[0] as T) : null;
-}
-    `,
-    `
-type A = 'a' | 'A';
-type B = 'b' | 'B';
-function first<T extends A | B | null>(array: ArrayLike<T>): T | null {
-  return array.length > 0 ? (array[0] as T) : null;
-}
     `,
   ],
 
@@ -229,24 +197,76 @@ declare const x: T;
 const y = x!;
       `,
     },
-    {
-      code: `
-function first<T extends string | number>(array: ArrayLike<T>): T | null {
+  ],
+});
+
+const ruleTesterWithNoUncheckedIndexAccess = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+    tsconfigRootDir: getFixturesRootDir(),
+    project: './tsconfig.noUncheckedIndexedAccess.json',
+  },
+  parser: '@typescript-eslint/parser',
+  dependencyConstraints: {
+    typescript: '4.1',
+  },
+});
+
+ruleTesterWithNoUncheckedIndexAccess.run(
+  'non-nullable-type-assertion-style - noUncheckedIndexedAccess',
+  rule,
+  {
+    valid: [
+      `
+function first<T>(array: ArrayLike<T>): T | null {
   return array.length > 0 ? (array[0] as T) : null;
 }
       `,
-      errors: [
-        {
-          column: 30,
-          line: 3,
-          messageId: 'preferNonNullAssertion',
-        },
-      ],
-      output: `
+      `
+function first<T extends string | null>(array: ArrayLike<T>): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
+      `,
+      `
+function first<T extends string | undefined>(array: ArrayLike<T>): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
+      `,
+      `
+function first<T extends string | null | undefined>(
+  array: ArrayLike<T>,
+): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
+      `,
+      `
+type A = 'a' | 'A';
+type B = 'b' | 'B';
+function first<T extends A | B | null>(array: ArrayLike<T>): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
+      `,
+    ],
+    invalid: [
+      {
+        code: `
+function first<T extends string | number>(array: ArrayLike<T>): T | null {
+  return array.length > 0 ? (array[0] as T) : null;
+}
+        `,
+        errors: [
+          {
+            column: 30,
+            line: 3,
+            messageId: 'preferNonNullAssertion',
+          },
+        ],
+        output: `
 function first<T extends string | number>(array: ArrayLike<T>): T | null {
   return array.length > 0 ? (array[0]!) : null;
 }
-      `,
-    },
-  ],
-});
+        `,
+      },
+    ],
+  },
+);

--- a/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/non-nullable-type-assertion-style.test.ts
@@ -207,9 +207,6 @@ const ruleTesterWithNoUncheckedIndexAccess = new RuleTester({
     project: './tsconfig.noUncheckedIndexedAccess.json',
   },
   parser: '@typescript-eslint/parser',
-  dependencyConstraints: {
-    typescript: '4.1',
-  },
 });
 
 ruleTesterWithNoUncheckedIndexAccess.run(

--- a/packages/typescript-estree/src/create-program/createWatchProgram.ts
+++ b/packages/typescript-estree/src/create-program/createWatchProgram.ts
@@ -159,11 +159,21 @@ function getProgramsForProjects(parseSettings: ParseSettings): ts.Program[] {
     );
   }
 
+  const currentProjectsFromSettings = new Set(parseSettings.projects);
+
   /*
    * before we go into the process of attempting to find and update every program
    * see if we know of a program that contains this file
    */
   for (const [tsconfigPath, existingWatch] of knownWatchProgramMap.entries()) {
+    if (!currentProjectsFromSettings.has(tsconfigPath)) {
+      // the current parser run doesn't specify this tsconfig in parserOptions.project
+      // so we don't want to consider it for caching purposes.
+      //
+      // if we did consider it we might return a program for a project
+      // that wasn't specified in the current parser run (which is obv bad!).
+      continue;
+    }
     let fileList = programFileListCache.get(tsconfigPath);
     let updatedProgram: ts.Program | null = null;
     if (!fileList) {


### PR DESCRIPTION
## PR Checklist

- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Discovered this while working on #5916

Previously we would consider any cached program as fair game during parsing.
Most of the time this isn't a problem because users always have the same config for an entire lint run.

However if the user has a different value for `parserOptions.project` around the place, then we would behave incorrectly - we would iterate through our cached programs and return a matching program for a file even if its tsconfig wasn't included in the current `parserOptions.project`! This is really bad because it means we'll lint a file with probably incorrect types!!!

I discovered this in the above PR because I defined two separate test runs with different tsconfigs in the same file.
Because our rule tester uses the exact same filename, the parser checked the cache, found the old program matched, and returned it - meaning we never used the new tsconfig (causing the test to fail!)

The fix is simply to enforce that we only consider a program from the cache if and only if its tsconfig exists in the current `parserOptions.project` set.