### PR TITLE
feat(eslint-plugin): [explicit-function-return-type] add allowFunctionsWithoutTypeParameters option

### DIFF
--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -401,6 +401,46 @@ new Foo(1, () => {});
       options: [{ allowConciseArrowFunctionExpressionsStartingWithVoid: true }],
     },
     {
+      code: 'const log = (a: string) => a;',
+      options: [{ allowFunctionsWithoutTypeParameters: true }],
+    },
+    {
+      code: 'const log = <A>(a: A): A => a;',
+      options: [{ allowFunctionsWithoutTypeParameters: true }],
+    },
+    {
+      code: `
+function log<A>(a: A): A {
+  return a;
+}
+      `,
+      options: [{ allowFunctionsWithoutTypeParameters: true }],
+    },
+    {
+      code: `
+function log(a: string) {
+  return a;
+}
+      `,
+      options: [{ allowFunctionsWithoutTypeParameters: true }],
+    },
+    {
+      code: `
+const log = function <A>(a: A): A {
+  return a;
+};
+      `,
+      options: [{ allowFunctionsWithoutTypeParameters: true }],
+    },
+    {
+      code: `
+const log = function (a: A): string {
+  return a;
+};
+      `,
+      options: [{ allowFunctionsWithoutTypeParameters: true }],
+    },
+    {
       filename: 'test.ts',
       options: [
         {
@@ -1318,6 +1358,29 @@ const func = (value: number) => ({ type: 'X', value } as const);
           endColumn: 41,
         },
       ],
+    },
+    {
+      code: 'const log = <A>(a: A) => a;',
+      errors: [{ messageId: 'missingReturnType' }],
+      options: [{ allowFunctionsWithoutTypeParameters: true }],
+    },
+    {
+      code: `
+function log<A>(a: A) {
+  return a;
+}
+      `,
+      errors: [{ messageId: 'missingReturnType' }],
+      options: [{ allowFunctionsWithoutTypeParameters: true }],
+    },
+    {
+      code: `
+const log = function <A>(a: A) {
+  return a;
+};
+      `,
+      errors: [{ messageId: 'missingReturnType' }],
+      options: [{ allowFunctionsWithoutTypeParameters: true }],
     },
     {
       filename: 'test.ts',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #730
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Adds a `allowFunctionsWithoutTypeParameters` option to ignore non-generic functions.

The issue is quite old but I think it makes a lot of sense to add this in. I don't often use this rule, but when I do think about it, I often mostly only want it for complex, performance-degrading types.