### PR TITLE
chore: use short form for nx project names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,12 +155,12 @@ jobs:
       # would override the config
       - name: Run unit tests with coverage for ${{ matrix.package }}
         if: env.PRIMARY_NODE_VERSION == matrix.node-version
-        run: npx nx test @typescript-eslint/${{ matrix.package }}
+        run: npx nx test ${{ matrix.package }}
         env:
           CI: true
       - name: Run unit tests for ${{ matrix.package }}
         if: env.PRIMARY_NODE_VERSION != matrix.node-version
-        run: npx nx test @typescript-eslint/${{ matrix.package }} --coverage=false
+        run: npx nx test ${{ matrix.package }} --coverage=false
         env:
           CI: true
 

--- a/packages/ast-spec/project.json
+++ b/packages/ast-spec/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@typescript-eslint/ast-spec",
+  "name": "ast-spec",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
   "implicitDependencies": [],

--- a/packages/eslint-plugin-internal/project.json
+++ b/packages/eslint-plugin-internal/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@typescript-eslint/eslint-plugin-internal",
+  "name": "eslint-plugin-internal",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
   "implicitDependencies": [],

--- a/packages/eslint-plugin-tslint/project.json
+++ b/packages/eslint-plugin-tslint/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@typescript-eslint/eslint-plugin-tslint",
+  "name": "eslint-plugin-tslint",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
   "implicitDependencies": [],

--- a/packages/eslint-plugin/project.json
+++ b/packages/eslint-plugin/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@typescript-eslint/eslint-plugin",
+  "name": "eslint-plugin",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
   "implicitDependencies": [],

--- a/packages/experimental-utils/project.json
+++ b/packages/experimental-utils/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@typescript-eslint/experimental-utils",
+  "name": "experimental-utils",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
   "implicitDependencies": [],

--- a/packages/parser/project.json
+++ b/packages/parser/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@typescript-eslint/parser",
+  "name": "parser",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
   "implicitDependencies": [],

--- a/packages/scope-manager/project.json
+++ b/packages/scope-manager/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@typescript-eslint/scope-manager",
+  "name": "scope-manager",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/scope-manager/src",
   "projectType": "library",

--- a/packages/type-utils/project.json
+++ b/packages/type-utils/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@typescript-eslint/type-utils",
+  "name": "type-utils",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
   "implicitDependencies": [],

--- a/packages/types/project.json
+++ b/packages/types/project.json
@@ -1,8 +1,8 @@
 {
-  "name": "@typescript-eslint/types",
+  "name": "types",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
-  "implicitDependencies": ["@typescript-eslint/ast-spec"],
+  "implicitDependencies": ["ast-spec"],
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/packages/typescript-estree/project.json
+++ b/packages/typescript-estree/project.json
@@ -1,8 +1,8 @@
 {
-  "name": "@typescript-eslint/typescript-estree",
+  "name": "typescript-estree",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
-  "implicitDependencies": ["@typescript-eslint/types"],
+  "implicitDependencies": ["types"],
   "targets": {
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/packages/utils/project.json
+++ b/packages/utils/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@typescript-eslint/utils",
+  "name": "utils",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
   "implicitDependencies": [],

--- a/packages/visitor-keys/project.json
+++ b/packages/visitor-keys/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@typescript-eslint/visitor-keys",
+  "name": "visitor-keys",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "type": "library",
   "implicitDependencies": [],


### PR DESCRIPTION
For example, allows us to write:

```sh
nx lint utils
```

instead of 

```sh
nx lint @typescript-eslint/utils
```

The names needed to match the package.json files a longgg time ago when I first set things up, but that's no longer the case so this would be a nice little QOL improvement