### PR TITLE
fix(eslint-plugin): add main to package.json to support commonjs

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -12,6 +12,7 @@
     "LICENSE"
   ],
   "type": "commonjs",
+  "main": "dist/index.js",
   "exports": {
     ".": {
       "types": "./index.d.ts",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7300
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds `main` to the package.json file in order to support older versions of node and related tools.  Find further information in the issue I created (#7300 (Enable commonjs require by adding main to package.json))