### PR TITLE
chore(website): migrate from lzstring.ts to lz-string package

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -30,7 +30,7 @@
     "json-schema-to-typescript": "^11.0.1",
     "json5": "^2.2.1",
     "konamimojisplosion": "^0.5.1",
-    "lzstring.ts": "^2.0.2",
+    "lz-string": "^1.5.0",
     "prettier": "*",
     "prism-react-renderer": "^1.3.3",
     "react": "^18.1.0",

--- a/packages/website/plugins/generated-rule-docs.ts
+++ b/packages/website/plugins/generated-rule-docs.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import type { JSONSchema7 } from 'json-schema';
 import type { JSONSchema } from 'json-schema-to-typescript';
 import { compile } from 'json-schema-to-typescript';
-import * as lz from 'lzstring.ts';
+import * as lz from 'lz-string';
 import type * as mdast from 'mdast';
 import { EOL } from 'os';
 import * as path from 'path';
@@ -417,7 +417,7 @@ export const generatedRuleDocs: Plugin = () => {
 };
 
 function convertToPlaygroundHash(eslintrc: string): string {
-  return lz.LZString.compressToEncodedURIComponent(eslintrc);
+  return lz.compressToEncodedURIComponent(eslintrc);
 }
 
 function nodeIsHeading(node: unist.Node): node is mdast.Heading {

--- a/packages/website/src/components/hooks/useHashState.ts
+++ b/packages/website/src/components/hooks/useHashState.ts
@@ -1,5 +1,5 @@
 import { toJsonConfig } from '@site/src/components/config/utils';
-import * as lz from 'lzstring.ts';
+import * as lz from 'lz-string';
 import { useCallback, useEffect, useState } from 'react';
 
 import { hasOwnProperty } from '../lib/has-own-property';
@@ -7,12 +7,12 @@ import { shallowEqual } from '../lib/shallowEqual';
 import type { ConfigModel } from '../types';
 
 function writeQueryParam(value: string): string {
-  return lz.LZString.compressToEncodedURIComponent(value);
+  return lz.compressToEncodedURIComponent(value);
 }
 
 function readQueryParam(value: string | null, fallback: string): string {
   return value
-    ? lz.LZString.decompressFromEncodedURIComponent(value) ?? fallback
+    ? lz.decompressFromEncodedURIComponent(value) ?? fallback
     : fallback;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9817,12 +9817,10 @@ lru-queue@^0.1.0:
   dependencies:
     es5-ext "~0.10.2"
 
-lzstring.ts@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lzstring.ts/-/lzstring.ts-2.0.2.tgz#1d269bd6ab423713f31e614f67018110ed860129"
-  integrity sha512-SEDSYQ3gNrGOdqWcXDO6OU/j3E/ff0WfndKOED4WV0oxDzgf4vijuIwbEE/m0f1LGuTbwH3jVHcwrLdRbQqh3A==
-  dependencies:
-    tslib "^1.10.0"
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
 magic-string@0.25.9, magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.9"
@@ -13527,7 +13525,7 @@ tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: [#6656 comment](https://github.com/typescript-eslint/typescript-eslint/pull/6656#pullrequestreview-1347474936)
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

migrate from fork of lz-string to main version as it has type definition now

change extracted from #6656