### PR TITLE
fix(utils): adjust errors type in InvalidTestCase to support error count

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-explicit-any.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-explicit-any.test.ts
@@ -1208,9 +1208,10 @@ const test = <T extends Partial<never>>() => {};
         output: code.replace(/any/, 'never'),
       },
     ];
+    const errors = testCase.errors as TSESLint.TestCaseError<MessageIds>[];
     acc.push({
       ...testCase,
-      errors: testCase.errors.map(e => ({
+      errors: errors.map(e => ({
         ...e,
         suggestions: e.suggestions ?? suggestions(testCase.code),
       })),
@@ -1221,7 +1222,7 @@ const test = <T extends Partial<never>>() => {};
       code,
       output: code.replace(/any/g, 'unknown'),
       options: [{ ...options[0], fixToUnknown: true }],
-      errors: testCase.errors.map(err => {
+      errors: errors.map(err => {
         if (err.line === undefined) {
           return err;
         }

--- a/packages/utils/src/eslint-utils/batchedSingleLineTests.ts
+++ b/packages/utils/src/eslint-utils/batchedSingleLineTests.ts
@@ -2,6 +2,7 @@ import type {
   InvalidTestCase,
   ValidTestCase,
 } from '../eslint-utils/rule-tester/RuleTester';
+import type { TestCaseError } from '../ts-eslint';
 
 /**
  * Converts a batch of single line tests into a number of separate test cases.
@@ -29,13 +30,19 @@ function batchedSingleLineTests<
   TMessageIds extends string,
   TOptions extends Readonly<unknown[]>,
 >(
-  test: InvalidTestCase<TMessageIds, TOptions>,
+  test: Omit<InvalidTestCase<TMessageIds, TOptions>, 'errors'> & {
+    errors: readonly TestCaseError<TMessageIds>[];
+  },
 ): InvalidTestCase<TMessageIds, TOptions>[];
 function batchedSingleLineTests<
   TMessageIds extends string,
   TOptions extends Readonly<unknown[]>,
 >(
-  options: ValidTestCase<TOptions> | InvalidTestCase<TMessageIds, TOptions>,
+  options:
+    | ValidTestCase<TOptions>
+    | (Omit<InvalidTestCase<TMessageIds, TOptions>, 'errors'> & {
+        errors: readonly TestCaseError<TMessageIds>[];
+      }),
 ): (ValidTestCase<TOptions> | InvalidTestCase<TMessageIds, TOptions>)[] {
   // -- eslint counts lines from 1
   const lineOffset = options.code.startsWith('\n') ? 2 : 1;

--- a/packages/utils/src/ts-eslint/RuleTester.ts
+++ b/packages/utils/src/ts-eslint/RuleTester.ts
@@ -80,7 +80,9 @@ interface InvalidTestCase<
   /**
    * Expected errors.
    */
-  readonly errors: readonly TestCaseError<TMessageIds>[];
+  readonly errors:
+    | readonly (TestCaseError<TMessageIds> | TMessageIds)[]
+    | number;
   /**
    * The expected code after autofixes are applied. If set to `null`, the test runner will assert that no autofix is suggested.
    */


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6269
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Corrected a ESLint RuleTester type