### PR TITLE
chore(website): [playground] improve design of error viewer

### DIFF
--- a/packages/website/src/components/ErrorsViewer.module.css
+++ b/packages/website/src/components/ErrorsViewer.module.css
@@ -22,3 +22,11 @@
 .fixer {
   margin: 0.5rem 0 0.5rem 1.5rem;
 }
+
+.errorPre {
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  white-space: break-spaces;
+  word-wrap: break-word;
+}

--- a/packages/website/src/components/ErrorsViewer.tsx
+++ b/packages/website/src/components/ErrorsViewer.tsx
@@ -5,6 +5,8 @@ import type Monaco from 'monaco-editor';
 import React, { useEffect, useState } from 'react';
 
 import styles from './ErrorsViewer.module.css';
+import type { AlertBlockProps } from './layout/AlertBlock';
+import AlertBlock from './layout/AlertBlock';
 import type { ErrorGroup, ErrorItem } from './types';
 
 export interface ErrorsViewerProps {
@@ -17,13 +19,7 @@ export interface ErrorViewerProps {
   readonly type: AlertBlockProps['type'];
 }
 
-interface AlertBlockProps {
-  readonly type: 'danger' | 'warning' | 'note' | 'info' | 'success';
-  readonly children: React.ReactNode;
-  readonly fixer?: boolean;
-}
-
-interface ErrorBlockProps {
+export interface ErrorBlockProps {
   readonly item: ErrorItem;
   readonly setIsLocked: (value: boolean) => void;
   readonly isLocked: boolean;
@@ -64,14 +60,6 @@ function FixButton(props: FixButtonProps): JSX.Element {
   );
 }
 
-function AlertBlock(props: AlertBlockProps): JSX.Element {
-  return (
-    <div className={`admonition alert alert--${props.type}`}>
-      <div className="admonition-content">{props.children}</div>
-    </div>
-  );
-}
-
 function ErrorBlock({
   item,
   setIsLocked,
@@ -80,9 +68,9 @@ function ErrorBlock({
   return (
     <AlertBlock type={severityClass(item.severity)}>
       <div className={clsx(!!item.fixer && styles.fixerContainer)}>
-        <div>
+        <pre className={styles.errorPre}>
           {item.message} {item.location}
-        </div>
+        </pre>
         {item.fixer && (
           <FixButton
             disabled={isLocked}
@@ -95,7 +83,7 @@ function ErrorBlock({
         <div>
           {item.suggestions.map((fixer, index) => (
             <div
-              key={index}
+              key={String(index)}
               className={clsx(styles.fixerContainer, styles.fixer)}
             >
               <span>&gt; {fixer.message}</span>
@@ -112,16 +100,6 @@ function ErrorBlock({
   );
 }
 
-function SuccessBlock(): JSX.Element {
-  return (
-    <AlertBlock type="success">
-      <div className={styles.fixerContainer}>
-        <div>All is ok!</div>
-      </div>
-    </AlertBlock>
-  );
-}
-
 export function ErrorViewer({
   value,
   title,
@@ -134,7 +112,9 @@ export function ErrorViewer({
           <div className={styles.fixerContainer}>
             <h4>{title}</h4>
           </div>
-          {type === 'danger' ? value.stack : value.message}
+          <pre className={styles.errorPre}>
+            {type === 'danger' ? value?.stack : value.message}
+          </pre>
         </AlertBlock>
       </div>
     </div>
@@ -170,19 +150,22 @@ export function ErrorsViewer({ value }: ErrorsViewerProps): JSX.Element {
                 )}
               </h4>
               {items.map((item, index) => (
-                <ErrorBlock
-                  isLocked={isLocked}
-                  setIsLocked={setIsLocked}
-                  item={item}
-                  key={index}
-                />
+                <div className="margin-bottom--sm" key={String(index)}>
+                  <ErrorBlock
+                    isLocked={isLocked}
+                    setIsLocked={setIsLocked}
+                    item={item}
+                  />
+                </div>
               ))}
             </div>
           );
         })
       ) : (
         <div className="margin-top--md">
-          <SuccessBlock />
+          <AlertBlock type="success">
+            <div>All is ok!</div>
+          </AlertBlock>
         </div>
       )}
     </div>

--- a/packages/website/src/components/ErrorsViewer.tsx
+++ b/packages/website/src/components/ErrorsViewer.tsx
@@ -83,7 +83,7 @@ function ErrorBlock({
         <div>
           {item.suggestions.map((fixer, index) => (
             <div
-              key={String(index)}
+              key={index}
               className={clsx(styles.fixerContainer, styles.fixer)}
             >
               <span>&gt; {fixer.message}</span>
@@ -150,7 +150,7 @@ export function ErrorsViewer({ value }: ErrorsViewerProps): JSX.Element {
                 )}
               </h4>
               {items.map((item, index) => (
-                <div className="margin-bottom--sm" key={String(index)}>
+                <div className="margin-bottom--sm" key={index}>
                   <ErrorBlock
                     isLocked={isLocked}
                     setIsLocked={setIsLocked}

--- a/packages/website/src/components/layout/AlertBlock.tsx
+++ b/packages/website/src/components/layout/AlertBlock.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export interface AlertBlockProps {
+  readonly type: 'success' | 'info' | 'note' | 'warning' | 'danger';
+  readonly children: React.ReactNode;
+}
+
+function AlertBlock(props: AlertBlockProps): JSX.Element {
+  return (
+    <div className={`admonition alert alert--${props.type}`}>
+      <div className="admonition-content">{props.children}</div>
+    </div>
+  );
+}
+
+export default AlertBlock;


### PR DESCRIPTION
## PR Checklist
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

migrate error viewer changes from #6656

notable changes:
- alerts have consistent small spacing between them
- text is printed as monospace font
- text is wrapped

![image](https://user-images.githubusercontent.com/625469/226911708-45902856-7e5b-4f50-ac8c-6db79ceb6a73.png) ![image](https://user-images.githubusercontent.com/625469/226911766-33a2b837-3278-475b-a010-65c504934ef6.png)

