### PR TITLE
fix(eslint-plugin): [sort-type-constituents] fixed behavior change

### DIFF
--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -210,6 +210,7 @@ function typeNodeRequiresParentheses(
   return (
     node.type === AST_NODE_TYPES.TSFunctionType ||
     node.type === AST_NODE_TYPES.TSConstructorType ||
+    node.type === AST_NODE_TYPES.TSConditionalType ||
     (node.type === AST_NODE_TYPES.TSUnionType && text.startsWith('|')) ||
     (node.type === AST_NODE_TYPES.TSIntersectionType && text.startsWith('&'))
   );

--- a/packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts
@@ -359,6 +359,7 @@ type T = 1 | string | {} | A;
         },
       ],
     },
+    "type A<T> = string | (T extends number ? 'hi' : 'there');",
   ],
   invalid: [
     ...invalid('|'),
@@ -372,6 +373,19 @@ type T = 1 | string | {} | A;
           data: {
             type: 'Intersection',
             name: 'T',
+          },
+        },
+      ],
+    },
+    {
+      output: "type A<T> = string | (T extends number ? 'hi' : 'there');",
+      code: "type A<T> = (T extends number ? 'hi' : 'there') | string;",
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+          data: {
+            type: 'Union',
+            name: 'A',
           },
         },
       ],


### PR DESCRIPTION
Fixed behavior change when sorting TSConditionalType (#6339)

## PR Checklist

- [x] Addresses an existing open issue: fixes #6339
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken
