### PR TITLE
fix(typescript-estree): check for relative/root paths in printing file path errors

### DIFF
--- a/packages/typescript-estree/src/create-program/createProjectProgram.ts
+++ b/packages/typescript-estree/src/create-program/createProjectProgram.ts
@@ -4,6 +4,7 @@ import * as ts from 'typescript';
 
 import { firstDefined } from '../node-utils';
 import type { ParseSettings } from '../parseSettings';
+import { describeFilePath } from './describeFilePath';
 import { getWatchProgramsForProjects } from './getWatchProgramsForProjects';
 import type { ASTAndProgram } from './shared';
 import { getAstFromProgram } from './shared';
@@ -40,19 +41,11 @@ function createProjectProgram(
     return astAndProgram;
   }
 
-  const describeFilePath = (filePath: string): string => {
-    const relative = path.relative(
-      parseSettings.tsconfigRootDir || process.cwd(),
-      filePath,
-    );
-    if (parseSettings.tsconfigRootDir) {
-      return `<tsconfigRootDir>/${relative}`;
-    }
-    return `<cwd>/${relative}`;
-  };
+  const describeProjectFilePath = (projectFile: string): string =>
+    describeFilePath(projectFile, parseSettings.tsconfigRootDir);
 
-  const describedFilePath = describeFilePath(parseSettings.filePath);
-  const relativeProjects = parseSettings.projects.map(describeFilePath);
+  const describedFilePath = describeProjectFilePath(parseSettings.filePath);
+  const relativeProjects = parseSettings.projects.map(describeProjectFilePath);
   const describedPrograms =
     relativeProjects.length === 1
       ? relativeProjects[0]

--- a/packages/typescript-estree/src/create-program/describeFilePath.ts
+++ b/packages/typescript-estree/src/create-program/describeFilePath.ts
@@ -1,0 +1,31 @@
+import path from 'path';
+
+export function describeFilePath(
+  filePath: string,
+  tsconfigRootDir: string,
+): string {
+  // If the TSConfig root dir is a parent of the filePath, use
+  // `<tsconfigRootDir>` as a prefix for the path.
+  const relative = path.relative(tsconfigRootDir, filePath);
+  if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
+    return `<tsconfigRootDir>/${relative}`;
+  }
+
+  // Root-like Mac/Linux (~/*, ~*) or Windows (C:/*, /) paths that aren't
+  // relative to the TSConfig root dir should be fully described.
+  // This avoids strings like <tsconfigRootDir>/../../../../repo/file.ts.
+  // https://github.com/typescript-eslint/typescript-eslint/issues/6289
+  if (/^[(\w+:)\\/~]/.test(filePath)) {
+    return filePath;
+  }
+
+  // Similarly, if the relative path would contain a lot of ../.., then
+  // ignore it and print the file path directly.
+  if (/\.\.[/\\]\.\./.test(relative)) {
+    return filePath;
+  }
+
+  // Lastly, since we've eliminated all special cases, we know the cleanest
+  // path to print is probably the prefixed relative one.
+  return `<tsconfigRootDir>/${relative}`;
+}

--- a/packages/typescript-estree/tests/lib/__snapshots__/describeFilePath.test.ts.snap
+++ b/packages/typescript-estree/tests/lib/__snapshots__/describeFilePath.test.ts.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ./elsewhere/repo/file.ts 1`] = `"./elsewhere/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ./elsewhere/repo/nested/file.ts 1`] = `"./elsewhere/repo/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ./repos/file.ts 1`] = `"<tsconfigRootDir>/../file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ./repos/other/file.ts 1`] = `"<tsconfigRootDir>/../other/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ./repos/repo/file.ts 1`] = `"<tsconfigRootDir>/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ./repos/repo/nested/file.ts 1`] = `"<tsconfigRootDir>/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath /elsewhere/repo/file.ts 1`] = `"/elsewhere/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath /elsewhere/repo/nested/file.ts 1`] = `"/elsewhere/repo/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath /file.ts 1`] = `"/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath /nested/file.ts 1`] = `"/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath /repos/repo/file.ts 1`] = `"/repos/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath /repos/repo/nested/file.ts 1`] = `"/repos/repo/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ~/file.ts 1`] = `"~/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ~/nested/file.ts 1`] = `"~/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ~/nested/file.ts 2`] = `"~/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ~/other/nested/path/to/file.ts 1`] = `"~/other/nested/path/to/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ~/other/repo/file.ts 1`] = `"~/other/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ~/repos/file.ts 1`] = `"~/repos/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ~/repos/other/file.ts 1`] = `"~/repos/other/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ~/repos/other/nested/file.ts 1`] = `"~/repos/other/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ~/repos/repo/file.ts 1`] = `"~/repos/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ~/repos/repo/nestedfile.ts 1`] = `"~/repos/repo/nestedfile.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath A:/file.ts 1`] = `"A:/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath A:/nested/file.ts 1`] = `"A:/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath ABC:/file.ts 1`] = `"ABC:/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath C:/file.ts 1`] = `"C:/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath file.ts 1`] = `"file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ./repos/repo filePath nested/file.ts 1`] = `"nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ./elsewhere/repo/file.ts 1`] = `"./elsewhere/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ./elsewhere/repo/nested/file.ts 1`] = `"./elsewhere/repo/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ./repos/file.ts 1`] = `"./repos/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ./repos/other/file.ts 1`] = `"./repos/other/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ./repos/repo/file.ts 1`] = `"./repos/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ./repos/repo/nested/file.ts 1`] = `"./repos/repo/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath /elsewhere/repo/file.ts 1`] = `"/elsewhere/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath /elsewhere/repo/nested/file.ts 1`] = `"/elsewhere/repo/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath /file.ts 1`] = `"/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath /nested/file.ts 1`] = `"/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath /repos/repo/file.ts 1`] = `"<tsconfigRootDir>/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath /repos/repo/nested/file.ts 1`] = `"<tsconfigRootDir>/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ~/file.ts 1`] = `"~/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ~/nested/file.ts 1`] = `"~/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ~/nested/file.ts 2`] = `"~/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ~/other/nested/path/to/file.ts 1`] = `"~/other/nested/path/to/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ~/other/repo/file.ts 1`] = `"~/other/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ~/repos/file.ts 1`] = `"~/repos/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ~/repos/other/file.ts 1`] = `"~/repos/other/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ~/repos/other/nested/file.ts 1`] = `"~/repos/other/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ~/repos/repo/file.ts 1`] = `"~/repos/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ~/repos/repo/nestedfile.ts 1`] = `"~/repos/repo/nestedfile.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath A:/file.ts 1`] = `"A:/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath A:/nested/file.ts 1`] = `"A:/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath ABC:/file.ts 1`] = `"ABC:/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath C:/file.ts 1`] = `"C:/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath file.ts 1`] = `"file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir /repos/repo filePath nested/file.ts 1`] = `"nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ./elsewhere/repo/file.ts 1`] = `"./elsewhere/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ./elsewhere/repo/nested/file.ts 1`] = `"./elsewhere/repo/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ./repos/file.ts 1`] = `"./repos/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ./repos/other/file.ts 1`] = `"./repos/other/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ./repos/repo/file.ts 1`] = `"./repos/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ./repos/repo/nested/file.ts 1`] = `"./repos/repo/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath /elsewhere/repo/file.ts 1`] = `"/elsewhere/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath /elsewhere/repo/nested/file.ts 1`] = `"/elsewhere/repo/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath /file.ts 1`] = `"/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath /nested/file.ts 1`] = `"/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath /repos/repo/file.ts 1`] = `"/repos/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath /repos/repo/nested/file.ts 1`] = `"/repos/repo/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ~/file.ts 1`] = `"~/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ~/nested/file.ts 1`] = `"~/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ~/nested/file.ts 2`] = `"~/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ~/other/nested/path/to/file.ts 1`] = `"~/other/nested/path/to/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ~/other/repo/file.ts 1`] = `"~/other/repo/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ~/repos/file.ts 1`] = `"~/repos/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ~/repos/other/file.ts 1`] = `"~/repos/other/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ~/repos/other/nested/file.ts 1`] = `"~/repos/other/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ~/repos/repo/file.ts 1`] = `"<tsconfigRootDir>/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ~/repos/repo/nestedfile.ts 1`] = `"<tsconfigRootDir>/nestedfile.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath A:/file.ts 1`] = `"A:/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath A:/nested/file.ts 1`] = `"A:/nested/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath ABC:/file.ts 1`] = `"ABC:/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath C:/file.ts 1`] = `"C:/file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath file.ts 1`] = `"file.ts"`;
+
+exports[`describeFilePath tsconfigRootDir ~/repos/repo filePath nested/file.ts 1`] = `"nested/file.ts"`;

--- a/packages/typescript-estree/tests/lib/describeFilePath.test.ts
+++ b/packages/typescript-estree/tests/lib/describeFilePath.test.ts
@@ -1,0 +1,41 @@
+import { describeFilePath } from '../../src/create-program/describeFilePath';
+
+describe('describeFilePath', () => {
+  describe.each(['./repos/repo', '/repos/repo', '~/repos/repo'])(
+    'tsconfigRootDir %s',
+    tsconfigRootDir => {
+      test.each([
+        './elsewhere/repo/file.ts',
+        './elsewhere/repo/nested/file.ts',
+        './repos/file.ts',
+        './repos/other/file.ts',
+        './repos/repo/file.ts',
+        './repos/repo/nested/file.ts',
+        '/elsewhere/repo/file.ts',
+        '/elsewhere/repo/nested/file.ts',
+        '/file.ts',
+        '/nested/file.ts',
+        '/repos/repo/file.ts',
+        '/repos/repo/nested/file.ts',
+        '~/file.ts',
+        '~/nested/file.ts',
+        '~/nested/file.ts',
+        '~/other/nested/path/to/file.ts',
+        '~/other/repo/file.ts',
+        '~/repos/file.ts',
+        '~/repos/other/file.ts',
+        '~/repos/other/nested/file.ts',
+        '~/repos/repo/file.ts',
+        '~/repos/repo/nestedfile.ts',
+        'A:/file.ts',
+        'A:/nested/file.ts',
+        'ABC:/file.ts',
+        'C:/file.ts',
+        'file.ts',
+        'nested/file.ts',
+      ])('filePath %s', filePath => {
+        expect(describeFilePath(filePath, tsconfigRootDir)).toMatchSnapshot();
+      });
+    },
+  );
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6289
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Completely eschews `process.cwd()` detection _(which already wasn't relevant anyway, as `tsconfigRootDir` defaults to `process.cwd()`!)_ in favor of checking whether the `tsconfigRootDir` against the printed `filePath`. 

This means that the nice <code>\`\<tsconfigRootDir\>/\`</code> prefix now only shows up when the `tsconfigRootDir` is a complete starter for the path. Siblings and distance parents will no longer show up.