### PR TITLE
feat(rule-tester): add support for snapshot testing rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
             'parser',
             'repo-tools',
             'rule-schema-to-typescript-types',
+            'rule-tester',
             'scope-manager',
             'type-utils',
             'typescript-estree',

--- a/.github/workflows/semantic-pr-titles.yml
+++ b/.github/workflows/semantic-pr-titles.yml
@@ -31,6 +31,9 @@ jobs:
             eslint-plugin-internal
             eslint-plugin-tslint
             parser
+            repo-tools
+            rule-schema-to-typescript-types
+            rule-tester
             scope-manager
             type-utils
             types

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -49,11 +49,14 @@
   "dependencies": {
     "@typescript-eslint/typescript-estree": "5.59.1",
     "@typescript-eslint/utils": "5.59.1",
+    "ajv": "^6.10.0",
     "lodash.merge": "4.6.2",
     "semver": "^7.3.7",
-    "ajv": "^6.10.0"
+    "make-dir": "^3.1.0",
+    "std-env": "^3.3.3"
   },
   "peerDependencies": {
+    "@babel/code-frame": "^7.21.4",
     "@eslint/eslintrc": ">=2",
     "eslint": ">=8"
   },

--- a/packages/rule-tester/src/snapshot/expectSnapshot.ts
+++ b/packages/rule-tester/src/snapshot/expectSnapshot.ts
@@ -1,0 +1,234 @@
+import assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import zlib from 'node:zlib';
+
+import makeDir from 'make-dir';
+
+import type { TestFramework } from '../TestFramework';
+import type { SingleTestResult, TestReportSuggestion } from './types';
+
+/**
+ * @param testFramework the test framework used by the RuleTester
+ * @param pathInfo information about the path that snapshots might be written to
+ * @param results the snapshot results collected from the tests
+ */
+export type RuleTesterExpectSnapshotFunction = (
+  testFramework: typeof TestFramework,
+  pathInfo: {
+    /**
+     * The base folder that snapshots should be written within
+     */
+    readonly snapshotBasePath: string;
+    /**
+     * The name of the rule being tested as provided to the `.run` method
+     */
+    readonly ruleName: string;
+  },
+  results: readonly SingleTestResult[],
+) => void;
+
+function hasErrorCode(e: unknown): e is { code: unknown } {
+  return typeof e === 'object' && e != null && 'code' in e;
+}
+
+/**
+ * Default snapshot tester which writes a single snapshot file for the test
+ */
+export const expectSnapshot: RuleTesterExpectSnapshotFunction = (
+  testFramework,
+  { snapshotBasePath, ruleName },
+  results,
+): void => {
+  if (results.length === 0) {
+    return;
+  }
+
+  const snapshotFolder = path.resolve(snapshotBasePath);
+  try {
+    makeDir.sync(snapshotFolder);
+  } catch (e) {
+    if (hasErrorCode(e) && e.code === 'EEXIST') {
+      // already exists - ignored
+    } else {
+      throw e;
+    }
+  }
+  const snapshotMdFilePath = path.join(
+    snapshotFolder,
+    `${ruleName}.snapshot.md`,
+  );
+  const snapshotMetaFilePath = path.join(
+    snapshotFolder,
+    `${ruleName}.snapshotstate`,
+  );
+
+  const existingSnapshotMeta = readSnapshotMeta(snapshotMetaFilePath);
+  const updateSnapshots = testFramework.getShouldUpdateSnapshots();
+
+  let passCount = 0;
+  const newResults = new Set<SingleTestResult>();
+  for (const result of results) {
+    testFramework.it(result.testName, () => {
+      const existingResult = existingSnapshotMeta[result.testHash];
+      if (existingResult == null) {
+        if (updateSnapshots === 'none') {
+          assert.fail('No existing result for test');
+        }
+
+        assert.ok(true, 'No existing result for test');
+        passCount += 1;
+        newResults.add(result);
+        return;
+      }
+
+      if (updateSnapshots === 'all') {
+        assert.ok(true, 'All snapshots are being force-updated');
+        passCount += 1;
+        return;
+      }
+
+      // we could just do `assert.deepStrictEquals` here, but for better DevX we
+      // don't want to expose users to our internal object representation, so
+      // instead we granularly assert everything with clear
+
+      assert.strictEqual(
+        result.fixOutput,
+        existingResult.fixOutput,
+        'The fix output has changed.',
+      );
+      assert.strictEqual(
+        result.errors.length,
+        existingResult.errors.length,
+        'The number of reported errors has changed.',
+      );
+
+      for (
+        let errorIndex = 0;
+        errorIndex < result.errors.length;
+        errorIndex += 1
+      ) {
+        const error = result.errors[errorIndex];
+        const existingError = existingResult.errors[errorIndex];
+        assert.strictEqual(
+          error.errorCodeFrame,
+          existingError.errorCodeFrame,
+          `The error at index ${errorIndex} has changed.`,
+        );
+
+        assert.strictEqual(
+          error.suggestions?.length,
+          existingError.suggestions?.length,
+          'The number of reported suggestions has changed.',
+        );
+
+        if (error.suggestions != null && existingError.suggestions != null) {
+          for (
+            let suggestionIndex = 0;
+            suggestionIndex < error.suggestions.length;
+            suggestionIndex += 1
+          ) {
+            // TS can't resolve the type here for whatever reason
+            const suggestion: TestReportSuggestion =
+              error.suggestions[suggestionIndex];
+            const existingSuggestion: TestReportSuggestion =
+              existingError.suggestions[suggestionIndex];
+
+            assert.strictEqual(
+              suggestion.message,
+              existingSuggestion.message,
+              `The message of the suggestion at index ${errorIndex} has changed.`,
+            );
+            assert.strictEqual(
+              suggestion.fixOutput,
+              existingSuggestion.fixOutput,
+              `The fix output of the suggestion at index ${errorIndex} has changed.`,
+            );
+          }
+        }
+      }
+
+      passCount += 1;
+    });
+  }
+
+  testFramework.afterAll(() => {
+    if (passCount !== results.length || updateSnapshots === 'none') {
+      return;
+    }
+
+    writeSnapshotMeta(
+      snapshotMetaFilePath,
+      Object.fromEntries(results.map(r => [r.testHash, r])),
+    );
+    writeMarkdown(ruleName, snapshotMdFilePath, results);
+  });
+};
+
+type SnapshotMeta = Record<string, SingleTestResult>;
+function readSnapshotMeta(metaPath: string): SnapshotMeta {
+  try {
+    const raw = fs.readFileSync(metaPath);
+    const uncompressedBuf = zlib.gunzipSync(raw);
+    return JSON.parse(uncompressedBuf.toString()) as SnapshotMeta;
+  } catch {
+    return {};
+  }
+}
+function writeSnapshotMeta(metaPath: string, blob: SnapshotMeta): void {
+  const buf = Buffer.from(JSON.stringify(blob));
+  const compressed = zlib.gzipSync(buf);
+  fs.writeFileSync(metaPath, compressed);
+}
+function writeMarkdown(
+  ruleName: string,
+  markdownPath: string,
+  results: readonly SingleTestResult[],
+): void {
+  const markdownLines = [`# ${ruleName}`, ''];
+
+  for (const result of results) {
+    const codeFence = (code: string): string =>
+      [
+        '<!-- prettier-ignore -->',
+        `\`\`\`${result.testLanguageFlavour}`,
+        code,
+        '```',
+      ].join('\n');
+
+    markdownLines.push(
+      `## ${result.testName}`,
+      '',
+      '### Test Code',
+      '',
+      codeFence(result.code),
+      '',
+      '### Fix Output',
+      '',
+      result.fixOutput == null ? 'No fix applied' : codeFence(result.fixOutput),
+      '',
+      '### Errors',
+      '',
+    );
+
+    for (const error of result.errors) {
+      markdownLines.push(codeFence(error.errorCodeFrame), '');
+
+      if (error.suggestions != null) {
+        markdownLines.push('#### Suggestions', '');
+        for (const suggestion of error.suggestions ?? []) {
+          markdownLines.push(
+            `##### ${suggestion.message}`,
+            '',
+            codeFence(suggestion.fixOutput),
+          );
+        }
+      }
+    }
+  }
+
+  // include a trailing newline
+  markdownLines.push('');
+
+  fs.writeFileSync(markdownPath, markdownLines.join('\n'), 'utf8');
+}

--- a/packages/rule-tester/src/snapshot/renderErrors.ts
+++ b/packages/rule-tester/src/snapshot/renderErrors.ts
@@ -1,0 +1,86 @@
+import * as crypto from 'node:crypto';
+import * as path from 'node:path';
+
+import type { SourceLocation as BabelSourceLocation } from '@babel/code-frame';
+import { codeFrameColumns } from '@babel/code-frame';
+import type { Linter } from '@typescript-eslint/utils/ts-eslint';
+
+import type { InvalidTestCase } from '../types/InvalidTestCase';
+import * as SourceCodeFixer from '../utils/SourceCodeFixer';
+import type { SingleTestResult, TestReportError } from './types';
+
+function renderError(code: string, error: Linter.LintMessage): string {
+  const location: BabelSourceLocation = {
+    start: {
+      line: error.line,
+      column: error.column,
+    },
+  };
+
+  if (
+    typeof error.endLine === 'number' &&
+    typeof error.endColumn === 'number'
+  ) {
+    location.end = {
+      line: error.endLine,
+      column: error.endColumn,
+    };
+  }
+
+  return codeFrameColumns(code, location, {
+    forceColor: false,
+    highlightCode: false,
+    linesAbove: Number.POSITIVE_INFINITY,
+    linesBelow: Number.POSITIVE_INFINITY,
+    message: error.message,
+  });
+}
+
+export function prepareErrorsForSnapshot(
+  testName: string,
+  testFilename: string,
+  test: InvalidTestCase<string, readonly unknown[]>,
+  output: string | null,
+  messages: Linter.LintMessage[],
+): SingleTestResult {
+  const errors: TestReportError[] = [];
+  for (const message of messages) {
+    errors.push({
+      errorCodeFrame: renderError(test.code, message),
+      suggestions:
+        message.suggestions == null
+          ? null
+          : message.suggestions.map(s => ({
+              message: s.desc,
+              fixOutput: SourceCodeFixer.applyFixes(test.code, [s]).output,
+            })),
+    });
+  }
+
+  const testFilenameExtension = path.extname(testFilename).substring(1);
+
+  const testHash = (() => {
+    const {
+      errors: _errors,
+      dependencyConstraints: _dependencyConstraints,
+      only: _only,
+      skip: _skip,
+      output: _output,
+      ...hashableProps
+    } = test;
+    return crypto
+      .createHash('sha256')
+      .update(JSON.stringify(hashableProps))
+      .digest('base64');
+  })();
+
+  return {
+    code: test.code,
+    errors,
+    fixOutput: output,
+    testLanguageFlavour:
+      testFilenameExtension === '' ? 'ts' : testFilenameExtension,
+    testName,
+    testHash,
+  };
+}

--- a/packages/rule-tester/src/snapshot/types.ts
+++ b/packages/rule-tester/src/snapshot/types.ts
@@ -1,0 +1,48 @@
+export interface TestReportSuggestion {
+  /**
+   * The hydrated suggestion message
+   */
+  readonly message: string;
+  /**
+   * The results of applying the suggestion fixer to the code.
+   */
+  readonly fixOutput: string;
+}
+export interface TestReportError {
+  /**
+   * The code string with the error rendered in it.
+   */
+  readonly errorCodeFrame: string;
+  /**
+   * Information about suggestions provided alongside the error.
+   */
+  readonly suggestions: TestReportSuggestion[] | null;
+}
+export interface SingleTestResult {
+  /**
+   * The original test code.
+   */
+  readonly code: string;
+  /**
+   * The results of applying the autofixers to the code.
+   * `null` if there was no fixers applied.
+   */
+  readonly fixOutput: string | null;
+  /**
+   * The errors reported during the test run.
+   */
+  readonly errors: readonly TestReportError[];
+  /**
+   * The unique hash for the test so that it can be uniquely keyed in an object
+   */
+  readonly testHash: string;
+  /**
+   * The resolved name of the test.
+   */
+  readonly testName: string;
+  /**
+   * The language flavour of the test code for rendering markdown code fences
+   * with appropriate syntax highlighting
+   */
+  readonly testLanguageFlavour: string;
+}

--- a/packages/rule-tester/src/types/RuleTesterConfig.ts
+++ b/packages/rule-tester/src/types/RuleTesterConfig.ts
@@ -2,6 +2,7 @@ import type { Linter, ParserOptions } from '@typescript-eslint/utils/ts-eslint';
 
 import type { DependencyConstraint } from './DependencyConstraint';
 
+// need to keep this in sync with the schema in `config-schema.ts`
 export interface RuleTesterConfig extends Linter.Config {
   /**
    * The default parser to use for tests.
@@ -24,4 +25,16 @@ export interface RuleTesterConfig extends Linter.Config {
     ts: string;
     tsx: string;
   }>;
+  /**
+   * Whether or not to do snapshot testing for "invalid" test cases.
+   * @default false
+   */
+  readonly snapshots?:
+    | false
+    | {
+        /**
+         * The absolute path to use as the basis for writing snapshots.
+         */
+        readonly snapshotBasePath: string;
+      };
 }

--- a/packages/rule-tester/src/utils/config-schema.ts
+++ b/packages/rule-tester/src/utils/config-schema.ts
@@ -2,6 +2,7 @@
 
 import type { JSONSchema } from '@typescript-eslint/utils';
 
+// need to keep this in sync with the types in `RuleTesterConfig.ts`
 const baseConfigProperties: JSONSchema.JSONSchema4['properties'] = {
   $schema: { type: 'string' },
   defaultFilenames: {
@@ -35,6 +36,24 @@ const baseConfigProperties: JSONSchema.JSONSchema4['properties'] = {
   reportUnusedDisableDirectives: { type: 'boolean' },
   rules: { type: 'object' },
   settings: { type: 'object' },
+  snapshots: {
+    oneOf: [
+      {
+        type: 'object',
+        properties: {
+          snapshotBasePath: {
+            type: 'string',
+          },
+        },
+        additionalProperties: false,
+        required: ['snapshotBasePath'],
+      },
+      {
+        type: 'boolean',
+        enum: [false],
+      },
+    ],
+  },
 
   ecmaFeatures: { type: 'object' }, // deprecated; logs a warning when used
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -13714,6 +13714,11 @@ std-env@^3.0.1:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.0.1.tgz#bc4cbc0e438610197e34c2d79c3df30b491f5182"
   integrity sha512-mC1Ps9l77/97qeOZc+HrOL7TIaOboHqMZ24dGVQrlxFcpPpfCHpH+qfUT7Dz+6mlG8+JPA1KfBQo19iC/+Ngcw==
 
+std-env@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.3.3.tgz#a54f06eb245fdcfef53d56f3c0251f1d5c3d01fe"
+  integrity sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==
+
 stop-iteration-iterator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz#6a60be0b4ee757d1ed5254858ec66b10c49285e4"


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/discussions/6499
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR adds support for snapshot testing rules using a custom, framework agnostic snapshot setup.

The snapshot emits two files for each `.run` call - a markdown file which is the human-readable results of the test, and a binary file which is a compressed json blob containing the machine-readable snapshot information.

I've done a test migration of our codebase here: https://github.com/typescript-eslint/typescript-eslint/tree/v6-rule-tester-snapshots-migrate-codebase

TODO:
- [ ] finalise snapshot format
- [ ] add docs
- [ ] add a version field so we can do breaking changes to the snapshot object format?
- [ ] add tests to validate it works as intended
- [ ] use [`filenamify`](https://github.com/sindresorhus/filenamify) to ensure test names are valid filenames