### PR TITLE
chore(typescript-estree): cleaned up watch program naming internally

### DIFF
--- a/packages/eslint-plugin-tslint/src/rules/config.ts
+++ b/packages/eslint-plugin-tslint/src/rules/config.ts
@@ -98,18 +98,13 @@ export default createRule<Options, MessageIds>({
     ],
   },
   defaultOptions: [{}],
-  create(context) {
+  create(
+    context,
+    [{ rules: tslintRules, rulesDirectory: tslintRulesDirectory, lintFile }],
+  ) {
     const fileName = context.getFilename();
     const sourceCode = context.getSourceCode().text;
     const parserServices = ESLintUtils.getParserServices(context);
-
-    /**
-     * The TSLint rules configuration passed in by the user
-     */
-    const [
-      { rules: tslintRules, rulesDirectory: tslintRulesDirectory, lintFile },
-    ] = context.options;
-
     const program = parserServices.program;
 
     /**

--- a/packages/typescript-estree/src/create-program/createProjectProgram.ts
+++ b/packages/typescript-estree/src/create-program/createProjectProgram.ts
@@ -4,7 +4,7 @@ import * as ts from 'typescript';
 
 import { firstDefined } from '../node-utils';
 import type { ParseSettings } from '../parseSettings';
-import { getProgramsForProjects } from './createWatchProgram';
+import { getWatchProgramsForProjects } from './getWatchProgramsForProjects';
 import type { ASTAndProgram } from './shared';
 import { getAstFromProgram } from './shared';
 
@@ -30,7 +30,7 @@ function createProjectProgram(
 ): ASTAndProgram | undefined {
   log('Creating project program for: %s', parseSettings.filePath);
 
-  const programsForProjects = getProgramsForProjects(parseSettings);
+  const programsForProjects = getWatchProgramsForProjects(parseSettings);
   const astAndProgram = firstDefined(programsForProjects, currentProgram =>
     getAstFromProgram(currentProgram, parseSettings),
   );

--- a/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
+++ b/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
@@ -138,7 +138,9 @@ function updateCachedFileList(
  * @param parseSettings Internal settings for parsing the file
  * @returns The programs corresponding to the supplied tsconfig paths
  */
-function getProgramsForProjects(parseSettings: ParseSettings): ts.Program[] {
+function getWatchProgramsForProjects(
+  parseSettings: ParseSettings,
+): ts.Program[] {
   const filePath = getCanonicalFileName(parseSettings.filePath);
   const results = [];
 
@@ -548,4 +550,4 @@ function maybeInvalidateProgram(
   return null;
 }
 
-export { clearWatchCaches, createWatchProgram, getProgramsForProjects };
+export { clearWatchCaches, getWatchProgramsForProjects };

--- a/packages/typescript-estree/src/index.ts
+++ b/packages/typescript-estree/src/index.ts
@@ -10,7 +10,7 @@ export {
 export { ParserServices, TSESTreeOptions } from './parser-options';
 export { simpleTraverse } from './simple-traverse';
 export * from './ts-estree';
-export { clearWatchCaches as clearCaches } from './create-program/createWatchProgram';
+export { clearWatchCaches as clearCaches } from './create-program/getWatchProgramsForProjects';
 export { createProgramFromConfigFile as createProgram } from './create-program/useProvidedPrograms';
 export * from './create-program/getScriptKind';
 export { typescriptVersionIsAtLeast } from './version-check';

--- a/packages/typescript-estree/tests/lib/persistentParse.test.ts
+++ b/packages/typescript-estree/tests/lib/persistentParse.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';
 
-import { clearWatchCaches } from '../../src/create-program/createWatchProgram';
+import { clearWatchCaches } from '../../src/create-program/getWatchProgramsForProjects';
 import { parseAndGenerateServices } from '../../src/parser';
 
 const CONTENTS = {

--- a/packages/typescript-estree/tests/lib/semanticInfo-singleRun.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo-singleRun.test.ts
@@ -60,10 +60,12 @@ jest.mock('../../src/create-program/useProvidedPrograms.ts', () => {
   };
 });
 
-jest.mock('../../src/create-program/createWatchProgram', () => {
+jest.mock('../../src/create-program/getWatchProgramsForProjects', () => {
   return {
-    ...jest.requireActual('../../src/create-program/createWatchProgram'),
-    getProgramsForProjects: jest.fn(() => [mockProgram]),
+    ...jest.requireActual(
+      '../../src/create-program/getWatchProgramsForProjects',
+    ),
+    getWatchProgramsForProjects: jest.fn(() => [mockProgram]),
   };
 });
 

--- a/packages/typescript-estree/tests/lib/semanticInfo.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo.test.ts
@@ -3,7 +3,7 @@ import glob from 'glob';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-import { clearWatchCaches } from '../../src/create-program/createWatchProgram';
+import { clearWatchCaches } from '../../src/create-program/getWatchProgramsForProjects';
 import { createProgramFromConfigFile as createProgram } from '../../src/create-program/useProvidedPrograms';
 import type { ParseAndGenerateServicesResult } from '../../src/parser';
 import { parseAndGenerateServices } from '../../src/parser';

--- a/packages/website-eslint/rollup.config.js
+++ b/packages/website-eslint/rollup.config.js
@@ -30,7 +30,7 @@ module.exports = {
             /utils\/dist\/eslint-utils\/rule-tester\/RuleTester\.js$/,
             /utils\/dist\/ts-eslint\/CLIEngine\.js$/,
             /utils\/dist\/ts-eslint\/RuleTester\.js$/,
-            /typescript-estree\/dist\/create-program\/createWatchProgram\.js/,
+            /typescript-estree\/dist\/create-program\/getWatchProgramsForProjects\.js/,
             /typescript-estree\/dist\/create-program\/createProjectProgram\.js/,
             /typescript-estree\/dist\/create-program\/createIsolatedProgram\.js/,
             /utils\/dist\/ts-eslint\/ESLint\.js/,


### PR DESCRIPTION
Just a small cleanup PR from an unused export I noticed in https://github.com/typescript-eslint/typescript-eslint/pull/6084/files#diff-8198ca001c396f4c9a35d64b92e18a9361516a5046f98f31cec808fe76e4fd78.

1. `createWatchProgram` is never used outside of [createWatchProgram.ts](https://github.com/typescript-eslint/typescript-eslint/pull/6084/files#diff-8198ca001c396f4c9a35d64b92e18a9361516a5046f98f31cec808fe76e4fd78)
2. That file is mostly used for its `getProgramsForProjects`, which is specifically getting _watch_ programs
3. I renamed the file and function both to `getWatchProgramsForProjects`