### PR TITLE
chore(website): correct Discord links to all be general invites

### DIFF
--- a/docs/contributing/Issues.mdx
+++ b/docs/contributing/Issues.mdx
@@ -31,7 +31,7 @@ Please don't:
 The issue tracker is not an appropriate place for questions or support requests.
 You can instead:
 
-- Ask in our [Discord channel](https://discord.gg/FSxKq8Tdyg)'s `#help` server
+- Ask in our [Discord server](https://discord.gg/FSxKq8Tdyg)'s `#help` server
 - Ask a question on [StackOverflow](https://stackoverflow.com/questions/tagged/typescript-eslint 'StackOverflow questions tagged with typescript-eslint') using the `typescript-eslint` tag
 - Publicly toot [@tseslint on Mastodon](https://fosstodon.org/@tseslint) or tweet [@tseslint on Twitter](https://twitter.com/tseslint)
 

--- a/packages/website/blog/2023-03-13-announcing-typescript-eslint-v6-beta.md
+++ b/packages/website/blog/2023-03-13-announcing-typescript-eslint-v6-beta.md
@@ -21,7 +21,7 @@ Our plan for typescript-eslint v6 is to:
 3. Release a stable version summer of 2023
 
 Nothing mentioned in this blog post is set in stone.
-If you feel passionately about any of the choices we've made here -positively or negatively- then do let us know on [the typescript-eslint Discord's `v6` channel](https://discord.com/channels/1026804805894672454/1084245444676292688)!
+If you feel passionately about any of the choices we've made here -positively or negatively- then do let us know on [the typescript-eslint Discord](https://discord.gg/FSxKq8Tdyg)'s `#v6` channel!
 
 <!--truncate-->
 
@@ -173,7 +173,7 @@ If you author any ESLint plugins or other tools that interact with TypeScript sy
 It includes some breaking changes that you may need to accommodate for.
 
 :::tip
-If you're having trouble working with the changes, please let us know on [the typescript-eslint Discord's `v6` channel](https://discord.com/channels/1026804805894672454/1084245444676292688)!
+If you're having trouble working with the changes, please let us know on [the typescript-eslint Discord](https://discord.gg/FSxKq8Tdyg)'s `#v6` channel!
 :::
 
 ### Type Checker Wrapper APIs


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6757
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Switches all channel-specific Discord links to be the general server invite. Any specific channels are now just mentioned as text after.