### PR TITLE
Type merging with empty interfaces

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-empty-interface.md
+++ b/packages/eslint-plugin/docs/rules/no-empty-interface.md
@@ -68,3 +68,4 @@ This rule accepts a single object option with the following default configuratio
 ## When Not To Use It
 
 If you don't care about having empty/meaningless interfaces, then you will not need this rule.
+Or if you want to use declaration merging to merge new properties into an existing interface.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

```ts
import 'module-a';
declare module "module-a" {
 	interface Person extends Mammal {} // Now interface Person has properties of both Person and Mammal
}
```

#### Elaborate example,

```ts
// region module-a
interface Person {
	name: string,
};
// endregion module-a


// region module-b
interface Mammal {
	age: number,
	sex: string // intentionally a string
};

interface Person extends Mammal {} // Now Person has properties of Mammal too
// endregion module-b


let person: Person = {
	age: 25,
	name: 'Jen',
	sex: 'curious',
};
```