### PR TITLE
fix(eslint-plugin): refactor schemas that use `$ref`

### DIFF
--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -105,30 +105,27 @@ export default util.createRule<Options, MessageIds>({
       errorStringGenericSimple:
         "Array type using '{{readonlyPrefix}}{{type}}[]' is forbidden for non-simple types. Use '{{className}}<{{type}}>' instead.",
     },
-    schema: {
-      $defs: {
-        arrayOption: {
-          enum: ['array', 'generic', 'array-simple'],
-        },
-      },
-      prefixItems: [
-        {
-          properties: {
-            default: {
-              $ref: '#/$defs/arrayOption',
-              description: 'The array type expected for mutable cases...',
-            },
-            readonly: {
-              $ref: '#/$defs/arrayOption',
-              description:
-                'The array type expected for readonly cases. If omitted, the value for `default` will be used.',
-            },
+    schema: [
+      {
+        $defs: {
+          arrayOption: {
+            enum: ['array', 'generic', 'array-simple'],
           },
-          type: 'object',
         },
-      ],
-      type: 'array',
-    },
+        properties: {
+          default: {
+            $ref: '#/items/0/$defs/arrayOption',
+            description: 'The array type expected for mutable cases...',
+          },
+          readonly: {
+            $ref: '#/items/0/$defs/arrayOption',
+            description:
+              'The array type expected for readonly cases. If omitted, the value for `default` will be used.',
+          },
+        },
+        type: 'object',
+      },
+    ],
   },
   defaultOptions: [
     {

--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -39,45 +39,42 @@ export default util.createRule<[Options], MessageIds>({
       tsDirectiveCommentDescriptionNotMatchPattern:
         'The description for the "@ts-{{directive}}" directive must match the {{format}} format.',
     },
-    schema: {
-      $defs: {
-        directiveConfigSchema: {
-          oneOf: [
-            {
-              type: 'boolean',
-              default: true,
-            },
-            {
-              enum: ['allow-with-description'],
-            },
-            {
-              type: 'object',
-              properties: {
-                descriptionFormat: { type: 'string' },
+    schema: [
+      {
+        $defs: {
+          directiveConfigSchema: {
+            oneOf: [
+              {
+                type: 'boolean',
+                default: true,
               },
-            },
-          ],
-        },
-      },
-      prefixItems: [
-        {
-          properties: {
-            'ts-expect-error': {
-              $ref: '#/$defs/directiveConfigSchema',
-            },
-            'ts-ignore': { $ref: '#/$defs/directiveConfigSchema' },
-            'ts-nocheck': { $ref: '#/$defs/directiveConfigSchema' },
-            'ts-check': { $ref: '#/$defs/directiveConfigSchema' },
-            minimumDescriptionLength: {
-              type: 'number',
-              default: defaultMinimumDescriptionLength,
-            },
+              {
+                enum: ['allow-with-description'],
+              },
+              {
+                type: 'object',
+                properties: {
+                  descriptionFormat: { type: 'string' },
+                },
+              },
+            ],
           },
-          additionalProperties: false,
         },
-      ],
-      type: 'array',
-    },
+        properties: {
+          'ts-expect-error': {
+            $ref: '#/items/0/$defs/directiveConfigSchema',
+          },
+          'ts-ignore': { $ref: '#/items/0/$defs/directiveConfigSchema' },
+          'ts-nocheck': { $ref: '#/items/0/$defs/directiveConfigSchema' },
+          'ts-check': { $ref: '#/items/0/$defs/directiveConfigSchema' },
+          minimumDescriptionLength: {
+            type: 'number',
+            default: defaultMinimumDescriptionLength,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
   defaultOptions: [
     {

--- a/packages/eslint-plugin/src/rules/comma-dangle.ts
+++ b/packages/eslint-plugin/src/rules/comma-dangle.ts
@@ -47,6 +47,7 @@ export default util.createRule<Options, MessageIds>({
       recommended: false,
       extendsBaseRule: true,
     },
+    // intentionally a non-array schema to mirror the base rule
     schema: {
       $defs: {
         value: {
@@ -61,19 +62,19 @@ export default util.createRule<Options, MessageIds>({
         {
           oneOf: [
             {
-              $ref: '#/$defs/value',
+              $ref: '#/items/0/$defs/value',
             },
             {
               type: 'object',
               properties: {
-                arrays: { $ref: '#/$defs/valueWithIgnore' },
-                objects: { $ref: '#/$defs/valueWithIgnore' },
-                imports: { $ref: '#/$defs/valueWithIgnore' },
-                exports: { $ref: '#/$defs/valueWithIgnore' },
-                functions: { $ref: '#/$defs/valueWithIgnore' },
-                enums: { $ref: '#/$defs/valueWithIgnore' },
-                generics: { $ref: '#/$defs/valueWithIgnore' },
-                tuples: { $ref: '#/$defs/valueWithIgnore' },
+                arrays: { $ref: '#/items/0/$defs/valueWithIgnore' },
+                objects: { $ref: '#/items/0/$defs/valueWithIgnore' },
+                imports: { $ref: '#/items/0/$defs/valueWithIgnore' },
+                exports: { $ref: '#/items/0/$defs/valueWithIgnore' },
+                functions: { $ref: '#/items/0/$defs/valueWithIgnore' },
+                enums: { $ref: '#/items/0/$defs/valueWithIgnore' },
+                generics: { $ref: '#/items/0/$defs/valueWithIgnore' },
+                tuples: { $ref: '#/items/0/$defs/valueWithIgnore' },
               },
               additionalProperties: false,
             },

--- a/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
+++ b/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
@@ -27,23 +27,6 @@ type MessageIds =
   | 'missingAccessibility'
   | 'addExplicitAccessibility';
 
-const accessibilityLevel = {
-  oneOf: [
-    {
-      const: 'explicit',
-      description: 'Always require an accessor.',
-    },
-    {
-      const: 'no-public',
-      description: 'Require an accessor except when public.',
-    },
-    {
-      const: 'off',
-      description: 'Never check whether there is an accessor.',
-    },
-  ],
-};
-
 export default util.createRule<Options, MessageIds>({
   name: 'explicit-member-accessibility',
   meta: {
@@ -63,41 +46,40 @@ export default util.createRule<Options, MessageIds>({
         'Public accessibility modifier on {{type}} {{name}}.',
       addExplicitAccessibility: "Add '{{ type }}' accessibility modifier",
     },
-    schema: {
-      $defs: {
-        accessibilityLevel,
-      },
-      prefixItems: [
-        {
-          type: 'object',
-          properties: {
-            accessibility: { $ref: '#/$defs/accessibilityLevel' },
-            overrides: {
-              type: 'object',
-              properties: {
-                accessors: { $ref: '#/$defs/accessibilityLevel' },
-                constructors: { $ref: '#/$defs/accessibilityLevel' },
-                methods: { $ref: '#/$defs/accessibilityLevel' },
-                properties: { $ref: '#/$defs/accessibilityLevel' },
-                parameterProperties: {
-                  $ref: '#/$defs/accessibilityLevel',
-                },
+    schema: [
+      {
+        $defs: {
+          accessibilityLevel: {
+            enum: ['explicit', 'no-public', 'off'],
+          },
+        },
+        type: 'object',
+        properties: {
+          accessibility: { $ref: '#/items/0/$defs/accessibilityLevel' },
+          overrides: {
+            type: 'object',
+            properties: {
+              accessors: { $ref: '#/items/0/$defs/accessibilityLevel' },
+              constructors: { $ref: '#/items/0/$defs/accessibilityLevel' },
+              methods: { $ref: '#/items/0/$defs/accessibilityLevel' },
+              properties: { $ref: '#/items/0/$defs/accessibilityLevel' },
+              parameterProperties: {
+                $ref: '#/items/0/$defs/accessibilityLevel',
               },
-
-              additionalProperties: false,
             },
-            ignoredMethodNames: {
-              type: 'array',
-              items: {
-                type: 'string',
-              },
+
+            additionalProperties: false,
+          },
+          ignoredMethodNames: {
+            type: 'array',
+            items: {
+              type: 'string',
             },
           },
-          additionalProperties: false,
         },
-      ],
-      type: 'array',
-    },
+        additionalProperties: false,
+      },
+    ],
   },
   defaultOptions: [{ accessibility: 'explicit' }],
   create(context, [option]) {

--- a/packages/eslint-plugin/src/rules/func-call-spacing.ts
+++ b/packages/eslint-plugin/src/rules/func-call-spacing.ts
@@ -24,6 +24,7 @@ export default util.createRule<Options, MessageIds>({
       extendsBaseRule: true,
     },
     fixable: 'whitespace',
+    // intentionally a non-array schema to mirror the base rule
     schema: {
       anyOf: [
         {

--- a/packages/eslint-plugin/src/rules/lines-around-comment.ts
+++ b/packages/eslint-plugin/src/rules/lines-around-comment.ts
@@ -51,89 +51,86 @@ export default util.createRule<Options, MessageIds>({
       recommended: false,
       extendsBaseRule: true,
     },
-    schema: {
-      type: 'array',
-      items: [
-        {
-          type: 'object',
-          properties: {
-            beforeBlockComment: {
-              type: 'boolean',
-              default: true,
-            },
-            afterBlockComment: {
-              type: 'boolean',
-              default: false,
-            },
-            beforeLineComment: {
-              type: 'boolean',
-              default: false,
-            },
-            afterLineComment: {
-              type: 'boolean',
-              default: false,
-            },
-            allowBlockStart: {
-              type: 'boolean',
-              default: false,
-            },
-            allowBlockEnd: {
-              type: 'boolean',
-              default: false,
-            },
-            allowClassStart: {
-              type: 'boolean',
-            },
-            allowClassEnd: {
-              type: 'boolean',
-            },
-            allowObjectStart: {
-              type: 'boolean',
-            },
-            allowObjectEnd: {
-              type: 'boolean',
-            },
-            allowArrayStart: {
-              type: 'boolean',
-            },
-            allowArrayEnd: {
-              type: 'boolean',
-            },
-            allowInterfaceStart: {
-              type: 'boolean',
-            },
-            allowInterfaceEnd: {
-              type: 'boolean',
-            },
-            allowTypeStart: {
-              type: 'boolean',
-            },
-            allowTypeEnd: {
-              type: 'boolean',
-            },
-            allowEnumStart: {
-              type: 'boolean',
-            },
-            allowEnumEnd: {
-              type: 'boolean',
-            },
-            allowModuleStart: {
-              type: 'boolean',
-            },
-            allowModuleEnd: {
-              type: 'boolean',
-            },
-            ignorePattern: {
-              type: 'string',
-            },
-            applyDefaultIgnorePatterns: {
-              type: 'boolean',
-            },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          beforeBlockComment: {
+            type: 'boolean',
+            default: true,
           },
-          additionalProperties: false,
+          afterBlockComment: {
+            type: 'boolean',
+            default: false,
+          },
+          beforeLineComment: {
+            type: 'boolean',
+            default: false,
+          },
+          afterLineComment: {
+            type: 'boolean',
+            default: false,
+          },
+          allowBlockStart: {
+            type: 'boolean',
+            default: false,
+          },
+          allowBlockEnd: {
+            type: 'boolean',
+            default: false,
+          },
+          allowClassStart: {
+            type: 'boolean',
+          },
+          allowClassEnd: {
+            type: 'boolean',
+          },
+          allowObjectStart: {
+            type: 'boolean',
+          },
+          allowObjectEnd: {
+            type: 'boolean',
+          },
+          allowArrayStart: {
+            type: 'boolean',
+          },
+          allowArrayEnd: {
+            type: 'boolean',
+          },
+          allowInterfaceStart: {
+            type: 'boolean',
+          },
+          allowInterfaceEnd: {
+            type: 'boolean',
+          },
+          allowTypeStart: {
+            type: 'boolean',
+          },
+          allowTypeEnd: {
+            type: 'boolean',
+          },
+          allowEnumStart: {
+            type: 'boolean',
+          },
+          allowEnumEnd: {
+            type: 'boolean',
+          },
+          allowModuleStart: {
+            type: 'boolean',
+          },
+          allowModuleEnd: {
+            type: 'boolean',
+          },
+          ignorePattern: {
+            type: 'string',
+          },
+          applyDefaultIgnorePatterns: {
+            type: 'boolean',
+          },
         },
-      ],
-    },
+        additionalProperties: false,
+      },
+    ],
     fixable: baseRule.meta.fixable,
     hasSuggestions: baseRule.meta.hasSuggestions,
     messages: baseRule.meta.messages,

--- a/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
+++ b/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
@@ -595,6 +595,7 @@ export default util.createRule<Options, MessageIds>({
     },
     fixable: 'whitespace',
     hasSuggestions: false,
+    // intentionally a non-array schema to mirror the base rule
     schema: {
       $defs: {
         paddingType: {

--- a/packages/eslint-plugin/src/rules/parameter-properties.ts
+++ b/packages/eslint-plugin/src/rules/parameter-properties.ts
@@ -38,40 +38,37 @@ export default util.createRule<Options, MessageIds>({
       preferParameterProperty:
         'Property {{parameter}} should be declared as a parameter property.',
     },
-    schema: {
-      $defs: {
-        modifier: {
-          enum: [
-            'readonly',
-            'private',
-            'protected',
-            'public',
-            'private readonly',
-            'protected readonly',
-            'public readonly',
-          ],
-        },
-      },
-      prefixItems: [
-        {
-          type: 'object',
-          properties: {
-            allow: {
-              type: 'array',
-              items: {
-                $ref: '#/$defs/modifier',
-              },
-              minItems: 1,
-            },
-            prefer: {
-              enum: ['class-property', 'parameter-property'],
-            },
+    schema: [
+      {
+        $defs: {
+          modifier: {
+            enum: [
+              'readonly',
+              'private',
+              'protected',
+              'public',
+              'private readonly',
+              'protected readonly',
+              'public readonly',
+            ],
           },
-          additionalProperties: false,
         },
-      ],
-      type: 'array',
-    },
+        type: 'object',
+        properties: {
+          allow: {
+            type: 'array',
+            items: {
+              $ref: '#/items/0/$defs/modifier',
+            },
+            minItems: 1,
+          },
+          prefer: {
+            enum: ['class-property', 'parameter-property'],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
   defaultOptions: [
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6852 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Updates rule schemas that use $ref to use an array-based schema instead of an object-based one and updates the doc gen to match.

ESLint will wrap an array schema in an array object: `[schema] -> { type: 'array', items: [schema] }`, so we can use that knowledge to reference the `$defs` with `#/items/0/$defs/...`.

This saves us manually recreating the tuple validation that ESLint already does for us.
It does require us to rewrite the `$ref` for our doc gen because we reference the schema object directly (eg `#/items/0/$defs/... -> #/$defs/...`