### PR TITLE
Fix typo in explicit-member-accessibility docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
+++ b/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
@@ -7,7 +7,7 @@ description: 'Require explicit accessibility modifiers on class properties and m
 > See **https://typescript-eslint.io/rules/explicit-member-accessibility** for documentation.
 
 TypeScript allows placing explicit `public`, `protected`, and `private` accessibility modifiers in front of class members.
-The modifiers exist solely in the type system and just server to describe who is allowed to access those members.
+The modifiers exist solely in the type system and just serve to describe who is allowed to access those members.
 
 Leaving off accessibility modifiers makes for less code to read and write.
 Members are `public` by default.


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fix minor typo in explicit-member-accessibility docs
