### PR TITLE
fix(typescript-estree): allow writing to deprecated node properties

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -3327,9 +3327,9 @@ export class Converter {
         ? (): Properties[typeof valueKey] => node[valueKey]
         : (): Properties[typeof valueKey] => {
             if (!warned) {
-              // eslint-disable-next-line no-console
-              console.warn(
+              process.emitWarning(
                 `The '${aliasKey}' property is deprecated on ${node.type} nodes. Use '${valueKey}' instead. See https://typescript-eslint.io/linting/troubleshooting#the-key-property-is-deprecated-on-type-nodes-use-key-instead-warnings.`,
+                'DeprecationWarning',
               );
               warned = true;
             }

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -3319,16 +3319,15 @@ export class Converter {
     aliasKey: AliasKey,
     valueKey: ValueKey,
   ): Properties & Record<AliasKey, Properties[ValueKey]> {
-    if (this.options.suppressDeprecatedPropertyWarnings) {
-      (node as any)[aliasKey] = node[valueKey];
-      return node as Properties & Record<AliasKey, Properties[ValueKey]>;
-    }
-
     let warned = false;
 
     Object.defineProperty(node, aliasKey, {
       configurable: true,
       get(): Properties[typeof valueKey] {
+        if (this.options.suppressDeprecatedPropertyWarnings) {
+          (node as any)[aliasKey] = node[valueKey];
+        }
+
         if (!warned) {
           // eslint-disable-next-line no-console
           console.warn(

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -3323,21 +3323,19 @@ export class Converter {
 
     Object.defineProperty(node, aliasKey, {
       configurable: true,
-      get(): Properties[typeof valueKey] {
-        if (this.options.suppressDeprecatedPropertyWarnings) {
-          (node as any)[aliasKey] = node[valueKey];
-        }
+      get: this.options.suppressDeprecatedPropertyWarnings
+        ? (): Properties[typeof valueKey] => node[valueKey]
+        : (): Properties[typeof valueKey] => {
+            if (!warned) {
+              // eslint-disable-next-line no-console
+              console.warn(
+                `The '${aliasKey}' property is deprecated on ${node.type} nodes. Use '${valueKey}' instead. See https://typescript-eslint.io/linting/troubleshooting#the-key-property-is-deprecated-on-type-nodes-use-key-instead-warnings.`,
+              );
+              warned = true;
+            }
 
-        if (!warned) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `The '${aliasKey}' property is deprecated on ${node.type} nodes. Use '${valueKey}' instead. See https://typescript-eslint.io/linting/troubleshooting#the-key-property-is-deprecated-on-type-nodes-use-key-instead-warnings.`,
-          );
-          warned = true;
-        }
-
-        return node[valueKey];
-      },
+            return node[valueKey];
+          },
       set(value): void {
         Object.defineProperty(node, aliasKey, {
           enumerable: true,

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -268,7 +268,7 @@ describe('convert', () => {
 
   describe('suppressDeprecatedPropertyWarnings', () => {
     const getEsCallExpression = (
-      converterOptions: ConverterOptions,
+      converterOptions?: ConverterOptions,
     ): TSESTree.CallExpression => {
       const ast = convertCode(`callee<T>();`);
       const tsCallExpression = (ast.statements[0] as ts.ExpressionStatement)
@@ -323,6 +323,23 @@ describe('convert', () => {
       esCallExpression.typeParameters;
 
       expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('does not allow enumeration of deprecated properties', () => {
+      const esCallExpression = getEsCallExpression();
+
+      expect(Object.keys(esCallExpression)).not.toContain('typeParameters');
+    });
+
+    it('allows writing to the deprecated property as a new enumerable value', () => {
+      const esCallExpression = getEsCallExpression();
+
+      // eslint-disable-next-line deprecation/deprecation
+      esCallExpression.typeParameters = undefined;
+
+      // eslint-disable-next-line deprecation/deprecation
+      expect(esCallExpression.typeParameters).toBeUndefined();
+      expect(Object.keys(esCallExpression)).toContain('typeParameters');
     });
   });
 });

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -7,6 +7,10 @@ import type { ConverterOptions } from '../../src/convert';
 import { Converter } from '../../src/convert';
 
 describe('convert', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   function convertCode(code: string): ts.SourceFile {
     return ts.createSourceFile(
       'text.ts',
@@ -285,8 +289,10 @@ describe('convert', () => {
       return maps.tsNodeToESTreeNodeMap.get(tsCallExpression);
     };
 
-    it('logs on a deprecated property access when suppressDeprecatedPropertyWarnings is false', () => {
-      const warn = jest.spyOn(console, 'warn').mockImplementation();
+    it('warns on a deprecated property access when suppressDeprecatedPropertyWarnings is false', () => {
+      const emitWarning = jest
+        .spyOn(process, 'emitWarning')
+        .mockImplementation();
       const esCallExpression = getEsCallExpression({
         suppressDeprecatedPropertyWarnings: false,
       });
@@ -294,13 +300,16 @@ describe('convert', () => {
       // eslint-disable-next-line deprecation/deprecation
       esCallExpression.typeParameters;
 
-      expect(warn).toHaveBeenCalledWith(
+      expect(emitWarning).toHaveBeenCalledWith(
         `The 'typeParameters' property is deprecated on CallExpression nodes. Use 'typeArguments' instead. See https://typescript-eslint.io/linting/troubleshooting#the-key-property-is-deprecated-on-type-nodes-use-key-instead-warnings.`,
+        'DeprecationWarning',
       );
     });
 
-    it('does not log on a subsequent deprecated property access when suppressDeprecatedPropertyWarnings is false', () => {
-      const warn = jest.spyOn(console, 'warn').mockImplementation();
+    it('does not warn on a subsequent deprecated property access when suppressDeprecatedPropertyWarnings is false', () => {
+      const emitWarning = jest
+        .spyOn(process, 'emitWarning')
+        .mockImplementation();
       const esCallExpression = getEsCallExpression({
         suppressDeprecatedPropertyWarnings: false,
       });
@@ -310,11 +319,13 @@ describe('convert', () => {
       esCallExpression.typeParameters;
       /* eslint-enable deprecation/deprecation */
 
-      expect(warn).toHaveBeenCalledTimes(1);
+      expect(emitWarning).toHaveBeenCalledTimes(1);
     });
 
-    it('does not log on a deprecated property access when suppressDeprecatedPropertyWarnings is true', () => {
-      const warn = jest.spyOn(console, 'warn').mockImplementation();
+    it('does not warn on a deprecated property access when suppressDeprecatedPropertyWarnings is true', () => {
+      const emitWarning = jest
+        .spyOn(process, 'emitWarning')
+        .mockImplementation();
       const esCallExpression = getEsCallExpression({
         suppressDeprecatedPropertyWarnings: true,
       });
@@ -322,7 +333,7 @@ describe('convert', () => {
       // eslint-disable-next-line deprecation/deprecation
       esCallExpression.typeParameters;
 
-      expect(warn).not.toHaveBeenCalled();
+      expect(emitWarning).not.toHaveBeenCalled();
     });
 
     it('does not allow enumeration of deprecated properties', () => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6668
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

In the node's `Object.defineProperty` _accessor descriptor_, it's now given a setter that sets it to a _data descriptor_. See terminology on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty.