### PR TITLE
chore: remove unnecessary project names from nx commands

### DIFF
--- a/packages/ast-spec/package.json
+++ b/packages/ast-spec/package.json
@@ -34,7 +34,7 @@
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf .rollup.cache && rimraf coverage",
     "clean-fixtures": "rimraf -g \"./src/**/fixtures/**/snapshots\"",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "lint": "nx lint @typescript-eslint/ast-spec",
+    "lint": "nx lint",
     "test": "jest",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/eslint-plugin-internal/package.json
+++ b/packages/eslint-plugin-internal/package.json
@@ -8,7 +8,7 @@
     "clean": "tsc -b tsconfig.build.json --clean",
     "postclean": "rimraf dist && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "lint": "nx lint @typescript-eslint/eslint-plugin-internal",
+    "lint": "nx lint",
     "test": "jest --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/eslint-plugin-tslint/package.json
+++ b/packages/eslint-plugin-tslint/package.json
@@ -33,7 +33,7 @@
     "clean": "tsc -b tsconfig.build.json --clean",
     "postclean": "rimraf dist && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "lint": "nx lint @typescript-eslint/eslint-plugin-tslint",
+    "lint": "nx lint",
     "test": "jest --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -39,7 +39,7 @@
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "generate:breaking-changes": "../../node_modules/.bin/ts-node tools/generate-breaking-changes.ts",
     "generate:configs": "../../node_modules/.bin/ts-node tools/generate-configs.ts",
-    "lint": "nx lint @typescript-eslint/eslint-plugin",
+    "lint": "nx lint",
     "test": "jest --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/experimental-utils/package.json
+++ b/packages/experimental-utils/package.json
@@ -34,7 +34,7 @@
     "clean": "tsc -b tsconfig.build.json --clean",
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "lint": "nx lint @typescript-eslint/experimental-utils",
+    "lint": "nx lint",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -37,7 +37,7 @@
     "clean": "tsc -b tsconfig.build.json --clean",
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "lint": "nx lint @typescript-eslint/parser",
+    "lint": "nx lint",
     "test": "jest --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/scope-manager/package.json
+++ b/packages/scope-manager/package.json
@@ -28,14 +28,14 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "cd ../../ && nx build @typescript-eslint/scope-manager",
-    "clean": "cd ../../ && nx clean @typescript-eslint/scope-manager",
-    "clean-fixtures": "cd ../../ && nx clean-fixtures @typescript-eslint/scope-manager",
+    "build": "nx build",
+    "clean": "nx clean",
+    "clean-fixtures": "nx clean-fixtures",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "generate:lib": "cd ../../ && nx generate-lib @typescript-eslint/scope-manager",
-    "lint": "nx lint @typescript-eslint/scope-manager",
-    "test": "cd ../../ && nx test @typescript-eslint/scope-manager --code-coverage",
-    "typecheck": "cd ../../ && nx typecheck @typescript-eslint/scope-manager"
+    "generate:lib": "nx generate-lib",
+    "lint": "nx lint",
+    "test": "nx test --code-coverage",
+    "typecheck": "nx typecheck"
   },
   "dependencies": {
     "@typescript-eslint/types": "5.43.0",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -34,7 +34,7 @@
     "clean": "tsc -b tsconfig.build.json --clean",
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "lint": "nx lint @typescript-eslint/type-utils",
+    "lint": "nx lint",
     "test": "jest --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -36,7 +36,7 @@
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "generate:lib": "../../node_modules/.bin/ts-node --files --transpile-only ../scope-manager/tools/generate-lib.ts",
-    "lint": "nx lint @typescript-eslint/types",
+    "lint": "nx lint",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "nx": {

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -37,7 +37,7 @@
     "clean": "tsc -b tsconfig.build.json --clean",
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "lint": "nx lint @typescript-eslint/typescript-estree",
+    "lint": "nx lint",
     "test": "jest --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,7 @@
     "clean": "tsc -b tsconfig.build.json --clean",
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "lint": "nx lint @typescript-eslint/utils",
+    "lint": "nx lint",
     "test": "jest --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/visitor-keys/package.json
+++ b/packages/visitor-keys/package.json
@@ -34,7 +34,7 @@
     "clean": "tsc -b tsconfig.build.json --clean",
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "lint": "nx lint @typescript-eslint/visitor-keys",
+    "lint": "nx lint",
     "test": "jest --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -6,7 +6,7 @@
     "build": "docusaurus build",
     "clear": "docusaurus clear",
     "format": "prettier --write \"./**/*.{md,mdx,ts,js,tsx,jsx}\" --ignore-path ../../.prettierignore",
-    "lint": "nx lint website",
+    "lint": "nx lint",
     "serve": "docusaurus serve",
     "start": "docusaurus start",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
## Overview

The Nx CLI doest the "right thing" when it is run within a package's directory - it infers the relevant project and looks up the target script name based on that.

Therefore we can remove any `cd`ing and explicit referencing of project names we currently do within package npm script aliases
