### PR TITLE
feat(eslint-plugin): [consistent-type-assertions] add suggestions for objectLiteralTypeAssertions

### DIFF
--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -268,6 +268,18 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 2,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithAnnotation',
+              data: { cast: 'Foo<int>' },
+              output: 'const x: Foo<int> = {};',
+            },
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo<int>' },
+              output: 'const x = {} satisfies Foo<int>;',
+            },
+          ],
         },
       ],
     }),
@@ -283,6 +295,18 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 2,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithAnnotation',
+              data: { cast: 'Foo<int>' },
+              output: 'const x: Foo<int> = {};',
+            },
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo<int>' },
+              output: 'const x = {} satisfies Foo<int>;',
+            },
+          ],
         },
       ],
     }),
@@ -298,34 +322,95 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 2,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithAnnotation',
+              data: { cast: 'Foo<int>' },
+              output: 'const x: Foo<int> = {};',
+            },
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo<int>' },
+              output: 'const x = {} satisfies Foo<int>;',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 3,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'print({ bar: 5 } satisfies Foo)',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 4,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'new print({ bar: 5 } satisfies Foo)',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 5,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'function foo() { throw { bar: 5 } satisfies Foo }',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 6,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo.Bar' },
+              output: 'function b(x = {} satisfies Foo.Bar) {}',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 7,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'function c(x = {} satisfies Foo) {}',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 8,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'print?.({ bar: 5 } satisfies Foo)',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 9,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'print?.call({ bar: 5 } satisfies Foo)',
+            },
+          ],
         },
       ],
     }),
@@ -341,26 +426,73 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 2,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithAnnotation',
+              data: { cast: 'Foo<int>' },
+              output: 'const x: Foo<int> = {};',
+            },
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo<int>' },
+              output: 'const x = {} satisfies Foo<int>;',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 3,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'print({ bar: 5 } satisfies Foo)',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 4,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'new print({ bar: 5 } satisfies Foo)',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 5,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'function foo() { throw { bar: 5 } satisfies Foo }',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 6,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'print?.({ bar: 5 } satisfies Foo)',
+            },
+          ],
         },
         {
           messageId: 'unexpectedObjectTypeAssertion',
           line: 7,
+          suggestions: [
+            {
+              messageId: 'replaceObjectTypeAssertionWithSatisfies',
+              data: { cast: 'Foo' },
+              output: 'print?.call({ bar: 5 } satisfies Foo)',
+            },
+          ],
         },
       ],
     }),

--- a/packages/typescript-estree/src/version-check.ts
+++ b/packages/typescript-estree/src/version-check.ts
@@ -24,6 +24,7 @@ const versions = [
   '4.6',
   '4.7',
   '4.8',
+  '4.9',
 ] as const;
 type Versions = typeof versions extends ArrayLike<infer U> ? U : never;
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6607
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Suggestions changes to code styled as `const x = { ... } as T;`. 

Suggestions:
```ts
const x: T = { ... }; // autofix for variable declarators
const x = { ... } satisfies T; // autofix for TypeScript 4.9+
```