### PR TITLE
fix(eslint-plugin): allow parser@^6.0.0

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -80,7 +80,7 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0 || ^6.0.0",
     "eslint": "^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -80,7 +80,7 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": ">=5.0.0 <7.0.0",
+    "@typescript-eslint/parser": "^5.0.0 || ^6.0.0 || ^6.0.0-alpha",
     "eslint": "^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -80,7 +80,7 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^5.0.0 || ^6.0.0 || ^6.0.0-alpha",
+    "@typescript-eslint/parser": ">=5.0.0 <7.0.0",
     "eslint": "^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -80,7 +80,7 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^5.0.0 || ^6.0.0",
+    "@typescript-eslint/parser": "^5.0.0 || ^6.0.0 || ^6.0.0-alpha",
     "eslint": "^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6634
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken


## Overview

Without this, on `npm i`:

```plaintext
joshgoldberg ~/repos/TypeScript $ npm i
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: typescript@5.1.0
npm ERR! Found: @typescript-eslint/parser@6.0.0-alpha.81
npm ERR! node_modules/@typescript-eslint/parser
npm ERR!   dev @typescript-eslint/parser@"^6.0.0-alpha.81" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @typescript-eslint/parser@"^5.0.0" from @typescript-eslint/eslint-plugin@6.0.0-alpha.81
npm ERR! node_modules/@typescript-eslint/eslint-plugin
npm ERR!   dev @typescript-eslint/eslint-plugin@"^6.0.0-alpha.81" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/josh/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/josh/.npm/_logs/2023-03-14T07_47_53_197Z-debug-0.log
```