### PR TITLE
chore: enable eqeqeq internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -110,7 +110,7 @@ module.exports = {
       'error',
       'always',
       {
-        null: 'ignore',
+        null: 'never',
       },
     ],
     'no-mixed-operators': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,6 +106,13 @@ module.exports = {
     //
 
     curly: ['error', 'all'],
+    eqeqeq: [
+      'error',
+      'always',
+      {
+        null: 'ignore',
+      },
+    ],
     'no-mixed-operators': 'error',
     'no-console': 'error',
     'no-process-exit': 'error',

--- a/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
+++ b/packages/eslint-plugin/src/rules/adjacent-overload-signatures.ts
@@ -65,7 +65,7 @@ export default util.createRule({
         case AST_NODE_TYPES.TSDeclareFunction:
         case AST_NODE_TYPES.FunctionDeclaration: {
           const name = member.id?.name ?? null;
-          if (name === null) {
+          if (name == null) {
             return null;
           }
           return {
@@ -143,7 +143,7 @@ export default util.createRule({
 
         members.forEach(member => {
           const method = getMemberMethod(member);
-          if (method === null) {
+          if (method == null) {
             lastMethod = null;
             return;
           }

--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -36,7 +36,7 @@ function stringifyNode(
 function getCustomMessage(
   bannedType: null | string | { message?: string; fixWith?: string },
 ): string {
-  if (bannedType === null) {
+  if (bannedType == null) {
     return '';
   }
 

--- a/packages/eslint-plugin/src/rules/comma-spacing.ts
+++ b/packages/eslint-plugin/src/rules/comma-spacing.ts
@@ -68,7 +68,7 @@ export default createRule<Options, MessageIds>({
       let previousToken = sourceCode.getFirstToken(node);
       for (const element of node.elements) {
         let token: TSESTree.Token | null;
-        if (element === null) {
+        if (element == null) {
           token = sourceCode.getTokenAfter(previousToken!);
           if (token && isCommaToken(token)) {
             ignoredTokens.add(token);

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -489,7 +489,7 @@ function getRank(
 ): number {
   const type = getNodeType(node);
 
-  if (type === null) {
+  if (type == null) {
     // shouldn't happen but just in case, put it on the end
     return orderConfig.length - 1;
   }
@@ -842,7 +842,7 @@ export default util.createRule<Options, MessageIds>({
             supportsModifiers,
           );
 
-          if (grouped === null) {
+          if (grouped == null) {
             return false;
           }
 

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/validator.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/validator.ts
@@ -101,25 +101,25 @@ function createValidator(
       let name: string | null = originalName;
 
       name = validateUnderscore('leading', config, name, node, originalName);
-      if (name === null) {
+      if (name == null) {
         // fail
         return;
       }
 
       name = validateUnderscore('trailing', config, name, node, originalName);
-      if (name === null) {
+      if (name == null) {
         // fail
         return;
       }
 
       name = validateAffix('prefix', config, name, node, originalName);
-      if (name === null) {
+      if (name == null) {
         // fail
         return;
       }
 
       name = validateAffix('suffix', config, name, node, originalName);
-      if (name === null) {
+      if (name == null) {
         // fail
         return;
       }
@@ -383,7 +383,7 @@ function createValidator(
     modifiers: Set<Modifiers>,
   ): boolean {
     const formats = config.format;
-    if (formats === null || formats.length === 0) {
+    if (!formats?.length) {
       return true;
     }
 
@@ -427,7 +427,7 @@ function isCorrectType(
   context: Context,
   selector: Selectors,
 ): boolean {
-  if (config.types === null) {
+  if (config.types == null) {
     return true;
   }
 

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -269,7 +269,7 @@ export default util.createRule<Options, MessageIds>({
           | TSESTree.FunctionExpression,
       ): void {
         const validator = validators.function;
-        if (!validator || node.id === null) {
+        if (!validator || node.id == null) {
           return;
         }
 
@@ -489,7 +489,7 @@ export default util.createRule<Options, MessageIds>({
         }
 
         const id = node.id;
-        if (id === null) {
+        if (id == null) {
           return;
         }
 

--- a/packages/eslint-plugin/src/rules/no-implied-eval.ts
+++ b/packages/eslint-plugin/src/rules/no-implied-eval.ts
@@ -135,7 +135,7 @@ export default util.createRule({
       node: TSESTree.NewExpression | TSESTree.CallExpression,
     ): void {
       const calleeName = getCalleeName(node.callee);
-      if (calleeName === null) {
+      if (calleeName == null) {
         return;
       }
 

--- a/packages/eslint-plugin/src/rules/no-inferrable-types.ts
+++ b/packages/eslint-plugin/src/rules/no-inferrable-types.ts
@@ -147,7 +147,7 @@ export default util.createRule<Options, MessageIds>({
         }
 
         case AST_NODE_TYPES.TSNullKeyword:
-          return init.type === AST_NODE_TYPES.Literal && init.value === null;
+          return init.type === AST_NODE_TYPES.Literal && init.value == null;
 
         case AST_NODE_TYPES.TSStringKeyword:
           return (

--- a/packages/eslint-plugin/src/rules/no-loss-of-precision.ts
+++ b/packages/eslint-plugin/src/rules/no-loss-of-precision.ts
@@ -25,7 +25,7 @@ export default util.createRule<Options, MessageIds>({
   },
   defaultOptions: [],
   create(context) {
-    /* istanbul ignore if */ if (baseRule === null) {
+    /* istanbul ignore if */ if (baseRule == null) {
       throw new Error(
         '@typescript-eslint/no-loss-of-precision requires at least ESLint v7.1.0',
       );

--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -250,7 +250,7 @@ export default util.createRule<Options, MessageId>({
 
     function checkVariableDeclaration(node: TSESTree.VariableDeclarator): void {
       const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
-      if (tsNode.initializer === undefined || node.init === null) {
+      if (tsNode.initializer === undefined || node.init == null) {
         return;
       }
       const varType = checker.getTypeAtLocation(tsNode.name);
@@ -344,7 +344,7 @@ export default util.createRule<Options, MessageId>({
 
     function checkReturnStatement(node: TSESTree.ReturnStatement): void {
       const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
-      if (tsNode.expression === undefined || node.argument === null) {
+      if (tsNode.expression === undefined || node.argument == null) {
         return;
       }
       const contextualType = checker.getContextualType(tsNode.expression);
@@ -368,7 +368,7 @@ export default util.createRule<Options, MessageId>({
       const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
       const value = tsNode.initializer;
       if (
-        node.value === null ||
+        node.value == null ||
         value === undefined ||
         !ts.isJsxExpression(value) ||
         value.expression === undefined

--- a/packages/eslint-plugin/src/rules/no-non-null-asserted-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-asserted-nullish-coalescing.ts
@@ -27,7 +27,7 @@ function isDefinitionWithAssignment(definition: Definition): boolean {
 
   const variableDeclarator = definition.node;
   return (
-    variableDeclarator.definite === true || variableDeclarator.init !== null
+    variableDeclarator.definite === true || variableDeclarator.init != null
   );
 }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -384,7 +384,7 @@ export default createRule<Options, MessageId>({
         | TSESTree.ForStatement
         | TSESTree.WhileStatement,
     ): void {
-      if (node.test === null) {
+      if (node.test == null) {
         // e.g. `for(;;)`
         return;
       }

--- a/packages/eslint-plugin/src/rules/no-unnecessary-qualifier.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-qualifier.ts
@@ -53,7 +53,7 @@ export default util.createRule({
 
       const alias = tryGetAliasedSymbol(symbol, checker);
 
-      return alias !== null && symbolIsNamespaceInScope(alias);
+      return alias != null && symbolIsNamespaceInScope(alias);
     }
 
     function getSymbolInScope(

--- a/packages/eslint-plugin/src/rules/no-use-before-define.ts
+++ b/packages/eslint-plugin/src/rules/no-use-before-define.ts
@@ -64,7 +64,7 @@ function isOuterEnum(
   reference: TSESLint.Scope.Reference,
 ): boolean {
   return (
-    variable.defs[0].type == DefinitionType.TSEnumName &&
+    variable.defs[0].type === DefinitionType.TSEnumName &&
     variable.scope.variableScope !== reference.from.variableScope
   );
 }

--- a/packages/eslint-plugin/src/rules/no-use-before-define.ts
+++ b/packages/eslint-plugin/src/rules/no-use-before-define.ts
@@ -21,7 +21,7 @@ function parseOptions(options: string | Config | null): Required<Config> {
 
   if (typeof options === 'string') {
     functions = options !== 'nofunc';
-  } else if (typeof options === 'object' && options !== null) {
+  } else if (typeof options === 'object' && options != null) {
     functions = options.functions !== false;
     classes = options.classes !== false;
     enums = options.enums !== false;

--- a/packages/eslint-plugin/src/rules/prefer-for-of.ts
+++ b/packages/eslint-plugin/src/rules/prefer-for-of.ts
@@ -24,8 +24,7 @@ export default util.createRule({
       node: TSESTree.Node | null,
     ): node is TSESTree.VariableDeclaration {
       return (
-        node !== null &&
-        node.type === AST_NODE_TYPES.VariableDeclaration &&
+        node?.type === AST_NODE_TYPES.VariableDeclaration &&
         node.kind !== 'const' &&
         node.declarations.length === 1
       );
@@ -39,7 +38,7 @@ export default util.createRule({
     }
 
     function isZeroInitialized(node: TSESTree.VariableDeclarator): boolean {
-      return node.init !== null && isLiteral(node.init, 0);
+      return node.init != null && isLiteral(node.init, 0);
     }
 
     function isMatchingIdentifier(
@@ -54,8 +53,7 @@ export default util.createRule({
       name: string,
     ): TSESTree.Expression | null {
       if (
-        node !== null &&
-        node.type === AST_NODE_TYPES.BinaryExpression &&
+        node?.type === AST_NODE_TYPES.BinaryExpression &&
         node.operator === '<' &&
         isMatchingIdentifier(node.left, name) &&
         node.right.type === AST_NODE_TYPES.MemberExpression &&

--- a/packages/eslint-plugin/src/rules/prefer-function-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-function-type.ts
@@ -82,8 +82,7 @@ export default util.createRule({
         typeof member.returnType !== 'undefined'
       ) {
         if (
-          tsThisTypes !== null &&
-          tsThisTypes.length > 0 &&
+          tsThisTypes?.length &&
           node.type === AST_NODE_TYPES.TSInterfaceDeclaration
         ) {
           // the message can be confusing if we don't point directly to the `this` node instead of the whole member
@@ -205,7 +204,7 @@ export default util.createRule({
         // inside an interface keep track of all ThisType references.
         // unless it's inside a nested type literal in which case it's invalid code anyway
         // we don't want to incorrectly say "it refers to name" while typescript says it's completely invalid.
-        if (literalNesting === 0 && tsThisTypes !== null) {
+        if (literalNesting === 0 && tsThisTypes != null) {
           tsThisTypes.push(node);
         }
       },

--- a/packages/eslint-plugin/src/rules/prefer-includes.ts
+++ b/packages/eslint-plugin/src/rules/prefer-includes.ts
@@ -38,7 +38,7 @@ export default createRule({
 
     function isNumber(node: TSESTree.Node, value: number): boolean {
       const evaluated = getStaticValue(node, globalScope);
-      return evaluated !== null && evaluated.value === value;
+      return evaluated != null && evaluated.value === value;
     }
 
     function isPositiveCheck(node: TSESTree.BinaryExpression): boolean {

--- a/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
+++ b/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
@@ -123,7 +123,7 @@ export default createRule({
 
         if (
           argumentNode.type === AST_NODE_TYPES.Literal &&
-          typeof argumentNode.value == 'string'
+          typeof argumentNode.value === 'string'
         ) {
           const regExp = RegExp(argumentNode.value);
           return context.report({

--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -60,7 +60,7 @@ export default createRule({
      */
     function isNull(node: TSESTree.Node): node is TSESTree.Literal {
       const evaluated = getStaticValue(node, globalScope);
-      return evaluated != null && evaluated.value === null;
+      return evaluated != null && evaluated.value == null;
     }
 
     /**

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -121,7 +121,7 @@ export default createRule({
         const unionTypes = unionTypeParts(discriminantType);
         const caseTypes: Set<ts.Type> = new Set();
         for (const switchCase of node.cases) {
-          if (switchCase.test === null) {
+          if (switchCase.test == null) {
             // Switch has 'default' branch - do nothing.
             return;
           }

--- a/packages/eslint-plugin/src/rules/triple-slash-reference.ts
+++ b/packages/eslint-plugin/src/rules/triple-slash-reference.ts
@@ -87,7 +87,7 @@ export default util.createRule<Options, MessageIds>({
         }
       },
       Program(node): void {
-        if (lib === 'always' && path === 'always' && types == 'always') {
+        if (lib === 'always' && path === 'always' && types === 'always') {
           return;
         }
         programNode = node;

--- a/packages/eslint-plugin/src/util/isNullLiteral.ts
+++ b/packages/eslint-plugin/src/util/isNullLiteral.ts
@@ -2,5 +2,5 @@ import type { TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 export function isNullLiteral(i: TSESTree.Node): boolean {
-  return i.type === AST_NODE_TYPES.Literal && i.value === null;
+  return i.type === AST_NODE_TYPES.Literal && i.value == null;
 }

--- a/packages/eslint-plugin/tests/rules/indent/indent.test.ts
+++ b/packages/eslint-plugin/tests/rules/indent/indent.test.ts
@@ -638,7 +638,7 @@ type Foo = string | {
           })
           .filter(
             (error): error is TSESLint.TestCaseError<MessageIds> =>
-              error !== null,
+              error != null,
           ),
       };
       if (invalid.errors.length > 0) {

--- a/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
@@ -1083,7 +1083,7 @@ function addOptional<
   function makeOptional(code: string): string;
   function makeOptional(code: string | null | undefined): string | null;
   function makeOptional(code: string | null | undefined): string | null {
-    if (code === null || code === undefined) {
+    if (code == null) {
       return null;
     }
     return (

--- a/packages/scope-manager/src/ScopeManager.ts
+++ b/packages/scope-manager/src/ScopeManager.ts
@@ -140,7 +140,7 @@ class ScopeManager {
   protected nestScope<T extends Scope>(scope: T): T;
   protected nestScope(scope: Scope): Scope {
     if (scope instanceof GlobalScope) {
-      assert(this.currentScope === null);
+      assert(this.currentScope == null);
       this.globalScope = scope;
     }
     this.currentScope = scope;

--- a/packages/scope-manager/src/referencer/ClassVisitor.ts
+++ b/packages/scope-manager/src/referencer/ClassVisitor.ts
@@ -163,7 +163,7 @@ class ClassVisitor extends Visitor {
        * }
        */
       if (
-        keyName !== null &&
+        keyName != null &&
         this.#classNode.body.body.find(
           (node): node is TSESTree.MethodDefinition =>
             node !== methodNode &&

--- a/packages/scope-manager/src/referencer/PatternVisitor.ts
+++ b/packages/scope-manager/src/referencer/PatternVisitor.ts
@@ -97,10 +97,7 @@ class PatternVisitor extends VisitorBase {
 
     this.#callback(pattern, {
       topLevel: pattern === this.#rootPattern,
-      rest:
-        lastRestElement !== null &&
-        lastRestElement !== undefined &&
-        lastRestElement.argument === pattern,
+      rest: lastRestElement != null && lastRestElement.argument === pattern,
       assignments: this.#assignments,
     });
   }

--- a/packages/scope-manager/src/referencer/Referencer.ts
+++ b/packages/scope-manager/src/referencer/Referencer.ts
@@ -124,7 +124,7 @@ class Referencer extends Visitor {
   }
 
   private referenceJsxPragma(): void {
-    if (this.#jsxPragma === null || this.#hasReferencedJsxFactory) {
+    if (this.#jsxPragma == null || this.#hasReferencedJsxFactory) {
       return;
     }
     this.#hasReferencedJsxFactory = this.referenceInSomeUpperScope(
@@ -134,7 +134,7 @@ class Referencer extends Visitor {
 
   private referenceJsxFragment(): void {
     if (
-      this.#jsxFragmentName === null ||
+      this.#jsxFragmentName == null ||
       this.#hasReferencedJsxFragmentFactory
     ) {
       return;

--- a/packages/typescript-estree/src/convert-comments.ts
+++ b/packages/typescript-estree/src/convert-comments.ts
@@ -22,7 +22,7 @@ export function convertComments(
     ast,
     (_, comment) => {
       const type =
-        comment.kind == ts.SyntaxKind.SingleLineCommentTrivia
+        comment.kind === ts.SyntaxKind.SingleLineCommentTrivia
           ? AST_TOKEN_TYPES.Line
           : AST_TOKEN_TYPES.Block;
       const range: TSESTree.Range = [comment.pos, comment.end];

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -2183,7 +2183,7 @@ export class Converter {
           type: AST_NODE_TYPES.Literal,
           raw: rawValue,
           value: value,
-          bigint: value === null ? bigint : String(value),
+          bigint: value == null ? bigint : String(value),
           range,
         });
       }

--- a/packages/typescript-estree/src/getModifiers.ts
+++ b/packages/typescript-estree/src/getModifiers.ts
@@ -31,7 +31,7 @@ export function getModifiers(
 export function getDecorators(
   node: ts.Node | null | undefined,
 ): undefined | ts.Decorator[] {
-  if (node == undefined) {
+  if (node == null) {
     return undefined;
   }
 

--- a/packages/typescript-estree/src/simple-traverse.ts
+++ b/packages/typescript-estree/src/simple-traverse.ts
@@ -5,7 +5,7 @@ import type { TSESTree } from './ts-estree';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isValidNode(x: any): x is TSESTree.Node {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  return x !== null && typeof x === 'object' && typeof x.type === 'string';
+  return x != null && typeof x === 'object' && typeof x.type === 'string';
 }
 
 function getVisitorKeysForNode(

--- a/packages/typescript-estree/tools/test-utils.ts
+++ b/packages/typescript-estree/tools/test-utils.ts
@@ -86,7 +86,7 @@ type UnknownObject = Record<string, unknown>;
 
 function isObjectLike(value: unknown | null): value is UnknownObject {
   return (
-    typeof value === 'object' && !(value instanceof RegExp) && value !== null
+    typeof value === 'object' && !(value instanceof RegExp) && value != null
   );
 }
 

--- a/packages/utils/src/eslint-utils/applyDefault.ts
+++ b/packages/utils/src/eslint-utils/applyDefault.ts
@@ -16,7 +16,7 @@ function applyDefault<TUser extends readonly unknown[], TDefault extends TUser>(
     JSON.stringify(defaultOptions),
   ) as AsMutable<TDefault>;
 
-  if (userOptions === null || userOptions === undefined) {
+  if (userOptions == null) {
     return options;
   }
 

--- a/packages/utils/src/eslint-utils/nullThrows.ts
+++ b/packages/utils/src/eslint-utils/nullThrows.ts
@@ -18,7 +18,7 @@ function nullThrows<T>(value: T | null | undefined, message: string): T {
 
   // so ignore it in coverage metrics.
   /* istanbul ignore if */
-  if (value === null || value === undefined) {
+  if (value == null) {
     throw new Error(`Non-null Assertion Failed: ${message}`);
   }
 

--- a/packages/utils/tests/eslint-utils/nullThrows.test.ts
+++ b/packages/utils/tests/eslint-utils/nullThrows.test.ts
@@ -1,0 +1,31 @@
+import { nullThrows, NullThrowsReasons } from '../../src/eslint-utils';
+
+describe('nullThrows', () => {
+  it('returns a falsy value when it exists', () => {
+    const value = 0;
+
+    const actual = nullThrows(value, NullThrowsReasons.MissingParent);
+
+    expect(actual).toBe(value);
+  });
+
+  it('returns a truthy value when it exists', () => {
+    const value = { abc: 'def' };
+
+    const actual = nullThrows(value, NullThrowsReasons.MissingParent);
+
+    expect(actual).toBe(value);
+  });
+
+  it('throws an error when the value is null', () => {
+    expect(() => nullThrows(null, NullThrowsReasons.MissingParent)).toThrow(
+      NullThrowsReasons.MissingParent,
+    );
+  });
+
+  it('throws an error when the value is undefined', () => {
+    expect(() =>
+      nullThrows(undefined, NullThrowsReasons.MissingParent),
+    ).toThrow(NullThrowsReasons.MissingParent);
+  });
+});

--- a/packages/website/src/components/ast/serializer/serializer.ts
+++ b/packages/website/src/components/ast/serializer/serializer.ts
@@ -26,7 +26,7 @@ function getSimpleModel(data: unknown): ASTViewerModelSimple {
       value: String(data),
       type: 'regexp',
     };
-  } else if (typeof data === 'undefined' || data === null) {
+  } else if (data == null) {
     return {
       value: String(data),
       type: 'undefined',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6227
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Enables the rule, allowing `== null` and `!= null` per our existing code style.