### PR TITLE
fix: add `requiresTypeChecking` to `prefer-optional-chain` metadata

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -39,6 +39,7 @@ export default util.createRule({
       description:
         'Enforce using concise optional chain expressions instead of chained logical ands, negated logical ors, or empty objects',
       recommended: 'strict',
+      requiresTypeChecking: true,
     },
     hasSuggestions: true,
     messages: {


### PR DESCRIPTION
We are using `requiresTypeChecking` field from metadata to build an ESlint preset (the one that switches off all rules requiring typing information) and encountered the only rule that is missing this field.

This PR fixes that, adding appropriate field to the `prefer-optional-chain` rule.
