### PR TITLE
chore: add merge_group trigger to run ci on the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - '**'
+  merge_group:
 
 env:
   PRIMARY_NODE_VERSION: 18


### PR DESCRIPTION
Need this so we can actually check PRs sitting the merge queue.