### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] allow nullish coalescing for naked type parameter

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -263,8 +263,14 @@ export default createRule<Options, MessageId>({
 
     function checkNodeForNullish(node: TSESTree.Expression): void {
       const type = getNodeType(node);
-      // Conditional is always necessary if it involves `any` or `unknown`
-      if (isTypeAnyType(type) || isTypeUnknownType(type)) {
+
+      // Conditional is always necessary if it involves `any`, `unknown` or a naked type parameter
+      if (
+        isTypeFlagSet(
+          type,
+          ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.TypeParameter,
+        )
+      ) {
         return;
       }
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -282,6 +282,11 @@ function test(a: unknown) {
   return a ?? 'default';
 }
     `,
+    `
+function test<T>(a: T) {
+  return a ?? 'default';
+}
+    `,
     // Indexing cases
     `
 declare const arr: object[];

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -287,6 +287,11 @@ function test<T>(a: T) {
   return a ?? 'default';
 }
     `,
+    `
+function test<T extends string | null>(a: T) {
+  return a ?? 'default';
+}
+    `,
     // Indexing cases
     `
 declare const arr: object[];
@@ -836,6 +841,14 @@ function test(a: string | false) {
       `,
       errors: [ruleError(3, 10, 'neverNullish')],
     },
+    {
+      code: `
+function test<T extends string>(a: T) {
+  return a ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 10, 'neverNullish')],
+    },
     // nullish + array index without optional chaining
     {
       code: `
@@ -857,6 +870,14 @@ function test(a: null) {
       code: `
 function test(a: null[]) {
   return a[0] ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 10, 'alwaysNullish')],
+    },
+    {
+      code: `
+function test<T extends null>(a: T) {
+  return a ?? 'default';
 }
       `,
       errors: [ruleError(3, 10, 'alwaysNullish')],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6902
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Allow nullish coalescing for a naked type parameter because it might be nullable.
