### PR TITLE
fix(eslint-plugin): [no-inferrable-types] apply also for parameter properties

### DIFF
--- a/packages/eslint-plugin/src/rules/no-inferrable-types.ts
+++ b/packages/eslint-plugin/src/rules/no-inferrable-types.ts
@@ -250,15 +250,19 @@ export default util.createRule<Options, MessageIds>({
       if (ignoreParameters || !node.params) {
         return;
       }
-      (
-        node.params.filter(
-          param =>
-            param.type === AST_NODE_TYPES.AssignmentPattern &&
-            param.left &&
-            param.right,
-        ) as TSESTree.AssignmentPattern[]
-      ).forEach(param => {
-        reportInferrableType(param, param.left.typeAnnotation, param.right);
+
+      node.params.forEach(param => {
+        if (param.type === AST_NODE_TYPES.TSParameterProperty) {
+          param = param.parameter;
+        }
+
+        if (
+          param.type === AST_NODE_TYPES.AssignmentPattern &&
+          param.left &&
+          param.right
+        ) {
+          reportInferrableType(param, param.left.typeAnnotation, param.right);
+        }
       });
     }
 

--- a/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts
@@ -289,5 +289,57 @@ class Foo {
         },
       ],
     },
+    {
+      code: `
+class Foo {
+  constructor(
+    a: number = 5,
+    public b: boolean = true,
+    readonly c: string = 'foo',
+  ) {}
+}
+      `,
+      output: `
+class Foo {
+  constructor(
+    a = 5,
+    public b = true,
+    readonly c = 'foo',
+  ) {}
+}
+      `,
+      options: [
+        {
+          ignoreParameters: false,
+          ignoreProperties: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'noInferrableType',
+          data: {
+            type: 'number',
+          },
+          line: 4,
+          column: 5,
+        },
+        {
+          messageId: 'noInferrableType',
+          data: {
+            type: 'boolean',
+          },
+          line: 5,
+          column: 12,
+        },
+        {
+          messageId: 'noInferrableType',
+          data: {
+            type: 'string',
+          },
+          line: 6,
+          column: 14,
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts
@@ -158,7 +158,7 @@ class Foo {
 class Foo {
   constructor(public a = true) {}
 }
-       `,
+      `,
     },
   ],
 

--- a/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts
@@ -153,6 +153,13 @@ class Foo {
 }
       `,
     },
+    {
+      code: `
+class Foo {
+  constructor(public a = true) {}
+}
+       `,
+    },
   ],
 
   invalid: [
@@ -292,20 +299,12 @@ class Foo {
     {
       code: `
 class Foo {
-  constructor(
-    a: number = 5,
-    public b: boolean = true,
-    readonly c: string = 'foo',
-  ) {}
+  constructor(public a: boolean = true) {}
 }
       `,
       output: `
 class Foo {
-  constructor(
-    a = 5,
-    public b = true,
-    readonly c = 'foo',
-  ) {}
+  constructor(public a = true) {}
 }
       `,
       options: [
@@ -318,26 +317,10 @@ class Foo {
         {
           messageId: 'noInferrableType',
           data: {
-            type: 'number',
-          },
-          line: 4,
-          column: 5,
-        },
-        {
-          messageId: 'noInferrableType',
-          data: {
             type: 'boolean',
           },
-          line: 5,
-          column: 12,
-        },
-        {
-          messageId: 'noInferrableType',
-          data: {
-            type: 'string',
-          },
-          line: 6,
-          column: 14,
+          line: 3,
+          column: 22,
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7278
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`TSParameterProperty` just may contain `AssignmentPattern` in `parameter`