### PR TITLE
fix(eslint-plugin): [no-unnecessary-boolean-literal-compare] fixer should handle parentheses

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -235,11 +235,10 @@ export default util.createRule<Options, MessageIds>({
               comparison.literalBooleanInComparison
             ) {
               if (!comparison.forTruthy) {
+                yield fixer.insertTextBefore(node, '!');
                 if (!util.isStrongPrecedenceNode(comparison.expression)) {
-                  yield fixer.insertTextBefore(node, '!(');
+                  yield fixer.insertTextBefore(node, '(');
                   yield fixer.insertTextAfter(node, ')');
-                } else {
-                  yield fixer.insertTextBefore(node, '!');
                 }
               }
               return;

--- a/packages/eslint-plugin/src/util/getWrappingFixer.ts
+++ b/packages/eslint-plugin/src/util/getWrappingFixer.ts
@@ -69,7 +69,7 @@ export function getWrappingFixer(
 /**
  * Check if a node will always have the same precedence if it's parent changes.
  */
-function isStrongPrecedenceNode(innerNode: TSESTree.Node): boolean {
+export function isStrongPrecedenceNode(innerNode: TSESTree.Node): boolean {
   return (
     innerNode.type === AST_NODE_TYPES.Literal ||
     innerNode.type === AST_NODE_TYPES.Identifier ||

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
@@ -326,5 +326,39 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
         }
       `,
     },
+    {
+      code: noFormat`
+        declare const x;
+        if (x instanceof Error === (false)) {
+        }
+      `,
+      errors: [
+        {
+          messageId: 'direct',
+        },
+      ],
+      output: `
+        declare const x;
+        if (!(x instanceof Error)) {
+        }
+      `,
+    },
+    {
+      code: noFormat`
+        declare const x;
+        if ((false) === x instanceof Error) {
+        }
+      `,
+      errors: [
+        {
+          messageId: 'direct',
+        },
+      ],
+      output: `
+        declare const x;
+        if (!(x instanceof Error)) {
+        }
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
@@ -1,5 +1,5 @@
 import rule from '../../src/rules/no-unnecessary-boolean-literal-compare';
-import { getFixturesRootDir, RuleTester } from '../RuleTester';
+import { getFixturesRootDir, noFormat, RuleTester } from '../RuleTester';
 
 const rootDir = getFixturesRootDir();
 const ruleTester = new RuleTester({
@@ -255,6 +255,74 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
       output: `
         declare const varBoolean: boolean;
         if (!varBoolean) {
+        }
+      `,
+    },
+    {
+      code: noFormat`
+        declare const x;
+        if ((x instanceof Error) === false) {
+        }
+      `,
+      errors: [
+        {
+          messageId: 'direct',
+        },
+      ],
+      output: `
+        declare const x;
+        if (!(x instanceof Error)) {
+        }
+      `,
+    },
+    {
+      code: noFormat`
+        declare const x;
+        if (false === (x instanceof Error)) {
+        }
+      `,
+      errors: [
+        {
+          messageId: 'direct',
+        },
+      ],
+      output: `
+        declare const x;
+        if (!(x instanceof Error)) {
+        }
+      `,
+    },
+    {
+      code: `
+        declare const x;
+        if (x instanceof Error === false) {
+        }
+      `,
+      errors: [
+        {
+          messageId: 'direct',
+        },
+      ],
+      output: `
+        declare const x;
+        if (!(x instanceof Error)) {
+        }
+      `,
+    },
+    {
+      code: noFormat`
+        declare const x;
+        if (typeof x === 'string' === false) {
+        }
+      `,
+      errors: [
+        {
+          messageId: 'direct',
+        },
+      ],
+      output: `
+        declare const x;
+        if (!(typeof x === 'string')) {
         }
       `,
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6567
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Add missing handling for removal and adding parenthesis in rule fixer

new cases covered:

```ts
if ((x instanceof Error) === false) {}
if (false === (x instanceof Error)) {}
if (x instanceof Error === false) {}
```

old fixer result

```ts
if (!(x instanceof Error) { }
if (!x instanceof Error)) { }
if (!x instanceof Error) { }
```

new fixer result

```ts
if (!(x instanceof Error)) { }
if (!(x instanceof Error)) { }
if (!(x instanceof Error)) { }
```

--------------

initially i was planning to extend range of fixer to include `)(` but after further investigation this  started generating to many edge cases

eg. `(false) === x instanceof Error`