### PR TITLE
feat(eslint-plugin): [consistent-type-assertions] autofix angle bracket assertions to as

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -1,4 +1,4 @@
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import * as util from '../util';
@@ -23,6 +23,7 @@ export default util.createRule<Options, MessageIds>({
   name: 'consistent-type-assertions',
   meta: {
     type: 'suggestion',
+    fixable: 'code',
     docs: {
       description: 'Enforce consistent usage of type assertions',
       recommended: 'strict',
@@ -100,6 +101,19 @@ export default util.createRule<Options, MessageIds>({
           messageId !== 'never'
             ? { cast: sourceCode.getText(node.typeAnnotation) }
             : {},
+        fix:
+          messageId === 'as'
+            ? (fixer): TSESLint.RuleFix[] => [
+                fixer.replaceText(
+                  node,
+                  context.getSourceCode().getText(node.expression),
+                ),
+                fixer.insertTextAfter(
+                  node,
+                  ` as ${context.getSourceCode().getText(node.typeAnnotation)}`,
+                ),
+              ]
+            : undefined,
       });
     }
 

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -195,6 +195,12 @@ ruleTester.run('consistent-type-assertions', rule, {
           line: 6,
         },
       ],
+      output: `
+const x = new Generic<int>() as Foo;
+const x = b as A;
+const x = [1] as readonly number[];
+const x = 'string' as a | b;
+const x = { key: 'value' } as const;`,
     }),
     ...batchedSingleLineTests({
       code: AS_TESTS_EXCEPT_CONST_CASE,

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -9,7 +9,12 @@ const ANGLE_BRACKET_TESTS_EXCEPT_CONST_CASE = `
 const x = <Foo>new Generic<int>();
 const x = <A>b;
 const x = <readonly number[]>[1];
-const x = <a | b>('string');`;
+const x = <a | b>('string');
+const x = <A>!'string';
+const x = <A>a + b;
+const x = <(A)>a + (b);
+const x = <Foo>(new Generic<string>());
+const x = (new (<Foo>Generic<string>)());`;
 
 const ANGLE_BRACKET_TESTS = `${ANGLE_BRACKET_TESTS_EXCEPT_CONST_CASE}
 const x = <const>{ key: 'value' };
@@ -19,7 +24,12 @@ const AS_TESTS_EXCEPT_CONST_CASE = `
 const x = new Generic<int>() as Foo;
 const x = b as A;
 const x = [1] as readonly number[];
-const x = ('string') as a | b;`;
+const x = ('string') as a | b;
+const x = !'string' as A;
+const x = a as A + b;
+const x = a as (A) + (b);
+const x = (new Generic<string>()) as Foo;
+const x = (new (Generic<string> as Foo)());`;
 
 const AS_TESTS = `${AS_TESTS_EXCEPT_CONST_CASE}
 const x = { key: 'value' } as const;
@@ -164,6 +174,26 @@ ruleTester.run('consistent-type-assertions', rule, {
           messageId: 'angle-bracket',
           line: 6,
         },
+        {
+          messageId: 'angle-bracket',
+          line: 7,
+        },
+        {
+          messageId: 'angle-bracket',
+          line: 8,
+        },
+        {
+          messageId: 'angle-bracket',
+          line: 9,
+        },
+        {
+          messageId: 'angle-bracket',
+          line: 10,
+        },
+        {
+          messageId: 'angle-bracket',
+          line: 11,
+        },
       ],
     }),
     ...batchedSingleLineTests({
@@ -194,13 +224,28 @@ ruleTester.run('consistent-type-assertions', rule, {
           messageId: 'as',
           line: 6,
         },
+        {
+          messageId: 'as',
+          line: 7,
+        },
+        {
+          messageId: 'as',
+          line: 8,
+        },
+        {
+          messageId: 'as',
+          line: 9,
+        },
+        {
+          messageId: 'as',
+          line: 10,
+        },
+        {
+          messageId: 'as',
+          line: 11,
+        },
       ],
-      output: `
-const x = new Generic<int>() as Foo;
-const x = b as A;
-const x = [1] as readonly number[];
-const x = 'string' as a | b;
-const x = { key: 'value' } as const;`,
+      output: AS_TESTS,
     }),
     ...batchedSingleLineTests({
       code: AS_TESTS_EXCEPT_CONST_CASE,
@@ -229,6 +274,22 @@ const x = { key: 'value' } as const;`,
         {
           messageId: 'never',
           line: 6,
+        },
+        {
+          messageId: 'never',
+          line: 7,
+        },
+        {
+          messageId: 'never',
+          line: 8,
+        },
+        {
+          messageId: 'never',
+          line: 9,
+        },
+        {
+          messageId: 'never',
+          line: 10,
         },
       ],
     }),
@@ -259,6 +320,22 @@ const x = { key: 'value' } as const;`,
         {
           messageId: 'never',
           line: 6,
+        },
+        {
+          messageId: 'never',
+          line: 7,
+        },
+        {
+          messageId: 'never',
+          line: 8,
+        },
+        {
+          messageId: 'never',
+          line: 9,
+        },
+        {
+          messageId: 'never',
+          line: 10,
         },
       ],
     }),


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6606
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Autofixes `const x = <T>{ ... }` to `const x = { ... } as T`