### PR TITLE
fix(eslint-plugin): [comma-dangle] fixed crash from undefined predicate.ignore

### DIFF
--- a/packages/eslint-plugin/src/rules/comma-dangle.ts
+++ b/packages/eslint-plugin/src/rules/comma-dangle.ts
@@ -98,7 +98,9 @@ export default util.createRule<Options, MessageIds>({
       'always-multiline': forceCommaIfMultiline,
       'only-multiline': allowCommaIfMultiline,
       never: forbidComma,
-      ignore: undefined,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/7220
+      // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-empty-function
+      ignore: () => {},
     };
 
     function last(nodes: TSESTree.Node[]): TSESTree.Node | null {

--- a/packages/eslint-plugin/tests/rules/comma-dangle.test.ts
+++ b/packages/eslint-plugin/tests/rules/comma-dangle.test.ts
@@ -76,6 +76,9 @@ ruleTester.run('comma-dangle', rule, {
     { code: 'type Foo = [string\n]', options: [{ tuples: 'only-multiline' }] },
     { code: 'type Foo = [string,\n]', options: [{ tuples: 'only-multiline' }] },
 
+    // ignore
+    { code: 'const a = <TYPE,>() => {}', options: [{ generics: 'ignore' }] },
+
     // each options
     {
       code: `


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7220
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Reverts `ignore` from `undefined` back to `() => {}`, and adds a test case for the crash. 

Shoutout+thanks to @erik-slovak for reporting in https://github.com/typescript-eslint/typescript-eslint/commit/42fe29f6912361521d551c0f629f06b54919af69#r121427176 & @sharpdressedcodes for pointing out the lack of unit test! 🙌 