### PR TITLE
chore: add workflow to automatically run prettier when renovate updates it

### DIFF
--- a/.github/workflows/prettier-update.yml
+++ b/.github/workflows/prettier-update.yml
@@ -1,0 +1,46 @@
+# This workflow is used to augment the capabilities of the renovate GitHub app by running a full
+# `prettier --write` when renovate opens a PR to change the version of prettier.
+
+name: Prettier Update
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'package.json'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  maybe_prettier_update:
+    # Only run if it was the renovate bot that triggered the workflow (otherwise we'll create a loop)
+    if: contains('["renovate[bot]"]', github.actor) == true
+    name: Run prettier formatting if required
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check if prettier was changed as part of the latest commit on the PR
+        id: prettier-package-check
+        run: |
+          git diff HEAD~1 -G"prettier" --exit-code package.json && echo "prettier unchanged" || echo "::set-output name=was-changed::true"
+
+      - name: Run prettier formatting if prettier was changed and commit the results
+        if: ${{ steps.prettier-package-check.outputs.was-changed == 'true' }}
+        env:
+          # We cannot use secrets.GITHUB_TOKEN for this because it is not permitted to kick off subsequent actions worfklow runs, so we use a PAT instead
+          GITHUB_TOKEN: ${{ secrets.JAMES_HENRY_GITHUB_TOKEN }}
+        run: |
+          yarn --ignore-scripts
+          yarn format
+
+          # Commit all the changes to the PR (see note on not being able to use secrets.GITHUB_TOKEN for this)
+          git config --global user.email "james@henry.sc"
+          git config --global user.name "JamesHenry"
+          git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
+
+          git add --all
+          git commit -m "chore: update formatting after prettier upgrade"
+          git push

--- a/.github/workflows/prettier-update.yml
+++ b/.github/workflows/prettier-update.yml
@@ -41,6 +41,11 @@ jobs:
           git config --global user.name "JamesHenry"
           git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
 
-          git add --all
-          git commit -m "chore: update formatting after prettier upgrade"
-          git push
+          # If the status is empty, there are no uncommitted changes
+          if [[ -z $(git status --porcelain) ]]; then
+            echo "No uncommitted changes"
+          else
+            git add --all
+            git commit -m "chore: update formatting after prettier upgrade"
+            git push
+          fi


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

If a prettier update causes formatting to change (which it usually does) then right now a maintainer has to manually update the relevant renovate PR by running `yarn format` locally and committing the results.

After this PR goes in, that `yarn format` and commit step will be done automatically on the PR without any maintainer involvement
