### PR TITLE
chore: don't run scheduled workflows on forks

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -13,6 +13,7 @@ jobs:
       pull-requests: write # to lock PRs (dessant/lock-threads)
 
     runs-on: ubuntu-latest
+    if: github.repository == 'typescript-eslint/typescript-eslint'
     steps:
       - uses: dessant/lock-threads@v4
         with:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6333
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Hi,
the scheduled GitHub action workflow probably doesn't need to run on forks as it fails for them due to some rate limiting. This PR disables the workflow on forks, only running it on the main repo.
