### PR TITLE
chore: removed eslint@6 fallbacks for rule messages, and a snapshot

### DIFF
--- a/packages/eslint-plugin/src/rules/no-invalid-this.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-this.ts
@@ -23,10 +23,7 @@ export default createRule<Options, MessageIds>({
       recommended: false,
       extendsBaseRule: true,
     },
-    // TODO: this rule has only had messages since v7.0 - remove this when we remove support for v6
-    messages: baseRule.meta.messages ?? {
-      unexpectedThis: "Unexpected 'this'.",
-    },
+    messages: baseRule.meta.messages,
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: baseRule.meta.schema,
   },

--- a/packages/eslint-plugin/src/rules/no-unused-expressions.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-expressions.ts
@@ -20,11 +20,7 @@ export default util.createRule<Options, MessageIds>({
     },
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: baseRule.meta.schema,
-    // TODO: this rule has only had messages since v7.0 - remove this when we remove support for v6
-    messages: baseRule.meta.messages ?? {
-      unusedExpression:
-        'Expected an assignment or function call and instead saw an expression.',
-    },
+    messages: baseRule.meta.messages,
   },
   defaultOptions: [
     {

--- a/packages/eslint-plugin/src/rules/no-useless-constructor.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-constructor.ts
@@ -54,10 +54,7 @@ export default util.createRule<Options, MessageIds>({
     },
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: baseRule.meta.schema,
-    // TODO: this rule has only had messages since v7.0 - remove this when we remove support for v6
-    messages: baseRule.meta.messages ?? {
-      noUselessConstructor: 'Useless constructor.',
-    },
+    messages: baseRule.meta.messages,
   },
   defaultOptions: [],
   create(context) {
@@ -65,8 +62,7 @@ export default util.createRule<Options, MessageIds>({
     return {
       MethodDefinition(node): void {
         if (
-          node.value &&
-          node.value.type === AST_NODE_TYPES.FunctionExpression &&
+          node.value?.type === AST_NODE_TYPES.FunctionExpression &&
           node.value.body &&
           checkAccessibility(node) &&
           checkParams(node)

--- a/packages/eslint-plugin/src/rules/quotes.ts
+++ b/packages/eslint-plugin/src/rules/quotes.ts
@@ -21,10 +21,7 @@ export default util.createRule<Options, MessageIds>({
     },
     fixable: 'code',
     hasSuggestions: baseRule.meta.hasSuggestions,
-    // TODO: this rule has only had messages since v7.0 - remove this when we remove support for v6
-    messages: baseRule.meta.messages ?? {
-      wrongQuotes: 'Strings must use {{description}}.',
-    },
+    messages: baseRule.meta.messages,
     schema: baseRule.meta.schema,
   },
   defaultOptions: [

--- a/packages/eslint-plugin/src/rules/semi.ts
+++ b/packages/eslint-plugin/src/rules/semi.ts
@@ -22,11 +22,7 @@ export default util.createRule<Options, MessageIds>({
     fixable: 'code',
     hasSuggestions: baseRule.meta.hasSuggestions,
     schema: baseRule.meta.schema,
-    // TODO: this rule has only had messages since v7.0 - remove this when we remove support for v6
-    messages: baseRule.meta.messages ?? {
-      missingSemi: 'Missing semicolon.',
-      extraSemi: 'Extra semicolon.',
-    },
+    messages: baseRule.meta.messages,
   },
   defaultOptions: [
     'always',


### PR DESCRIPTION
## Overview

I stumbled onto some more references to ESLint v6 in the codebase. I hadn't known about them. 🔪 

cc @bmish from #5968 -> #5972 