### PR TITLE
docs: remove hourglass for types allowlist from v6 beta post

### DIFF
--- a/packages/website/blog/2023-03-13-announcing-typescript-eslint-v6-beta.md
+++ b/packages/website/blog/2023-03-13-announcing-typescript-eslint-v6-beta.md
@@ -162,7 +162,7 @@ Several rules were changed in significant enough ways to be considered breaking 
 - [feat: drop support for node v12](https://github.com/typescript-eslint/typescript-eslint/pull/5918)
 - [feat: bump minimum supported TS version to 4.2.4](https://github.com/typescript-eslint/typescript-eslint/pull/5915): this matches [DefinitelyTyped's 2-year support window](https://github.com/DefinitelyTyped/DefinitelyTyped#support-window).
 - [chore: drop support for ESLint v6](https://github.com/typescript-eslint/typescript-eslint/pull/5972)
-- ⏳ [feat(eslint-plugin): [prefer-readonly-parameter-types] added an optional type allowlist](https://github.com/typescript-eslint/typescript-eslint/4436): changes the public `isTypeReadonlyArrayOrTuple` function's first argument from a `checker: ts.TypeChecker` to a full `program: ts.Program`
+- [feat(eslint-plugin): [prefer-readonly-parameter-types] added an optional type allowlist](https://github.com/typescript-eslint/typescript-eslint/4436): changes the public `isTypeReadonlyArrayOrTuple` function's first argument from a `checker: ts.TypeChecker` to a full `program: ts.Program`
 
 ## Developer-Facing Changes
 

--- a/packages/website/blog/2023-03-13-announcing-typescript-eslint-v6-beta.md
+++ b/packages/website/blog/2023-03-13-announcing-typescript-eslint-v6-beta.md
@@ -162,7 +162,7 @@ Several rules were changed in significant enough ways to be considered breaking 
 - [feat: drop support for node v12](https://github.com/typescript-eslint/typescript-eslint/pull/5918)
 - [feat: bump minimum supported TS version to 4.2.4](https://github.com/typescript-eslint/typescript-eslint/pull/5915): this matches [DefinitelyTyped's 2-year support window](https://github.com/DefinitelyTyped/DefinitelyTyped#support-window).
 - [chore: drop support for ESLint v6](https://github.com/typescript-eslint/typescript-eslint/pull/5972)
-- [feat(eslint-plugin): [prefer-readonly-parameter-types] added an optional type allowlist](https://github.com/typescript-eslint/typescript-eslint/4436): changes the public `isTypeReadonlyArrayOrTuple` function's first argument from a `checker: ts.TypeChecker` to a full `program: ts.Program`
+- [feat(eslint-plugin): [prefer-readonly-parameter-types] added an optional type allowlist](https://github.com/typescript-eslint/typescript-eslint/pull/4436): changes the public `isTypeReadonlyArrayOrTuple` function's first argument from a `checker: ts.TypeChecker` to a full `program: ts.Program`
 
 ## Developer-Facing Changes
 


### PR DESCRIPTION
## Overview

As promised in the blog post. As PRs get merged, the ⌛s go away. 
