### PR TITLE
chore(website): [playground] option to disable scroll and display tokens

### DIFF
--- a/packages/website/src/components/OptionsSelector.tsx
+++ b/packages/website/src/components/OptionsSelector.tsx
@@ -15,19 +15,26 @@ import InputLabel from './layout/InputLabel';
 import { createMarkdown, createMarkdownParams } from './lib/markdown';
 import { fileTypes } from './options';
 import type { ConfigModel } from './types';
+import Checkbox from '@site/src/components/inputs/Checkbox';
 
 export interface OptionsSelectorParams {
   readonly state: ConfigModel;
   readonly setState: (cfg: Partial<ConfigModel>) => void;
   readonly tsVersions: readonly string[];
-  readonly isLoading: boolean;
+  readonly enableScrolling: boolean;
+  readonly setEnableScrolling: (checked: boolean) => void;
+  readonly showTokens: boolean;
+  readonly setShowTokens: (checked: boolean) => void;
 }
 
 function OptionsSelectorContent({
   state,
   setState,
+  enableScrolling,
+  setEnableScrolling,
+  showTokens,
+  setShowTokens,
   tsVersions,
-  isLoading,
 }: OptionsSelectorParams): JSX.Element {
   const [copyLink, copyLinkToClipboard] = useClipboard(() =>
     document.location.toString(),
@@ -36,26 +43,16 @@ function OptionsSelectorContent({
     createMarkdown(state),
   );
 
-  const updateTS = useCallback(
-    (version: string) => {
-      setState({ ts: version });
-    },
-    [setState],
-  );
-
   const openIssue = useCallback(() => {
-    if (isLoading) {
-      return;
-    }
+    const params = createMarkdownParams(state);
+
     window
       .open(
-        `https://github.com/typescript-eslint/typescript-eslint/issues/new?${createMarkdownParams(
-          state,
-        )}`,
+        `https://github.com/typescript-eslint/typescript-eslint/issues/new?${params}`,
         '_blank',
       )
       ?.focus();
-  }, [state, isLoading]);
+  }, [state]);
 
   return (
     <>
@@ -66,7 +63,7 @@ function OptionsSelectorContent({
             className="text--right"
             value={state.ts}
             disabled={!tsVersions.length}
-            onChange={updateTS}
+            onChange={(ts): void => setState({ ts })}
             options={(tsVersions.length && tsVersions) || [state.ts]}
           />
         </InputLabel>
@@ -86,8 +83,22 @@ function OptionsSelectorContent({
           <Dropdown
             name="sourceType"
             value={state.sourceType}
-            onChange={(e): void => setState({ sourceType: e })}
+            onChange={(sourceType): void => setState({ sourceType })}
             options={['script', 'module']}
+          />
+        </InputLabel>
+        <InputLabel name="Auto scroll">
+          <Checkbox
+            name="enableScrolling"
+            checked={enableScrolling}
+            onChange={setEnableScrolling}
+          />
+        </InputLabel>
+        <InputLabel name="Show tokens">
+          <Checkbox
+            name="showTokens"
+            checked={showTokens}
+            onChange={setShowTokens}
           />
         </InputLabel>
       </Expander>

--- a/packages/website/src/components/OptionsSelector.tsx
+++ b/packages/website/src/components/OptionsSelector.tsx
@@ -2,6 +2,7 @@ import {
   NavbarSecondaryMenuFiller,
   useWindowSize,
 } from '@docusaurus/theme-common';
+import Checkbox from '@site/src/components/inputs/Checkbox';
 import CopyIcon from '@site/src/icons/copy.svg';
 import IconExternalLink from '@theme/Icon/ExternalLink';
 import React, { useCallback } from 'react';
@@ -15,7 +16,6 @@ import InputLabel from './layout/InputLabel';
 import { createMarkdown, createMarkdownParams } from './lib/markdown';
 import { fileTypes } from './options';
 import type { ConfigModel } from './types';
-import Checkbox from '@site/src/components/inputs/Checkbox';
 
 export interface OptionsSelectorParams {
   readonly state: ConfigModel;

--- a/packages/website/src/components/OptionsSelector.tsx
+++ b/packages/website/src/components/OptionsSelector.tsx
@@ -21,19 +21,11 @@ export interface OptionsSelectorParams {
   readonly state: ConfigModel;
   readonly setState: (cfg: Partial<ConfigModel>) => void;
   readonly tsVersions: readonly string[];
-  readonly enableScrolling: boolean;
-  readonly setEnableScrolling: (checked: boolean) => void;
-  readonly showTokens: boolean;
-  readonly setShowTokens: (checked: boolean) => void;
 }
 
 function OptionsSelectorContent({
   state,
   setState,
-  enableScrolling,
-  setEnableScrolling,
-  showTokens,
-  setShowTokens,
   tsVersions,
 }: OptionsSelectorParams): JSX.Element {
   const [copyLink, copyLinkToClipboard] = useClipboard(() =>
@@ -90,15 +82,15 @@ function OptionsSelectorContent({
         <InputLabel name="Auto scroll">
           <Checkbox
             name="enableScrolling"
-            checked={enableScrolling}
-            onChange={setEnableScrolling}
+            checked={state.scroll}
+            onChange={(scroll): void => setState({ scroll })}
           />
         </InputLabel>
         <InputLabel name="Show tokens">
           <Checkbox
             name="showTokens"
-            checked={showTokens}
-            onChange={setShowTokens}
+            checked={state.showTokens}
+            onChange={(showTokens): void => setState({ showTokens })}
           />
         </InputLabel>
       </Expander>

--- a/packages/website/src/components/Playground.tsx
+++ b/packages/website/src/components/Playground.tsx
@@ -37,9 +37,6 @@ function Playground(): JSX.Element {
   const [visualEslintRc, setVisualEslintRc] = useState(false);
   const [visualTSConfig, setVisualTSConfig] = useState(false);
 
-  const [enableScrolling, setEnableScrolling] = useState<boolean>(true);
-  const [showTokens, setShowTokens] = useState<boolean>(false);
-
   const onLoaded = useCallback(
     (ruleNames: RuleDetails[], tsVersions: readonly string[]): void => {
       setRuleNames(ruleNames);
@@ -90,10 +87,6 @@ function Playground(): JSX.Element {
               state={state}
               tsVersions={tsVersions}
               setState={setState}
-              setEnableScrolling={setEnableScrolling}
-              enableScrolling={enableScrolling}
-              setShowTokens={setShowTokens}
-              showTokens={showTokens}
             />
           </div>
           <ConditionalSplitPane
@@ -181,8 +174,8 @@ function Playground(): JSX.Element {
                     key={String(state.showAST)}
                     filter={state.showAST === 'es' ? esQueryFilter : undefined}
                     value={astToShow}
-                    showTokens={showTokens}
-                    enableScrolling={enableScrolling}
+                    showTokens={state.showTokens}
+                    enableScrolling={state.scroll}
                     cursorPosition={position}
                     onHoverNode={setSelectedRange}
                   />

--- a/packages/website/src/components/Playground.tsx
+++ b/packages/website/src/components/Playground.tsx
@@ -37,6 +37,9 @@ function Playground(): JSX.Element {
   const [visualEslintRc, setVisualEslintRc] = useState(false);
   const [visualTSConfig, setVisualTSConfig] = useState(false);
 
+  const [enableScrolling, setEnableScrolling] = useState<boolean>(true);
+  const [showTokens, setShowTokens] = useState<boolean>(false);
+
   const onLoaded = useCallback(
     (ruleNames: RuleDetails[], tsVersions: readonly string[]): void => {
       setRuleNames(ruleNames);
@@ -84,10 +87,13 @@ function Playground(): JSX.Element {
         >
           <div className={clsx(styles.options, 'thin-scrollbar')}>
             <OptionsSelector
-              isLoading={isLoading}
               state={state}
               tsVersions={tsVersions}
               setState={setState}
+              setEnableScrolling={setEnableScrolling}
+              enableScrolling={enableScrolling}
+              setShowTokens={setShowTokens}
+              showTokens={showTokens}
             />
           </div>
           <ConditionalSplitPane
@@ -175,7 +181,8 @@ function Playground(): JSX.Element {
                     key={String(state.showAST)}
                     filter={state.showAST === 'es' ? esQueryFilter : undefined}
                     value={astToShow}
-                    enableScrolling={true}
+                    showTokens={showTokens}
+                    enableScrolling={enableScrolling}
                     cursorPosition={position}
                     onHoverNode={setSelectedRange}
                   />

--- a/packages/website/src/components/ast/ASTViewer.tsx
+++ b/packages/website/src/components/ast/ASTViewer.tsx
@@ -16,6 +16,7 @@ export interface ASTViewerProps {
   readonly filter?: ESQuery.Selector;
   readonly enableScrolling?: boolean;
   readonly hideCopyButton?: boolean;
+  readonly showTokens?: boolean;
 }
 
 function tryToApplyFilter<T>(value: T, filter?: ESQuery.Selector): T | T[] {
@@ -37,6 +38,7 @@ function ASTViewer({
   filter,
   enableScrolling,
   hideCopyButton,
+  showTokens,
 }: ASTViewerProps): JSX.Element {
   const model = useMemo(() => {
     if (filter) {
@@ -74,6 +76,7 @@ function ASTViewer({
         lastElement={true}
         selectedPath={selectedPath}
         onHover={onHoverNode}
+        showTokens={showTokens}
       />
       {!hideCopyButton && <CopyButton value={model} />}
     </div>

--- a/packages/website/src/components/ast/DataRenderer.tsx
+++ b/packages/website/src/components/ast/DataRenderer.tsx
@@ -26,6 +26,7 @@ export interface JsonRenderProps<T> {
   readonly level: string;
   readonly onHover?: OnHoverNodeFn;
   readonly selectedPath?: string;
+  readonly showTokens?: boolean;
 }
 
 export interface ExpandableRenderProps
@@ -47,6 +48,7 @@ function RenderExpandableObject({
   level,
   onHover,
   selectedPath,
+  showTokens,
 }: ExpandableRenderProps): JSX.Element {
   const [expanded, toggleExpanded, setExpanded] = useBool(
     () => level === 'ast' || !!selectedPath?.startsWith(level),
@@ -121,6 +123,7 @@ function RenderExpandableObject({
               onHover={onHover}
               selectedPath={selectedPath}
               nodeType={nodeType}
+              showTokens={showTokens}
             />
           ))}
         </div>
@@ -143,10 +146,10 @@ function JsonObject(
       nodeType: nodeType,
       typeName: getTypeName(props.value, nodeType),
       value: Object.entries(props.value).filter(item =>
-        filterProperties(item[0], item[1], nodeType),
+        filterProperties(item[0], item[1], nodeType, props.showTokens),
       ),
     };
-  }, [props.value]);
+  }, [props.value, props.showTokens]);
 
   return (
     <RenderExpandableObject

--- a/packages/website/src/components/ast/utils.ts
+++ b/packages/website/src/components/ast/utils.ts
@@ -229,10 +229,7 @@ export function filterProperties(
 
   switch (type) {
     case 'esNode': {
-      if (key === 'tokens') {
-        return showTokens === true;
-      }
-      return true;
+      return key !== 'tokens' || !!showTokens;
     }
     case 'scopeManager':
       return (

--- a/packages/website/src/components/ast/utils.ts
+++ b/packages/website/src/components/ast/utils.ts
@@ -217,6 +217,7 @@ export function filterProperties(
   key: string,
   value: unknown,
   type: ParentNodeType,
+  showTokens?: boolean,
 ): boolean {
   if (
     value === undefined ||
@@ -227,8 +228,12 @@ export function filterProperties(
   }
 
   switch (type) {
-    case 'esNode':
-      return key !== 'tokens' && key !== 'comments';
+    case 'esNode': {
+      if (key === 'tokens') {
+        return showTokens === true;
+      }
+      return true;
+    }
     case 'scopeManager':
       return (
         key !== 'declaredVariables' &&

--- a/packages/website/src/components/hooks/useHashState.ts
+++ b/packages/website/src/components/hooks/useHashState.ts
@@ -88,7 +88,7 @@ const parseStateFromUrl = (hash: string): Partial<ConfigModel> | undefined => {
       fileType,
       eslintrc: eslintrc ?? '',
       tsconfig: tsconfig ?? '',
-      showTokens: searchParams.get('showTokens') === 'true',
+      showTokens: searchParams.get('tokens') === 'true',
     };
   } catch (e) {
     console.warn(e);

--- a/packages/website/src/components/hooks/useHashState.ts
+++ b/packages/website/src/components/hooks/useHashState.ts
@@ -88,6 +88,7 @@ const parseStateFromUrl = (hash: string): Partial<ConfigModel> | undefined => {
       fileType,
       eslintrc: eslintrc ?? '',
       tsconfig: tsconfig ?? '',
+      showTokens: searchParams.get('showTokens') === 'true',
     };
   } catch (e) {
     console.warn(e);
@@ -111,6 +112,7 @@ const writeStateToUrl = (newState: ConfigModel): string | undefined => {
     searchParams.set('code', writeQueryParam(newState.code));
     searchParams.set('eslintrc', writeQueryParam(newState.eslintrc));
     searchParams.set('tsconfig', writeQueryParam(newState.tsconfig));
+    searchParams.set('tokens', String(!!newState.showTokens));
     return searchParams.toString();
   } catch (e) {
     console.warn(e);
@@ -149,6 +151,7 @@ const retrieveStateFromLocalStorage = (): Partial<ConfigModel> | undefined => {
         state.showAST = readShowAST(showAST);
       }
     }
+    state.scroll = hasOwnProperty('scroll', config) && !!config.scroll;
 
     return state;
   } catch (e) {
@@ -163,6 +166,7 @@ const writeStateToLocalStorage = (newState: ConfigModel): void => {
     fileType: newState.fileType,
     sourceType: newState.sourceType,
     showAST: newState.showAST,
+    scroll: newState.scroll,
   };
   window.localStorage.setItem('config', JSON.stringify(config));
 };

--- a/packages/website/src/components/options.ts
+++ b/packages/website/src/components/options.ts
@@ -41,4 +41,6 @@ export const defaultConfig: ConfigModel = {
   eslintrc: toJson({
     rules: {},
   }),
+  scroll: true,
+  showTokens: false,
 };

--- a/packages/website/src/components/types.ts
+++ b/packages/website/src/components/types.ts
@@ -27,6 +27,8 @@ export interface ConfigModel {
   code: string;
   ts: string;
   showAST?: ConfigShowAst;
+  scroll?: boolean;
+  showTokens?: boolean;
 }
 
 export type SelectedRange = [number, number];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6769
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- always display comments in ast
- allow to display tokens by enabling flag
- allow to disable scrolling -> this is useful for mobile devices