### PR TITLE
docs(website): pruning flow for issues and PRs

### DIFF
--- a/.github/replies.yml
+++ b/.github/replies.yml
@@ -1,5 +1,8 @@
 replies:
   - body: |
+      👋 Hey @{{ author }}! Just checking in, is this still something you have time for? No worries if not - I just don't want to leave it hanging.
+    name: Checking In
+  - body: |
       Thanks for posting! This is a duplicate of #<insert issue>. Before filing an issue, please [use our issue search](https://github.com/typescript-eslint/typescript-eslint/issues) to check for open and closed issues that already address what you're looking for.
     name: Clearly Duplicate Issue
   - body: |
@@ -52,6 +55,12 @@ replies:
       If this issue is important to you — consider being that champion.
       If not — please use the subscribe function and wait patiently for someone else to implement this.
     name: Progress - Nice
+  - body: |
+      Closing this issue as it's been stale for ~6 weeks without activity. Feel free to reopen @{{ author }} if you have time - but no worries if not! If anybody wants to drive it forward, please do either post here or in a new issue with the info we asked about. Thanks! 😊
+    name: Pruning Stale Issue
+  - body: |
+      Closing this PR as it's been stale for ~6 weeks without activity. Feel free to reopen @{{ author }} if you have time - but no worries if not! If anybody wants to drive it forward, please do post your own PR - and if you use this as a start, consider adding `Co-authored-by: @{{ author }}` at the end of your PR description. Thanks! 😊
+    name: Pruning Stale PR
   - body: |
       As per [our contributing guidelines](https://github.com/typescript-eslint/typescript-eslint/blob/master/CONTRIBUTING.md#addressing-feedback-and-beyond) this PR is in the queue of PRs to reviewed, and will be reviewed when we are able.
       \

--- a/docs/maintenance/ISSUES.md
+++ b/docs/maintenance/ISSUES.md
@@ -108,5 +108,6 @@ Every so often, we like to [search for open issues `awaiting response`](https://
 Our flow for issues that have been waiting for >=1 month is:
 
 1. Ping the author with a message like the _Checking In_ template
-2. Wait 2 weeks
-3. If they still haven't responded, close the issue with a message like the _Pruning Stale Issue_ template
+2. Add the `stale` label to the issue
+3. Wait 2 weeks
+4. If they still haven't responded, close the issue with a message like the _Pruning Stale Issue_ template

--- a/docs/maintenance/ISSUES.md
+++ b/docs/maintenance/ISSUES.md
@@ -1,7 +1,7 @@
 ---
 id: issues
-sidebar_label: Issue Management
-title: Issue Management
+sidebar_label: Issues
+title: Issues
 ---
 
 This document serves as a guide for how you might manage issues, also known as issue triaging.
@@ -101,3 +101,12 @@ TODO: This will be filled out... soon!
 ### 🚀 New Rules
 
 TODO: This will be filled out... soon!
+
+## Pruning Old Issues
+
+Every so often, we like to [search for open issues `awaiting response`](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22awaiting+response%22) to find ones that might have been forgotten.
+Our flow for issues that have been waiting for >=1 month is:
+
+1. Ping the author with a message like the _Checking In_ template
+2. Wait 2 weeks
+3. If they still haven't responded, close the issue with a message like the _Pruning Stale Issue_ template

--- a/docs/maintenance/PULL_REQUESTS.md
+++ b/docs/maintenance/PULL_REQUESTS.md
@@ -29,5 +29,6 @@ Every so often, we like to [search for open PRs `awaiting response`](https://git
 Our flow for PRs that have been waiting for >=1 month is:
 
 1. Ping the author with a message like the _Checking In_ template
-2. Wait 2 weeks
-3. If they still haven't responded, close the PR with a message like the _Pruning Stale PR_ template
+2. Add the `stale` label to the PR
+3. Wait 2 weeks
+4. If they still haven't responded, close the PR with a message like the _Pruning Stale PR_ template

--- a/docs/maintenance/PULL_REQUESTS.md
+++ b/docs/maintenance/PULL_REQUESTS.md
@@ -1,0 +1,25 @@
+---
+id: pull-requests
+title: Pull Requests
+---
+
+This document serves as a guide for how you might review pull requests.
+
+Use your best judgement when reviewing PRs, and most of all remember to be **kind, friendly, and encouraging** when responding to users.
+Many users are new to open source and/or typed linting.
+It's imperative we give them a positive, uplifting experience.
+
+:::tip
+If you're ever unsure on any part of PR reviews, don't hesitate to loop in a maintainer that has more context to help!
+:::
+
+TODO: This will be filled out... soon!
+
+## Pruning Old PRs
+
+Every so often, we like to [search for open PRs `awaiting response`](https://github.com/typescript-eslint/typescript-eslint/pulls?q=is%3Aopen+is%3Apr+label%3A%22awaiting+response%22) to find ones that might have been forgotten.
+Our flow for PRs that have been waiting for >=1 month is:
+
+1. Ping the author with a message like the _Checking In_ template
+2. Wait 2 weeks
+3. If they still haven't responded, close the PR with a message like the _Pruning Stale PR_ template

--- a/docs/maintenance/PULL_REQUESTS.md
+++ b/docs/maintenance/PULL_REQUESTS.md
@@ -13,6 +13,14 @@ It's imperative we give them a positive, uplifting experience.
 If you're ever unsure on any part of PR reviews, don't hesitate to loop in a maintainer that has more context to help!
 :::
 
+## PR Flow
+
+:::note
+We include a set of common responses to PRs in [`.github/replies.yml`](https://github.com/typescript-eslint/typescript-eslint/blob/main/.github/replies.yml), intended to be used with the [Refined Saved Replies](https://github.com/JoshuaKGoldberg/refined-saved-replies) extension.
+Don't treat these as exact responses you must use: they're just a starting copy+paste helper.
+Please do adopt your specific responses to your personal tone and to match the thread for non-straightforward PRs.
+:::
+
 TODO: This will be filled out... soon!
 
 ## Pruning Old PRs

--- a/packages/website/sidebars/sidebar.base.js
+++ b/packages/website/sidebars/sidebar.base.js
@@ -56,6 +56,7 @@ module.exports = {
       collapsible: false,
       items: [
         'maintenance/issues',
+        'maintenance/pull-requests',
         'maintenance/releases',
         'maintenance/versioning',
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5942
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Describes how we close old issues & PRs. And by _"we"_ I mean how _I_ have been doing it 😄 - would be nice to see if there's a better way! 
