### PR TITLE
fix(eslint-plugin): [prefer-regexp-exec] skip malformed regexes

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
+++ b/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
@@ -125,7 +125,12 @@ export default createRule({
           argumentNode.type === AST_NODE_TYPES.Literal &&
           typeof argumentNode.value === 'string'
         ) {
-          const regExp = RegExp(argumentNode.value);
+          let regExp: RegExp;
+          try {
+            regExp = RegExp(argumentNode.value);
+          } catch {
+            return;
+          }
           return context.report({
             node: memberNode.property,
             messageId: 'regExpExecOverStringMatch',

--- a/packages/eslint-plugin/tests/rules/prefer-regexp-exec.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-regexp-exec.test.ts
@@ -74,6 +74,12 @@ const matchCount = (str: string, re: RegExp) => {
   return (str.match(re) || []).length;
 };
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/6928
+    `
+function test(str: string) {
+  str.match('[a-z');
+}
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6928
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The fix try-catches any string literals denoting malformed regular expressions passed to the function constructor `RegExp`. If a runtime error is thrown, the visited node is skipped, and no issue is reported.
