### PR TITLE
fix(ast-spec): change MemberExpression.object to Expression

### DIFF
--- a/packages/ast-spec/src/expression/MemberExpression/spec.ts
+++ b/packages/ast-spec/src/expression/MemberExpression/spec.ts
@@ -2,11 +2,10 @@ import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
 import type { PrivateIdentifier } from '../../special/PrivateIdentifier/spec';
 import type { Expression } from '../../unions/Expression';
-import type { LeftHandSideExpression } from '../../unions/LeftHandSideExpression';
 import type { Identifier } from '../Identifier/spec';
 
 interface MemberExpressionBase extends BaseNode {
-  object: LeftHandSideExpression;
+  object: Expression;
   property: Expression | Identifier | PrivateIdentifier;
   computed: boolean;
   optional: boolean;

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -568,9 +568,7 @@ export default createRule<Options, MessageId>({
       return false;
     }
 
-    function isOptionableExpression(
-      node: TSESTree.LeftHandSideExpression,
-    ): boolean {
+    function isOptionableExpression(node: TSESTree.Expression): boolean {
       const type = getNodeType(node);
       const isOwnNullable =
         node.type === AST_NODE_TYPES.MemberExpression

--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -47,7 +47,7 @@ export default createRule({
      * Check if a given node is a string.
      * @param node The node to check.
      */
-    function isStringType(node: TSESTree.LeftHandSideExpression): boolean {
+    function isStringType(node: TSESTree.Expression): boolean {
       const objectType = typeChecker.getTypeAtLocation(
         service.esTreeNodeToTSNodeMap.get(node),
       );

--- a/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
+++ b/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
@@ -48,9 +48,8 @@ export default util.createRule<Options, MessageIds>({
 
     /**
      * Check if a given node is an array which all elements are string.
-     * @param node
      */
-    function isStringArrayNode(node: TSESTree.LeftHandSideExpression): boolean {
+    function isStringArrayNode(node: TSESTree.Expression): boolean {
       const type = checker.getTypeAtLocation(
         service.esTreeNodeToTSNodeMap.get(node),
       );


### PR DESCRIPTION
BREAKING CHANGE:
Switches the AST type for `MemberExpression`'s `object` property

## PR Checklist

- [x] Addresses an existing open issue: fixes #6192
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Switches the AST type for `MemberExpression`'s `object` property from `LeftHandSideExpression` to `Expression`.