### PR TITLE
fix(eslint-plugin): [strict-boolean-expressions] handle truthy enums

### DIFF
--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -726,7 +726,12 @@ export default util.createRule<Options, MessageId>({
       }
 
       // nullable enum
-      if (is('nullish', 'number', 'enum') || is('nullish', 'string', 'enum')) {
+      if (
+        is('nullish', 'number', 'enum') ||
+        is('nullish', 'string', 'enum') ||
+        is('nullish', 'truthy number', 'enum') ||
+        is('nullish', 'truthy string', 'enum')
+      ) {
         if (!options.allowNullableEnum) {
           if (isLogicalNegationExpression(node.parent!)) {
             context.report({

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -168,6 +168,38 @@ ruleTester.run('strict-boolean-expressions', rule, {
     },
     {
       code: `
+        enum ExampleEnum {
+          This = 1,
+          That = 2,
+        }
+        const rand = Math.random();
+        let theEnum: ExampleEnum | null = null;
+        if (rand < 0.3) {
+          theEnum = ExampleEnum.This;
+        }
+        if (!theEnum) {
+        }
+      `,
+      options: [{ allowNullableEnum: true }],
+    },
+    {
+      code: `
+        enum ExampleEnum {
+          This = 'one',
+          That = 'two',
+        }
+        const rand = Math.random();
+        let theEnum: ExampleEnum | null = null;
+        if (rand < 0.3) {
+          theEnum = ExampleEnum.This;
+        }
+        if (!theEnum) {
+        }
+      `,
+      options: [{ allowNullableEnum: true }],
+    },
+    {
+      code: `
 declare const x: string[] | null;
 // eslint-disable-next-line
 if (x) {
@@ -1143,6 +1175,66 @@ if (y) {
         enum ExampleEnum {
           This = '',
           That = 0,
+        }
+        const theEnum = Math.random() < 0.3 ? ExampleEnum.This : null;
+        if (theEnum == null) {
+        }
+      `,
+    },
+    {
+      options: [{ allowNullableEnum: false }],
+      code: `
+        enum ExampleEnum {
+          This = 'one',
+          That = 'two',
+        }
+        const theEnum = Math.random() < 0.3 ? ExampleEnum.This : null;
+        if (!theEnum) {
+        }
+      `,
+      errors: [
+        {
+          line: 7,
+          column: 14,
+          messageId: 'conditionErrorNullableEnum',
+          endLine: 7,
+          endColumn: 21,
+        },
+      ],
+      output: `
+        enum ExampleEnum {
+          This = 'one',
+          That = 'two',
+        }
+        const theEnum = Math.random() < 0.3 ? ExampleEnum.This : null;
+        if (theEnum == null) {
+        }
+      `,
+    },
+    {
+      options: [{ allowNullableEnum: false }],
+      code: `
+        enum ExampleEnum {
+          This = 1,
+          That = 2,
+        }
+        const theEnum = Math.random() < 0.3 ? ExampleEnum.This : null;
+        if (!theEnum) {
+        }
+      `,
+      errors: [
+        {
+          line: 7,
+          column: 14,
+          messageId: 'conditionErrorNullableEnum',
+          endLine: 7,
+          endColumn: 21,
+        },
+      ],
+      output: `
+        enum ExampleEnum {
+          This = 1,
+          That = 2,
         }
         const theEnum = Math.random() < 0.3 ? ExampleEnum.This : null;
         if (theEnum == null) {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6583
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The `allowNullableEnum: true` option for the strict-boolean-expressions rule is not respected if all enum values are explicitly set to truthy strings or truthy numbers.
