### PR TITLE
chore: remove bug tag from pre-filled bug search

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
@@ -16,7 +16,7 @@ body:
           required: true
         - label: I have updated to the latest version of the packages.
           required: true
-        - label: I have [searched for related issues](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+label%3Abug+label%3A%22package%3A+eslint-plugin%22) and found none that matched my issue.
+        - label: I have [searched for related issues](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+label%3A%22package%3A+eslint-plugin%22) and found none that matched my issue.
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/docs/linting/troubleshooting) and my problem is not listed.
           required: true


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Sometimes we remove the `bug` tag when we mark an issue as "working as intended". So let's just remove this from the pre-filled search entirely