### PR TITLE
chore: add action to enforce semantic-pr titles

### DIFF
--- a/.github/workflows/semantic-pr-titles.yml
+++ b/.github/workflows/semantic-pr-titles.yml
@@ -1,0 +1,52 @@
+name: Semantic PR Titles
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # keep this synchronized with the /CONTRIBUTING.md
+          types: |
+            docs
+            feat
+            fix
+            test
+            chore
+          # deps is used by renovate for its PRs
+          scopes: |
+            deps
+            ast-spec
+            eslint-plugin
+            eslint-plugin-internal
+            eslint-plugin-tslint
+            experimental-utils
+            parser
+            scope-manager
+            type-utils
+            types
+            typescript-estree
+            utils
+            visitor-keys
+            website
+          # we allow "cross package" PRs with no scope
+          requireScope: false
+          # ensure that the subject is lower-case first
+          # also allows "[rule-name] " prefix for eslint-plugin rule PRs
+          # https://regexr.com/733ed
+          subjectPattern: ^(\[[a-z\-]+\] )?[a-z].+[^\.]$
+          subjectPatternError: |
+            The "subject" must start with a lower-case letter and must not
+            end with a full-stop.
+            For PRs that add or change ESLint-plugin rules, you should begin
+            the title with "[rule-name] "

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,8 @@ Within the body of your PR, make sure you reference the issue that you have work
 
 Must be one of the following:
 
+<!-- Keep this synchronized with /.github/workflows/semantic-pr-titles.yml -->
+
 - `docs` - if you only change documentation, and not shipped code
 - `feat` - for any new functionality additions
 - `fix` - for any bug fixes that don't add new functionality


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5110
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

I've seen a few PRs recently that haven't had the correct titles.
I accidentally merged one that was missing the colon!

This PR adds an action that will validate the PR titles match the semantic commit spec using this action:
https://github.com/amannn/action-semantic-pull-request

