### PR TITLE
fix(type-utils): fixed TypeOrValueSpecifier not accounting for scoped DT packages

### DIFF
--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -146,6 +146,22 @@ function typeDeclaredInFile(
   );
 }
 
+function typeDeclaredInPackage(
+  packageName: string,
+  declarationFiles: ts.SourceFile[],
+): boolean {
+  const typesPackageName =
+    '@types/' +
+    (packageName[0] === '@'
+      ? packageName.substring(1).replaceAll('/', '__')
+      : packageName);
+  return declarationFiles.some(
+    declaration =>
+      declaration.fileName.includes(`node_modules/${packageName}/`) ||
+      declaration.fileName.includes(`node_modules/${typesPackageName}/`),
+  );
+}
+
 export function typeMatchesSpecifier(
   type: ts.Type,
   specifier: TypeOrValueSpecifier,
@@ -170,12 +186,6 @@ export function typeMatchesSpecifier(
         program.isSourceFileDefaultLibrary(declaration),
       );
     case 'package':
-      return declarationFiles.some(
-        declaration =>
-          declaration.fileName.includes(`node_modules/${specifier.package}/`) ||
-          declaration.fileName.includes(
-            `node_modules/@types/${specifier.package}/`,
-          ),
-      );
+      return typeDeclaredInPackage(specifier.package, declarationFiles);
   }
 }

--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -153,10 +153,11 @@ function typeDeclaredInPackage(
   // Handle scoped packages - if the name starts with @, remove it and replace / with __
   const typesPackageName =
     '@types/' + packageName.replace(/^@([^/]+)\//, '$1__');
-  return declarationFiles.some(
-    declaration =>
-      declaration.fileName.includes(`node_modules/${packageName}/`) ||
-      declaration.fileName.includes(`node_modules/${typesPackageName}/`),
+  const matcher = new RegExp(
+    `node_modules/(?:${packageName}|${typesPackageName})/`,
+  );
+  return declarationFiles.some(declaration =>
+    matcher.test(declaration.fileName),
   );
 }
 

--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -153,7 +153,7 @@ function typeDeclaredInPackage(
   const typesPackageName =
     '@types/' +
     (packageName[0] === '@'
-      ? packageName.substring(1).replaceAll('/', '__')
+      ? packageName.substring(1).replace('/', '__')
       : packageName);
   return declarationFiles.some(
     declaration =>

--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -150,11 +150,9 @@ function typeDeclaredInPackage(
   packageName: string,
   declarationFiles: ts.SourceFile[],
 ): boolean {
+  // Handle scoped packages - if the name starts with @, remove it and replace / with __
   const typesPackageName =
-    '@types/' +
-    (packageName[0] === '@'
-      ? packageName.substring(1).replace('/', '__')
-      : packageName);
+    '@types/' + packageName.replace(/^@([^/]+)\//, '$1__');
   return declarationFiles.some(
     declaration =>
       declaration.fileName.includes(`node_modules/${packageName}/`) ||

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -235,6 +235,76 @@ describe('TypeOrValueSpecifier', () => {
 
     it.each<[string, TypeOrValueSpecifier]>([
       [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: 'Node', package: 'typescript' },
+      ],
+      [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: ['Node', 'Symbol'], package: 'typescript' },
+      ],
+      [
+        'import {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: 'Node', package: 'typescript' },
+      ],
+      [
+        'import {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: ['Node', 'Symbol'], package: 'typescript' },
+      ],
+      [
+        'import * as ts from "typescript"; type Test = ts.Node;',
+        { from: 'package', name: 'Node', package: 'typescript' },
+      ],
+      [
+        'import * as ts from "typescript"; type Test = ts.Node;',
+        { from: 'package', name: ['Node', 'Symbol'], package: 'typescript' },
+      ],
+      [
+        'import type * as ts from "typescript"; type Test = ts.Node;',
+        { from: 'package', name: 'Node', package: 'typescript' },
+      ],
+      [
+        'import type * as ts from "typescript"; type Test = ts.Node;',
+        { from: 'package', name: ['Node', 'Symbol'], package: 'typescript' },
+      ],
+      [
+        'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
+        { from: 'package', name: 'Node', package: 'typescript' },
+      ],
+      [
+        'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
+        { from: 'package', name: ['Node', 'Symbol'], package: 'typescript' },
+      ],
+    ])('matches a matching package specifier: %s', runTestPositive);
+
+    it.each<[string, TypeOrValueSpecifier]>([
+      [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: 'Symbol', package: 'typescript' },
+      ],
+      [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: ['Symbol', 'Checker'], package: 'typescript' },
+      ],
+      [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: 'Node', package: 'other-package' },
+      ],
+      [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: ['Node', 'Symbol'], package: 'other-package' },
+      ],
+      [
+        'interface Node {prop: string}; type Test = Node;',
+        { from: 'package', name: 'Node', package: 'typescript' },
+      ],
+      [
+        'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
+        { from: 'package', name: 'TsNode', package: 'typescript' },
+      ],
+    ])("doesn't match a mismatched lib specifier: %s", runTestNegative);
+
+    it.each<[string, TypeOrValueSpecifier]>([
+      [
         'interface Foo {prop: string}; type Test = Foo;',
         { from: 'lib', name: 'Foo' },
       ],

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -279,6 +279,15 @@ describe('TypeOrValueSpecifier', () => {
         'import {SemVer} from "semver"; type Test = SemVer;',
         { from: 'package', name: 'SemVer', package: 'semver' },
       ],
+      // The following type is available from the org-scoped @types/babel__code-frame package.
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@babel/code-frame',
+        },
+      ],
     ])('matches a matching package specifier: %s', runTestPositive);
 
     it.each<[string, TypeOrValueSpecifier]>([

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -139,7 +139,8 @@ describe('TypeOrValueSpecifier', () => {
         .program!.getTypeChecker()
         .getTypeAtLocation(
           services.esTreeNodeToTSNodeMap.get(
-            (ast.body[0] as TSESTree.TSTypeAliasDeclaration).id,
+            (ast.body[ast.body.length - 1] as TSESTree.TSTypeAliasDeclaration)
+              .id,
           ),
         );
       expect(typeMatchesSpecifier(type, specifier, services.program!)).toBe(

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -279,7 +279,7 @@ describe('TypeOrValueSpecifier', () => {
         'import {SemVer} from "semver"; type Test = SemVer;',
         { from: 'package', name: 'SemVer', package: 'semver' },
       ],
-      // The following type is available from the org-scoped @types/babel__code-frame package.
+      // The following type is available from the scoped @types/babel__code-frame package.
       [
         'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
         {

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -274,6 +274,11 @@ describe('TypeOrValueSpecifier', () => {
         'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
         { from: 'package', name: ['Node', 'Symbol'], package: 'typescript' },
       ],
+      // The following type is available from the @types/semver package.
+      [
+        'import {SemVer} from "semver"; type Test = SemVer;',
+        { from: 'package', name: 'SemVer', package: 'semver' },
+      ],
     ])('matches a matching package specifier: %s', runTestPositive);
 
     it.each<[string, TypeOrValueSpecifier]>([


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6698
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- Added TypeOrValueSPecifier tests for package specifiers
