### PR TITLE
docs: update troubleshooting to include typescript project references not being supported yet

### DIFF
--- a/docs/linting/Troubleshooting.mdx
+++ b/docs/linting/Troubleshooting.mdx
@@ -252,6 +252,6 @@ If you think you're having issues with performance, see our [Performance Trouble
 
 ## Are TypeScript project references supported?
 
-No, TypeScript project references is not yet supported. 
+No, TypeScript project references is not yet supported.
 
 See [issue #2094 discussing project references](https://github.com/typescript-eslint/typescript-eslint/issues/2094) for more details.

--- a/docs/linting/Troubleshooting.mdx
+++ b/docs/linting/Troubleshooting.mdx
@@ -252,6 +252,6 @@ If you think you're having issues with performance, see our [Performance Trouble
 
 ## Are TypeScript project references supported?
 
-No, TypeScript project references is not yet supported.
+No, TypeScript project references are not yet supported.
 
 See [issue #2094 discussing project references](https://github.com/typescript-eslint/typescript-eslint/issues/2094) for more details.

--- a/docs/linting/Troubleshooting.mdx
+++ b/docs/linting/Troubleshooting.mdx
@@ -250,7 +250,7 @@ Rules such as [`no-unsafe-argument`](https://typescript-eslint.io/rules/no-unsaf
 
 If you think you're having issues with performance, see our [Performance Troubleshooting documentation](./troubleshooting/Performance.md).
 
-## Is TypeScript project references supported?
+## Are TypeScript project references supported?
 
 No, TypeScript project references is not yet supported. 
 

--- a/docs/linting/Troubleshooting.mdx
+++ b/docs/linting/Troubleshooting.mdx
@@ -249,3 +249,9 @@ Rules such as [`no-unsafe-argument`](https://typescript-eslint.io/rules/no-unsaf
 ## My linting feels really slow
 
 If you think you're having issues with performance, see our [Performance Troubleshooting documentation](./troubleshooting/Performance.md).
+
+## Is TypeScript project references supported?
+
+No, TypeScript project references is not yet supported. 
+
+See [this issue](https://github.com/typescript-eslint/typescript-eslint/issues/2094) for more details.

--- a/docs/linting/Troubleshooting.mdx
+++ b/docs/linting/Troubleshooting.mdx
@@ -254,4 +254,4 @@ If you think you're having issues with performance, see our [Performance Trouble
 
 No, TypeScript project references is not yet supported. 
 
-See [this issue](https://github.com/typescript-eslint/typescript-eslint/issues/2094 "typescript-eslint issue 2094 (project references support)") for more details.
+See [issue #2094 discussing project references](https://github.com/typescript-eslint/typescript-eslint/issues/2094) for more details.

--- a/docs/linting/Troubleshooting.mdx
+++ b/docs/linting/Troubleshooting.mdx
@@ -254,4 +254,4 @@ If you think you're having issues with performance, see our [Performance Trouble
 
 No, TypeScript project references is not yet supported. 
 
-See [this issue](https://github.com/typescript-eslint/typescript-eslint/issues/2094) for more details.
+See [this issue](https://github.com/typescript-eslint/typescript-eslint/issues/2094 "typescript-eslint issue 2094 (project references support)") for more details.


### PR DESCRIPTION
Add to the troubleshooting and FAQ that currently Typescript project references are not yet supported.

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6363 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Added an entry to the troubleshooting and FAQ docs that TypeScript project references is not yet supported. 