### PR TITLE
docs: fix broken links v6 docs

### DIFF
--- a/docs/linting/Configurations.mdx
+++ b/docs/linting/Configurations.mdx
@@ -89,7 +89,7 @@ module.exports = {
 };
 ```
 
-See [`configs/recommended-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/recommended-type-checked.ts) for the exact contents of this config.
+See [`configs/recommended-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/v6/packages/eslint-plugin/src/configs/recommended-type-checked.ts) for the exact contents of this config.
 
 ### `strict`
 
@@ -119,7 +119,7 @@ module.exports = {
 };
 ```
 
-See [`configs/strict-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/strict-type-checked.ts) for the exact contents of this config.
+See [`configs/strict-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/v6/packages/eslint-plugin/src/configs/strict-type-checked.ts) for the exact contents of this config.
 
 :::caution
 We recommend a TypeScript project extend from `plugin:@typescript-eslint/strict-type-checked` only if a nontrivial percentage of its developers are highly proficient in TypeScript.
@@ -136,7 +136,7 @@ module.exports = {
 };
 ```
 
-See [`configs/stylistic.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/stylistic.ts) for the exact contents of this config.
+See [`configs/stylistic.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/v6/packages/eslint-plugin/src/configs/stylistic.ts) for the exact contents of this config.
 
 ### `stylistic-type-checked`
 
@@ -149,7 +149,7 @@ module.exports = {
 };
 ```
 
-See [`configs/stylistic-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/strict-type-checked.ts) for the exact contents of this config.
+See [`configs/stylistic-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/v6/packages/eslint-plugin/src/configs/strict-type-checked.ts) for the exact contents of this config.
 
 ## Other Configurations
 
@@ -181,7 +181,7 @@ See [`configs/base.ts`](https://github.com/typescript-eslint/typescript-eslint/b
 A utility ruleset that will disable type-aware linting and all type-aware rules available in our project.
 This config is useful if you'd like to have your base config concerned with type-aware linting, and then conditionally use [overrides](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-based-on-glob-patterns) to disable type-aware linting on specific subsets of your codebase.
 
-See [`configs/disable-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/disable-type-checked.ts) for the exact contents of this config.
+See [`configs/disable-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/v6/packages/eslint-plugin/src/configs/disable-type-checked.ts) for the exact contents of this config.
 
 :::info
 If you use type-aware rules from other plugins, you will need to manually disable these rules or use a premade config they provide to disable them.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7081
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
This pr fixes broken links in the configurations section for v6.
The links to the following configs were pointing to the main branch, since `v6` is not merged yet to main, I changed them back to point to `v6`
- strict-type-checked.ts
- stylistic.ts
- strict-type-checked.ts
- recommended-type-checked.ts
- disable-type-checked.ts
<!-- Description of what is changed and how the code change does that. -->
