### PR TITLE
fix(eslint-plugin): [no-floating-promises] finally should be transparent to unhandled promises

### DIFF
--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -255,9 +255,10 @@ export default util.createRule<Options, MessageId>({
         }
 
         // `x.finally()` is transparent to resolution of the promise, so check `x`.
-        const promiseFinally = parsePromiseFinallyCall(node);
-        if (promiseFinally) {
-          return isUnhandledPromise(checker, promiseFinally.object);
+        // ("object" in this context is the `x` in `x.finally()`)
+        const promiseFinallyObject = getObjectFromFinallyCall(node);
+        if (promiseFinallyObject) {
+          return isUnhandledPromise(checker, promiseFinallyObject);
         }
 
         // All other cases are unhandled.
@@ -384,12 +385,12 @@ function getRejectionHandlerFromThenCall(
   }
 }
 
-function parsePromiseFinallyCall(
+function getObjectFromFinallyCall(
   expression: TSESTree.CallExpression,
-): { object: TSESTree.Expression } | undefined {
+): TSESTree.Expression | undefined {
   return expression.callee.type === AST_NODE_TYPES.MemberExpression &&
     expression.callee.property.type === AST_NODE_TYPES.Identifier &&
     expression.callee.property.name === 'finally'
-    ? { object: expression.callee.object }
+    ? expression.callee.object
     : undefined;
 }

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -456,10 +456,19 @@ Promise.reject().catch(definitelyCallable);
 Promise.reject()
   .catch(() => {})
   .finally(() => {});
+      `,
+    },
+    {
+      code: `
 Promise.reject()
   .catch(() => {})
   .finally(() => {})
   .finally(() => {});
+      `,
+      options: [{ ignoreVoid: false }],
+    },
+    {
+      code: `
 Promise.reject()
   .catch(() => {})
   .finally(() => {})
@@ -1582,28 +1591,26 @@ Promise.reject() || 3;
     {
       code: `
 Promise.reject().finally(() => {});
+      `,
+      errors: [{ line: 2, messageId: 'floatingVoid' }],
+    },
+    {
+      code: `
 Promise.reject()
   .finally(() => {})
   .finally(() => {});
+      `,
+      options: [{ ignoreVoid: false }],
+      errors: [{ line: 2, messageId: 'floating' }],
+    },
+    {
+      code: `
 Promise.reject()
   .finally(() => {})
   .finally(() => {})
   .finally(() => {});
       `,
-      errors: [
-        {
-          line: 2,
-          messageId: 'floatingVoid',
-        },
-        {
-          line: 3,
-          messageId: 'floatingVoid',
-        },
-        {
-          line: 6,
-          messageId: 'floatingVoid',
-        },
-      ],
+      errors: [{ line: 2, messageId: 'floatingVoid' }],
     },
     {
       code: `
@@ -1611,69 +1618,39 @@ Promise.reject()
   .then(() => {})
   .finally(() => {});
       `,
-      errors: [
-        {
-          line: 2,
-          messageId: 'floatingVoid',
-        },
-      ],
+      errors: [{ line: 2, messageId: 'floatingVoid' }],
     },
     {
       code: `
 declare const returnsPromise: () => Promise<void> | null;
 returnsPromise()?.finally(() => {});
       `,
-      errors: [
-        {
-          line: 3,
-          messageId: 'floatingVoid',
-        },
-      ],
+      errors: [{ line: 3, messageId: 'floatingVoid' }],
     },
     {
       code: `
 const promiseIntersection: Promise<number> & number;
 promiseIntersection.finally(() => {});
       `,
-      errors: [
-        {
-          line: 3,
-          messageId: 'floatingVoid',
-        },
-      ],
+      errors: [{ line: 3, messageId: 'floatingVoid' }],
     },
     {
       code: `
 Promise.resolve().finally(() => {}), 123;
       `,
-      errors: [
-        {
-          line: 2,
-          messageId: 'floatingVoid',
-        },
-      ],
+      errors: [{ line: 2, messageId: 'floatingVoid' }],
     },
     {
       code: `
 (async () => true)().finally();
       `,
-      errors: [
-        {
-          line: 2,
-          messageId: 'floatingVoid',
-        },
-      ],
+      errors: [{ line: 2, messageId: 'floatingVoid' }],
     },
     {
       code: `
 Promise.reject(new Error('message')).finally(() => {});
       `,
-      errors: [
-        {
-          line: 2,
-          messageId: 'floatingVoid',
-        },
-      ],
+      errors: [{ line: 2, messageId: 'floatingVoid' }],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -186,7 +186,6 @@ async function test() {
     () => {},
   );
   promiseIntersection.then(() => {}).catch(() => {});
-  promiseIntersection.then(() => {}).catch(() => {});
   promiseIntersection.catch(() => {});
   return promiseIntersection;
 }

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -31,7 +31,6 @@ async function test() {
     .catch(() => {})
     .finally(() => {});
   Promise.resolve('value').catch(() => {});
-  Promise.resolve('value').finally(() => {});
   return Promise.resolve('value');
 }
     `,
@@ -58,7 +57,6 @@ async function test() {
     .catch(() => {})
     .finally(() => {});
   Promise.reject(new Error('message')).catch(() => {});
-  Promise.reject(new Error('message')).finally(() => {});
   return Promise.reject(new Error('message'));
 }
     `,
@@ -77,7 +75,6 @@ async function test() {
     .catch(() => {})
     .finally(() => {});
   (async () => true)().catch(() => {});
-  (async () => true)().finally(() => {});
   return (async () => true)();
 }
     `,
@@ -97,7 +94,6 @@ async function test() {
     .catch(() => {})
     .finally(() => {});
   returnsPromise().catch(() => {});
-  returnsPromise().finally(() => {});
   return returnsPromise();
 }
     `,
@@ -106,7 +102,6 @@ async function test() {
   const x = Promise.resolve();
   const y = x.then(() => {});
   y.catch(() => {});
-  y.finally(() => {});
 }
     `,
     `
@@ -117,7 +112,6 @@ async function test() {
     `
 async function test() {
   Promise.resolve().catch(() => {}), 123;
-  Promise.resolve().finally(() => {}), 123;
   123,
     Promise.resolve().then(
       () => {},
@@ -160,7 +154,6 @@ async function test() {
     .catch(() => {})
     .finally(() => {});
   promiseValue.catch(() => {});
-  promiseValue.finally(() => {});
   return promiseValue;
 }
     `,
@@ -193,12 +186,8 @@ async function test() {
     () => {},
   );
   promiseIntersection.then(() => {}).catch(() => {});
-  promiseIntersection
-    .then(() => {})
-    .catch(() => {})
-    .finally(() => {});
+  promiseIntersection.then(() => {}).catch(() => {});
   promiseIntersection.catch(() => {});
-  promiseIntersection.finally(() => {});
   return promiseIntersection;
 }
     `,
@@ -218,7 +207,6 @@ async function test() {
     .catch(() => {})
     .finally(() => {});
   canThen.catch(() => {});
-  canThen.finally(() => {});
   return canThen;
 }
     `,
@@ -315,7 +303,6 @@ async function test() {
     .catch(() => {})
     .finally(() => {});
   promise.catch(() => {});
-  promise.finally(() => {});
   return promise;
 }
     `,
@@ -333,7 +320,6 @@ async function test() {
     ?.then(() => {})
     ?.catch(() => {});
   returnsPromise()?.catch(() => {});
-  returnsPromise()?.finally(() => {});
   return returnsPromise();
 }
     `,
@@ -464,6 +450,22 @@ declare const definitelyCallable: () => void;
 Promise.reject().catch(definitelyCallable);
       `,
       options: [{ ignoreVoid: false }],
+    },
+    {
+      code: `
+Promise.reject()
+  .catch(() => {})
+  .finally(() => {});
+Promise.reject()
+  .catch(() => {})
+  .finally(() => {})
+  .finally(() => {});
+Promise.reject()
+  .catch(() => {})
+  .finally(() => {})
+  .finally(() => {})
+  .finally(() => {});
+      `,
     },
   ],
 
@@ -612,7 +614,6 @@ async function test() {
   (async () => true)();
   (async () => true)().then(() => {});
   (async () => true)().catch();
-  (async () => true)().finally();
 }
       `,
       errors: [
@@ -626,10 +627,6 @@ async function test() {
         },
         {
           line: 5,
-          messageId: 'floatingVoid',
-        },
-        {
-          line: 6,
           messageId: 'floatingVoid',
         },
       ],
@@ -940,7 +937,6 @@ async function test() {
   promiseIntersection;
   promiseIntersection.then(() => {});
   promiseIntersection.catch();
-  promiseIntersection.finally();
 }
       `,
       errors: [
@@ -954,10 +950,6 @@ async function test() {
         },
         {
           line: 7,
-          messageId: 'floatingVoid',
-        },
-        {
-          line: 8,
           messageId: 'floatingVoid',
         },
       ],
@@ -1584,6 +1576,102 @@ Promise.reject() || 3;
         {
           line: 2,
           messageId: 'floating',
+        },
+      ],
+    },
+    {
+      code: `
+Promise.reject().finally(() => {});
+Promise.reject()
+  .finally(() => {})
+  .finally(() => {});
+Promise.reject()
+  .finally(() => {})
+  .finally(() => {})
+  .finally(() => {});
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 3,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 6,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
+      code: `
+Promise.reject()
+  .then(() => {})
+  .finally(() => {});
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
+      code: `
+declare const returnsPromise: () => Promise<void> | null;
+returnsPromise()?.finally(() => {});
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
+      code: `
+const promiseIntersection: Promise<number> & number;
+promiseIntersection.finally(() => {});
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
+      code: `
+Promise.resolve().finally(() => {}), 123;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
+      code: `
+(async () => true)().finally();
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
+      code: `
+Promise.reject(new Error('message')).finally(() => {});
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'floatingVoid',
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5692
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
The existing implementation treats `.finally` as though it can account for a rejected promise. It cannot prevent rejection. This PR implements the change recommended in the discussion for this issue, namely, to make `.finally` transparent to the rule and check whatever comes before it.

```
Promise.reject().finally(() => {}) // was ok, now an error
Promise.reject().catch(() => {}).finally(() => {}).finally(() => {}) // was ok - still ok
```

Note - this will have conflicts with https://github.com/typescript-eslint/typescript-eslint/pull/6881. It would be simpler to merge that PR first and then deal with the conflicts here.