### PR TITLE
docs: add await keyword in correct example of no-floating-promises.md

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-floating-promises.md
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.md
@@ -58,7 +58,7 @@ returnsPromise().then(
 
 Promise.reject('value').catch(() => {});
 
-Promise.reject('value').finally(() => {});
+await Promise.reject('value').finally(() => {});
 ```
 
 ## Options


### PR DESCRIPTION
Add await keyword in correct example

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

https://typescript-eslint.io/rules/no-floating-promises/#examples

The sample that was supposed to be correct was not actually the correct code.  
It appears that await is required.

(translated by DeepL)

<img width="693" alt="image" src="https://github.com/typescript-eslint/typescript-eslint/assets/46584540/28ade80a-097f-43c1-8889-cd8228f801c5">

Link: [https://typescript-eslint.io/play/#ts=5.1.6&fileType=.tsx&code=MYew...](https://typescript-eslint.io/play/#ts=5.1.6&fileType=.tsx&code=MYewdgzgLgBAlmUAnJBTYsC8MCGECeiMAFAJQyYB8MA3gFAwyiSwAOSIAtnBKhTGFQB3GAAUO3XsWJoIIADYA3VABoYaAFboo5KutRylqYgHJFOeQFdUJ0qQDcDGOy49Ujp3kLAYAM0uIUHDg%2BlCWSJDirlLk9IyMaGERMGYW1iaOjAC%2BTonhkRJuZAB0UAAWqGDSutQ0MFkOdE5RkqjFmtqm5lY2pMXAOFDAZWQejC1u7ahaGF1pvcW%2BCBby%2BKN0WR7M0EwgKNr8XkRkFLVO22yFvPyCIhNSMgYKymodGDX6hspzPbaNjDghDg4Jdou4mgCCER-IFgmBQvkIPdjLEnAlUEl4alfpl6rkMYjkSVypViGiSB86lkVOSTnoqTTGI1mlc2m8oD90n0BkMRnTavVmeNWVMZhzsVzFst5KtqqdaIL7DAAPTKgSoVAAE1wQJBMAA1qh8EI9pqNkA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1oDN4OBDfMwDmtYtA4BbSshTooiaBOiRwYAL4h1QA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false) 
