### PR TITLE
docs(eslint-plugin): [prefer-function-type] mention global augmentation edge case in docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-function-type.md
+++ b/packages/eslint-plugin/docs/rules/prefer-function-type.md
@@ -85,3 +85,8 @@ type Intersection = ((data: string) => number) & ((id: number) => string);
 ## When Not To Use It
 
 If you specifically want to use an interface or type literal with a single call signature for stylistic reasons, you can disable this rule.
+
+This rule has a known edge case of sometimes triggering on global augmentations such as `interface Function`.
+These edge cases are rare and often symptomatic of odd code.
+We recommend you use an [inline ESLint disable comment](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1).
+See [#454](https://github.com/typescript-eslint/typescript-eslint/issues/454) for details.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #454
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a comment in the docs warning about the global augmentation edge case.
