### PR TITLE
fix: [no-invalid-void-type] allow void in return type unions

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-invalid-void-type.md
+++ b/packages/eslint-plugin/docs/rules/no-invalid-void-type.md
@@ -10,7 +10,7 @@ description: 'Disallow `void` type outside of generic or return types.'
 Attempting to use a `void` type outside of a return type or generic type argument is often a sign of programmer error.
 `void` can also be misleading for other developers even if used correctly.
 
-> The `void` type means cannot be mixed with any other types, other than `never`, which accepts all types.
+> The `void` type cannot be mixed with any other type (except `never`, which accepts all types).
 > If you think you need this then you probably want the `undefined` type instead.
 
 ## Examples
@@ -50,6 +50,8 @@ let trulyUndefined = void 0;
 async function promiseMeSomething(): Promise<void> {}
 
 type stillVoid = void | never;
+
+function voidReturnUnion(): void | number {}
 ```
 
 ## Options

--- a/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
@@ -164,19 +164,23 @@ export default util.createRule<[Options], MessageIds>({
       );
     }
 
-    function isValidReturnUnion(node: TSESTree.TSUnionType): boolean {
-      if (node.parent.type === AST_NODE_TYPES.TSTypeAnnotation) {
+    /**
+     * @brief checks whether a node is a return type annotation
+     * @return true if the node is a return type annotation
+     */
+    function isNodeReturnTypeAnnotation(node: TSESTree.Node): boolean {
+      if (node.parent?.type === AST_NODE_TYPES.TSTypeAnnotation) {
+        const parentParent = node.parent.parent;
         if (
-          node.parent.parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-          node.parent.parent.type === AST_NODE_TYPES.FunctionDeclaration ||
-          node.parent.parent.type === AST_NODE_TYPES.FunctionExpression ||
-          node.parent.parent.type ===
-            AST_NODE_TYPES.TSCallSignatureDeclaration ||
-          node.parent.parent.type === AST_NODE_TYPES.TSDeclareFunction ||
-          node.parent.parent.type === AST_NODE_TYPES.TSFunctionType ||
-          node.parent.parent.type === AST_NODE_TYPES.TSMethodSignature
+          parentParent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+          parentParent.type === AST_NODE_TYPES.FunctionDeclaration ||
+          parentParent.type === AST_NODE_TYPES.FunctionExpression ||
+          parentParent.type === AST_NODE_TYPES.TSCallSignatureDeclaration ||
+          parentParent.type === AST_NODE_TYPES.TSDeclareFunction ||
+          parentParent.type === AST_NODE_TYPES.TSFunctionType ||
+          parentParent.type === AST_NODE_TYPES.TSMethodSignature
         ) {
-          return node.parent.parent.returnType === node.parent;
+          return parentParent.returnType === node.parent;
         }
       }
       return false;
@@ -210,7 +214,7 @@ export default util.createRule<[Options], MessageIds>({
           }
 
           // A void union is valid in the return type position
-          if (isValidReturnUnion(node.parent)) {
+          if (isNodeReturnTypeAnnotation(node.parent)) {
             return;
           }
         }

--- a/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
@@ -122,6 +122,26 @@ ruleTester.run('allowInGenericTypeArguments: true', rule, {
     'type promiseNeverUnion = Promise<void> | never;',
     'const arrowGeneric1 = <T = void>(arg: T) => {};',
     'declare function functionDeclaration1<T = void>(arg: T): void;',
+    'function validFunctionReturnVoidUnion(): void | number {}',
+    'declare function validFunctionDeclarationReturnVoidUnion(): void | number;',
+    'const validArrowReturnVoidUnion = (): void | number => {};',
+    'const validFunctionExpresionReturnVoidUnion = function (): void | number {};',
+    'type FunctionTypeDeclaration = () => void | number;',
+    `
+interface IValidCallSignature {
+  (): void | number;
+}
+    `,
+    `
+interface IValidMethodSignature {
+  method(): void | number;
+}
+    `,
+    `
+interface IValidPropertySignature {
+  method: () => void | number;
+}
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
@@ -125,7 +125,7 @@ ruleTester.run('allowInGenericTypeArguments: true', rule, {
     'function validFunctionReturnVoidUnion(): void | number {}',
     'declare function validFunctionDeclarationReturnVoidUnion(): void | number;',
     'const validArrowReturnVoidUnion = (): void | number => {};',
-    'const validFunctionExpresionReturnVoidUnion = function (): void | number {};',
+    'const validFunctionExpressionReturnVoidUnion = function (): void | number {};',
     'type FunctionTypeDeclaration = () => void | number;',
     `
 interface IValidCallSignature {
@@ -139,7 +139,7 @@ interface IValidMethodSignature {
     `,
     `
 interface IValidPropertySignature {
-  method: () => void | number;
+  property: () => void | number;
 }
     `,
   ],

--- a/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-invalid-void-type.test.ts
@@ -354,16 +354,6 @@ interface IValidPropertySignature {
       ],
     },
     {
-      code: 'declare function test(): number | void;',
-      errors: [
-        {
-          messageId: 'invalidVoidUnionConstituent',
-          line: 1,
-          column: 35,
-        },
-      ],
-    },
-    {
       code: 'declare function test<T extends number | void>(): T;',
       errors: [
         {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5752
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Update `no-invalid-void-type` to allow unions in the return type position.

I've also updated the docs for some additional clarity.

The `no-invalid-void-type` flags some valid void unions as violations, specifically unions in the return type position. Some valid examples from the new test cases:

```ts
function validFunctionReturnVoidUnion(): void | number {}

const validArrowReturnVoidUnion = (): void | number => {};

const validFunctionExpressionReturnVoidUnion = function (): void | number {};

declare function validFunctionDeclarationReturnVoidUnion(): void | number;

type FunctionTypeDeclaration = () => void | number;
    
interface ValidInterface {
  (): void | number;
  method(): void | number;
  methodArrow: () => void | number;
}
```