### PR TITLE
chore(eslint-plugin-tslint): take rule options from create parameter

### DIFF
--- a/packages/eslint-plugin-tslint/src/rules/config.ts
+++ b/packages/eslint-plugin-tslint/src/rules/config.ts
@@ -98,18 +98,13 @@ export default createRule<Options, MessageIds>({
     ],
   },
   defaultOptions: [{}],
-  create(context) {
+  create(
+    context,
+    [{ rules: tslintRules, rulesDirectory: tslintRulesDirectory, lintFile }],
+  ) {
     const fileName = context.getFilename();
     const sourceCode = context.getSourceCode().text;
     const parserServices = ESLintUtils.getParserServices(context);
-
-    /**
-     * The TSLint rules configuration passed in by the user
-     */
-    const [
-      { rules: tslintRules, rulesDirectory: tslintRulesDirectory, lintFile },
-    ] = context.options;
-
     const program = parserServices.program;
 
     /**


### PR DESCRIPTION
## Overview

This is showing up as an unchanged file annotation in #6084 [[failing action job](https://github.com/typescript-eslint/typescript-eslint/actions/runs/3545759537/jobs/5954200630)]:

```plaintext
/home/runner/work/typescript-eslint/typescript-eslint/packages/eslint-plugin-tslint/src/rules/config.ts
Error:   111:9  error  Retrieve options from create's second parameter so that defaultOptions are applied  no-restricted-syntax
```

I don't know why this wasn't caught in #6074.