### PR TITLE
fix(eslint-plugin): [no-shadow] add call and method signatures to `ignoreFunctionTypeParameterNameValueShadow`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -20,6 +20,12 @@ type Options = [
   },
 ];
 
+const allowedFunctionVariableDefTypes = new Set([
+  AST_NODE_TYPES.TSCallSignatureDeclaration,
+  AST_NODE_TYPES.TSFunctionType,
+  AST_NODE_TYPES.TSMethodSignature,
+]);
+
 export default util.createRule<Options, MessageIds>({
   name: 'no-shadow',
   meta: {
@@ -147,8 +153,8 @@ export default util.createRule<Options, MessageIds>({
         return false;
       }
 
-      return variable.defs.every(
-        def => def.node.type === AST_NODE_TYPES.TSFunctionType,
+      return variable.defs.every(def =>
+        allowedFunctionVariableDefTypes.has(def.node.type),
       );
     }
 

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -145,6 +145,27 @@ type Fn = (Foo: string) => typeof Foo;
         Foo: 'writable',
       },
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/6098
+    {
+      code: `
+const arg = 0;
+
+interface Test {
+  (arg: string): typeof arg;
+}
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
+    },
+    {
+      code: `
+const arg = 0;
+
+interface Test {
+  p1(arg: string): typeof arg;
+}
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
+    },
     // https://github.com/typescript-eslint/typescript-eslint/issues/2724
     {
       code: `
@@ -521,6 +542,48 @@ type Fn = (Foo: string) => typeof Foo;
           messageId: 'noShadowGlobal',
           data: {
             name: 'Foo',
+          },
+        },
+      ],
+    },
+
+    // https://github.com/typescript-eslint/typescript-eslint/issues/6098
+    {
+      code: `
+const arg = 0;
+
+interface Test {
+  (arg: string): typeof arg;
+}
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }],
+      errors: [
+        {
+          messageId: 'noShadow',
+          data: {
+            name: 'arg',
+            shadowedLine: 2,
+            shadowedColumn: 7,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+const arg = 0;
+
+interface Test {
+  p1(arg: string): typeof arg;
+}
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }],
+      errors: [
+        {
+          messageId: 'noShadow',
+          data: {
+            name: 'arg',
+            shadowedLine: 2,
+            shadowedColumn: 7,
           },
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6098
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Adds call signatures and method signatures to the node types that `no-shadow` will ignore when `ignoreFunctionTypeParameterNameValueShadow` is `true`.

I embarrassingly got this rule's logic wrong the first time I tried triaging the issues, so asking for more oversight here. 🥲 