### PR TITLE
fix(eslint-plugin): [sort-type-constituents, sort-type-union-intersection-members] handle some required parentheses cases in the fixer

### DIFF
--- a/packages/eslint-plugin/src/rules/sort-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-constituents.ts
@@ -220,7 +220,9 @@ export default util.createRule<Options, MessageIds>({
           const fix: TSESLint.ReportFixFunction = fixer => {
             const sorted = expectedOrder
               .map(t =>
-                typeNodeRequiresParentheses(t.node, t.text)
+                typeNodeRequiresParentheses(t.node, t.text) ||
+                (node.type === AST_NODE_TYPES.TSIntersectionType &&
+                  t.node.type === AST_NODE_TYPES.TSUnionType)
                   ? `(${t.text})`
                   : t.text,
               )

--- a/packages/eslint-plugin/src/rules/sort-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-constituents.ts
@@ -2,7 +2,7 @@ import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import * as util from '../util';
-import { getEnumNames } from '../util';
+import { getEnumNames, typeNodeRequiresParentheses } from '../util';
 
 enum Group {
   conditional = 'conditional',
@@ -96,21 +96,6 @@ function getGroup(node: TSESTree.TypeNode): Group {
   }
 }
 
-interface Constituent {
-  group: number;
-  node: TSESTree.TypeNode;
-  text: string;
-}
-
-function requiresParentheses({ node, text }: Constituent): boolean {
-  return (
-    node.type === AST_NODE_TYPES.TSFunctionType ||
-    node.type === AST_NODE_TYPES.TSConstructorType ||
-    (node.type === AST_NODE_TYPES.TSUnionType && text.startsWith('|')) ||
-    (node.type === AST_NODE_TYPES.TSIntersectionType && text.startsWith('&'))
-  );
-}
-
 export type Options = [
   {
     checkIntersections?: boolean;
@@ -191,7 +176,7 @@ export default util.createRule<Options, MessageIds>({
     function checkSorting(
       node: TSESTree.TSIntersectionType | TSESTree.TSUnionType,
     ): void {
-      const sourceOrder = node.types.map((type): Constituent => {
+      const sourceOrder = node.types.map(type => {
         const group = groupOrder?.indexOf(getGroup(type)) ?? -1;
         return {
           group: group === -1 ? Number.MAX_SAFE_INTEGER : group,
@@ -234,7 +219,11 @@ export default util.createRule<Options, MessageIds>({
 
           const fix: TSESLint.ReportFixFunction = fixer => {
             const sorted = expectedOrder
-              .map(t => (requiresParentheses(t) ? `(${t.text})` : t.text))
+              .map(t =>
+                typeNodeRequiresParentheses(t.node, t.text)
+                  ? `(${t.text})`
+                  : t.text,
+              )
               .join(
                 node.type === AST_NODE_TYPES.TSIntersectionType ? ' & ' : ' | ',
               );

--- a/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
@@ -222,7 +222,9 @@ export default util.createRule<Options, MessageIds>({
           const fix: TSESLint.ReportFixFunction = fixer => {
             const sorted = expectedOrder
               .map(t =>
-                typeNodeRequiresParentheses(t.node, t.text)
+                typeNodeRequiresParentheses(t.node, t.text) ||
+                (node.type === AST_NODE_TYPES.TSIntersectionType &&
+                  t.node.type === AST_NODE_TYPES.TSUnionType)
                   ? `(${t.text})`
                   : t.text,
               )

--- a/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-union-intersection-members.ts
@@ -96,10 +96,18 @@ function getGroup(node: TSESTree.TypeNode): Group {
   }
 }
 
-function requiresParentheses(node: TSESTree.TypeNode): boolean {
+interface Constituent {
+  group: number;
+  node: TSESTree.TypeNode;
+  text: string;
+}
+
+function requiresParentheses({ node, text }: Constituent): boolean {
   return (
     node.type === AST_NODE_TYPES.TSFunctionType ||
-    node.type === AST_NODE_TYPES.TSConstructorType
+    node.type === AST_NODE_TYPES.TSConstructorType ||
+    (node.type === AST_NODE_TYPES.TSUnionType && text.startsWith('|')) ||
+    (node.type === AST_NODE_TYPES.TSIntersectionType && text.startsWith('&'))
   );
 }
 
@@ -185,7 +193,7 @@ export default util.createRule<Options, MessageIds>({
     function checkSorting(
       node: TSESTree.TSIntersectionType | TSESTree.TSUnionType,
     ): void {
-      const sourceOrder = node.types.map(type => {
+      const sourceOrder = node.types.map((type): Constituent => {
         const group = groupOrder?.indexOf(getGroup(type)) ?? -1;
         return {
           group: group === -1 ? Number.MAX_SAFE_INTEGER : group,
@@ -228,7 +236,7 @@ export default util.createRule<Options, MessageIds>({
 
           const fix: TSESLint.ReportFixFunction = fixer => {
             const sorted = expectedOrder
-              .map(t => (requiresParentheses(t.node) ? `(${t.text})` : t.text))
+              .map(t => (requiresParentheses(t) ? `(${t.text})` : t.text))
               .join(
                 node.type === AST_NODE_TYPES.TSIntersectionType ? ' & ' : ' | ',
               );

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -203,6 +203,18 @@ function findLastIndex<T>(
   return -1;
 }
 
+function typeNodeRequiresParentheses(
+  node: TSESTree.TypeNode,
+  text: string,
+): boolean {
+  return (
+    node.type === AST_NODE_TYPES.TSFunctionType ||
+    node.type === AST_NODE_TYPES.TSConstructorType ||
+    (node.type === AST_NODE_TYPES.TSUnionType && text.startsWith('|')) ||
+    (node.type === AST_NODE_TYPES.TSIntersectionType && text.startsWith('&'))
+  );
+}
+
 export {
   arrayGroupByToMap,
   arraysAreEqual,
@@ -216,6 +228,7 @@ export {
   isDefinitionFile,
   MemberNameType,
   RequireKeys,
+  typeNodeRequiresParentheses,
   upperCaseFirst,
   findLastIndex,
 };

--- a/packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts
@@ -288,8 +288,8 @@ type T =
       ],
     },
     {
-      code: `type T = (| A) ${operator} B`,
-      output: `type T = B ${operator} (| A)`,
+      code: `type T = (| A) ${operator} B;`,
+      output: `type T = B ${operator} (| A);`,
       errors: [
         {
           messageId: 'notSortedNamed',
@@ -301,8 +301,8 @@ type T =
       ],
     },
     {
-      code: `type T = (& A) ${operator} B`,
-      output: `type T = B ${operator} (& A)`,
+      code: `type T = (& A) ${operator} B;`,
+      output: `type T = B ${operator} (& A);`,
       errors: [
         {
           messageId: 'notSortedNamed',

--- a/packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts
@@ -360,5 +360,21 @@ type T = 1 | string | {} | A;
       ],
     },
   ],
-  invalid: [...invalid('|'), ...invalid('&')],
+  invalid: [
+    ...invalid('|'),
+    ...invalid('&'),
+    {
+      code: 'type T = (B | C) & A;',
+      output: `type T = A & (B | C);`,
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+          data: {
+            type: 'Intersection',
+            name: 'T',
+          },
+        },
+      ],
+    },
+  ],
 });

--- a/packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts
@@ -287,6 +287,32 @@ type T =
         },
       ],
     },
+    {
+      code: `type T = (| A) ${operator} B`,
+      output: `type T = B ${operator} (| A)`,
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+          data: {
+            type,
+            name: 'T',
+          },
+        },
+      ],
+    },
+    {
+      code: `type T = (& A) ${operator} B`,
+      output: `type T = B ${operator} (& A)`,
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+          data: {
+            type,
+            name: 'T',
+          },
+        },
+      ],
+    },
   ];
 };
 

--- a/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
@@ -288,8 +288,8 @@ type T =
       ],
     },
     {
-      code: `type T = (| A) ${operator} B`,
-      output: `type T = B ${operator} (| A)`,
+      code: `type T = (| A) ${operator} B;`,
+      output: `type T = B ${operator} (| A);`,
       errors: [
         {
           messageId: 'notSortedNamed',
@@ -301,8 +301,8 @@ type T =
       ],
     },
     {
-      code: `type T = (& A) ${operator} B`,
-      output: `type T = B ${operator} (& A)`,
+      code: `type T = (& A) ${operator} B;`,
+      output: `type T = B ${operator} (& A);`,
       errors: [
         {
           messageId: 'notSortedNamed',

--- a/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
@@ -360,5 +360,21 @@ type T = 1 | string | {} | A;
       ],
     },
   ],
-  invalid: [...invalid('|'), ...invalid('&')],
+  invalid: [
+    ...invalid('|'),
+    ...invalid('&'),
+    {
+      code: 'type T = (B | C) & A;',
+      output: `type T = A & (B | C);`,
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+          data: {
+            type: 'Intersection',
+            name: 'T',
+          },
+        },
+      ],
+    },
+  ],
 });

--- a/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-union-intersection-members.test.ts
@@ -287,6 +287,32 @@ type T =
         },
       ],
     },
+    {
+      code: `type T = (| A) ${operator} B`,
+      output: `type T = B ${operator} (| A)`,
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+          data: {
+            type,
+            name: 'T',
+          },
+        },
+      ],
+    },
+    {
+      code: `type T = (& A) ${operator} B`,
+      output: `type T = B ${operator} (& A)`,
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+          data: {
+            type,
+            name: 'T',
+          },
+        },
+      ],
+    },
   ];
 };
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6117
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

`requiresParentheses` now returns `true` for union types starting with `|` and intersection types starting with `&`.