### PR TITLE
fix(eslint-plugin): correct crashes with getTypeArguments for ts < 3.7

### DIFF
--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -555,7 +555,7 @@ function voidFunctionArguments(
             // Unwrap 'Array<MaybeVoidFunction>' to 'MaybeVoidFunction',
             // so that we'll handle it in the same way as a non-rest
             // 'param: MaybeVoidFunction'
-            type = checker.getTypeArguments(type)[0];
+            type = util.getTypeArguments(type, checker)[0];
             for (let i = index; i < node.arguments.length; i++) {
               checkThenableOrVoidArgument(
                 checker,
@@ -569,7 +569,7 @@ function voidFunctionArguments(
           } else if (checker.isTupleType(type)) {
             // Check each type in the tuple - for example, [boolean, () => void] would
             // add the index of the second tuple parameter to 'voidReturnIndices'
-            const typeArgs = checker.getTypeArguments(type);
+            const typeArgs = util.getTypeArguments(type, checker);
             for (
               let i = index;
               i < node.arguments.length && i - index < typeArgs.length;

--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -57,13 +57,13 @@ class FunctionSignature {
         // is a rest param
         if (checker.isArrayType(type)) {
           restType = {
-            type: checker.getTypeArguments(type)[0],
+            type: util.getTypeArguments(type, checker)[0],
             kind: RestTypeKind.Array,
             index: i,
           };
         } else if (checker.isTupleType(type)) {
           restType = {
-            typeArguments: checker.getTypeArguments(type),
+            typeArguments: util.getTypeArguments(type, checker),
             kind: RestTypeKind.Tuple,
             index: i,
           };
@@ -202,8 +202,10 @@ export default util.createRule<[], MessageIds>({
                 });
               } else if (checker.isTupleType(spreadArgType)) {
                 // foo(...[tuple1, tuple2])
-                const spreadTypeArguments =
-                  checker.getTypeArguments(spreadArgType);
+                const spreadTypeArguments = util.getTypeArguments(
+                  spreadArgType,
+                  checker,
+                );
                 for (const tupleType of spreadTypeArguments) {
                   const parameterType = signature.getNextParameterType();
                   if (parameterType == null) {

--- a/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
+++ b/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
@@ -55,7 +55,7 @@ export default util.createRule<Options, MessageIds>({
         service.esTreeNodeToTSNodeMap.get(node),
       );
       if (checker.isArrayType(type) || checker.isTupleType(type)) {
-        const typeArgs = checker.getTypeArguments(type);
+        const typeArgs = util.getTypeArguments(type, checker);
         return typeArgs.every(
           arg => util.getTypeName(checker, arg) === 'string',
         );

--- a/packages/type-utils/src/isTypeReadonly.ts
+++ b/packages/type-utils/src/isTypeReadonly.ts
@@ -10,6 +10,7 @@ import {
 } from 'tsutils';
 import * as ts from 'typescript';
 
+import { getTypeArguments } from './getTypeArguments';
 import { getTypeOfPropertyOfType } from './propertyTypes';
 
 const enum Readonlyness {
@@ -52,9 +53,7 @@ function isTypeReadonlyArrayOrTuple(
   function checkTypeArguments(arrayType: ts.TypeReference): Readonlyness {
     const typeArguments =
       // getTypeArguments was only added in TS3.7
-      checker.getTypeArguments
-        ? checker.getTypeArguments(arrayType)
-        : arrayType.typeArguments ?? [];
+      getTypeArguments(arrayType, checker);
 
     // this shouldn't happen in reality as:
     // - tuples require at least 1 type argument


### PR DESCRIPTION
## PR Checklist

- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Tested in playground on ts 3.5.1

```Awk
TypeError: e.getTypeArguments is not a function
Occurred while linting <input>:4
Rule: "@typescript-eslint/no-unsafe-argument"
    at FunctionSignature.create (https://typescript-eslint.io/sandbox/index.js:20:1047289)
    at CallExpression, NewExpression (https://typescript-eslint.io/sandbox/index.js:20:1048838)
    at https://typescript-eslint.io/sandbox/index.js:20:259967
    at https://typescript-eslint.io/sandbox/index.js:20:250486
    at Array.forEach (<anonymous>)
    at Object.emit (https://typescript-eslint.io/sandbox/index.js:20:250474)
    at NodeEventGenerator$1.applySelector (https://typescript-eslint.io/sandbox/index.js:4:122618)
    at NodeEventGenerator$1.applySelectors (https://typescript-eslint.io/sandbox/index.js:4:122920)
    at NodeEventGenerator$1.enterNode (https://typescript-eslint.io/sandbox/index.js:4:123011)
    at CodePathAnalyzer$1.enterNode (https://typescript-eslint.io/sandbox/index.js:4:56566)
```

### no-unsafe-argument
[playground main](https://typescript-eslint.io/play/#ts=3.5.1&sourceType=module&code=PQKgpgzgNglgdgFwAQCIACCCeAHSBjAJxmwQFpJZFg4B7UgVzggEMAzMU5ggc3oFswiFAC5UYAgRoEUIYAFgAUIoAmYPFC5gkrRngQwacbTRoAKAHSXsXZnwiiA2nH4AjcQBokEBETjdPzHCYALoAlKIAbjQwygDciqwmpgCMngDkzGmeyUjMELlBofEKQA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEC+JtA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA)
[playground this branch](https://deploy-preview-6767--typescript-eslint.netlify.app/play/#ts=3.5.1&sourceType=module&code=PQKgpgzgNglgdgFwAQCIACCCeAHSBjAJxmwQFpJZFg4B7UgVzggEMAzMU5ggc3oFswiFAC5UYAgRoEUIYAFgAUIoAmYPFC5gkrRngQwacbTRoAKAHSXsXZnwiiA2nH4AjcQBokEBETjdPzHCYALoAlKIAbjQwygDciqwmpgCMngDkzGmeyUjMELlBofEKQA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEC+JtA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA)

```ts
/*eslint "@typescript-eslint/no-unsafe-argument": "error"*/

declare function foo(...params: [number, string, any]): void;
foo(1, 'a', 1 as any);
```

### no-misused-promises

[playground main](https://typescript-eslint.io/play/#ts=3.5.1&sourceType=module&code=PQKgpgzgNglgdgFwAQCIACCCeAHSBjAJxmwQFpJZFg4B7UgWxggFcIwATU7AmxtiFAC5UYAjwIoQwALAAoOezB4oAQwJgkAM2Zw8CGDThaaNABQA6S9jUr6EYQG04zegCNRAXQCUwgG40YdgBuOU0TUwBGLxDZIA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEC+JtA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA) 
[playground this branch](https://deploy-preview-6767--typescript-eslint.netlify.app/play/#ts=3.5.1&sourceType=module&code=PQKgpgzgNglgdgFwAQCIACCCeAHSBjAJxmwQFpJZFg4B7UgWxggFcIwATU7AmxtiFAC5UYAjwIoQwALAAoOezB4oAQwJgkAM2Zw8CGDThaaNABQA6S9jUr6EYQG04zegCNRAXQCUwgG40YdgBuOU0TUwBGLxDZIA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEC+JtA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA)

```ts
/*eslint "@typescript-eslint/no-misused-promises": "error"*/

declare function foo(...params: [number]): void;
foo(1);
```

### require-array-sort-compare

[playground main](https://typescript-eslint.io/play/#ts=3.5.1&sourceType=module&code=PQKgpgzgNglgdgFwAQCIACCCeAHSBjAJxmwQFpJZFgCwBHAVxhtIEMCCXNSIB7AsvDwC22NmBQAuJAG0UYdnxQAaJAG9UMAOZw+YAMoIicTQEF2nCJKSH6YJAF8AukhDAAsAChPAM3pw8CDA8cEjeABQsUhCG8JrSjgCUap5ISCwAdLz8YQkA3J72QA&eslintrc=N4KAvkA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA) 
[playground this branch](https://deploy-preview-6767--typescript-eslint.netlify.app/play/#ts=3.5.1&sourceType=module&code=PQKgpgzgNglgdgFwAQCIACCCeAHSBjAJxmwQFpJZFgCwBHAVxhtIEMCCXNSIB7AsvDwC22NmBQAuJAG0UYdnxQAaJAG9UMAOZw+YAMoIicTQEF2nCJKSH6YJAF8AukhDAAsAChPAM3pw8CDA8cEjeABQsUhCG8JrSjgCUap5ISCwAdLz8YQkA3J72QA&eslintrc=N4KAvkA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA)

```ts
/*eslint "@typescript-eslint/require-array-sort-compare": ["error", { "ignoreStringArrays": true }] */

function f(a: string[]) {
  a.sort();
}
```

-------------

note: type rules are not working on ts 3.3 this is most likely related to playground bug tho

ref #1752
