### PR TITLE
docs(eslint-plugin): remove invalid examples for unified-signatures

### DIFF
--- a/packages/eslint-plugin/docs/rules/unified-signatures.md
+++ b/packages/eslint-plugin/docs/rules/unified-signatures.md
@@ -38,6 +38,13 @@ function x(x: number | string): void;
 function y(...x: number[]): void;
 ```
 
+```ts
+// This rule won't check overload signatures with different rest parameter types.
+// See https://github.com/microsoft/TypeScript/issues/5077
+function f(...a: number[]): void;
+function f(...a: string[]): void;
+```
+
 ## Options
 
 ### `ignoreDifferentlyNamedParameters`
@@ -53,21 +60,11 @@ function f(a: number): void;
 function f(a: string): void;
 ```
 
-```ts
-function f(...a: number[]): void;
-function f(...b: string[]): void;
-```
-
 ### ✅ Correct
 
 ```ts
 function f(a: number): void;
 function f(b: string): void;
-```
-
-```ts
-function f(...a: number[]): void;
-function f(...a: string[]): void;
 ```
 
 ## Options


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6284
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The invalid example for `unified-signatures`:

```ts
function f(...a: number[]): void;
function f(...b: string[]): void;
```

Is removed, and:

```ts
function f(...a: number[]): void;
function f(...a: string[]): void;
```

Is moved out of the `ignoreDifferentlyNamedParameters` part, and added comments about why the rule won't check overload signatures with different rest parameter types.