### PR TITLE
chore(website): remove swc: true to fix builds

### DIFF
--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -3,7 +3,6 @@
 require('ts-node').register({
   scope: true,
   scopeDir: __dirname,
-  swc: true,
   transpileOnly: true,
 });
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7165
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Stops using `swc: true` in ts-node so that the website will build again.