### PR TITLE
chore: fix repo linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -214,7 +214,6 @@ module.exports = {
         'jest/no-alias-methods': 'error',
         'jest/no-identical-title': 'error',
         'jest/no-jasmine-globals': 'error',
-        'jest/no-jest-import': 'error',
         'jest/no-test-prefixes': 'error',
         'jest/no-done-callback': 'error',
         'jest/no-test-return-statement': 'error',

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -397,6 +397,7 @@ describe('parseAndGenerateServices', () => {
         let result:
           | parser.ParseAndGenerateServicesResult<typeof config>
           | undefined;
+        // eslint-disable-next-line jest/valid-expect
         const exp = expect(() => {
           result = parser.parseAndGenerateServices(code, {
             ...config,


### PR DESCRIPTION
When the renovate PR went in which upgraded the major version of `eslint-plugin-jest` some issues were introduced.

- `valid-expect` is triggered by some more unusual, advanced assertion we have, so we can simply ignore it
- `no-jest-import` rule was removed by the plugin, so we remove it from our config