### PR TITLE
chore(website): validate rule options in editor

### DIFF
--- a/packages/website/src/components/editor/LoadedEditor.tsx
+++ b/packages/website/src/components/editor/LoadedEditor.tsx
@@ -147,16 +147,23 @@ export const LoadedEditor: React.FC<LoadedEditorProps> = ({
   }, [webLinter, onEsASTChange, onScopeChange, onTsASTChange]);
 
   useEffect(() => {
+    const createRuleUri = (name: string): string =>
+      monaco.Uri.parse(`/rules/${name.replace('@', '')}.json`).toString();
+
     // configure the JSON language support with schemas and schema associations
     monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
       validate: true,
       enableSchemaRequest: false,
       allowComments: true,
       schemas: [
+        ...Array.from(webLinter.rules.values()).map(rule => ({
+          uri: createRuleUri(rule.name),
+          schema: rule.schema,
+        })),
         {
           uri: monaco.Uri.file('eslint-schema.json').toString(), // id of the first schema
           fileMatch: ['/.eslintrc'], // associate with our model
-          schema: getEslintJsonSchema(webLinter),
+          schema: getEslintJsonSchema(webLinter, createRuleUri),
         },
         {
           uri: monaco.Uri.file('ts-schema.json').toString(), // id of the first schema

--- a/packages/website/src/components/editor/LoadedEditor.tsx
+++ b/packages/website/src/components/editor/LoadedEditor.tsx
@@ -8,6 +8,7 @@ import { createCompilerOptions } from '../lib/createCompilerOptions';
 import { debounce } from '../lib/debounce';
 import {
   getEslintJsonSchema,
+  getRuleJsonSchemaWithErrorLevel,
   getTypescriptJsonSchema,
 } from '../lib/jsonSchema';
 import { parseTSConfig, tryParseEslintModule } from '../lib/parseConfig';
@@ -158,7 +159,7 @@ export const LoadedEditor: React.FC<LoadedEditorProps> = ({
       schemas: [
         ...Array.from(webLinter.rules.values()).map(rule => ({
           uri: createRuleUri(rule.name),
-          schema: rule.schema,
+          schema: getRuleJsonSchemaWithErrorLevel(rule.schema),
         })),
         {
           uri: monaco.Uri.file('eslint-schema.json').toString(), // id of the first schema

--- a/packages/website/src/components/editor/LoadedEditor.tsx
+++ b/packages/website/src/components/editor/LoadedEditor.tsx
@@ -159,7 +159,7 @@ export const LoadedEditor: React.FC<LoadedEditorProps> = ({
       schemas: [
         ...Array.from(webLinter.rules.values()).map(rule => ({
           uri: createRuleUri(rule.name),
-          schema: getRuleJsonSchemaWithErrorLevel(rule.schema),
+          schema: getRuleJsonSchemaWithErrorLevel(rule.name, rule.schema),
         })),
         {
           uri: monaco.Uri.file('eslint-schema.json').toString(), // id of the first schema

--- a/packages/website/src/components/editor/createProvideCodeActions.ts
+++ b/packages/website/src/components/editor/createProvideCodeActions.ts
@@ -34,9 +34,9 @@ export function createProvideCodeActions(
               edits: [
                 {
                   resource: model.uri,
-                  // @ts-expect-error monaco for ts >= 4.8
+                  // monaco for ts >= 4.8
                   textEdit: editOperation,
-                  // monaco for ts < 4.8
+                  // @ts-expect-error monaco for ts < 4.8
                   edit: editOperation,
                 },
               ],

--- a/packages/website/src/components/editor/useSandboxServices.ts
+++ b/packages/website/src/components/editor/useSandboxServices.ts
@@ -125,6 +125,7 @@ export const useSandboxServices = (
     };
     // colorMode and jsx can't be reactive here because we don't want to force a recreation
     // updating of colorMode and jsx is handled in LoadedEditor
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return services;

--- a/packages/website/src/components/lib/jsonSchema.ts
+++ b/packages/website/src/components/lib/jsonSchema.ts
@@ -51,19 +51,11 @@ export function getRuleJsonSchemaWithErrorLevel(
     };
   }
   if (typeof ruleSchema.items === 'object' && ruleSchema.items) {
-    // this is a workaround for naming-convention rule
-    if (ruleSchema.items.oneOf) {
-      return {
-        ...ruleSchema,
-        items: [defaultRuleSchema],
-        additionalItems: ruleSchema.items,
-      };
-    }
-    // example: padding-line-between-statements
+    // example: naming-convention rule
     return {
       ...ruleSchema,
-      items: [defaultRuleSchema, ruleSchema.items],
-      additionalItems: false,
+      items: [defaultRuleSchema],
+      additionalItems: ruleSchema.items,
     };
   }
   // example eqeqeq

--- a/packages/website/src/components/lib/jsonSchema.ts
+++ b/packages/website/src/components/lib/jsonSchema.ts
@@ -17,17 +17,19 @@ const defaultRuleSchema: JSONSchema4 = {
  * monaco.languages.json.jsonDefaults.diagnosticsOptions.schemas.filter(item => item.schema.type === 'array')
  */
 export function getRuleJsonSchemaWithErrorLevel(
+  name: string,
   ruleSchema: JSONSchema4 | JSONSchema4[],
 ): JSONSchema4 {
   if (Array.isArray(ruleSchema)) {
     return {
       type: 'array',
       items: [defaultRuleSchema, ...ruleSchema],
+      minItems: 1,
       additionalItems: false,
     };
   }
   // TODO: delete this once we update schemas
-  // example: ban-ts-comments
+  // example: ban-ts-comment
   if (Array.isArray(ruleSchema.prefixItems)) {
     const { prefixItems, ...rest } = ruleSchema;
     return {
@@ -38,7 +40,7 @@ export function getRuleJsonSchemaWithErrorLevel(
       additionalItems: false,
     };
   }
-  // example: @typescript-eslint/explicit-member-accessibility
+  // example: explicit-member-accessibility
   if (Array.isArray(ruleSchema.items)) {
     return {
       ...ruleSchema,
@@ -49,7 +51,7 @@ export function getRuleJsonSchemaWithErrorLevel(
     };
   }
   if (typeof ruleSchema.items === 'object' && ruleSchema.items) {
-    // this is a workaround for @typescript-eslint/naming-convention rule
+    // this is a workaround for naming-convention rule
     if (ruleSchema.items.oneOf) {
       return {
         ...ruleSchema,
@@ -57,7 +59,7 @@ export function getRuleJsonSchemaWithErrorLevel(
         additionalItems: ruleSchema.items,
       };
     }
-    // example: @typescript-eslint/padding-line-between-statements
+    // example: padding-line-between-statements
     return {
       ...ruleSchema,
       items: [defaultRuleSchema, ruleSchema.items],
@@ -69,7 +71,7 @@ export function getRuleJsonSchemaWithErrorLevel(
     return {
       ...ruleSchema,
       anyOf: ruleSchema.anyOf.map(item =>
-        getRuleJsonSchemaWithErrorLevel(item),
+        getRuleJsonSchemaWithErrorLevel(name, item),
       ),
     };
   }
@@ -78,11 +80,17 @@ export function getRuleJsonSchemaWithErrorLevel(
     return {
       ...ruleSchema,
       oneOf: ruleSchema.oneOf.map(item =>
-        getRuleJsonSchemaWithErrorLevel(item),
+        getRuleJsonSchemaWithErrorLevel(name, item),
       ),
     };
   }
-  return ruleSchema;
+  console.log('unsupported rule schema', name, ruleSchema);
+  return {
+    type: 'array',
+    items: [defaultRuleSchema],
+    minItems: 1,
+    additionalItems: false,
+  };
 }
 
 /**

--- a/packages/website/src/components/lib/jsonSchema.ts
+++ b/packages/website/src/components/lib/jsonSchema.ts
@@ -84,7 +84,9 @@ export function getRuleJsonSchemaWithErrorLevel(
       ),
     };
   }
-  console.log('unsupported rule schema', name, ruleSchema);
+  if (typeof ruleSchema !== 'object' || Object.keys(ruleSchema).length) {
+    console.error('unsupported rule schema', name, ruleSchema);
+  }
   return {
     type: 'array',
     items: [defaultRuleSchema],

--- a/packages/website/src/components/linter/createLinter.ts
+++ b/packages/website/src/components/linter/createLinter.ts
@@ -1,5 +1,5 @@
 import type * as tsvfs from '@site/src/vendor/typescript-vfs';
-import type { TSESLint } from '@typescript-eslint/utils';
+import type { JSONSchema, TSESLint } from '@typescript-eslint/utils';
 import type * as ts from 'typescript';
 
 import { createCompilerOptions } from '../lib/createCompilerOptions';
@@ -15,7 +15,15 @@ import type {
 } from './types';
 
 export interface CreateLinter {
-  rules: Map<string, { name: string; description?: string; url?: string }>;
+  rules: Map<
+    string,
+    {
+      name: string;
+      description?: string;
+      url?: string;
+      schema: JSONSchema.JSONSchema4;
+    }
+  >;
   configs: string[];
   triggerFix(filename: string): TSESLint.Linter.FixReport | undefined;
   triggerLint(filename: string): void;
@@ -56,6 +64,7 @@ export function createLinter(
       name: name,
       description: item.meta?.docs?.description,
       url: item.meta?.docs?.url,
+      schema: item.meta?.schema ?? [],
     });
   });
 

--- a/packages/website/src/components/linter/utils.ts
+++ b/packages/website/src/components/linter/utils.ts
@@ -102,8 +102,9 @@ export function parseMarkers(
 
     result[group].items.push({
       message:
-        (marker.owner !== 'eslint' && code ? `${code.value}: ` : '') +
-        marker.message,
+        (marker.owner !== 'eslint' && marker.owner !== 'json' && code.value
+          ? `${code.value}: `
+          : '') + marker.message,
       location: `${marker.startLineNumber}:${marker.startColumn} - ${marker.endLineNumber}:${marker.endColumn}`,
       severity: marker.severity,
       fixer: fixers.find(item => item.isPreferred),


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Enable rule schema validation in playground

https://user-images.githubusercontent.com/625469/232217302-aee2b593-50e7-4abf-a83b-8eab08d2ffa9.mp4

[config with errors](https://deploy-preview-6907--typescript-eslint.netlify.app/play/#ts=5.0.4&fileType=.tsx&code=FBA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6JgQwFtmBzWsgHsmAN0QtKw9GADa4bDkTRog6JAA08hVgXZIyREjL5V0ubt2RxsLpC26AuvYgBfTRZ0X9hxMdMZzCz1rW2dsB3cgyAAzVS4OfGkmBHgwl3sI%2BzwiUmQKajoGZjYhJmRKZHxxOl5xJUoyAWFKuD9oVACwq2VTSIVIHMRaABM7BUz%2BghJyKhp6ZEYWVkQAD2JGMko6LkQuACMlWg4yMhRyvcpGIjMupRU1PuxPS2PT5HPLrcJpSDHddPGj0glGGI3EhEYlRuXjuvTCACYMo9WKwwHAkGA8gALXYcMAAdy2WLAgj2ACtfPgwMxqVUuMgslNcvk5kUlsQOMNhnxaIshgd8PjEOJaJUErtqh1ZLceg8ws9%2Bnt4BwmABrAAyzEQPw48HxHEIqDSSPsKLA%2BCxFUxWMECGGYFh0BJTHNgjAF14YA4ygNWSYglosGSBlByoO8ClgX6jo0YWiuoMJoUZvRiExZBx8QJRK9PsI1JdW12DP63ugBvoSB2LFoTEQ%2BL50MsMceOA4fwgE2wKYQaexuPNWISYFK%2BA4zGQzsQAHloll4IJeA1dUd3pReExq3RBKRyyZ2k3o7LY15dfrDSfdArgkxYtBTgAxVQASWiAGUx3TJdJ8HBEMbAVNVFU3TTM8QtYdR3HMovSYQhZyyRAAEdkOQw9gmPVsoDPA0jUA5NUU5bl8EkTh4BHHEyFVEs9CZGYCnmRY2GiINGjIXV4FFDlNiYXh0MUY8kz0f1aGgFBfwaKpQV4Bc9gTMxunuDQoCqKF1CgOSHjAeEuxwOi8lmQoFmKVg5KYWh8GQJouC3BT9WgJhlMgfFICcVwQBcIA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA)
[config without errors](https://deploy-preview-6907--typescript-eslint.netlify.app/play/#ts=5.0.4&fileType=.tsx&code=FBA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6JgQwFtmBzWsgHsmAN0QtKw9GADa4bDkTRog6JAA08hVgXZIyREjL5V0ubt2RxsLpC26Aupos4AZqq4d8ZyGW6GAYQ4DSAd7CABfZ10dC31DRGNTDHMXRSYbOzSncL13aE9vDAz4eFyI%2BxyFPCJSZApqOgZmNiEmZEpkfHE6XnElSjIBYS64JOhUFNyrZVNo6trEWg4mJkF8L0kmLOwqvQIScioaemRGFlZEAA9iRjJKOi5ELgAjJWWyMhQOl8pGIjM0yUKjU82wsUsHE%2B30ov3%2BhGkVhudweOwUFQUexwlAAJrQceJCIwuoC4sDTJUwaxWGA4EgwPUABbPDhgADuD0ZYEELwAVol8GBmELulxkPYaod6scmmcWqxiBwcTi%2BLRzks3vg2YhxLQul5nj1JrIgbNQbkIdUXvAVgBrAAyzEQiI48DZHEIqDB1SY1yKUAAVBpcjhiNBECJEUHypT7NSwPhGZ0GYzBAgcWBydBuUwE4IwL9eGAOMoPRK1rRYBkDHibW94MbUtUs2iwFiwPG6YgGWRmZ52Zzi6XCELcw9nuLqiXoB76EgnixaL62erSZYW96oK73Z7W%2B3Owhu0yWQnGV4wG0NsxkDnEAB5VwS%2BCCXiDV3LZAdXhMBd0QSkGcTAmNdmzNYM4m3D0vQtEMoHEfIvgAMVUABJVwAGUNlFI1pHwOBEBjTEqRpLsez7VlE3PS8OGvYsmEIB8JUQABHFiWJAvQN2mZBPGgbxYwUeMlRVfAtldC9mTIW1J32RZpUaU5zjYVwqyGPxSj1RV7iYXgOMUMCBL0Ctw1GQZujxXhnxeV1G1NEFwMsboSU3SBrLUQycAOOoGhOZoLmsphaHwZBhi4X89Kgd1oG2TdLT0YKBEk21cPwwjdnkCoIiAA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA)


```jsonc
{
  "rules": {
    "@typescript-eslint/naming-convention": [
      "error",
      {
        "selector": [
          "enum"
        ]
      },
      {
        "selector": [
          "enum"
        ],
        "format": null
      }
    ],
    "@typescript-eslint/consistent-generic-constructors": [
      "error",
      "type-d"
    ],
    "@typescript-eslint/explicit-member-accessibility": [
      "error",
      {
        "accessibility": ""
      }
    ],
    "id-denylist": [
      "error",
      2
    ],
    // rule schema with object in items
    "@typescript-eslint/padding-line-between-statements": [
      "error",
      {
        "blankLine": "always"
      }
    ],
    // this should error on to big array
    "no-unused-labels": [
      "error",
      false
    ],
    // rule schema with array in items
    "array-element-newline": [
      "error",
      "a"
    ],
    // rule schema that contains oneOf
    "logical-assignment-operators": [
      "error",
      "always",
      {
        "enforceForIfStatements": true
      }
    ],
    // rule schema that contains anyOf
    "eqeqeq": [
      "error",
      "always"
    ],
    // additional checks
    "@typescript-eslint/func-call-spacing": [
      "error"
    ],
    "no-restricted-globals": ["error", "test", "bar", 2],
    "@typescript-eslint/ban-ts-comment": ["warn", "w"]
  }
}
```

ref: #6896 #6899