### PR TITLE
fix(eslint-plugin): do not use .at(), Node 14 does not support it

### DIFF
--- a/packages/eslint-plugin/src/rules/key-spacing.ts
+++ b/packages/eslint-plugin/src/rules/key-spacing.ts
@@ -15,7 +15,7 @@ const baseSchema = Array.isArray(baseRule.meta.schema)
   : baseRule.meta.schema;
 
 /**
- * To replace with native .at() once Node 14 stops being supported
+ * TODO: replace with native .at() once Node 14 stops being supported
  */
 function at<T>(arr: T[], position: number): T | undefined {
   if (position < 0) {
@@ -51,7 +51,6 @@ export default util.createRule<Options, MessageIds>({
     function adjustedColumn(position: TSESTree.Position): number {
       const line = position.line - 1; // position.line is 1-indexed
       return util.getStringLength(
-        // use at() just for codecov, so it has a positive position case
         at(sourceCode.lines, line)!.slice(0, position.column),
       );
     }

--- a/packages/eslint-plugin/src/rules/key-spacing.ts
+++ b/packages/eslint-plugin/src/rules/key-spacing.ts
@@ -51,7 +51,8 @@ export default util.createRule<Options, MessageIds>({
     function adjustedColumn(position: TSESTree.Position): number {
       const line = position.line - 1; // position.line is 1-indexed
       return util.getStringLength(
-        sourceCode.lines[line].slice(0, position.column),
+        // use at() just for codecov, so it has a positive position case
+        at(sourceCode.lines, line)!.slice(0, position.column),
       );
     }
 

--- a/packages/eslint-plugin/src/rules/key-spacing.ts
+++ b/packages/eslint-plugin/src/rules/key-spacing.ts
@@ -14,6 +14,16 @@ const baseSchema = Array.isArray(baseRule.meta.schema)
   ? baseRule.meta.schema[0]
   : baseRule.meta.schema;
 
+/**
+ * To replace with native .at() once Node 14 stops being supported
+ */
+function at<T>(arr: T[], position: number): T | undefined {
+  if (position < 0) {
+    return arr[arr.length + position];
+  }
+  return arr[position];
+}
+
 export default util.createRule<Options, MessageIds>({
   name: 'key-spacing',
   meta: {
@@ -87,7 +97,7 @@ export default util.createRule<Options, MessageIds>({
       return code.slice(
         0,
         sourceCode.getTokenAfter(
-          node.parameters.at(-1)!,
+          at(node.parameters, -1)!,
           util.isClosingBracketToken,
         )!.range[1] - node.range[0],
       );
@@ -102,7 +112,7 @@ export default util.createRule<Options, MessageIds>({
       return getLastTokenBeforeColon(
         node.type !== AST_NODE_TYPES.TSIndexSignature
           ? node.key
-          : node.parameters.at(-1)!,
+          : at(node.parameters, -1)!,
       ).loc.end;
     }
 
@@ -202,7 +212,7 @@ export default util.createRule<Options, MessageIds>({
       if (
         leadingComments.length &&
         leadingComments[0].loc.start.line - groupEndLine <= 1 &&
-        candidateValueStartLine - leadingComments.at(-1)!.loc.end.line <= 1
+        candidateValueStartLine - at(leadingComments, -1)!.loc.end.line <= 1
       ) {
         for (let i = 1; i < leadingComments.length; i++) {
           if (
@@ -373,7 +383,7 @@ export default util.createRule<Options, MessageIds>({
         let prevNode: TSESTree.Node | undefined = undefined;
 
         for (const node of members) {
-          let prevAlignedNode = currentAlignGroup.at(-1);
+          let prevAlignedNode = at(currentAlignGroup, -1);
           if (prevAlignedNode !== prevNode) {
             prevAlignedNode = undefined;
           }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6396
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
