### PR TITLE
fix(eslint-plugin): fix key-spacing when type starts on next line

### DIFF
--- a/packages/eslint-plugin/src/rules/key-spacing.ts
+++ b/packages/eslint-plugin/src/rules/key-spacing.ts
@@ -85,6 +85,15 @@ export default util.createRule<Options, MessageIds>({
       );
     }
 
+    function canBeAligned(
+      node: TSESTree.Node,
+    ): node is KeyTypeNodeWithTypeAnnotation {
+      return (
+        isKeyTypeNode(node) &&
+        node.typeAnnotation.loc.start.line === node.loc.end.line
+      );
+    }
+
     /**
      * To handle index signatures, to get the whole text for the parameters
      */
@@ -281,7 +290,7 @@ export default util.createRule<Options, MessageIds>({
       }
 
       for (const node of group) {
-        if (!isKeyTypeNode(node)) {
+        if (!canBeAligned(node)) {
           continue;
         }
         const { typeAnnotation } = node;
@@ -356,7 +365,7 @@ export default util.createRule<Options, MessageIds>({
           ? options.multiLine.mode
           : options.mode) ?? 'strict';
 
-      if (isKeyTypeNode(node)) {
+      if (canBeAligned(node)) {
         checkBeforeColon(node, expectedWhitespaceBeforeColon, mode);
         checkAfterColon(node, expectedWhitespaceAfterColon, mode);
       }

--- a/packages/eslint-plugin/src/rules/key-spacing.ts
+++ b/packages/eslint-plugin/src/rules/key-spacing.ts
@@ -85,7 +85,7 @@ export default util.createRule<Options, MessageIds>({
       );
     }
 
-    function canBeAligned(
+    function isApplicable(
       node: TSESTree.Node,
     ): node is KeyTypeNodeWithTypeAnnotation {
       return (
@@ -290,7 +290,7 @@ export default util.createRule<Options, MessageIds>({
       }
 
       for (const node of group) {
-        if (!canBeAligned(node)) {
+        if (!isApplicable(node)) {
           continue;
         }
         const { typeAnnotation } = node;
@@ -365,7 +365,7 @@ export default util.createRule<Options, MessageIds>({
           ? options.multiLine.mode
           : options.mode) ?? 'strict';
 
-      if (canBeAligned(node)) {
+      if (isApplicable(node)) {
         checkBeforeColon(node, expectedWhitespaceBeforeColon, mode);
         checkAfterColon(node, expectedWhitespaceAfterColon, mode);
       }

--- a/packages/eslint-plugin/tests/rules/key-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/key-spacing.test.ts
@@ -15,6 +15,37 @@ ruleTester.run('key-spacing', rule, {
     {
       code: `
 interface X {
+  x:
+    | number
+    | string;
+}
+      `,
+      options: [{ align: 'value' }],
+    },
+    {
+      code: `
+interface X {
+  abcdef: string;
+  x:
+    | number
+    | string;
+  defgh: string;
+}
+      `,
+      options: [{ align: 'value' }],
+    },
+    {
+      code: `
+interface X {
+  x:
+    | number; abcd: string;
+}
+      `,
+      options: [{ align: 'value' }],
+    },
+    {
+      code: `
+interface X {
   a:   number;
   abc: string
 };

--- a/packages/eslint-plugin/tests/rules/key-spacing.test.ts
+++ b/packages/eslint-plugin/tests/rules/key-spacing.test.ts
@@ -11,7 +11,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('key-spacing', rule, {
   valid: [
-    // align: value
+    // non-applicable
     {
       code: `
 interface X {
@@ -21,6 +21,16 @@ interface X {
 }
       `,
       options: [{ align: 'value' }],
+    },
+    {
+      code: `
+interface X {
+  x:
+    | number
+    | string;
+}
+      `,
+      options: [{}],
     },
     {
       code: `
@@ -43,6 +53,7 @@ interface X {
       `,
       options: [{ align: 'value' }],
     },
+    // align: value
     {
       code: `
 interface X {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6409
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The problem was not on the align part of the rule, but the space before / after the colon part of the rule. Now it checks that the type annotation is on the same line as the key, through the `isApplicable` helper.