### PR TITLE
fix(typescript-estree): remove ts.sys watch program override

### DIFF
--- a/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
+++ b/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
@@ -261,10 +261,7 @@ function createWatchProgram(
   const watchCompilerHost = ts.createWatchCompilerHost(
     tsconfigPath,
     createDefaultCompilerOptionsFromExtra(parseSettings),
-    {
-      ...ts.sys,
-      getCurrentDirectory: () => parseSettings.tsconfigRootDir,
-    },
+    ts.sys,
     ts.createAbstractBuilder,
     diagnosticReporter,
     // TODO: file issue on TypeScript to suggest making optional?


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7246
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fixes the relativity issue more surgically than a full revert (#7251).

Co-authored-by: @bradzacher 