### PR TITLE
fix: allow type imports in moduleResolution: node

### DIFF
--- a/packages/eslint-plugin-tslint/package.json
+++ b/packages/eslint-plugin-tslint/package.json
@@ -11,6 +11,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,6 +11,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -9,6 +9,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/rule-schema-to-typescript-types/package.json
+++ b/packages/rule-schema-to-typescript-types/package.json
@@ -3,6 +3,7 @@
   "version": "6.0.0",
   "private": true,
   "type": "commonjs",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -9,6 +9,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/scope-manager/package.json
+++ b/packages/scope-manager/package.json
@@ -9,6 +9,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -10,6 +10,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,6 +10,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -9,6 +9,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,6 +10,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/visitor-keys/package.json
+++ b/packages/visitor-keys/package.json
@@ -10,6 +10,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/website-eslint/package.json
+++ b/packages/website-eslint/package.json
@@ -7,6 +7,7 @@
     "dist"
   ],
   "type": "commonjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7185
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Package types lookup in `"moduleResolution": "node"` adheres to Node 10 (`"moduleResolution": "node10"`), which doesn't support `"exports"` > `"."` > `"types"` field in the `package.json`. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/a8dece2e3aab25f9ddbef1ac2f1c22ae8d27bc6f/docs/problems/NoResolution.md#true-positive-node-10-doesnt-support-packagejson-exports recommends using a newer `moduleResolution` in your TSConfig. To help out users still using Node 10 module resolution, this adds explicit `"types": "./(dist/)index.d.ts"` entries to the `package.json`s.

Note that you can avoid the need for this code change by setting a new module resolution strategy, such as `"moduleResolution": "node16"`, in your TSConfig:

```diff
{
  // node-lts-strictest is deprecated in favor of using an array to combine node-lts and strictest but doing so
  // currently leads to problems with the eslint-plugin-import package, see
  // https://github.com/import-js/eslint-plugin-import/issues/2751
  "extends": "@tsconfig/node-lts-strictest/tsconfig.json",
  "compilerOptions": {
+    "moduleResolution": "Node16",
  },
}

```