### PR TITLE
feat(typescript-estree): allow erroring on TypeScript syntactic diagn…

### DIFF
--- a/packages/parser/tests/lib/parser.ts
+++ b/packages/parser/tests/lib/parser.ts
@@ -36,7 +36,6 @@ describe('parser', () => {
       filePath: 'isolated-file.src.ts',
       project: 'tsconfig.json',
       errorOnUnknownASTType: false,
-      errorOnTypeScriptSyntacticAndSemanticIssues: false,
       tsconfigRootDir: 'tests/fixtures/services',
       extraFileExtensions: ['.foo'],
     };
@@ -90,7 +89,6 @@ describe('parser', () => {
       filePath: 'isolated-file.src.ts',
       project: 'tsconfig.json',
       errorOnUnknownASTType: false,
-      errorOnTypeScriptSyntacticAndSemanticIssues: false,
       tsconfigRootDir: 'tests/fixtures/services',
       extraFileExtensions: ['.foo'],
     };

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -26,6 +26,12 @@ type EcmaVersion =
 
 type SourceType = 'script' | 'module';
 
+enum TypeScriptIssueDetection {
+  None = 0,
+  Syntactic = 1,
+  SyntacticOrSemantic = 2,
+}
+
 interface ParserOptions {
   ecmaFeatures?: {
     globalReturn?: boolean;
@@ -44,7 +50,7 @@ interface ParserOptions {
   // typescript-estree specific
   comment?: boolean;
   debugLevel?: DebugLevel;
-  errorOnTypeScriptSyntacticAndSemanticIssues?: boolean;
+  errorOnTypeScriptIssues?: TypeScriptIssueDetection;
   errorOnUnknownASTType?: boolean;
   EXPERIMENTAL_useSourceOfProjectReferenceRedirect?: boolean; // purposely undocumented for now
   extraFileExtensions?: string[];
@@ -62,4 +68,10 @@ interface ParserOptions {
   [additionalProperties: string]: unknown;
 }
 
-export { DebugLevel, EcmaVersion, ParserOptions, SourceType };
+export {
+  DebugLevel,
+  EcmaVersion,
+  ParserOptions,
+  SourceType,
+  TypeScriptIssueDetection,
+};

--- a/packages/typescript-estree/src/index.ts
+++ b/packages/typescript-estree/src/index.ts
@@ -15,6 +15,7 @@ export { createProgramFromConfigFile as createProgram } from './create-program/u
 export * from './create-program/getScriptKind';
 export { typescriptVersionIsAtLeast } from './version-check';
 export * from './getModifiers';
+export { TypeScriptIssueDetection } from '@typescript-eslint/types';
 
 // re-export for backwards-compat
 export { visitorKeys } from '@typescript-eslint/visitor-keys';

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -1,3 +1,4 @@
+import { TypeScriptIssueDetection } from '@typescript-eslint/types';
 import debug from 'debug';
 import { sync as globSync } from 'globby';
 import isGlob from 'is-glob';
@@ -41,7 +42,8 @@ export function createParseSettings(
         : Array.isArray(options.debugLevel)
         ? new Set(options.debugLevel)
         : new Set(),
-    errorOnTypeScriptSyntacticAndSemanticIssues: false,
+    errorOnTypeScriptIssues:
+      options.errorOnTypeScriptIssues ?? TypeScriptIssueDetection.None,
     errorOnUnknownASTType: options.errorOnUnknownASTType === true,
     EXPERIMENTAL_useSourceOfProjectReferenceRedirect:
       options.EXPERIMENTAL_useSourceOfProjectReferenceRedirect === true,

--- a/packages/typescript-estree/src/parseSettings/index.ts
+++ b/packages/typescript-estree/src/parseSettings/index.ts
@@ -1,3 +1,4 @@
+import type { TypeScriptIssueDetection } from '@typescript-eslint/types';
 import type * as ts from 'typescript';
 
 import type { CanonicalPath } from '../create-program/shared';
@@ -44,7 +45,7 @@ export interface MutableParseSettings {
   /**
    * Whether to error if TypeScript reports a semantic or syntactic error diagnostic.
    */
-  errorOnTypeScriptSyntacticAndSemanticIssues: boolean;
+  errorOnTypeScriptIssues: TypeScriptIssueDetection;
 
   /**
    * Whether to error if an unknown AST node type is encountered.

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -1,4 +1,7 @@
-import type { DebugLevel } from '@typescript-eslint/types';
+import type {
+  DebugLevel,
+  TypeScriptIssueDetection,
+} from '@typescript-eslint/types';
 import type * as ts from 'typescript';
 
 import type { TSESTree, TSESTreeToTSNode, TSNode, TSToken } from './ts-estree';
@@ -78,7 +81,7 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
   /**
    * Causes the parser to error if the TypeScript compiler returns any unexpected syntax/semantic errors.
    */
-  errorOnTypeScriptSyntacticAndSemanticIssues?: boolean;
+  errorOnTypeScriptIssues?: TypeScriptIssueDetection;
 
   /**
    * ***EXPERIMENTAL FLAG*** - Use this at your own risk.

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -89,9 +89,9 @@ function parseWithNodeMapsInternal<T extends TSESTreeOptions = TSESTreeOptions>(
   /**
    * Ensure users do not attempt to use parse() when they need parseAndGenerateServices()
    */
-  if (options?.errorOnTypeScriptSyntacticAndSemanticIssues) {
+  if (options?.errorOnTypeScriptIssues) {
     throw new Error(
-      `"errorOnTypeScriptSyntacticAndSemanticIssues" is only supported for parseAndGenerateServices()`,
+      `"errorOnTypeScriptIssues" is only supported for parseAndGenerateServices()`,
     );
   }
 
@@ -137,16 +137,6 @@ function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
    * Reset the parse configuration
    */
   const parseSettings = createParseSettings(code, options);
-
-  if (typeof options !== 'undefined') {
-    if (
-      typeof options.errorOnTypeScriptSyntacticAndSemanticIssues ===
-        'boolean' &&
-      options.errorOnTypeScriptSyntacticAndSemanticIssues
-    ) {
-      parseSettings.errorOnTypeScriptSyntacticAndSemanticIssues = true;
-    }
-  }
 
   /**
    * If this is a single run in which the user has not provided any existing programs but there
@@ -223,8 +213,12 @@ function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
    * Even if TypeScript parsed the source code ok, and we had no problems converting the AST,
    * there may be other syntactic or semantic issues in the code that we can optionally report on.
    */
-  if (program && parseSettings.errorOnTypeScriptSyntacticAndSemanticIssues) {
-    const error = getFirstSemanticOrSyntacticError(program, ast);
+  if (parseSettings.errorOnTypeScriptIssues) {
+    const error = getFirstSemanticOrSyntacticError(
+      program,
+      ast,
+      parseSettings.errorOnTypeScriptIssues,
+    );
     if (error) {
       throw convertError(error);
     }

--- a/packages/typescript-estree/src/semantic-or-syntactic-errors.ts
+++ b/packages/typescript-estree/src/semantic-or-syntactic-errors.ts
@@ -1,3 +1,4 @@
+import { TypeScriptIssueDetection } from '@typescript-eslint/types';
 import type {
   Diagnostic,
   DiagnosticWithLocation,
@@ -10,33 +11,30 @@ export interface SemanticOrSyntacticError extends Diagnostic {
   message: string;
 }
 
-/**
- * By default, diagnostics from the TypeScript compiler contain all errors - regardless of whether
- * they are related to generic ECMAScript standards, or TypeScript-specific constructs.
- *
- * Therefore, we filter out all diagnostics, except for the ones we explicitly want to consider when
- * the user opts in to throwing errors on semantic issues.
- */
 export function getFirstSemanticOrSyntacticError(
   program: Program,
   ast: SourceFile,
+  issueDetection: TypeScriptIssueDetection,
 ): SemanticOrSyntacticError | undefined {
+  if (!issueDetection) {
+    return undefined;
+  }
+
   try {
-    const supportedSyntacticDiagnostics = whitelistSupportedDiagnostics(
-      program.getSyntacticDiagnostics(ast),
-    );
+    const supportedSyntacticDiagnostics = program.getSyntacticDiagnostics(ast);
     if (supportedSyntacticDiagnostics.length) {
       return convertDiagnosticToSemanticOrSyntacticError(
         supportedSyntacticDiagnostics[0],
       );
     }
-    const supportedSemanticDiagnostics = whitelistSupportedDiagnostics(
-      program.getSemanticDiagnostics(ast),
-    );
-    if (supportedSemanticDiagnostics.length) {
-      return convertDiagnosticToSemanticOrSyntacticError(
-        supportedSemanticDiagnostics[0],
-      );
+
+    if (issueDetection === TypeScriptIssueDetection.SyntacticOrSemantic) {
+      const supportedSemanticDiagnostics = program.getSemanticDiagnostics(ast);
+      if (supportedSemanticDiagnostics.length) {
+        return convertDiagnosticToSemanticOrSyntacticError(
+          supportedSemanticDiagnostics[0],
+        );
+      }
     }
     return undefined;
   } catch (e) {
@@ -55,57 +53,6 @@ export function getFirstSemanticOrSyntacticError(
     /* istanbul ignore next */
     return undefined;
   }
-}
-
-function whitelistSupportedDiagnostics(
-  diagnostics: readonly (DiagnosticWithLocation | Diagnostic)[],
-): readonly (DiagnosticWithLocation | Diagnostic)[] {
-  return diagnostics.filter(diagnostic => {
-    switch (diagnostic.code) {
-      case 1013: // "A rest parameter or binding pattern may not have a trailing comma."
-      case 1014: // "A rest parameter must be last in a parameter list."
-      case 1044: // "'{0}' modifier cannot appear on a module or namespace element."
-      case 1045: // "A '{0}' modifier cannot be used with an interface declaration."
-      case 1048: // "A rest parameter cannot have an initializer."
-      case 1049: // "A 'set' accessor must have exactly one parameter."
-      case 1070: // "'{0}' modifier cannot appear on a type member."
-      case 1071: // "'{0}' modifier cannot appear on an index signature."
-      case 1085: // "Octal literals are not available when targeting ECMAScript 5 and higher. Use the syntax '{0}'."
-      case 1090: // "'{0}' modifier cannot appear on a parameter."
-      case 1096: // "An index signature must have exactly one parameter."
-      case 1097: // "'{0}' list cannot be empty."
-      case 1098: // "Type parameter list cannot be empty."
-      case 1099: // "Type argument list cannot be empty."
-      case 1117: // "An object literal cannot have multiple properties with the same name in strict mode."
-      case 1121: // "Octal literals are not allowed in strict mode."
-      case 1123: //  "Variable declaration list cannot be empty."
-      case 1141: // "String literal expected."
-      case 1162: // "An object member cannot be declared optional."
-      case 1164: // "Computed property names are not allowed in enums."
-      case 1172: // "'extends' clause already seen."
-      case 1173: // "'extends' clause must precede 'implements' clause."
-      case 1175: // "'implements' clause already seen."
-      case 1176: // "Interface declaration cannot have 'implements' clause."
-      case 1190: // "The variable declaration of a 'for...of' statement cannot have an initializer."
-      case 1196: // "Catch clause variable type annotation must be 'any' or 'unknown' if specified."
-      case 1200: // "Line terminator not permitted before arrow."
-      case 1206: // "Decorators are not valid here."
-      case 1211: // "A class declaration without the 'default' modifier must have a name."
-      case 1242: // "'abstract' modifier can only appear on a class, method, or property declaration."
-      case 1246: // "An interface property cannot have an initializer."
-      case 1255: // "A definite assignment assertion '!' is not permitted in this context."
-      case 1308: // "'await' expression is only allowed within an async function."
-      case 2364: // "The left-hand side of an assignment expression must be a variable or a property access."
-      case 2369: // "A parameter property is only allowed in a constructor implementation."
-      case 2452: // "An enum member cannot have a numeric name."
-      case 2462: // "A rest element must be last in a destructuring pattern."
-      case 8017: // "Octal literal types must use ES2015 syntax. Use the syntax '{0}'."
-      case 17012: // "'{0}' is not a valid meta-property for keyword '{1}'. Did you mean '{2}'?"
-      case 17013: // "Meta-property '{0}' is only allowed in the body of a function declaration, function expression, or constructor."
-        return true;
-    }
-    return false;
-  });
 }
 
 function convertDiagnosticToSemanticOrSyntacticError(

--- a/packages/typescript-estree/tests/ast-alignment/parse.ts
+++ b/packages/typescript-estree/tests/ast-alignment/parse.ts
@@ -4,6 +4,7 @@ import type babelParser from '@babel/parser';
 import type { ParserPlugin } from '@babel/parser';
 import type { File } from '@babel/types';
 import type { TSESTree } from '@typescript-eslint/types';
+import { TypeScriptIssueDetection } from '@typescript-eslint/types';
 
 import type { TSError } from '../../src/node-utils';
 import type { AST } from '../../src/parser';
@@ -64,7 +65,7 @@ function parseWithTypeScriptESTree(text: string, jsx = true): AST<any> {
        * two parsers. By default, the TypeScript compiler is much more
        * forgiving.
        */
-      errorOnTypeScriptSyntacticAndSemanticIssues: true,
+      errorOnTypeScriptIssues: TypeScriptIssueDetection.Syntactic,
       jsx,
     });
     return result.ast;

--- a/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/semantic-diagnostics-enabled.test.ts.snap
@@ -1,86 +1,282 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/block-trailing-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/block-trailing-comment.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 6,
+  "lineNumber": 2,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/comment-within-condition.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/comment-within-condition.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 25,
+  "lineNumber": 2,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/export-default-anonymous-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/export-default-anonymous-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsdoc-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsdoc-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-attr-and-text-with-url.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-attr-and-text-with-url.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-block-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-block-comment.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 43,
+  "lineNumber": 3,
+  "message": "Cannot find name 'Foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-comment-after-jsx.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-comment-after-jsx.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 43,
+  "lineNumber": 3,
+  "message": "Cannot find name 'Foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-comment-after-self-closing-jsx.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-comment-after-self-closing-jsx.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 43,
+  "lineNumber": 3,
+  "message": "Cannot find name 'Foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-generic-with-comment-in-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-generic-with-comment-in-tag.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 25,
+  "lineNumber": 3,
+  "message": "Cannot find name 'Component'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-tag-comment-after-prop.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-tag-comment-after-prop.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 39,
+  "lineNumber": 3,
+  "message": "Cannot find name 'Foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-tag-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-tag-comments.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 43,
+  "lineNumber": 3,
+  "message": "Cannot find name 'Foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-text-with-multiline-non-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-text-with-multiline-non-comment.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 37,
+  "lineNumber": 3,
+  "message": "Cannot find name 'Foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-text-with-url.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-text-with-url.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-with-greather-than.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-with-greather-than.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 24,
+  "lineNumber": 2,
+  "message": "Cannot find name 'test'. Do you need to install type definitions for a test runner? Try \`npm i --save-dev @types/jest\` or \`npm i --save-dev @types/mocha\`.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/jsx-with-operators.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/jsx-with-operators.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 24,
+  "lineNumber": 2,
+  "message": "Cannot find name 'test'. Do you need to install type definitions for a test runner? Try \`npm i --save-dev @types/jest\` or \`npm i --save-dev @types/mocha\`.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/line-comment-with-block-syntax.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/line-comment-with-block-syntax.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/mix-line-and-block-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/mix-line-and-block-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/no-comment-regex.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/no-comment-regex.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/no-comment-template.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/no-comment-template.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Cannot find name '__dirname'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/surrounding-call-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/surrounding-call-comments.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 36,
+  "lineNumber": 3,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/surrounding-debugger-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/surrounding-debugger-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/surrounding-return-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/surrounding-return-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/surrounding-throw-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/surrounding-throw-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/surrounding-while-loop-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/surrounding-while-loop-comments.src 1`] = `
+TSError {
+  "column": 61,
+  "index": 61,
+  "lineNumber": 1,
+  "message": "'each' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/switch-fallthrough-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/switch-fallthrough-comment.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/switch-fallthrough-comment-in-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/switch-fallthrough-comment-in-function.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 126,
+  "lineNumber": 7,
+  "message": "Cannot find name 'doIt'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/switch-no-default-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/switch-no-default-comment.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/switch-no-default-comment-in-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/switch-no-default-comment-in-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/switch-no-default-comment-in-nested-functions.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/switch-no-default-comment-in-nested-functions.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'module'. Do you need to install type definitions for node? Try \`npm i --save-dev @types/node\`.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/template-string-block.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/template-string-block.src 1`] = `
+TSError {
+  "column": 3,
+  "index": 3,
+  "lineNumber": 1,
+  "message": "Cannot find name 'name'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/comments/type-assertion-regression-test.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/comments/type-assertion-regression-test.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 13,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrayLiteral/array-literal-in-lhs.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrayLiteral/array-literal-in-lhs.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'fn'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrayLiteral/array-literals-in-binary-expr.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrayLiteral/array-literals-in-binary-expr.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Operator '+' cannot be applied to types '{}' and '{}'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/as-param.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/as-param.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/as-param-with-params.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/as-param-with-params.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/basic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/basic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/basic-in-binary-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/basic-in-binary-expression.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Operator '+' cannot be applied to types '(a: any) => {}' and 'number'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/block-body.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/block-body.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'e' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/block-body-not-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/block-body-not-object.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'e' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-dup-params.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-dup-params.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Duplicate identifier 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-missing-paren.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-missing-paren.src 1`] = `
 TSError {
   "column": 9,
   "index": 9,
@@ -89,7 +285,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-not-arrow.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-not-arrow.src 1`] = `
 TSError {
   "column": 26,
   "index": 26,
@@ -98,7 +294,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-numeric-param.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-numeric-param.src 1`] = `
 TSError {
   "column": 5,
   "index": 5,
@@ -107,7 +303,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-numeric-param-multi.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-numeric-param-multi.src 1`] = `
 TSError {
   "column": 9,
   "index": 9,
@@ -116,7 +312,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-reverse-arrow.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-reverse-arrow.src 1`] = `
 TSError {
   "column": 1,
   "index": 1,
@@ -125,34 +321,97 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-strict-default-param-eval.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-strict-dup-params.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-strict-eval.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-strict-eval-return.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-strict-octal.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-strict-default-param-eval.src 1`] = `
 TSError {
-  "column": 21,
-  "index": 21,
+  "column": 15,
+  "index": 15,
   "lineNumber": 1,
-  "message": "Octal literals are not available when targeting ECMAScript 5 and higher. Use the syntax '0o0'.",
+  "message": "Invalid use of 'eval' in strict mode.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-strict-param-arguments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-strict-dup-params.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Duplicate identifier 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-strict-param-eval.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-strict-eval.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "'eval' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-strict-param-names.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-strict-eval-return.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Invalid use of 'eval' in strict mode.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-strict-param-no-paren-arguments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-strict-octal.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-strict-param-no-paren-eval.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-strict-param-arguments.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Invalid use of 'arguments' in strict mode.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-two-lines.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-strict-param-eval.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Invalid use of 'eval' in strict mode.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-strict-param-names.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Invalid use of 'eval' in strict mode.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-strict-param-no-paren-arguments.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Invalid use of 'arguments' in strict mode.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-strict-param-no-paren-eval.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Invalid use of 'eval' in strict mode.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-two-lines.src 1`] = `
 TSError {
   "column": 1,
   "index": 12,
@@ -161,7 +420,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/error-wrapped-param.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/error-wrapped-param.src 1`] = `
 TSError {
   "column": 6,
   "index": 6,
@@ -170,65 +429,170 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/iife.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/iife.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'e' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/multiple-params.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/multiple-params.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/no-auto-return.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/no-auto-return.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/not-strict-arguments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/not-strict-arguments.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'arguments' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/not-strict-eval.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/not-strict-eval.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'eval' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/not-strict-eval-params.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/not-strict-eval-params.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "'eval' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/not-strict-octal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/not-strict-octal.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/return-arrow-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/return-arrow-function.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/return-sequence.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/return-sequence.src 1`] = `
+TSError {
+  "column": 19,
+  "index": 19,
+  "lineNumber": 1,
+  "message": "Left side of comma operator is unused and has no side effects.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/single-param.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/single-param.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'e' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/single-param-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/single-param-parens.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "'e' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/arrowFunctions/single-param-return-identifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/arrowFunctions/single-param-return-identifier.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "'sun' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/and-operator-array-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/and-operator-array-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/delete-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/delete-expression.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/do-while-statements.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/do-while-statements.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/identifiers-double-underscore.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/identifiers-double-underscore.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/instanceof.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/instanceof.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/new-with-member-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/new-with-member-expression.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/new-without-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/new-without-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/or-operator-array-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/or-operator-array-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/typeof-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/typeof-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/update-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/update-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/basics/void-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/basics/void-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/bigIntLiterals/binary.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/bigIntLiterals/binary.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/bigIntLiterals/decimal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/bigIntLiterals/decimal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/bigIntLiterals/hex.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/bigIntLiterals/hex.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/bigIntLiterals/numeric-separator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/bigIntLiterals/numeric-separator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/bigIntLiterals/octal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/bigIntLiterals/octal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/binaryLiterals/invalid.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/binaryLiterals/invalid.src 1`] = `
 TSError {
   "column": 4,
   "index": 4,
@@ -237,77 +601,203 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/binaryLiterals/lowercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/binaryLiterals/lowercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/binaryLiterals/uppercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/binaryLiterals/uppercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/blockBindings/const.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/blockBindings/const.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "Cannot find name 'bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/blockBindings/let.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/blockBindings/let.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 10,
+  "lineNumber": 1,
+  "message": "Cannot find name 'bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/blockBindings/let-in-switchcase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/blockBindings/let-in-switchcase.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Cannot find name 'answer'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/callExpression/call-expression-with-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/callExpression/call-expression-with-array.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/callExpression/call-expression-with-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/callExpression/call-expression-with-object.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/callExpression/mixed-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/callExpression/mixed-expression.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 59,
+  "lineNumber": 4,
+  "message": "Expected 0 arguments, but got 1.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/callExpression/new-expression-with-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/callExpression/new-expression-with-array.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Cannot find name 'bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/callExpression/new-expression-with-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/callExpression/new-expression-with-object.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Cannot find name 'bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-accessor-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-accessor-properties.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 13,
+  "lineNumber": 1,
+  "message": "A 'get' accessor must return a value.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-computed-static-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-computed-static-method.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 17,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'. Did you mean 'A'?",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-method-named-prototype.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-method-named-prototype.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-method-named-static.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-method-named-static.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-method-named-with-space.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-method-named-with-space.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-one-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-one-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-one-method-super.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-one-method-super.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 27,
+  "lineNumber": 3,
+  "message": "Super calls are not permitted outside constructors or in nested functions inside constructors.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-private-identifier-accessor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-private-identifier-accessor.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 53,
+  "lineNumber": 3,
+  "message": "'value' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-private-identifier-field.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-private-identifier-field.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 14,
+  "lineNumber": 2,
+  "message": "'#priv1' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-private-identifier-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-private-identifier-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-static-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-static-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-static-method-named-prototype.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-static-method-named-prototype.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "Duplicate identifier '["prototype"]'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-static-method-named-static.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-static-method-named-static.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-static-methods-and-accessor-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-static-methods-and-accessor-properties.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "Duplicate identifier 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-two-computed-static-methods.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-two-computed-static-methods.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-two-methods.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-two-methods.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-two-methods-computed-constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-two-methods-computed-constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-two-methods-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-two-methods-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-two-methods-three-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-two-methods-three-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-two-methods-two-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-two-methods-two-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-two-static-methods-named-constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-two-static-methods-named-constructor.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'static' modifier cannot appear on a constructor declaration.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-with-constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-with-constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-with-constructor-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-with-constructor-parameters.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 21,
+  "lineNumber": 1,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-with-constructor-with-space.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-with-constructor-with-space.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/class-with-no-body.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/class-with-no-body.src 1`] = `
 TSError {
   "column": 0,
   "index": 10,
@@ -316,19 +806,40 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/derived-class-assign-to-var.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/derived-class-assign-to-var.src 1`] = `
+TSError {
+  "column": 24,
+  "index": 24,
+  "lineNumber": 1,
+  "message": "Type '0' is not a constructor function type.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/derived-class-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/derived-class-expression.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Type '0' is not a constructor function type.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/empty-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/empty-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/empty-class-double-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/empty-class-double-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/empty-class-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/empty-class-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/empty-literal-derived-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/empty-literal-derived-class.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "Type '0' is not a constructor function type.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/invalid-class-declaration.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/invalid-class-declaration.src 1`] = `
 TSError {
   "column": 0,
   "index": 0,
@@ -337,7 +848,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/invalid-class-setter-declaration.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/invalid-class-setter-declaration.src 1`] = `
 TSError {
   "column": 14,
   "index": 14,
@@ -346,7 +857,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/invalid-class-two-super-classes.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/invalid-class-two-super-classes.src 1`] = `
 TSError {
   "column": 18,
   "index": 18,
@@ -355,97 +866,384 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/named-class-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/named-class-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/classes/named-derived-class-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/classes/named-derived-class-expression.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 17,
+  "lineNumber": 1,
+  "message": "Type '0' is not a constructor function type.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/commaOperator/comma-operator-conditional.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/commaOperator/comma-operator-conditional.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/commaOperator/comma-operator-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/commaOperator/comma-operator-multi.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 10,
+  "lineNumber": 1,
+  "message": "Left side of comma operator is unused and has no side effects.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/commaOperator/comma-operator-nested.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/commaOperator/comma-operator-nested.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 10,
+  "lineNumber": 1,
+  "message": "Left side of comma operator is unused and has no side effects.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/commaOperator/comma-operator-return.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/commaOperator/comma-operator-return.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 38,
+  "lineNumber": 3,
+  "message": "Left side of comma operator is unused and has no side effects.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/commaOperator/comma-operator-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/commaOperator/comma-operator-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/commaOperator/comma-operator-simple-nested.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/commaOperator/comma-operator-simple-nested.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Left side of comma operator is unused and has no side effects.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/defaultParams/class-constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/defaultParams/class-constructor.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 26,
+  "lineNumber": 2,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/defaultParams/class-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/defaultParams/class-method.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "'bar' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/defaultParams/declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/defaultParams/declaration.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/defaultParams/expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/defaultParams/expression.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/defaultParams/method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/defaultParams/method.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/defaultParams/not-all-params.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/defaultParams/not-all-params.src 1`] = `
+TSError {
+  "column": 19,
+  "index": 19,
+  "lineNumber": 1,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/array-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/array-member.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Type '20' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/array-to-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/array-to-array.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Type '[any, any]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/array-var-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/array-var-undefined.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Type '[]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/call-expression-destruction-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/call-expression-destruction-array.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/call-expression-destruction-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/call-expression-destruction-object.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/class-constructor-params-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/class-constructor-params-array.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 26,
+  "lineNumber": 2,
+  "message": "Type '[any, any]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/class-constructor-params-defaults-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/class-constructor-params-defaults-array.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 26,
+  "lineNumber": 2,
+  "message": "Type '[number?, number?]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/class-constructor-params-defaults-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/class-constructor-params-defaults-object.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 26,
+  "lineNumber": 2,
+  "message": "All destructured elements are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/class-constructor-params-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/class-constructor-params-object.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 26,
+  "lineNumber": 2,
+  "message": "All destructured elements are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/class-method-params-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/class-method-params-array.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "Type '[any, any]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/class-method-params-defaults-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/class-method-params-defaults-array.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "Type '[number?, number?]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/class-method-params-defaults-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/class-method-params-defaults-object.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "All destructured elements are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/class-method-params-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/class-method-params-object.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "All destructured elements are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-array.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-array-all.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-array-all.src 1`] = `
+TSError {
+  "column": 29,
+  "index": 29,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-array-longform-nested-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-array-longform-nested-multi.src 1`] = `
+TSError {
+  "column": 37,
+  "index": 37,
+  "lineNumber": 1,
+  "message": "Cannot find name 'b'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-array-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-array-multi.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 21,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-array-nested-all.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-array-nested-all.src 1`] = `
+TSError {
+  "column": 26,
+  "index": 26,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-array-nested-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-array-nested-multi.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 22,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-object-all.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-object-all.src 1`] = `
+TSError {
+  "column": 29,
+  "index": 29,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-object-assign.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-object-assign.src 1`] = `
+TSError {
+  "column": 3,
+  "index": 3,
+  "lineNumber": 1,
+  "message": "No value exists in scope for the shorthand property 'Object'. Either declare one or provide an initializer.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-object-longform.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-object-longform.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-object-longform-all.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-object-longform-all.src 1`] = `
+TSError {
+  "column": 40,
+  "index": 40,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-object-longform-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-object-longform-multi.src 1`] = `
+TSError {
+  "column": 30,
+  "index": 30,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-object-mixed-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-object-mixed-multi.src 1`] = `
+TSError {
+  "column": 24,
+  "index": 24,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-object-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-object-multi.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 21,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-object-nested-all.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-object-nested-all.src 1`] = `
+TSError {
+  "column": 29,
+  "index": 29,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/defaults-object-nested-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/defaults-object-nested-multi.src 1`] = `
+TSError {
+  "column": 25,
+  "index": 25,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/destructured-array-catch.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/destructured-array-catch.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 34,
+  "lineNumber": 3,
+  "message": "'b' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/destructured-object-catch.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/destructured-object-catch.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 34,
+  "lineNumber": 3,
+  "message": "'b' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/invalid-defaults-object-assign.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/invalid-defaults-object-assign.src 1`] = `
 TSError {
   "column": 0,
   "index": 0,
@@ -454,103 +1252,328 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/named-param.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/nested-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/nested-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/object-var-named.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/object-var-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/param-defaults-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/param-defaults-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/param-defaults-object-nested.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/params-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/params-array-wrapped.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/params-multi-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/params-nested-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/params-nested-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/params-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/params-object-wrapped.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring/sparse-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-nested-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-nested-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-nested-object-named.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-arrowFunctions/param-defaults-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-arrowFunctions/param-defaults-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-arrowFunctions/param-defaults-object-nested.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-blockBindings/array-const-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-blockBindings/array-let-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-blockBindings/object-const-named.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-blockBindings/object-const-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-blockBindings/object-let-named.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-blockBindings/object-let-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-defaultParams/param-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-defaultParams/param-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-defaultParams/param-object-short.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-defaultParams/param-object-wrapped.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-forOf/loop.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/complex-destructured.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/destructured-array-literal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/destructuring-param.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/error-complex-destructured-spread-first.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/named-param.src 1`] = `
 TSError {
-  "column": 1,
-  "index": 1,
+  "column": 17,
+  "index": 17,
   "lineNumber": 1,
-  "message": "A rest element must be last in a destructuring pattern.",
+  "message": "Cannot find name 'text'.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/invalid-not-final-array-empty.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/nested-array.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Type '[number, number, [number, number]]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/nested-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/object-var-named.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Initializer provides no value for this binding element and the binding element has no default value.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/object-var-undefined.src 1`] = `
 TSError {
   "column": 5,
   "index": 5,
   "lineNumber": 1,
-  "message": "A rest parameter or binding pattern may not have a trailing comma.",
+  "message": "Initializer provides no value for this binding element and the binding element has no default value.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/multi-destructured.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/param-defaults-array.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "Type '[number?]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/not-final-array.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/param-defaults-object.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/param-defaults-object-nested.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/params-array.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "Type '[any, any]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/params-array-wrapped.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "Type '[any, any]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/params-multi-object.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/params-nested-array.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "Type '[any, any, [any, any]]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/params-nested-object.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "'y' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/params-object.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "All destructured elements are unused.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/params-object-wrapped.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "All destructured elements are unused.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring/sparse-array.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-array.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Type '[any]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-nested-array.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Type '[any, [any]]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-nested-object.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 2,
+  "lineNumber": 1,
+  "message": "'y' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-nested-object-named.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "'y' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-object.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "'y' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-arrowFunctions/param-defaults-array.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Type '[number?]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-arrowFunctions/param-defaults-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-arrowFunctions/param-defaults-object-nested.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-blockBindings/array-const-undefined.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 6,
+  "lineNumber": 1,
+  "message": "Type '[]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-blockBindings/array-let-undefined.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Type '[]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-blockBindings/object-const-named.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Initializer provides no value for this binding element and the binding element has no default value.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-blockBindings/object-const-undefined.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Initializer provides no value for this binding element and the binding element has no default value.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-blockBindings/object-let-named.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Initializer provides no value for this binding element and the binding element has no default value.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-blockBindings/object-let-undefined.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 5,
+  "lineNumber": 1,
+  "message": "Initializer provides no value for this binding element and the binding element has no default value.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-defaultParams/param-array.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "Type '[number]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-defaultParams/param-object.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'f'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-defaultParams/param-object-short.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-defaultParams/param-object-wrapped.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-forOf/loop.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 6,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/complex-destructured.src 1`] = `
+TSError {
+  "column": 3,
+  "index": 3,
+  "lineNumber": 1,
+  "message": "No value exists in scope for the shorthand property 'a'. Either declare one or provide an initializer.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/destructured-array-literal.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/destructuring-param.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "Type '[any, any, ...[any][]]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/error-complex-destructured-spread-first.src 1`] = `
 TSError {
   "column": 1,
   "index": 1,
@@ -559,41 +1582,131 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/single-destructured.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/invalid-not-final-array-empty.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/var-complex-destructured.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/multi-destructured.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/var-destructured-array-literal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/not-final-array.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "A rest element must be last in a destructuring pattern.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/var-multi-destructured.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/single-destructured.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/destructuring-and-spread/var-single-destructured.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/var-complex-destructured.src 1`] = `
+TSError {
+  "column": 23,
+  "index": 23,
+  "lineNumber": 1,
+  "message": "Cannot find name 'd'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/directives/block.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/var-destructured-array-literal.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 21,
+  "lineNumber": 1,
+  "message": "Cannot find name 'd'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/directives/directive-in-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/var-multi-destructured.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "Cannot find name 'c'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/directives/first-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/destructuring-and-spread/var-single-destructured.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 13,
+  "lineNumber": 1,
+  "message": "Cannot find name 'b'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/directives/function-non-strict.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/directives/block.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 39,
+  "lineNumber": 3,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/directives/non-directive-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/directives/directive-in-class.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 85,
+  "lineNumber": 8,
+  "message": "A 'get' accessor must return a value.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/directives/non-unique-directive.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/directives/first-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/directives/program.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/directives/function-non-strict.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/directives/program-order.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/directives/non-directive-string.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 57,
+  "lineNumber": 6,
+  "message": "Type 'false' is not comparable to type 'true'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/directives/raw.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/directives/non-unique-directive.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalAsyncIteration/async-generators.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/directives/program.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalAsyncIteration/async-iterator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/directives/program-order.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalDynamicImport/dynamic-import.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/directives/raw.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalDynamicImport/error-dynamic-import-params.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalAsyncIteration/async-generators.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalAsyncIteration/async-iterator.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 44,
+  "lineNumber": 2,
+  "message": "'item' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalDynamicImport/dynamic-import.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalDynamicImport/error-dynamic-import-params.src 1`] = `
 TSError {
   "column": 7,
   "index": 7,
@@ -602,13 +1715,34 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/arg-spread.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/arg-spread.src 1`] = `
+TSError {
+  "column": 18,
+  "index": 18,
+  "lineNumber": 1,
+  "message": "'b' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/destructuring-assign-mirror.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/destructuring-assign-mirror.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 2,
+  "lineNumber": 1,
+  "message": "No value exists in scope for the shorthand property 'a'. Either declare one or provide an initializer.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/function-parameter-object-spread.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/function-parameter-object-spread.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 13,
+  "lineNumber": 1,
+  "message": "'bar' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/invalid-rest.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/invalid-rest.src 1`] = `
 TSError {
   "column": 18,
   "index": 18,
@@ -617,7 +1751,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/invalid-rest-trailing-comma.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/invalid-rest-trailing-comma.src 1`] = `
 TSError {
   "column": 16,
   "index": 16,
@@ -626,49 +1760,112 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/object-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/object-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/property-spread.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/property-spread.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/shorthand-method-args.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/shorthand-method-args.src 1`] = `
+TSError {
+  "column": 38,
+  "index": 41,
+  "lineNumber": 2,
+  "message": "'options' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/shorthand-methods.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/shorthand-methods.src 1`] = `
+TSError {
+  "column": 38,
+  "index": 48,
+  "lineNumber": 2,
+  "message": "'options' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/shorthand-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/shorthand-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/single-spread.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/single-spread.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/spread-trailing-comma.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/spread-trailing-comma.src 1`] = `
+TSError {
+  "column": 3,
+  "index": 3,
+  "lineNumber": 1,
+  "message": "No value exists in scope for the shorthand property 'a'. Either declare one or provide an initializer.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalObjectRestSpread/two-spread.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalObjectRestSpread/two-spread.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalOptionalCatchBinding/optional-catch-binding.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalOptionalCatchBinding/optional-catch-binding.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/experimentalOptionalCatchBinding/optional-catch-binding-finally.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/experimentalOptionalCatchBinding/optional-catch-binding-finally.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/exponentiationOperators/exponential-operators.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/exponentiationOperators/exponential-operators.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/for/for-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/for/for-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/for/for-loop.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/for/for-loop.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/for/for-with-coma.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/for/for-with-coma.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/for/for-with-const.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/for/for-with-const.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 22,
+  "lineNumber": 1,
+  "message": "Cannot find name 'j'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/for/for-with-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/for/for-with-function.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 5,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/for/for-with-let.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/for/for-with-let.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 22,
+  "lineNumber": 1,
+  "message": "Cannot find name 'j'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-array.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-bare-nonstrict.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-bare-nonstrict.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 58,
+  "lineNumber": 4,
+  "message": "The variable declaration of a 'for...in' statement cannot have an initializer.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-destruction.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-destruction.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Type 'string' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-destruction-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-destruction-object.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "The left-hand side of a 'for...in' statement cannot be a destructuring pattern.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-object.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-object.src 1`] = `
 TSError {
   "column": 14,
   "index": 14,
@@ -677,29 +1874,92 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-object-with-body.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-object-with-body.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-with-assigment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-with-assigment.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "The variable declaration of a 'for...in' statement cannot have an initializer.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-with-bare-assigment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-with-bare-assigment.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-with-const.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-with-const.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "Cannot find name 'list'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-with-milti-asigment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-with-milti-asigment.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "The variable declaration of a 'for...in' statement cannot have an initializer.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-with-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-with-rest.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 5,
+  "lineNumber": 1,
+  "message": "The left-hand side of a 'for...in' statement cannot be a destructuring pattern.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forIn/for-in-with-var.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forIn/for-in-with-var.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Cannot find name 'list'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forOf/for-of-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forOf/for-of-array.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forOf/for-of-destruction.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forOf/for-of-destruction.src 1`] = `
+TSError {
+  "column": 26,
+  "index": 26,
+  "lineNumber": 1,
+  "message": "Cannot find name 'obj'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forOf/for-of-destruction-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forOf/for-of-destruction-object.src 1`] = `
+TSError {
+  "column": 26,
+  "index": 26,
+  "lineNumber": 1,
+  "message": "Cannot find name 'obj'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forOf/for-of-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forOf/for-of-object.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forOf/for-of-with-function-initializer.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forOf/for-of-with-function-initializer.src 1`] = `
 TSError {
   "column": 9,
   "index": 9,
@@ -708,47 +1968,117 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forOf/for-of-with-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forOf/for-of-with-rest.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 10,
+  "lineNumber": 1,
+  "message": "Cannot find name 'xx'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forOf/for-of-with-var-and-braces.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forOf/for-of-with-var-and-braces.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forOf/for-of-with-var-and-no-braces.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forOf/for-of-with-var-and-no-braces.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forOf/invalid-for-of-with-const-and-no-braces.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forOf/invalid-for-of-with-const-and-no-braces.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/forOf/invalid-for-of-with-let-and-no-braces.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/forOf/invalid-for-of-with-let-and-no-braces.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/function/return-multiline-sequence.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/function/return-multiline-sequence.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 40,
+  "lineNumber": 3,
+  "message": "Left side of comma operator is unused and has no side effects.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/function/return-sequence.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/function/return-sequence.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 35,
+  "lineNumber": 2,
+  "message": "Left side of comma operator is unused and has no side effects.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/generators/anonymous-generator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/generators/anonymous-generator.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/generators/async-generator-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/generators/async-generator-function.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/generators/async-generator-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/generators/async-generator-method.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/generators/double-yield.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/generators/double-yield.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/generators/empty-generator-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/generators/empty-generator-declaration.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/generators/generator-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/generators/generator-declaration.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/generators/yield-delegation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/generators/yield-delegation.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/generators/yield-without-value.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/generators/yield-without-value.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/generators/yield-without-value-in-call.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/generators/yield-without-value-in-call.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/generators/yield-without-value-no-semi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/generators/yield-without-value-no-semi.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/globalReturn/return-identifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/globalReturn/return-identifier.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "A 'return' statement can only be used within a function body.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/globalReturn/return-no-arg.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/globalReturn/return-no-arg.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "A 'return' statement can only be used within a function body.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/globalReturn/return-true.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/globalReturn/return-true.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "A 'return' statement can only be used within a function body.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/hexLiterals/invalid.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/hexLiterals/invalid.src 1`] = `
 TSError {
   "column": 4,
   "index": 4,
@@ -757,119 +2087,322 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/hexLiterals/lowercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/hexLiterals/lowercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/hexLiterals/uppercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/hexLiterals/uppercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/importMeta/simple-import-meta.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/importMeta/simple-import-meta.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/labels/label-break.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/labels/label-break.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/labels/label-continue.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/labels/label-continue.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/error-delete.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/error-delete.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 26,
+  "lineNumber": 2,
+  "message": "'delete' cannot be called on an identifier in strict mode.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/error-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/error-function.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 16,
+  "lineNumber": 2,
+  "message": "A default export must be at the top level of a file or module declaration.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/error-strict.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/error-strict.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 28,
+  "lineNumber": 3,
+  "message": "'with' statements are not allowed in strict mode.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-async-named-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-async-named-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-const.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-const.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-default-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-default-array.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-default-async-named-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-default-async-named-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-default-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-default-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-default-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-default-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-default-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-default-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-default-named-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-default-named-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-default-named-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-default-named-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-default-number.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-default-number.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-default-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-default-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-default-value.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-default-value.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-from-batch.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-from-batch.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-from-default.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-from-default.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Circular definition of import alias 'default'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-from-named-as-default.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-from-named-as-default.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Module '"./estree"' has no exported member 'foo'. Did you mean to use 'import foo from "./estree"' instead?",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-from-named-as-specifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-from-named-as-specifier.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Module '"./estree"' has no exported member 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-from-named-as-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-from-named-as-specifiers.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Module '"./estree"' has no exported member 'foo'. Did you mean to use 'import foo from "./estree"' instead?",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-from-specifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-from-specifier.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Circular definition of import alias 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-from-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-from-specifiers.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Circular definition of import alias 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-let.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-let.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-named-as-default.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-named-as-default.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-named-as-specifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-named-as-specifier.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-named-as-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-named-as-specifiers.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-named-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-named-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-named-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-named-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-named-specifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-named-specifier.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-named-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-named-specifiers.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-named-specifiers-comma.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-named-specifiers-comma.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-var.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-var.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-var-anonymous-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-var-anonymous-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/export-var-number.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/export-var-number.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-default.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-default.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-default-and-named-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-default-and-named-specifiers.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "All imports in import declaration are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-default-and-namespace-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-default-and-namespace-specifiers.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "All imports in import declaration are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-default-as.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-default-as.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-jquery.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-jquery.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'$' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-module.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-module.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-named-as-specifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-named-as-specifier.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'baz' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-named-as-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-named-as-specifiers.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "All imports in import declaration are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-named-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-named-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-named-specifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-named-specifier.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'bar' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-named-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-named-specifiers.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "All imports in import declaration are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-named-specifiers-comma.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-named-specifiers-comma.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "All imports in import declaration are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-namespace-specifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-namespace-specifier.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/import-null-as-nil.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/import-null-as-nil.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'nil' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-await.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-await.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "Identifier expected. 'await' is a reserved word at the top-level of a module.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-export-batch-missing-from-clause.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-export-batch-missing-from-clause.src 1`] = `
 TSError {
   "column": 0,
   "index": 9,
@@ -878,7 +2411,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-export-batch-token.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-export-batch-token.src 1`] = `
 TSError {
   "column": 9,
   "index": 9,
@@ -887,7 +2420,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-export-default.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-export-default.src 1`] = `
 TSError {
   "column": 20,
   "index": 20,
@@ -896,7 +2429,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-export-default-equal.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-export-default-equal.src 1`] = `
 TSError {
   "column": 15,
   "index": 15,
@@ -905,7 +2438,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-export-default-token.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-export-default-token.src 1`] = `
 TSError {
   "column": 17,
   "index": 17,
@@ -914,7 +2447,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-export-module-specifier.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-export-module-specifier.src 1`] = `
 TSError {
   "column": 19,
   "index": 19,
@@ -923,9 +2456,16 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-export-named-default.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-export-named-default.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Cannot find name 'default'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-export-named-extra-comma.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-export-named-extra-comma.src 1`] = `
 TSError {
   "column": 16,
   "index": 16,
@@ -934,7 +2474,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-export-named-middle-comma.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-export-named-middle-comma.src 1`] = `
 TSError {
   "column": 12,
   "index": 12,
@@ -943,7 +2483,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-default.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-default.src 1`] = `
 TSError {
   "column": 7,
   "index": 7,
@@ -952,7 +2492,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-default-after-named.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-default-after-named.src 1`] = `
 TSError {
   "column": 12,
   "index": 12,
@@ -961,7 +2501,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-default-after-named-after-default.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-default-after-named-after-default.src 1`] = `
 TSError {
   "column": 17,
   "index": 17,
@@ -970,7 +2510,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-default-missing-module-specifier.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-default-missing-module-specifier.src 1`] = `
 TSError {
   "column": 0,
   "index": 11,
@@ -979,7 +2519,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-default-module-specifier.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-default-module-specifier.src 1`] = `
 TSError {
   "column": 15,
   "index": 15,
@@ -988,7 +2528,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-missing-module-specifier.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-missing-module-specifier.src 1`] = `
 TSError {
   "column": 0,
   "index": 20,
@@ -997,7 +2537,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-module-specifier.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-module-specifier.src 1`] = `
 TSError {
   "column": 17,
   "index": 17,
@@ -1006,7 +2546,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-named-after-named.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-named-after-named.src 1`] = `
 TSError {
   "column": 12,
   "index": 12,
@@ -1015,7 +2555,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-named-after-namespace.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-named-after-namespace.src 1`] = `
 TSError {
   "column": 15,
   "index": 15,
@@ -1024,7 +2564,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-named-as-missing-from.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-named-as-missing-from.src 1`] = `
 TSError {
   "column": 0,
   "index": 24,
@@ -1033,7 +2573,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-named-extra-comma.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-named-extra-comma.src 1`] = `
 TSError {
   "column": 16,
   "index": 16,
@@ -1042,7 +2582,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-named-middle-comma.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-named-middle-comma.src 1`] = `
 TSError {
   "column": 12,
   "index": 12,
@@ -1051,7 +2591,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-namespace-after-named.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-namespace-after-named.src 1`] = `
 TSError {
   "column": 12,
   "index": 12,
@@ -1060,7 +2600,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/modules/invalid-import-namespace-missing-as.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/modules/invalid-import-namespace-missing-as.src 1`] = `
 TSError {
   "column": 9,
   "index": 9,
@@ -1069,7 +2609,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/newTarget/invalid-new-target.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/newTarget/invalid-new-target.src 1`] = `
 TSError {
   "column": 8,
   "index": 8,
@@ -1078,7 +2618,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/newTarget/invalid-unknown-property.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/newTarget/invalid-unknown-property.src 1`] = `
 TSError {
   "column": 25,
   "index": 25,
@@ -1087,21 +2627,70 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/newTarget/simple-new-target.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/newTarget/simple-new-target.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 23,
+  "lineNumber": 2,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteral/object-literal-in-lhs.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteral/object-literal-in-lhs.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'fn'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralComputedProperties/computed-addition-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralComputedProperties/computed-addition-property.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 23,
+  "lineNumber": 2,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralComputedProperties/computed-and-identifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralComputedProperties/computed-and-identifier.src 1`] = `
+TSError {
+  "column": 3,
+  "index": 3,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralComputedProperties/computed-getter-and-setter.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralComputedProperties/computed-getter-and-setter.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 6,
+  "lineNumber": 1,
+  "message": "A 'get' accessor must return a value.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralComputedProperties/computed-string-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralComputedProperties/computed-string-property.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 23,
+  "lineNumber": 2,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralComputedProperties/computed-variable-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralComputedProperties/computed-variable-property.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "Cannot find name 'bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralComputedProperties/invalid-computed-variable-property.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralComputedProperties/invalid-computed-variable-property.src 1`] = `
 TSError {
   "column": 0,
   "index": 20,
@@ -1110,7 +2699,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralComputedProperties/invalid-standalone-computed-variable-property.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralComputedProperties/invalid-standalone-computed-variable-property.src 1`] = `
 TSError {
   "column": 5,
   "index": 5,
@@ -1119,13 +2708,27 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralComputedProperties/standalone-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralComputedProperties/standalone-expression.src 1`] = `
+TSError {
+  "column": 3,
+  "index": 3,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralComputedProperties/standalone-expression-with-addition.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralComputedProperties/standalone-expression-with-addition.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralComputedProperties/standalone-expression-with-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralComputedProperties/standalone-expression-with-method.src 1`] = `
+TSError {
+  "column": 3,
+  "index": 3,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralDuplicateProperties/error-proto-property.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralDuplicateProperties/error-proto-property.src 1`] = `
 TSError {
   "column": 1,
   "index": 62,
@@ -1134,7 +2737,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralDuplicateProperties/error-proto-string-property.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralDuplicateProperties/error-proto-string-property.src 1`] = `
 TSError {
   "column": 1,
   "index": 64,
@@ -1143,7 +2746,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralDuplicateProperties/strict-duplicate-properties.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralDuplicateProperties/strict-duplicate-properties.src 1`] = `
 TSError {
   "column": 1,
   "index": 39,
@@ -1152,7 +2755,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralDuplicateProperties/strict-duplicate-string-properties.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralDuplicateProperties/strict-duplicate-string-properties.src 1`] = `
 TSError {
   "column": 1,
   "index": 41,
@@ -1161,7 +2764,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralShorthandMethods/invalid-method-no-braces.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralShorthandMethods/invalid-method-no-braces.src 1`] = `
 TSError {
   "column": 13,
   "index": 19,
@@ -1170,23 +2773,72 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralShorthandMethods/method-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralShorthandMethods/method-property.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 37,
+  "lineNumber": 3,
+  "message": "Cannot find name 'bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralShorthandMethods/simple-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralShorthandMethods/simple-method.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralShorthandMethods/simple-method-named-get.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralShorthandMethods/simple-method-named-get.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralShorthandMethods/simple-method-named-set.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralShorthandMethods/simple-method-named-set.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralShorthandMethods/simple-method-with-argument.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralShorthandMethods/simple-method-with-argument.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralShorthandMethods/simple-method-with-string-name.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralShorthandMethods/simple-method-with-string-name.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralShorthandMethods/string-name-method-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralShorthandMethods/string-name-method-property.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 39,
+  "lineNumber": 3,
+  "message": "Cannot find name 'bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/objectLiteralShorthandProperties/shorthand-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/objectLiteralShorthandProperties/shorthand-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/octalLiterals/invalid.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/octalLiterals/invalid.src 1`] = `
 TSError {
   "column": 4,
   "index": 4,
@@ -1195,7 +2847,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/octalLiterals/legacy.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/octalLiterals/legacy.src 1`] = `
 TSError {
   "column": 0,
   "index": 0,
@@ -1204,71 +2856,127 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/octalLiterals/lowercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/octalLiterals/lowercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/octalLiterals/strict-uppercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/octalLiterals/strict-uppercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/octalLiterals/uppercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/octalLiterals/uppercase.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/regex/regexp-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/regex/regexp-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/regexUFlag/regex-u-extended-escape.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/regexUFlag/regex-u-extended-escape.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/regexUFlag/regex-u-invalid-extended-escape.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/regexUFlag/regex-u-invalid-extended-escape.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/regexUFlag/regex-u-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/regexUFlag/regex-u-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/regexYFlag/regexp-y-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/regexYFlag/regexp-y-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/restParams/basic-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/restParams/basic-rest.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 11,
+  "lineNumber": 1,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/restParams/class-constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/restParams/class-constructor.src 1`] = `
+TSError {
+  "column": 19,
+  "index": 29,
+  "lineNumber": 2,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/restParams/class-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/restParams/class-method.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 21,
+  "lineNumber": 2,
+  "message": "'bar' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/restParams/error-no-default.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/restParams/error-no-default.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Function implementation is missing or not immediately following the declaration.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/restParams/error-not-last.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Function implementation is missing or not immediately following the declaration.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/restParams/func-expression.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 21,
+  "lineNumber": 1,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/restParams/func-expression-multi.src 1`] = `
 TSError {
   "column": 17,
   "index": 17,
   "lineNumber": 1,
-  "message": "A rest parameter cannot have an initializer.",
+  "message": "'a' is declared but its value is never read.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/restParams/error-not-last.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/restParams/invalid-rest-param.src 1`] = `
 TSError {
   "column": 14,
   "index": 14,
   "lineNumber": 1,
-  "message": "A rest parameter must be last in a parameter list.",
+  "message": "'a' is declared but its value is never read.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/restParams/func-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/restParams/single-rest.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "'b' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/restParams/func-expression-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/simple-literals/literal-float.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/restParams/invalid-rest-param.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/simple-literals/literal-float-negative.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/restParams/single-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/simple-literals/literal-null.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/simple-literals/literal-float.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/simple-literals/literal-number.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/simple-literals/literal-float-negative.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/simple-literals/literal-number-negative.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/simple-literals/literal-null.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/simple-literals/literal-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/simple-literals/literal-number.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/simple-literals/literal-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/simple-literals/literal-number-negative.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/spread/complex-spread.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "No value exists in scope for the shorthand property 'ka'. Either declare one or provide an initializer.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/simple-literals/literal-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/simple-literals/literal-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/spread/complex-spread.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/spread/error-invalid-if.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/spread/error-invalid-if.src 1`] = `
 TSError {
   "column": 6,
   "index": 6,
@@ -1277,7 +2985,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/spread/error-invalid-sequence.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/spread/error-invalid-sequence.src 1`] = `
 TSError {
   "column": 4,
   "index": 4,
@@ -1286,37 +2994,86 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/spread/multi-function-call.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/spread/multi-function-call.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/spread/not-final-param.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/spread/not-final-param.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'func'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/spread/simple-function-call.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/spread/simple-function-call.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/templateStrings/deeply-nested.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/templateStrings/deeply-nested.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'raw'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/templateStrings/error-octal-literal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/templateStrings/error-octal-literal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/templateStrings/escape-characters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/templateStrings/escape-characters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/templateStrings/expressions.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/templateStrings/expressions.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/templateStrings/multi-line-template-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/templateStrings/multi-line-template-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/templateStrings/simple-template-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/templateStrings/simple-template-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/templateStrings/single-dollar-sign.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/templateStrings/single-dollar-sign.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/templateStrings/tagged-no-placeholders.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/templateStrings/tagged-no-placeholders.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/templateStrings/tagged-template-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/templateStrings/tagged-template-string.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/unicodeCodePointEscapes/basic-string-literal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/unicodeCodePointEscapes/basic-string-literal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/unicodeCodePointEscapes/complex-string-literal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/unicodeCodePointEscapes/complex-string-literal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/unicodeCodePointEscapes/ignored.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/unicodeCodePointEscapes/ignored.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 82,
+  "lineNumber": 6,
+  "message": "'h' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/unicodeCodePointEscapes/invalid-empty-escape.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/unicodeCodePointEscapes/invalid-empty-escape.src 1`] = `
 TSError {
   "column": 4,
   "index": 4,
@@ -1325,7 +3082,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/javascript/unicodeCodePointEscapes/invalid-too-large-escape.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/javascript/unicodeCodePointEscapes/invalid-too-large-escape.src 1`] = `
 TSError {
   "column": 10,
   "index": 10,
@@ -1334,17 +3091,31 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/attributes.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/attributes.src 1`] = `
+TSError {
+  "column": 20,
+  "index": 20,
+  "lineNumber": 1,
+  "message": "Cannot find name 'quz'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/element-keyword-name.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/element-keyword-name.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/embedded-comment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-conditional.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/embedded-conditional.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 6,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-invalid-js-identifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/embedded-invalid-js-identifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/embedded-tags.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/embedded-tags.src 1`] = `
 TSError {
   "column": 40,
   "index": 40,
@@ -1353,17 +3124,17 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/empty-placeholder.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/empty-placeholder.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/escape-patterns-ignored.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/escape-patterns-ignored.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/escape-patterns-unknown.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/escape-patterns-unknown.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/escape-patterns-valid.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/escape-patterns-valid.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/escape-patters-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/escape-patters-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-attribute.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-attribute.src 1`] = `
 TSError {
   "column": 5,
   "index": 5,
@@ -1372,7 +3143,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-attribute-missing-equals.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-attribute-missing-equals.src 1`] = `
 TSError {
   "column": 14,
   "index": 14,
@@ -1381,7 +3152,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-broken-tag.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-broken-tag.src 1`] = `
 TSError {
   "column": 12,
   "index": 12,
@@ -1390,7 +3161,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-computed-end-tag-name.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-computed-end-tag-name.src 1`] = `
 TSError {
   "column": 2,
   "index": 2,
@@ -1399,7 +3170,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-computed-string-end-tag-name.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-computed-string-end-tag-name.src 1`] = `
 TSError {
   "column": 2,
   "index": 2,
@@ -1408,7 +3179,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-embedded-expression.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-embedded-expression.src 1`] = `
 TSError {
   "column": 9,
   "index": 9,
@@ -1417,7 +3188,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-leading-dot-tag-name.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-leading-dot-tag-name.src 1`] = `
 TSError {
   "column": 0,
   "index": 0,
@@ -1426,7 +3197,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-matching-placeholder-in-closing-tag.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-matching-placeholder-in-closing-tag.src 1`] = `
 TSError {
   "column": 27,
   "index": 27,
@@ -1435,7 +3206,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-mismatched-closing-tag.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-mismatched-closing-tag.src 1`] = `
 TSError {
   "column": 5,
   "index": 5,
@@ -1444,7 +3215,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-mismatched-closing-tags.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-mismatched-closing-tags.src 1`] = `
 TSError {
   "column": 1,
   "index": 1,
@@ -1453,7 +3224,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-mismatched-dot-tag-name.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-mismatched-dot-tag-name.src 1`] = `
 TSError {
   "column": 9,
   "index": 9,
@@ -1462,7 +3233,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-mismatched-namespace-tag.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-mismatched-namespace-tag.src 1`] = `
 TSError {
   "column": 7,
   "index": 7,
@@ -1471,7 +3242,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-missing-closing-tag.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-missing-closing-tag.src 1`] = `
 TSError {
   "column": 1,
   "index": 1,
@@ -1480,7 +3251,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-missing-closing-tag-attribute-placeholder.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-missing-closing-tag-attribute-placeholder.src 1`] = `
 TSError {
   "column": 1,
   "index": 1,
@@ -1489,7 +3260,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-missing-namespace-name.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-missing-namespace-name.src 1`] = `
 TSError {
   "column": 0,
   "index": 0,
@@ -1498,7 +3269,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-missing-namespace-value.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-missing-namespace-value.src 1`] = `
 TSError {
   "column": 2,
   "index": 2,
@@ -1507,7 +3278,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-missing-spread-operator.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-missing-spread-operator.src 1`] = `
 TSError {
   "column": 6,
   "index": 6,
@@ -1516,7 +3287,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-namespace-name-with-docts.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-namespace-name-with-docts.src 1`] = `
 TSError {
   "column": 4,
   "index": 4,
@@ -1525,9 +3296,16 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-namespace-value-with-dots.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-namespace-value-with-dots.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a:b'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-no-common-parent.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-no-common-parent.src 1`] = `
 TSError {
   "column": 8,
   "index": 8,
@@ -1536,7 +3314,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-no-common-parent-with-comment.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-no-common-parent-with-comment.src 1`] = `
 TSError {
   "column": 8,
   "index": 8,
@@ -1545,7 +3323,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-no-tag-name.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-no-tag-name.src 1`] = `
 TSError {
   "column": 0,
   "index": 0,
@@ -1554,7 +3332,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-placeholder-in-closing-tag.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-placeholder-in-closing-tag.src 1`] = `
 TSError {
   "column": 16,
   "index": 16,
@@ -1563,7 +3341,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-shorthand-fragment-no-closing.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-shorthand-fragment-no-closing.src 1`] = `
 TSError {
   "column": 0,
   "index": 0,
@@ -1572,7 +3350,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-trailing-dot-tag-name.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-trailing-dot-tag-name.src 1`] = `
 TSError {
   "column": 3,
   "index": 3,
@@ -1581,7 +3359,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/invalid-unexpected-comma.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/invalid-unexpected-comma.src 1`] = `
 TSError {
   "column": 19,
   "index": 19,
@@ -1590,13 +3368,34 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/japanese-characters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/japanese-characters.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name '日本語'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/less-than-operator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/less-than-operator.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/member-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/member-expression.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/member-expression-private.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/member-expression-private.src 1`] = `
 TSError {
   "column": 10,
   "index": 10,
@@ -1605,17 +3404,24 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/member-expression-this.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/member-expression-this.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/multiple-blank-spaces.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/multiple-blank-spaces.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/namespace-this-name.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/namespace-this-name.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/namespaced-attribute-and-value-inserted.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/namespaced-attribute-and-value-inserted.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 17,
+  "lineNumber": 1,
+  "message": "Cannot find name 'value'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/namespaced-name-and-attribute.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/namespaced-name-and-attribute.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/newslines-and-entities.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/newslines-and-entities.src 1`] = `
 TSError {
   "column": 8,
   "index": 8,
@@ -1624,11 +3430,11 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/self-closing-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/self-closing-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/self-closing-tag-inside-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/self-closing-tag-inside-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/self-closing-tag-with-newline.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/self-closing-tag-with-newline.src 1`] = `
 TSError {
   "column": 2,
   "index": 2,
@@ -1637,33 +3443,89 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/shorthand-fragment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/shorthand-fragment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/shorthand-fragment-with-child.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/shorthand-fragment-with-child.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/spread-child.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/spread-child.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 5,
+  "lineNumber": 1,
+  "message": "JSX spread child must be an array type.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/spread-operator-attribute-and-regular-attribute.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/spread-operator-attribute-and-regular-attribute.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Cannot find name 'props'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/spread-operator-attributes.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/spread-operator-attributes.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Cannot find name 'props'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/tag-names-with-dots.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/tag-names-with-dots.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/tag-names-with-multi-dots.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/tag-names-with-multi-dots.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/tag-names-with-multi-dots-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/tag-names-with-multi-dots-multi.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/test-content.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/test-content.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx/trailing-spread-operator-attribute.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx/trailing-spread-operator-attribute.src 1`] = `
+TSError {
+  "column": 40,
+  "index": 40,
+  "lineNumber": 1,
+  "message": "Cannot find name 'props'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx-useJSXTextNode/self-closing-tag-inside-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx-useJSXTextNode/self-closing-tag-inside-tag.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/jsx-useJSXTextNode/test-content.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/jsx-useJSXTextNode/test-content.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/tsx/generic-jsx-element.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/tsx/generic-jsx-element.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'MyComponent'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/tsx/generic-jsx-member-expression-private.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/tsx/generic-jsx-member-expression-private.src 1`] = `
 TSError {
   "column": 22,
   "index": 22,
@@ -1672,15 +3534,36 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/tsx/generic-jsx-opening-element.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/tsx/generic-jsx-opening-element.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'MyComponent'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/tsx/react-typed-props.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/tsx/react-typed-props.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/babylon-convergence/type-parameter-whitespace-loc.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/babylon-convergence/type-parameter-whitespace-loc.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 10,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/babylon-convergence/type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/babylon-convergence/type-parameters.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 10,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/abstract-class-with-abstract-constructor.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/abstract-class-with-abstract-constructor.src 1`] = `
 TSError {
   "column": 4,
   "index": 43,
@@ -1689,13 +3572,20 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/abstract-class-with-abstract-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/abstract-class-with-abstract-method.src 1`] = `
+TSError {
+  "column": 29,
+  "index": 68,
+  "lineNumber": 2,
+  "message": "Cannot find name 'Promise'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/abstract-class-with-abstract-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/abstract-class-with-abstract-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/abstract-class-with-abstract-readonly-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/abstract-class-with-abstract-readonly-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/abstract-class-with-abstract-static-constructor.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/abstract-class-with-abstract-static-constructor.src 1`] = `
 TSError {
   "column": 2,
   "index": 41,
@@ -1704,15 +3594,36 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/abstract-class-with-declare-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/abstract-class-with-declare-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/abstract-class-with-optional-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/abstract-class-with-optional-method.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 60,
+  "lineNumber": 2,
+  "message": "Cannot find name 'Promise'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/abstract-class-with-override-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/abstract-class-with-override-method.src 1`] = `
+TSError {
+  "column": 44,
+  "index": 44,
+  "lineNumber": 1,
+  "message": "Cannot find name 'SomeComponent'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/abstract-class-with-override-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/abstract-class-with-override-property.src 1`] = `
+TSError {
+  "column": 44,
+  "index": 44,
+  "lineNumber": 1,
+  "message": "Cannot find name 'SomeComponent'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/abstract-interface.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/abstract-interface.src 1`] = `
 TSError {
   "column": 7,
   "index": 7,
@@ -1721,19 +3632,26 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/angle-bracket-type-assertion.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/angle-bracket-type-assertion.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/angle-bracket-type-assertion-arrow-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/angle-bracket-type-assertion-arrow-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/arrow-function-with-optional-parameter.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/arrow-function-with-optional-parameter.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/arrow-function-with-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/arrow-function-with-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/async-function-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/async-function-expression.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/async-function-with-var-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/async-function-with-var-declaration.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 32,
+  "lineNumber": 2,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/await-without-async-function.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/await-without-async-function.src 1`] = `
 TSError {
   "column": 14,
   "index": 31,
@@ -1742,23 +3660,65 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/call-signatures.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/call-signatures.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/call-signatures-with-generics.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/call-signatures-with-generics.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/cast-as-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/cast-as-expression.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/cast-as-multi.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/cast-as-multi.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/cast-as-multi-assign.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/cast-as-multi-assign.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/cast-as-operator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/cast-as-operator.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/cast-as-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/cast-as-simple.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "Cannot find name 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/catch-clause-with-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/catch-clause-with-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/catch-clause-with-invalid-annotation.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/catch-clause-with-invalid-annotation.src 1`] = `
 TSError {
   "column": 12,
   "index": 19,
@@ -1767,35 +3727,105 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-multi-line-keyword-abstract.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-multi-line-keyword-abstract.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'abstract'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-multi-line-keyword-declare.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-multi-line-keyword-declare.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'declare'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-private-identifier-field-with-accessibility-error.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-private-identifier-field-with-accessibility-error.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 14,
+  "lineNumber": 2,
+  "message": "An accessibility modifier cannot be used with a private identifier.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-private-identifier-field-with-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-private-identifier-field-with-annotation.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 14,
+  "lineNumber": 2,
+  "message": "'#priv1' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-private-identifier-readonly-field.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-private-identifier-readonly-field.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 23,
+  "lineNumber": 2,
+  "message": "'#priv' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-static-blocks.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-static-blocks.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 51,
+  "lineNumber": 4,
+  "message": "Cannot find name 'someCondition'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-accessibility-modifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-accessibility-modifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-modifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-constructor-and-modifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-parameter-property-with-modifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-constructor-and-parameter-property-with-modifiers.src 1`] = `
+TSError {
+  "column": 35,
+  "index": 35,
+  "lineNumber": 1,
+  "message": "Cannot find name 'SomeComponent'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-parameter-proptery-with-override-modifier.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-constructor-and-parameter-proptery-with-override-modifier.src 1`] = `
+TSError {
+  "column": 35,
+  "index": 35,
+  "lineNumber": 1,
+  "message": "Cannot find name 'SomeComponent'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-return-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-constructor-and-return-type.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 27,
+  "lineNumber": 2,
+  "message": "Type annotation cannot appear on a constructor declaration.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-constructor-and-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-constructor-and-type-parameters.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 23,
+  "lineNumber": 2,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-declare-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-declare-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-definite-assignment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-definite-assignment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-export-parameter-properties.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-export-parameter-properties.src 1`] = `
 TSError {
   "column": 16,
   "index": 28,
@@ -1804,68 +3834,222 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-extends-and-implements.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-extends-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-extends-generic-multiple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-generic-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-generic-method-default.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-implements.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-implements-and-extends.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-extends-and-implements.src 1`] = `
 TSError {
-  "column": 57,
-  "index": 57,
+  "column": 42,
+  "index": 42,
   "lineNumber": 1,
-  "message": "'extends' clause must precede 'implements' clause.",
+  "message": "Cannot find name 'MyOtherClass'.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-implements-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-extends-generic.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'A' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-implements-generic-multiple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-extends-generic-multiple.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'A' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-generic-method.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 20,
+  "lineNumber": 2,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-mixin.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-generic-method-default.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 20,
+  "lineNumber": 2,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-mixin-reference.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-implements.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 21,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-optional-computed-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-implements-and-extends.src 1`] = `
+TSError {
+  "column": 45,
+  "index": 45,
+  "lineNumber": 1,
+  "message": "Cannot find name 'MyInterface'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-optional-computed-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-implements-generic.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 21,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-optional-methods.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-implements-generic-multiple.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 21,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-optional-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-method.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 19,
+  "lineNumber": 2,
+  "message": "A function whose declared type is neither 'void' nor 'any' must return a value.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-optional-property-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-mixin.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 60,
+  "lineNumber": 2,
+  "message": "A mixin class must have a constructor with a single rest parameter of type 'any[]'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-override-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-mixin-reference.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 21,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Constructor'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-override-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-optional-computed-method.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 248,
+  "lineNumber": 15,
+  "message": "A computed property name in a method overload must refer to an expression whose type is a literal type or a 'unique symbol' type.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-private-optional-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-optional-computed-property.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 22,
+  "lineNumber": 2,
+  "message": "'['foo']' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-private-parameter-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-optional-methods.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 50,
+  "lineNumber": 4,
+  "message": "'baz' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-property-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-optional-properties.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 98,
+  "lineNumber": 6,
+  "message": "'baz' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-property-values.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-optional-property-undefined.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 20,
+  "lineNumber": 2,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-protected-parameter-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-override-method.src 1`] = `
+TSError {
+  "column": 35,
+  "index": 35,
+  "lineNumber": 1,
+  "message": "Cannot find name 'SomeComponent'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-public-parameter-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-override-property.src 1`] = `
+TSError {
+  "column": 35,
+  "index": 35,
+  "lineNumber": 1,
+  "message": "Cannot find name 'SomeComponent'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-readonly-parameter-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-private-optional-property.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 14,
+  "lineNumber": 2,
+  "message": "'#prop' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-readonly-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-private-parameter-properties.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 34,
+  "lineNumber": 2,
+  "message": "Property 'firstName' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-static-parameter-properties.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-property-function.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 58,
+  "lineNumber": 3,
+  "message": "Type '() => any' is not assignable to type 'string'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-property-values.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 61,
+  "lineNumber": 6,
+  "message": "Cannot find name 'Array'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-protected-parameter-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-public-parameter-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-readonly-parameter-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-readonly-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-static-parameter-properties.src 1`] = `
 TSError {
   "column": 16,
   "index": 28,
@@ -1874,59 +4058,178 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-two-methods-computed-constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-two-methods-computed-constructor.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 12,
+  "lineNumber": 2,
+  "message": "Duplicate function implementation.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-type-parameter.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-type-parameter.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-type-parameter-default.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-type-parameter-default.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/class-with-type-parameter-underscore.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/class-with-type-parameter-underscore.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/const-assertions.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/const-assertions.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 17,
+  "lineNumber": 2,
+  "message": "Cannot redeclare block-scoped variable 'x'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/const-enum.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/const-enum.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/declare-class-with-optional-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/declare-class-with-optional-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/declare-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/declare-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/destructuring-assignment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/destructuring-assignment.src 1`] = `
+TSError {
+  "column": 3,
+  "index": 3,
+  "lineNumber": 1,
+  "message": "No value exists in scope for the shorthand property 'foo'. Either declare one or provide an initializer.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/destructuring-assignment-nested.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/destructuring-assignment-nested.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 22,
+  "lineNumber": 1,
+  "message": "Type '[]' must have a '[Symbol.iterator]()' method that returns an iterator.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/destructuring-assignment-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/destructuring-assignment-object.src 1`] = `
+TSError {
+  "column": 3,
+  "index": 3,
+  "lineNumber": 1,
+  "message": "No value exists in scope for the shorthand property 'foo'. Either declare one or provide an initializer.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/destructuring-assignment-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/destructuring-assignment-property.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 13,
+  "lineNumber": 1,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/directive-in-module.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/directive-in-module.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 35,
+  "lineNumber": 3,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/directive-in-namespace.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/directive-in-namespace.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 38,
+  "lineNumber": 3,
+  "message": "'a' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/dynamic-import-with-import-assertions.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/dynamic-import-with-import-assertions.src 1`] = `[TypeError: Cannot read properties of undefined (reading 'getLineAndCharacterOfPosition')]`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-all-with-import-assertions.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-all-with-import-assertions.src 1`] = `
+TSError {
+  "column": 20,
+  "index": 20,
+  "lineNumber": 1,
+  "message": "Import assertions are only supported when the '--module' option is set to 'esnext' or 'nodenext'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-as-namespace.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-as-namespace.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Global module exports may only appear in module files.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-assignment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-assignment.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-declare-const-named-enum.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-declare-const-named-enum.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-declare-named-enum.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-declare-named-enum.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-default-class-with-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-default-class-with-generic.src 1`] = `
+TSError {
+  "column": 20,
+  "index": 20,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-default-class-with-multiple-generics.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-default-class-with-multiple-generics.src 1`] = `
+TSError {
+  "column": 20,
+  "index": 20,
+  "lineNumber": 1,
+  "message": "All type parameters are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-default-interface.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-default-interface.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-named-class-with-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-named-class-with-generic.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-named-class-with-multiple-generics.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-named-class-with-multiple-generics.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "All type parameters are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-named-enum.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-named-enum.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-named-enum-computed-number.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-named-enum-computed-number.src 1`] = `
 TSError {
   "column": 4,
   "index": 22,
@@ -1935,9 +4238,9 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-named-enum-computed-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-named-enum-computed-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-named-enum-computed-var-ref.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-named-enum-computed-var-ref.src 1`] = `
 TSError {
   "column": 4,
   "index": 22,
@@ -1946,75 +4249,257 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-star-as-ns-from.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-star-as-ns-from.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-type.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-type-as.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-type-as.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Cannot find name 'A'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-type-from.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-type-from.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Circular definition of import alias 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-type-from-as.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-type-from-as.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Module '"./estree"' has no exported member 'B'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-type-star-from.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-type-star-from.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Only named exports may use 'export type'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/export-with-import-assertions.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/export-with-import-assertions.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Circular definition of import alias 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-anonymus-with-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-anonymus-with-type-parameters.src 1`] = `
+TSError {
+  "column": 19,
+  "index": 19,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-anynomus-with-return-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-anynomus-with-return-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-overloads.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-overloads.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-with-await.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-with-await.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-with-object-type-with-optional-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-with-object-type-with-optional-properties.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 13,
+  "lineNumber": 1,
+  "message": "All destructured elements are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-with-object-type-without-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-with-object-type-without-annotation.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 13,
+  "lineNumber": 1,
+  "message": "All destructured elements are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-with-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-with-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-with-type-parameters-that-have-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-with-type-parameters-that-have-comments.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-with-type-parameters-with-constraint.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-with-type-parameters-with-constraint.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-with-types.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-with-types.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/function-with-types-assignation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/function-with-types-assignation.src 1`] = `
+TSError {
+  "column": 30,
+  "index": 30,
+  "lineNumber": 1,
+  "message": "'age' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/global-this.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/global-this.src 1`] = `
+TSError {
+  "column": 11,
+  "index": 189,
+  "lineNumber": 12,
+  "message": "Property 'answer' does not exist on type 'typeof globalThis'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-equal-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-equal-declaration.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-equal-type-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-equal-type-declaration.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-export-equal-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-export-equal-declaration.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Import assignment cannot be used when targeting ECMAScript modules. Consider using 'import * as ns from "mod"', 'import {a} from "mod"', 'import d from "mod"', or another module format instead.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-export-equal-type-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-export-equal-type-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-type-default.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-type-default.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-type-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-type-empty.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 55,
+  "lineNumber": 2,
+  "message": "'type' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-type-error.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-type-error.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "All imports in import declaration are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-type-named.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-type-named.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "All imports in import declaration are unused.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-type-named-as.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-type-named-as.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'bar' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-type-star-as-ns.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-type-star-as-ns.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/import-with-import-assertions.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/import-with-import-assertions.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "'foo' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-extends.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-extends.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 22,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-extends-multiple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-extends-multiple.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 22,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-type-parameters.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 13,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-with-all-property-types.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-with-all-property-types.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 55,
+  "lineNumber": 4,
+  "message": "A computed property name in an interface must refer to an expression whose type is a literal type or a 'unique symbol' type.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.src 1`] = `
 TSError {
   "column": 9,
   "index": 26,
@@ -2023,31 +4508,80 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-with-extends-member-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-with-extends-member-expression.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 22,
+  "lineNumber": 1,
+  "message": "Cannot find namespace 'bar'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-with-extends-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-with-extends-type-parameters.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 13,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-with-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-with-generic.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "'T' is declared but its value is never read.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-with-jsdoc.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-with-jsdoc.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-with-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-with-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-with-optional-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-with-optional-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/interface-without-type-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/interface-without-type-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/intrinsic-keyword.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/intrinsic-keyword.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/keyof-operator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/keyof-operator.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/keyword-variables.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/keyword-variables.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 105,
+  "lineNumber": 7,
+  "message": "Identifier expected. 'await' is a reserved word at the top-level of a module.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/nested-type-arguments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/nested-type-arguments.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 17,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Array'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/never-type-param.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/never-type-param.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Cannot find name 'X'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/new-target-in-arrow-function-body.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/new-target-in-arrow-function-body.src 1`] = `
 TSError {
   "column": 16,
   "index": 16,
@@ -2056,312 +4590,669 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/non-null-assertion-operator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/null-and-undefined-type-annotations.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/nullish-coalescing.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/object-with-escaped-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/object-with-typed-methods.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-call.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-call-with-non-null-assertion.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-call-with-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-element-access.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-element-access-with-non-null-assertion.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-element-access-with-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-with-non-null-assertion.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/optional-chain-with-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/parenthesized-use-strict.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/private-fields-in-in.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/readonly-arrays.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/readonly-tuples.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/short-circuiting-assignment-and-and.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/short-circuiting-assignment-or-or.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/short-circuiting-assignment-question-question.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/symbol-type-param.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-alias-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-alias-declaration-export.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-alias-declaration-export-function-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-alias-declaration-export-object-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-alias-declaration-with-constrained-type-parameter.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-alias-object-without-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-assertion-in-arrow-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-assertion-in-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-assertion-in-interface.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-assertion-in-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-assertion-with-guard-in-arrow-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-assertion-with-guard-in-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-assertion-with-guard-in-interface.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-assertion-with-guard-in-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-guard-in-arrow-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-guard-in-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-guard-in-interface.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-guard-in-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-import-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-import-type-with-type-parameters-in-type-reference.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-only-export-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-only-import-specifiers.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-parameters-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-parameters-comments-heritage.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/type-reference-comments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-bigint.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-boolean.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-false.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-never.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-null.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-number.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-symbol.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-true.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-unknown.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-keyword-void.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-method-signature.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/typed-this.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/union-intersection.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/unique-symbol.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/unknown-type-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/var-with-definite-assignment.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/var-with-dotted-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/var-with-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/basics/variable-declaration-type-annotation-spacing.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/declare/abstract-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/declare/class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/declare/enum.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/declare/function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/declare/interface.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/declare/module.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/declare/namespace.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/declare/type-alias.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/declare/variable.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-instance-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-static-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/accessor-decorators/accessor-decorator-instance-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/accessor-decorators/accessor-decorator-static-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/class-decorators/class-decorator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/class-decorators/class-decorator-factory.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/class-decorators/class-parameter-property.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/class-decorators/export-default-class-decorator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/class-decorators/export-named-class-decorator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/method-decorators/method-decorator-factory-static-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/method-decorators/method-decorator-static-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/parameter-decorators/parameter-array-pattern-decorator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/parameter-decorators/parameter-decorator-constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-instance-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-static-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/parameter-decorators/parameter-decorator-instance-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/parameter-decorators/parameter-decorator-static-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/parameter-decorators/parameter-object-pattern-decorator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/parameter-decorators/parameter-rest-element-decorator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/decorators/property-decorators/property-decorator-static-member.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/class-empty-extends.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/non-null-assertion-operator.src 1`] = `
 TSError {
-  "column": 17,
-  "index": 17,
+  "column": 27,
+  "index": 27,
   "lineNumber": 1,
-  "message": "'extends' list cannot be empty.",
+  "message": "Cannot find name 'Entity'.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/class-empty-extends-implements.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/null-and-undefined-type-annotations.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/nullish-coalescing.src 1`] = `
 TSError {
-  "column": 17,
-  "index": 17,
-  "lineNumber": 1,
-  "message": "'extends' list cannot be empty.",
+  "column": 6,
+  "index": 52,
+  "lineNumber": 2,
+  "message": "'len' is declared but its value is never read.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/class-extends-empty-implements.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/object-with-escaped-properties.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/object-with-typed-methods.src 1`] = `
 TSError {
-  "column": 32,
-  "index": 32,
-  "lineNumber": 1,
-  "message": "'implements' list cannot be empty.",
+  "column": 15,
+  "index": 29,
+  "lineNumber": 2,
+  "message": "'T' is declared but its value is never read.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/class-multiple-implements.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/optional-chain.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/optional-chain-call.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/optional-chain-call-with-non-null-assertion.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/optional-chain-call-with-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/optional-chain-element-access.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/optional-chain-element-access-with-non-null-assertion.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/optional-chain-element-access-with-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/optional-chain-with-non-null-assertion.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/optional-chain-with-parens.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/parenthesized-use-strict.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/private-fields-in-in.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/readonly-arrays.src 1`] = `
 TSError {
-  "column": 21,
-  "index": 21,
+  "column": 9,
+  "index": 9,
   "lineNumber": 1,
-  "message": "'implements' clause already seen.",
+  "message": "Duplicate function implementation.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/decorator-on-enum-declaration.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/readonly-tuples.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 50,
+  "lineNumber": 2,
+  "message": "Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/short-circuiting-assignment-and-and.src 1`] = `
 TSError {
   "column": 0,
   "index": 0,
   "lineNumber": 1,
-  "message": "Decorators are not valid here.",
+  "message": "Cannot find name 'a'.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/decorator-on-function.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/short-circuiting-assignment-or-or.src 1`] = `
 TSError {
   "column": 0,
   "index": 0,
   "lineNumber": 1,
-  "message": "Decorators are not valid here.",
+  "message": "Cannot find name 'a'.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/decorator-on-interface-declaration.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/short-circuiting-assignment-question-question.src 1`] = `
 TSError {
   "column": 0,
   "index": 0,
   "lineNumber": 1,
-  "message": "Decorators are not valid here.",
+  "message": "Cannot find name 'a'.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/decorator-on-variable.src 1`] = `
-TSError {
-  "column": 0,
-  "index": 0,
-  "lineNumber": 1,
-  "message": "Decorators are not valid here.",
-}
-`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/empty-type-arguments.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/symbol-type-param.src 1`] = `
 TSError {
   "column": 14,
   "index": 14,
   "lineNumber": 1,
-  "message": "Type argument list cannot be empty.",
+  "message": "'abc' is declared but its value is never read.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/empty-type-arguments-in-call-expression.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-alias-declaration.src 1`] = `
 TSError {
-  "column": 3,
-  "index": 3,
+  "column": 17,
+  "index": 17,
   "lineNumber": 1,
-  "message": "Type argument list cannot be empty.",
+  "message": "Cannot find name 'Success'.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/empty-type-arguments-in-new-expression.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-alias-declaration-export.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-alias-declaration-export-function-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-alias-declaration-export-object-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-alias-declaration-with-constrained-type-parameter.src 1`] = `
 TSError {
-  "column": 7,
-  "index": 7,
+  "column": 28,
+  "index": 28,
   "lineNumber": 1,
-  "message": "Type argument list cannot be empty.",
+  "message": "Cannot find name 'Success'.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/empty-type-parameters.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-alias-object-without-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-assertion-in-arrow-function.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 22,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-assertion-in-function.src 1`] = `
+TSError {
+  "column": 23,
+  "index": 23,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-assertion-in-interface.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-assertion-in-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-assertion-with-guard-in-arrow-function.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 22,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-assertion-with-guard-in-function.src 1`] = `
+TSError {
+  "column": 28,
+  "index": 28,
+  "lineNumber": 1,
+  "message": "'x' is declared but its value is never read.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-assertion-with-guard-in-interface.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-assertion-with-guard-in-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-guard-in-arrow-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-guard-in-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-guard-in-interface.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-guard-in-method.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-import-type.src 1`] = `
+TSError {
+  "column": 23,
+  "index": 23,
+  "lineNumber": 1,
+  "message": "File '/Users/josh/repos/typescript-eslint/packages/typescript-estree/estree.ts' is not a module.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-import-type-with-type-parameters-in-type-reference.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Cannot find name 'A'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-only-export-specifiers.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Circular definition of import alias 'A'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-only-import-specifiers.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "All imports in import declaration are unused.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-parameters-comments.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-parameters-comments-heritage.src 1`] = `
+TSError {
+  "column": 43,
+  "index": 43,
+  "lineNumber": 1,
+  "message": "Cannot extend an interface 'bar'. Did you mean 'implements'?",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/type-reference-comments.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 36,
+  "lineNumber": 2,
+  "message": "Cannot find namespace 'interop'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-bigint.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-boolean.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-false.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-never.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-null.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-number.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-object.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-symbol.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-true.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-undefined.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-unknown.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-keyword-void.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-method-signature.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/typed-this.src 1`] = `
+TSError {
+  "column": 43,
+  "index": 65,
+  "lineNumber": 2,
+  "message": "Cannot find name 'Event'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/union-intersection.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/unique-symbol.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'unique symbol' types are not allowed here.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/unknown-type-annotation.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/var-with-definite-assignment.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 6,
+  "lineNumber": 1,
+  "message": "'const' declarations must be initialized.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/var-with-dotted-type.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Cannot find namespace 'A'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/var-with-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/basics/variable-declaration-type-annotation-spacing.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/declare/abstract-class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/declare/class.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/declare/enum.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/declare/function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/declare/interface.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/declare/module.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/declare/namespace.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/declare/type-alias.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/declare/variable.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-instance-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 19,
+  "lineNumber": 2,
+  "message": "Cannot find name 'configurable'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-static-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 19,
+  "lineNumber": 2,
+  "message": "Cannot find name 'foo'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/accessor-decorators/accessor-decorator-instance-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "Cannot find name 'hidden'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/accessor-decorators/accessor-decorator-static-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "Cannot find name 'adminonly'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/class-decorators/class-decorator.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'sealed'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/class-decorators/class-decorator-factory.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Component'. Did you mean 'FooComponent'?",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/class-decorators/class-parameter-property.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 24,
+  "lineNumber": 2,
+  "message": "Experimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option in your 'tsconfig' or 'jsconfig' to remove this warning.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/class-decorators/export-default-class-decorator.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'sealed'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/class-decorators/export-named-class-decorator.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Cannot find name 'sealed'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "Cannot find name 'onlyRead'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/method-decorators/method-decorator-factory-static-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "Cannot find name 'Foo'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "Cannot find name 'onlyRead'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/method-decorators/method-decorator-static-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "Cannot find name 'Foo'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/parameter-decorators/parameter-array-pattern-decorator.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "Experimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option in your 'tsconfig' or 'jsconfig' to remove this warning.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/parameter-decorators/parameter-decorator-constructor.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 32,
+  "lineNumber": 2,
+  "message": "Experimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option in your 'tsconfig' or 'jsconfig' to remove this warning.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-instance-member.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 20,
+  "lineNumber": 2,
+  "message": "Experimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option in your 'tsconfig' or 'jsconfig' to remove this warning.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-static-member.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 33,
+  "lineNumber": 2,
+  "message": "Experimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option in your 'tsconfig' or 'jsconfig' to remove this warning.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/parameter-decorators/parameter-decorator-instance-member.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 26,
+  "lineNumber": 2,
+  "message": "Experimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option in your 'tsconfig' or 'jsconfig' to remove this warning.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/parameter-decorators/parameter-decorator-static-member.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 39,
+  "lineNumber": 2,
+  "message": "Experimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option in your 'tsconfig' or 'jsconfig' to remove this warning.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/parameter-decorators/parameter-object-pattern-decorator.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "Experimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option in your 'tsconfig' or 'jsconfig' to remove this warning.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/parameter-decorators/parameter-rest-element-decorator.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "Experimental support for decorators is a feature that is subject to change in a future release. Set the 'experimentalDecorators' option in your 'tsconfig' or 'jsconfig' to remove this warning.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 27,
+  "lineNumber": 2,
+  "message": "Cannot find name 'Input'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "Cannot find name 'configurable'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "Cannot find name 'foo'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/decorators/property-decorators/property-decorator-static-member.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "Cannot find name 'baz'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/class-empty-extends.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 17,
+  "lineNumber": 1,
+  "message": "'extends' list cannot be empty.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/class-empty-extends-implements.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 17,
+  "lineNumber": 1,
+  "message": "'extends' list cannot be empty.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/class-extends-empty-implements.src 1`] = `
+TSError {
+  "column": 18,
+  "index": 18,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Bar'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/class-multiple-implements.src 1`] = `
+TSError {
+  "column": 19,
+  "index": 19,
+  "lineNumber": 1,
+  "message": "Cannot find name 'b'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/decorator-on-enum-declaration.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Decorators are not valid here.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/decorator-on-function.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Decorators are not valid here.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/decorator-on-interface-declaration.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Decorators are not valid here.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/decorator-on-variable.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Decorators are not valid here.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/empty-type-arguments.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 6,
+  "lineNumber": 1,
+  "message": "'const' declarations must be initialized.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/empty-type-arguments-in-call-expression.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/empty-type-arguments-in-new-expression.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Foo'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/empty-type-parameters.src 1`] = `
 TSError {
   "column": 11,
   "index": 11,
@@ -2370,7 +5261,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/empty-type-parameters-in-arrow-function.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/empty-type-parameters-in-arrow-function.src 1`] = `
 TSError {
   "column": 11,
   "index": 11,
@@ -2379,7 +5270,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/empty-type-parameters-in-constructor.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/empty-type-parameters-in-constructor.src 1`] = `
 TSError {
   "column": 13,
   "index": 25,
@@ -2388,7 +5279,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/empty-type-parameters-in-function-expression.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/empty-type-parameters-in-function-expression.src 1`] = `
 TSError {
   "column": 20,
   "index": 20,
@@ -2397,7 +5288,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/empty-type-parameters-in-method.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/empty-type-parameters-in-method.src 1`] = `
 TSError {
   "column": 6,
   "index": 18,
@@ -2406,7 +5297,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/empty-type-parameters-in-method-signature.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/empty-type-parameters-in-method-signature.src 1`] = `
 TSError {
   "column": 6,
   "index": 22,
@@ -2415,7 +5306,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/enum-with-keywords.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/enum-with-keywords.src 1`] = `
 TSError {
   "column": 7,
   "index": 7,
@@ -2424,7 +5315,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/index-signature-parameters.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/index-signature-parameters.src 1`] = `
 TSError {
   "column": 3,
   "index": 16,
@@ -2433,7 +5324,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-empty-extends.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-empty-extends.src 1`] = `
 TSError {
   "column": 21,
   "index": 21,
@@ -2442,7 +5333,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-implements.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-implements.src 1`] = `
 TSError {
   "column": 12,
   "index": 12,
@@ -2451,7 +5342,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-export.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-index-signature-export.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2460,7 +5351,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-private.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-index-signature-private.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2469,7 +5360,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-protected.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-index-signature-protected.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2478,7 +5369,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-public.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-index-signature-public.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2487,7 +5378,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-index-signature-static.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-index-signature-static.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2496,7 +5387,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-method-export.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-method-export.src 1`] = `
 TSError {
   "column": 4,
   "index": 20,
@@ -2505,7 +5396,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-method-private.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-method-private.src 1`] = `
 TSError {
   "column": 4,
   "index": 20,
@@ -2514,7 +5405,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-method-protected.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-method-protected.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2523,7 +5414,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-method-public.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-method-public.src 1`] = `
 TSError {
   "column": 4,
   "index": 20,
@@ -2532,9 +5423,16 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-method-readonly.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-method-readonly.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 18,
+  "lineNumber": 2,
+  "message": "'readonly' modifier can only appear on a property declaration or index signature.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-method-static.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-method-static.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2543,16 +5441,16 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-multiple-extends.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-multiple-extends.src 1`] = `
 TSError {
-  "column": 26,
-  "index": 26,
+  "column": 22,
+  "index": 22,
   "lineNumber": 1,
-  "message": "'extends' clause already seen.",
+  "message": "Cannot find name 'bar'.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-property-export.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-property-export.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2561,7 +5459,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-property-private.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-property-private.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2570,7 +5468,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-property-protected.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-property-protected.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2579,7 +5477,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-property-public.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-property-public.src 1`] = `
 TSError {
   "column": 4,
   "index": 20,
@@ -2588,7 +5486,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-property-static.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-property-static.src 1`] = `
 TSError {
   "column": 2,
   "index": 18,
@@ -2597,7 +5495,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-property-with-default-value.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-property-with-default-value.src 1`] = `
 TSError {
   "column": 16,
   "index": 32,
@@ -2606,7 +5504,7 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-with-no-body.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-with-no-body.src 1`] = `
 TSError {
   "column": 0,
   "index": 14,
@@ -2615,27 +5513,34 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/interface-with-optional-index-signature.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/object-assertion-not-allowed.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/interface-with-optional-index-signature.src 1`] = `
 TSError {
-  "column": 3,
-  "index": 3,
-  "lineNumber": 1,
-  "message": "A definite assignment assertion '!' is not permitted in this context.",
+  "column": 6,
+  "index": 22,
+  "lineNumber": 2,
+  "message": "An index signature parameter cannot have a question mark.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/object-optional-not-allowed.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/object-assertion-not-allowed.src 1`] = `
 TSError {
-  "column": 3,
-  "index": 3,
+  "column": 2,
+  "index": 2,
   "lineNumber": 1,
-  "message": "An object member cannot be declared optional.",
+  "message": "No value exists in scope for the shorthand property 'a'. Either declare one or provide an initializer.",
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/errorRecovery/solo-const.src 1`] = `
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/object-optional-not-allowed.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 2,
+  "lineNumber": 1,
+  "message": "No value exists in scope for the shorthand property 'a'. Either declare one or provide an initializer.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/errorRecovery/solo-const.src 1`] = `
 TSError {
   "column": 5,
   "index": 5,
@@ -2644,158 +5549,327 @@ TSError {
 }
 `;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/expressions/call-expression-type-arguments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/expressions/call-expression-type-arguments.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/expressions/instantiation-expression.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'a'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/expressions/new-expression-type-arguments.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Cannot find name 'A'. Did you mean 'a'?",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/expressions/optional-call-expression-type-arguments.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/expressions/tagged-template-expression-type-arguments.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Cannot find name 'foo'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/namespaces-and-modules/ambient-module-declaration-with-import.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 49,
+  "lineNumber": 2,
+  "message": "File '/Users/josh/repos/typescript-eslint/packages/typescript-estree/estree.ts' is not a module.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.src 1`] = `
+TSError {
+  "column": 44,
+  "index": 67,
+  "lineNumber": 2,
+  "message": "Cannot find name 'Selection'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/namespaces-and-modules/global-module-declaration.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Augmentations for the global scope can only be directly nested in external modules or ambient module declarations.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/namespaces-and-modules/module-with-default-exports.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Only ambient modules can use quoted names.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/namespaces-and-modules/nested-internal-module.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/namespaces-and-modules/shorthand-ambient-module-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/array-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/conditional.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/conditional-infer.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/conditional-infer-nested.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 93,
+  "lineNumber": 4,
+  "message": "Cannot find name 'Promise'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/conditional-infer-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/expressions/instantiation-expression.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/conditional-infer-with-constraint.src 1`] = `
+TSError {
+  "column": 50,
+  "index": 50,
+  "lineNumber": 1,
+  "message": "Cannot find name 'MustBeNumber'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/expressions/new-expression-type-arguments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/conditional-with-null.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/expressions/optional-call-expression-type-arguments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/expressions/tagged-template-expression-type-arguments.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/constructor-abstract.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/namespaces-and-modules/ambient-module-declaration-with-import.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/constructor-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/constructor-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/namespaces-and-modules/global-module-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/constructor-in-generic.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Array'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/namespaces-and-modules/module-with-default-exports.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/constructor-with-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/namespaces-and-modules/nested-internal-module.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/namespaces-and-modules/shorthand-ambient-module-declaration.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/function-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/array-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/function-in-generic.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Array'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/conditional.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/function-with-array-destruction.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/conditional-infer.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/function-with-object-destruction.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/conditional-infer-nested.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/function-with-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/conditional-infer-simple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/function-with-this.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/conditional-infer-with-constraint.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/index-signature.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/conditional-with-null.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/index-signature-readonly.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/constructor.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/index-signature-without-type.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 15,
+  "lineNumber": 2,
+  "message": "An index signature must have a type annotation.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/constructor-abstract.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/indexed.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Cannot find name 'T'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/constructor-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/interface-with-accessors.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/constructor-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/intersection-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/constructor-in-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/literal-number.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/constructor-with-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/literal-number-negative.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/function.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/literal-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/function-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/mapped.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/function-in-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/mapped-named-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/function-with-array-destruction.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/mapped-readonly.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/function-with-object-destruction.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/mapped-readonly-minus.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/function-with-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/mapped-readonly-plus.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/function-with-this.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/mapped-untypped.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/index-signature.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/nested-types.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/index-signature-readonly.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/object-literal-type-with-accessors.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/index-signature-without-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/optional-variance-in.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/indexed.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/optional-variance-in-and-out.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/interface-with-accessors.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/optional-variance-in-out.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/intersection-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/optional-variance-out.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/literal-number.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/parenthesized-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/literal-number-negative.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/reference.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Cannot find name 'T'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/literal-string.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/reference-generic.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Array'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/mapped.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/reference-generic-nested.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Array'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/mapped-named-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/template-literal-type-1.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/mapped-readonly.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/template-literal-type-2.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/mapped-readonly-minus.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/template-literal-type-3.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/mapped-readonly-plus.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/template-literal-type-4.src 1`] = `
+TSError {
+  "column": 49,
+  "index": 49,
+  "lineNumber": 1,
+  "message": "Cannot find name 'Uppercase'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/mapped-untypped.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/this-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/nested-types.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/this-type-expanded.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 131,
+  "lineNumber": 9,
+  "message": "Type 'number' is not assignable to type 'this'.
+  'this' could be instantiated with an arbitrary type which could be unrelated to 'number'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/object-literal-type-with-accessors.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/tuple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/optional-variance-in.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/tuple-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/optional-variance-in-and-out.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/tuple-named.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/optional-variance-in-out.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/tuple-named-optional.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/optional-variance-out.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/tuple-named-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/parenthesized-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/tuple-named-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/reference.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/tuple-optional.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/reference-generic.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/tuple-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/reference-generic-nested.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/tuple-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/template-literal-type-1.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/type-literal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/template-literal-type-2.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/type-operator.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 13,
+  "lineNumber": 1,
+  "message": "Cannot find name 'T'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/template-literal-type-3.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/typeof.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Cannot find name 'y'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/template-literal-type-4.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/typeof-this.src 1`] = `
+TSError {
+  "column": 21,
+  "index": 44,
+  "lineNumber": 2,
+  "message": "Property 'foo' does not exist on type 'typeof globalThis'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/this-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/typeof-with-type-parameters.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Cannot find name 'y'.",
+}
+`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/this-type-expanded.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/union-intersection.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
 
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/tuple.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/tuple-empty.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/tuple-named.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/tuple-named-optional.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/tuple-named-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/tuple-named-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/tuple-optional.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/tuple-rest.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/tuple-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/type-literal.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/type-operator.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/typeof.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/typeof-this.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/typeof-with-type-parameters.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/union-intersection.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
-
-exports[`Parse all fixtures with "errorOnTypeScriptSyntacticAndSemanticIssues" enabled fixtures/typescript/types/union-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic fixtures/typescript/types/union-type.src 1`] = `"TEST OUTPUT: No semantic or syntactic issues found"`;

--- a/packages/typescript-estree/tests/lib/__snapshots__/syntactic-diagnostics-enabled.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/syntactic-diagnostics-enabled.test.ts.snap
@@ -1,0 +1,2297 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/block-trailing-comment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/comment-within-condition.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/export-default-anonymous-class.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsdoc-comment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-attr-and-text-with-url.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-block-comment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-comment-after-jsx.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-comment-after-self-closing-jsx.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-generic-with-comment-in-tag.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-tag-comment-after-prop.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-tag-comments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-text-with-multiline-non-comment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-text-with-url.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-with-greather-than.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/jsx-with-operators.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/line-comment-with-block-syntax.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/mix-line-and-block-comments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/no-comment-regex.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/no-comment-template.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/surrounding-call-comments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/surrounding-debugger-comments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/surrounding-return-comments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/surrounding-throw-comments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/surrounding-while-loop-comments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/switch-fallthrough-comment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/switch-fallthrough-comment-in-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/switch-no-default-comment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/switch-no-default-comment-in-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/switch-no-default-comment-in-nested-functions.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/template-string-block.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/comments/type-assertion-regression-test.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrayLiteral/array-literal-in-lhs.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrayLiteral/array-literals-in-binary-expr.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/as-param.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/as-param-with-params.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/basic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/basic-in-binary-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/block-body.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/block-body-not-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-dup-params.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-missing-paren.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "';' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-not-arrow.src 1`] = `
+TSError {
+  "column": 26,
+  "index": 26,
+  "lineNumber": 1,
+  "message": "Expression expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-numeric-param.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 5,
+  "lineNumber": 1,
+  "message": "';' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-numeric-param-multi.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "';' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-reverse-arrow.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "Expression expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-strict-default-param-eval.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-strict-dup-params.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-strict-eval.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-strict-eval-return.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-strict-octal.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-strict-param-arguments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-strict-param-eval.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-strict-param-names.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-strict-param-no-paren-arguments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-strict-param-no-paren-eval.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-two-lines.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/error-wrapped-param.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 6,
+  "lineNumber": 1,
+  "message": "';' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/iife.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/multiple-params.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/no-auto-return.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/not-strict-arguments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/not-strict-eval.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/not-strict-eval-params.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/not-strict-octal.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/return-arrow-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/return-sequence.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/single-param.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/single-param-parens.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/arrowFunctions/single-param-return-identifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/and-operator-array-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/delete-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/do-while-statements.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/identifiers-double-underscore.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/instanceof.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/new-with-member-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/new-without-parens.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/or-operator-array-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/typeof-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/update-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/basics/void-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/bigIntLiterals/binary.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/bigIntLiterals/decimal.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/bigIntLiterals/hex.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/bigIntLiterals/numeric-separator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/bigIntLiterals/octal.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/binaryLiterals/invalid.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "';' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/binaryLiterals/lowercase.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/binaryLiterals/uppercase.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/blockBindings/const.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/blockBindings/let.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/blockBindings/let-in-switchcase.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/callExpression/call-expression-with-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/callExpression/call-expression-with-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/callExpression/mixed-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/callExpression/new-expression-with-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/callExpression/new-expression-with-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-accessor-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-computed-static-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-method-named-prototype.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-method-named-static.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-method-named-with-space.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-one-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-one-method-super.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-private-identifier-accessor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-private-identifier-field.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-private-identifier-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-static-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-static-method-named-prototype.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-static-method-named-static.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-static-methods-and-accessor-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-two-computed-static-methods.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-two-methods.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-two-methods-computed-constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-two-methods-semi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-two-methods-three-semi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-two-methods-two-semi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-two-static-methods-named-constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-with-constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-with-constructor-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-with-constructor-with-space.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/class-with-no-body.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 10,
+  "lineNumber": 2,
+  "message": "'{' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/derived-class-assign-to-var.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/derived-class-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/empty-class.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/empty-class-double-semi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/empty-class-semi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/empty-literal-derived-class.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/invalid-class-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/invalid-class-setter-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/invalid-class-two-super-classes.src 1`] = `
+TSError {
+  "column": 18,
+  "index": 18,
+  "lineNumber": 1,
+  "message": "Classes can only extend a single class.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/named-class-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/classes/named-derived-class-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/commaOperator/comma-operator-conditional.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/commaOperator/comma-operator-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/commaOperator/comma-operator-nested.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/commaOperator/comma-operator-return.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/commaOperator/comma-operator-simple.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/commaOperator/comma-operator-simple-nested.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/defaultParams/class-constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/defaultParams/class-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/defaultParams/declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/defaultParams/expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/defaultParams/method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/defaultParams/not-all-params.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/array-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/array-to-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/array-var-undefined.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/call-expression-destruction-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/call-expression-destruction-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/class-constructor-params-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/class-constructor-params-defaults-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/class-constructor-params-defaults-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/class-constructor-params-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/class-method-params-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/class-method-params-defaults-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/class-method-params-defaults-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/class-method-params-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-array-all.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-array-longform-nested-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-array-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-array-nested-all.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-array-nested-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-object-all.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-object-assign.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-object-longform.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-object-longform-all.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-object-longform-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-object-mixed-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-object-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-object-nested-all.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/defaults-object-nested-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/destructured-array-catch.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/destructured-object-catch.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/invalid-defaults-object-assign.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/named-param.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/nested-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/nested-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/object-var-named.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/object-var-undefined.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/param-defaults-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/param-defaults-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/param-defaults-object-nested.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/params-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/params-array-wrapped.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/params-multi-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/params-nested-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/params-nested-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/params-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/params-object-wrapped.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring/sparse-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-nested-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-nested-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-nested-object-named.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-arrowFunctions/arrow-param-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-arrowFunctions/param-defaults-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-arrowFunctions/param-defaults-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-arrowFunctions/param-defaults-object-nested.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-blockBindings/array-const-undefined.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-blockBindings/array-let-undefined.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-blockBindings/object-const-named.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-blockBindings/object-const-undefined.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-blockBindings/object-let-named.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-blockBindings/object-let-undefined.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-defaultParams/param-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-defaultParams/param-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-defaultParams/param-object-short.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-defaultParams/param-object-wrapped.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-forOf/loop.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/complex-destructured.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/destructured-array-literal.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/destructuring-param.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/error-complex-destructured-spread-first.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/invalid-not-final-array-empty.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/multi-destructured.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/not-final-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/single-destructured.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/var-complex-destructured.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/var-destructured-array-literal.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/var-multi-destructured.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/destructuring-and-spread/var-single-destructured.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/directives/block.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/directives/directive-in-class.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/directives/first-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/directives/function-non-strict.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/directives/non-directive-string.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/directives/non-unique-directive.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/directives/program.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/directives/program-order.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/directives/raw.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalAsyncIteration/async-generators.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalAsyncIteration/async-iterator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalDynamicImport/dynamic-import.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalDynamicImport/error-dynamic-import-params.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Dynamic import requires exactly one or two arguments.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/arg-spread.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/destructuring-assign-mirror.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/function-parameter-object-spread.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/invalid-rest.src 1`] = `
+TSError {
+  "column": 18,
+  "index": 18,
+  "lineNumber": 1,
+  "message": "',' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/invalid-rest-trailing-comma.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/object-rest.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/property-spread.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/shorthand-method-args.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/shorthand-methods.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/shorthand-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/single-spread.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/spread-trailing-comma.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalObjectRestSpread/two-spread.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalOptionalCatchBinding/optional-catch-binding.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/experimentalOptionalCatchBinding/optional-catch-binding-finally.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/exponentiationOperators/exponential-operators.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/for/for-empty.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/for/for-loop.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/for/for-with-coma.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/for/for-with-const.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/for/for-with-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/for/for-with-let.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-bare-nonstrict.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-destruction.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-destruction-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-object.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "';' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-object-with-body.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-with-assigment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-with-bare-assigment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-with-const.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-with-milti-asigment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-with-rest.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forIn/for-in-with-var.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forOf/for-of-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forOf/for-of-destruction.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forOf/for-of-destruction-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forOf/for-of-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forOf/for-of-with-function-initializer.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forOf/for-of-with-rest.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forOf/for-of-with-var-and-braces.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forOf/for-of-with-var-and-no-braces.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forOf/invalid-for-of-with-const-and-no-braces.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/forOf/invalid-for-of-with-let-and-no-braces.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/function/return-multiline-sequence.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/function/return-sequence.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/generators/anonymous-generator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/generators/async-generator-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/generators/async-generator-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/generators/double-yield.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/generators/empty-generator-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/generators/generator-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/generators/yield-delegation.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/generators/yield-without-value.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/generators/yield-without-value-in-call.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/generators/yield-without-value-no-semi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/globalReturn/return-identifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/globalReturn/return-no-arg.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/globalReturn/return-true.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/hexLiterals/invalid.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "';' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/hexLiterals/lowercase.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/hexLiterals/uppercase.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/importMeta/simple-import-meta.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/labels/label-break.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/labels/label-continue.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/error-delete.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/error-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/error-strict.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-async-named-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-const.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-default-array.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-default-async-named-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-default-class.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-default-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-default-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-default-named-class.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-default-named-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-default-number.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-default-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-default-value.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-from-batch.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-from-default.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-from-named-as-default.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-from-named-as-specifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-from-named-as-specifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-from-specifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-from-specifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-let.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-named-as-default.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-named-as-specifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-named-as-specifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-named-class.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-named-empty.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-named-specifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-named-specifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-named-specifiers-comma.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-var.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-var-anonymous-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/export-var-number.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-default.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-default-and-named-specifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-default-and-namespace-specifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-default-as.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-jquery.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-module.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-named-as-specifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-named-as-specifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-named-empty.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-named-specifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-named-specifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-named-specifiers-comma.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-namespace-specifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/import-null-as-nil.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-await.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-class.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-export-batch-missing-from-clause.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 9,
+  "lineNumber": 2,
+  "message": "'from' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-export-batch-token.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'from' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-export-default.src 1`] = `
+TSError {
+  "column": 20,
+  "index": 20,
+  "lineNumber": 1,
+  "message": "';' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-export-default-equal.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Expression expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-export-default-token.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 17,
+  "lineNumber": 1,
+  "message": "';' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-export-module-specifier.src 1`] = `
+TSError {
+  "column": 19,
+  "index": 19,
+  "lineNumber": 1,
+  "message": "Module specifier must be a string literal.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-export-named-default.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-export-named-extra-comma.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-export-named-middle-comma.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-default.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Expression expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-default-after-named.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "'from' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-default-after-named-after-default.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 17,
+  "lineNumber": 1,
+  "message": "'from' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-default-missing-module-specifier.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 11,
+  "lineNumber": 2,
+  "message": "'=' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-default-module-specifier.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "Module specifier must be a string literal.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-missing-module-specifier.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 20,
+  "lineNumber": 2,
+  "message": "'from' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-module-specifier.src 1`] = `
+TSError {
+  "column": 17,
+  "index": 17,
+  "lineNumber": 1,
+  "message": "Module specifier must be a string literal.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-named-after-named.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "'from' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-named-after-namespace.src 1`] = `
+TSError {
+  "column": 15,
+  "index": 15,
+  "lineNumber": 1,
+  "message": "'from' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-named-as-missing-from.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 24,
+  "lineNumber": 2,
+  "message": "'from' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-named-extra-comma.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-named-middle-comma.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-namespace-after-named.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "'from' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/modules/invalid-import-namespace-missing-as.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'as' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/newTarget/invalid-new-target.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/newTarget/invalid-unknown-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/newTarget/simple-new-target.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteral/object-literal-in-lhs.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralComputedProperties/computed-addition-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralComputedProperties/computed-and-identifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralComputedProperties/computed-getter-and-setter.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralComputedProperties/computed-string-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralComputedProperties/computed-variable-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralComputedProperties/invalid-computed-variable-property.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 20,
+  "lineNumber": 3,
+  "message": "':' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralComputedProperties/invalid-standalone-computed-variable-property.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 5,
+  "lineNumber": 1,
+  "message": "':' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralComputedProperties/standalone-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralComputedProperties/standalone-expression-with-addition.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralComputedProperties/standalone-expression-with-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralDuplicateProperties/error-proto-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralDuplicateProperties/error-proto-string-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralDuplicateProperties/strict-duplicate-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralDuplicateProperties/strict-duplicate-string-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralShorthandMethods/invalid-method-no-braces.src 1`] = `
+TSError {
+  "column": 13,
+  "index": 19,
+  "lineNumber": 2,
+  "message": "'{' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralShorthandMethods/method-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralShorthandMethods/simple-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralShorthandMethods/simple-method-named-get.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralShorthandMethods/simple-method-named-set.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralShorthandMethods/simple-method-with-argument.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralShorthandMethods/simple-method-with-string-name.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralShorthandMethods/string-name-method-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/objectLiteralShorthandProperties/shorthand-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/octalLiterals/invalid.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "';' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/octalLiterals/legacy.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/octalLiterals/lowercase.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/octalLiterals/strict-uppercase.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/octalLiterals/uppercase.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/regex/regexp-simple.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/regexUFlag/regex-u-extended-escape.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/regexUFlag/regex-u-invalid-extended-escape.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/regexUFlag/regex-u-simple.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/regexYFlag/regexp-y-simple.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/restParams/basic-rest.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/restParams/class-constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/restParams/class-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/restParams/error-no-default.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/restParams/error-not-last.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/restParams/func-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/restParams/func-expression-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/restParams/invalid-rest-param.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/restParams/single-rest.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/simple-literals/literal-float.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/simple-literals/literal-float-negative.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/simple-literals/literal-null.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/simple-literals/literal-number.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/simple-literals/literal-number-negative.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/simple-literals/literal-string.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/simple-literals/literal-undefined.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/spread/complex-spread.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/spread/error-invalid-if.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 6,
+  "lineNumber": 1,
+  "message": "Expression expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/spread/error-invalid-sequence.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Expression expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/spread/multi-function-call.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/spread/not-final-param.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/spread/simple-function-call.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/templateStrings/deeply-nested.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/templateStrings/error-octal-literal.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/templateStrings/escape-characters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/templateStrings/expressions.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/templateStrings/multi-line-template-string.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/templateStrings/simple-template-string.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/templateStrings/single-dollar-sign.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/templateStrings/tagged-no-placeholders.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/templateStrings/tagged-template-string.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/unicodeCodePointEscapes/basic-string-literal.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/unicodeCodePointEscapes/complex-string-literal.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/unicodeCodePointEscapes/ignored.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/unicodeCodePointEscapes/invalid-empty-escape.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Hexadecimal digit expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/javascript/unicodeCodePointEscapes/invalid-too-large-escape.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 10,
+  "lineNumber": 1,
+  "message": "An extended Unicode escape value must be between 0x0 and 0x10FFFF inclusive.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/attributes.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/element-keyword-name.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/embedded-comment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/embedded-conditional.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/embedded-invalid-js-identifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/embedded-tags.src 1`] = `
+TSError {
+  "column": 40,
+  "index": 40,
+  "lineNumber": 1,
+  "message": "Unexpected token. Did you mean \`{'>'}\` or \`&gt;\`?",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/empty-placeholder.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/escape-patterns-ignored.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/escape-patterns-unknown.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/escape-patterns-valid.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/escape-patters-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-attribute.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 5,
+  "lineNumber": 1,
+  "message": "'{' or JSX element expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-attribute-missing-equals.src 1`] = `
+TSError {
+  "column": 14,
+  "index": 14,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-broken-tag.src 1`] = `
+TSError {
+  "column": 12,
+  "index": 12,
+  "lineNumber": 1,
+  "message": "Unterminated string literal.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-computed-end-tag-name.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 2,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-computed-string-end-tag-name.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 2,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-embedded-expression.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "'}' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-leading-dot-tag-name.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Expression expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-matching-placeholder-in-closing-tag.src 1`] = `
+TSError {
+  "column": 27,
+  "index": 27,
+  "lineNumber": 1,
+  "message": "'>' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-mismatched-closing-tag.src 1`] = `
+TSError {
+  "column": 5,
+  "index": 5,
+  "lineNumber": 1,
+  "message": "Expected corresponding JSX closing tag for 'a'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-mismatched-closing-tags.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "JSX element 'a' has no corresponding closing tag.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-mismatched-dot-tag-name.src 1`] = `
+TSError {
+  "column": 9,
+  "index": 9,
+  "lineNumber": 1,
+  "message": "Expected corresponding JSX closing tag for 'a.b.c'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-mismatched-namespace-tag.src 1`] = `
+TSError {
+  "column": 7,
+  "index": 7,
+  "lineNumber": 1,
+  "message": "Expected corresponding JSX closing tag for 'a:b'.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-missing-closing-tag.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "JSX element 'a' has no corresponding closing tag.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-missing-closing-tag-attribute-placeholder.src 1`] = `
+TSError {
+  "column": 1,
+  "index": 1,
+  "lineNumber": 1,
+  "message": "JSX element 'a' has no corresponding closing tag.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-missing-namespace-name.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Expression expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-missing-namespace-value.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 2,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-missing-spread-operator.src 1`] = `
+TSError {
+  "column": 6,
+  "index": 6,
+  "lineNumber": 1,
+  "message": "'...' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-namespace-name-with-docts.src 1`] = `
+TSError {
+  "column": 4,
+  "index": 4,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-namespace-value-with-dots.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-no-common-parent.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "JSX expressions must have one parent element.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-no-common-parent-with-comment.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "JSX expressions must have one parent element.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-no-tag-name.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "Declaration or statement expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-placeholder-in-closing-tag.src 1`] = `
+TSError {
+  "column": 16,
+  "index": 16,
+  "lineNumber": 1,
+  "message": "'>' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-shorthand-fragment-no-closing.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 0,
+  "lineNumber": 1,
+  "message": "JSX fragment has no corresponding closing tag.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-trailing-dot-tag-name.src 1`] = `
+TSError {
+  "column": 3,
+  "index": 3,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/invalid-unexpected-comma.src 1`] = `
+TSError {
+  "column": 19,
+  "index": 19,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/japanese-characters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/less-than-operator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/member-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/member-expression-private.src 1`] = `
+TSError {
+  "column": 10,
+  "index": 10,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/member-expression-this.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/multiple-blank-spaces.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/namespace-this-name.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/namespaced-attribute-and-value-inserted.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/namespaced-name-and-attribute.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/newslines-and-entities.src 1`] = `
+TSError {
+  "column": 8,
+  "index": 8,
+  "lineNumber": 1,
+  "message": "Invalid character.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/self-closing-tag.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/self-closing-tag-inside-tag.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/self-closing-tag-with-newline.src 1`] = `
+TSError {
+  "column": 2,
+  "index": 2,
+  "lineNumber": 1,
+  "message": "Invalid character.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/shorthand-fragment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/shorthand-fragment-with-child.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/spread-child.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/spread-operator-attribute-and-regular-attribute.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/spread-operator-attributes.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/tag-names-with-dots.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/tag-names-with-multi-dots.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/tag-names-with-multi-dots-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/test-content.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx/trailing-spread-operator-attribute.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx-useJSXTextNode/self-closing-tag-inside-tag.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/jsx-useJSXTextNode/test-content.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/tsx/generic-jsx-element.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/tsx/generic-jsx-member-expression-private.src 1`] = `
+TSError {
+  "column": 22,
+  "index": 22,
+  "lineNumber": 1,
+  "message": "Identifier expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/tsx/generic-jsx-opening-element.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/tsx/react-typed-props.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/babylon-convergence/type-parameter-whitespace-loc.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/babylon-convergence/type-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/abstract-class-with-abstract-constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/abstract-class-with-abstract-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/abstract-class-with-abstract-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/abstract-class-with-abstract-readonly-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/abstract-class-with-abstract-static-constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/abstract-class-with-declare-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/abstract-class-with-optional-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/abstract-class-with-override-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/abstract-class-with-override-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/abstract-interface.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/angle-bracket-type-assertion.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/angle-bracket-type-assertion-arrow-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/arrow-function-with-optional-parameter.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/arrow-function-with-type-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/async-function-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/async-function-with-var-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/await-without-async-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/call-signatures.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/call-signatures-with-generics.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/cast-as-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/cast-as-multi.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/cast-as-multi-assign.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/cast-as-operator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/cast-as-simple.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/catch-clause-with-annotation.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/catch-clause-with-invalid-annotation.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-multi-line-keyword-abstract.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-multi-line-keyword-declare.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-private-identifier-field-with-accessibility-error.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-private-identifier-field-with-annotation.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-private-identifier-readonly-field.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-static-blocks.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-accessibility-modifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-constructor-and-modifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-constructor-and-parameter-property-with-modifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-constructor-and-parameter-proptery-with-override-modifier.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-constructor-and-return-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-constructor-and-type-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-declare-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-definite-assignment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-export-parameter-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-extends-and-implements.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-extends-generic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-extends-generic-multiple.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-generic-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-generic-method-default.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-implements.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-implements-and-extends.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-implements-generic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-implements-generic-multiple.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-mixin.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-mixin-reference.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-optional-computed-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-optional-computed-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-optional-methods.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-optional-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-optional-property-undefined.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-override-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-override-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-private-optional-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-private-parameter-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-property-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-property-values.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-protected-parameter-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-public-parameter-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-readonly-parameter-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-readonly-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-static-parameter-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-two-methods-computed-constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-type-parameter.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-type-parameter-default.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/class-with-type-parameter-underscore.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/const-assertions.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/const-enum.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/declare-class-with-optional-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/declare-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/destructuring-assignment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/destructuring-assignment-nested.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/destructuring-assignment-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/destructuring-assignment-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/directive-in-module.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/directive-in-namespace.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/dynamic-import-with-import-assertions.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-all-with-import-assertions.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-as-namespace.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-assignment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-declare-const-named-enum.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-declare-named-enum.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-default-class-with-generic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-default-class-with-multiple-generics.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-default-interface.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-named-class-with-generic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-named-class-with-multiple-generics.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-named-enum.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-named-enum-computed-number.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-named-enum-computed-string.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-named-enum-computed-var-ref.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-star-as-ns-from.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-type-as.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-type-from.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-type-from-as.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-type-star-from.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/export-with-import-assertions.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-anonymus-with-type-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-anynomus-with-return-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-overloads.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-with-await.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-with-object-type-with-optional-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-with-object-type-without-annotation.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-with-type-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-with-type-parameters-that-have-comments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-with-type-parameters-with-constraint.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-with-types.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/function-with-types-assignation.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/global-this.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-equal-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-equal-type-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-export-equal-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-export-equal-type-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-type-default.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-type-empty.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-type-error.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-type-named.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-type-named-as.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-type-star-as-ns.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/import-with-import-assertions.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-extends.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-extends-multiple.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-type-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-with-all-property-types.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-with-construct-signature-with-parameter-accessibility.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-with-extends-member-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-with-extends-type-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-with-generic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-with-jsdoc.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-with-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-with-optional-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/interface-without-type-annotation.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/intrinsic-keyword.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/keyof-operator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/keyword-variables.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/nested-type-arguments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/never-type-param.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/new-target-in-arrow-function-body.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/non-null-assertion-operator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/null-and-undefined-type-annotations.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/nullish-coalescing.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/object-with-escaped-properties.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/object-with-typed-methods.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/optional-chain.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/optional-chain-call.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/optional-chain-call-with-non-null-assertion.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/optional-chain-call-with-parens.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/optional-chain-element-access.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/optional-chain-element-access-with-non-null-assertion.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/optional-chain-element-access-with-parens.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/optional-chain-with-non-null-assertion.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/optional-chain-with-parens.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/parenthesized-use-strict.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/private-fields-in-in.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/readonly-arrays.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/readonly-tuples.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/short-circuiting-assignment-and-and.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/short-circuiting-assignment-or-or.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/short-circuiting-assignment-question-question.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/symbol-type-param.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-alias-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-alias-declaration-export.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-alias-declaration-export-function-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-alias-declaration-export-object-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-alias-declaration-with-constrained-type-parameter.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-alias-object-without-annotation.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-assertion-in-arrow-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-assertion-in-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-assertion-in-interface.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-assertion-in-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-assertion-with-guard-in-arrow-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-assertion-with-guard-in-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-assertion-with-guard-in-interface.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-assertion-with-guard-in-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-guard-in-arrow-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-guard-in-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-guard-in-interface.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-guard-in-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-import-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-import-type-with-type-parameters-in-type-reference.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-only-export-specifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-only-import-specifiers.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-parameters-comments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-parameters-comments-heritage.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/type-reference-comments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-bigint.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-boolean.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-false.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-never.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-null.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-number.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-object.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-string.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-symbol.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-true.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-undefined.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-unknown.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-keyword-void.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-method-signature.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/typed-this.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/union-intersection.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/unique-symbol.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/unknown-type-annotation.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/var-with-definite-assignment.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/var-with-dotted-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/var-with-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/basics/variable-declaration-type-annotation-spacing.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/declare/abstract-class.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/declare/class.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/declare/enum.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/declare/function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/declare/interface.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/declare/module.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/declare/namespace.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/declare/type-alias.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/declare/variable.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-instance-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/accessor-decorators/accessor-decorator-factory-static-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/accessor-decorators/accessor-decorator-instance-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/accessor-decorators/accessor-decorator-static-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/class-decorators/class-decorator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/class-decorators/class-decorator-factory.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/class-decorators/class-parameter-property.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/class-decorators/export-default-class-decorator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/class-decorators/export-named-class-decorator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/method-decorators/method-decorator-factory-instance-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/method-decorators/method-decorator-factory-static-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/method-decorators/method-decorator-instance-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/method-decorators/method-decorator-static-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/parameter-decorators/parameter-array-pattern-decorator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/parameter-decorators/parameter-decorator-constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-instance-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/parameter-decorators/parameter-decorator-decorator-static-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/parameter-decorators/parameter-decorator-instance-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/parameter-decorators/parameter-decorator-static-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/parameter-decorators/parameter-object-pattern-decorator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/parameter-decorators/parameter-rest-element-decorator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/property-decorators/property-decorator-factory-instance-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/property-decorators/property-decorator-factory-static-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/property-decorators/property-decorator-instance-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/decorators/property-decorators/property-decorator-static-member.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/class-empty-extends.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/class-empty-extends-implements.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/class-extends-empty-implements.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/class-multiple-implements.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/decorator-on-enum-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/decorator-on-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/decorator-on-interface-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/decorator-on-variable.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/empty-type-arguments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/empty-type-arguments-in-call-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/empty-type-arguments-in-new-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/empty-type-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/empty-type-parameters-in-arrow-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/empty-type-parameters-in-constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/empty-type-parameters-in-function-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/empty-type-parameters-in-method.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/empty-type-parameters-in-method-signature.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/enum-with-keywords.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/index-signature-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-empty-extends.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-implements.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-index-signature-export.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-index-signature-private.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-index-signature-protected.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-index-signature-public.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-index-signature-static.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-method-export.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-method-private.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-method-protected.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-method-public.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-method-readonly.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-method-static.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-multiple-extends.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-property-export.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-property-private.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-property-protected.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-property-public.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-property-static.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-property-with-default-value.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-with-no-body.src 1`] = `
+TSError {
+  "column": 0,
+  "index": 14,
+  "lineNumber": 2,
+  "message": "'{' expected.",
+}
+`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/interface-with-optional-index-signature.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/object-assertion-not-allowed.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/object-optional-not-allowed.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/errorRecovery/solo-const.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/expressions/call-expression-type-arguments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/expressions/instantiation-expression.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/expressions/new-expression-type-arguments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/expressions/optional-call-expression-type-arguments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/expressions/tagged-template-expression-type-arguments.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/namespaces-and-modules/ambient-module-declaration-with-import.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/namespaces-and-modules/declare-namespace-with-exported-function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/namespaces-and-modules/global-module-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/namespaces-and-modules/module-with-default-exports.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/namespaces-and-modules/nested-internal-module.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/namespaces-and-modules/shorthand-ambient-module-declaration.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/array-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/conditional.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/conditional-infer.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/conditional-infer-nested.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/conditional-infer-simple.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/conditional-infer-with-constraint.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/conditional-with-null.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/constructor.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/constructor-abstract.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/constructor-empty.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/constructor-generic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/constructor-in-generic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/constructor-with-rest.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/function.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/function-generic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/function-in-generic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/function-with-array-destruction.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/function-with-object-destruction.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/function-with-rest.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/function-with-this.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/index-signature.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/index-signature-readonly.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/index-signature-without-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/indexed.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/interface-with-accessors.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/intersection-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/literal-number.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/literal-number-negative.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/literal-string.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/mapped.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/mapped-named-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/mapped-readonly.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/mapped-readonly-minus.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/mapped-readonly-plus.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/mapped-untypped.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/nested-types.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/object-literal-type-with-accessors.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/optional-variance-in.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/optional-variance-in-and-out.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/optional-variance-in-out.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/optional-variance-out.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/parenthesized-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/reference.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/reference-generic.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/reference-generic-nested.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/template-literal-type-1.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/template-literal-type-2.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/template-literal-type-3.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/template-literal-type-4.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/this-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/this-type-expanded.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/tuple.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/tuple-empty.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/tuple-named.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/tuple-named-optional.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/tuple-named-rest.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/tuple-named-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/tuple-optional.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/tuple-rest.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/tuple-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/type-literal.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/type-operator.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/typeof.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/typeof-this.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/typeof-with-type-parameters.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/union-intersection.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;
+
+exports[`Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic fixtures/typescript/types/union-type.src 1`] = `"TEST OUTPUT: No syntactic issues found"`;

--- a/packages/typescript-estree/tests/lib/syntactic-diagnostics-enabled.test.ts
+++ b/packages/typescript-estree/tests/lib/syntactic-diagnostics-enabled.test.ts
@@ -7,7 +7,7 @@ import { formatSnapshotName, isJSXFileType } from '../../tools/test-utils';
 import { serializer } from '../../tools/tserror-serializer';
 
 /**
- * Process all fixtures, we will only snapshot the ones that have semantic errors
+ * Process all fixtures, we will only snapshot the ones that have syntactic errors
  * which are ignored by default parsing logic.
  */
 const FIXTURES_DIR = path.join(__dirname, '../../../shared-fixtures/fixtures');
@@ -18,7 +18,7 @@ const testFiles = glob.sync('**/*.src.*', {
 
 expect.addSnapshotSerializer(serializer);
 
-describe('Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.SyntacticOrSemantic', () => {
+describe('Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIssueDetection.Syntactic', () => {
   testFiles.forEach(filename => {
     const code = readFileSync(path.join(FIXTURES_DIR, filename), 'utf8');
     const fileExtension = path.extname(filename);
@@ -27,17 +27,14 @@ describe('Parse all fixtures with "errorOnTypeScriptIssues" set to TypeScriptIss
       range: true,
       tokens: true,
       errorOnUnknownASTType: true,
-      errorOnTypeScriptIssues:
-        parser.TypeScriptIssueDetection.SyntacticOrSemantic,
+      errorOnTypeScriptIssues: parser.TypeScriptIssueDetection.Syntactic,
       jsx: isJSXFileType(fileExtension),
     };
     it(formatSnapshotName(filename, FIXTURES_DIR, fileExtension), () => {
       expect.assertions(1);
       try {
         parser.parseAndGenerateServices(code, config);
-        expect(
-          'TEST OUTPUT: No semantic or syntactic issues found',
-        ).toMatchSnapshot();
+        expect('TEST OUTPUT: No syntactic issues found').toMatchSnapshot();
       } catch (err) {
         expect(err).toMatchSnapshot();
       }

--- a/packages/website/src/components/linter/config.ts
+++ b/packages/website/src/components/linter/config.ts
@@ -19,7 +19,7 @@ export const parseSettings: ParseSettings = {
   range: true,
   tokens: [],
   tsconfigRootDir: '/',
-  errorOnTypeScriptSyntacticAndSemanticIssues: false,
+  errorOnTypeScriptIssues: 0,
   EXPERIMENTAL_useSourceOfProjectReferenceRedirect: false,
   singleRun: false,
   programs: null,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1852
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Adds a `TypeScriptIssueDetection` enum so typescript-estree can be told to  call `program.getSyntacticDiagnostics(ast)` but not `program.getSemanticDiagnostics(ast)`.

Note that this is partially in conflict with #6066. That PR removes the partial program; this PR explicitly uses it.

Competitor/sibling to #6247.