### PR TITLE
chore(deps): remove unnecessary dependency on grapheme-splitter

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -61,7 +61,6 @@
     "@typescript-eslint/utils": "6.0.0",
     "@typescript-eslint/visitor-keys": "6.0.0",
     "debug": "^4.3.4",
-    "grapheme-splitter": "^1.0.4",
     "graphemer": "^1.4.0",
     "ignore": "^5.2.4",
     "natural-compare": "^1.4.0",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7189
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Remove direct dependency on grapheme-splitter.
N.B. there is still a transitive dependency on grapheme-splitter through `eslint` (this will disappear once eslint is updated past 8.41.0), so this does not actually change the contents of yarn.lock. It does, however, change the built package to no longer require grapheme-splitter.
