### PR TITLE
chore(typescript-estree): remove unnecessary this.inTypeMode field

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -68,7 +68,6 @@ export class Converter {
   private readonly tsNodeToESTreeNodeMap = new WeakMap();
 
   private allowPattern = false;
-  private inTypeMode = false;
 
   /**
    * Converts a TypeScript node into an ESTree node
@@ -96,14 +95,12 @@ export class Converter {
    * Converts a TypeScript node into an ESTree node.
    * @param node the child ts.Node
    * @param parent parentNode
-   * @param inTypeMode flag to determine if we are in typeMode
    * @param allowPattern flag to determine if patterns are allowed
    * @returns the converted ESTree node
    */
   private converter(
     node?: ts.Node,
     parent?: ts.Node,
-    inTypeMode?: boolean,
     allowPattern?: boolean,
   ): any {
     /**
@@ -113,11 +110,7 @@ export class Converter {
       return null;
     }
 
-    const typeMode = this.inTypeMode;
     const pattern = this.allowPattern;
-    if (inTypeMode !== undefined) {
-      this.inTypeMode = inTypeMode;
-    }
     if (allowPattern !== undefined) {
       this.allowPattern = allowPattern;
     }
@@ -129,7 +122,6 @@ export class Converter {
 
     this.registerTSNodeInNodeMap(node, result);
 
-    this.inTypeMode = typeMode;
     this.allowPattern = pattern;
     return result;
   }
@@ -225,7 +217,7 @@ export class Converter {
    * @returns the converted ESTree node
    */
   private convertPattern(child?: ts.Node, parent?: ts.Node): any | null {
-    return this.converter(child, parent, this.inTypeMode, true);
+    return this.converter(child, parent, true);
   }
 
   /**
@@ -235,17 +227,7 @@ export class Converter {
    * @returns the converted ESTree node
    */
   private convertChild(child?: ts.Node, parent?: ts.Node): any | null {
-    return this.converter(child, parent, this.inTypeMode, false);
-  }
-
-  /**
-   * Converts a TypeScript node into an ESTree node.
-   * @param child the child ts.Node
-   * @param parent parentNode
-   * @returns the converted ESTree node
-   */
-  private convertType(child?: ts.Node, parent?: ts.Node): any | null {
-    return this.converter(child, parent, true, false);
+    return this.converter(child, parent, false);
   }
 
   private createNode<T extends TSESTree.Node = TSESTree.Node>(
@@ -306,7 +288,7 @@ export class Converter {
       type: AST_NODE_TYPES.TSTypeAnnotation,
       loc,
       range: [annotationStartCol, child.end],
-      typeAnnotation: this.convertType(child),
+      typeAnnotation: this.convertChild(child),
     } as TSESTree.TSTypeAnnotation;
   }
 
@@ -365,7 +347,9 @@ export class Converter {
     return this.createNode<TSESTree.TSTypeParameterInstantiation>(node, {
       type: AST_NODE_TYPES.TSTypeParameterInstantiation,
       range: [typeArguments.pos - 1, greaterThanToken.end],
-      params: typeArguments.map(typeArgument => this.convertType(typeArgument)),
+      params: typeArguments.map(typeArgument =>
+        this.convertChild(typeArgument),
+      ),
     });
   }
 
@@ -384,7 +368,7 @@ export class Converter {
       range: [typeParameters.pos - 1, greaterThanToken.end],
       loc: getLocFor(typeParameters.pos - 1, greaterThanToken.end, this.ast),
       params: typeParameters.map(typeParameter =>
-        this.convertType(typeParameter),
+        this.convertChild(typeParameter),
       ),
     } as TSESTree.TSTypeParameterDeclaration;
   }
@@ -1062,12 +1046,7 @@ export class Converter {
         return this.createNode<TSESTree.Property>(node, {
           type: AST_NODE_TYPES.Property,
           key: this.convertChild(node.name),
-          value: this.converter(
-            node.initializer,
-            node,
-            this.inTypeMode,
-            this.allowPattern,
-          ),
+          value: this.converter(node.initializer, node, this.allowPattern),
           computed: isComputedProperty(node.name),
           method: false,
           shorthand: false,
@@ -1962,7 +1941,6 @@ export class Converter {
             left: this.converter(
               node.left,
               node,
-              this.inTypeMode,
               type === AST_NODE_TYPES.AssignmentExpression,
             ),
             right: this.convertChild(node.right),
@@ -2320,7 +2298,7 @@ export class Converter {
       case SyntaxKind.TypeReference: {
         return this.createNode<TSESTree.TSTypeReference>(node, {
           type: AST_NODE_TYPES.TSTypeReference,
-          typeName: this.convertType(node.typeName),
+          typeName: this.convertChild(node.typeName),
           typeParameters: node.typeArguments
             ? this.convertTypeArgumentsToTypeParameters(
                 node.typeArguments,
@@ -2333,11 +2311,11 @@ export class Converter {
       case SyntaxKind.TypeParameter: {
         return this.createNode<TSESTree.TSTypeParameter>(node, {
           type: AST_NODE_TYPES.TSTypeParameter,
-          name: this.convertType(node.name),
+          name: this.convertChild(node.name),
           constraint: node.constraint
-            ? this.convertType(node.constraint)
+            ? this.convertChild(node.constraint)
             : undefined,
-          default: node.default ? this.convertType(node.default) : undefined,
+          default: node.default ? this.convertChild(node.default) : undefined,
           in: hasModifier(SyntaxKind.InKeyword, node),
           out: hasModifier(SyntaxKind.OutKeyword, node),
         });
@@ -2384,32 +2362,32 @@ export class Converter {
       case SyntaxKind.ArrayType: {
         return this.createNode<TSESTree.TSArrayType>(node, {
           type: AST_NODE_TYPES.TSArrayType,
-          elementType: this.convertType(node.elementType),
+          elementType: this.convertChild(node.elementType),
         });
       }
 
       case SyntaxKind.IndexedAccessType: {
         return this.createNode<TSESTree.TSIndexedAccessType>(node, {
           type: AST_NODE_TYPES.TSIndexedAccessType,
-          objectType: this.convertType(node.objectType),
-          indexType: this.convertType(node.indexType),
+          objectType: this.convertChild(node.objectType),
+          indexType: this.convertChild(node.indexType),
         });
       }
 
       case SyntaxKind.ConditionalType: {
         return this.createNode<TSESTree.TSConditionalType>(node, {
           type: AST_NODE_TYPES.TSConditionalType,
-          checkType: this.convertType(node.checkType),
-          extendsType: this.convertType(node.extendsType),
-          trueType: this.convertType(node.trueType),
-          falseType: this.convertType(node.falseType),
+          checkType: this.convertChild(node.checkType),
+          extendsType: this.convertChild(node.extendsType),
+          trueType: this.convertChild(node.trueType),
+          falseType: this.convertChild(node.falseType),
         });
       }
 
       case SyntaxKind.TypeQuery: {
         return this.createNode<TSESTree.TSTypeQuery>(node, {
           type: AST_NODE_TYPES.TSTypeQuery,
-          exprName: this.convertType(node.exprName),
+          exprName: this.convertChild(node.exprName),
           typeParameters:
             node.typeArguments &&
             this.convertTypeArgumentsToTypeParameters(node.typeArguments, node),
@@ -2419,8 +2397,8 @@ export class Converter {
       case SyntaxKind.MappedType: {
         const result = this.createNode<TSESTree.TSMappedType>(node, {
           type: AST_NODE_TYPES.TSMappedType,
-          typeParameter: this.convertType(node.typeParameter),
-          nameType: this.convertType(node.nameType) ?? null,
+          typeParameter: this.convertChild(node.typeParameter),
+          nameType: this.convertChild(node.nameType) ?? null,
         });
 
         if (node.readonlyToken) {
@@ -2440,7 +2418,7 @@ export class Converter {
         }
 
         if (node.type) {
-          result.typeAnnotation = this.convertType(node.type);
+          result.typeAnnotation = this.convertChild(node.type);
         }
         return result;
       }
@@ -2452,7 +2430,7 @@ export class Converter {
         const result = this.createNode<TSESTree.TSTypeAliasDeclaration>(node, {
           type: AST_NODE_TYPES.TSTypeAliasDeclaration,
           id: this.convertChild(node.name),
-          typeAnnotation: this.convertType(node.type),
+          typeAnnotation: this.convertChild(node.type),
         });
 
         if (hasModifier(SyntaxKind.DeclareKeyword, node)) {
@@ -2748,31 +2726,31 @@ export class Converter {
 
       // TypeScript specific types
       case SyntaxKind.ParenthesizedType: {
-        return this.convertType(node.type);
+        return this.convertChild(node.type);
       }
       case SyntaxKind.UnionType: {
         return this.createNode<TSESTree.TSUnionType>(node, {
           type: AST_NODE_TYPES.TSUnionType,
-          types: node.types.map(el => this.convertType(el)),
+          types: node.types.map(el => this.convertChild(el)),
         });
       }
       case SyntaxKind.IntersectionType: {
         return this.createNode<TSESTree.TSIntersectionType>(node, {
           type: AST_NODE_TYPES.TSIntersectionType,
-          types: node.types.map(el => this.convertType(el)),
+          types: node.types.map(el => this.convertChild(el)),
         });
       }
       case SyntaxKind.AsExpression: {
         return this.createNode<TSESTree.TSAsExpression>(node, {
           type: AST_NODE_TYPES.TSAsExpression,
           expression: this.convertChild(node.expression),
-          typeAnnotation: this.convertType(node.type),
+          typeAnnotation: this.convertChild(node.type),
         });
       }
       case SyntaxKind.InferType: {
         return this.createNode<TSESTree.TSInferType>(node, {
           type: AST_NODE_TYPES.TSInferType,
-          typeParameter: this.convertType(node.typeParameter),
+          typeParameter: this.convertChild(node.typeParameter),
         });
       }
       case SyntaxKind.LiteralType: {
@@ -2788,14 +2766,14 @@ export class Converter {
         } else {
           return this.createNode<TSESTree.TSLiteralType>(node, {
             type: AST_NODE_TYPES.TSLiteralType,
-            literal: this.convertType(node.literal),
+            literal: this.convertChild(node.literal),
           });
         }
       }
       case SyntaxKind.TypeAssertionExpression: {
         return this.createNode<TSESTree.TSTypeAssertion>(node, {
           type: AST_NODE_TYPES.TSTypeAssertion,
-          typeAnnotation: this.convertType(node.type),
+          typeAnnotation: this.convertChild(node.type),
           expression: this.convertChild(node.expression),
         });
       }
@@ -2834,9 +2812,9 @@ export class Converter {
         const elementTypes =
           'elementTypes' in node
             ? (node as any).elementTypes.map((el: ts.Node) =>
-                this.convertType(el),
+                this.convertChild(el),
               )
-            : node.elements.map(el => this.convertType(el));
+            : node.elements.map(el => this.convertChild(el));
 
         return this.createNode<TSESTree.TSTupleType>(node, {
           type: AST_NODE_TYPES.TSTupleType,
@@ -2846,7 +2824,7 @@ export class Converter {
       case SyntaxKind.NamedTupleMember: {
         const member = this.createNode<TSESTree.TSNamedTupleMember>(node, {
           type: AST_NODE_TYPES.TSNamedTupleMember,
-          elementType: this.convertType(node.type, node),
+          elementType: this.convertChild(node.type, node),
           label: this.convertChild(node.name, node),
           optional: node.questionToken != null,
         });
@@ -2866,13 +2844,13 @@ export class Converter {
       case SyntaxKind.OptionalType: {
         return this.createNode<TSESTree.TSOptionalType>(node, {
           type: AST_NODE_TYPES.TSOptionalType,
-          typeAnnotation: this.convertType(node.type),
+          typeAnnotation: this.convertChild(node.type),
         });
       }
       case SyntaxKind.RestType: {
         return this.createNode<TSESTree.TSRestType>(node, {
           type: AST_NODE_TYPES.TSRestType,
-          typeAnnotation: this.convertType(node.type),
+          typeAnnotation: this.convertChild(node.type),
         });
       }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5914
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I missed this when I did #5915 - this piece of converter state is now completely unnecessary because #5915 cleaned up the last reference to it.

This PR just deletes the now unused code.