### PR TITLE
chore(typescript-estree): remove unnecessary babel test exclude

### DIFF
--- a/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
+++ b/packages/typescript-estree/tests/ast-alignment/fixtures-to-test.ts
@@ -477,11 +477,6 @@ tester.addFixturePatternConfig('typescript/expressions', {
      * @see https://github.com/babel/babel/issues/14613
      */
     'instantiation-expression',
-    /**
-     * TS 4.9 `satisfies` operator has not been implemented in Babel yet.
-     * @see https://github.com/babel/babel/pull/14211
-     */
-    'satisfies-expression',
   ],
 });
 


### PR DESCRIPTION
## Overview

Noticed we've since been updated to a version of Babel that supports `satisfies`.