### PR TITLE
fix(scope-manager): correct decorators(.length) check in ClassVisitor for methods

### DIFF
--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -536,6 +536,18 @@ ruleTester.run('consistent-type-imports', rule, {
       parserOptions: withMetaConfigParserOptions,
     },
 
+    // https://github.com/typescript-eslint/typescript-eslint/issues/7327
+    {
+      code: `
+        import type { ClassA } from './classA';
+
+        export class ClassB {
+          public constructor(node: ClassA) {}
+        }
+      `,
+      parserOptions: withMetaConfigParserOptions,
+    },
+
     // https://github.com/typescript-eslint/typescript-eslint/issues/2989
     `
 import type * as constants from './constants';

--- a/packages/scope-manager/src/referencer/ClassVisitor.ts
+++ b/packages/scope-manager/src/referencer/ClassVisitor.ts
@@ -192,7 +192,7 @@ class ClassVisitor extends Visitor {
     if (
       !withMethodDecorators &&
       methodNode.kind === 'constructor' &&
-      this.#classNode.decorators
+      this.#classNode.decorators.length
     ) {
       withMethodDecorators = true;
     }

--- a/packages/scope-manager/tests/fixtures/class/emit-metadata/nested-class-inner.ts.shot
+++ b/packages/scope-manager/tests/fixtures/class/emit-metadata/nested-class-inner.ts.shot
@@ -57,7 +57,7 @@ ScopeManager {
           identifier: Identifier<"T">,
           isRead: true,
           isTypeReference: true,
-          isValueReference: true,
+          isValueReference: false,
           isWrite: false,
           resolved: Variable$5,
         },

--- a/packages/scope-manager/tests/fixtures/class/emit-metadata/nested-class-outer.ts.shot
+++ b/packages/scope-manager/tests/fixtures/class/emit-metadata/nested-class-outer.ts.shot
@@ -65,7 +65,7 @@ ScopeManager {
           identifier: Identifier<"T">,
           isRead: true,
           isTypeReference: true,
-          isValueReference: true,
+          isValueReference: false,
           isWrite: false,
           resolved: Variable$5,
         },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7327
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a missing `.decorators` check and updates snapshots.

I tried for a bit to get a `@typescript-eslint/consistent-type-imports` unit test to fail without the change, but couldn't.