### PR TITLE
docs: fix typo in troubleshooting anchor link

### DIFF
--- a/docs/linting/Troubleshooting.mdx
+++ b/docs/linting/Troubleshooting.mdx
@@ -243,7 +243,7 @@ See [this issue comment](https://github.com/typescript-eslint/typescript-eslint/
 
 ### I get `no-unsafe-*` complaints for cross-file changes
 
-See [Changes to one file are not reflected in linting other files in my IDE](#changes-to-one-file-are-not-reflected-in-linting-other-files-in-my-ide).
+See [Changes to one file are not reflected in linting other files in my IDE](#changes-to-one-file-are-not-reflected-when-linting-other-files-in-my-ide).
 Rules such as [`no-unsafe-argument`](https://typescript-eslint.io/rules/no-unsafe-argument), [`no-unsafe-assignment`](https://typescript-eslint.io/rules/no-unsafe-assignment), and [`no-unsafe-call`](https://typescript-eslint.io/rules/no-unsafe-call) are often impacted.
 
 ## My linting feels really slow


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The first link is broken in the section [I get no-unsafe-* complaints for cross-file changes](https://typescript-eslint.io/linting/troubleshooting/#i-get-no-unsafe--complaints-for-cross-file-changes) from the troubleshooting page.