### PR TITLE
chore(website): [playground] regression fix for parsing comments

### DIFF
--- a/packages/website/src/components/linter/WebLinter.ts
+++ b/packages/website/src/components/linter/WebLinter.ts
@@ -127,7 +127,7 @@ export class WebLinter {
 
     const { estree: ast, astMaps } = this.lintUtils.astConverter(
       tsAst,
-      { ...parseSettings, code, jsx: isJsx },
+      { ...parseSettings, code, codeFullText: code, jsx: isJsx },
       true,
     );
 


### PR DESCRIPTION
## PR Checklist

- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Add missing required field `codeFullText` to v6 playground

eg. comments where not parsed correctly
```ts
/* eslint "@typescript-eslint/no-unused-vars": "error" */

const x = 2
```

[playground this branch](https://deploy-preview-6768--typescript-eslint.netlify.app/play/#ts=5.0.2&sourceType=module&code=PQKgBApgzgNglgOwC5gEQAEkE8AO0DGATnDkgLTTzLAID2ZArgg1BACZkBuAhoVKgC40EQoVqFUYEMACwAKHn5aCKCgAeYALxgATEA&eslintrc=N4KABGBEBOCuA2BTAzpAXGYBfEWg&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA)
[playground v6](https://v6--typescript-eslint.netlify.app/play/#ts=5.0.2&sourceType=module&code=PQKgBApgzgNglgOwC5gEQAEkE8AO0DGATnDkgLTTzLAID2ZArgg1BACZkBuAhoVKgC40EQoVqFUYEMACwAKHn5aCKCgAeYALxgATEA&eslintrc=N4KABGBEBOCuA2BTAzpAXGYBfEWg&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA)
