### PR TITLE
fix(eslint-plugin): use a default export for the rules type

### DIFF
--- a/packages/eslint-plugin/rules.d.ts
+++ b/packages/eslint-plugin/rules.d.ts
@@ -41,4 +41,4 @@ export interface TypeScriptESLintRules {
   [ruleName: string]: RuleModule<string, unknown[]>;
 }
 declare const rules: TypeScriptESLintRules;
-export = rules;
+export default rules;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7261
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
We have `skipLibCheck` turned on so we never got errors for this :sadge: (`skipLibCheck` means "do not check any `.d.ts` files)