### PR TITLE
docs: fix typo in Custom Rules doc page

### DIFF
--- a/docs/developers/Custom_Rules.mdx
+++ b/docs/developers/Custom_Rules.mdx
@@ -243,7 +243,7 @@ export const rule = createRule({
         const type = services.getTypeAtLocation(node);
 
         // 3. Check the TS type using the TypeScript APIs
-        if (tsutils.isTypeFlagSet(nodeType, ts.TypeFlags.EnumLike)) {
+        if (tsutils.isTypeFlagSet(type, ts.TypeFlags.EnumLike)) {
           context.report({
             messageId: 'loopOverEnum',
             node: node.right,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] ~~Addresses an existing open issue~~
- [ ] ~~That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~~
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR fixes a typo that causes the ["Typed Rules" example on the "Custom Rules" doc page](https://typescript-eslint.io/developers/custom-rules#typed-rules) not to typecheck.