### PR TITLE
docs: [ban-types] update documentation; suggest option and defaults

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -113,6 +113,7 @@ const defaultTypes = {
       '- If you want a type meaning "any value", you probably want `unknown` instead.',
       '- If you really want a type meaning "any non-nullish value", you probably want `NonNullable<unknown>` instead.',
     ].join('\n'),
+    suggest: ['object', 'unknown', 'NonNullable<unknown>'],
   },
   '{}': {
     message: [
@@ -122,6 +123,12 @@ const defaultTypes = {
       '- If you want a type meaning "empty object", you probably want `Record<string, never>` instead.',
       '- If you really want a type meaning "any non-nullish value", you probably want `NonNullable<unknown>` instead.',
     ].join('\n'),
+    suggest: [
+      'object',
+      'unknown',
+      'Record<string, never>',
+      'NonNullable<unknown>',
+    ],
   },
 };
 ```
@@ -141,6 +148,7 @@ The values can be:
 - An object with the following properties:
   - `message: string` - the message to display when the type is matched.
   - `fixWith?: string` - a string to replace the banned type with when the fixer is run. If this is omitted, no fix will be done.
+  - `suggest?: string[]` - a list of suggested replacements for the banned type.
 
 ### `extendDefaults`
 

--- a/packages/eslint-plugin/docs/rules/ban-types.md
+++ b/packages/eslint-plugin/docs/rules/ban-types.md
@@ -111,6 +111,7 @@ const defaultTypes = {
       'The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.',
       '- If you want a type meaning "any object", you probably want `object` instead.',
       '- If you want a type meaning "any value", you probably want `unknown` instead.',
+      '- If you really want a type meaning "any non-nullish value", you probably want `NonNullable<unknown>` instead.',
     ].join('\n'),
   },
   '{}': {
@@ -119,6 +120,7 @@ const defaultTypes = {
       '- If you want a type meaning "any object", you probably want `object` instead.',
       '- If you want a type meaning "any value", you probably want `unknown` instead.',
       '- If you want a type meaning "empty object", you probably want `Record<string, never>` instead.',
+      '- If you really want a type meaning "any non-nullish value", you probably want `NonNullable<unknown>` instead.',
     ].join('\n'),
   },
 };


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- Update the _Default Options_ documentation of the [ban-types](https://typescript-eslint.io/rules/ban-types) rule.  
- Documents the `suggest` option.

This was missed in #6876.
