### PR TITLE
docs: update info about the supported TypeScript version range

### DIFF
--- a/docs/users/Versioning.mdx
+++ b/docs/users/Versioning.mdx
@@ -48,7 +48,7 @@ Support for specific Current status releases are considered periodically.
 
 ### TypeScript
 
-> The version range of TypeScript currently supported is `>=4.3.5 <5.1.0`.
+> The version range of TypeScript currently supported is `>=4.3.5 <5.2.0`.
 
 Note that we mirror [DefinitelyTyped's version support window](https://github.com/DefinitelyTyped/DefinitelyTyped/#support-window) - meaning we only support versions of TypeScript less than 2 years old.
 

--- a/packages/typescript-estree/src/parseSettings/warnAboutTSVersion.ts
+++ b/packages/typescript-estree/src/parseSettings/warnAboutTSVersion.ts
@@ -3,7 +3,7 @@ import * as ts from 'typescript';
 
 import type { ParseSettings } from './index';
 /**
- * This needs to be kept in sync with /docs/maintenance/Versioning.mdx
+ * This needs to be kept in sync with /docs/users/Versioning.mdx
  * in the typescript-eslint monorepo
  */
 const SUPPORTED_TYPESCRIPT_VERSIONS = '>=4.3.5 <5.2.0';


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7320
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Just a quick fix. In the future this should be handled appropriately as described here: https://github.com/typescript-eslint/typescript-eslint/issues/6389
