### PR TITLE
chore(website): add links to and widen Silver Supporters

### DIFF
--- a/packages/website/src/components/FinancialContributors/Sponsor.tsx
+++ b/packages/website/src/components/FinancialContributors/Sponsor.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 
 import styles from './styles.module.css';
-import type { SponsorData, SponsorIncludeOptions } from './types';
+import type { SponsorData } from './types';
 
 interface SponsorProps {
-  include?: SponsorIncludeOptions;
+  includeName?: boolean;
   sponsor: SponsorData;
 }
 
-export function Sponsor({ include = {}, sponsor }: SponsorProps): JSX.Element {
+export function Sponsor({ includeName, sponsor }: SponsorProps): JSX.Element {
   let children = <img alt={`${sponsor.name} logo`} src={sponsor.image} />;
 
-  if (include.name) {
+  if (includeName) {
     children = (
       <>
         {children}
@@ -20,19 +20,15 @@ export function Sponsor({ include = {}, sponsor }: SponsorProps): JSX.Element {
     );
   }
 
-  if (include.link) {
-    children = (
-      <a
-        className={styles.sponsorLink}
-        href={sponsor.website ?? undefined}
-        title={sponsor.name}
-        target="_blank"
-        rel="noopener sponsored"
-      >
-        {children}
-      </a>
-    );
-  }
-
-  return children;
+  return (
+    <a
+      className={styles.sponsorLink}
+      href={sponsor.website ?? undefined}
+      title={sponsor.name}
+      target="_blank"
+      rel="noopener sponsored"
+    >
+      {children}
+    </a>
+  );
 }

--- a/packages/website/src/components/FinancialContributors/Sponsors/index.tsx
+++ b/packages/website/src/components/FinancialContributors/Sponsors/index.tsx
@@ -2,12 +2,12 @@ import clsx from 'clsx';
 import React from 'react';
 
 import { Sponsor } from '../Sponsor';
-import type { SponsorData, SponsorIncludeOptions } from '../types';
+import type { SponsorData } from '../types';
 import styles from './styles.module.css';
 
 interface SponsorsProps {
   className: string;
-  include?: SponsorIncludeOptions;
+  includeName?: boolean;
   expanded?: boolean;
   sponsors: SponsorData[];
   title: string;
@@ -16,7 +16,7 @@ interface SponsorsProps {
 
 export function Sponsors({
   className,
-  include,
+  includeName,
   title,
   tier,
   sponsors,
@@ -27,7 +27,7 @@ export function Sponsors({
       <ul className={clsx(styles.sponsorsTier, styles[`tier-${tier}`])}>
         {sponsors.map(sponsor => (
           <li key={sponsor.id}>
-            <Sponsor include={include} sponsor={sponsor} />
+            <Sponsor includeName={includeName} sponsor={sponsor} />
           </li>
         ))}
       </ul>

--- a/packages/website/src/components/FinancialContributors/Sponsors/styles.module.css
+++ b/packages/website/src/components/FinancialContributors/Sponsors/styles.module.css
@@ -82,7 +82,6 @@
   .tierArea {
     margin: 16px 0;
     width: auto;
-    padding: 0 60px;
   }
 
   .tier-gold-supporter {

--- a/packages/website/src/components/FinancialContributors/index.tsx
+++ b/packages/website/src/components/FinancialContributors/index.tsx
@@ -16,14 +16,13 @@ export function FinancialContributors(): JSX.Element {
       <div className={styles.sponsorsContainer}>
         <Sponsors
           className={styles.tierSponsorArea}
-          include={{ link: true, name: true }}
+          includeName
           tier="platinum-sponsor"
           title="Platinum Sponsors"
           sponsors={sponsors.slice(0, 6)}
         />
         <Sponsors
           className={styles.tierSupporterArea}
-          include={{ link: true }}
           tier="gold-supporter"
           title="Gold Supporters"
           sponsors={sponsors.slice(6, 16)}

--- a/packages/website/src/components/FinancialContributors/styles.module.css
+++ b/packages/website/src/components/FinancialContributors/styles.module.css
@@ -13,6 +13,10 @@
   margin: 48px 24px 24px;
 }
 
+.tierOtherArea {
+  padding: 0;
+}
+
 .become {
   font-size: 1.25rem;
   padding: 0.75rem 1.75rem;
@@ -36,18 +40,17 @@
     max-width: 100%;
   }
 
-  .tierArea {
-    margin: 16px 0;
-    width: auto;
-    padding: 0 60px;
-  }
-
   .tierSponsorArea {
     grid-area: 1 / 1 / 3 / 2;
   }
 
   .tierSupporterArea {
     grid-area: 1 / 2 / 2 / 3;
+  }
+
+  .tierSponsorArea,
+  .tierSupporterArea {
+    padding: 0 60px;
   }
 
   .tierOtherArea {

--- a/packages/website/src/components/FinancialContributors/types.ts
+++ b/packages/website/src/components/FinancialContributors/types.ts
@@ -7,8 +7,3 @@ export interface SponsorData {
   totalDonations: number;
   website?: string;
 }
-
-export interface SponsorIncludeOptions {
-  link?: boolean;
-  name?: boolean;
-}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6324
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Simplifies `include` to just `includeName` now that every tier includes links.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img alt="Before screenshot with less wide silver supporters" src="https://user-images.githubusercontent.com/3335181/211897331-a9442308-d0a9-4ca0-b2e5-a21dd8651281.png" />
</td>
<td>
<img alt="After screenshot with wider silver supporters" src="https://user-images.githubusercontent.com/3335181/211897407-0c6f9b39-51ef-4d22-bfcc-26db046ab5a1.png" />
</td>
</tr>
</tbody>
</table>
