### PR TITLE
docs: add FAQ entry about running ESLint on transpiled code

### DIFF
--- a/docs/linting/Troubleshooting.md
+++ b/docs/linting/Troubleshooting.md
@@ -107,6 +107,13 @@ This is to be expected - ESLint rules do not check file extensions on purpose, a
 
 If you have some pure JavaScript code that you do not want to apply certain lint rules to, then you can use [ESLint's `overrides` configuration](https://eslint.org/docs/user-guide/configuring#configuration-based-on-glob-patterns) to turn off certain rules, or even change the parser based on glob patterns.
 
+## Should I run ESLint on transpiled output JavaScript files?
+
+No.
+
+Source TypeScript files have all the content of output JavaScript files, plus type annotations.
+There's no benefit to also linting output JavaScript files.
+
 ## TypeScript should be installed locally
 
 Make sure that you have installed TypeScript locally i.e. by using `npm install typescript`, not `npm install -g typescript`,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6143
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Mentions that no, you don't need to additionally run ESLint on transpiled JS code.

I couldn't find this explicitly mentioned anywhere else.