### PR TITLE
chore: add discussion template for RFCs

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/rfcs.yml
+++ b/.github/DISCUSSION_TEMPLATE/rfcs.yml
@@ -1,0 +1,24 @@
+title: RFCs - Your Title Here
+labels: ['rfc']
+body:
+  - type: textarea
+    id: rfc
+    attributes:
+      label: RFC
+      value: |
+        Suggested changes...
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Info
+      value: |
+        Any additional info...
+  - type: checkboxes
+    id: required-checks
+    attributes:
+      label: Before you submit your RFC, please confirm the following. If any of these required steps are not taken, we may not be able to review your RFC. Help us to help you!
+      options:
+        - label: I have [searched for related discussions](https://github.com/typescript-eslint/typescript-eslint/discussions) and [searched for related issues](https://github.com/typescript-eslint/typescript-eslint/issues) and found none that match my proposal.
+          required: true
+        - label: I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/rfcs.yml
+++ b/.github/DISCUSSION_TEMPLATE/rfcs.yml
@@ -1,24 +1,24 @@
-title: RFCs - Your Title Here
-labels: ['rfc']
 body:
-  - type: textarea
-    id: rfc
-    attributes:
+  - attributes:
       label: RFC
       value: |
         Suggested changes...
-  - type: textarea
-    id: additional
-    attributes:
+    id: rfc
+    type: textarea
+  - attributes:
       label: Additional Info
       value: |
         Any additional info...
-  - type: checkboxes
-    id: required-checks
-    attributes:
+    id: additional
+    type: textarea
+  - attributes:
       label: Before you submit your RFC, please confirm the following. If any of these required steps are not taken, we may not be able to review your RFC. Help us to help you!
       options:
         - label: I have [searched for related discussions](https://github.com/typescript-eslint/typescript-eslint/discussions) and [searched for related issues](https://github.com/typescript-eslint/typescript-eslint/issues) and found none that match my proposal.
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
           required: true
+    id: required-checks
+    type: checkboxes
+labels: ['rfc']
+title: Your Title Here


### PR DESCRIPTION
## Overview

Sets up a discussion form for the RFC category. Perhaps the first public non-GitHub repo to do so in the ✨ world ✨ - and the universe!

![Spinning view of the Earth from space](https://user-images.githubusercontent.com/3335181/202500738-708110c6-05fa-49e7-a018-46e294bc7cc0.gif)

Co-authored-by: @entcheva