### PR TITLE
feat(eslint-plugin): [ban-types] add NonNullable suggestion and allow custom suggestions

### DIFF
--- a/packages/eslint-plugin/src/rules/ban-types.ts
+++ b/packages/eslint-plugin/src/rules/ban-types.ts
@@ -88,6 +88,7 @@ const defaultTypes: Types = {
       'The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.',
       '- If you want a type meaning "any object", you probably want `object` instead.',
       '- If you want a type meaning "any value", you probably want `unknown` instead.',
+      '- If you really want a type meaning "any non-nullish value", you probably want `NonNullable<unknown>` instead.',
     ].join('\n'),
   },
   '{}': {
@@ -96,6 +97,7 @@ const defaultTypes: Types = {
       '- If you want a type meaning "any object", you probably want `object` instead.',
       '- If you want a type meaning "any value", you probably want `unknown` instead.',
       '- If you want a type meaning "empty object", you probably want `Record<string, never>` instead.',
+      '- If you really want a type meaning "any non-nullish value", you probably want `NonNullable<unknown>` instead.',
     ].join('\n'),
   },
 };

--- a/packages/eslint-plugin/tests/rules/ban-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-types.test.ts
@@ -137,6 +137,43 @@ ruleTester.run('ban-types', rule, {
       options,
     },
     {
+      code: 'let a: Object;',
+      errors: [
+        {
+          messageId: 'bannedTypeMessage',
+          data: {
+            name: 'Object',
+            customMessage: [
+              ' The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.',
+              '- If you want a type meaning "any object", you probably want `object` instead.',
+              '- If you want a type meaning "any value", you probably want `unknown` instead.',
+              '- If you really want a type meaning "any non-nullish value", you probably want `NonNullable<unknown>` instead.',
+            ].join('\n'),
+          },
+          line: 1,
+          column: 8,
+          suggestions: [
+            {
+              messageId: 'bannedTypeReplacement',
+              data: { name: 'Object', replacement: 'object' },
+              output: 'let a: object;',
+            },
+            {
+              messageId: 'bannedTypeReplacement',
+              data: { name: 'Object', replacement: 'unknown' },
+              output: 'let a: unknown;',
+            },
+            {
+              messageId: 'bannedTypeReplacement',
+              data: { name: 'Object', replacement: 'NonNullable<unknown>' },
+              output: 'let a: NonNullable<unknown>;',
+            },
+          ],
+        },
+      ],
+      options: [{}],
+    },
+    {
       code: 'let aa: Foo;',
       errors: [
         {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6486 and fixes #6875
- [/] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22) (will revert if the issue is rejected)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR adds `NonNullable<unknown>` to the list of alternatives for `Object` and `{}`, and introduces suggestions to automatically replace those types with `NonNullable<unknown>`.