### PR TITLE
chore: more aggressively clean local dev caches

### DIFF
--- a/packages/ast-spec/src/base/BaseNode.ts
+++ b/packages/ast-spec/src/base/BaseNode.ts
@@ -3,6 +3,8 @@ import type { AST_NODE_TYPES } from '../ast-node-types';
 import type { NodeOrTokenData } from './NodeOrTokenData';
 
 export interface BaseNode extends NodeOrTokenData {
+  type: AST_NODE_TYPES;
+
   /**
    * The parent node of the current node
    *
@@ -10,6 +12,4 @@ export interface BaseNode extends NodeOrTokenData {
    * while traversing.
    */
   // parent?: Node;
-
-  type: AST_NODE_TYPES;
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -33,7 +33,7 @@
     "build": "tsc -b tsconfig.build.json",
     "postbuild": "downlevel-dts dist _ts3.4/dist",
     "clean": "tsc -b tsconfig.build.json --clean",
-    "postclean": "rimraf dist && rimraf _ts3.4 && rimraf coverage",
+    "postclean": "rimraf dist && rimraf src/generated && rimraf _ts3.4 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "generate:lib": "../../node_modules/.bin/ts-node --files --transpile-only ../scope-manager/tools/generate-lib.ts",
     "lint": "nx lint",

--- a/tools/postinstall.ts
+++ b/tools/postinstall.ts
@@ -21,7 +21,10 @@ void (async function (): Promise<void> {
   // Install git hooks
   await $`yarn husky install`;
 
-  // // Build all the packages ready for use
+  // Clean any caches that may be invalid now
+  await $`yarn clean`;
+
+  // Build all the packages ready for use
   await $`yarn build`;
 })();
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6163
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

I took another hard look at local build caching w.r.t. #6144 and #6163. I think the issue was that out-of-date files kept getting out of date, most often `packages/types/src/generated/ast-spec.ts`. This adds two layers of protection:

* For specifically the `types` package, also cleans `src/generated/` in `yarn clean`: since it's generated similar to `dist/`.
* Generally runs `yarn clean` in the postinstall script: as a backup precaution to make sure if you've pulled in build/cache changes, to wipe more things that might be out of date now. Ideally Nx should be caching them when the next line's `yarn build` runs anyway.

I moved the `BaseNode` JSDoc comments to below its `type` as a way to test this. They show up erroneously in the built output so this is a good change anyway. And, #5252 will blow those changes away once v6 lands.