### PR TITLE
feat(eslint-plugin): [explicit-function-return-type] allowed name regex and direct function calls #6295

### DIFF
--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -453,6 +453,24 @@ export const foo = {
     },
     {
       filename: 'test.ts',
+      options: [
+        {
+          allowedNames: ['test.*'],
+        },
+      ],
+      code: `
+const test1 = () => {
+  return;
+};
+export const foo = {
+  test2() {
+    return 0;
+  },
+};
+      `,
+    },
+    {
+      filename: 'test.ts',
       code: `
 class Test {
   constructor() {}
@@ -552,6 +570,35 @@ const x: Bar<Foo> = arg1 => arg2 => arg1 + arg2;
         {
           allowTypedFunctionExpressions: true,
           allowHigherOrderFunctions: true,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+function innerFunction1(a: number): number {
+  return 0;
+}
+function test1(a: number) {
+  return innerFunction1(a);
+}
+
+function innerFunction2(a: number): number {
+  return 0;
+}
+const test2 = (a: number) => innerFunction2(a);
+
+const innerFunction3 = (a: number): number => 0;
+const test3 = (a: number) => innerFunction3(a);
+
+const innerFunction4 = (a: number): number => 0;
+const test4 = (a: number) => {
+  return innerFunction4(a);
+};
+      `,
+      options: [
+        {
+          allowFunctionContainingOnlyOtherFunctionCall: true,
         },
       ],
     },
@@ -1411,6 +1458,80 @@ class Foo {
           endLine: 4,
           column: 3,
           endColumn: 18,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      options: [
+        {
+          allowedNames: ['test.*'],
+        },
+      ],
+      code: `
+const test1 = () => {
+  return;
+};
+export const foo = {
+  tes() {
+    return 0;
+  },
+};
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 6,
+          endLine: 6,
+          column: 3,
+          endColumn: 8,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+const innerFunction = (a: number, b: number): number => 0;
+const test = (a: number, b: number) => {
+  const x = 10;
+  return innerFunction(a);
+};
+      `,
+      options: [
+        {
+          allowFunctionContainingOnlyOtherFunctionCall: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 14,
+          endColumn: 39,
+        },
+      ],
+    },
+    {
+      filename: 'test.ts',
+      code: `
+const innerFunction = (a: number, b: number): number => 0;
+const test = (a: number, b: number) => {
+  const x = 10;
+};
+      `,
+      options: [
+        {
+          allowFunctionContainingOnlyOtherFunctionCall: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 3,
+          endLine: 3,
+          column: 14,
+          endColumn: 39,
         },
       ],
     },


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6295 
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

### Link to the rule's documentation

https://typescript-eslint.io/rules/explicit-function-return-type/

### Description

1. Function name macher can be used only to disable the rule on particular function names, In my opinion it should be possible to allow all functions that ends with particular string etc. This can be obtained by changing the function uncludes to regex match. However if that induces significant perfomance issue, it may be extracted to another option e.g. 'allowedRegexNames'

2. It is possible to disable rule for some kind of short function or those returning other functions directly, I found a usecase where it would be nice if i could disable the rule for functions which directly return other function calls e.g.NgRx selector factory, factories in general, or functions which use other functions but set some parameters, and want to use inferred type from inner function.

### Fail

```typescript
// options: [{ allowedNames: ['test.*'] } ],

export const foo = {
  tes() {
    return 0;
  },
};

// options: [{ allowFunctionContainingOnlyOtherFunctionCall: true } ],

const innerFunction = (a: number, b: number): number => 0;
const test = (a: number, b: number) => {
  const x = 10;
  return innerFunction(a);
};
```


### Pass

```typescript
// options: [{ allowedNames: ['test.*'] } ],

const test1 = () => {
  return;
};
export const foo = {
  test2() {
    return 0;
  },
};

// options: [{ allowFunctionContainingOnlyOtherFunctionCall: true } ],

function innerFunction1(a: number): number {
  return 0;
}
function test1(a: number, b: number) {
  return innerFunction1(a);
}

function innerFunction2(a: number): number {
  return 0;
}
const test2 = (a: number) => innerFunction2(a);

const innerFunction3 = (a: number): number => 0;
const test3 = (a: number) => innerFunction3(a);

const innerFunction4 = (a: number): number => 0;
const test4 = (a: number) => {
  return innerFunction4(a);
};
```
