### PR TITLE
docs: add a section suggesting gifs for pr reviews

### DIFF
--- a/docs/maintenance/Pull_Requests.mdx
+++ b/docs/maintenance/Pull_Requests.mdx
@@ -33,7 +33,6 @@ Our flow for PRs that have been waiting for >=1 month is:
 3. Wait 2 weeks
 4. If they still haven't responded, close the PR with a message like the _Pruning Stale PR_ template
 
-
 ## Suggestions
 
 Add some fun to PR reviews with GIFs. It's a great way to create a fun and welcoming environment while still maintaining a professional and productive one. The benefits of using GIFs in PR reviews are that it adds a touch of humor and lightheartedness to the process, builds camaraderie and team spirit, and can help break the ice by making users feel welcomed. Please remember to use appropriate and respectful GIFs and use them sparingly; GIFs should enhance the conversation, not detract from it. Check out [GIFs for Github here](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) or [for Firefox here](https://addons.mozilla.org/en-US/firefox/addon/gifs-for-github/). Have some fun with it and happy GIF-ing.

--- a/docs/maintenance/Pull_Requests.mdx
+++ b/docs/maintenance/Pull_Requests.mdx
@@ -32,3 +32,8 @@ Our flow for PRs that have been waiting for >=1 month is:
 2. Add the `stale` label to the PR
 3. Wait 2 weeks
 4. If they still haven't responded, close the PR with a message like the _Pruning Stale PR_ template
+
+
+## Suggestions
+
+Add some fun to PR reviews with GIFs. It's a great way to create a fun and welcoming environment while still maintaining a professional and productive one. The benefits of using GIFs in PR reviews are that it adds a touch of humor and lightheartedness to the process, builds camaraderie and team spirit, and can help break the ice by making users feel welcomed. Please remember to use appropriate and respectful GIFs and use them sparingly; GIFs should enhance the conversation, not detract from it. Check out [GIFs for Github here](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) or [for Firefox here](https://addons.mozilla.org/en-US/firefox/addon/gifs-for-github/). Have some fun with it and happy GIF-ing.

--- a/docs/maintenance/Pull_Requests.mdx
+++ b/docs/maintenance/Pull_Requests.mdx
@@ -35,4 +35,8 @@ Our flow for PRs that have been waiting for >=1 month is:
 
 ## Suggestions
 
-Add some fun to PR reviews with GIFs. It's a great way to create a fun and welcoming environment while still maintaining a professional and productive one. The benefits of using GIFs in PR reviews are that it adds a touch of humor and lightheartedness to the process, builds camaraderie and team spirit, and can help break the ice by making users feel welcomed. Please remember to use appropriate and respectful GIFs and use them sparingly; GIFs should enhance the conversation, not detract from it. Check out [GIFs for Github here](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) or [for Firefox here](https://addons.mozilla.org/en-US/firefox/addon/gifs-for-github/). Have some fun with it and happy GIF-ing.
+Consider adding fun to PR reviews with GIFs.
+The benefits of using GIFs in PR reviews are that it adds a touch of humor and lightheartedness to the process, builds camaraderie and team spirit, and can help break the ice by making users feel welcomed.
+Please remember to use appropriate and respectful GIFs and use them sparingly; GIFs should enhance the conversation, not detract from it.
+
+> We like to use the _GIFs for Github_ extension: available as [GIFs for GitHub (Chrome)](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) and [GIFs for GitHub (Firefox)](https://addons.mozilla.org/en-US/firefox/addon/gifs-for-github). ✨


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6889 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Added a suggestion section in the pull request docs with a section in adding gifs to PR reviews. I wasn't sure if I should add a new section called suggestions or put it below the first section. I was worried that the first section might become too verbose and that it might be better to break it up this way. I can definitely change/switch it to however is best though, no worries. Just wanted to say that I thought this was a great idea. Adding gifs to PR reviews can really make a difference, imho. 

![andy](https://user-images.githubusercontent.com/90116354/235326255-4d48bc7d-2e47-43d7-8443-91d10ac68581.gif)
