### PR TITLE
test(website): add Playwright test for Playground linting

### DIFF
--- a/packages/website/playwright.config.ts
+++ b/packages/website/playwright.config.ts
@@ -4,6 +4,7 @@ import { devices } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   fullyParallel: true,
+
   reporter: 'html',
   retries: 0,
   testDir: './tests',
@@ -22,6 +23,7 @@ const config: PlaywrightTestConfig = {
   webServer: {
     command: 'yarn start',
     port: 3000,
+    reuseExistingServer: !process.env.CI,
   },
   workers: process.env.CI ? 1 : undefined,
 };

--- a/packages/website/playwright.config.ts
+++ b/packages/website/playwright.config.ts
@@ -4,7 +4,6 @@ import { devices } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   fullyParallel: true,
-
   reporter: 'html',
   retries: 0,
   testDir: './tests',

--- a/packages/website/src/components/config/ConfigEditor.tsx
+++ b/packages/website/src/components/config/ConfigEditor.tsx
@@ -129,8 +129,12 @@ function ConfigEditor(props: ConfigEditorProps): JSX.Element {
                 <label className={styles.searchResult} key={item.key}>
                   <span className={styles.searchResultDescription}>
                     <span className={styles.searchResultName}>{item.key}</span>
-                    {item.label && <br />}
-                    {item.label && <span>{item.label}</span>}
+                    {item.label && (
+                      <>
+                        <br />
+                        <span> {item.label}</span>
+                      </>
+                    )}
                   </span>
                   {item.type === 'boolean' && (
                     <Checkbox

--- a/packages/website/tests/playground.spec.ts
+++ b/packages/website/tests/playground.spec.ts
@@ -1,0 +1,65 @@
+import AxeBuilder from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+test.describe('Playground', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/play');
+  });
+
+  test('Accessibility', async ({ page }) => {
+    await new AxeBuilder({ page }).analyze();
+  });
+
+  test('Usage', async ({ page }) => {
+    // 1. Type some valid code in the playground
+    await writeInEditor(page, 'let value: string[];');
+
+    // 2. Enable a lint rule
+    await page.getByRole('tab', { name: 'eslintrc' }).click();
+    await page.getByRole('button', { name: 'Visual Editor' }).click();
+    await page
+      .getByLabel(
+        '@typescript-eslint/array-type Require consistently using either `T[]` or `Array<T>` for arrays',
+      )
+      .check();
+    await page.getByRole('button', { name: 'Close' }).click();
+
+    // 3. Make sure it still says "All is ok!"
+    await expect(page.getByText('All is ok!')).toBeVisible();
+
+    // 4. Change the code to violate the lint rule
+    await page.getByRole('tab', { name: 'code' }).click();
+    await writeInEditor(page, 'let value: Array<string>;');
+
+    // 5. Make sure it now says the complaint
+    await expect(
+      page.getByText(
+        `Array type using 'Array<string>' is forbidden. Use 'string[]' instead. 1:12 - 1:25`,
+      ),
+    ).toBeVisible();
+
+    // 6. Press the 'fix' button to autofix that complaint
+    await page.getByRole('button', { name: 'fix' }).click();
+
+    // 7. Make sure the code is updated, and it says "All is ok!"
+    await expect(page.getByText('let value: string[];')).toBeVisible();
+    await expect(page.getByText('All is ok!')).toBeVisible();
+  });
+});
+
+async function writeInEditor(page: Page, text: string): Promise<void> {
+  const monacoEditor = page.locator('.monaco-editor').nth(0);
+  await monacoEditor.click();
+
+  // Select all existing text and delete it first...
+  await page.keyboard.down('Control');
+  await page.keyboard.down('A');
+  await page.keyboard.up('Control');
+  await page.keyboard.up('A');
+  await page.keyboard.down('Delete');
+  await page.keyboard.up('Delete');
+
+  // ...and then type in the text
+  await page.keyboard.type(text);
+}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5579
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Adds a playground test that:

1. Types passing code & enables a rule with no issues
2. Changes the code to fail the rule
3. Autofixes the code to pass again

Also fixes an accessibility oddity with labels in the visual dropdown for rules. There's no space between rule name and description currently:

```diff
await page
  .getByLabel(
-    '@typescript-eslint/array-typeRequire consistently using either `T[]` or `Array<T>` for arrays',
+    '@typescript-eslint/array-type Require consistently using either `T[]` or `Array<T>` for arrays',
  )
  .check();

```