### PR TITLE
fix(eslint-plugin): [no-extra-parens] false positive when used with `satisfies` keyword

### DIFF
--- a/packages/eslint-plugin/src/rules/no-extra-parens.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-parens.ts
@@ -241,6 +241,10 @@ export default util.createRule<Options, MessageIds>({
           });
         }
 
+        if (node.object.type === AST_NODE_TYPES.TSSatisfiesExpression) {
+          return; // ignore
+        }
+
         return rules.MemberExpression(node);
       },
       NewExpression: callExp,

--- a/packages/eslint-plugin/tests/rules/no-extra-parens.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extra-parens.test.ts
@@ -242,6 +242,11 @@ f<(number | string)[]>(['a', 1])
         },
       },
     }),
+    {
+      code: `
+const a = (['a', 'b'] satisfies A[]).includes('a');
+      `,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7017
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Added new condition inside `MemberExpression` type rule for **SatisfiesExpression** node type, added new simple test.



_This is my first PR, be kind 😄 ❤️_ 