### PR TITLE
chore: collapse generated snapshots in PR view by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 
 # force github to treat out custom jest snapshot extension as normal jest snapshots
 *.shot linguist-language=Jest-Snapshot
+*.shot linguist-generated


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Per discussion with @JoshuaKGoldberg. This makes snapshots collapsed just like `yarn.lock` changes.