### PR TITLE
feat(eslint-plugin): [no-unnecessary-condition] add `allowAssertTypePredicateParameterConditions` option

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md
@@ -83,6 +83,18 @@ for (; true; ) {}
 do {} while (true);
 ```
 
+### `allowAssertTypePredicateParameterConditions`
+
+Example of correct code for `{ allowAssertTypePredicateParameterConditions: true }`:
+
+```ts
+function assert(condition: unknown): asserts condition {
+  // do something with condition
+}
+const obj = {};
+assert(obj != null);
+```
+
 ### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
 
 If this is set to `false`, then the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.

--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -343,4 +343,5 @@ export {
   isTypedFunctionExpression,
   isValidFunctionExpressionReturnType,
   ancestorHasReturnType,
+  isFunctionArgument,
 };

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -575,6 +575,16 @@ get({ foo: null }, 'foo');
     `,
     {
       code: `
+        function assert(condition: unknown): asserts condition {
+          // do something with condition
+        }
+        const obj = {};
+        assert(obj != null);
+      `,
+      options: [{ allowAssertTypePredicateParameterConditions: true }],
+    },
+    {
+      code: `
 function getElem(dict: Record<string, { foo: string }>, key: string) {
   if (dict[key]) {
     return dict[key].foo;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -575,6 +575,13 @@ get({ foo: null }, 'foo');
     `,
     {
       code: `
+        function foo(val: unknown) {}
+        foo([] === true);
+      `,
+      options: [{ allowAssertTypePredicateParameterConditions: true }],
+    },
+    {
+      code: `
         function assert(condition: unknown): asserts condition {
           // do something with condition
         }
@@ -1800,6 +1807,54 @@ foo &&= null;
           endLine: 3,
           column: 1,
           endColumn: 4,
+        },
+      ],
+    },
+    {
+      code: `
+        if (true == true) {
+        }
+      `,
+      options: [{ allowAssertTypePredicateParameterConditions: true }],
+      errors: [
+        {
+          messageId: 'literalBooleanExpression',
+          line: 2,
+          endLine: 2,
+          column: 13,
+          endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: `
+        const f = (value: boolean) => value;
+        f(true === true);
+      `,
+      options: [{ allowAssertTypePredicateParameterConditions: true }],
+      errors: [
+        {
+          messageId: 'literalBooleanExpression',
+          line: 3,
+          endLine: 3,
+          column: 11,
+          endColumn: 24,
+        },
+      ],
+    },
+    {
+      code: `
+        const f = (value: unknown): value is boolean => true;
+        f(false == 'false');
+      `,
+      options: [{ allowAssertTypePredicateParameterConditions: true }],
+      errors: [
+        {
+          messageId: 'literalBooleanExpression',
+          line: 3,
+          endLine: 3,
+          column: 11,
+          endColumn: 27,
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2752
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The new option makes it possible to turn the rule off for parameters in type predicates that use `asserts` keyword.

Example of code that doesn't trigger the rule with this option enabled:

```ts
function assert(condition: unknown): asserts condition {
  // do something with condition
}
const obj = {};
assert(obj != null);
```

**How it works**

For `BinaryExpression` nodes, there is a new condition which will check the parent type (provided that the new `allowAssertTypePredicateParameterConditions` option is turned on.
<!-- Description of what is changed and how the code change does that. -->
