### PR TITLE
fix: update getLib for new TypeScript targets ES2021, ES2022

### DIFF
--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -54,10 +54,14 @@ function getLib(compilerOptions: CompilerOptions): Lib[] {
   }
 
   const target = compilerOptions.target ?? ScriptTarget.ES5;
-  // https://github.com/Microsoft/TypeScript/blob/59ad375234dc2efe38d8ee0ba58414474c1d5169/src/compiler/utilitiesPublic.ts#L13-L32
+  // https://github.com/microsoft/TypeScript/blob/ae582a22ee1bb052e19b7c1bc4cac60509b574e0/src/compiler/utilitiesPublic.ts#L13-L36
   switch (target) {
     case ScriptTarget.ESNext:
       return ['esnext.full'];
+    case ScriptTarget.ES2022:
+      return ['es2022.full'];
+    case ScriptTarget.ES2021:
+      return ['es2021.full'];
     case ScriptTarget.ES2020:
       return ['es2020.full'];
     case ScriptTarget.ES2019:


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Support for the `es2021.full` and `es2022.full` libs was added in #3460 and #4615, but the `getLib` function wasn’t updated to use them; if `target` is set to `"ES2021"` or `"ES2022"` in `tsconfig.json`, `getLib` would incorrectly fall back to `['lib']` rather than `['es2021.full']` or `['es2022.full']`. Add these missing cases.