### PR TITLE
chore: hardcode v6 branch name in v6 canary publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
     name: Publish the next major version code as a canary version
     runs-on: ubuntu-latest
     needs: [integration_tests, lint_with_build, lint_without_build, unit_tests]
-    if: github.ref == 'refs/heads/v${major}'
+    if: github.ref == 'refs/heads/v6'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6511
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Not sure if this is why the job is being skipped.

If this is the right fix, we'll want to update https://typescript-eslint.io/maintenance/releases#1-pre-release-preparation too.