### PR TITLE
chore: bump console-fail-test to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@types/rimraf": "^3.0.2",
     "@types/semver": "^7.3.9",
     "@types/tmp": "^0.2.3",
-    "console-fail-test": "^0.2.0",
+    "console-fail-test": "^0.2.3",
     "cross-env": "^7.0.3",
     "cross-fetch": "^3.1.5",
     "cspell": "^6.0.0",

--- a/packages/utils/tests/eslint-utils/nullThrows.test.ts
+++ b/packages/utils/tests/eslint-utils/nullThrows.test.ts
@@ -1,8 +1,11 @@
 import { nullThrows, NullThrowsReasons } from '../../src/eslint-utils';
 
 describe('nullThrows', () => {
-  it('returns a falsy value when it exists', () => {
+  it.only('returns a falsy value when it exists', () => {
     const value = 0;
+    const x = { prop: {} };
+    x.prop = x;
+    console.log(x);
 
     const actual = nullThrows(value, NullThrowsReasons.MissingParent);
 

--- a/packages/utils/tests/eslint-utils/nullThrows.test.ts
+++ b/packages/utils/tests/eslint-utils/nullThrows.test.ts
@@ -1,11 +1,8 @@
 import { nullThrows, NullThrowsReasons } from '../../src/eslint-utils';
 
 describe('nullThrows', () => {
-  it.only('returns a falsy value when it exists', () => {
+  it('returns a falsy value when it exists', () => {
     const value = 0;
-    const x = { prop: {} };
-    x.prop = x;
-    console.log(x);
 
     const actual = nullThrows(value, NullThrowsReasons.MissingParent);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5602,10 +5602,10 @@ console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-console-fail-test@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/console-fail-test/-/console-fail-test-0.2.1.tgz#55a6498b60d2f80195ea9d1ee846599103e18745"
-  integrity sha512-4FLY7ywNGBlqE7aTeAn+8BtwOfFZtIFUq2IUYfXnXQwetRJEBhdrJ3Ig0fV7ics/94aNCrJCjRU2WiWUpwIjhg==
+console-fail-test@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/console-fail-test/-/console-fail-test-0.2.3.tgz#e6b0dbe2d3d3ab1c971503f4ff114bca77e4976c"
+  integrity sha512-p1xfi9ubVM2X3NpjPH1Gm8Gxc7vXyTwcOIquU8rpUDA+ISSitAOiBDnT/Bti1We5YzZKRxgI0JU+fFvOmOXtvA==
 
 content-disposition@0.5.2:
   version "0.5.2"


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes ~#000~ https://github.com/JoshuaKGoldberg/console-fail-test/issues/206
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Brings in the `console-fail-test` fix here.