### PR TITLE
fix(typescript-estree): fix TSNode type error on old ts versions

### DIFF
--- a/packages/typescript-estree/src/ts-estree/ts-nodes.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-nodes.ts
@@ -4,18 +4,13 @@ import type * as ts from 'typescript';
 // Eg: https://github.com/typescript-eslint/typescript-eslint/issues/2388, https://github.com/typescript-eslint/typescript-eslint/issues/2784
 /* eslint-disable @typescript-eslint/no-empty-interface */
 declare module 'typescript' {
-  // added in TS 4.0
-  export interface NamedTupleMember extends ts.Node {}
-  // added in TS 4.1
-  export interface TemplateLiteralTypeNode extends ts.Node {}
-  // added in TS 4.3
-  export interface PrivateIdentifier extends ts.Node {}
-  export interface ClassStaticBlockDeclaration extends ts.Node {}
   // added in TS 4.5
   export interface AssertClause extends ts.Node {}
   export interface AssertEntry extends ts.Node {}
   // added in TS 4.9
   export interface SatisfiesExpression extends ts.Node {}
+  // added in TS 5.1
+  export interface JsxNamespacedName extends ts.Node {}
 }
 /* eslint-enable @typescript-eslint/no-empty-interface */
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## Overview

<!-- Description of what is changed and how the code change does that. -->
Found this when upgrading an internal codebase that's on TS4.9
Also realised we forgot to clean this up with the v6 min version bump!