### PR TITLE
fix(eslint-plugin): [unified-signatures] no parameters function

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -213,11 +213,9 @@ export default util.createRule<Options, MessageIds>({
         b.typeParameters !== undefined ? b.typeParameters.params : undefined;
 
       if (ignoreDifferentlyNamedParameters) {
-        if (b.params.length === 0) {
-          return false;
-        }
         for (let i = 0; i < a.params.length; i += 1) {
           if (
+            b.params[i] &&
             a.params[i].type === b.params[i].type &&
             getStaticParameterName(a.params[i]) !==
               getStaticParameterName(b.params[i])

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -213,9 +213,9 @@ export default util.createRule<Options, MessageIds>({
         b.typeParameters !== undefined ? b.typeParameters.params : undefined;
 
       if (ignoreDifferentlyNamedParameters) {
-        for (let i = 0; i < a.params.length; i += 1) {
+        const commonParamsLength = Math.min(a.params.length, b.params.length);
+        for (let i = 0; i < commonParamsLength; i += 1) {
           if (
-            b.params[i] &&
             a.params[i].type === b.params[i].type &&
             getStaticParameterName(a.params[i]) !==
               getStaticParameterName(b.params[i])

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -213,6 +213,9 @@ export default util.createRule<Options, MessageIds>({
         b.typeParameters !== undefined ? b.typeParameters.params : undefined;
 
       if (ignoreDifferentlyNamedParameters) {
+        if (b.params.length === 0) {
+          return false;
+        }
         for (let i = 0; i < a.params.length; i += 1) {
           if (
             a.params[i].type === b.params[i].type &&

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -184,6 +184,13 @@ function f(): string;
     },
     {
       code: `
+function f(v: boolean, u: boolean): number;
+function f(v: boolean): string;
+      `,
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: `
 function f(v: number, u?: string): void {}
 function f(v: number): void;
 function f(): string;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -177,6 +177,21 @@ function f(v: number, u?: string): void {}
     },
     {
       code: `
+function f(v: boolean): number;
+function f(): string;
+      `,
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: `
+function f(v: number, u?: string): void {}
+function f(v: number): void;
+function f(): string;
+      `,
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: `
 function f(a: boolean, ...c: number[]): void;
 function f(a: boolean, ...d: string[]): void;
 function f(a: boolean, ...c: (number | string)[]): void {}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6882 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Add guard clause because b.params[i].type is not accessible when comparing to a function with no parameters
