### PR TITLE
chore(website): fix base rule source links for extended rules

### DIFF
--- a/packages/website/plugins/generated-rule-docs.ts
+++ b/packages/website/plugins/generated-rule-docs.ts
@@ -298,43 +298,7 @@ export const generatedRuleDocs: Plugin = () => {
       }
     }
 
-    // 6. Add a notice about coming from ESLint core for extension rules
-    if (meta.docs.extendsBaseRule) {
-      root.children.push({
-        children: [
-          {
-            type: 'jsx',
-            value: '<sup>',
-          },
-          {
-            type: 'text',
-            value: 'Taken with ❤️ ',
-          },
-          {
-            type: 'link',
-            title: null,
-            url: `https://github.com/eslint/eslint/blob/main/docs/rules/${
-              meta.docs.extendsBaseRule === true
-                ? file.stem
-                : meta.docs.extendsBaseRule
-            }.md`,
-            children: [
-              {
-                type: 'text',
-                value: 'from ESLint core',
-              },
-            ],
-          },
-          {
-            type: 'jsx',
-            value: '</sup>',
-          },
-        ],
-        type: 'paragraph',
-      } as mdast.Paragraph);
-    }
-
-    // 7. Also add a link to view the rule's source and test code
+    // 6. Add a link to view the rule's source and test code
     root.children.push(
       {
         children: [
@@ -392,6 +356,42 @@ export const generatedRuleDocs: Plugin = () => {
         type: 'list',
       } as mdast.List,
     );
+
+    // 7. Also add a notice about coming from ESLint core for extension rules
+    if (meta.docs.extendsBaseRule) {
+      root.children.push({
+        children: [
+          {
+            type: 'jsx',
+            value: '<sup>',
+          },
+          {
+            type: 'text',
+            value: 'Taken with ❤️ ',
+          },
+          {
+            type: 'link',
+            title: null,
+            url: `https://github.com/eslint/eslint/blob/main/docs/src/rules/${
+              meta.docs.extendsBaseRule === true
+                ? file.stem
+                : meta.docs.extendsBaseRule
+            }.md`,
+            children: [
+              {
+                type: 'text',
+                value: 'from ESLint core',
+              },
+            ],
+          },
+          {
+            type: 'jsx',
+            value: '</sup>',
+          },
+        ],
+        type: 'paragraph',
+      } as mdast.Paragraph);
+    }
   };
 };
 

--- a/packages/website/plugins/generated-rule-docs.ts
+++ b/packages/website/plugins/generated-rule-docs.ts
@@ -313,7 +313,11 @@ export const generatedRuleDocs: Plugin = () => {
           {
             type: 'link',
             title: null,
-            url: `https://github.com/eslint/eslint/blob/main/docs/rules/${meta.docs.extendsBaseRule}.md`,
+            url: `https://github.com/eslint/eslint/blob/main/docs/rules/${
+              meta.docs.extendsBaseRule === true
+                ? file.stem
+                : meta.docs.extendsBaseRule
+            }.md`,
             children: [
               {
                 type: 'text',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6293
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

If `meta.docs.extendsBaseRule` is `true`, then we should just go with `file.stem`.

Corrects the link to be the right md source path. Also moves the link to be underneath the new _Resources_ section while I'm in the area. Feels like that makes more sense.