### PR TITLE
docs: mention granular unit tests preference under Local Development

### DIFF
--- a/docs/contributing/Local_Development.mdx
+++ b/docs/contributing/Local_Development.mdx
@@ -66,6 +66,16 @@ Coverage reports are be generated locally whenever `yarn test` is run.
 
 The `codecov` bot should also comment on your PR with the percentage, as well as links to the line-by-line coverage of each file touched by your PR.
 
+#### Granular Unit Tests
+
+Most tests in most packages are set up as small, self-contained unit tests.
+We generally prefer that to keep tests and their failure reports granular.
+
+For rule tests we recommend, when reasonable:
+
+- Including both `valid` and `invalid` code changes in most PRs that affect rule behavior
+- Limiting to one error per `invalid` case
+
 ### Type Checking
 
 All code should pass TypeScript type checking.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6887
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I ended up filing this under _Local Development_ instead of _Pull Requests_ as the latter has dealt mostly with the PR itself.