### PR TITLE
chore: update to TypeScript 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,10 +108,10 @@
     "ts-node": "10.7.0",
     "tslint": "^6.1.3",
     "tsx": "^3.12.1",
-    "typescript": ">=3.3.1 <5.1.0 || 5.0.1-rc"
+    "typescript": ">=3.3.1 <5.1.0"
   },
   "resolutions": {
-    "typescript": "~5.0.1-rc",
+    "typescript": "~5.0.2",
     "@types/node": "^18.11.9",
     "@jest/create-cache-key-function": "^29",
     "@jest/reporters": "^29",

--- a/packages/website/src/components/editor/LoadedEditor.tsx
+++ b/packages/website/src/components/editor/LoadedEditor.tsx
@@ -113,7 +113,6 @@ export const LoadedEditor: React.FC<LoadedEditorProps> = ({
       jsx,
       parseTSConfig(tsconfig).compilerOptions,
     );
-    // @ts-expect-error Monaco typescript.CompilerOptions is incompatible with typescript 5.0 types
     webLinter.updateCompilerOptions(config);
     sandboxInstance.setCompilerSettings(config);
   }, [jsx, sandboxInstance, tsconfig, webLinter]);

--- a/packages/website/src/components/editor/config.ts
+++ b/packages/website/src/components/editor/config.ts
@@ -28,7 +28,6 @@ export function createCompilerOptions(
   const options = config.options as Monaco.languages.typescript.CompilerOptions;
 
   if (!options.lib) {
-    // @ts-expect-error Monaco typescript.CompilerOptions is incompatible with typescript 5.0 types
     options.lib = [window.ts.getDefaultLibFileName(options)];
   }
 

--- a/packages/website/src/components/editor/useSandboxServices.ts
+++ b/packages/website/src/components/editor/useSandboxServices.ts
@@ -110,7 +110,6 @@ export const useSandboxServices = (
         const system = sandboxInstance.tsvfs.createSystem(libEntries);
         window.esquery = lintUtils.esquery;
 
-        // @ts-expect-error Monaco typescript.CompilerOptions is incompatible with typescript 5.0 types
         const webLinter = new WebLinter(system, compilerOptions, lintUtils);
 
         onLoaded(

--- a/patches/typescript+5.0.2.patch
+++ b/patches/typescript+5.0.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/typescript/lib/typescript.d.ts b/node_modules/typescript/lib/typescript.d.ts
-index 2201712..6e04c82 100644
+index 374e65a..9d5a88c 100644
 --- a/node_modules/typescript/lib/typescript.d.ts
 +++ b/node_modules/typescript/lib/typescript.d.ts
 @@ -368,8 +368,8 @@ declare namespace ts {
@@ -12,7 +12,7 @@ index 2201712..6e04c82 100644
          JSDocComment = 323,
          JSDocText = 324,
          JSDocTypeLiteral = 325,
-@@ -4517,7 +4517,13 @@ declare namespace ts {
+@@ -4522,7 +4522,13 @@ declare namespace ts {
      function symbolName(symbol: Symbol): string;
      function getNameOfJSDocTypedef(declaration: JSDocTypedefTag): Identifier | PrivateIdentifier | undefined;
      function getNameOfDeclaration(declaration: Declaration | Expression | undefined): DeclarationName | undefined;
@@ -26,7 +26,7 @@ index 2201712..6e04c82 100644
      function getModifiers(node: HasModifiers): readonly Modifier[] | undefined;
      /**
       * Gets the JSDoc parameter tags for the node if present.
-@@ -5022,7 +5028,13 @@ declare namespace ts {
+@@ -5027,7 +5033,13 @@ declare namespace ts {
      function isModuleName(node: Node): node is ModuleName;
      function isBinaryOperatorToken(node: Node): node is BinaryOperatorToken;
      function setTextRange<T extends TextRange>(range: T, location: TextRange | undefined): T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13457,10 +13457,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*, "typescript@>=3.3.1 <5.1.0 || 5.0.1-rc", "typescript@^3 || ^4", typescript@next, typescript@~4.8.4, typescript@~5.0.1-rc:
-  version "5.0.1-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.1-rc.tgz#f2ccabbdb9646b43b5e006dc6f7b0eaf9a222c8b"
-  integrity sha512-zh75jY8gPo/y7fpmlTVN2bb2MigoLx4hGk+Cla9pY6lgSTvzJrmQQrRt5S80VTsEt6biWPZJgLK2nm6f0Ya+mA==
+typescript@*, "typescript@>=3.3.1 <5.1.0", "typescript@^3 || ^4", typescript@next, typescript@~4.8.4, typescript@~5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: #6380 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
TS 5.0 has been released https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/

So we can update `typescript` to 5.0.2