### PR TITLE
chore: use workerIdleMemoryLimit in jest tests

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -36,4 +36,5 @@ module.exports = {
       },
     ],
   },
+  workerIdleMemoryLimit: '300MB',
 };

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -51,7 +51,7 @@
     "generate:breaking-changes": "yarn tsx tools/generate-breaking-changes.mts",
     "generate:configs": "yarn tsx tools/generate-configs.ts",
     "lint": "nx lint",
-    "test": "jest --coverage",
+    "test": "jest --coverage --logHeapUsage",
     "test-single": "jest --no-coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7245
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Set worker memory limit, so CI does not run out of memory while running them.