### PR TITLE
test(ast-spec): snapshot codeframe of error

### DIFF
--- a/packages/ast-spec/package.json
+++ b/packages/ast-spec/package.json
@@ -46,6 +46,7 @@
     "@babel/core": "*",
     "@babel/eslint-parser": "*",
     "@babel/parser": "*",
+    "@babel/code-frame": "*",
     "@microsoft/api-extractor": "^7.23.2",
     "@types/babel__core": "*",
     "glob": "*",

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/_error_/missing-body/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/_error_/missing-body/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ClassDeclaration _error_ missing-body TSESTree - Error 1`] = `[TSError: '{' expected.]`;
+exports[`AST Fixtures declaration ClassDeclaration _error_ missing-body TSESTree - Error 1`] = `
+"TSError
+> 1 | class Foo;
+    |          ^ '{' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ClassDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `[TSError: '{' expected.]`;
+exports[`AST Fixtures declaration ClassDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `
+"TSError
+> 1 | class 'Foo' {}
+    |       ^ '{' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/_error_/non-identifier-type-param/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/_error_/non-identifier-type-param/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ClassDeclaration _error_ non-identifier-type-param TSESTree - Error 1`] = `[TSError: Type parameter declaration expected.]`;
+exports[`AST Fixtures declaration ClassDeclaration _error_ non-identifier-type-param TSESTree - Error 1`] = `
+"TSError
+> 1 | class C<1> {}
+    |         ^ Type parameter declaration expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportAllDeclaration/fixtures/_error_/missing-source/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportAllDeclaration/fixtures/_error_/missing-source/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportAllDeclaration _error_ missing-source TSESTree - Error 1`] = `[TSError: Expression expected.]`;
+exports[`AST Fixtures declaration ExportAllDeclaration _error_ missing-source TSESTree - Error 1`] = `
+"TSError
+> 1 | export * from;
+    |              ^ Expression expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportAllDeclaration/fixtures/_error_/named-non-identifier/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportAllDeclaration/fixtures/_error_/named-non-identifier/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportAllDeclaration _error_ named-non-identifier TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration ExportAllDeclaration _error_ named-non-identifier TSESTree - Error 1`] = `
+"TSError
+> 1 | export * as 'foo' from 'module';
+    |             ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportAllDeclaration/fixtures/_error_/non-string-source/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportAllDeclaration/fixtures/_error_/non-string-source/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportAllDeclaration _error_ non-string-source TSESTree - Error 1`] = `[TSError: Module specifier must be a string literal.]`;
+exports[`AST Fixtures declaration ExportAllDeclaration _error_ non-string-source TSESTree - Error 1`] = `
+"TSError
+> 1 | export * from module;
+    |              ^ Module specifier must be a string literal.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportDefaultDeclaration/fixtures/_error_/enum/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportDefaultDeclaration/fixtures/_error_/enum/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportDefaultDeclaration _error_ enum TSESTree - Error 1`] = `[TSError: Expression expected.]`;
+exports[`AST Fixtures declaration ExportDefaultDeclaration _error_ enum TSESTree - Error 1`] = `
+"TSError
+> 1 | export default enum Foo {}
+    |                ^ Expression expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportDefaultDeclaration/fixtures/_error_/namespace/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportDefaultDeclaration/fixtures/_error_/namespace/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportDefaultDeclaration _error_ namespace TSESTree - Error 1`] = `[TSError: ';' expected.]`;
+exports[`AST Fixtures declaration ExportDefaultDeclaration _error_ namespace TSESTree - Error 1`] = `
+"TSError
+> 1 | export default namespace Foo {}
+    |                          ^ ';' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportDefaultDeclaration/fixtures/_error_/type-alias/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportDefaultDeclaration/fixtures/_error_/type-alias/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportDefaultDeclaration _error_ type-alias TSESTree - Error 1`] = `[TSError: ';' expected.]`;
+exports[`AST Fixtures declaration ExportDefaultDeclaration _error_ type-alias TSESTree - Error 1`] = `
+"TSError
+> 1 | export default type Foo = 1;
+    |                     ^ ';' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportDefaultDeclaration/fixtures/_error_/variable-declaration/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportDefaultDeclaration/fixtures/_error_/variable-declaration/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportDefaultDeclaration _error_ variable-declaration TSESTree - Error 1`] = `[TSError: Expression expected.]`;
+exports[`AST Fixtures declaration ExportDefaultDeclaration _error_ variable-declaration TSESTree - Error 1`] = `
+"TSError
+> 1 | export default const x = 1;
+    |                ^ Expression expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/aliased-literal/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/aliased-literal/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportNamedDeclaration _error_ aliased-literal TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration ExportNamedDeclaration _error_ aliased-literal TSESTree - Error 1`] = `
+"TSError
+> 1 | export { a as 'a' };
+    |               ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/anonymous-function-expression/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/anonymous-function-expression/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportNamedDeclaration _error_ anonymous-function-expression TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration ExportNamedDeclaration _error_ anonymous-function-expression TSESTree - Error 1`] = `
+"TSError
+> 1 | export function () {}
+    |                 ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/arrow-function/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/arrow-function/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportNamedDeclaration _error_ arrow-function TSESTree - Error 1`] = `[TSError: Declaration or statement expected.]`;
+exports[`AST Fixtures declaration ExportNamedDeclaration _error_ arrow-function TSESTree - Error 1`] = `
+"TSError
+> 1 | export () => {};
+    | ^ Declaration or statement expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/class-expression/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/class-expression/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportNamedDeclaration _error_ class-expression TSESTree - Error 1`] = `[TSError: Declaration or statement expected.]`;
+exports[`AST Fixtures declaration ExportNamedDeclaration _error_ class-expression TSESTree - Error 1`] = `
+"TSError
+> 1 | export (class Foo {});
+    | ^ Declaration or statement expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/identifier-direct/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/identifier-direct/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportNamedDeclaration _error_ identifier-direct TSESTree - Error 1`] = `[TSError: Declaration or statement expected.]`;
+exports[`AST Fixtures declaration ExportNamedDeclaration _error_ identifier-direct TSESTree - Error 1`] = `
+"TSError
+> 1 | export a;
+    | ^ Declaration or statement expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/literal-braced/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/literal-braced/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportNamedDeclaration _error_ literal-braced TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration ExportNamedDeclaration _error_ literal-braced TSESTree - Error 1`] = `
+"TSError
+> 1 | export { 'a' };
+    |          ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/literal-direct/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ExportNamedDeclaration/fixtures/_error_/literal-direct/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ExportNamedDeclaration _error_ literal-direct TSESTree - Error 1`] = `[TSError: Declaration or statement expected.]`;
+exports[`AST Fixtures declaration ExportNamedDeclaration _error_ literal-direct TSESTree - Error 1`] = `
+"TSError
+> 1 | export 'a';
+    | ^ Declaration or statement expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/FunctionDeclaration/fixtures/_error_/missing-id-and-not-exported/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/FunctionDeclaration/fixtures/_error_/missing-id-and-not-exported/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration FunctionDeclaration _error_ missing-id-and-not-exported TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration FunctionDeclaration _error_ missing-id-and-not-exported TSESTree - Error 1`] = `
+"TSError
+> 1 | function () {}
+    |          ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/FunctionDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/FunctionDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration FunctionDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration FunctionDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `
+"TSError
+> 1 | function 1() {}
+    |          ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/FunctionDeclaration/fixtures/_error_/non-identifier-type-param/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/FunctionDeclaration/fixtures/_error_/non-identifier-type-param/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration FunctionDeclaration _error_ non-identifier-type-param TSESTree - Error 1`] = `[TSError: Type parameter declaration expected.]`;
+exports[`AST Fixtures declaration FunctionDeclaration _error_ non-identifier-type-param TSESTree - Error 1`] = `
+"TSError
+> 1 | function foo<1>() {}
+    |              ^ Type parameter declaration expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/default-non-identifier/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/default-non-identifier/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ImportDeclaration _error_ default-non-identifier TSESTree - Error 1`] = `[TSError: Declaration or statement expected.]`;
+exports[`AST Fixtures declaration ImportDeclaration _error_ default-non-identifier TSESTree - Error 1`] = `
+"TSError
+> 1 | import 1 from 'mod';
+    | ^ Declaration or statement expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/named-and-namespace/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/named-and-namespace/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ImportDeclaration _error_ named-and-namespace TSESTree - Error 1`] = `[TSError: 'from' expected.]`;
+exports[`AST Fixtures declaration ImportDeclaration _error_ named-and-namespace TSESTree - Error 1`] = `
+"TSError
+> 1 | import { b }, * as a from 'a';
+    |             ^ 'from' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/named-non-identifier/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/named-non-identifier/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ImportDeclaration _error_ named-non-identifier TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration ImportDeclaration _error_ named-non-identifier TSESTree - Error 1`] = `
+"TSError
+> 1 | import { 1 } from 'mod';
+    |          ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/namespace-and-default/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/namespace-and-default/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ImportDeclaration _error_ namespace-and-default TSESTree - Error 1`] = `[TSError: 'from' expected.]`;
+exports[`AST Fixtures declaration ImportDeclaration _error_ namespace-and-default TSESTree - Error 1`] = `
+"TSError
+> 1 | import * as b, a from 'mod';
+    |              ^ 'from' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/namespace-and-named/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/namespace-and-named/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ImportDeclaration _error_ namespace-and-named TSESTree - Error 1`] = `[TSError: 'from' expected.]`;
+exports[`AST Fixtures declaration ImportDeclaration _error_ namespace-and-named TSESTree - Error 1`] = `
+"TSError
+> 1 | import * as a, { b } from 'a';
+    |              ^ 'from' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/namespace-and-namespace/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/namespace-and-namespace/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ImportDeclaration _error_ namespace-and-namespace TSESTree - Error 1`] = `[TSError: 'from' expected.]`;
+exports[`AST Fixtures declaration ImportDeclaration _error_ namespace-and-namespace TSESTree - Error 1`] = `
+"TSError
+> 1 | import * as a, * as b from 'a';
+    |              ^ 'from' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/namespace-non-identifier/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/namespace-non-identifier/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ImportDeclaration _error_ namespace-non-identifier TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration ImportDeclaration _error_ namespace-non-identifier TSESTree - Error 1`] = `
+"TSError
+> 1 | import * as 1 from 'mod';
+    |             ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/non-string-source/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/non-string-source/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration ImportDeclaration _error_ non-string-source TSESTree - Error 1`] = `[TSError: Module specifier must be a string literal.]`;
+exports[`AST Fixtures declaration ImportDeclaration _error_ non-string-source TSESTree - Error 1`] = `
+"TSError
+> 1 | import * as x from module;
+    |                   ^ Module specifier must be a string literal.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSDeclareFunction/fixtures/_error_/missing-id-and-not-exported/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSDeclareFunction/fixtures/_error_/missing-id-and-not-exported/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSDeclareFunction _error_ missing-id-and-not-exported TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration TSDeclareFunction _error_ missing-id-and-not-exported TSESTree - Error 1`] = `
+"TSError
+> 1 | declare function ();
+    |                  ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSDeclareFunction/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSDeclareFunction/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSDeclareFunction _error_ non-identifier-name TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration TSDeclareFunction _error_ non-identifier-name TSESTree - Error 1`] = `
+"TSError
+> 1 | declare function 1();
+    |                  ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSDeclareFunction/fixtures/_error_/non-identifier-type-param/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSDeclareFunction/fixtures/_error_/non-identifier-type-param/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSDeclareFunction _error_ non-identifier-type-param TSESTree - Error 1`] = `[TSError: Type parameter declaration expected.]`;
+exports[`AST Fixtures declaration TSDeclareFunction _error_ non-identifier-type-param TSESTree - Error 1`] = `
+"TSError
+> 1 | declare function f<1>(): void;
+    |                    ^ Type parameter declaration expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSEnumDeclaration/fixtures/_error_/missing-body/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSEnumDeclaration/fixtures/_error_/missing-body/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSEnumDeclaration _error_ missing-body TSESTree - Error 1`] = `[TSError: '{' expected.]`;
+exports[`AST Fixtures declaration TSEnumDeclaration _error_ missing-body TSESTree - Error 1`] = `
+"TSError
+> 1 | enum Foo;
+    |         ^ '{' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSEnumDeclaration/fixtures/_error_/missing-id/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSEnumDeclaration/fixtures/_error_/missing-id/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSEnumDeclaration _error_ missing-id TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration TSEnumDeclaration _error_ missing-id TSESTree - Error 1`] = `
+"TSError
+> 1 | enum {}
+    |      ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSEnumDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSEnumDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSEnumDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration TSEnumDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `
+"TSError
+> 1 | enum 1 {}
+    |      ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/entity-name-invalid/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/entity-name-invalid/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ entity-name-invalid TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ entity-name-invalid TSESTree - Error 1`] = `
+"TSError
+> 1 | import F = 1;
+    |            ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/missing-id/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/missing-id/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ missing-id TSESTree - Error 1`] = `[TSError: Declaration or statement expected.]`;
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ missing-id TSESTree - Error 1`] = `
+"TSError
+> 1 | import = A.B;
+    | ^ Declaration or statement expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/missing-reference/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/missing-reference/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ missing-reference TSESTree - Error 1`] = `[TSError: '=' expected.]`;
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ missing-reference TSESTree - Error 1`] = `
+"TSError
+> 1 | import F;
+    |         ^ '=' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSInterfaceDeclaration/fixtures/_error_/missing-body/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSInterfaceDeclaration/fixtures/_error_/missing-body/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSInterfaceDeclaration _error_ missing-body TSESTree - Error 1`] = `[TSError: '{' expected.]`;
+exports[`AST Fixtures declaration TSInterfaceDeclaration _error_ missing-body TSESTree - Error 1`] = `
+"TSError
+> 1 | interface F;
+    |            ^ '{' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSInterfaceDeclaration/fixtures/_error_/missing-id/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSInterfaceDeclaration/fixtures/_error_/missing-id/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSInterfaceDeclaration _error_ missing-id TSESTree - Error 1`] = `[TSError: Interface must be given a name.]`;
+exports[`AST Fixtures declaration TSInterfaceDeclaration _error_ missing-id TSESTree - Error 1`] = `
+"TSError
+> 1 | interface {}
+    |           ^ Interface must be given a name.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSInterfaceDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSInterfaceDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSInterfaceDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `[TSError: Interface name cannot be '1'.]`;
+exports[`AST Fixtures declaration TSInterfaceDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `
+"TSError
+> 1 | interface 1 {}
+    |           ^ Interface name cannot be '1'.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSInterfaceDeclaration/fixtures/_error_/non-identifier-type-param/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSInterfaceDeclaration/fixtures/_error_/non-identifier-type-param/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSInterfaceDeclaration _error_ non-identifier-type-param TSESTree - Error 1`] = `[TSError: Type parameter declaration expected.]`;
+exports[`AST Fixtures declaration TSInterfaceDeclaration _error_ non-identifier-type-param TSESTree - Error 1`] = `
+"TSError
+> 1 | interface F<1> {}
+    |             ^ Type parameter declaration expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/module-invalid-id/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/module-invalid-id/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSModuleDeclaration _error_ module-invalid-id TSESTree - Error 1`] = `[TSError: Namespace name cannot be '1'.]`;
+exports[`AST Fixtures declaration TSModuleDeclaration _error_ module-invalid-id TSESTree - Error 1`] = `
+"TSError
+> 1 | module 1 {}
+    |        ^ Namespace name cannot be '1'.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/module-missing-body/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/module-missing-body/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSModuleDeclaration _error_ module-missing-body TSESTree - Error 1`] = `[TSError: '{' expected.]`;
+exports[`AST Fixtures declaration TSModuleDeclaration _error_ module-missing-body TSESTree - Error 1`] = `
+"TSError
+> 1 | module F;
+    |         ^ '{' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/namespace-declare-no-body/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/namespace-declare-no-body/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSModuleDeclaration _error_ namespace-declare-no-body TSESTree - Error 1`] = `[TSError: '{' expected.]`;
+exports[`AST Fixtures declaration TSModuleDeclaration _error_ namespace-declare-no-body TSESTree - Error 1`] = `
+"TSError
+> 1 | declare namespace F;
+    |                    ^ '{' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/namespace-id-literal/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/namespace-id-literal/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSModuleDeclaration _error_ namespace-id-literal TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration TSModuleDeclaration _error_ namespace-id-literal TSESTree - Error 1`] = `
+"TSError
+> 1 | namespace 'a' {}
+    |           ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/namespace-invalid-id/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/namespace-invalid-id/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSModuleDeclaration _error_ namespace-invalid-id TSESTree - Error 1`] = `[TSError: Namespace name cannot be '1'.]`;
+exports[`AST Fixtures declaration TSModuleDeclaration _error_ namespace-invalid-id TSESTree - Error 1`] = `
+"TSError
+> 1 | namespace 1 {}
+    |           ^ Namespace name cannot be '1'.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/namespace-no-body/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSModuleDeclaration/fixtures/_error_/namespace-no-body/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSModuleDeclaration _error_ namespace-no-body TSESTree - Error 1`] = `[TSError: '{' expected.]`;
+exports[`AST Fixtures declaration TSModuleDeclaration _error_ namespace-no-body TSESTree - Error 1`] = `
+"TSError
+> 1 | namespace F;
+    |            ^ '{' expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSNamespaceExportDeclaration/fixtures/_error_/missing-id/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSNamespaceExportDeclaration/fixtures/_error_/missing-id/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSNamespaceExportDeclaration _error_ missing-id TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration TSNamespaceExportDeclaration _error_ missing-id TSESTree - Error 1`] = `
+"TSError
+> 1 | export as namespace;
+    |                    ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSNamespaceExportDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSNamespaceExportDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSNamespaceExportDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `[TSError: Identifier expected.]`;
+exports[`AST Fixtures declaration TSNamespaceExportDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `
+"TSError
+> 1 | export as namespace 1;
+    |                     ^ Identifier expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSTypeAliasDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSTypeAliasDeclaration/fixtures/_error_/non-identifier-name/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSTypeAliasDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `[TSError: Type alias name cannot be '1'.]`;
+exports[`AST Fixtures declaration TSTypeAliasDeclaration _error_ non-identifier-name TSESTree - Error 1`] = `
+"TSError
+> 1 | type 1 = 2;
+    |      ^ Type alias name cannot be '1'.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSTypeAliasDeclaration/fixtures/_error_/non-identifier-type-parameter/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSTypeAliasDeclaration/fixtures/_error_/non-identifier-type-parameter/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSTypeAliasDeclaration _error_ non-identifier-type-parameter TSESTree - Error 1`] = `[TSError: Type parameter declaration expected.]`;
+exports[`AST Fixtures declaration TSTypeAliasDeclaration _error_ non-identifier-type-parameter TSESTree - Error 1`] = `
+"TSError
+> 1 | type T<1> = 2;
+    |        ^ Type parameter declaration expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/VariableDeclaration/fixtures/_error_/missing-id-with-value/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/VariableDeclaration/fixtures/_error_/missing-id-with-value/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration VariableDeclaration _error_ missing-id-with-value TSESTree - Error 1`] = `[TSError: Variable declaration expected.]`;
+exports[`AST Fixtures declaration VariableDeclaration _error_ missing-id-with-value TSESTree - Error 1`] = `
+"TSError
+> 1 | const = 1;
+    |       ^ Variable declaration expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/legacy-fixtures/basics/fixtures/_error_/class-with-export-parameter-properties/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/legacy-fixtures/basics/fixtures/_error_/class-with-export-parameter-properties/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures legacy-fixtures basics _error_ class-with-export-parameter-properties TSESTree - Error 1`] = `[TSError: A parameter cannot have an export modifier.]`;
+exports[`AST Fixtures legacy-fixtures basics _error_ class-with-export-parameter-properties TSESTree - Error 1`] = `
+"TSError
+  2 |
+  3 | class Foo {
+> 4 |     constructor(export a: string) {
+    |                 ^ A parameter cannot have an export modifier.
+  5 |
+  6 |     }
+  7 | }"
+`;

--- a/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/interface-index-signature-export/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/interface-index-signature-export/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures legacy-fixtures errorRecovery _error_ interface-index-signature-export TSESTree - Error 1`] = `[TSError: An index signature cannot have an export modifier.]`;
+exports[`AST Fixtures legacy-fixtures errorRecovery _error_ interface-index-signature-export TSESTree - Error 1`] = `
+"TSError
+  1 | // TODO: This fixture might be too large, and if so should be split up.
+  2 |
+> 3 | interface Foo {
+    |                ^ An index signature cannot have an export modifier.
+  4 |   export [baz: string]: string;
+  5 | }
+  6 |"
+`;

--- a/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/interface-method-export/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/interface-method-export/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures legacy-fixtures errorRecovery _error_ interface-method-export TSESTree - Error 1`] = `[TSError: A method signature cannot have an export modifier.]`;
+exports[`AST Fixtures legacy-fixtures errorRecovery _error_ interface-method-export TSESTree - Error 1`] = `
+"TSError
+  1 | // TODO: This fixture might be too large, and if so should be split up.
+  2 |
+> 3 | interface Foo {
+    |                ^ A method signature cannot have an export modifier.
+  4 |     export g(bar: string): void;
+  5 | }
+  6 |"
+`;

--- a/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/interface-property-export/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/interface-property-export/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures legacy-fixtures errorRecovery _error_ interface-property-export TSESTree - Error 1`] = `[TSError: A property signature cannot have an export modifier.]`;
+exports[`AST Fixtures legacy-fixtures errorRecovery _error_ interface-property-export TSESTree - Error 1`] = `
+"TSError
+  1 | // TODO: This fixture might be too large, and if so should be split up.
+  2 |
+> 3 | interface Foo {
+    |                ^ A property signature cannot have an export modifier.
+  4 |   export a: string;
+  5 | }
+  6 |"
+`;

--- a/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/interface-property-with-default-value/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/interface-property-with-default-value/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures legacy-fixtures errorRecovery _error_ interface-property-with-default-value TSESTree - Error 1`] = `[TSError: A property signature cannot have an initializer.]`;
+exports[`AST Fixtures legacy-fixtures errorRecovery _error_ interface-property-with-default-value TSESTree - Error 1`] = `
+"TSError
+  1 | // TODO: This fixture might be too large, and if so should be split up.
+  2 |
+> 3 | interface Foo {
+    |                ^ A property signature cannot have an initializer.
+  4 |   bar: string = 'a';
+  5 | }
+  6 |"
+`;

--- a/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/interface-with-no-body/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/interface-with-no-body/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures legacy-fixtures errorRecovery _error_ interface-with-no-body TSESTree - Error 1`] = `[TSError: '{' expected.]`;
+exports[`AST Fixtures legacy-fixtures errorRecovery _error_ interface-with-no-body TSESTree - Error 1`] = `
+"TSError
+  2 |
+  3 | interface Foo
+> 4 |
+    | ^ '{' expected."
+`;

--- a/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/object-assertion-not-allowed/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/object-assertion-not-allowed/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures legacy-fixtures errorRecovery _error_ object-assertion-not-allowed TSESTree - Error 1`] = `[TSError: A shorthand property assignment cannot have an exclamation token.]`;
+exports[`AST Fixtures legacy-fixtures errorRecovery _error_ object-assertion-not-allowed TSESTree - Error 1`] = `
+"TSError
+  1 | // TODO: This fixture might be too large, and if so should be split up.
+  2 |
+> 3 | ({a!} = {})
+    |   ^ A shorthand property assignment cannot have an exclamation token.
+  4 |"
+`;

--- a/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/object-optional-not-allowed/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/legacy-fixtures/errorRecovery/fixtures/_error_/object-optional-not-allowed/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures legacy-fixtures errorRecovery _error_ object-optional-not-allowed TSESTree - Error 1`] = `[TSError: A shorthand property assignment cannot have a question token.]`;
+exports[`AST Fixtures legacy-fixtures errorRecovery _error_ object-optional-not-allowed TSESTree - Error 1`] = `
+"TSError
+  1 | // TODO: This fixture might be too large, and if so should be split up.
+  2 |
+> 3 | ({a?} = {})
+    |   ^ A shorthand property assignment cannot have a question token.
+  4 |"
+`;

--- a/packages/ast-spec/src/legacy-fixtures/expressions/fixtures/_error_/instantiation-expression/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/legacy-fixtures/expressions/fixtures/_error_/instantiation-expression/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures legacy-fixtures expressions _error_ instantiation-expression TSESTree - Error 1`] = `[TSError: Expression expected.]`;
+exports[`AST Fixtures legacy-fixtures expressions _error_ instantiation-expression TSESTree - Error 1`] = `
+"TSError
+  3 | a<b>;
+  4 |
+> 5 | a<b><c>;
+    |        ^ Expression expected.
+  6 | a<b><c>();
+  7 | a<b><c>?.();
+  8 | a?.b<c><d>();"
+`;

--- a/packages/ast-spec/tests/fixtures.test.ts
+++ b/packages/ast-spec/tests/fixtures.test.ts
@@ -13,6 +13,7 @@ import type {
 import { ParserResponseType } from './util/parsers/parser-types';
 import { parseTSESTree } from './util/parsers/typescript-estree';
 import { diffHasChanges, snapshotDiff } from './util/snapshot-diff';
+import { serializeError } from './util/serialize-error';
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
 const SRC_DIR = path.resolve(PACKAGE_ROOT, 'src');
@@ -171,7 +172,9 @@ function nestDescribe(fixture: Fixture, segments = fixture.segments): void {
         }
 
         it('TSESTree - Error', () => {
-          expect(tsestreeParsed.error).toMatchSpecificSnapshot(
+          expect(
+            serializeError(tsestreeParsed.error, contents),
+          ).toMatchSpecificSnapshot(
             fixture.snapshotFiles.error.tsestree(snapshotCounter++),
           );
         });

--- a/packages/ast-spec/tests/util/serialize-error.ts
+++ b/packages/ast-spec/tests/util/serialize-error.ts
@@ -1,0 +1,22 @@
+import { codeFrameColumns } from '@babel/code-frame';
+import { TSError } from '@typescript-eslint/typescript-estree';
+
+export function serializeError(
+  error: unknown,
+  contents: string,
+): unknown | string {
+  if (!(error instanceof TSError)) {
+    return error;
+  }
+
+  const { message, lineNumber: line, column, name } = error;
+  return (
+    name +
+    '\n' +
+    codeFrameColumns(
+      contents,
+      { start: { line, column: column + 1 } },
+      { highlightCode: false, message },
+    )
+  );
+}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

During upgrade parser to v6 in Prettier, I found some error location should be improved, but before that, let's make the error visible?
