### PR TITLE
docs(eslint-plugin): [prefer-function-type] mention false positives on global augmentations

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-function-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-function-type.ts
@@ -1,6 +1,6 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
-import ts from 'typescript';
+import * as ts from 'typescript';
 
 import * as util from '../util';
 


### PR DESCRIPTION
BREAKING CHANGE:
Adds type checking to `@typescript-eslint/prefer-function-type`.

## PR Checklist

- [x] Addresses an existing open issue: fixes #454
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
