### PR TITLE
docs(website): fix wrong example in `prefer-includes`

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-includes.md
+++ b/packages/eslint-plugin/docs/rules/prefer-includes.md
@@ -57,7 +57,7 @@ const userDefined: {
 
 str.includes(value);
 array.includes(value);
-readonlyArray.includes(value);
+!readonlyArray.includes(value);
 typedArray.includes(value);
 maybe?.includes('');
 userDefined.includes(value);


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] ~~Addresses an existing open issue:~~ Is this necessary for a minor documentation change :thinking: ?
- [x] ~~That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~~
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`readonlyArray.indexOf(value) === -1` is checking if `value` is **not included** in `readonlyArray`. So it should be
`!readonlyArray.includes(value)`.

https://github.com/typescript-eslint/typescript-eslint/blob/5b0e577f2552e8b2c53a3fb22edc9d219589b937/packages/eslint-plugin/tests/rules/prefer-includes.test.ts#L153-L179