### PR TITLE
feat(eslint-plugin): [restrict-plus-operands] change checkCompoundAssignments to skipCompoundAssignments

### DIFF
--- a/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
+++ b/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
@@ -31,36 +31,6 @@ var foo = 1n + 1n;
 
 ## Options
 
-### `checkCompoundAssignments`
-
-Examples of code for this rule with `{ checkCompoundAssignments: true }`:
-
-<!--tabs-->
-
-#### ❌ Incorrect
-
-```ts
-/*eslint @typescript-eslint/restrict-plus-operands: ["error", { "checkCompoundAssignments": true }]*/
-
-let foo: string | undefined;
-foo += 'some data';
-
-let bar: string = '';
-bar += 0;
-```
-
-#### ✅ Correct
-
-```ts
-/*eslint @typescript-eslint/restrict-plus-operands: ["error", { "checkCompoundAssignments": true }]*/
-
-let foo: number = 0;
-foo += 1;
-
-let bar = '';
-bar += 'test';
-```
-
 ### `allowAny`
 
 Examples of code for this rule with `{ allowAny: true }`:
@@ -82,6 +52,38 @@ var fn = (a: any, b: any) => a + b;
 var fn = (a: any, b: string) => a + b;
 var fn = (a: any, b: bigint) => a + b;
 var fn = (a: any, b: number) => a + b;
+```
+
+### `skipCompoundAssignments`
+
+Whether to skip checking `+=` assignments.
+
+Examples of code for this rule with `{ skipCompoundAssignments: true }`:
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+/*eslint @typescript-eslint/restrict-plus-operands: ["error", { "skipCompoundAssignments": true }]*/
+
+let numeric = 0;
+numeric = numeric + 'some data';
+
+let stringy = 'some data';
+stringy = stringy + 0;
+```
+
+#### ✅ Correct
+
+```ts
+/*eslint @typescript-eslint/restrict-plus-operands: ["error", { "skipCompoundAssignments": true }]*/
+
+let numeric = 0;
+numeric += 'some data';
+
+let stringy = 'some data';
+stringy += 0;
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
+++ b/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
@@ -5,8 +5,8 @@ import * as util from '../util';
 
 type Options = [
   {
-    checkCompoundAssignments?: boolean;
     allowAny?: boolean;
+    skipCompoundAssignments?: boolean;
   },
 ];
 type MessageIds =
@@ -42,12 +42,13 @@ export default util.createRule<Options, MessageIds>({
         type: 'object',
         additionalProperties: false,
         properties: {
-          checkCompoundAssignments: {
-            description: 'Whether to check compound assignments such as `+=`.',
-            type: 'boolean',
-          },
           allowAny: {
             description: 'Whether to allow `any` typed values.',
+            type: 'boolean',
+          },
+          skipCompoundAssignments: {
+            description:
+              'Whether to skip checking compound assignments such as `+=`.',
             type: 'boolean',
           },
         },
@@ -56,11 +57,11 @@ export default util.createRule<Options, MessageIds>({
   },
   defaultOptions: [
     {
-      checkCompoundAssignments: false,
       allowAny: false,
+      skipCompoundAssignments: false,
     },
   ],
-  create(context, [{ checkCompoundAssignments, allowAny }]) {
+  create(context, [{ allowAny, skipCompoundAssignments }]) {
     const services = util.getParserServices(context);
     const checker = services.program.getTypeChecker();
 
@@ -191,7 +192,7 @@ export default util.createRule<Options, MessageIds>({
 
     return {
       "BinaryExpression[operator='+']": checkPlusOperands,
-      ...(checkCompoundAssignments && {
+      ...(!skipCompoundAssignments && {
         "AssignmentExpression[operator='+=']"(node): void {
           checkPlusOperands(node);
         },

--- a/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
@@ -161,23 +161,23 @@ const b = A('') + '!';
     `,
     {
       code: `
-let foo: number = 0;
-foo += 1;
+let foo = '';
+foo += 0;
       `,
       options: [
         {
-          checkCompoundAssignments: false,
+          skipCompoundAssignments: true,
         },
       ],
     },
     {
       code: `
-let foo: number = 0;
-foo += 'string';
+let foo = 0;
+foo += '';
       `,
       options: [
         {
-          checkCompoundAssignments: false,
+          skipCompoundAssignments: true,
         },
       ],
     },
@@ -801,14 +801,9 @@ function foo<T extends 1>(a: T) {
     },
     {
       code: `
-let foo: string | undefined;
-foo += 'some data';
+let foo: string = '';
+foo += 1;
       `,
-      options: [
-        {
-          checkCompoundAssignments: true,
-        },
-      ],
       errors: [
         {
           messageId: 'notStrings',
@@ -819,14 +814,9 @@ foo += 'some data';
     },
     {
       code: `
-let foo = '';
-foo += 0;
+let foo = 0;
+foo += '';
       `,
-      options: [
-        {
-          checkCompoundAssignments: true,
-        },
-      ],
       errors: [
         {
           messageId: 'notStrings',

--- a/packages/eslint-plugin/tests/schema-snapshots/restrict-plus-operands.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/restrict-plus-operands.shot
@@ -12,8 +12,8 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "description": "Whether to allow \`any\` typed values.",
         "type": "boolean"
       },
-      "checkCompoundAssignments": {
-        "description": "Whether to check compound assignments such as \`+=\`.",
+      "skipCompoundAssignments": {
+        "description": "Whether to skip checking compound assignments such as \`+=\`.",
         "type": "boolean"
       }
     },
@@ -28,8 +28,8 @@ type Options = [
   {
     /** Whether to allow \`any\` typed values. */
     allowAny?: boolean;
-    /** Whether to check compound assignments such as \`+=\`. */
-    checkCompoundAssignments?: boolean;
+    /** Whether to skip checking compound assignments such as \`+=\`. */
+    skipCompoundAssignments?: boolean;
   },
 ];
 "


### PR DESCRIPTION
BREAKING CHANGE:
Renames an option for `restrict-plus-operands`

## PR Checklist

- [x] Addresses an existing open issue: fixes #6851
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Renames the option, so that the default state of off means we lint `+=`s.