### PR TITLE
feat(eslint-plugin): [strict-boolean-expressions] add `allowEnum` option

### DIFF
--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -133,6 +133,72 @@ ruleTester.run('strict-boolean-expressions', rule, {
       `,
     }),
 
+    // enum in boolean context
+    ...batchedSingleLineTests<Options>({
+      code: noFormat`
+        enum Foo { Bar, Baz }; (val: Foo) => val ? 1 : 0;
+        enum Foo { Bar, Baz = 1 }; (val: Foo) => val ? 1 : 0;
+        enum Foo { Bar = 0, Baz = 1 }; (val: Foo) => val ? 1 : 0;
+        enum Foo { Bar = 1, Baz = 2 }; (val: Foo) => val ? 1 : 0;
+        enum Foo { Bar, Baz = 'baz' }; (val: Foo) => val ? 1 : 0;
+        enum Foo { Bar = '', Baz = 'baz' }; (val: Foo) => val ? 1 : 0;
+        enum Foo { Bar = 'bar', Baz = 'baz' }; (val: Foo) => val ? 1 : 0;
+        enum Foo { Bar = 0, Baz = 'baz' }; (val: Foo) => val ? 1 : 0;
+        enum Foo { Bar = 1, Baz = '' }; (val: Foo) => val ? 1 : 0;
+        enum Foo { Bar = 0, Baz = '' }; (val: Foo) => val ? 1 : 0;
+        enum Foo { Bar = 1, Baz = 'baz' }; (val: Foo) => val ? 1 : 0;
+      `,
+      options: [{ allowEnum: true }],
+    }),
+    {
+      code: `
+        enum ExampleEnum {
+          This = 1,
+          That = 2,
+        }
+        const rand = Math.random();
+        let theEnum: ExampleEnum | null = null;
+        if (rand < 0.3) {
+          theEnum = ExampleEnum.This;
+        }
+        if (!theEnum) {
+        }
+      `,
+      options: [{ allowEnum: true }],
+    },
+    {
+      code: `
+        enum ExampleEnum {
+          This = 'one',
+          That = 'two',
+        }
+        const rand = Math.random();
+        let theEnum: ExampleEnum | null = null;
+        if (rand < 0.3) {
+          theEnum = ExampleEnum.This;
+        }
+        if (!theEnum) {
+        }
+      `,
+      options: [{ allowEnum: true }],
+    },
+    {
+      code: `
+        enum ExampleEnum {
+          This = 1,
+          That = 'two',
+        }
+        const rand = Math.random();
+        let theEnum: ExampleEnum | null = null;
+        if (rand < 0.3) {
+          theEnum = ExampleEnum.This;
+        }
+        if (!theEnum) {
+        }
+      `,
+      options: [{ allowEnum: true }],
+    },
+
     // nullable enum in boolean context
     {
       code: `
@@ -155,38 +221,6 @@ ruleTester.run('strict-boolean-expressions', rule, {
         enum ExampleEnum {
           This = 0,
           That = 1,
-        }
-        const rand = Math.random();
-        let theEnum: ExampleEnum | null = null;
-        if (rand < 0.3) {
-          theEnum = ExampleEnum.This;
-        }
-        if (!theEnum) {
-        }
-      `,
-      options: [{ allowNullableEnum: true }],
-    },
-    {
-      code: `
-        enum ExampleEnum {
-          This = 1,
-          That = 2,
-        }
-        const rand = Math.random();
-        let theEnum: ExampleEnum | null = null;
-        if (rand < 0.3) {
-          theEnum = ExampleEnum.This;
-        }
-        if (!theEnum) {
-        }
-      `,
-      options: [{ allowNullableEnum: true }],
-    },
-    {
-      code: `
-        enum ExampleEnum {
-          This = 'one',
-          That = 'two',
         }
         const rand = Math.random();
         let theEnum: ExampleEnum | null = null;
@@ -1221,66 +1255,6 @@ if (y) {
         enum ExampleEnum {
           This = '',
           That = 0,
-        }
-        const theEnum = Math.random() < 0.3 ? ExampleEnum.This : null;
-        if (theEnum == null) {
-        }
-      `,
-    },
-    {
-      options: [{ allowNullableEnum: false }],
-      code: `
-        enum ExampleEnum {
-          This = 'one',
-          That = 'two',
-        }
-        const theEnum = Math.random() < 0.3 ? ExampleEnum.This : null;
-        if (!theEnum) {
-        }
-      `,
-      errors: [
-        {
-          line: 7,
-          column: 14,
-          messageId: 'conditionErrorNullableEnum',
-          endLine: 7,
-          endColumn: 21,
-        },
-      ],
-      output: `
-        enum ExampleEnum {
-          This = 'one',
-          That = 'two',
-        }
-        const theEnum = Math.random() < 0.3 ? ExampleEnum.This : null;
-        if (theEnum == null) {
-        }
-      `,
-    },
-    {
-      options: [{ allowNullableEnum: false }],
-      code: `
-        enum ExampleEnum {
-          This = 1,
-          That = 2,
-        }
-        const theEnum = Math.random() < 0.3 ? ExampleEnum.This : null;
-        if (!theEnum) {
-        }
-      `,
-      errors: [
-        {
-          line: 7,
-          column: 14,
-          messageId: 'conditionErrorNullableEnum',
-          endLine: 7,
-          endColumn: 21,
-        },
-      ],
-      output: `
-        enum ExampleEnum {
-          This = 1,
-          That = 2,
         }
         const theEnum = Math.random() < 0.3 ? ExampleEnum.This : null;
         if (theEnum == null) {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6577
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Adds `allowEnum` option, which returns early for all enums. This rule should also report suggestions – however this is beyond the scope of this issue. I will create another issue where we can discuss what the suggestions should be. 

Additionally, this PR moves `is('nullish', 'truthy number', 'enum')` and `is('nullish', 'truthy string', 'enum')` conditions from `allowNullableEnum` scope, because it should be treated as an edge case similar to what we do with nullish truthy numbers and truthy strings when `allowString` or `allowNumber` is turned on.