### PR TITLE
chore: add working-directory input to prepare-install action

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -47,6 +47,7 @@
     "autofix",
     "autofixers",
     "autofixes",
+    "automations",
     "backticks",
     "bigint",
     "bivariant",

--- a/.github/actions/prepare-install/action.yml
+++ b/.github/actions/prepare-install/action.yml
@@ -1,5 +1,12 @@
-name: 'Prepare: Checkout and Install'
-description: 'Prepares the repo for a job by checking out and installing dependencies'
+# IMPORTANT NOTE TO MAINTAINERS
+#
+# Changes to this composite action should be carefully considered and reviewed because it is referenced
+# and executed by multiple workflows in our private-automations repository.
+#
+# Ensure that a member of @typescript-eslint/core-team tests changes there before merging.
+
+name: 'Prepare: Install'
+description: 'Prepares the repo by installing dependencies'
 inputs:
   node-version:
     description: 'The node version to setup'
@@ -7,6 +14,11 @@ inputs:
   registry-url:
     description: 'Define registry-url'
     required: false
+  # NOTE: This is required for our use-case of sharing this action across multiple repos
+  working-directory:
+    description: 'Override the working directory to run the installation in'
+    required: false
+    default: '.'
 
 # outputs: - no outputs
 
@@ -15,6 +27,7 @@ runs:
   steps:
     - name: echo github.ref
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: echo ${{ github.ref }}
 
     - name: Use Node.js ${{ inputs.node-version }}
@@ -40,6 +53,7 @@ runs:
     # if the cache was hit - this will run in <1s
     - name: Install dependencies
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: |
         yarn --ignore-engines --frozen-lockfile --ignore-scripts
         yarn check-clean-workspace-after-install


### PR DESCRIPTION
This allows us to directly reuse out dependency installation logic in our private-workflows, and by landing it before the yarn 3 PR we can make that change in only one place and have it work everywhere (and stay in sync over time)