### PR TITLE
chore(website): manually centered homepage buttons

### DIFF
--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -120,7 +120,7 @@ function Feature({ title, description }: FeatureItem): JSX.Element {
       <p>{description}</p>
       <div className={styles.buttons}>
         <Link
-          className="button button--primary"
+          className={clsx('button button--primary', styles.buttonCentered)}
           to={useBaseUrl('getting-started')}
         >
           Get Started
@@ -140,7 +140,7 @@ function Home(): JSX.Element {
           <p className="hero__subtitle">{siteConfig.tagline}</p>
           <div className={styles.buttons}>
             <Link
-              className={clsx('button button--primary', styles.buttonPrimary)}
+              className="button button--primary"
               to={useBaseUrl('getting-started')}
             >
               Get Started

--- a/packages/website/src/pages/styles.module.css
+++ b/packages/website/src/pages/styles.module.css
@@ -35,6 +35,10 @@
   margin: 1rem 1rem;
 }
 
+.buttonCentered {
+  margin: auto;
+}
+
 .buttonPrimary {
   border: var(--ifm-button-border-width) solid var(--ifm-button-color);
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6081
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

I haven't been able to figure out any kind of caching issue. So as a bandaid fix for now, this just adds a manual class to the buttons. 🤷 