### PR TITLE
docs(website): fix typed rules heading link in custom rule docs

### DIFF
--- a/docs/Custom_Rules.mdx
+++ b/docs/Custom_Rules.mdx
@@ -14,7 +14,7 @@ The main three changes to custom rules writing are:
 
 - [Utils Package](#utils-package): we recommend using `@typescript-eslint/utils` to create custom rules
 - [AST Extensions](#ast-extensions): targeting TypeScript-specific syntax in your rule selectors
-- [Typed Rules](#typed-rules): using the TypeScript type checker to inform rule logic
+- [Typed Rules](#type-checking): using the TypeScript type checker to inform rule logic
 
 ## Utils Package
 

--- a/docs/Custom_Rules.mdx
+++ b/docs/Custom_Rules.mdx
@@ -14,7 +14,7 @@ The main three changes to custom rules writing are:
 
 - [Utils Package](#utils-package): we recommend using `@typescript-eslint/utils` to create custom rules
 - [AST Extensions](#ast-extensions): targeting TypeScript-specific syntax in your rule selectors
-- [Typed Rules](#type-checking): using the TypeScript type checker to inform rule logic
+- [Typed Rules](#typed-rules): using the TypeScript type checker to inform rule logic
 
 ## Utils Package
 
@@ -202,7 +202,7 @@ export const rule = createRule({
 });
 ```
 
-## Type Checking
+## Typed Rules
 
 :::tip
 Read TypeScript's [Compiler APIs > Using the Type Checker](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#using-the-type-checker) section for how to use a program's type checker.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The link is not matching. the link should address https://typescript-eslint.io/custom-rules#type-checking
