### PR TITLE
chore: check package.json existence in package-packages.ts

### DIFF
--- a/tests/integration/pack-packages.ts
+++ b/tests/integration/pack-packages.ts
@@ -30,10 +30,12 @@ const tarFolder = tmp.dirSync({
 const tseslintPackages: PackageJSON['devDependencies'] = {};
 for (const pkg of PACKAGES) {
   const packageDir = path.join(PACKAGES_DIR, pkg);
-  const packageJson: PackageJSON = require(path.join(
-    packageDir,
-    'package.json',
-  ));
+  const packagePath = path.join(packageDir, 'package.json');
+  if (!fs.existsSync(packagePath)) {
+    continue;
+  }
+
+  const packageJson = require(packagePath) as PackageJSON;
   if (packageJson.private === true) {
     continue;
   }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6453
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Makes sure a `package.json` file exists in a `packages/*` directory before requiring the file.