### PR TITLE
fix(eslint-plugin): replace auto-fix of class literal property style rule with suggestion

### DIFF
--- a/docs/linting/Typed_Linting.mdx
+++ b/docs/linting/Typed_Linting.mdx
@@ -47,7 +47,7 @@ You may see new rules reporting errors based on type information!
 The `parserOptions.project` option can be turned on with either:
 
 - `true`: to always use `tsconfig.json`s nearest to source files
-- `string | string[]`: any number of glob paths to match TSConfig files relative to `parserOptions.tsconfigRootDir`, or the CWD if that is not provided
+- `string | string[]`: any number of glob paths to match TSConfig files relative to the
 
 For example, if you use a specific `tsconfig.eslint.json` for linting, you'd specify:
 

--- a/docs/linting/Typed_Linting.mdx
+++ b/docs/linting/Typed_Linting.mdx
@@ -47,7 +47,7 @@ You may see new rules reporting errors based on type information!
 The `parserOptions.project` option can be turned on with either:
 
 - `true`: to always use `tsconfig.json`s nearest to source files
-- `string | string[]`: any number of glob paths to match TSConfig files relative to the
+- `string | string[]`: any number of glob paths to match TSConfig files relative to `parserOptions.tsconfigRootDir`, or the CWD if that is not provided
 
 For example, if you use a specific `tsconfig.eslint.json` for linting, you'd specify:
 

--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -52,8 +52,7 @@ export default util.createRule<Options, MessageIds>({
     hasSuggestions: true,
     messages: {
       preferFieldStyle: 'Literals should be exposed using readonly fields.',
-      preferFieldStyleSuggestion:
-        'Replace the literals with readonly fields.',
+      preferFieldStyleSuggestion:'Replace the literals with readonly fields.',
       preferGetterStyle: 'Literals should be exposed using getters.',
       preferGetterStyleSuggestion: 'Replace the literals with getters.',
     },

--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -53,9 +53,9 @@ export default util.createRule<Options, MessageIds>({
     messages: {
       preferFieldStyle: 'Literals should be exposed using readonly fields.',
       preferFieldStyleSuggestion:
-        'Try replacing the literals with readonly fields.',
+        'Replace the literals with readonly fields.',
       preferGetterStyle: 'Literals should be exposed using getters.',
-      preferGetterStyleSuggestion: 'Replace the literals with readonly fields.',
+      preferGetterStyleSuggestion: 'Replace the literals with getters.',
     },
     schema: [{ enum: ['fields', 'getters'] }],
   },

--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -1,4 +1,4 @@
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import * as util from '../util';
@@ -90,7 +90,7 @@ export default util.createRule<Options, MessageIds>({
             suggest: [
               {
                 messageId: 'preferFieldStyleSuggestion',
-                fix(fixer) {
+                fix(fixer): TSESLint.RuleFix {
                   const sourceCode = context.getSourceCode();
                   const name = sourceCode.getText(node.key);
 
@@ -125,7 +125,7 @@ export default util.createRule<Options, MessageIds>({
             suggest: [
               {
                 messageId: 'preferGetterStyleSuggestion',
-                fix(fixer) {
+                fix(fixer): TSESLint.RuleFix {
                   const sourceCode = context.getSourceCode();
                   const name = sourceCode.getText(node.key);
 

--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -52,7 +52,7 @@ export default util.createRule<Options, MessageIds>({
     hasSuggestions: true,
     messages: {
       preferFieldStyle: 'Literals should be exposed using readonly fields.',
-      preferFieldStyleSuggestion:'Replace the literals with readonly fields.',
+      preferFieldStyleSuggestion: 'Replace the literals with readonly fields.',
       preferGetterStyle: 'Literals should be exposed using getters.',
       preferGetterStyleSuggestion: 'Replace the literals with getters.',
     },

--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -55,7 +55,7 @@ export default util.createRule<Options, MessageIds>({
       preferFieldStyleSuggestion:
         'Try replacing the literals with readonly fields.',
       preferGetterStyle: 'Literals should be exposed using getters.',
-      preferGetterStyleSuggestion: 'Try replacing the literals with getters.',
+      preferGetterStyleSuggestion: 'Replace the literals with readonly fields.',
     },
     schema: [{ enum: ['fields', 'getters'] }],
   },

--- a/packages/eslint-plugin/tests/rules/class-literal-property-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-literal-property-style.test.ts
@@ -187,16 +187,21 @@ class Mx {
   }
 }
       `,
-      output: `
-class Mx {
-  readonly p1 = 'hello world';
-}
-      `,
       errors: [
         {
           messageId: 'preferFieldStyle',
           column: 7,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
+class Mx {
+  readonly p1 = 'hello world';
+}
+      `,
+            },
+          ],
         },
       ],
     },
@@ -208,16 +213,21 @@ class Mx {
   }
 }
       `,
-      output: `
-class Mx {
-  readonly p1 = \`hello world\`;
-}
-      `,
       errors: [
         {
           messageId: 'preferFieldStyle',
           column: 7,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
+class Mx {
+  readonly p1 = \`hello world\`;
+}
+      `,
+            },
+          ],
         },
       ],
     },
@@ -229,16 +239,21 @@ class Mx {
   }
 }
       `,
-      output: `
-class Mx {
-  static readonly p1 = 'hello world';
-}
-      `,
       errors: [
         {
           messageId: 'preferFieldStyle',
           column: 14,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
+class Mx {
+  static readonly p1 = 'hello world';
+}
+      `,
+            },
+          ],
         },
       ],
     },
@@ -250,16 +265,21 @@ class Mx {
   }
 }
       `,
-      output: `
-class Mx {
-  public static readonly foo = 1;
-}
-      `,
       errors: [
         {
           messageId: 'preferFieldStyle',
           column: 21,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
+class Mx {
+  public static readonly foo = 1;
+}
+      `,
+            },
+          ],
         },
       ],
     },
@@ -271,16 +291,21 @@ class Mx {
   }
 }
       `,
-      output: `
-class Mx {
-  public readonly [myValue] = 'a literal value';
-}
-      `,
       errors: [
         {
           messageId: 'preferFieldStyle',
           column: 15,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
+class Mx {
+  public readonly [myValue] = 'a literal value';
+}
+      `,
+            },
+          ],
         },
       ],
     },
@@ -292,16 +317,21 @@ class Mx {
   }
 }
       `,
-      output: `
-class Mx {
-  public readonly [myValue] = 12345n;
-}
-      `,
       errors: [
         {
           messageId: 'preferFieldStyle',
           column: 15,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
+class Mx {
+  public readonly [myValue] = 12345n;
+}
+      `,
+            },
+          ],
         },
       ],
     },
@@ -311,16 +341,21 @@ class Mx {
   public readonly [myValue] = 'a literal value';
 }
       `,
-      output: `
-class Mx {
-  public get [myValue]() { return 'a literal value'; }
-}
-      `,
       errors: [
         {
           messageId: 'preferGetterStyle',
           column: 20,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferGetterStyleSuggestion',
+              output: `
+class Mx {
+  public get [myValue]() { return 'a literal value'; }
+}
+      `,
+            },
+          ],
         },
       ],
       options: ['getters'],
@@ -331,16 +366,21 @@ class Mx {
   readonly p1 = 'hello world';
 }
       `,
-      output: `
-class Mx {
-  get p1() { return 'hello world'; }
-}
-      `,
       errors: [
         {
           messageId: 'preferGetterStyle',
           column: 12,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferGetterStyleSuggestion',
+              output: `
+class Mx {
+  get p1() { return 'hello world'; }
+}
+      `,
+            },
+          ],
         },
       ],
       options: ['getters'],
@@ -351,16 +391,21 @@ class Mx {
   readonly p1 = \`hello world\`;
 }
       `,
-      output: `
-class Mx {
-  get p1() { return \`hello world\`; }
-}
-      `,
       errors: [
         {
           messageId: 'preferGetterStyle',
           column: 12,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferGetterStyleSuggestion',
+              output: `
+class Mx {
+  get p1() { return \`hello world\`; }
+}
+      `,
+            },
+          ],
         },
       ],
       options: ['getters'],
@@ -371,16 +416,21 @@ class Mx {
   static readonly p1 = 'hello world';
 }
       `,
-      output: `
-class Mx {
-  static get p1() { return 'hello world'; }
-}
-      `,
       errors: [
         {
           messageId: 'preferGetterStyle',
           column: 19,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferGetterStyleSuggestion',
+              output: `
+class Mx {
+  static get p1() { return 'hello world'; }
+}
+      `,
+            },
+          ],
         },
       ],
       options: ['getters'],
@@ -393,16 +443,21 @@ class Mx {
   }
 }
       `,
-      output: `
-class Mx {
-  protected readonly p1 = 'hello world';
-}
-      `,
       errors: [
         {
           messageId: 'preferFieldStyle',
           column: 17,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
+class Mx {
+  protected readonly p1 = 'hello world';
+}
+      `,
+            },
+          ],
         },
       ],
       options: ['fields'],
@@ -413,16 +468,21 @@ class Mx {
   protected readonly p1 = 'hello world';
 }
       `,
-      output: `
-class Mx {
-  protected get p1() { return 'hello world'; }
-}
-      `,
       errors: [
         {
           messageId: 'preferGetterStyle',
           column: 22,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferGetterStyleSuggestion',
+              output: `
+class Mx {
+  protected get p1() { return 'hello world'; }
+}
+      `,
+            },
+          ],
         },
       ],
       options: ['getters'],
@@ -435,16 +495,21 @@ class Mx {
   }
 }
       `,
-      output: `
-class Mx {
-  public static readonly p1 = 'hello world';
-}
-      `,
       errors: [
         {
           messageId: 'preferFieldStyle',
           column: 21,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
+class Mx {
+  public static readonly p1 = 'hello world';
+}
+      `,
+            },
+          ],
         },
       ],
     },
@@ -454,16 +519,21 @@ class Mx {
   public static readonly p1 = 'hello world';
 }
       `,
-      output: `
-class Mx {
-  public static get p1() { return 'hello world'; }
-}
-      `,
       errors: [
         {
           messageId: 'preferGetterStyle',
           column: 26,
           line: 3,
+          suggestions: [
+            {
+              messageId: 'preferGetterStyleSuggestion',
+              output: `
+class Mx {
+  public static get p1() { return 'hello world'; }
+}
+      `,
+            },
+          ],
         },
       ],
       options: ['getters'],
@@ -483,7 +553,15 @@ class Mx {
   }
 }
       `,
-      output: `
+      errors: [
+        {
+          messageId: 'preferFieldStyle',
+          column: 14,
+          line: 3,
+          suggestions: [
+            {
+              messageId: 'preferFieldStyleSuggestion',
+              output: `
 class Mx {
   public readonly myValue = gql\`
       {
@@ -495,11 +573,8 @@ class Mx {
     \`;
 }
       `,
-      errors: [
-        {
-          messageId: 'preferFieldStyle',
-          column: 14,
-          line: 3,
+            },
+          ],
         },
       ],
     },
@@ -516,7 +591,15 @@ class Mx {
   \`;
 }
       `,
-      output: `
+      errors: [
+        {
+          messageId: 'preferGetterStyle',
+          column: 19,
+          line: 3,
+          suggestions: [
+            {
+              messageId: 'preferGetterStyleSuggestion',
+              output: `
 class Mx {
   public get myValue() { return gql\`
     {
@@ -528,11 +611,8 @@ class Mx {
   \`; }
 }
       `,
-      errors: [
-        {
-          messageId: 'preferGetterStyle',
-          column: 19,
-          line: 3,
+            },
+          ],
         },
       ],
       options: ['getters'],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5962 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
This PR changes the fixer for the class literal property style rule in the eslint-plugin package from an autofixer to a suggestion fixer.
<!-- Description of what is changed and how the code change does that. -->
