### PR TITLE
chore: drafted ESLint parsing context

### DIFF
--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -3,7 +3,11 @@ import type {
   ScopeManager,
 } from '@typescript-eslint/scope-manager';
 import { analyze } from '@typescript-eslint/scope-manager';
-import type { Lib, TSESTree } from '@typescript-eslint/types';
+import type {
+  ESLintParsingContext,
+  Lib,
+  TSESTree,
+} from '@typescript-eslint/types';
 import { ParserOptions } from '@typescript-eslint/types';
 import type {
   ParserServices,
@@ -85,6 +89,7 @@ function parse(
 function parseForESLint(
   code: string,
   options?: ParserOptions | null,
+  parserContext?: ESLintParsingContext,
 ): ParseForESLintResult {
   if (!options || typeof options !== 'object') {
     options = {};
@@ -125,7 +130,11 @@ function parseForESLint(
     parserOptions.loggerFn = false;
   }
 
-  const { ast, services } = parseAndGenerateServices(code, parserOptions);
+  const { ast, services } = parseAndGenerateServices(
+    code,
+    parserOptions,
+    parserContext,
+  );
   ast.sourceType = options.sourceType;
 
   let emitDecoratorMetadata = options.emitDecoratorMetadata === true;

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -62,4 +62,13 @@ interface ParserOptions {
   [additionalProperties: string]: unknown;
 }
 
+export interface ESLintOptions {
+  fix?: boolean;
+}
+
+export interface ESLintParsingContext {
+  mode: 'persistent' | 'single';
+  options: ESLintOptions;
+}
+
 export { DebugLevel, EcmaVersion, ParserOptions, SourceType };

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -1,3 +1,4 @@
+import { ESLintParsingContext } from '@typescript-eslint/types';
 import debug from 'debug';
 import { sync as globSync } from 'globby';
 import isGlob from 'is-glob';
@@ -18,8 +19,11 @@ const log = debug(
 
 export function createParseSettings(
   code: string,
-  options: Partial<TSESTreeOptions> = {},
+  options: Partial<TSESTreeOptions> | undefined,
+  parsingContext: ESLintParsingContext | undefined,
 ): MutableParseSettings {
+  options ??= {};
+
   const tsconfigRootDir =
     typeof options.tsconfigRootDir === 'string'
       ? options.tsconfigRootDir
@@ -63,7 +67,7 @@ export function createParseSettings(
     programs: Array.isArray(options.programs) ? options.programs : null,
     projects: [],
     range: options.range === true,
-    singleRun: inferSingleRun(options),
+    singleRun: inferSingleRun(options, parsingContext),
     tokens: options.tokens === true ? [] : null,
     tsconfigRootDir,
   };

--- a/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
+++ b/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
@@ -1,3 +1,4 @@
+import { ESLintParsingContext } from '@typescript-eslint/types';
 import { normalize } from 'path';
 
 import type { TSESTreeOptions } from '../parser-options';
@@ -14,7 +15,17 @@ import type { TSESTreeOptions } from '../parser-options';
  *
  * @returns Whether this is part of a single run, rather than a long-running process.
  */
-export function inferSingleRun(options: TSESTreeOptions | undefined): boolean {
+export function inferSingleRun(
+  options: TSESTreeOptions | undefined,
+  parsingContext: ESLintParsingContext | undefined,
+): boolean {
+  // If a version of ESLint that supports providing contexts is used by a consumer
+  // that also knows to specify the parsing context is provided, rejoice!
+  // We can explicitly determine process style from the parsing context.
+  if (parsingContext) {
+    return parsingContext.mode === 'single' && !parsingContext.options.fix;
+  }
+
   if (
     // single-run implies type-aware linting - no projects means we can't be in single-run mode
     options?.project == null ||

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -1,3 +1,4 @@
+import { ESLintParsingContext } from '@typescript-eslint/types';
 import debug from 'debug';
 import type * as ts from 'typescript';
 
@@ -69,20 +70,27 @@ interface ParseWithNodeMapsResult<T extends TSESTreeOptions> {
 function parse<T extends TSESTreeOptions = TSESTreeOptions>(
   code: string,
   options?: T,
+  parserContext?: ESLintParsingContext,
 ): AST<T> {
-  const { ast } = parseWithNodeMapsInternal(code, options, false);
+  const { ast } = parseWithNodeMapsInternal(
+    code,
+    options,
+    parserContext,
+    false,
+  );
   return ast;
 }
 
 function parseWithNodeMapsInternal<T extends TSESTreeOptions = TSESTreeOptions>(
   code: string,
   options: T | undefined,
+  parsingContext: ESLintParsingContext | undefined,
   shouldPreserveNodeMaps: boolean,
 ): ParseWithNodeMapsResult<T> {
   /**
    * Reset the parse configuration
    */
-  const parseSettings = createParseSettings(code, options);
+  const parseSettings = createParseSettings(code, options, parsingContext);
 
   /**
    * Ensure users do not attempt to use parse() when they need parseAndGenerateServices()
@@ -117,8 +125,9 @@ function parseWithNodeMapsInternal<T extends TSESTreeOptions = TSESTreeOptions>(
 function parseWithNodeMaps<T extends TSESTreeOptions = TSESTreeOptions>(
   code: string,
   options?: T,
+  parsingContext?: ESLintParsingContext,
 ): ParseWithNodeMapsResult<T> {
-  return parseWithNodeMapsInternal(code, options, true);
+  return parseWithNodeMapsInternal(code, options, parsingContext, true);
 }
 
 let parseAndGenerateServicesCalls: { [fileName: string]: number } = {};
@@ -130,11 +139,12 @@ function clearParseAndGenerateServicesCalls(): void {
 function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
   code: string,
   options: T,
+  parsingContext: ESLintParsingContext | undefined,
 ): ParseAndGenerateServicesResult<T> {
   /**
    * Reset the parse configuration
    */
-  const parseSettings = createParseSettings(code, options);
+  const parseSettings = createParseSettings(code, options, parsingContext);
 
   if (typeof options !== 'undefined') {
     if (

--- a/packages/visitor-keys/src/visitor-keys.ts
+++ b/packages/visitor-keys/src/visitor-keys.ts
@@ -150,7 +150,7 @@ const SharedVisitorKeys = (() => {
 })();
 
 const additionalKeys: AdditionalKeys = {
-  AccessorProperty: SharedVisitorKeys.PropertyDefinition,
+  // AccessorProperty: SharedVisitorKeys.PropertyDefinition,
   ArrayPattern: ['decorators', 'elements', 'typeAnnotation'],
   ArrowFunctionExpression: SharedVisitorKeys.AnonymousFunction,
   AssignmentPattern: ['decorators', 'left', 'right', 'typeAnnotation'],
@@ -177,7 +177,7 @@ const additionalKeys: AdditionalKeys = {
   RestElement: ['decorators', 'argument', 'typeAnnotation'],
   StaticBlock: ['body'],
   TaggedTemplateExpression: ['tag', 'typeParameters', 'quasi'],
-  TSAbstractAccessorProperty: SharedVisitorKeys.AbstractPropertyDefinition,
+  // TSAbstractAccessorProperty: SharedVisitorKeys.AbstractPropertyDefinition,
   TSAbstractKeyword: [],
   TSAbstractMethodDefinition: ['key', 'value'],
   TSAbstractPropertyDefinition: SharedVisitorKeys.AbstractPropertyDefinition,


### PR DESCRIPTION
Reference of how we might be able to use a _"parsing context"_ if given one from ESLint.

Specifically, `inferSingleRun` becomes much smarter - we can _know_ (instead of guess) whether to enable single-run mode if given that parsing context. 