### PR TITLE
feat(typescript-estree): lazily compute loc

### DIFF
--- a/packages/typescript-estree/src/convert-comments.ts
+++ b/packages/typescript-estree/src/convert-comments.ts
@@ -26,7 +26,6 @@ export function convertComments(
           ? AST_TOKEN_TYPES.Line
           : AST_TOKEN_TYPES.Block;
       const range: TSESTree.Range = [comment.pos, comment.end];
-      const loc = getLocFor(range[0], range[1], ast);
 
       // both comments start with 2 characters - /* or //
       const textStart = range[0] + 2;
@@ -40,7 +39,7 @@ export function convertComments(
         type,
         value: code.slice(textStart, textStart + textEnd),
         range,
-        loc,
+        loc: getLocFor(range[0], range[1], ast),
       });
     },
     ast,

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -3,7 +3,7 @@
 import * as ts from 'typescript';
 
 import { getDecorators, getModifiers } from './getModifiers';
-import type { TSError } from './node-utils';
+import type { OptionalRangeAndLoc, TSError } from './node-utils';
 import {
   canContainDirective,
   createError,
@@ -251,7 +251,7 @@ export class Converter {
 
   private createNode<T extends TSESTree.Node = TSESTree.Node>(
     node: TSESTreeToTSNode<T>,
-    data: TSESTree.OptionalRangeAndLoc<T>,
+    data: OptionalRangeAndLoc<T>,
   ): T {
     const result = data;
     if (!result.range) {
@@ -2820,7 +2820,7 @@ export class Converter {
                 id,
                 body,
                 global: true,
-              } satisfies TSESTree.OptionalRangeAndLoc<
+              } satisfies OptionalRangeAndLoc<
                 Omit<TSESTree.TSModuleDeclarationGlobal, 'type'>
               >;
             } else if (node.flags & ts.NodeFlags.Namespace) {
@@ -2834,7 +2834,7 @@ export class Converter {
                 kind: 'namespace',
                 id,
                 body,
-              } satisfies TSESTree.OptionalRangeAndLoc<
+              } satisfies OptionalRangeAndLoc<
                 Omit<TSESTree.TSModuleDeclarationNamespace, 'type'>
               >;
             } else {
@@ -2842,7 +2842,7 @@ export class Converter {
                 kind: 'module',
                 id,
                 ...(body != null ? { body } : {}),
-              } satisfies TSESTree.OptionalRangeAndLoc<
+              } satisfies OptionalRangeAndLoc<
                 Omit<TSESTree.TSModuleDeclarationModule, 'type'>
               >;
             }

--- a/packages/typescript-estree/src/simple-traverse.ts
+++ b/packages/typescript-estree/src/simple-traverse.ts
@@ -13,7 +13,8 @@ function getVisitorKeysForNode(
   node: TSESTree.Node,
 ): readonly (keyof TSESTree.Node)[] {
   const keys = allVisitorKeys[node.type];
-  return (keys ?? []) as never;
+  // @ts-expect-error -- keys will provably be of the correct type - it's just not possible to type
+  return keys ?? [];
 }
 
 type SimpleTraverseOptions =


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: #6366

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR changes our AST conversion to lazily compute the `.loc` for all nodes, comments, and tokens.

TS does not compute node location during the parsing sequence. This means that in order to calculate the location, we need to ask TS to convert the range to a location - which involves doing a binary search of the line:range mapping.

Ideally TS would calculate and store these as it goes - but understandably they don't because TS doesn't need the information for the most part!

## Perf Result

This change reduces time spent in `getLineAndCharacterFor` in our codebase from 231ms to 68ms, however the time spent in `astConverter` was mostly a neutral change - suggesting that the code of just declaring the getters and setters cost the same as the time saved.

I'm really surprised that accessors are so expensive to define. Really sad that this is a dead end. I'm putting this up and closing it immediately just so there's a clear log of things for people to see.