### PR TITLE
fix(eslint-plugin): [lines-around-comment] extend rule options instead of overriding them

### DIFF
--- a/packages/ast-spec/src/ast-token-types.ts
+++ b/packages/ast-spec/src/ast-token-types.ts
@@ -14,4 +14,5 @@ export enum AST_TOKEN_TYPES {
   // comment types
   Block = 'Block',
   Line = 'Line',
+  Shebang = 'Shebang',
 }

--- a/packages/ast-spec/src/token/ShebangComment/spec.ts
+++ b/packages/ast-spec/src/token/ShebangComment/spec.ts
@@ -1,0 +1,6 @@
+import type { AST_TOKEN_TYPES } from '../../ast-token-types';
+import type { BaseToken } from '../../base/BaseToken';
+
+export interface ShebangComment extends BaseToken {
+  type: AST_TOKEN_TYPES.Shebang;
+}

--- a/packages/ast-spec/src/token/spec.ts
+++ b/packages/ast-spec/src/token/spec.ts
@@ -1,4 +1,5 @@
 export * from './BlockComment/spec';
+export * from './ShebangComment/spec';
 export * from './BooleanToken/spec';
 export * from './IdentifierToken/spec';
 export * from './JSXIdentifierToken/spec';

--- a/packages/ast-spec/src/unions/Comment.ts
+++ b/packages/ast-spec/src/unions/Comment.ts
@@ -1,4 +1,5 @@
 import type { BlockComment } from '../token/BlockComment/spec';
 import type { LineComment } from '../token/LineComment/spec';
+import type { ShebangComment } from '../token/ShebangComment/spec';
 
-export type Comment = BlockComment | LineComment;
+export type Comment = BlockComment | LineComment | ShebangComment;

--- a/packages/eslint-plugin/src/rules/ban-tslint-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-tslint-comment.ts
@@ -36,6 +36,11 @@ export default util.createRule({
       Program(): void {
         const comments = sourceCode.getAllComments();
         comments.forEach(c => {
+          // edge case to support
+          if (c.type === AST_TOKEN_TYPES.Shebang) {
+            return;
+          }
+
           if (ENABLE_DISABLE_REGEX.test(c.value)) {
             context.report({
               data: { text: toText(c.value, c.type) },

--- a/packages/eslint-plugin/src/rules/lines-around-comment.ts
+++ b/packages/eslint-plugin/src/rules/lines-around-comment.ts
@@ -51,89 +51,34 @@ export default util.createRule<Options, MessageIds>({
       recommended: false,
       extendsBaseRule: true,
     },
-    schema: {
-      type: 'array',
-      items: [
-        {
-          type: 'object',
-          properties: {
-            beforeBlockComment: {
-              type: 'boolean',
-              default: true,
-            },
-            afterBlockComment: {
-              type: 'boolean',
-              default: false,
-            },
-            beforeLineComment: {
-              type: 'boolean',
-              default: false,
-            },
-            afterLineComment: {
-              type: 'boolean',
-              default: false,
-            },
-            allowBlockStart: {
-              type: 'boolean',
-              default: false,
-            },
-            allowBlockEnd: {
-              type: 'boolean',
-              default: false,
-            },
-            allowClassStart: {
-              type: 'boolean',
-            },
-            allowClassEnd: {
-              type: 'boolean',
-            },
-            allowObjectStart: {
-              type: 'boolean',
-            },
-            allowObjectEnd: {
-              type: 'boolean',
-            },
-            allowArrayStart: {
-              type: 'boolean',
-            },
-            allowArrayEnd: {
-              type: 'boolean',
-            },
-            allowInterfaceStart: {
-              type: 'boolean',
-            },
-            allowInterfaceEnd: {
-              type: 'boolean',
-            },
-            allowTypeStart: {
-              type: 'boolean',
-            },
-            allowTypeEnd: {
-              type: 'boolean',
-            },
-            allowEnumStart: {
-              type: 'boolean',
-            },
-            allowEnumEnd: {
-              type: 'boolean',
-            },
-            allowModuleStart: {
-              type: 'boolean',
-            },
-            allowModuleEnd: {
-              type: 'boolean',
-            },
-            ignorePattern: {
-              type: 'string',
-            },
-            applyDefaultIgnorePatterns: {
-              type: 'boolean',
-            },
-          },
-          additionalProperties: false,
+    schema: util.extendSchema(baseRule.meta.schema, {
+      properties: {
+        allowInterfaceStart: {
+          type: 'boolean',
         },
-      ],
-    },
+        allowInterfaceEnd: {
+          type: 'boolean',
+        },
+        allowTypeStart: {
+          type: 'boolean',
+        },
+        allowTypeEnd: {
+          type: 'boolean',
+        },
+        allowEnumStart: {
+          type: 'boolean',
+        },
+        allowEnumEnd: {
+          type: 'boolean',
+        },
+        allowModuleStart: {
+          type: 'boolean',
+        },
+        allowModuleEnd: {
+          type: 'boolean',
+        },
+      },
+    }),
     fixable: baseRule.meta.fixable,
     hasSuggestions: baseRule.meta.hasSuggestions,
     messages: baseRule.meta.messages,
@@ -400,7 +345,8 @@ export default util.createRule<Options, MessageIds>({
       if ('node' in descriptor) {
         if (
           descriptor.node.type === AST_TOKEN_TYPES.Line ||
-          descriptor.node.type === AST_TOKEN_TYPES.Block
+          descriptor.node.type === AST_TOKEN_TYPES.Block ||
+          descriptor.node.type === AST_TOKEN_TYPES.Shebang
         ) {
           if (isCommentNearTSConstruct(descriptor.node)) {
             return;
@@ -448,6 +394,8 @@ export default util.createRule<Options, MessageIds>({
                 before: options.beforeBlockComment,
               });
             }
+          } else if (token.type === AST_TOKEN_TYPES.Shebang) {
+            // do we want to do anything here?
           }
         });
       },

--- a/packages/eslint-plugin/src/util/index.ts
+++ b/packages/eslint-plugin/src/util/index.ts
@@ -19,6 +19,7 @@ export * from '@typescript-eslint/type-utils';
 const {
   applyDefault,
   deepMerge,
+  extendSchema,
   isObjectNotArray,
   getParserServices,
   nullThrows,
@@ -31,6 +32,7 @@ type InferOptionsTypeFromRule<T> = ESLintUtils.InferOptionsTypeFromRule<T>;
 export {
   applyDefault,
   deepMerge,
+  extendSchema,
   isObjectNotArray,
   getParserServices,
   nullThrows,

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -759,6 +759,7 @@ declare module 'eslint/lib/rules/lines-around-comment' {
         allowModuleEnd?: boolean;
         ignorePattern?: string;
         applyDefaultIgnorePatterns?: boolean;
+        afterHashbangComment?: boolean;
       }?,
     ],
     {

--- a/packages/utils/src/eslint-utils/extendSchema.ts
+++ b/packages/utils/src/eslint-utils/extendSchema.ts
@@ -1,0 +1,25 @@
+import type { JSONSchema4 } from 'json-schema';
+
+import { deepMerge } from './deepMerge';
+
+/**
+ * Extends schema with additional properties using `deepMerge`
+ * If original schema is wrapped in array, it also returns a wrapped object
+ */
+export function extendSchema(
+  schema: JSONSchema4 | readonly JSONSchema4[],
+  additionalProperties: Record<string, unknown>,
+): JSONSchema4 | [JSONSchema4] {
+  const isWrappedInArray = Array.isArray(schema);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const unwrappedSchema = isWrappedInArray ? schema[0] : schema;
+
+  const mergedSchema: JSONSchema4 = deepMerge(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- https://github.com/microsoft/TypeScript/issues/17002
+    unwrappedSchema,
+    additionalProperties,
+  );
+
+  return isWrappedInArray ? [mergedSchema] : mergedSchema;
+}

--- a/packages/utils/src/eslint-utils/index.ts
+++ b/packages/utils/src/eslint-utils/index.ts
@@ -6,3 +6,4 @@ export * from './RuleCreator';
 export * from './rule-tester/RuleTester';
 export * from './deepMerge';
 export * from './nullThrows';
+export * from './extendSchema';


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6636
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adjusts `lines-around-comment` schema to extend base rule properties instead of overriding them.

Additionally:
- creates `extendSchema` util, which uses `deepMerge` underneath and returns the merged schema in the same format as input -> either wrapped in array or not (however I am not sure why some rules wrap schema in braces and some don't). This could help avoid duplication and rule file bloating, like in `key-spacing`:
```ts
// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
const baseSchema = Array.isArray(baseRule.meta.schema)
  ? baseRule.meta.schema[0]
  : baseRule.meta.schema;
const schema = util.deepMerge(
  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- https://github.com/microsoft/TypeScript/issues/17002
  baseSchema,
  {
    properties: {
      overrides: {
        properties: {
          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
          type: baseSchema.properties.overrides.properties.import,
        },
      },
    },
  },
);
```
shortened to:
```ts
const schema = util.extendSchema(baseRule.meta.schema,
  {
    properties: {
      overrides: {
        properties: {
          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
          type: baseSchema.properties.overrides.properties.import,
        },
      },
    },
  },
);
```
- adds `AST_TOKEN_TYPES.Shebang`. I've noticed, that we're missing this in typings. Adding this highlighted some places, where additional edge cases should be supported e.g. `ban-tslint-comment`

@bradzacher let me know if this is what you had in mind in https://github.com/typescript-eslint/typescript-eslint/issues/6636#issuecomment-1477505325

<!-- Description of what is changed and how the code change does that. -->
