### PR TITLE
fix(typescript-estree): forbid `override` on non-constructor function/methods

### DIFF
--- a/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-function-parameter/fixture.ts
+++ b/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-function-parameter/fixture.ts
@@ -1,0 +1,1 @@
+function foo(override parameter) {}

--- a/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-function-parameter/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-function-parameter/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter TSParameterProperty _error_ override-function-parameter TSESTree - Error 1`] = `
+"TSError
+> 1 | function foo(override parameter) {}
+    |              ^^^^^^^^ A parameter property is only allowed in a constructor implementation.
+  2 |"
+`;

--- a/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-function-parameter/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-function-parameter/snapshots/2-Babel-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter TSParameterProperty _error_ override-function-parameter Babel - Error 1`] = `[SyntaxError: A parameter property is only allowed in a constructor implementation. (1:13)]`;

--- a/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-function-parameter/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-function-parameter/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter TSParameterProperty _error_ override-function-parameter Error Alignment 1`] = `"Both errored"`;

--- a/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-method-parameter/fixture.ts
+++ b/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-method-parameter/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  method(override parameter) {}
+}

--- a/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-method-parameter/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-method-parameter/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter TSParameterProperty _error_ override-method-parameter TSESTree - Error 1`] = `
+"TSError
+  1 | class Foo {
+> 2 |   method(override parameter) {}
+    |          ^^^^^^^^ A parameter property is only allowed in a constructor implementation.
+  3 | }
+  4 |"
+`;

--- a/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-method-parameter/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-method-parameter/snapshots/2-Babel-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter TSParameterProperty _error_ override-method-parameter Babel - Error 1`] = `[SyntaxError: A parameter property is only allowed in a constructor implementation. (2:9)]`;

--- a/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-method-parameter/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/parameter/TSParameterProperty/fixtures/_error_/override-method-parameter/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter TSParameterProperty _error_ override-method-parameter Error Alignment 1`] = `"Both errored"`;

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -3278,7 +3278,8 @@ export class Converter {
         (modifier.kind === SyntaxKind.PublicKeyword ||
           modifier.kind === SyntaxKind.PrivateKeyword ||
           modifier.kind === SyntaxKind.ProtectedKeyword ||
-          modifier.kind === SyntaxKind.ReadonlyKeyword)
+          modifier.kind === SyntaxKind.ReadonlyKeyword ||
+          modifier.kind === SyntaxKind.OverrideKeyword)
       ) {
         const func = getContainingFunction(node)!;
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Missed in #6615
