### PR TITLE
docs: fleshed out RFC and Technical Discussions forms

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/rfcs.yml
+++ b/.github/DISCUSSION_TEMPLATE/rfcs.yml
@@ -15,6 +15,7 @@ body:
       label: Before you submit your RFC, please confirm the following. If any of these required steps are not taken, we may not be able to review your RFC. Help us to help you!
       options:
         - label: I have [read the discussions guidelines](https://typescript-eslint.io/contributing/discussions) and per those guidelines, this fits a discussion category, _not_ a help request or standard issue.
+          required: true
         - label: I have [searched for related discussions](https://github.com/typescript-eslint/typescript-eslint/discussions) and [searched for related issues](https://github.com/typescript-eslint/typescript-eslint/issues) and found none that match my proposal.
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.

--- a/.github/DISCUSSION_TEMPLATE/technical-discussions.yml
+++ b/.github/DISCUSSION_TEMPLATE/technical-discussions.yml
@@ -15,6 +15,7 @@ body:
       label: Before you submit your discussion, please confirm the following. If any of these required steps are not taken, we may not be able to review your RFC. Help us to help you!
       options:
         - label: I have [read the discussions guidelines](https://typescript-eslint.io/contributing/discussions) and per those guidelines, this fits a discussion category, _not_ a help request or standard issue.
+          required: true
         - label: I have [searched for related discussions](https://github.com/typescript-eslint/typescript-eslint/discussions) and [searched for related issues](https://github.com/typescript-eslint/typescript-eslint/issues) and found none that match my proposal.
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.

--- a/.github/DISCUSSION_TEMPLATE/technical-discussions.yml
+++ b/.github/DISCUSSION_TEMPLATE/technical-discussions.yml
@@ -1,9 +1,9 @@
 body:
   - attributes:
-      label: RFC
+      label: Body
       value: |
-        Suggested changes...
-    id: rfc
+        Body of the technical discussion...
+    id: body
     type: textarea
   - attributes:
       label: Additional Info
@@ -12,7 +12,7 @@ body:
     id: additional
     type: textarea
   - attributes:
-      label: Before you submit your RFC, please confirm the following. If any of these required steps are not taken, we may not be able to review your RFC. Help us to help you!
+      label: Before you submit your discussion, please confirm the following. If any of these required steps are not taken, we may not be able to review your RFC. Help us to help you!
       options:
         - label: I have [read the discussions guidelines](https://typescript-eslint.io/contributing/discussions) and per those guidelines, this fits a discussion category, _not_ a help request or standard issue.
         - label: I have [searched for related discussions](https://github.com/typescript-eslint/typescript-eslint/discussions) and [searched for related issues](https://github.com/typescript-eslint/typescript-eslint/issues) and found none that match my proposal.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7038; fixes #7058
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Addresses #7058 by adding the new checkbox to the existing `rfcs.yml` template. Then also uses a similar template for `technical-discussions.yml`.