### PR TITLE
docs(eslint-plugin): fix no-unnecessary-type-assertion doc examples

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
@@ -14,6 +14,26 @@ This rule reports when a type assertion does not change the type of an expressio
 
 <!--tabs-->
 
+### ❌ Incorrect
+
+```ts
+const foo = <number>3;
+```
+
+```ts
+const foo = 3 as number;
+```
+
+```ts
+const foo = 'foo' as const;
+```
+
+```ts
+function foo(x: number | undefined): number {
+  return x!;
+}
+```
+
 ### ✅ Correct
 
 ```ts
@@ -38,26 +58,6 @@ const foo = 3 as Foo;
 ```ts
 function foo(x: number): number {
   return x!; // unnecessary non-null
-}
-```
-
-### ❌ Incorrect
-
-```ts
-const foo = <number>3;
-```
-
-```ts
-const foo = 3 as number;
-```
-
-```ts
-const foo = 'foo' as const;
-```
-
-```ts
-function foo(x: number | undefined): number {
-  return x!;
 }
 ```
 

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.md
@@ -14,7 +14,7 @@ This rule reports when a type assertion does not change the type of an expressio
 
 <!--tabs-->
 
-### ❌ Incorrect
+### ✅ Correct
 
 ```ts
 const foo = 3;
@@ -41,7 +41,7 @@ function foo(x: number): number {
 }
 ```
 
-### ✅ Correct
+### ❌ Incorrect
 
 ```ts
 const foo = <number>3;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: none
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The examples in the doc for [no-unnecessary-type-assertion](https://typescript-eslint.io/rules/no-unnecessary-type-assertion/) seem the wrong way around for me. This swaps them.