### PR TITLE
fix(eslint-plugin): [no-import-type-side-effects] correctly ignore zero-specifier imports

### DIFF
--- a/packages/eslint-plugin/src/rules/no-import-type-side-effects.ts
+++ b/packages/eslint-plugin/src/rules/no-import-type-side-effects.ts
@@ -29,6 +29,10 @@ export default util.createRule<Options, MessageIds>({
       'ImportDeclaration[importKind!="type"]'(
         node: TSESTree.ImportDeclaration,
       ): void {
+        if (node.specifiers.length === 0) {
+          return;
+        }
+
         const specifiers: TSESTree.ImportSpecifier[] = [];
         for (const specifier of node.specifiers) {
           if (

--- a/packages/eslint-plugin/tests/rules/no-import-type-side-effects.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-import-type-side-effects.test.ts
@@ -18,6 +18,7 @@ ruleTester.run('no-import-type-side-effects', rule, {
     "import type T, { U } from 'mod';",
     "import T, { type U } from 'mod';",
     "import type * as T from 'mod';",
+    "import 'mod';",
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6431
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
<p align="center">
  <img width="700" src="https://user-images.githubusercontent.com/7462525/217792790-1c9d90da-6df7-4bc3-8aab-78897c517590.jpg" />
</p>
