### PR TITLE
docs: add /* eslint-env node */ on top of suggested configs

### DIFF
--- a/docs/Getting_Started.mdx
+++ b/docs/Getting_Started.mdx
@@ -20,6 +20,7 @@ npm install --save-dev @typescript-eslint/parser @typescript-eslint/eslint-plugi
 Next, create a `.eslintrc.cjs` config file in the root of your project, and populate it with the following:
 
 ```js title=".eslintrc.cjs"
+/* eslint-env node */
 module.exports = {
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   parser: '@typescript-eslint/parser',

--- a/docs/linting/Typed_Linting.mdx
+++ b/docs/linting/Typed_Linting.mdx
@@ -7,6 +7,7 @@ Some typescript-eslint rules utilize the awesome power of TypeScript's type chec
 To tap into TypeScript's additional powers, there are two small changes you need to make to your config file:
 
 ```js title=".eslintrc.js"
+/* eslint-env node */
 module.exports = {
   extends: [
     'eslint:recommended',

--- a/docs/linting/troubleshooting/Formatting.mdx
+++ b/docs/linting/troubleshooting/Formatting.mdx
@@ -38,6 +38,7 @@ You can then configure your formatter separately from ESLint.
 Using this config by adding it to the end of your `extends`:
 
 ```js title=".eslintrc.js"
+/* eslint-env node */
 module.exports = {
   extends: [
     'eslint:recommended',

--- a/docs/linting/typed-linting/Monorepos.mdx
+++ b/docs/linting/typed-linting/Monorepos.mdx
@@ -43,6 +43,7 @@ Paths may be provided as [Node globs](https://github.com/isaacs/node-glob/blob/f
 For each file being linted, the first matching project path will be used as its backing TSConfig.
 
 ```js title=".eslintrc.js"
+/* eslint-env node */
 module.exports = {
   extends: [
     'eslint:recommended',
@@ -68,6 +69,7 @@ Using wide globs `**` in your `parserOptions.project` may degrade linting perfor
 Instead of globs that use `**` to recursively check all folders, prefer paths that use a single `*` at a time.
 
 ```js title=".eslintrc.js"
+/* eslint-env node */
 module.exports = {
   extends: [
     'eslint:recommended',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6825
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

For each `module.exports =` in a `.mdx` file in a code block that includes most or all of a config file, adds the `/* eslint-env node */` comment.
