### PR TITLE
fix(typescript-estree): do not call export of clearProgramCache

### DIFF
--- a/packages/typescript-estree/src/clear-caches.ts
+++ b/packages/typescript-estree/src/clear-caches.ts
@@ -18,4 +18,4 @@ export function clearCaches(): void {
 }
 
 // TODO - delete this in next major
-export const clearProgramCache = clearCaches();
+export const clearProgramCache = clearCaches;


### PR DESCRIPTION
Calling it exports `undefined` instead of making it an alias of `clearCaches`, which I believe was the intent.

On DefinitelyTyped, [I worked around the problem](https://github.com/microsoft/DefinitelyTyped-tools/pull/620); clearProgramCaches isn't needed now anyway.
