### PR TITLE
fix(eslint-plugin): [no-confusing-void-expression] check sequence expressions for void is in last position

### DIFF
--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -205,6 +205,7 @@ export default util.createRule<Options, MessageId>({
             suggest: [{ messageId: 'voidExprWrapVoid', fix: wrapVoidFix }],
           });
         }
+
         context.report({
           node,
           messageId: 'invalidVoidExpr',
@@ -225,6 +226,11 @@ export default util.createRule<Options, MessageId>({
         node.parent,
         util.NullThrowsReasons.MissingParent,
       );
+      if (parent.type === AST_NODE_TYPES.SequenceExpression) {
+        if (node !== parent.expressions[parent.expressions.length - 1]) {
+          return null;
+        }
+      }
 
       if (parent.type === AST_NODE_TYPES.ExpressionStatement) {
         // e.g. `{ console.log("foo"); }`

--- a/packages/eslint-plugin/tests/rules/no-confusing-void-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-confusing-void-expression.test.ts
@@ -57,6 +57,18 @@ ruleTester.run('no-confusing-void-expression', rule, {
         return void console.log('foo');
       `,
     }),
+    `
+function cool(input: string) {
+  return console.log(input), input;
+}
+    `,
+    {
+      code: `
+function cool(input: string) {
+  return input, console.log(input), input;
+}
+      `,
+    },
   ],
 
   invalid: [
@@ -87,6 +99,14 @@ ruleTester.run('no-confusing-void-expression', rule, {
       ],
     }),
 
+    {
+      code: `
+function notcool(input: string) {
+  return input, console.log(input);
+}
+      `,
+      errors: [{ line: 3, column: 17, messageId: 'invalidVoidExpr' }],
+    },
     {
       code: "() => console.log('foo');",
       errors: [{ line: 1, column: 7, messageId: 'invalidVoidExprArrow' }],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6414 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Added a check to sequence expressions that ignores void unless it is in the last position of a SequenceExpression
