### PR TITLE
fix(eslint-plugin): [no-floating-promises] false negative calling .then with second argument undefined

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-floating-promises.md
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.md
@@ -83,7 +83,7 @@ With this option set to `true`, and if you are using `no-void`, you should turn 
 
 ### `ignoreIIFE`
 
-This allows you to skip checking of async IIFEs (Immediately Invocated function Expressions).
+This allows you to skip checking of async IIFEs (Immediately Invoked function Expressions).
 
 Examples of **correct** code for this rule with `{ ignoreIIFE: true }`:
 

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -61,7 +61,7 @@ export default util.createRule<Options, MessageId>({
           },
           ignoreIIFE: {
             description:
-              'Whether to ignore async IIFEs (Immediately Invocated Function Expressions).',
+              'Whether to ignore async IIFEs (Immediately Invoked Function Expressions).',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -15,9 +15,22 @@ type Options = [
 
 type MessageId =
   | 'floating'
+  | 'floatingVoid'
+  | 'floatingUselessRejectionHandler'
+  | 'floatingUselessRejectionHandlerVoid'
   | 'floatingFixAwait'
   | 'floatingFixVoid'
-  | 'floatingVoid';
+  | 'floatingFixAwait';
+
+const messageBase =
+  'Promises must be awaited, end with a call to .catch, or end with a call to .then with a rejection handler.';
+
+const messageBaseVoid =
+  'Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler' +
+  ' or be explicitly marked as ignored with the `void` operator.';
+
+const messageRejectionHandler =
+  'A rejection handler that is not a function will be ignored.';
 
 export default util.createRule<Options, MessageId>({
   name: 'no-floating-promises',
@@ -30,13 +43,14 @@ export default util.createRule<Options, MessageId>({
     },
     hasSuggestions: true,
     messages: {
-      floating:
-        'Promises must be awaited, end with a call to .catch, or end with a call to .then with a rejection handler.',
+      floating: messageBase,
       floatingFixAwait: 'Add await operator.',
-      floatingVoid:
-        'Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler' +
-        ' or be explicitly marked as ignored with the `void` operator.',
+      floatingVoid: messageBaseVoid,
       floatingFixVoid: 'Add void operator to ignore.',
+      floatingUselessRejectionHandler:
+        messageBase + ' ' + messageRejectionHandler,
+      floatingUselessRejectionHandlerVoid:
+        messageBaseVoid + ' ' + messageRejectionHandler,
     },
     schema: [
       {
@@ -80,11 +94,18 @@ export default util.createRule<Options, MessageId>({
           expression = expression.expression;
         }
 
-        if (isUnhandledPromise(checker, expression)) {
+        const { isUnhandled, nonFunctionHandler } = isUnhandledPromise(
+          checker,
+          expression,
+        );
+
+        if (isUnhandled) {
           if (options.ignoreVoid) {
             context.report({
               node,
-              messageId: 'floatingVoid',
+              messageId: nonFunctionHandler
+                ? 'floatingUselessRejectionHandlerVoid'
+                : 'floatingVoid',
               suggest: [
                 {
                   messageId: 'floatingFixVoid',
@@ -110,7 +131,9 @@ export default util.createRule<Options, MessageId>({
           } else {
             context.report({
               node,
-              messageId: 'floating',
+              messageId: nonFunctionHandler
+                ? 'floatingUselessRejectionHandler'
+                : 'floating',
               suggest: [
                 {
                   messageId: 'floatingFixAwait',
@@ -168,16 +191,32 @@ export default util.createRule<Options, MessageId>({
       );
     }
 
+    function isValidRejectionHandler(rejectionHandler: TSESTree.Node): boolean {
+      // Note - when merged with main, getTypeAtLocation will be available as an
+      // instance method and these expressions can be chained.
+
+      return (
+        services.esTreeNodeToTSNodeMap
+          .get(rejectionHandler)
+          .getTypeAtLocation()
+          .getCallSignatures().length > 0
+      );
+    }
+
     function isUnhandledPromise(
       checker: ts.TypeChecker,
       node: TSESTree.Node,
-    ): boolean {
+    ): { isUnhandled: boolean; nonFunctionHandler?: boolean } {
       // First, check expressions whose resulting types may not be promise-like
       if (node.type === AST_NODE_TYPES.SequenceExpression) {
         // Any child in a comma expression could return a potentially unhandled
         // promise, so we check them all regardless of whether the final returned
         // value is promise-like.
-        return node.expressions.some(item => isUnhandledPromise(checker, item));
+        return (
+          node.expressions
+            .map(item => isUnhandledPromise(checker, item))
+            .find(result => result.isUnhandled) ?? { isUnhandled: false }
+        );
       }
 
       if (
@@ -192,24 +231,45 @@ export default util.createRule<Options, MessageId>({
 
       // Check the type. At this point it can't be unhandled if it isn't a promise
       if (!isPromiseLike(checker, services.esTreeNodeToTSNodeMap.get(node))) {
-        return false;
+        return { isUnhandled: false };
       }
 
       if (node.type === AST_NODE_TYPES.CallExpression) {
         // If the outer expression is a call, it must be either a `.then()` or
         // `.catch()` that handles the promise.
-        return (
-          !isPromiseCatchCallWithHandler(node) &&
-          !isPromiseThenCallWithRejectionHandler(node) &&
-          !isPromiseFinallyCallWithHandler(node)
-        );
+
+        const catchRejectionHandler = getRejectionHandlerFromCatchCall(node);
+        if (catchRejectionHandler) {
+          if (isValidRejectionHandler(catchRejectionHandler)) {
+            return { isUnhandled: false };
+          } else {
+            return { isUnhandled: true, nonFunctionHandler: true };
+          }
+        }
+
+        const thenRejectionHandler = getRejectionHandlerFromThenCall(node);
+        if (thenRejectionHandler) {
+          if (isValidRejectionHandler(thenRejectionHandler)) {
+            return { isUnhandled: false };
+          } else {
+            return { isUnhandled: true, nonFunctionHandler: true };
+          }
+        }
+
+        if (isPromiseFinallyCallWithHandler(node)) {
+          return { isUnhandled: false };
+        }
+
+        return { isUnhandled: true };
       } else if (node.type === AST_NODE_TYPES.ConditionalExpression) {
         // We must be getting the promise-like value from one of the branches of the
         // ternary. Check them directly.
-        return (
-          isUnhandledPromise(checker, node.alternate) ||
-          isUnhandledPromise(checker, node.consequent)
-        );
+        const alternateResult = isUnhandledPromise(checker, node.alternate);
+        if (alternateResult.isUnhandled) {
+          return alternateResult;
+        } else {
+          return isUnhandledPromise(checker, node.consequent);
+        }
       } else if (
         node.type === AST_NODE_TYPES.MemberExpression ||
         node.type === AST_NODE_TYPES.Identifier ||
@@ -218,18 +278,20 @@ export default util.createRule<Options, MessageId>({
         // If it is just a property access chain or a `new` call (e.g. `foo.bar` or
         // `new Promise()`), the promise is not handled because it doesn't have the
         // necessary then/catch call at the end of the chain.
-        return true;
+        return { isUnhandled: true };
       } else if (node.type === AST_NODE_TYPES.LogicalExpression) {
-        return (
-          isUnhandledPromise(checker, node.left) ||
-          isUnhandledPromise(checker, node.right)
-        );
+        const leftResult = isUnhandledPromise(checker, node.left);
+        if (leftResult.isUnhandled) {
+          return leftResult;
+        } else {
+          return isUnhandledPromise(checker, node.right);
+        }
       }
 
       // We conservatively return false for all other types of expressions because
       // we don't want to accidentally fail if the promise is handled internally but
       // we just can't tell.
-      return false;
+      return { isUnhandled: false };
     }
   },
 });
@@ -291,26 +353,34 @@ function isFunctionParam(
   return false;
 }
 
-function isPromiseCatchCallWithHandler(
+function getRejectionHandlerFromCatchCall(
   expression: TSESTree.CallExpression,
-): boolean {
-  return (
+): TSESTree.CallExpressionArgument | undefined {
+  if (
     expression.callee.type === AST_NODE_TYPES.MemberExpression &&
     expression.callee.property.type === AST_NODE_TYPES.Identifier &&
     expression.callee.property.name === 'catch' &&
     expression.arguments.length >= 1
-  );
+  ) {
+    return expression.arguments[0];
+  } else {
+    return undefined;
+  }
 }
 
-function isPromiseThenCallWithRejectionHandler(
+function getRejectionHandlerFromThenCall(
   expression: TSESTree.CallExpression,
-): boolean {
-  return (
+): TSESTree.CallExpressionArgument | undefined {
+  if (
     expression.callee.type === AST_NODE_TYPES.MemberExpression &&
     expression.callee.property.type === AST_NODE_TYPES.Identifier &&
     expression.callee.property.name === 'then' &&
     expression.arguments.length >= 2
-  );
+  ) {
+    return expression.arguments[1];
+  } else {
+    return undefined;
+  }
 }
 
 function isPromiseFinallyCallWithHandler(

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -19,8 +19,7 @@ type MessageId =
   | 'floatingUselessRejectionHandler'
   | 'floatingUselessRejectionHandlerVoid'
   | 'floatingFixAwait'
-  | 'floatingFixVoid'
-  | 'floatingFixAwait';
+  | 'floatingFixVoid';
 
 const messageBase =
   'Promises must be awaited, end with a call to .catch, or end with a call to .then with a rejection handler.';

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -192,13 +192,12 @@ export default util.createRule<Options, MessageId>({
     }
 
     function isValidRejectionHandler(rejectionHandler: TSESTree.Node): boolean {
-      // Note - when merged with main, getTypeAtLocation will be available as an
-      // instance method and these expressions can be chained.
-
       return (
-        services.esTreeNodeToTSNodeMap
-          .get(rejectionHandler)
-          .getTypeAtLocation()
+        services.program
+          .getTypeChecker()
+          .getTypeAtLocation(
+            services.esTreeNodeToTSNodeMap.get(rejectionHandler),
+          )
           .getCallSignatures().length > 0
       );
     }

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -147,7 +147,7 @@ async function test() {
     `,
     `
 async function test() {
-  const promiseValue: Promise<number>;
+  declare const promiseValue: Promise<number>;
 
   await promiseValue;
   promiseValue.then(
@@ -166,7 +166,7 @@ async function test() {
     `,
     `
 async function test() {
-  const promiseUnion: Promise<number> | number;
+  declare const promiseUnion: Promise<number> | number;
 
   await promiseUnion;
   promiseUnion.then(
@@ -185,7 +185,7 @@ async function test() {
     `,
     `
 async function test() {
-  const promiseIntersection: Promise<number> & number;
+  declare const promiseIntersection: Promise<number> & number;
 
   await promiseIntersection;
   promiseIntersection.then(
@@ -228,7 +228,7 @@ async function test() {
   await (Math.random() > 0.5 ? foo : 0);
   await (Math.random() > 0.5 ? bar : 0);
 
-  const intersectionPromise: Promise<number> & number;
+  declare const intersectionPromise: Promise<number> & number;
   await intersectionPromise;
 }
     `,
@@ -455,6 +455,13 @@ async function foo() {
   condition || myPromise();
   condition ?? myPromise();
 }
+      `,
+      options: [{ ignoreVoid: false }],
+    },
+    {
+      code: `
+declare const definitelyCallable: () => void;
+Promise.reject().catch(definitelyCallable);
       `,
       options: [{ ignoreVoid: false }],
     },
@@ -883,7 +890,7 @@ async function test() {
     {
       code: `
 async function test() {
-  const promiseValue: Promise<number>;
+  declare const promiseValue: Promise<number>;
 
   promiseValue;
   promiseValue.then(() => {});
@@ -913,7 +920,7 @@ async function test() {
     {
       code: `
 async function test() {
-  const promiseUnion: Promise<number> | number;
+  declare const promiseUnion: Promise<number> | number;
 
   promiseUnion;
 }
@@ -928,7 +935,7 @@ async function test() {
     {
       code: `
 async function test() {
-  const promiseIntersection: Promise<number> & number;
+  declare const promiseIntersection: Promise<number> & number;
 
   promiseIntersection;
   promiseIntersection.then(() => {});
@@ -1143,7 +1150,7 @@ async function test() {
     {
       code: `
         (async function () {
-          const promiseIntersection: Promise<number> & number;
+          declare const promiseIntersection: Promise<number> & number;
           promiseIntersection;
           promiseIntersection.then(() => {});
           promiseIntersection.catch();
@@ -1426,6 +1433,157 @@ async function foo() {
       `,
             },
           ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const maybeCallable: string | (() => void);
+declare const definitelyCallable: () => void;
+Promise.resolve().then(() => {}, undefined);
+Promise.resolve().then(() => {}, null);
+Promise.resolve().then(() => {}, 3);
+Promise.resolve().then(() => {}, maybeCallable);
+Promise.resolve().then(() => {}, definitelyCallable);
+
+Promise.resolve().catch(undefined);
+Promise.resolve().catch(null);
+Promise.resolve().catch(3);
+Promise.resolve().catch(maybeCallable);
+Promise.resolve().catch(definitelyCallable);
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'floatingUselessRejectionHandlerVoid',
+        },
+        {
+          line: 5,
+          messageId: 'floatingUselessRejectionHandlerVoid',
+        },
+        {
+          line: 6,
+          messageId: 'floatingUselessRejectionHandlerVoid',
+        },
+        {
+          line: 7,
+          messageId: 'floatingUselessRejectionHandlerVoid',
+        },
+        {
+          line: 10,
+          messageId: 'floatingUselessRejectionHandlerVoid',
+        },
+        {
+          line: 11,
+          messageId: 'floatingUselessRejectionHandlerVoid',
+        },
+        {
+          line: 12,
+          messageId: 'floatingUselessRejectionHandlerVoid',
+        },
+        {
+          line: 13,
+          messageId: 'floatingUselessRejectionHandlerVoid',
+        },
+      ],
+    },
+    {
+      code: `
+Promise.reject() || 3;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
+      code: `
+void Promise.resolve().then(() => {}, undefined);
+      `,
+      options: [{ ignoreVoid: false }],
+      errors: [
+        {
+          line: 2,
+          messageId: 'floatingUselessRejectionHandler',
+        },
+      ],
+    },
+    {
+      code: `
+declare const maybeCallable: string | (() => void);
+Promise.resolve().then(() => {}, maybeCallable);
+      `,
+      options: [{ ignoreVoid: false }],
+      errors: [
+        {
+          line: 3,
+          messageId: 'floatingUselessRejectionHandler',
+        },
+      ],
+    },
+    {
+      code: `
+declare const maybeCallable: string | (() => void);
+declare const definitelyCallable: () => void;
+Promise.resolve().then(() => {}, undefined);
+Promise.resolve().then(() => {}, null);
+Promise.resolve().then(() => {}, 3);
+Promise.resolve().then(() => {}, maybeCallable);
+Promise.resolve().then(() => {}, definitelyCallable);
+
+Promise.resolve().catch(undefined);
+Promise.resolve().catch(null);
+Promise.resolve().catch(3);
+Promise.resolve().catch(maybeCallable);
+Promise.resolve().catch(definitelyCallable);
+      `,
+      options: [{ ignoreVoid: false }],
+      errors: [
+        {
+          line: 4,
+          messageId: 'floatingUselessRejectionHandler',
+        },
+        {
+          line: 5,
+          messageId: 'floatingUselessRejectionHandler',
+        },
+        {
+          line: 6,
+          messageId: 'floatingUselessRejectionHandler',
+        },
+        {
+          line: 7,
+          messageId: 'floatingUselessRejectionHandler',
+        },
+        {
+          line: 10,
+          messageId: 'floatingUselessRejectionHandler',
+        },
+        {
+          line: 11,
+          messageId: 'floatingUselessRejectionHandler',
+        },
+        {
+          line: 12,
+          messageId: 'floatingUselessRejectionHandler',
+        },
+        {
+          line: 13,
+          messageId: 'floatingUselessRejectionHandler',
+        },
+      ],
+    },
+    {
+      code: `
+Promise.reject() || 3;
+      `,
+      options: [{ ignoreVoid: false }],
+      errors: [
+        {
+          line: 2,
+          messageId: 'floating',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/schema-snapshots/no-floating-promises.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-floating-promises.shot
@@ -9,7 +9,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "ignoreIIFE": {
-        "description": "Whether to ignore async IIFEs (Immediately Invocated Function Expressions).",
+        "description": "Whether to ignore async IIFEs (Immediately Invoked Function Expressions).",
         "type": "boolean"
       },
       "ignoreVoid": {
@@ -26,7 +26,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
-    /** Whether to ignore async IIFEs (Immediately Invocated Function Expressions). */
+    /** Whether to ignore async IIFEs (Immediately Invoked Function Expressions). */
     ignoreIIFE?: boolean;
     /** Whether to ignore \`void\` expressions. */
     ignoreVoid?: boolean;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6850 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

In no-floating-promises, the presence of an `onRejected` handler for `.then` or `.catch` is one of the valid ways of terminating an expression involving a promise. However, not all values supplied for `onRejected` are actually valid. Namely, anything that is not a function (looking at you, `null` and `undefined`) is simply ignored in EcmaScript. This PR adds validation to the rejection handler to verify that it is actually a function.

In short,
```
Promise.reject().then(() => {}) // previously was invalid, still is invalid
Promise.reject().then(() => {}, undefined) // previously was valid, now is invalid
```

In addition to that narrow issue, I have added the same validation for the `.catch` handler, since the same principles applies.
```
Promise.reject().catch() // previously was invalid, still is invalid
Promise.reject().catch(undefined) // previously was valid, now is invalid
```

In general, any `onRejected` argument to `.then` or `.catch` is now required to be callable.

There is a special case error message per discussion in the issue. 

I do have several things to bring to the attention of reviewers

1. I notice that this rule considers any "Promise-like" thenables, not just EcmaScript Promises. The claim that all rejection handlers are ignored if they are not callable is explicitly based on EcmaScript Promises, and may not be true for other Promise implementations. Is this a concern? Or should we go ahead with flagging errors assuming the ES implementation, despite the fact that, in principle, they could be false positives for an arbitrary thenable?

2. The rule at present never flags on a `.finally` that has a nonzero number of arguments. I don't actually understand why (is this intentional behavior or a bug??), since finally can make a resolved promise reject, but it can never make a rejected promise resolve. Because I don't understand the intention, and because the finally handler is not a rejection handler, I made no attempt to add validation to the handler in `.finally`.

3. I'm not totally happy with passing the result object up the recursion in `isHandledPromise`, but I'm not sure I know of a simpler way of passing the additional info required in order to special case the error message. Open to suggestions...


PS this is my first open source PR. Apologies in advance if I commit any major faux pas