### PR TITLE
fix(eslint-plugin): [prefer-nullish-coalescing] handle case when type of left side is null or undefined

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -310,6 +310,8 @@ export default util.createRule<Options, MessageIds>({
           .filter((flag): flag is number => flag !== undefined)
           .reduce((previous, flag) => previous | flag, 0);
         if (
+          type.flags !== ts.TypeFlags.Null &&
+          type.flags !== ts.TypeFlags.Undefined &&
           (type as ts.UnionOrIntersectionType).types.some(t =>
             tsutils.isTypeFlagSet(t, ignorableFlags),
           )

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -1208,5 +1208,47 @@ x || y;
         },
       ],
     },
+    {
+      code: `
+declare const x: null;
+x || y;
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+        },
+      ],
+    },
+    {
+      code: `
+const x = undefined;
+x || y;
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+        },
+      ],
+    },
+    {
+      code: `
+null || y;
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+        },
+      ],
+    },
+    {
+      code: `
+undefined || y;
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7222
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The edge case: the type of left side can be explicitly `null` or `undefined`. Then there will be no `types` property and `type` can't be treated as `ts.UnionOrIntersectionType`
