### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] account for optional chaining on potentially void values

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -126,8 +126,7 @@ export default createRule<Options, MessageId>({
       noOverlapBooleanExpression:
         'Unnecessary conditional, the types have no overlap.',
       never: 'Unnecessary conditional, value is `never`.',
-      neverOptionalChain:
-        'Unnecessary optional chain on a non-nullish value. Please ensure you are not declaring a variable with the `void` type outside of a return type or generic type argument. Use `undefined` instead.',
+      neverOptionalChain: 'Unnecessary optional chain on a non-nullish value.',
       noStrictNullCheck:
         'This rule requires the `strictNullChecks` compiler option to be turned on to function correctly.',
     },
@@ -575,10 +574,15 @@ export default createRule<Options, MessageId>({
         node.type === AST_NODE_TYPES.MemberExpression
           ? !isNullableOriginFromPrev(node)
           : true;
+      const unionParts = unionTypeParts(type);
+      const possiblyVoid = unionParts.some(
+        part => part.flags & ts.TypeFlags.Void,
+      );
       return (
         isTypeAnyType(type) ||
         isTypeUnknownType(type) ||
-        (isNullableType(type, { allowUndefined: true }) && isOwnNullable)
+        (isNullableType(type, { allowUndefined: true }) && isOwnNullable) ||
+        (possiblyVoid && isOwnNullable)
       );
     }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -126,7 +126,8 @@ export default createRule<Options, MessageId>({
       noOverlapBooleanExpression:
         'Unnecessary conditional, the types have no overlap.',
       never: 'Unnecessary conditional, value is `never`.',
-      neverOptionalChain: 'Unnecessary optional chain on a non-nullish value.',
+      neverOptionalChain:
+        'Unnecessary optional chain on a non-nullish value. Please ensure you are not declaring a variable with the `void` type outside of a return type or generic type argument. Use `undefined` instead.',
       noStrictNullCheck:
         'This rule requires the `strictNullChecks` compiler option to be turned on to function correctly.',
     },

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -574,15 +574,11 @@ export default createRule<Options, MessageId>({
         node.type === AST_NODE_TYPES.MemberExpression
           ? !isNullableOriginFromPrev(node)
           : true;
-      const unionParts = unionTypeParts(type);
-      const possiblyVoid = unionParts.some(
-        part => part.flags & ts.TypeFlags.Void,
-      );
+      const possiblyVoid = isTypeFlagSet(type, ts.TypeFlags.Void);
       return (
-        isTypeAnyType(type) ||
-        isTypeUnknownType(type) ||
-        (isNullableType(type, { allowUndefined: true }) && isOwnNullable) ||
-        (possiblyVoid && isOwnNullable)
+        isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown) ||
+        (isOwnNullable &&
+          (isNullableType(type, { allowUndefined: true }) || possiblyVoid))
       );
     }
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -545,6 +545,10 @@ type OptionalFoo = Foo | undefined;
 declare const foo: OptionalFoo;
 foo?.[1]?.length;
     `,
+    `
+let variable = 'abc' as string | void;
+variable?.[0];
+    `,
   ],
   invalid: [
     // Ensure that it's checking in all the right places

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -346,6 +346,10 @@ do {} while (true);
       options: [{ allowConstantLoopConditions: true }],
     },
     `
+let variable = 'abc' as string | void;
+variable?.[0];
+    `,
+    `
 let foo: undefined | { bar: true };
 foo?.bar;
     `,
@@ -544,10 +548,6 @@ interface Foo {
 type OptionalFoo = Foo | undefined;
 declare const foo: OptionalFoo;
 foo?.[1]?.length;
-    `,
-    `
-let variable = 'abc' as string | void;
-variable?.[0];
     `,
   ],
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6261
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR adds a check for `void` types in the [no-unnecessary-condition] rule. It also adds a valid test case to its valid tests array.
