### PR TITLE
fix(type-utils): checking of type aliases' type names by `typeMatchesSpecifier`

### DIFF
--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -120,7 +120,7 @@ function specifierNameMatches(type: ts.Type, name: string | string[]): boolean {
   if (typeof name === 'string') {
     name = [name];
   }
-  const symbol = type.getSymbol();
+  const symbol = type.aliasSymbol ?? type.getSymbol();
   if (symbol === undefined) {
     return false;
   }

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -176,28 +176,42 @@ describe('TypeOrValueSpecifier', () => {
       runTestNegative,
     );
 
-    it.each<[string, TypeOrValueSpecifier]>([
+    it.each<[string, TypeOrValueSpecifier]>(
       [
-        'interface Foo {prop: string}; type Test = Foo;',
-        { from: 'file', name: 'Foo' },
-      ],
-      [
-        'interface Foo {prop: string}; type Test = Foo;',
-        { from: 'file', name: ['Foo', 'Bar'] },
-      ],
-      [
-        'interface Foo {prop: string}; type Test = Foo;',
-        { from: 'file', name: 'Foo', path: 'tests/fixtures/file.ts' },
-      ],
-      [
-        'interface Foo {prop: string}; type Test = Foo;',
-        {
-          from: 'file',
-          name: ['Foo', 'Bar'],
-          path: 'tests/fixtures/file.ts',
-        },
-      ],
-    ])('matches a matching file specifier: %s', runTestPositive);
+        [
+          'interface Foo {prop: string}; type Test = Foo;',
+          'type Foo = {prop: string}; type Test = Foo;',
+        ].map((test): [string, TypeOrValueSpecifier] => [
+          test,
+          { from: 'file', name: 'Foo' },
+        ]),
+        [
+          'interface Foo {prop: string}; type Test = Foo;',
+          'type Foo = {prop: string}; type Test = Foo;',
+        ].map((test): [string, TypeOrValueSpecifier] => [
+          test,
+          { from: 'file', name: ['Foo', 'Bar'] },
+        ]),
+        [
+          'interface Foo {prop: string}; type Test = Foo;',
+          'type Foo = {prop: string}; type Test = Foo;',
+        ].map((test): [string, TypeOrValueSpecifier] => [
+          test,
+          { from: 'file', name: 'Foo', path: 'tests/fixtures/file.ts' },
+        ]),
+        [
+          'interface Foo {prop: string}; type Test = Foo;',
+          'type Foo = {prop: string}; type Test = Foo;',
+        ].map((test): [string, TypeOrValueSpecifier] => [
+          test,
+          {
+            from: 'file',
+            name: ['Foo', 'Bar'],
+            path: 'tests/fixtures/file.ts',
+          },
+        ]),
+      ].flat(),
+    )('matches a matching file specifier: %s', runTestPositive);
 
     it.each<[string, TypeOrValueSpecifier]>([
       [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6818
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Handle type aliases in addition to interfaces.
