### PR TITLE
docs: correct explicit-module-boundary-types correct case

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md
@@ -56,7 +56,7 @@ export var fn = function (): number {
 };
 
 // A return value of type string
-export var arrowFn = (arg: string): string => `test ${arg}`;
+export var arrowFn = (): string => 'test';
 
 // All arguments should be typed
 export var arrowFn = (arg: string): string => `test ${arg}`;


### PR DESCRIPTION
Updates "Correct" version to match "Incorrect" version of empty function that expects nothing and returns a string (The "Correct" version was expecting a string and returning a concatenated string)

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
