### PR TITLE
docs(eslint-plugin): [lines-around-comment] fix typo

### DIFF
--- a/packages/eslint-plugin/docs/rules/lines-around-comment.md
+++ b/packages/eslint-plugin/docs/rules/lines-around-comment.md
@@ -27,8 +27,8 @@ See the [ESLint documentation](https://eslint.org/docs/rules/lines-around-commen
 
 In addition to the options supported by the `lines-around-comment` rule in ESLint core, the rule adds the following options:
 
-- `allowEnumEnd: true` doesn't require a blank line after an interface body block end
-- `allowEnumStart: true` doesn't require a blank line before an interface body block start
+- `allowEnumEnd: true` doesn't require a blank line after an enum body block end
+- `allowEnumStart: true` doesn't require a blank line before an enum body block start
 - `allowInterfaceEnd: true` doesn't require a blank line before an interface body block end
 - `allowInterfaceStart: true` doesn't require a blank line after an interface body block start
 - `allowModuleEnd: true` doesn't require a blank line before a module body block end


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adding the rules to the documentation ([#75eb5b5](https://github.com/typescript-eslint/typescript-eslint/commit/75eb5b5fa3cea7999e006819e5c4f26cbd9c48be)) seems to have introduced a typo (`interface` instead of `enum`):

- `allowEnumEnd: true` doesn't require a blank line after an **interface** body block end
- `allowEnumStart: true` doesn't require a blank line before an **interface** body block start
- `allowInterfaceEnd: true` doesn't require a blank line before an interface body block end
- `allowInterfaceStart: true` doesn't require a blank line after an interface body block start

(Emphasis mine.)

[According to Contributing](https://typescript-eslint.io/contributing/pull-requests/), at least to my understanding, the change is eligible without an open issue:

> Only send pull requests that resolve [open issues marked as accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+is%3Aopen+label%3A%22accepting+prs%22)
One exception: extremely minor documentation typos

Since this is my first pull request, any help or guidance is much appreciated.