### PR TITLE
fix(eslint-plugin): [keyword-spacing] prevent crash on no options

### DIFF
--- a/packages/eslint-plugin/src/rules/keyword-spacing.ts
+++ b/packages/eslint-plugin/src/rules/keyword-spacing.ts
@@ -25,7 +25,7 @@ export default util.createRule<Options, MessageIds>({
   },
   defaultOptions: [{}],
 
-  create(context) {
+  create(context, [{ after }]) {
     const sourceCode = context.getSourceCode();
     const baseRules = baseRule.create(context);
     return {
@@ -58,7 +58,7 @@ export default util.createRule<Options, MessageIds>({
         const punctuatorToken = sourceCode.getTokenAfter(typeToken)!;
         const spacesBetweenTypeAndPunctuator =
           punctuatorToken.range[0] - typeToken.range[1];
-        if (context.options[0].after && spacesBetweenTypeAndPunctuator === 0) {
+        if (after && spacesBetweenTypeAndPunctuator === 0) {
           context.report({
             loc: punctuatorToken.loc,
             messageId: 'expectedBefore',
@@ -68,7 +68,7 @@ export default util.createRule<Options, MessageIds>({
             },
           });
         }
-        if (!context.options[0].after && spacesBetweenTypeAndPunctuator > 0) {
+        if (!after && spacesBetweenTypeAndPunctuator > 0) {
           context.report({
             loc: punctuatorToken.loc,
             messageId: 'unexpectedBefore',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6060
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Sources the `after` option from the second parameter to `create` instead of `context.options`. Turns out the latter is the raw user-provided options before `defaultOptions` are applied.
