### PR TITLE
chore: remove duplicated and unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@types/is-glob": "^4.0.2",
     "@types/jest": "^29.0.2",
     "@types/jest-specific-snapshot": "^0.5.5",
-    "@types/lodash": "^4.14.182",
     "@types/marked": "^4.0.3",
     "@types/node": "^18.11.9",
     "@types/prettier": "^2.6.0",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -61,7 +61,7 @@
     "debug": "^4.3.4",
     "grapheme-splitter": "^1.0.4",
     "ignore": "^5.2.0",
-    "natural-compare-lite": "^1.4.0",
+    "natural-compare": "^1.4.0",
     "semver": "^7.3.7",
     "ts-api-utils": "^0.0.46"
   },
@@ -69,7 +69,7 @@
     "@types/debug": "*",
     "@types/json-schema": "*",
     "@types/marked": "*",
-    "@types/natural-compare-lite": "^1.4.0",
+    "@types/natural-compare": "^1.4.0",
     "@types/prettier": "*",
     "cross-fetch": "*",
     "json-schema": "*",

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
-import naturalCompare from 'natural-compare-lite';
+import naturalCompare from 'natural-compare';
 
 import * as util from '../util';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3888,10 +3888,10 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
-"@types/natural-compare-lite@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@types/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#90724682da3c304dd8d643b4e9ba00f53f29d454"
-  integrity sha512-ZDcj/yWsRPacqKPpCExWWFq9X1JQwEOfHsu8deN1Qfa6M02z6tN4DK6AMf2IkM7709gp3QW6Bo7m2NFDhA485w==
+"@types/natural-compare@^1.4.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@types/natural-compare/-/natural-compare-1.4.1.tgz#fc2b11ea100d380b0de7af15768bef209157bfb9"
+  integrity sha512-9dr4UakpvN0QUvwNefk9+o14Sr1pPPIDWkgCxPkHcg3kyjtc9eKK1ng6dZ23vRwByloCqXYtZ1T5nJxkk3Ib3A==
 
 "@types/ncp@^2.0.5":
   version "2.0.5"
@@ -10715,11 +10715,6 @@ nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
-
-natural-compare-lite@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
-  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- We are no longer using `lodash` and we can safely remove `@types` for it
- `natural-compare-lite` and `natural-compare` is a same package with exact same code, and instead of using `natural-compare-lite` we should use `natural-compare` as its already required by `eslint`
  - this package had marginal amounts of downloads before was added to our project :>
