### PR TITLE
fix(typescript-estree): stub out `ts.SatisfiesExpression` on old TS versions

### DIFF
--- a/packages/typescript-estree/src/ts-estree/ts-nodes.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-nodes.ts
@@ -4,12 +4,18 @@ import type * as ts from 'typescript';
 // Eg: https://github.com/typescript-eslint/typescript-eslint/issues/2388, https://github.com/typescript-eslint/typescript-eslint/issues/2784
 declare module 'typescript' {
   /* eslint-disable @typescript-eslint/no-empty-interface */
+  // added in TS 4.0
   export interface NamedTupleMember extends ts.Node {}
+  // added in TS 4.1
   export interface TemplateLiteralTypeNode extends ts.Node {}
+  // added in TS 4.3
   export interface PrivateIdentifier extends ts.Node {}
   export interface ClassStaticBlockDeclaration extends ts.Node {}
+  // added in TS 4.5
   export interface AssertClause extends ts.Node {}
   export interface AssertEntry extends ts.Node {}
+  // added in TS 4.9
+  export interface SatisfiesExpression extends ts.Node {}
   /* eslint-enable @typescript-eslint/no-empty-interface */
 }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Another thing we need to add to the "new syntax" contributor guide.
This union is part of the API surface for the package, so we need to ensure we don't break the build on old TS versions by "stubbing" out the new AST node types.

Also added version comments so it's easy to tell when we can remove them as we bump the minimum TS version

