### PR TITLE
docs: remove redundant configurations in `recommended` with `recommended-type-checked`

### DIFF
--- a/docs/linting/Typed_Linting.mdx
+++ b/docs/linting/Typed_Linting.mdx
@@ -11,6 +11,7 @@ To tap into TypeScript's additional powers, there are two small changes you need
 module.exports = {
   extends: [
     'eslint:recommended',
+    // Remove this line
     'plugin:@typescript-eslint/recommended',
     // Add this line
     'plugin:@typescript-eslint/recommended-type-checked',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

1. I have checked that both `recommended-type-checked` and `recommended + recommended-type-checked` have same configs in the following ways
    - `npx eslint --print-config target-path | jq .rules` # v6.1.0
    - https://github.com/typescript-eslint/typescript-eslint/blob/9105011681514372a7e851768d83a603fa19e8f2/packages/eslint-plugin/tools/generate-configs.ts#L230-L241
2. So I created this PR because I understood that merging redundant configs is a recommended way since v6.

<details>
<summary>

rendering diff in `yarn nx run website:build && yarn start`

</summary>

Before
---

<img width="731" alt="before" src="https://github.com/typescript-eslint/typescript-eslint/assets/1180335/f325d420-6a12-4cda-9540-02d0c8f58cd3">

After
---

<img width="747" alt="after" src="https://github.com/typescript-eslint/typescript-eslint/assets/1180335/006c5813-41dc-466f-8374-fa7559d31ed7">

</details>

NOTE
---

- [failed CI](https://github.com/typescript-eslint/typescript-eslint/actions/runs/5631010460/job/15257576226) looks related to https://github.com/typescript-eslint/typescript-eslint/issues/7168