### PR TITLE
feat(eslint-plugin): specify which method is unbound and added test case

### DIFF
--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -241,7 +241,7 @@ export default util.createRule<Options, MessageIds>({
               }
 
               checkMethodAndReport(
-                node,
+                property.key,
                 initTypes.getProperty(property.key.name),
               );
             }

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -603,6 +603,43 @@ const { a, b } = values;
         {
           line: 7,
           column: 9,
+          endColumn: 10,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      code: `
+const values = {
+  a() {},
+  b: () => {},
+};
+
+const { a: c } = values;
+      `,
+      errors: [
+        {
+          line: 7,
+          column: 9,
+          endColumn: 10,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      code: `
+const values = {
+  a() {},
+  b: () => {},
+};
+
+const { b, a } = values;
+      `,
+      errors: [
+        {
+          line: 7,
+          column: 12,
+          endColumn: 13,
           messageId: 'unboundWithoutThisAnnotation',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -590,5 +590,22 @@ class OtherClass extends BaseClass {
         },
       ],
     },
+    {
+      code: `
+const values = {
+  a() {},
+  b: () => {},
+};
+
+const { a, b } = values;
+      `,
+      errors: [
+        {
+          line: 7,
+          column: 9,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6276
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Specified which destructured method is unbound  and causing an error. Also added a test case for this in `unbound-method.test.ts`
