### PR TITLE
feat(eslint-plugin): [consistent-type-assertions] add `arrayLiteralTypeAssertions` option

### DIFF
--- a/packages/eslint-plugin/docs/rules/consistent-type-assertions.md
+++ b/packages/eslint-plugin/docs/rules/consistent-type-assertions.md
@@ -103,6 +103,34 @@ const foo = <Foo props={{ ... } as Bar}/>;
 
 <!--/tabs-->
 
+### `arrayLiteralTypeAssertions`
+
+Always prefer `const x: T[] = [ ... ];` to `const x = [ ... ] as T[];` (or similar with angle brackets). The rationale for this is exactly the same as for `objectLiteralTypeAssertions`.
+
+The const assertion `const x = [1, 2, 3] as const`, introduced in TypeScript 3.4, is considered beneficial and is ignored by this option.
+
+Assertions to `any` are also ignored by this option.
+
+Examples of code for `{ assertionStyle: 'as', arrayLiteralTypeAssertions: 'never' }`:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+const x = [] as string[];
+const y = ['a'] as string[];
+```
+
+#### ✅ Correct
+
+```ts
+const x: string[] = [];
+const y: string[] = ['a'];
+```
+
+<!--/tabs-->
+
 ## When Not To Use It
 
 If you do not want to enforce consistent type assertions.

--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -11,7 +11,9 @@ type MessageIds =
   | 'unexpectedObjectTypeAssertion'
   | 'unexpectedArrayTypeAssertion'
   | 'replaceObjectTypeAssertionWithAnnotation'
-  | 'replaceObjectTypeAssertionWithSatisfies';
+  | 'replaceObjectTypeAssertionWithSatisfies'
+  | 'replaceArrayTypeAssertionWithAnnotation'
+  | 'replaceArrayTypeAssertionWithSatisfies';
 type OptUnion =
   | {
       assertionStyle: 'as' | 'angle-bracket';
@@ -43,6 +45,10 @@ export default util.createRule<Options, MessageIds>({
         'Use const x: {{cast}} = { ... } instead.',
       replaceObjectTypeAssertionWithSatisfies:
         'Use const x = { ... } satisfies {{cast}} instead.',
+      replaceArrayTypeAssertionWithAnnotation:
+        'Use const x: [{cast}] = [ ... ] instead.',
+      replaceArrayTypeAssertionWithSatisfies:
+        'Use const x = [ ... ] satisfies [{cast}] instead.',
     },
     schema: [
       {
@@ -253,7 +259,6 @@ export default util.createRule<Options, MessageIds>({
         checkType(node.typeAnnotation) &&
         node.expression.type === AST_NODE_TYPES.ArrayExpression
       ) {
-        /*
         const suggest: TSESLint.ReportSuggestionArray<MessageIds> = [];
         if (
           node.parent?.type === AST_NODE_TYPES.VariableDeclarator &&
@@ -261,7 +266,7 @@ export default util.createRule<Options, MessageIds>({
         ) {
           const { parent } = node;
           suggest.push({
-            messageId: 'replaceObjectTypeAssertionWithAnnotation',
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
             data: { cast: sourceCode.getText(node.typeAnnotation) },
             fix: fixer => [
               fixer.insertTextAfter(
@@ -273,7 +278,7 @@ export default util.createRule<Options, MessageIds>({
           });
         }
         suggest.push({
-          messageId: 'replaceObjectTypeAssertionWithSatisfies',
+          messageId: 'replaceArrayTypeAssertionWithAnnotation',
           data: { cast: sourceCode.getText(node.typeAnnotation) },
           fix: fixer => [
             fixer.replaceText(node, getTextWithParentheses(node.expression)),
@@ -285,12 +290,11 @@ export default util.createRule<Options, MessageIds>({
             ),
           ],
         });
-        */
 
         context.report({
           node,
           messageId: 'unexpectedArrayTypeAssertion',
-          suggest: [],
+          suggest,
         });
       }
     }

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -76,6 +76,7 @@ const x = <Array<string>>[];
 const x = <Array<string>>['a'];
 const x = <'a'[]>[Math.random() ? 'a' : 'b'];
 `;
+/*
 const ARRAY_LITERAL_DECLARATIONS = `
 const x: string[] = [];
 const x: string[] = ['a'];
@@ -83,6 +84,7 @@ const x: Array<string> = [];
 const x: Array<string> = ['a'];
 const x: 'a'[] = [Math.random() ? 'a' : 'b'];
 `;
+*/
 
 ruleTester.run('consistent-type-assertions', rule, {
   valid: [
@@ -870,5 +872,36 @@ ruleTester.run('consistent-type-assertions', rule, {
       ],
       output: ARRAY_LITERAL_AS_CASTS,
     },
+    ...batchedSingleLineTests({
+      code: ARRAY_LITERAL_AS_CASTS,
+      options: [
+        {
+          assertionStyle: 'as',
+          arrayLiteralTypeAssertions: 'never',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          line: 2,
+        },
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          line: 3,
+        },
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          line: 4,
+        },
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          line: 5,
+        },
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          line: 6,
+        },
+      ],
+    }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -741,7 +741,7 @@ ruleTester.run('consistent-type-assertions', rule, {
         },
       ],
     },
-    {
+    ...batchedSingleLineTests({
       code: ARRAY_LITERAL_AS_CASTS,
       options: [
         {
@@ -770,8 +770,8 @@ ruleTester.run('consistent-type-assertions', rule, {
           line: 6,
         },
       ],
-    },
-    {
+    }),
+    ...batchedSingleLineTests({
       code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
       options: [
         {
@@ -800,8 +800,8 @@ ruleTester.run('consistent-type-assertions', rule, {
           line: 6,
         },
       ],
-    },
-    {
+    }),
+    ...batchedSingleLineTests({
       code: ARRAY_LITERAL_AS_CASTS,
       options: [
         {
@@ -831,8 +831,8 @@ ruleTester.run('consistent-type-assertions', rule, {
         },
       ],
       output: null,
-    },
-    {
+    }),
+    ...batchedSingleLineTests({
       code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
       options: [
         {
@@ -862,7 +862,7 @@ ruleTester.run('consistent-type-assertions', rule, {
         },
       ],
       output: ARRAY_LITERAL_AS_CASTS,
-    },
+    }),
     ...batchedSingleLineTests({
       code: ARRAY_LITERAL_AS_CASTS,
       options: [

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -904,4 +904,35 @@ ruleTester.run('consistent-type-assertions', rule, {
       ],
     }),
   ],
+  ...batchedSingleLineTests({
+    code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+    options: [
+      {
+        assertionStyle: 'angle-brackets',
+        arrayLiteralTypeAssertions: 'never',
+      },
+    ],
+    errors: [
+      {
+        messageId: 'unexpectedArrayTypeAssertion',
+        line: 2,
+      },
+      {
+        messageId: 'unexpectedArrayTypeAssertion',
+        line: 3,
+      },
+      {
+        messageId: 'unexpectedArrayTypeAssertion',
+        line: 4,
+      },
+      {
+        messageId: 'unexpectedArrayTypeAssertion',
+        line: 5,
+      },
+      {
+        messageId: 'unexpectedArrayTypeAssertion',
+        line: 6,
+      },
+    ],
+  }),
 });

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -63,12 +63,15 @@ print?.call(<Foo>{ bar: 5 })
 `;
 
 const ARRAY_LITERAL_AS_CASTS = `
-const errorMessages = [] as string[];
-const errorMessages = ['a'] as string[];
+const x = [] as string[];
+const x = ['a'] as string[];
+const x = [] as Array<string>;
+const x = ['a'] as Array<string>;
+const x = [Math.random() ? 'a' : 'b'] as 'a'[];
 `;
 const ARRAY_LITERAL_ANGLE_BRACKET_CASTS = `
-const errorMessages = <string[]>[];
-const errorMessages = <string[]>['a'];
+const x = <string[]>[];
+const x = <string[]>['a'];
 `;
 
 ruleTester.run('consistent-type-assertions', rule, {
@@ -732,6 +735,54 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           messageId: 'never',
           line: 1,
+        },
+      ],
+    },
+    {
+      code: ARRAY_LITERAL_AS_CASTS,
+      options: [
+        {
+          assertionStyle: 'never',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'never',
+          line: 2,
+        },
+        {
+          messageId: 'never',
+          line: 3,
+        },
+        {
+          messageId: 'never',
+          line: 4,
+        },
+        {
+          messageId: 'never',
+          line: 5,
+        },
+        {
+          messageId: 'never',
+          line: 6,
+        },
+      ],
+    },
+    {
+      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+      options: [
+        {
+          assertionStyle: 'never',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'never',
+          line: 2,
+        },
+        {
+          messageId: 'never',
+          line: 3,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -874,6 +874,7 @@ ruleTester.run('consistent-type-assertions', rule, {
     },
     ...batchedSingleLineTests({
       code: ARRAY_LITERAL_AS_CASTS,
+      only: true,
       options: [
         {
           assertionStyle: 'as',
@@ -884,6 +885,18 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           messageId: 'unexpectedArrayTypeAssertion',
           line: 2,
+          suggestions: [
+            {
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              data: { cast: 'string' },
+              output: 'const x: string[] = [];',
+            },
+            {
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              data: { cast: 'string' },
+              output: 'const x = [] satisfies string[];',
+            },
+          ],
         },
         {
           messageId: 'unexpectedArrayTypeAssertion',

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -72,6 +72,16 @@ const x = [Math.random() ? 'a' : 'b'] as 'a'[];
 const ARRAY_LITERAL_ANGLE_BRACKET_CASTS = `
 const x = <string[]>[];
 const x = <string[]>['a'];
+const x = <Array<string>>[];
+const x = <Array<string>>['a'];
+const x = <'a'[]>[Math.random() ? 'a' : 'b'];
+`;
+const ARRAY_LITERAL_DECLARATIONS = `
+const x: string[] = [];
+const x: string[] = ['a'];
+const x: Array<string> = [];
+const x: Array<string> = ['a'];
+const x: 'a'[] = [Math.random() ? 'a' : 'b'];
 `;
 
 ruleTester.run('consistent-type-assertions', rule, {
@@ -130,6 +140,22 @@ ruleTester.run('consistent-type-assertions', rule, {
         },
       ],
     }),
+    ...batchedSingleLineTests({
+      code: ARRAY_LITERAL_AS_CASTS,
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests({
+      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+      options: [
+        {
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    }),
     {
       code: 'const x = <const>[1];',
       options: [
@@ -157,22 +183,6 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           assertionStyle: 'as',
           objectLiteralTypeAssertions: 'allow-as-parameter',
-        },
-      ],
-    },
-    {
-      code: ARRAY_LITERAL_AS_CASTS,
-      options: [
-        {
-          assertionStyle: 'as',
-        },
-      ],
-    },
-    {
-      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
-      options: [
-        {
-          assertionStyle: 'angle-bracket',
         },
       ],
     },
@@ -784,13 +794,25 @@ ruleTester.run('consistent-type-assertions', rule, {
           messageId: 'never',
           line: 3,
         },
+        {
+          messageId: 'never',
+          line: 4,
+        },
+        {
+          messageId: 'never',
+          line: 5,
+        },
+        {
+          messageId: 'never',
+          line: 6,
+        },
       ],
     },
     {
       code: ARRAY_LITERAL_AS_CASTS,
       options: [
         {
-          assertionStyle: 'angle',
+          assertionStyle: 'angle-bracket',
         },
       ],
       errors: [
@@ -815,6 +837,7 @@ ruleTester.run('consistent-type-assertions', rule, {
           line: 6,
         },
       ],
+      output: null,
     },
     {
       code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
@@ -832,7 +855,20 @@ ruleTester.run('consistent-type-assertions', rule, {
           messageId: 'as',
           line: 3,
         },
+        {
+          messageId: 'as',
+          line: 4,
+        },
+        {
+          messageId: 'as',
+          line: 5,
+        },
+        {
+          messageId: 'as',
+          line: 6,
+        },
       ],
+      output: ARRAY_LITERAL_AS_CASTS,
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -62,6 +62,15 @@ print?.(<Foo>{ bar: 5 })
 print?.call(<Foo>{ bar: 5 })
 `;
 
+const ARRAY_LITERAL_AS_CASTS = `
+const errorMessages = [] as string[];
+const errorMessages = ['a'] as string[];
+`;
+const ARRAY_LITERAL_ANGLE_BRACKET_CASTS = `
+const errorMessages = <string[]>[];
+const errorMessages = <string[]>['a'];
+`;
+
 ruleTester.run('consistent-type-assertions', rule, {
   valid: [
     ...batchedSingleLineTests({
@@ -145,6 +154,22 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           assertionStyle: 'as',
           objectLiteralTypeAssertions: 'allow-as-parameter',
+        },
+      ],
+    },
+    {
+      code: ARRAY_LITERAL_AS_CASTS,
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
+      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+      options: [
+        {
+          assertionStyle: 'angle-bracket',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -786,5 +786,53 @@ ruleTester.run('consistent-type-assertions', rule, {
         },
       ],
     },
+    {
+      code: ARRAY_LITERAL_AS_CASTS,
+      options: [
+        {
+          assertionStyle: 'angle',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'angle-bracket',
+          line: 2,
+        },
+        {
+          messageId: 'angle-bracket',
+          line: 3,
+        },
+        {
+          messageId: 'angle-bracket',
+          line: 4,
+        },
+        {
+          messageId: 'angle-bracket',
+          line: 5,
+        },
+        {
+          messageId: 'angle-bracket',
+          line: 6,
+        },
+      ],
+    },
+    {
+      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'as',
+          line: 2,
+        },
+        {
+          messageId: 'as',
+          line: 3,
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -882,7 +882,7 @@ ruleTester.run('consistent-type-assertions', rule, {
               output: 'const x: string[] = [];',
             },
             {
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
               data: { cast: 'string' },
               output: 'const x = [] satisfies string[];',
             },
@@ -898,7 +898,7 @@ ruleTester.run('consistent-type-assertions', rule, {
               output: `const x: string[] = ['a'];`,
             },
             {
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
               data: { cast: 'string' },
               output: `const x = ['a'] satisfies string[];`,
             },
@@ -914,7 +914,7 @@ ruleTester.run('consistent-type-assertions', rule, {
               output: 'const x: Array<string> = [];',
             },
             {
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
               data: { cast: 'string' },
               output: 'const x = [] satisfies Array<string>;',
             },
@@ -930,7 +930,7 @@ ruleTester.run('consistent-type-assertions', rule, {
               output: `const x: Array<string> = ['a'];`,
             },
             {
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
               data: { cast: 'string' },
               output: `const x = ['a'] satisfies Array<string>;`,
             },
@@ -946,7 +946,7 @@ ruleTester.run('consistent-type-assertions', rule, {
               output: `const x: 'a'[] = [Math.random() ? 'a' : 'b'];`,
             },
             {
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
               data: { cast: 'string' },
               output: `const x = [Math.random() ? 'a' : 'b'] satisfies 'a'[];`,
             },
@@ -974,7 +974,7 @@ ruleTester.run('consistent-type-assertions', rule, {
             output: 'const x: string[] = [];',
           },
           {
-            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            messageId: 'replaceArrayTypeAssertionWithSatisfies',
             data: { cast: 'string' },
             output: 'const x = [] satisfies string[];',
           },
@@ -990,7 +990,7 @@ ruleTester.run('consistent-type-assertions', rule, {
             output: `const x: string[] = ['a'];`,
           },
           {
-            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            messageId: 'replaceArrayTypeAssertionWithSatisfies',
             data: { cast: 'string' },
             output: `const x = ['a'] satisfies string[];`,
           },
@@ -1006,7 +1006,7 @@ ruleTester.run('consistent-type-assertions', rule, {
             output: 'const x: Array<string> = [];',
           },
           {
-            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            messageId: 'replaceArrayTypeAssertionWithSatisfies',
             data: { cast: 'string' },
             output: 'const x = [] satisfies Array<string>;',
           },
@@ -1022,7 +1022,7 @@ ruleTester.run('consistent-type-assertions', rule, {
             output: `const x: Array<string> = ['a'];`,
           },
           {
-            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            messageId: 'replaceArrayTypeAssertionWithSatisfies',
             data: { cast: 'string' },
             output: `const x = ['a'] satisfies Array<string>;`,
           },
@@ -1038,7 +1038,7 @@ ruleTester.run('consistent-type-assertions', rule, {
             output: `const x: 'a'[] = [Math.random() ? 'a' : 'b'];`,
           },
           {
-            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            messageId: 'replaceArrayTypeAssertionWithSatisfies',
             data: { cast: 'string' },
             output: `const x = [Math.random() ? 'a' : 'b'] satisfies 'a'[];`,
           },

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -76,15 +76,6 @@ const x = <Array<string>>[];
 const x = <Array<string>>['a'];
 const x = <'a'[]>[Math.random() ? 'a' : 'b'];
 `;
-/*
-const ARRAY_LITERAL_DECLARATIONS = `
-const x: string[] = [];
-const x: string[] = ['a'];
-const x: Array<string> = [];
-const x: Array<string> = ['a'];
-const x: 'a'[] = [Math.random() ? 'a' : 'b'];
-`;
-*/
 
 ruleTester.run('consistent-type-assertions', rule, {
   valid: [
@@ -874,7 +865,6 @@ ruleTester.run('consistent-type-assertions', rule, {
     },
     ...batchedSingleLineTests({
       code: ARRAY_LITERAL_AS_CASTS,
-      only: true,
       options: [
         {
           assertionStyle: 'as',
@@ -901,18 +891,66 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           messageId: 'unexpectedArrayTypeAssertion',
           line: 3,
+          suggestions: [
+            {
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              data: { cast: 'string' },
+              output: `const x: string[] = ['a'];`,
+            },
+            {
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              data: { cast: 'string' },
+              output: `const x = ['a'] satisfies string[];`,
+            },
+          ],
         },
         {
           messageId: 'unexpectedArrayTypeAssertion',
           line: 4,
+          suggestions: [
+            {
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              data: { cast: 'string' },
+              output: 'const x: Array<string> = [];',
+            },
+            {
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              data: { cast: 'string' },
+              output: 'const x = [] satisfies Array<string>;',
+            },
+          ],
         },
         {
           messageId: 'unexpectedArrayTypeAssertion',
           line: 5,
+          suggestions: [
+            {
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              data: { cast: 'string' },
+              output: `const x: Array<string> = ['a'];`,
+            },
+            {
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              data: { cast: 'string' },
+              output: `const x = ['a'] satisfies Array<string>;`,
+            },
+          ],
         },
         {
           messageId: 'unexpectedArrayTypeAssertion',
           line: 6,
+          suggestions: [
+            {
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              data: { cast: 'string' },
+              output: `const x: 'a'[] = [Math.random() ? 'a' : 'b'];`,
+            },
+            {
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              data: { cast: 'string' },
+              output: `const x = [Math.random() ? 'a' : 'b'] satisfies 'a'[];`,
+            },
+          ],
         },
       ],
     }),
@@ -929,22 +967,82 @@ ruleTester.run('consistent-type-assertions', rule, {
       {
         messageId: 'unexpectedArrayTypeAssertion',
         line: 2,
+        suggestions: [
+          {
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            data: { cast: 'string' },
+            output: 'const x: string[] = [];',
+          },
+          {
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            data: { cast: 'string' },
+            output: 'const x = [] satisfies string[];',
+          },
+        ],
       },
       {
         messageId: 'unexpectedArrayTypeAssertion',
         line: 3,
+        suggestions: [
+          {
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            data: { cast: 'string' },
+            output: `const x: string[] = ['a'];`,
+          },
+          {
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            data: { cast: 'string' },
+            output: `const x = ['a'] satisfies string[];`,
+          },
+        ],
       },
       {
         messageId: 'unexpectedArrayTypeAssertion',
         line: 4,
+        suggestions: [
+          {
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            data: { cast: 'string' },
+            output: 'const x: Array<string> = [];',
+          },
+          {
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            data: { cast: 'string' },
+            output: 'const x = [] satisfies Array<string>;',
+          },
+        ],
       },
       {
         messageId: 'unexpectedArrayTypeAssertion',
         line: 5,
+        suggestions: [
+          {
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            data: { cast: 'string' },
+            output: `const x: Array<string> = ['a'];`,
+          },
+          {
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            data: { cast: 'string' },
+            output: `const x = ['a'] satisfies Array<string>;`,
+          },
+        ],
       },
       {
         messageId: 'unexpectedArrayTypeAssertion',
         line: 6,
+        suggestions: [
+          {
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            data: { cast: 'string' },
+            output: `const x: 'a'[] = [Math.random() ? 'a' : 'b'];`,
+          },
+          {
+            messageId: 'replaceArrayTypeAssertionWithAnnotation',
+            data: { cast: 'string' },
+            output: `const x = [Math.random() ? 'a' : 'b'] satisfies 'a'[];`,
+          },
+        ],
       },
     ],
   }),


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6374
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR adds an `arrayLiteralTypeAssertions` option to the `consistent-type-assertions` rule as described in the linked issue. This uses the same auto-fixer as the `objectLiteralTypeAssertions` option.

I didn't include an equivalent of the `"allow-as-parameter"` option but I can do so if there's a need.

If I may step on my soapbox for a moment:

1. The `objectLiteralTypeAssertions` option (and this new one) are an awkward fit for the `consistent-type-assertions`, which you would expect to just enforce consistency between `x as T` and `<T>x`. Both options would make more sense in a distinct rule that bans type assertions (rather than enforcing a consistent style).
2. I'm not sure why you'd ever want to enable `objectLiteralTypeAssertions` but not `arrayLiteralTypeAssertions`, or vice versa. It also feels odd that we're singling out these two types but allowing constructs with other types such as `const x = 'foo' as string;`