### PR TITLE
docs: mention re-requesting PR reviews

### DIFF
--- a/docs/contributing/Pull_Requests.mdx
+++ b/docs/contributing/Pull_Requests.mdx
@@ -74,4 +74,7 @@ We generally review PRs oldest to newest, unless we consider a newer PR higher p
 
 Once we have reviewed your PR, we will provide any feedback that needs addressing.
 If you feel a requested change is wrong, don't be afraid to discuss with us in the comments.
-Once the feedback is addressed, and the PR is reviewed, we'll ensure the branch is up to date with `main`, and merge it for you.
+
+Once you've addressed all our feedback by making code changes and/or started a followup discussion, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) from each maintainer whose feedback you addressed.
+
+Once the feedback is addressed, and the PR is approved, we'll ensure the branch is up to date with `main`, and merge it for you.

--- a/docs/contributing/Pull_Requests.mdx
+++ b/docs/contributing/Pull_Requests.mdx
@@ -75,6 +75,9 @@ We generally review PRs oldest to newest, unless we consider a newer PR higher p
 Once we have reviewed your PR, we will provide any feedback that needs addressing.
 If you feel a requested change is wrong, don't be afraid to discuss with us in the comments.
 
+Please post comments as [line comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request) when possible, so that they can be threaded.
+You can [resolve conversations](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#resolving-conversations) on your own when you feel they're resolved - no need to comment explicitly and/or wait for a maintainer.
+
 Once you've addressed all our feedback by making code changes and/or started a followup discussion, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) from each maintainer whose feedback you addressed.
 
 Once the feedback is addressed, and the PR is approved, we'll ensure the branch is up to date with `main`, and merge it for you.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6492
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a mention about re-requesting review with a link to the GitHub docs. This way it's not ambiguous whether folks should wait for us.