### PR TITLE
feat(eslint-plugin): [restrict-plus-operands] add allow* options

### DIFF
--- a/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
+++ b/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
@@ -18,48 +18,18 @@ This rule reports when a `+` operation combines two values of different types, o
 ### ❌ Incorrect
 
 ```ts
-var foo = '5.5' + 5;
-var foo = 1n + 1;
+let foo = '5.5' + 5;
+let foo = 1n + 1;
 ```
 
 ### ✅ Correct
 
 ```ts
-var foo = parseInt('5.5', 10) + 10;
-var foo = 1n + 1n;
+let foo = parseInt('5.5', 10) + 10;
+let foo = 1n + 1n;
 ```
 
 ## Options
-
-### `checkCompoundAssignments`
-
-Examples of code for this rule with `{ checkCompoundAssignments: true }`:
-
-<!--tabs-->
-
-#### ❌ Incorrect
-
-```ts
-/*eslint @typescript-eslint/restrict-plus-operands: ["error", { "checkCompoundAssignments": true }]*/
-
-let foo: string | undefined;
-foo += 'some data';
-
-let bar: string = '';
-bar += 0;
-```
-
-#### ✅ Correct
-
-```ts
-/*eslint @typescript-eslint/restrict-plus-operands: ["error", { "checkCompoundAssignments": true }]*/
-
-let foo: number = 0;
-foo += 1;
-
-let bar = '';
-bar += 'test';
-```
 
 ### `allowAny`
 
@@ -70,18 +40,123 @@ Examples of code for this rule with `{ allowAny: true }`:
 #### ❌ Incorrect
 
 ```ts
-var fn = (a: any, b: boolean) => a + b;
-var fn = (a: any, b: []) => a + b;
-var fn = (a: any, b: {}) => a + b;
+let fn = (a: number, b: []) => a + b;
+let fn = (a: string, b: []) => a + b;
 ```
 
 #### ✅ Correct
 
 ```ts
-var fn = (a: any, b: any) => a + b;
-var fn = (a: any, b: string) => a + b;
-var fn = (a: any, b: bigint) => a + b;
-var fn = (a: any, b: number) => a + b;
+let fn = (a: number, b: any) => a + b;
+let fn = (a: string, b: any) => a + b;
+```
+
+### `allowBoolean`
+
+Examples of code for this rule with `{ allowBoolean: true }`:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+let fn = (a: number, b: unknown) => a + b;
+let fn = (a: string, b: unknown) => a + b;
+```
+
+#### ✅ Correct
+
+```ts
+let fn = (a: number, b: boolean) => a + b;
+let fn = (a: string, b: boolean) => a + b;
+```
+
+### `allowNullish`
+
+Examples of code for this rule with `{ allowNullish: true }`:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+let fn = (a: number, b: unknown) => a + b;
+let fn = (a: number, b: never) => a + b;
+let fn = (a: string, b: unknown) => a + b;
+let fn = (a: string, b: never) => a + b;
+```
+
+#### ✅ Correct
+
+```ts
+let fn = (a: number, b: undefined) => a + b;
+let fn = (a: number, b: null) => a + b;
+let fn = (a: string, b: undefined) => a + b;
+let fn = (a: string, b: null) => a + b;
+```
+
+### `allowNumberAndString`
+
+Examples of code for this rule with `{ allowNumberAndString: true }`:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+let fn = (a: number, b: unknown) => a + b;
+let fn = (a: number, b: never) => a + b;
+```
+
+#### ✅ Correct
+
+```ts
+let fn = (a: number, b: string) => a + b;
+let fn = (a: number, b: number | string) => a + b;
+```
+
+### `allowRegExp`
+
+Examples of code for this rule with `{ allowRegExp: true }`:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+let fn = (a: number, b: RegExp) => a + b;
+```
+
+#### ✅ Correct
+
+```ts
+let fn = (a: string, b: RegExp) => a + b;
+```
+
+### `checkCompoundAssignments`
+
+Examples of code for this rule with `{ checkCompoundAssignments: true }`:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+let foo: string | undefined;
+foo += 'some data';
+
+let bar: string = '';
+bar += 0;
+```
+
+#### ✅ Correct
+
+```ts
+let foo: number = 0;
+foo += 1;
+
+let bar = '';
+bar += 'test';
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
+++ b/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
@@ -6,10 +6,10 @@ import * as util from '../util';
 
 type Options = [
   {
-    allowNumber?: boolean;
-    allowBoolean?: boolean;
     allowAny?: boolean;
+    allowBoolean?: boolean;
     allowNullish?: boolean;
+    allowNumber?: boolean;
     allowRegExp?: boolean;
   },
 ];
@@ -33,9 +33,9 @@ export default util.createRule<Options, MessageId>({
       {
         type: 'object',
         properties: {
-          allowNumber: {
+          allowAny: {
             description:
-              'Whether to allow `number` typed values in template expressions.',
+              'Whether to allow `any` typed values in template expressions.',
             type: 'boolean',
           },
           allowBoolean: {
@@ -43,14 +43,14 @@ export default util.createRule<Options, MessageId>({
               'Whether to allow `boolean` typed values in template expressions.',
             type: 'boolean',
           },
-          allowAny: {
-            description:
-              'Whether to allow `any` typed values in template expressions.',
-            type: 'boolean',
-          },
           allowNullish: {
             description:
               'Whether to allow `nullish` typed values in template expressions.',
+            type: 'boolean',
+          },
+          allowNumber: {
+            description:
+              'Whether to allow `number` typed values in template expressions.',
             type: 'boolean',
           },
           allowRegExp: {

--- a/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
@@ -13,53 +13,53 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('restrict-plus-operands', rule, {
   valid: [
-    'var x = 5;',
-    "var y = '10';",
-    'var z = 8.2;',
-    "var w = '6.5';",
-    'var foo = 5 + 10;',
-    "var foo = '5.5' + '10';",
-    "var foo = parseInt('5.5', 10) + 10;",
-    "var foo = parseFloat('5.5', 10) + 10;",
-    'var foo = 1n + 1n;',
-    'var foo = BigInt(1) + 1n;',
+    'let x = 5;',
+    "let y = '10';",
+    'let z = 8.2;',
+    "let w = '6.5';",
+    'let foo = 5 + 10;',
+    "let foo = '5.5' + '10';",
+    "let foo = parseInt('5.5', 10) + 10;",
+    "let foo = parseFloat('5.5', 10) + 10;",
+    'let foo = 1n + 1n;',
+    'let foo = BigInt(1) + 1n;',
     `
-      var foo = 1n;
+      let foo = 1n;
       foo + 2n;
     `,
     `
 function test(s: string, n: number): number {
   return 2;
 }
-var foo = test('5.5', 10) + 10;
+let foo = test('5.5', 10) + 10;
     `,
     `
-var x = 5;
-var z = 8.2;
-var foo = x + z;
+let x = 5;
+let z = 8.2;
+let foo = x + z;
     `,
     `
-var w = '6.5';
-var y = '10';
-var foo = y + w;
+let w = '6.5';
+let y = '10';
+let foo = y + w;
     `,
-    'var foo = 1 + 1;',
-    "var foo = '1' + '1';",
+    'let foo = 1 + 1;',
+    "let foo = '1' + '1';",
     `
-var pair: { first: number; second: string } = { first: 5, second: '10' };
-var foo = pair.first + 10;
-    `,
-    `
-var pair: { first: number; second: string } = { first: 5, second: '10' };
-var foo = pair.first + (10 as number);
+let pair: { first: number; second: string } = { first: 5, second: '10' };
+let foo = pair.first + 10;
     `,
     `
-var pair: { first: number; second: string } = { first: 5, second: '10' };
-var foo = '5.5' + pair.second;
+let pair: { first: number; second: string } = { first: 5, second: '10' };
+let foo = pair.first + (10 as number);
     `,
     `
-var pair: { first: number; second: string } = { first: 5, second: '10' };
-var foo = ('5.5' as string) + pair.second;
+let pair: { first: number; second: string } = { first: 5, second: '10' };
+let foo = '5.5' + pair.second;
+    `,
+    `
+let pair: { first: number; second: string } = { first: 5, second: '10' };
+let foo = ('5.5' as string) + pair.second;
     `,
     `
       const foo =
@@ -157,6 +157,84 @@ function A(s: string) {
 }
 const b = A('') + '!';
     `,
+    `
+declare const a: \`template\${string}\`;
+declare const b: '';
+const x = a + b;
+    `,
+    `
+const a: \`template\${0}\`;
+declare const b: '';
+const x = a + b;
+    `,
+    {
+      code: `
+        declare const a: RegExp;
+        declare const b: string;
+        const x = a + b;
+      `,
+      options: [
+        {
+          allowRegExp: true,
+        },
+      ],
+    },
+    {
+      code: `
+        const a = /regexp/;
+        declare const b: string;
+        const x = a + b;
+      `,
+      options: [
+        {
+          allowRegExp: true,
+        },
+      ],
+    },
+    // TypeScript handles this case, so we don't have to
+    {
+      code: `
+const f = (a: RegExp, b: RegExp) => a + b;
+      `,
+      options: [
+        {
+          allowRegExp: true,
+        },
+      ],
+    },
+    {
+      code: `
+let foo: string | undefined;
+foo = foo + 'some data';
+      `,
+      options: [
+        {
+          allowNullish: true,
+        },
+      ],
+    },
+    {
+      code: `
+let foo: string | null;
+foo = foo + 'some data';
+      `,
+      options: [
+        {
+          allowNullish: true,
+        },
+      ],
+    },
+    {
+      code: `
+let foo: string | null | undefined;
+foo = foo + 'some data';
+      `,
+      options: [
+        {
+          allowNullish: true,
+        },
+      ],
+    },
     {
       code: `
 let foo: number = 0;
@@ -181,7 +259,7 @@ foo += 'string';
     },
     {
       code: `
-export const f = (a: any, b: any) => a + b;
+const f = (a: any, b: any) => a + b;
       `,
       options: [
         {
@@ -191,7 +269,7 @@ export const f = (a: any, b: any) => a + b;
     },
     {
       code: `
-export const f = (a: any, b: string) => a + b;
+const f = (a: any, b: string) => a + b;
       `,
       options: [
         {
@@ -201,7 +279,7 @@ export const f = (a: any, b: string) => a + b;
     },
     {
       code: `
-export const f = (a: any, b: bigint) => a + b;
+const f = (a: any, b: bigint) => a + b;
       `,
       options: [
         {
@@ -211,101 +289,219 @@ export const f = (a: any, b: bigint) => a + b;
     },
     {
       code: `
-export const f = (a: any, b: number) => a + b;
+const f = (a: any, b: number) => a + b;
       `,
       options: [
         {
           allowAny: true,
+        },
+      ],
+    },
+    {
+      code: `
+const f = (a: any, b: boolean) => a + b;
+      `,
+      options: [
+        {
+          allowAny: true,
+          allowBoolean: true,
+        },
+      ],
+    },
+    {
+      code: `
+const f = (a: string, b: string | number) => a + b;
+      `,
+      options: [
+        {
+          allowAny: true,
+          allowBoolean: true,
+          allowNullish: true,
+          allowNumberAndString: true,
+          allowRegExp: true,
+        },
+      ],
+    },
+    {
+      code: `
+const f = (a: string | number, b: number) => a + b;
+      `,
+      options: [
+        {
+          allowAny: true,
+          allowBoolean: true,
+          allowNullish: true,
+          allowNumberAndString: true,
+          allowRegExp: true,
+        },
+      ],
+    },
+    {
+      code: `
+const f = (a: string | number, b: string | number) => a + b;
+      `,
+      options: [
+        {
+          allowAny: true,
+          allowBoolean: true,
+          allowNullish: true,
+          allowNumberAndString: true,
+          allowRegExp: true,
         },
       ],
     },
   ],
   invalid: [
     {
-      code: "var foo = '1' + 1;",
+      code: "let foo = '1' + 1;",
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            left: 'string',
+            right: 'number',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 1,
           column: 11,
         },
       ],
     },
     {
-      code: 'var foo = [] + {};',
+      code: 'let foo = [] + {};',
       errors: [
         {
-          messageId: 'notValidTypes',
+          data: {
+            stringLike: 'string',
+            type: 'never[]',
+          },
+          column: 11,
+          endColumn: 13,
+          line: 1,
+          messageId: 'invalid',
+        },
+        {
+          data: {
+            stringLike: 'string',
+            type: '{}',
+          },
+          column: 16,
+          endColumn: 18,
+          line: 1,
+          messageId: 'invalid',
+        },
+      ],
+    },
+    {
+      code: "let foo = 5 + '10';",
+      errors: [
+        {
+          data: {
+            left: 'number',
+            right: 'string',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 1,
           column: 11,
         },
       ],
     },
     {
-      code: "var foo = 5 + '10';",
+      code: 'let foo = [] + 5;',
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            stringLike: 'string',
+            type: 'never[]',
+          },
+          messageId: 'invalid',
+          line: 1,
+          column: 11,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: 'let foo = [] + [];',
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'never[]',
+          },
+          messageId: 'invalid',
+          line: 1,
+          endColumn: 13,
+          column: 11,
+        },
+        {
+          data: {
+            stringLike: 'string',
+            type: 'never[]',
+          },
+          messageId: 'invalid',
+          line: 1,
+          endColumn: 18,
+          column: 16,
+        },
+      ],
+    },
+    {
+      code: 'let foo = 5 + [3];',
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'number[]',
+          },
+          column: 15,
+          endColumn: 18,
+          line: 1,
+          messageId: 'invalid',
+        },
+      ],
+    },
+    {
+      code: "let foo = '5' + {};",
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: '{}',
+          },
+          messageId: 'invalid',
+          line: 1,
+          endColumn: 19,
+          column: 17,
+        },
+      ],
+    },
+    {
+      code: "let foo = 5.5 + '5';",
+      errors: [
+        {
+          data: {
+            left: 'number',
+            right: 'string',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 1,
           column: 11,
         },
       ],
     },
     {
-      code: 'var foo = [] + 5;',
+      code: "let foo = '5.5' + 5;",
       errors: [
         {
-          messageId: 'notNumbers',
-          line: 1,
-          column: 11,
-        },
-      ],
-    },
-    {
-      code: 'var foo = [] + [];',
-      errors: [
-        {
-          messageId: 'notValidTypes',
-          line: 1,
-          column: 11,
-        },
-      ],
-    },
-    {
-      code: 'var foo = 5 + [];',
-      errors: [
-        {
-          messageId: 'notNumbers',
-          line: 1,
-          column: 11,
-        },
-      ],
-    },
-    {
-      code: "var foo = '5' + {};",
-      errors: [
-        {
-          messageId: 'notStrings',
-          line: 1,
-          column: 11,
-        },
-      ],
-    },
-    {
-      code: "var foo = 5.5 + '5';",
-      errors: [
-        {
-          messageId: 'notStrings',
-          line: 1,
-          column: 11,
-        },
-      ],
-    },
-    {
-      code: "var foo = '5.5' + 5;",
-      errors: [
-        {
-          messageId: 'notStrings',
+          data: {
+            left: 'string',
+            right: 'number',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 1,
           column: 11,
         },
@@ -313,13 +509,18 @@ export const f = (a: any, b: number) => a + b;
     },
     {
       code: `
-var x = 5;
-var y = '10';
-var foo = x + y;
+let x = 5;
+let y = '10';
+let foo = x + y;
       `,
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            left: 'number',
+            right: 'string',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 4,
           column: 11,
         },
@@ -327,13 +528,18 @@ var foo = x + y;
     },
     {
       code: `
-var x = 5;
-var y = '10';
-var foo = y + x;
+let x = 5;
+let y = '10';
+let foo = y + x;
       `,
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            right: 'number',
+            left: 'string',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 4,
           column: 11,
         },
@@ -341,12 +547,33 @@ var foo = y + x;
     },
     {
       code: `
-var x = 5;
-var foo = x + {};
+let x = 5;
+let foo = x + {};
       `,
       errors: [
         {
-          messageId: 'notNumbers',
+          data: {
+            stringLike: 'string',
+            type: '{}',
+          },
+          messageId: 'invalid',
+          line: 3,
+          column: 15,
+        },
+      ],
+    },
+    {
+      code: `
+let y = '10';
+let foo = [] + y;
+      `,
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'never[]',
+          },
+          messageId: 'invalid',
           line: 3,
           column: 11,
         },
@@ -354,48 +581,74 @@ var foo = x + {};
     },
     {
       code: `
-var y = '10';
-var foo = [] + y;
+let pair = { first: 5, second: '10' };
+let foo = pair + pair;
       `,
       errors: [
         {
-          messageId: 'notStrings',
-          line: 3,
+          data: {
+            stringLike: 'string',
+            type: '{ first: number; second: string; }',
+          },
           column: 11,
+          endColumn: 15,
+          line: 3,
+          messageId: 'invalid',
+        },
+        {
+          data: {
+            stringLike: 'string',
+            type: '{ first: number; second: string; }',
+          },
+          column: 18,
+          endColumn: 22,
+          line: 3,
+          messageId: 'invalid',
         },
       ],
     },
     {
       code: `
-var pair: { first: number; second: string } = { first: 5, second: '10' };
-var foo = pair.first + '10';
+type Valued = { value: number };
+let value: Valued = { value: 0 };
+let combined = value + 0;
       `,
       errors: [
         {
-          messageId: 'notStrings',
-          line: 3,
+          data: {
+            stringLike: 'string',
+            type: 'Valued',
+          },
+          column: 16,
+          endColumn: 21,
+          line: 4,
+          messageId: 'invalid',
+        },
+      ],
+    },
+    {
+      code: 'let foo = 1n + 1;',
+      errors: [
+        {
+          data: {
+            left: 'bigint',
+            right: 'number',
+          },
+          messageId: 'bigintAndNumber',
+          line: 1,
           column: 11,
         },
       ],
     },
     {
-      code: `
-var pair: { first: number; second: string } = { first: 5, second: '10' };
-var foo = 5 + pair.second;
-      `,
+      code: 'let foo = 1 + 1n;',
       errors: [
         {
-          messageId: 'notStrings',
-          line: 3,
-          column: 11,
-        },
-      ],
-    },
-    {
-      code: "var foo = parseInt('5.5', 10) + '10';",
-      errors: [
-        {
-          messageId: 'notStrings',
+          data: {
+            left: 'number',
+            right: 'bigint',
+          },
+          messageId: 'bigintAndNumber',
           line: 1,
           column: 11,
         },
@@ -403,45 +656,16 @@ var foo = 5 + pair.second;
     },
     {
       code: `
-var pair = { first: 5, second: '10' };
-var foo = pair + pair;
-      `,
-      errors: [
-        {
-          messageId: 'notValidTypes',
-          line: 3,
-          column: 11,
-        },
-      ],
-    },
-    {
-      code: 'var foo = 1n + 1;',
-      errors: [
-        {
-          messageId: 'notBigInts',
-          line: 1,
-          column: 11,
-        },
-      ],
-    },
-    {
-      code: 'var foo = 1 + 1n;',
-      errors: [
-        {
-          messageId: 'notBigInts',
-          line: 1,
-          column: 11,
-        },
-      ],
-    },
-    {
-      code: `
-        var foo = 1n;
+        let foo = 1n;
         foo + 1;
       `,
       errors: [
         {
-          messageId: 'notBigInts',
+          data: {
+            left: 'bigint',
+            right: 'number',
+          },
+          messageId: 'bigintAndNumber',
           line: 3,
           column: 9,
         },
@@ -449,12 +673,16 @@ var foo = pair + pair;
     },
     {
       code: `
-        var foo = 1;
+        let foo = 1;
         foo + 1n;
       `,
       errors: [
         {
-          messageId: 'notBigInts',
+          data: {
+            left: 'number',
+            right: 'bigint',
+          },
+          messageId: 'bigintAndNumber',
           line: 3,
           column: 9,
         },
@@ -469,7 +697,12 @@ function foo<T extends string>(a: T) {
       `,
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            left: 'string',
+            right: 'number',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 3,
           column: 10,
         },
@@ -483,7 +716,12 @@ function foo<T extends 'a' | 'b'>(a: T) {
       `,
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            left: 'string',
+            right: 'number',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 3,
           column: 10,
         },
@@ -497,7 +735,12 @@ function foo<T extends number>(a: T) {
       `,
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            left: 'number',
+            right: 'string',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 3,
           column: 10,
         },
@@ -511,7 +754,12 @@ function foo<T extends 1>(a: T) {
       `,
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            left: 'number',
+            right: 'string',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 3,
           column: 10,
         },
@@ -519,13 +767,18 @@ function foo<T extends 1>(a: T) {
     },
     {
       code: `
-        declare const a: boolean & string;
-        declare const b: string;
+        declare const a: \`template\${number}\`;
+        declare const b: number;
         const x = a + b;
       `,
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            left: 'string',
+            right: 'number',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 4,
           column: 19,
         },
@@ -533,41 +786,17 @@ function foo<T extends 1>(a: T) {
     },
     {
       code: `
-        declare const a: number & string;
+        declare const a: never;
         declare const b: string;
         const x = a + b;
       `,
       errors: [
         {
-          messageId: 'notStrings',
-          line: 4,
-          column: 19,
-        },
-      ],
-    },
-    {
-      code: `
-        declare const a: symbol & string;
-        declare const b: string;
-        const x = a + b;
-      `,
-      errors: [
-        {
-          messageId: 'notStrings',
-          line: 4,
-          column: 19,
-        },
-      ],
-    },
-    {
-      code: `
-        declare const a: object & string;
-        declare const b: string;
-        const x = a + b;
-      `,
-      errors: [
-        {
-          messageId: 'notStrings',
+          data: {
+            stringLike: 'string',
+            type: 'never',
+          },
+          messageId: 'invalid',
           line: 4,
           column: 19,
         },
@@ -581,7 +810,29 @@ function foo<T extends 1>(a: T) {
       `,
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            stringLike: 'string',
+            type: 'never',
+          },
+          messageId: 'invalid',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: boolean & string;
+        declare const b: string;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'never',
+          },
+          messageId: 'invalid',
           line: 4,
           column: 19,
         },
@@ -595,7 +846,11 @@ function foo<T extends 1>(a: T) {
       `,
       errors: [
         {
-          messageId: 'notValidAnys',
+          data: {
+            stringLike: 'string',
+            type: 'any',
+          },
+          messageId: 'invalid',
           line: 4,
           column: 19,
         },
@@ -609,7 +864,11 @@ function foo<T extends 1>(a: T) {
       `,
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            stringLike: 'string',
+            type: '{ a: 1; } & { b: 2; }',
+          },
+          messageId: 'invalid',
           line: 4,
           column: 19,
         },
@@ -617,70 +876,64 @@ function foo<T extends 1>(a: T) {
     },
     {
       code: `
-        declare const a: boolean & number;
-        declare const b: number;
+        interface A {
+          a: 1;
+        }
+        declare const a: A;
+        declare const b: string;
         const x = a + b;
       `,
       errors: [
         {
-          messageId: 'notNumbers',
-          line: 4,
+          data: {
+            stringLike: 'string',
+            type: 'A',
+          },
+          messageId: 'invalid',
+          line: 7,
           column: 19,
         },
       ],
     },
     {
       code: `
-        declare const a: symbol & number;
-        declare const b: number;
+        interface A {
+          a: 1;
+        }
+        interface A2 extends A {
+          b: 2;
+        }
+        declare const a: A2;
+        declare const b: string;
         const x = a + b;
       `,
       errors: [
         {
-          messageId: 'notNumbers',
-          line: 4,
+          data: {
+            stringLike: 'string',
+            type: 'A2',
+          },
+          messageId: 'invalid',
+          line: 10,
           column: 19,
         },
       ],
     },
     {
       code: `
-        declare const a: object & number;
-        declare const b: number;
+        type A = { a: 1 } & { b: 2 };
+        declare const a: A;
+        declare const b: string;
         const x = a + b;
       `,
       errors: [
         {
-          messageId: 'notNumbers',
-          line: 4,
-          column: 19,
-        },
-      ],
-    },
-    {
-      code: `
-        declare const a: never & number;
-        declare const b: number;
-        const x = a + b;
-      `,
-      errors: [
-        {
-          messageId: 'notNumbers',
-          line: 4,
-          column: 19,
-        },
-      ],
-    },
-    {
-      code: `
-        declare const a: any & number;
-        declare const b: number;
-        const x = a + b;
-      `,
-      errors: [
-        {
-          messageId: 'notValidAnys',
-          line: 4,
+          data: {
+            stringLike: 'string',
+            type: 'A',
+          },
+          messageId: 'invalid',
+          line: 5,
           column: 19,
         },
       ],
@@ -693,7 +946,11 @@ function foo<T extends 1>(a: T) {
       `,
       errors: [
         {
-          messageId: 'notNumbers',
+          data: {
+            stringLike: 'string',
+            type: '{ a: 1; } & { b: 2; }',
+          },
+          messageId: 'invalid',
           line: 4,
           column: 19,
         },
@@ -701,13 +958,17 @@ function foo<T extends 1>(a: T) {
     },
     {
       code: `
-        declare const a: boolean & bigint;
+        declare const a: never;
         declare const b: bigint;
         const x = a + b;
       `,
       errors: [
         {
-          messageId: 'notBigInts',
+          data: {
+            stringLike: 'string',
+            type: 'never',
+          },
+          messageId: 'invalid',
           line: 4,
           column: 19,
         },
@@ -715,69 +976,17 @@ function foo<T extends 1>(a: T) {
     },
     {
       code: `
-        declare const a: number & bigint;
+        declare const a: any;
         declare const b: bigint;
         const x = a + b;
       `,
       errors: [
         {
-          messageId: 'notBigInts',
-          line: 4,
-          column: 19,
-        },
-      ],
-    },
-    {
-      code: `
-        declare const a: symbol & bigint;
-        declare const b: bigint;
-        const x = a + b;
-      `,
-      errors: [
-        {
-          messageId: 'notBigInts',
-          line: 4,
-          column: 19,
-        },
-      ],
-    },
-    {
-      code: `
-        declare const a: object & bigint;
-        declare const b: bigint;
-        const x = a + b;
-      `,
-      errors: [
-        {
-          messageId: 'notBigInts',
-          line: 4,
-          column: 19,
-        },
-      ],
-    },
-    {
-      code: `
-        declare const a: never & bigint;
-        declare const b: bigint;
-        const x = a + b;
-      `,
-      errors: [
-        {
-          messageId: 'notBigInts',
-          line: 4,
-          column: 19,
-        },
-      ],
-    },
-    {
-      code: `
-        declare const a: any & bigint;
-        declare const b: bigint;
-        const x = a + b;
-      `,
-      errors: [
-        {
-          messageId: 'notValidAnys',
+          data: {
+            stringLike: 'string',
+            type: 'any',
+          },
+          messageId: 'invalid',
           line: 4,
           column: 19,
         },
@@ -791,7 +1000,119 @@ function foo<T extends 1>(a: T) {
       `,
       errors: [
         {
-          messageId: 'notBigInts',
+          data: {
+            stringLike: 'string',
+            type: '{ a: 1; } & { b: 2; }',
+          },
+          messageId: 'invalid',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: RegExp;
+        declare const b: string;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'RegExp',
+          },
+          messageId: 'invalid',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        const a = /regexp/;
+        declare const b: string;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'RegExp',
+          },
+          messageId: 'invalid',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: Symbol;
+        declare const b: string;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'Symbol',
+          },
+          messageId: 'invalid',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: symbol;
+        declare const b: string;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'symbol',
+          },
+          messageId: 'invalid',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        declare const a: unique symbol;
+        declare const b: string;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'unique symbol',
+          },
+          messageId: 'invalid',
+          line: 4,
+          column: 19,
+        },
+      ],
+    },
+    {
+      code: `
+        const a = Symbol('');
+        declare const b: string;
+        const x = a + b;
+      `,
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'unique symbol',
+          },
+          messageId: 'invalid',
           line: 4,
           column: 19,
         },
@@ -809,7 +1130,33 @@ foo += 'some data';
       ],
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            stringLike: 'string',
+            type: 'string | undefined',
+          },
+          messageId: 'invalid',
+          line: 3,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+let foo: string | null;
+foo += 'some data';
+      `,
+      options: [
+        {
+          checkCompoundAssignments: true,
+        },
+      ],
+      errors: [
+        {
+          data: {
+            stringLike: 'string',
+            type: 'string | null',
+          },
+          messageId: 'invalid',
           line: 3,
           column: 1,
         },
@@ -827,7 +1174,12 @@ foo += 0;
       ],
       errors: [
         {
-          messageId: 'notStrings',
+          data: {
+            left: 'string',
+            right: 'number',
+            stringLike: 'string',
+          },
+          messageId: 'mismatched',
           line: 3,
           column: 1,
         },
@@ -844,9 +1196,9 @@ const f = (a: any, b: boolean) => a + b;
       ],
       errors: [
         {
-          messageId: 'notValidAnys',
+          messageId: 'invalid',
           line: 2,
-          column: 35,
+          column: 39,
         },
       ],
     },
@@ -861,13 +1213,37 @@ const f = (a: any, b: []) => a + b;
       ],
       errors: [
         {
-          messageId: 'notValidAnys',
+          data: {
+            stringLike: 'string, allowing a string + `any`',
+            type: '[]',
+          },
+          messageId: 'invalid',
           line: 2,
-          column: 30,
+          column: 34,
         },
       ],
     },
-
+    {
+      code: `
+const f = (a: any, b: boolean) => a + b;
+      `,
+      options: [
+        {
+          allowBoolean: true,
+        },
+      ],
+      errors: [
+        {
+          data: {
+            stringLike: 'string, allowing a string + `boolean`',
+            type: 'any',
+          },
+          messageId: 'invalid',
+          line: 2,
+          column: 35,
+        },
+      ],
+    },
     {
       code: `
 const f = (a: any, b: any) => a + b;
@@ -879,9 +1255,14 @@ const f = (a: any, b: any) => a + b;
       ],
       errors: [
         {
-          messageId: 'notValidAnys',
+          messageId: 'invalid',
           line: 2,
           column: 31,
+        },
+        {
+          messageId: 'invalid',
+          line: 2,
+          column: 35,
         },
       ],
     },
@@ -896,7 +1277,7 @@ const f = (a: any, b: string) => a + b;
       ],
       errors: [
         {
-          messageId: 'notValidAnys',
+          messageId: 'invalid',
           line: 2,
           column: 34,
         },
@@ -913,7 +1294,7 @@ const f = (a: any, b: bigint) => a + b;
       ],
       errors: [
         {
-          messageId: 'notValidAnys',
+          messageId: 'invalid',
           line: 2,
           column: 34,
         },
@@ -930,7 +1311,7 @@ const f = (a: any, b: number) => a + b;
       ],
       errors: [
         {
-          messageId: 'notValidAnys',
+          messageId: 'invalid',
           line: 2,
           column: 34,
         },
@@ -940,16 +1321,109 @@ const f = (a: any, b: number) => a + b;
       code: `
 const f = (a: any, b: boolean) => a + b;
       `,
+      errors: [
+        {
+          messageId: 'invalid',
+          line: 2,
+          column: 35,
+        },
+        {
+          messageId: 'invalid',
+          line: 2,
+          column: 39,
+        },
+      ],
       options: [
         {
           allowAny: false,
         },
       ],
+    },
+    {
+      code: `
+const f = (a: number, b: RegExp) => a + b;
+      `,
       errors: [
         {
-          messageId: 'notValidAnys',
+          messageId: 'invalid',
           line: 2,
-          column: 35,
+          column: 41,
+        },
+      ],
+      options: [
+        {
+          allowRegExp: true,
+        },
+      ],
+    },
+    {
+      code: `
+let foo: string | boolean;
+foo = foo + 'some data';
+      `,
+      errors: [
+        {
+          data: {
+            stringLike:
+              'string, allowing a string + any of: `null`, `undefined`',
+            type: 'string | boolean',
+          },
+          messageId: 'invalid',
+          line: 3,
+          column: 7,
+        },
+      ],
+      options: [
+        {
+          allowNullish: true,
+        },
+      ],
+    },
+    {
+      code: `
+let foo: boolean;
+foo = foo + 'some data';
+      `,
+      errors: [
+        {
+          data: {
+            stringLike:
+              'string, allowing a string + any of: `null`, `undefined`',
+            type: 'boolean',
+          },
+          messageId: 'invalid',
+          line: 3,
+          column: 7,
+        },
+      ],
+      options: [
+        {
+          allowNullish: true,
+        },
+      ],
+    },
+    {
+      code: `
+const f = (a: any, b: unknown) => a + b;
+      `,
+      options: [
+        {
+          allowAny: true,
+          allowBoolean: true,
+          allowNullish: true,
+          allowRegExp: true,
+        },
+      ],
+      errors: [
+        {
+          data: {
+            stringLike:
+              'string, allowing a string + any of: `any`, `boolean`, `null`, `RegExp`, `undefined`',
+            type: 'unknown',
+          },
+          messageId: 'invalid',
+          line: 2,
+          column: 39,
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6110
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Brings in the `allowBoolean`, `allowNullish`, and `allowRegExp` options from `@typescript-eslint/restrict-template-expressions`. Also adds an `allowNumberWithString` option equivalent to the `allowNumber` option, as a more-specific-to-this-rule name.

Internally streamlines the rule a bit by having comparisons directly refer to `ts.TypeFlags` checks whenever possible.