### PR TITLE
docs: include 'Contains' notes in recommended configs docs

### DIFF
--- a/docs/linting/Configurations.mdx
+++ b/docs/linting/Configurations.mdx
@@ -48,15 +48,15 @@ module.exports = {
 We recommend that most projects should extend from one of:
 
 - [`recommended`](#recommended): Recommended rules for code correctness that you can drop in without additional configuration.
-- [`recommended-type-checked`](#recommended-type-checked): Additional recommended rules that require type information.
-- [`strict`](#strict): Additional strict rules that can also catch bugs but are more opinionated than recommended rules.
-- [`strict-type-checked`](#strict-type-checked): Additional strict rules require type information.
+- [`recommended-type-checked`](#recommended-type-checked): Contains `recommended` + additional recommended rules that require type information.
+- [`strict`](#strict): Contains `recommended` + additional strict rules that can also catch bugs but are more opinionated than recommended rules.
+- [`strict-type-checked`](#strict-type-checked): Contains `strict` + additional strict rules require type information.
 
 Additionally, we provide a [`stylistic`](#stylistic) config that enforces concise and consistent code.
 We recommend that most projects should extend from either:
 
 - [`stylistic`](#stylistic): Stylistic rules you can drop in without additional configuration.
-- [`stylistic-type-checked`](#stylistic-type-checked): Additional stylistic rules that require type information.
+- [`stylistic-type-checked`](#stylistic-type-checked): Contains `strict` + additional stylistic rules that require type information.
 
 :::note
 These configurations are our recommended starting points, but **you don't need to use them as-is**.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7195
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a "`Contains +`" before each of the four configs that are supersets of others.

Aside: @sajikix's https://zenn.dev/cybozu_frontend/articles/ts-eslint-v6-guide has a really great visualization of the configs. 😄 

cc @marekdedic 