### PR TITLE
fix(type-utils): ensure external sources don't match for the `FileSpecifier`

### DIFF
--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import type * as ts from 'typescript';
+import * as ts from 'typescript';
 
 interface FileSpecifier {
   from: 'file';
@@ -134,9 +134,20 @@ function typeDeclaredInFile(
 ): boolean {
   if (relativePath === undefined) {
     const cwd = program.getCurrentDirectory().toLowerCase();
-    return declarationFiles.some(declaration =>
-      declaration.fileName.toLowerCase().startsWith(cwd),
+    const typeRoots = ts.getEffectiveTypeRoots(
+      program.getCompilerOptions(),
+      program,
     );
+
+    return declarationFiles.some(declaration => {
+      const fileName = declaration.fileName.toLowerCase();
+      return (
+        !(
+          program.isSourceFileFromExternalLibrary(declaration) ||
+          typeRoots?.some(typeRoot => fileName.startsWith(typeRoot)) === true
+        ) && fileName.startsWith(cwd)
+      );
+    });
   }
   const absolutePath = path
     .join(program.getCurrentDirectory(), relativePath)

--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -140,12 +140,15 @@ function typeDeclaredInFile(
     );
 
     return declarationFiles.some(declaration => {
+      if (program.isSourceFileFromExternalLibrary(declaration)) {
+        return false;
+      }
       const fileName = declaration.fileName.toLowerCase();
+      if (!fileName.startsWith(cwd)) {
+        return false;
+      }
       return (
-        !(
-          program.isSourceFileFromExternalLibrary(declaration) ||
-          typeRoots?.some(typeRoot => fileName.startsWith(typeRoot)) === true
-        ) && fileName.startsWith(cwd)
+        typeRoots?.some(typeRoot => fileName.startsWith(typeRoot)) !== true
       );
     });
   }

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -210,6 +210,15 @@ describe('TypeOrValueSpecifier', () => {
             path: 'tests/fixtures/file.ts',
           },
         ]),
+        ['type RegExp = {prop: string};'].map(
+          (test): [string, TypeOrValueSpecifier] => [
+            test,
+            {
+              from: 'file',
+              name: 'RegExp',
+            },
+          ],
+        ),
       ].flat(),
     )('matches a matching file specifier: %s', runTestPositive);
 
@@ -232,6 +241,13 @@ describe('TypeOrValueSpecifier', () => {
           from: 'file',
           name: ['Foo', 'Bar'],
           path: 'tests/fixtures/wrong-file.ts',
+        },
+      ],
+      [
+        'type Test = RegExp & {prop: string};',
+        {
+          from: 'file',
+          name: 'RegExp',
         },
       ],
     ])("doesn't match a mismatched file specifier: %s", runTestNegative);


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6819
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This is an alternative to #6860 (closes #6860).


