### PR TITLE
chore(typescript-estree): refactor createWatchProgram module-scoped variable

### DIFF
--- a/packages/eslint-plugin-tslint/src/rules/config.ts
+++ b/packages/eslint-plugin-tslint/src/rules/config.ts
@@ -98,18 +98,13 @@ export default createRule<Options, MessageIds>({
     ],
   },
   defaultOptions: [{}],
-  create(context) {
+  create(
+    context,
+    [{ rules: tslintRules, rulesDirectory: tslintRulesDirectory, lintFile }],
+  ) {
     const fileName = context.getFilename();
     const sourceCode = context.getSourceCode().text;
     const parserServices = ESLintUtils.getParserServices(context);
-
-    /**
-     * The TSLint rules configuration passed in by the user
-     */
-    const [
-      { rules: tslintRules, rulesDirectory: tslintRulesDirectory, lintFile },
-    ] = context.options;
-
     const program = parserServices.program;
 
     /**

--- a/packages/type-utils/tests/isTypeReadonly.test.ts
+++ b/packages/type-utils/tests/isTypeReadonly.test.ts
@@ -1,4 +1,4 @@
-import { parseForESLint } from '@typescript-eslint/parser';
+import { clearCaches, parseForESLint } from '@typescript-eslint/parser';
 import type { TSESTree } from '@typescript-eslint/utils';
 import path from 'path';
 import type * as ts from 'typescript';
@@ -16,6 +16,7 @@ describe('isTypeReadonly', () => {
       type: ts.Type;
       checker: ts.TypeChecker;
     } {
+      clearCaches();
       const { ast, services } = parseForESLint(code, {
         project: './tsconfig.json',
         filePath: path.join(rootDir, 'file.ts'),

--- a/packages/type-utils/tests/isUnsafeAssignment.test.ts
+++ b/packages/type-utils/tests/isUnsafeAssignment.test.ts
@@ -1,4 +1,4 @@
-import { parseForESLint } from '@typescript-eslint/parser';
+import { clearCaches, parseForESLint } from '@typescript-eslint/parser';
 import type { TSESTree } from '@typescript-eslint/utils';
 import path from 'path';
 import type * as ts from 'typescript';
@@ -14,6 +14,7 @@ describe('isUnsafeAssignment', () => {
     receiver: ts.Type;
     checker: ts.TypeChecker;
   } {
+    clearCaches();
     const { ast, services } = parseForESLint(code, {
       project: './tsconfig.json',
       filePath: path.join(rootDir, 'file.ts'),


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5891
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

The only real thing the variable stored was `filePath`. `code` is now available in `parseSettings.code`.
