### PR TITLE
chore(type-utils): fixed TypeOrValueSpecifier tests relativity

### DIFF
--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -196,18 +196,18 @@ describe('TypeOrValueSpecifier', () => {
       ],
       [
         'interface Foo {prop: string}; type Test = Foo;',
-        { from: 'file', name: 'Foo', path: 'file.ts' },
+        { from: 'file', name: 'Foo', path: 'tests/fixtures/file.ts' },
       ],
       [
         'type Foo = {prop: string}; type Test = Foo;',
-        { from: 'file', name: 'Foo', path: 'file.ts' },
+        { from: 'file', name: 'Foo', path: 'tests/fixtures/file.ts' },
       ],
       [
         'interface Foo {prop: string}; type Test = Foo;',
         {
           from: 'file',
           name: 'Foo',
-          path: './////file.ts',
+          path: 'tests/../tests/fixtures/////file.ts',
         },
       ],
       [
@@ -215,7 +215,7 @@ describe('TypeOrValueSpecifier', () => {
         {
           from: 'file',
           name: 'Foo',
-          path: './////file.ts',
+          path: 'tests/../tests/fixtures/////file.ts',
         },
       ],
       [
@@ -223,7 +223,7 @@ describe('TypeOrValueSpecifier', () => {
         {
           from: 'file',
           name: ['Foo', 'Bar'],
-          path: 'file.ts',
+          path: 'tests/fixtures/file.ts',
         },
       ],
       [
@@ -231,7 +231,7 @@ describe('TypeOrValueSpecifier', () => {
         {
           from: 'file',
           name: ['Foo', 'Bar'],
-          path: 'file.ts',
+          path: 'tests/fixtures/file.ts',
         },
       ],
     ])('matches a matching file specifier: %s', runTestPositive);
@@ -247,14 +247,14 @@ describe('TypeOrValueSpecifier', () => {
       ],
       [
         'interface Foo {prop: string}; type Test = Foo;',
-        { from: 'file', name: 'Foo', path: 'wrong-file.ts' },
+        { from: 'file', name: 'Foo', path: 'tests/fixtures/wrong-file.ts' },
       ],
       [
         'interface Foo {prop: string}; type Test = Foo;',
         {
           from: 'file',
           name: ['Foo', 'Bar'],
-          path: 'wrong-file.ts',
+          path: 'tests/fixtures/wrong-file.ts',
         },
       ],
     ])("doesn't match a mismatched file specifier: %s", runTestNegative);
@@ -399,14 +399,14 @@ describe('TypeOrValueSpecifier', () => {
       ['type Test = RegExp;', { from: 'file', name: ['RegExp', 'BigInt'] }],
       [
         'type Test = RegExp;',
-        { from: 'file', name: 'RegExp', path: 'file.ts' },
+        { from: 'file', name: 'RegExp', path: 'tests/fixtures/file.ts' },
       ],
       [
         'type Test = RegExp;',
         {
           from: 'file',
           name: ['RegExp', 'BigInt'],
-          path: 'file.ts',
+          path: 'tests/fixtures/file.ts',
         },
       ],
       [


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #7255
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Reverts changes to `TypeOrValueSpecifier.test.ts` that were broken by #7252. @bradzacher had actually questioned them in the PR. So, great - looks like we do have test coverage for the current directory after all (accidentally).