### PR TITLE
fix(typescript-estree): remove duplicate hash from parserOptions.project complaint

### DIFF
--- a/packages/typescript-estree/src/create-program/createProjectProgram.ts
+++ b/packages/typescript-estree/src/create-program/createProjectProgram.ts
@@ -105,7 +105,7 @@ function createProjectProgram(
       `- Change ESLint's list of included files to not include this file`,
       `- Change ${describedSpecifiers} to include this file`,
       `- Create a new TSConfig that includes this file and include it in your parserOptions.project`,
-      `See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting##i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file`,
+      `See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file`,
     );
   }
 

--- a/packages/typescript-estree/tests/lib/__snapshots__/parse.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/parse.test.ts.snap
@@ -72,7 +72,7 @@ See the typescript-eslint docs for more info: https://typescript-eslint.io/linti
 `;
 
 exports[`parseAndGenerateServices invalid project error messages throws when non of multiple projects include the file 1`] = `
-"ESLint was configured to run on \`<tsconfigRootDir>/ts/notIncluded0j1.ts\` using \`parserOptions.project\`:
+"ESLint was configured to run on \`<tsconfigRootDir>/ts/notIncluded0j1.ts\` using \`parserOptions.project\`: 
 - <tsconfigRootDir>/tsconfig.json
 - <tsconfigRootDir>/tsconfig.extra.json
 However, none of those TSConfigs include this file. Either:

--- a/packages/typescript-estree/tests/lib/__snapshots__/parse.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/parse.test.ts.snap
@@ -23,7 +23,7 @@ However, that TSConfig does not include this file. Either:
 - Change ESLint's list of included files to not include this file
 - Change that TSConfig to include this file
 - Create a new TSConfig that includes this file and include it in your parserOptions.project
-See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting##i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
+See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
 `;
 
 exports[`parseAndGenerateServices invalid file error messages "parserOptions.extraFileExtensions" is non-empty the extension matches the file isn't included 1`] = `
@@ -32,7 +32,7 @@ However, that TSConfig does not include this file. Either:
 - Change ESLint's list of included files to not include this file
 - Change that TSConfig to include this file
 - Create a new TSConfig that includes this file and include it in your parserOptions.project
-See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting##i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
+See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
 `;
 
 exports[`parseAndGenerateServices invalid file error messages project includes errors for not included files 1`] = `
@@ -41,7 +41,7 @@ However, that TSConfig does not include this file. Either:
 - Change ESLint's list of included files to not include this file
 - Change that TSConfig to include this file
 - Create a new TSConfig that includes this file and include it in your parserOptions.project
-See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting##i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
+See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
 `;
 
 exports[`parseAndGenerateServices invalid file error messages project includes errors for not included files 2`] = `
@@ -50,7 +50,7 @@ However, that TSConfig does not include this file. Either:
 - Change ESLint's list of included files to not include this file
 - Change that TSConfig to include this file
 - Create a new TSConfig that includes this file and include it in your parserOptions.project
-See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting##i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
+See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
 `;
 
 exports[`parseAndGenerateServices invalid file error messages project includes errors for not included files 3`] = `
@@ -59,7 +59,7 @@ However, that TSConfig does not include this file. Either:
 - Change ESLint's list of included files to not include this file
 - Change that TSConfig to include this file
 - Create a new TSConfig that includes this file and include it in your parserOptions.project
-See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting##i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
+See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
 `;
 
 exports[`parseAndGenerateServices invalid file error messages project includes errors for not included files 4`] = `
@@ -68,18 +68,18 @@ However, that TSConfig does not include this file. Either:
 - Change ESLint's list of included files to not include this file
 - Change that TSConfig to include this file
 - Create a new TSConfig that includes this file and include it in your parserOptions.project
-See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting##i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
+See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
 `;
 
 exports[`parseAndGenerateServices invalid project error messages throws when non of multiple projects include the file 1`] = `
-"ESLint was configured to run on \`<tsconfigRootDir>/ts/notIncluded0j1.ts\` using \`parserOptions.project\`: 
+"ESLint was configured to run on \`<tsconfigRootDir>/ts/notIncluded0j1.ts\` using \`parserOptions.project\`:
 - <tsconfigRootDir>/tsconfig.json
 - <tsconfigRootDir>/tsconfig.extra.json
 However, none of those TSConfigs include this file. Either:
 - Change ESLint's list of included files to not include this file
 - Change one of those TSConfigs to include this file
 - Create a new TSConfig that includes this file and include it in your parserOptions.project
-See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting##i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
+See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file"
 `;
 
 exports[`parseAndGenerateServices isolated parsing should parse .js file - with JSX content - parserOptions.jsx = false 1`] = `


### PR DESCRIPTION
## PR Checklist

- ~[ ] Addresses an existing open issue: fixes #000~ something I just noticed...
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

There are two `##`s in this error message we give. Turns out that is not allowed for browser hash navigation.

```plaintext
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting##i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
```