### PR TITLE
fix: correct handling of additionalProperties in object schemas

### DIFF
--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -112,6 +112,7 @@ export default util.createRule<Options, MessageIds>({
             enum: ['array', 'generic', 'array-simple'],
           },
         },
+        additionalProperties: false,
         properties: {
           default: {
             $ref: '#/items/0/$defs/arrayOption',

--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -53,6 +53,7 @@ export default util.createRule<[Options], MessageIds>({
               },
               {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                   descriptionFormat: { type: 'string' },
                 },

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/schema.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/schema.ts
@@ -40,6 +40,7 @@ const $DEFS: Record<string, JSONSchema.JSONSchema4> = {
   },
   matchRegexConfig: {
     type: 'object',
+    additionalProperties: false,
     properties: {
       match: { type: 'boolean' },
       regex: { type: 'string' },

--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -83,6 +83,7 @@ export default util.createRule<Options, MessageId>({
     schema: [
       {
         type: 'object',
+        additionalProperties: false,
         properties: {
           checksConditionals: {
             type: 'boolean',

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -31,6 +31,7 @@ export default util.createRule<Options, MessageIds>({
     schema: [
       {
         type: 'object',
+        additionalProperties: false,
         properties: {
           typesToIgnore: {
             description: 'A list of type names to ignore.',

--- a/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
+++ b/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
@@ -30,6 +30,7 @@ export default util.createRule<Options, MessageIds>({
     schema: [
       {
         type: 'object',
+        additionalProperties: false,
         properties: {
           ignoreStringArrays: {
             description:

--- a/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
+++ b/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
@@ -33,6 +33,7 @@ export default util.createRule<Options, MessageId>({
     schema: [
       {
         type: 'object',
+        additionalProperties: false,
         properties: {
           allowNumber: {
             description:

--- a/packages/eslint-plugin/src/rules/sort-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/sort-type-constituents.ts
@@ -124,6 +124,7 @@ export default util.createRule<Options, MessageIds>({
     schema: [
       {
         type: 'object',
+        additionalProperties: false,
         properties: {
           checkIntersections: {
             description: 'Whether to check intersection types.',

--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -31,6 +31,7 @@ export default util.createRule<[Options], MessageIds>({
     schema: [
       {
         type: 'object',
+        additionalProperties: false,
         properties: {
           [OptionKeys.ArrayDestructuring]: { type: 'boolean' },
           [OptionKeys.ArrowParameter]: { type: 'boolean' },

--- a/packages/eslint-plugin/tests/schema-snapshots/array-type.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/array-type.shot
@@ -11,6 +11,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "enum": ["array", "array-simple", "generic"]
       }
     },
+    "additionalProperties": false,
     "properties": {
       "default": {
         "$ref": "#/items/0/$defs/arrayOption",

--- a/packages/eslint-plugin/tests/schema-snapshots/ban-ts-comment.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/ban-ts-comment.shot
@@ -17,6 +17,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
             "enum": ["allow-with-description"]
           },
           {
+            "additionalProperties": false,
             "properties": {
               "descriptionFormat": {
                 "type": "string"

--- a/packages/eslint-plugin/tests/schema-snapshots/naming-convention.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/naming-convention.shot
@@ -21,6 +21,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
       ]
     },
     "matchRegexConfig": {
+      "additionalProperties": false,
       "properties": {
         "match": {
           "type": "boolean"

--- a/packages/eslint-plugin/tests/schema-snapshots/no-misused-promises.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-misused-promises.shot
@@ -6,6 +6,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 [
   {
+    "additionalProperties": false,
     "properties": {
       "checksConditionals": {
         "type": "boolean"

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-type-assertion.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-type-assertion.shot
@@ -6,6 +6,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 [
   {
+    "additionalProperties": false,
     "properties": {
       "typesToIgnore": {
         "description": "A list of type names to ignore.",

--- a/packages/eslint-plugin/tests/schema-snapshots/require-array-sort-compare.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/require-array-sort-compare.shot
@@ -6,6 +6,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 [
   {
+    "additionalProperties": false,
     "properties": {
       "ignoreStringArrays": {
         "description": "Whether to ignore arrays in which all elements are strings.",

--- a/packages/eslint-plugin/tests/schema-snapshots/restrict-template-expressions.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/restrict-template-expressions.shot
@@ -6,6 +6,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 [
   {
+    "additionalProperties": false,
     "properties": {
       "allowAny": {
         "description": "Whether to allow \`any\` typed values in template expressions.",

--- a/packages/eslint-plugin/tests/schema-snapshots/sort-type-constituents.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/sort-type-constituents.shot
@@ -6,6 +6,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 [
   {
+    "additionalProperties": false,
     "properties": {
       "checkIntersections": {
         "description": "Whether to check intersection types.",

--- a/packages/eslint-plugin/tests/schema-snapshots/typedef.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/typedef.shot
@@ -6,6 +6,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 [
   {
+    "additionalProperties": false,
     "properties": {
       "arrayDestructuring": {
         "type": "boolean"

--- a/packages/rule-schema-to-typescript-types/src/generateObjectType.ts
+++ b/packages/rule-schema-to-typescript-types/src/generateObjectType.ts
@@ -13,13 +13,16 @@ export function generateObjectType(
   const commentLines = getCommentLines(schema);
 
   let indexSignature: AST | null = null;
-  if (schema.additionalProperties === true) {
+  if (
+    schema.additionalProperties === true ||
+    schema.additionalProperties === undefined
+  ) {
     indexSignature = {
       type: 'type-reference',
       typeName: 'unknown',
       commentLines: [],
     };
-  } else if (schema.additionalProperties) {
+  } else if (typeof schema.additionalProperties === 'object') {
     const indexSigType = generateType(schema.additionalProperties, refMap);
     indexSignature = indexSigType;
   }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
@domdomegg's #6894 made me realise I'd incorrectly handled this case in the schema gen.
When it's missing/`undefined` it's the same as being `true` - but I treated it as `false`