### PR TITLE
docs(eslint-plugin): explicit-function-return-type: missing allowFunctionsWithoutTypeParameters sections

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -242,6 +242,38 @@ const log = (message: string) => {
 var log = (message: string) => void console.log(message);
 ```
 
+### `allowFunctionsWithoutTypeParameters`
+
+Examples of code for this rule with `{ allowFunctionsWithoutTypeParameters: true }`:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+function foo<T>(t: T) {
+  return t;
+}
+
+const bar = <T>(t: T) => t;
+```
+
+#### ✅ Correct
+
+```ts
+function foo<T>(t: T): T {
+  return t;
+}
+
+const bar = <T>(t: T): T => t;
+
+const allowedFunction(x: string) {
+  return x;
+}
+
+const allowedArrow = (x: string) => x;
+```
+
 ### `allowedNames`
 
 You may pass function/method names you would like this rule to ignore, like so:

--- a/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
+++ b/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
@@ -93,6 +93,7 @@ export default util.createRule<Options, MessageIds>({
       allowHigherOrderFunctions: true,
       allowDirectConstAssertionInArrowFunctions: true,
       allowConciseArrowFunctionExpressionsStartingWithVoid: false,
+      allowFunctionsWithoutTypeParameters: false,
       allowedNames: [],
       allowIIFEs: false,
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6465
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

#6105 added the allowFunctionsWithoutTypeParameters option to explicit-function-return-type but didn't add additional documentation that would make it more useful to use; the implicit default value (`false`), and examples of correct and incorrect cases.

This documentation only PR adds the missing pieces.