### PR TITLE
fix: throw error on invalid `ThrowStatement`

### DIFF
--- a/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument-2/fixture.ts
+++ b/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument-2/fixture.ts
@@ -1,0 +1,3 @@
+throw
+
+// dummy comment

--- a/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument-2/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument-2/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures statement ThrowStatement _error_ missing-argument-2 TSESTree - Error 1`] = `
+"TSError
+> 1 | throw
+    |      ^ Expression expected.
+  2 |
+  3 | // dummy comment
+  4 |"
+`;

--- a/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument-2/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument-2/snapshots/2-Babel-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures statement ThrowStatement _error_ missing-argument-2 Babel - Error 1`] = `[SyntaxError: Illegal newline after throw. (1:5)]`;

--- a/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument-2/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument-2/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures statement ThrowStatement _error_ missing-argument-2 Error Alignment 1`] = `"Both errored"`;

--- a/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument/fixture.ts
+++ b/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument/fixture.ts
@@ -1,0 +1,1 @@
+function a() {throw}

--- a/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures statement ThrowStatement _error_ missing-argument TSESTree - Error 1`] = `
+"TSError
+> 1 | function a() {throw}
+    |                    ^ Expression expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument/snapshots/2-Babel-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures statement ThrowStatement _error_ missing-argument Babel - Error 1`] = `[SyntaxError: Unexpected token (1:19)]`;

--- a/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/statement/ThrowStatement/fixtures/_error_/missing-argument/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures statement ThrowStatement _error_ missing-argument Error Alignment 1`] = `"Both errored"`;

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -822,11 +822,20 @@ export class Converter {
 
       // Exceptions
 
-      case SyntaxKind.ThrowStatement:
+      case SyntaxKind.ThrowStatement: {
+        const { expression } = node;
+        if (
+          expression.kind === SyntaxKind.Identifier &&
+          !(expression as ts.Identifier).text
+        ) {
+          throw createError(this.ast, node.end, 'Expression expected.');
+        }
+
         return this.createNode<TSESTree.ThrowStatement>(node, {
           type: AST_NODE_TYPES.ThrowStatement,
-          argument: this.convertChild(node.expression),
+          argument: this.convertChild(expression),
         });
+      }
 
       case SyntaxKind.TryStatement:
         return this.createNode<TSESTree.TryStatement>(node, {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Throw same error for `throw` and `throw\n`

Ref: https://github.com/typescript-eslint/typescript-eslint/issues/1852#issuecomment-1451679124

