### PR TITLE
test: allow to execute tests on windows

### DIFF
--- a/packages/ast-spec/tests/fixtures.test.ts
+++ b/packages/ast-spec/tests/fixtures.test.ts
@@ -74,7 +74,7 @@ const FIXTURES: readonly Fixture[] = [...VALID_FIXTURES, ...ERROR_FIXTURES].map(
       isError: absolute.includes('/_error_/'),
       isJSX: ext.endsWith('x'),
       name,
-      relative: path.relative(SRC_DIR, absolute).replace(/\\/g, '/'),
+      relative: path.posix.relative(SRC_DIR, absolute),
       segments,
       snapshotFiles: {
         success: {

--- a/packages/ast-spec/tests/fixtures.test.ts
+++ b/packages/ast-spec/tests/fixtures.test.ts
@@ -74,7 +74,7 @@ const FIXTURES: readonly Fixture[] = [...VALID_FIXTURES, ...ERROR_FIXTURES].map(
       isError: absolute.includes('/_error_/'),
       isJSX: ext.endsWith('x'),
       name,
-      relative: path.posix.relative(SRC_DIR, absolute),
+      relative: path.relative(SRC_DIR, absolute).replace(/\\/g, '/'),
       segments,
       snapshotFiles: {
         success: {

--- a/packages/ast-spec/tests/fixtures.test.ts
+++ b/packages/ast-spec/tests/fixtures.test.ts
@@ -38,10 +38,18 @@ const fixturesWithErrorDifferences = {
 } as const;
 
 const VALID_FIXTURES: readonly string[] = glob.sync(
-  `${SRC_DIR}/**/fixtures/*/fixture.{ts,tsx}`,
+  `**/fixtures/*/fixture.{ts,tsx}`,
+  {
+    cwd: SRC_DIR,
+    absolute: true,
+  },
 );
 const ERROR_FIXTURES: readonly string[] = glob.sync(
-  `${SRC_DIR}/**/fixtures/_error_/*/fixture.{ts,tsx}`,
+  `**/fixtures/_error_/*/fixture.{ts,tsx}`,
+  {
+    cwd: SRC_DIR,
+    absolute: true,
+  },
 );
 
 const FIXTURES: readonly Fixture[] = [...VALID_FIXTURES, ...ERROR_FIXTURES].map(
@@ -66,7 +74,7 @@ const FIXTURES: readonly Fixture[] = [...VALID_FIXTURES, ...ERROR_FIXTURES].map(
       isError: absolute.includes('/_error_/'),
       isJSX: ext.endsWith('x'),
       name,
-      relative: path.relative(SRC_DIR, absolute),
+      relative: path.relative(SRC_DIR, absolute).replace(/\\/g, '/'),
       segments,
       snapshotFiles: {
         success: {

--- a/packages/shared-fixtures/fixtures/typescript/basics/type-import-type.src.ts
+++ b/packages/shared-fixtures/fixtures/typescript/basics/type-import-type.src.ts
@@ -1,2 +1,0 @@
-type A = typeof import('A');
-type B = import('B').X<Y>;

--- a/packages/typescript-estree/tests/lib/getProjectConfigFiles.test.ts
+++ b/packages/typescript-estree/tests/lib/getProjectConfigFiles.test.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { ExpiringCache } from '../../src/parseSettings/ExpiringCache';
 import { getProjectConfigFiles } from '../../src/parseSettings/getProjectConfigFiles';
 
@@ -51,12 +53,16 @@ describe('getProjectConfigFiles', () => {
       getProjectConfigFiles(parseSettings, true);
       const actual = getProjectConfigFiles(parseSettings, true);
 
-      expect(actual).toEqual(['repos/repo/packages/package/tsconfig.json']);
+      expect(actual).toEqual([
+        path.normalize('repos/repo/packages/package/tsconfig.json'),
+      ]);
       expect(mockExistsSync).toHaveBeenCalledTimes(1);
     });
 
     it('returns a nearby parent tsconfig.json when it was previously cached by a different directory search', () => {
-      mockExistsSync.mockImplementation(input => input === 'a/tsconfig.json');
+      mockExistsSync.mockImplementation(
+        input => input === path.normalize('a/tsconfig.json'),
+      );
 
       const tsconfigMatchCache = new ExpiringCache<string, string>(1);
 
@@ -81,12 +87,14 @@ describe('getProjectConfigFiles', () => {
         true,
       );
 
-      expect(actual).toEqual(['a/tsconfig.json']);
+      expect(actual).toEqual([path.normalize('a/tsconfig.json')]);
       expect(mockExistsSync).toHaveBeenCalledTimes(4);
     });
 
     it('returns a distant parent tsconfig.json when it was previously cached by a different directory search', () => {
-      mockExistsSync.mockImplementation(input => input === 'a/tsconfig.json');
+      mockExistsSync.mockImplementation(
+        input => input === path.normalize('a/tsconfig.json'),
+      );
 
       const tsconfigMatchCache = new ExpiringCache<string, string>(1);
 
@@ -111,7 +119,7 @@ describe('getProjectConfigFiles', () => {
         true,
       );
 
-      expect(actual).toEqual(['a/tsconfig.json']);
+      expect(actual).toEqual([path.normalize('a/tsconfig.json')]);
       expect(mockExistsSync).toHaveBeenCalledTimes(6);
     });
   });
@@ -122,17 +130,19 @@ describe('getProjectConfigFiles', () => {
 
       const actual = getProjectConfigFiles(parseSettings, true);
 
-      expect(actual).toEqual(['repos/repo/packages/package/tsconfig.json']);
+      expect(actual).toEqual([
+        path.normalize('repos/repo/packages/package/tsconfig.json'),
+      ]);
     });
 
     it('returns a parent tsconfig.json when matched', () => {
       mockExistsSync.mockImplementation(
-        filePath => filePath === 'repos/repo/tsconfig.json',
+        filePath => filePath === path.normalize('repos/repo/tsconfig.json'),
       );
 
       const actual = getProjectConfigFiles(parseSettings, true);
 
-      expect(actual).toEqual(['repos/repo/tsconfig.json']);
+      expect(actual).toEqual([path.normalize('repos/repo/tsconfig.json')]);
     });
 
     it('throws when searching hits .', () => {

--- a/packages/typescript-estree/tests/lib/parse.project-true.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.project-true.test.ts
@@ -42,7 +42,7 @@ describe('parseAndGenerateServices', () => {
           filePath: join(PROJECT_DIR, 'notIncluded.ts'),
         }),
       ).toThrow(
-        /project was set to `true` but couldn't find any tsconfig.json relative to '.+\/tests\/fixtures\/projectTrue\/notIncluded.ts' within '.+\/tests\/fixtures\/projectTrue'./,
+        /project was set to `true` but couldn't find any tsconfig.json relative to '.+[/\\]tests[/\\]fixtures[/\\]projectTrue[/\\]notIncluded.ts' within '.+[/\\]tests[/\\]fixtures[/\\]projectTrue'./,
       );
     });
   });


### PR DESCRIPTION
Partially fix running tests on windows machines, with this change most tests do pass with exception to

https://github.com/typescript-eslint/typescript-eslint/blob/98dec37c407717a0ff1002bf483113d15bbb4958/packages/utils/tests/eslint-utils/rule-tester/RuleTester.test.ts#L146-L188

filename is not correctly normalized in this test, this can be fixed after updating jest to 29.4 with EqualityTesters - https://jestjs.io/docs/expect#expectaddequalitytesterstesters