### PR TITLE
fix(ast-spec): a JSXEmptyExpression is not a possible JSXExpression

### DIFF
--- a/packages/ast-spec/src/unions/JSXExpression.ts
+++ b/packages/ast-spec/src/unions/JSXExpression.ts
@@ -1,8 +1,4 @@
-import type { JSXEmptyExpression } from '../jsx/JSXEmptyExpression/spec';
 import type { JSXExpressionContainer } from '../jsx/JSXExpressionContainer/spec';
 import type { JSXSpreadChild } from '../jsx/JSXSpreadChild/spec';
 
-export type JSXExpression =
-  | JSXEmptyExpression
-  | JSXExpressionContainer
-  | JSXSpreadChild;
+export type JSXExpression = JSXExpressionContainer | JSXSpreadChild;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6315
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

As described in the linked issue, a `JSXEmptyExpression` node is only generated as the child of a `JSXExpressionContainer` node, and so cannot appear in the same place as a `JSXExpression`.
