### PR TITLE
fix(eslint-plugin): [unified-signatures] allow overloads with different named and different number of parameters

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -212,10 +212,7 @@ export default util.createRule<Options, MessageIds>({
       const bTypeParams =
         b.typeParameters !== undefined ? b.typeParameters.params : undefined;
 
-      if (
-        ignoreDifferentlyNamedParameters &&
-        a.params.length === b.params.length
-      ) {
+      if (ignoreDifferentlyNamedParameters) {
         for (let i = 0; i < a.params.length; i += 1) {
           if (
             a.params[i].type === b.params[i].type &&

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -169,6 +169,14 @@ function f(a: number | string): void {}
     },
     {
       code: `
+function f(m: number): void;
+function f(v: number, u: string): void;
+function f(v: number, u?: string): void {}
+      `,
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: `
 function f(a: boolean, ...c: number[]): void;
 function f(a: boolean, ...d: string[]): void;
 function f(a: boolean, ...c: (number | string)[]): void {}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6832
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Allows explicit different names with overloads where the number of parameters differ. 