### PR TITLE
fix(ast-spec): correct some incorrect ast types

### DIFF
--- a/packages/ast-spec/src/expression/ArrayExpression/spec.ts
+++ b/packages/ast-spec/src/expression/ArrayExpression/spec.ts
@@ -5,5 +5,8 @@ import type { Expression } from '../../unions/Expression';
 
 export interface ArrayExpression extends BaseNode {
   type: AST_NODE_TYPES.ArrayExpression;
-  elements: (Expression | SpreadElement)[];
+  /**
+   * an element will be `null` in the case of a sparse array: `[1, ,3]`
+   */
+  elements: (Expression | SpreadElement | null)[];
 }

--- a/packages/ast-spec/src/expression/MemberExpression/spec.ts
+++ b/packages/ast-spec/src/expression/MemberExpression/spec.ts
@@ -2,11 +2,10 @@ import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
 import type { PrivateIdentifier } from '../../special/PrivateIdentifier/spec';
 import type { Expression } from '../../unions/Expression';
-import type { LeftHandSideExpression } from '../../unions/LeftHandSideExpression';
 import type { Identifier } from '../Identifier/spec';
 
 interface MemberExpressionBase extends BaseNode {
-  object: LeftHandSideExpression;
+  object: Expression;
   property: Expression | Identifier | PrivateIdentifier;
   computed: boolean;
   optional: boolean;

--- a/packages/ast-spec/src/unions/ObjectLiteralElement.ts
+++ b/packages/ast-spec/src/unions/ObjectLiteralElement.ts
@@ -1,8 +1,7 @@
-import type { MethodDefinition } from '../element/MethodDefinition/spec';
 import type { Property } from '../element/Property/spec';
 import type { SpreadElement } from '../element/SpreadElement/spec';
 
-export type ObjectLiteralElement = MethodDefinition | Property | SpreadElement;
+export type ObjectLiteralElement = Property | SpreadElement;
 
 // TODO - breaking change remove this
 export type ObjectLiteralElementLike = ObjectLiteralElement;

--- a/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
+++ b/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
@@ -197,8 +197,11 @@ export default createRule<Options, MessageIds>({
       }
     }
 
-    function checkExpression(node: TSESTree.Node, isErrorTest: boolean): void {
-      switch (node.type) {
+    function checkExpression(
+      node: TSESTree.Node | null,
+      isErrorTest: boolean,
+    ): void {
+      switch (node?.type) {
         case AST_NODE_TYPES.Literal:
           checkLiteral(node, isErrorTest);
           break;
@@ -478,7 +481,7 @@ export default createRule<Options, MessageIds>({
 
     function checkValidTest(tests: TSESTree.ArrayExpression): void {
       for (const test of tests.elements) {
-        switch (test.type) {
+        switch (test?.type) {
           case AST_NODE_TYPES.ObjectExpression:
             // delegate object-style tests to the invalid checker
             checkInvalidTest(test, false);
@@ -546,7 +549,7 @@ export default createRule<Options, MessageIds>({
 
               case 'invalid':
                 for (const element of prop.value.elements) {
-                  if (element.type === AST_NODE_TYPES.ObjectExpression) {
+                  if (element?.type === AST_NODE_TYPES.ObjectExpression) {
                     checkInvalidTest(element);
                   }
                 }
@@ -575,7 +578,7 @@ export default createRule<Options, MessageIds>({
             }
 
             for (const errorElement of testProp.value.elements) {
-              if (errorElement.type !== AST_NODE_TYPES.ObjectExpression) {
+              if (errorElement?.type !== AST_NODE_TYPES.ObjectExpression) {
                 continue;
               }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -568,9 +568,7 @@ export default createRule<Options, MessageId>({
       return false;
     }
 
-    function isOptionableExpression(
-      node: TSESTree.LeftHandSideExpression,
-    ): boolean {
+    function isOptionableExpression(node: TSESTree.Expression): boolean {
       const type = getNodeType(node);
       const isOwnNullable =
         node.type === AST_NODE_TYPES.MemberExpression

--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -47,7 +47,7 @@ export default createRule({
      * Check if a given node is a string.
      * @param node The node to check.
      */
-    function isStringType(node: TSESTree.LeftHandSideExpression): boolean {
+    function isStringType(node: TSESTree.Expression): boolean {
       const objectType = typeChecker.getTypeAtLocation(
         service.esTreeNodeToTSNodeMap.get(node),
       );

--- a/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
+++ b/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
@@ -50,7 +50,7 @@ export default util.createRule<Options, MessageIds>({
      * Check if a given node is an array which all elements are string.
      * @param node
      */
-    function isStringArrayNode(node: TSESTree.LeftHandSideExpression): boolean {
+    function isStringArrayNode(node: TSESTree.Expression): boolean {
       const type = checker.getTypeAtLocation(
         service.esTreeNodeToTSNodeMap.get(node),
       );

--- a/packages/typescript-estree/tests/lib/semanticInfo.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo.test.ts
@@ -365,7 +365,7 @@ function testIsolatedFile(
   const declaration = (parseResult.ast.body[0] as TSESTree.VariableDeclaration)
     .declarations[0];
   const arrayMember = (declaration.init! as TSESTree.ArrayExpression)
-    .elements[0];
+    .elements[0]!;
   expect(parseResult).toHaveProperty('services.esTreeNodeToTSNodeMap');
 
   // get corresponding TS node


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6192
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
These changes will be disruptive to downstream consumers but they are correct and will help expose potentially bad code.
Particularly the sparse array type fix because it's meant to include `null`, not just some other node type. They're a rarer case in code (because sparse arrays are one of the dumbest features in JS), but if encountered it will crash code that doesn't expect it.