### PR TITLE
chore: enabled no-else-return internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,6 +122,7 @@ module.exports = {
         null: 'never',
       },
     ],
+    'no-else-return': 'error',
     'no-mixed-operators': 'error',
     'no-console': 'error',
     'no-process-exit': 'error',

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -296,25 +296,22 @@ export default util.createRule<Options, MessageIds>({
                             messageId: 'aImportInDecoMeta',
                             data: { typeImports },
                           };
-                        } else {
-                          return {
-                            messageId: 'aImportIsOnlyTypes',
-                            data: { typeImports },
-                          };
                         }
-                      } else {
-                        if (isTypeImport) {
-                          return {
-                            messageId: 'someImportsInDecoMeta',
-                            data: { typeImports }, // typeImports are all the value specifiers that are in the type position
-                          };
-                        } else {
-                          return {
-                            messageId: 'someImportsAreOnlyTypes',
-                            data: { typeImports }, // typeImports are all the type specifiers in the value position
-                          };
-                        }
+                        return {
+                          messageId: 'aImportIsOnlyTypes',
+                          data: { typeImports },
+                        };
                       }
+                      if (isTypeImport) {
+                        return {
+                          messageId: 'someImportsInDecoMeta',
+                          data: { typeImports }, // typeImports are all the value specifiers that are in the type position
+                        };
+                      }
+                      return {
+                        messageId: 'someImportsAreOnlyTypes',
+                        data: { typeImports }, // typeImports are all the type specifiers in the value position
+                      };
                     })();
 
                     context.report({

--- a/packages/eslint-plugin/src/rules/indent.ts
+++ b/packages/eslint-plugin/src/rules/indent.ts
@@ -159,21 +159,20 @@ export default util.createRule<Options, MessageIds>({
           type,
           ...base,
         } as TSESTree.Property;
-      } else {
-        return {
-          type,
-          accessibility: undefined,
-          declare: false,
-          decorators: [],
-          definite: false,
-          optional: false,
-          override: false,
-          readonly: false,
-          static: false,
-          typeAnnotation: undefined,
-          ...base,
-        } as TSESTree.PropertyDefinition;
       }
+      return {
+        type,
+        accessibility: undefined,
+        declare: false,
+        decorators: [],
+        definite: false,
+        optional: false,
+        override: false,
+        readonly: false,
+        static: false,
+        typeAnnotation: undefined,
+        ...base,
+      } as TSESTree.PropertyDefinition;
     }
 
     return Object.assign({}, rules, {

--- a/packages/eslint-plugin/src/rules/key-spacing.ts
+++ b/packages/eslint-plugin/src/rules/key-spacing.ts
@@ -143,12 +143,11 @@ export default util.createRule<Options, MessageIds>({
                 typeAnnotation.range[0] - difference,
                 typeAnnotation.range[0],
               ]);
-            } else {
-              return fixer.insertTextBefore(
-                typeAnnotation,
-                ' '.repeat(-difference),
-              );
             }
+            return fixer.insertTextBefore(
+              typeAnnotation,
+              ' '.repeat(-difference),
+            );
           },
           data: {
             computed: '',
@@ -177,12 +176,11 @@ export default util.createRule<Options, MessageIds>({
                 typeAnnotation.typeAnnotation.range[0] - difference,
                 typeAnnotation.typeAnnotation.range[0],
               ]);
-            } else {
-              return fixer.insertTextBefore(
-                typeAnnotation.typeAnnotation,
-                ' '.repeat(-difference),
-              );
             }
+            return fixer.insertTextBefore(
+              typeAnnotation.typeAnnotation,
+              ' '.repeat(-difference),
+            );
           },
           data: {
             computed: '',
@@ -314,9 +312,8 @@ export default util.createRule<Options, MessageIds>({
                   toCheck.range[0] - difference,
                   toCheck.range[0],
                 ]);
-              } else {
-                return fixer.insertTextBefore(toCheck, ' '.repeat(-difference));
               }
+              return fixer.insertTextBefore(toCheck, ' '.repeat(-difference));
             },
             data: {
               computed: '',

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -114,15 +114,14 @@ export default util.createRule<Options, MessageId>({
                     );
                     if (isHigherPrecedenceThanUnary(tsNode)) {
                       return fixer.insertTextBefore(node, 'void ');
-                    } else {
-                      return [
-                        fixer.insertTextBefore(node, 'void ('),
-                        fixer.insertTextAfterRange(
-                          [expression.range[1], expression.range[1]],
-                          ')',
-                        ),
-                      ];
                     }
+                    return [
+                      fixer.insertTextBefore(node, 'void ('),
+                      fixer.insertTextAfterRange(
+                        [expression.range[1], expression.range[1]],
+                        ')',
+                      ),
+                    ];
                   },
                 },
               ],
@@ -151,15 +150,14 @@ export default util.createRule<Options, MessageId>({
                     );
                     if (isHigherPrecedenceThanUnary(tsNode)) {
                       return fixer.insertTextBefore(node, 'await ');
-                    } else {
-                      return [
-                        fixer.insertTextBefore(node, 'await ('),
-                        fixer.insertTextAfterRange(
-                          [expression.range[1], expression.range[1]],
-                          ')',
-                        ),
-                      ];
                     }
+                    return [
+                      fixer.insertTextBefore(node, 'await ('),
+                      fixer.insertTextAfterRange(
+                        [expression.range[1], expression.range[1]],
+                        ')',
+                      ),
+                    ];
                   },
                 },
               ],
@@ -240,18 +238,16 @@ export default util.createRule<Options, MessageId>({
         if (catchRejectionHandler) {
           if (isValidRejectionHandler(catchRejectionHandler)) {
             return { isUnhandled: false };
-          } else {
-            return { isUnhandled: true, nonFunctionHandler: true };
           }
+          return { isUnhandled: true, nonFunctionHandler: true };
         }
 
         const thenRejectionHandler = getRejectionHandlerFromThenCall(node);
         if (thenRejectionHandler) {
           if (isValidRejectionHandler(thenRejectionHandler)) {
             return { isUnhandled: false };
-          } else {
-            return { isUnhandled: true, nonFunctionHandler: true };
           }
+          return { isUnhandled: true, nonFunctionHandler: true };
         }
 
         // `x.finally()` is transparent to resolution of the promise, so check `x`.
@@ -269,9 +265,8 @@ export default util.createRule<Options, MessageId>({
         const alternateResult = isUnhandledPromise(checker, node.alternate);
         if (alternateResult.isUnhandled) {
           return alternateResult;
-        } else {
-          return isUnhandledPromise(checker, node.consequent);
         }
+        return isUnhandledPromise(checker, node.consequent);
       } else if (
         node.type === AST_NODE_TYPES.MemberExpression ||
         node.type === AST_NODE_TYPES.Identifier ||
@@ -285,9 +280,8 @@ export default util.createRule<Options, MessageId>({
         const leftResult = isUnhandledPromise(checker, node.left);
         if (leftResult.isUnhandled) {
           return leftResult;
-        } else {
-          return isUnhandledPromise(checker, node.right);
         }
+        return isUnhandledPromise(checker, node.right);
       }
 
       // We conservatively return false for all other types of expressions because
@@ -365,9 +359,8 @@ function getRejectionHandlerFromCatchCall(
     expression.arguments.length >= 1
   ) {
     return expression.arguments[0];
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 function getRejectionHandlerFromThenCall(
@@ -380,9 +373,8 @@ function getRejectionHandlerFromThenCall(
     expression.arguments.length >= 2
   ) {
     return expression.arguments[1];
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 function getObjectFromFinallyCall(

--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -537,11 +537,10 @@ export default util.createRule<Options, MessageIds>({
           line: identifier.loc.start.line,
           column: identifier.loc.start.column + 1,
         };
-      } else {
-        return {
-          global: true,
-        };
       }
+      return {
+        global: true,
+      };
     }
 
     /**

--- a/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
+++ b/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
@@ -50,11 +50,8 @@ export default util.createRule({
           }
         }
         return false;
-      } else {
-        return (
-          (type.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) !== 0
-        );
       }
+      return (type.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) !== 0;
     };
 
     const sameTypeWithoutNullish = (

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -333,16 +333,15 @@ function getFixer(
           left: sourceCode.getText(lastOperand.node.left),
           right: unaryOperator + newCode,
         };
-      } else {
-        const unaryOperator =
-          lastOperand.node.left.type === AST_NODE_TYPES.UnaryExpression
-            ? lastOperand.node.left.operator + ' '
-            : '';
-        return {
-          left: unaryOperator + newCode,
-          right: sourceCode.getText(lastOperand.node.right),
-        };
       }
+      const unaryOperator =
+        lastOperand.node.left.type === AST_NODE_TYPES.UnaryExpression
+          ? lastOperand.node.left.operator + ' '
+          : '';
+      return {
+        left: unaryOperator + newCode,
+        right: sourceCode.getText(lastOperand.node.right),
+      };
     })();
 
     newCode = `${left} ${operator} ${right}`;

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
@@ -144,13 +144,12 @@ export function gatherLogicalOperands(
               comparedValue: comparedValueRight,
               isYoda: false,
             };
-          } else {
-            return {
-              comparedExpression: operand.right,
-              comparedValue: getComparisonValueType(operand.left),
-              isYoda: true,
-            };
           }
+          return {
+            comparedExpression: operand.right,
+            comparedValue: getComparisonValueType(operand.left),
+            isYoda: true,
+          };
         })();
 
         if (comparedValue === ComparisonValueType.UndefinedStringLiteral) {

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -156,12 +156,11 @@ export default util.createRule({
     ): TSESLint.RuleFix | TSESLint.RuleFix[] {
       if (isHighPrecendence) {
         return fixer.insertTextBefore(node, 'await ');
-      } else {
-        return [
-          fixer.insertTextBefore(node, 'await ('),
-          fixer.insertTextAfter(node, ')'),
-        ];
       }
+      return [
+        fixer.insertTextBefore(node, 'await ('),
+        fixer.insertTextAfter(node, ')'),
+      ];
     }
 
     function isHigherPrecedenceThanAwait(node: ts.Node): boolean {

--- a/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
+++ b/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
@@ -76,9 +76,8 @@ function getIdentifierRules(
     return rules.variable;
   } else if (isFunctionOrFunctionType(scope)) {
     return rules.parameter;
-  } else {
-    return rules.colon;
   }
+  return rules.colon;
 }
 
 function getRules(
@@ -95,9 +94,8 @@ function getRules(
     return rules.property;
   } else if (isFunction(scope)) {
     return rules.returnType;
-  } else {
-    return rules.colon;
   }
+  return rules.colon;
 }
 
 export default util.createRule<Options, MessageIds>({

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -135,12 +135,11 @@ function getNameFromMember(
         type: MemberNameType.Quoted,
         name: `"${name}"`,
       };
-    } else {
-      return {
-        type: MemberNameType.Normal,
-        name,
-      };
     }
+    return {
+      type: MemberNameType.Normal,
+      name,
+    };
   }
 
   return {

--- a/packages/type-utils/src/predicates.ts
+++ b/packages/type-utils/src/predicates.ts
@@ -26,9 +26,8 @@ export function isNullableType(
 
   if (allowUndefined) {
     return (flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined)) !== 0;
-  } else {
-    return (flags & ts.TypeFlags.Null) !== 0;
   }
+  return (flags & ts.TypeFlags.Null) !== 0;
 }
 
 /**

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -186,22 +186,21 @@ export class Converter {
             exportKind: 'value',
           },
         );
-      } else {
-        const isType =
-          result.type === AST_NODE_TYPES.TSInterfaceDeclaration ||
-          result.type === AST_NODE_TYPES.TSTypeAliasDeclaration;
-        const isDeclare = 'declare' in result && result.declare === true;
-        return this.createNode<TSESTree.ExportNamedDeclaration>(node, {
-          type: AST_NODE_TYPES.ExportNamedDeclaration,
-          // @ts-expect-error - TODO, narrow the types here
-          declaration: result,
-          specifiers: [],
-          source: null,
-          exportKind: isType || isDeclare ? 'type' : 'value',
-          range: [exportKeyword.getStart(this.ast), result.range[1]],
-          assertions: [],
-        });
       }
+      const isType =
+        result.type === AST_NODE_TYPES.TSInterfaceDeclaration ||
+        result.type === AST_NODE_TYPES.TSTypeAliasDeclaration;
+      const isDeclare = 'declare' in result && result.declare === true;
+      return this.createNode<TSESTree.ExportNamedDeclaration>(node, {
+        type: AST_NODE_TYPES.ExportNamedDeclaration,
+        // @ts-expect-error - TODO, narrow the types here
+        declaration: result,
+        specifiers: [],
+        source: null,
+        exportKind: isType || isDeclare ? 'type' : 'value',
+        range: [exportKeyword.getStart(this.ast), result.range[1]],
+        assertions: [],
+      });
     }
 
     return result;
@@ -329,9 +328,8 @@ export class Converter {
               const raw = child.expression.raw;
               child.directive = raw.slice(1, -1);
               return child; // child can be null, but it's filtered below
-            } else {
-              allowDirectives = false;
             }
+            allowDirectives = false;
           }
           return child; // child can be null, but it's filtered below
         })
@@ -1034,12 +1032,11 @@ export class Converter {
             optional: false,
             typeAnnotation: undefined,
           });
-        } else {
-          return this.createNode<TSESTree.ArrayExpression>(node, {
-            type: AST_NODE_TYPES.ArrayExpression,
-            elements: node.elements.map(el => this.convertChild(el)),
-          });
         }
+        return this.createNode<TSESTree.ArrayExpression>(node, {
+          type: AST_NODE_TYPES.ArrayExpression,
+          elements: node.elements.map(el => this.convertChild(el)),
+        });
       }
 
       case SyntaxKind.ObjectLiteralExpression: {
@@ -1147,18 +1144,17 @@ export class Converter {
             shorthand: true,
             kind: 'init',
           });
-        } else {
-          return this.createNode<TSESTree.Property>(node, {
-            type: AST_NODE_TYPES.Property,
-            computed: false,
-            key: this.convertChild(node.name),
-            kind: 'init',
-            method: false,
-            optional: false,
-            shorthand: true,
-            value: this.convertChild(node.name),
-          });
         }
+        return this.createNode<TSESTree.Property>(node, {
+          type: AST_NODE_TYPES.Property,
+          computed: false,
+          key: this.convertChild(node.name),
+          kind: 'init',
+          method: false,
+          optional: false,
+          shorthand: true,
+          value: this.convertChild(node.name),
+        });
       }
 
       case SyntaxKind.ComputedPropertyName:
@@ -1456,49 +1452,47 @@ export class Converter {
               typeAnnotation: undefined,
               value: undefined,
             });
-          } else {
-            return arrayItem;
           }
-        } else {
-          let result: TSESTree.Property | TSESTree.RestElement;
-          if (node.dotDotDotToken) {
-            result = this.createNode<TSESTree.RestElement>(node, {
-              type: AST_NODE_TYPES.RestElement,
-              argument: this.convertChild(node.propertyName ?? node.name),
-              decorators: [],
-              optional: false,
-              typeAnnotation: undefined,
-              value: undefined,
-            });
-          } else {
-            result = this.createNode<TSESTree.Property>(node, {
-              type: AST_NODE_TYPES.Property,
-              key: this.convertChild(node.propertyName ?? node.name),
-              value: this.convertChild(node.name),
-              computed: Boolean(
-                node.propertyName &&
-                  node.propertyName.kind === SyntaxKind.ComputedPropertyName,
-              ),
-              method: false,
-              optional: false,
-              shorthand: !node.propertyName,
-              kind: 'init',
-            });
-          }
-
-          if (node.initializer) {
-            result.value = this.createNode<TSESTree.AssignmentPattern>(node, {
-              type: AST_NODE_TYPES.AssignmentPattern,
-              decorators: [],
-              left: this.convertChild(node.name),
-              optional: false,
-              range: [node.name.getStart(this.ast), node.initializer.end],
-              right: this.convertChild(node.initializer),
-              typeAnnotation: undefined,
-            });
-          }
-          return result;
+          return arrayItem;
         }
+        let result: TSESTree.Property | TSESTree.RestElement;
+        if (node.dotDotDotToken) {
+          result = this.createNode<TSESTree.RestElement>(node, {
+            type: AST_NODE_TYPES.RestElement,
+            argument: this.convertChild(node.propertyName ?? node.name),
+            decorators: [],
+            optional: false,
+            typeAnnotation: undefined,
+            value: undefined,
+          });
+        } else {
+          result = this.createNode<TSESTree.Property>(node, {
+            type: AST_NODE_TYPES.Property,
+            key: this.convertChild(node.propertyName ?? node.name),
+            value: this.convertChild(node.name),
+            computed: Boolean(
+              node.propertyName &&
+                node.propertyName.kind === SyntaxKind.ComputedPropertyName,
+            ),
+            method: false,
+            optional: false,
+            shorthand: !node.propertyName,
+            kind: 'init',
+          });
+        }
+
+        if (node.initializer) {
+          result.value = this.createNode<TSESTree.AssignmentPattern>(node, {
+            type: AST_NODE_TYPES.AssignmentPattern,
+            decorators: [],
+            left: this.convertChild(node.name),
+            optional: false,
+            range: [node.name.getStart(this.ast), node.initializer.end],
+            right: this.convertChild(node.initializer),
+            typeAnnotation: undefined,
+          });
+        }
+        return result;
       }
 
       case SyntaxKind.ArrowFunction: {
@@ -1621,12 +1615,11 @@ export class Converter {
             typeAnnotation: undefined,
             value: undefined,
           });
-        } else {
-          return this.createNode<TSESTree.SpreadElement>(node, {
-            type: AST_NODE_TYPES.SpreadElement,
-            argument: this.convertChild(node.expression),
-          });
         }
+        return this.createNode<TSESTree.SpreadElement>(node, {
+          type: AST_NODE_TYPES.SpreadElement,
+          argument: this.convertChild(node.expression),
+        });
       }
 
       case SyntaxKind.Parameter: {
@@ -1899,24 +1892,23 @@ export class Converter {
             declaration: null,
             assertions: this.convertAssertClasue(node.assertClause),
           });
-        } else {
-          this.assertModuleSpecifier(node, false);
-          return this.createNode<TSESTree.ExportAllDeclaration>(node, {
-            type: AST_NODE_TYPES.ExportAllDeclaration,
-            source: this.convertChild(node.moduleSpecifier),
-            exportKind: node.isTypeOnly ? 'type' : 'value',
-            exported:
-              // note - for compat with 3.7.x, where node.exportClause is always undefined and
-              //        SyntaxKind.NamespaceExport does not exist yet (i.e. is undefined), this
-              //        cannot be shortened to an optional chain, or else you end up with
-              //        undefined === undefined, and the true path will hard error at runtime
-              node.exportClause &&
-              node.exportClause.kind === SyntaxKind.NamespaceExport
-                ? this.convertChild(node.exportClause.name)
-                : null,
-            assertions: this.convertAssertClasue(node.assertClause),
-          });
         }
+        this.assertModuleSpecifier(node, false);
+        return this.createNode<TSESTree.ExportAllDeclaration>(node, {
+          type: AST_NODE_TYPES.ExportAllDeclaration,
+          source: this.convertChild(node.moduleSpecifier),
+          exportKind: node.isTypeOnly ? 'type' : 'value',
+          exported:
+            // note - for compat with 3.7.x, where node.exportClause is always undefined and
+            //        SyntaxKind.NamespaceExport does not exist yet (i.e. is undefined), this
+            //        cannot be shortened to an optional chain, or else you end up with
+            //        undefined === undefined, and the true path will hard error at runtime
+            node.exportClause &&
+            node.exportClause.kind === SyntaxKind.NamespaceExport
+              ? this.convertChild(node.exportClause.name)
+              : null,
+          assertions: this.convertAssertClasue(node.assertClause),
+        });
       }
 
       case SyntaxKind.ExportSpecifier:
@@ -1933,13 +1925,12 @@ export class Converter {
             type: AST_NODE_TYPES.TSExportAssignment,
             expression: this.convertChild(node.expression),
           });
-        } else {
-          return this.createNode<TSESTree.ExportDefaultDeclaration>(node, {
-            type: AST_NODE_TYPES.ExportDefaultDeclaration,
-            declaration: this.convertChild(node.expression),
-            exportKind: 'value',
-          });
         }
+        return this.createNode<TSESTree.ExportDefaultDeclaration>(node, {
+          type: AST_NODE_TYPES.ExportDefaultDeclaration,
+          declaration: this.convertChild(node.expression),
+          exportKind: 'value',
+        });
 
       // Unary Operations
 
@@ -1956,14 +1947,13 @@ export class Converter {
             prefix: node.kind === SyntaxKind.PrefixUnaryExpression,
             argument: this.convertChild(node.operand),
           });
-        } else {
-          return this.createNode<TSESTree.UnaryExpression>(node, {
-            type: AST_NODE_TYPES.UnaryExpression,
-            operator,
-            prefix: node.kind === SyntaxKind.PrefixUnaryExpression,
-            argument: this.convertChild(node.operand),
-          });
         }
+        return this.createNode<TSESTree.UnaryExpression>(node, {
+          type: AST_NODE_TYPES.UnaryExpression,
+          operator,
+          prefix: node.kind === SyntaxKind.PrefixUnaryExpression,
+          argument: this.convertChild(node.operand),
+        });
       }
 
       case SyntaxKind.DeleteExpression:
@@ -2021,35 +2011,34 @@ export class Converter {
             this.convertChild(node.right) as TSESTree.Expression,
           );
           return result;
-        } else {
-          const expressionType = getBinaryExpressionType(node.operatorToken);
-          if (
-            this.allowPattern &&
-            expressionType.type === AST_NODE_TYPES.AssignmentExpression
-          ) {
-            return this.createNode<TSESTree.AssignmentPattern>(node, {
-              type: AST_NODE_TYPES.AssignmentPattern,
-              decorators: [],
-              left: this.convertPattern(node.left, node),
-              optional: false,
-              right: this.convertChild(node.right),
-              typeAnnotation: undefined,
-            });
-          }
-          return this.createNode<
-            | TSESTree.AssignmentExpression
-            | TSESTree.BinaryExpression
-            | TSESTree.LogicalExpression
-          >(node, {
-            ...expressionType,
-            left: this.converter(
-              node.left,
-              node,
-              expressionType.type === AST_NODE_TYPES.AssignmentExpression,
-            ),
+        }
+        const expressionType = getBinaryExpressionType(node.operatorToken);
+        if (
+          this.allowPattern &&
+          expressionType.type === AST_NODE_TYPES.AssignmentExpression
+        ) {
+          return this.createNode<TSESTree.AssignmentPattern>(node, {
+            type: AST_NODE_TYPES.AssignmentPattern,
+            decorators: [],
+            left: this.convertPattern(node.left, node),
+            optional: false,
             right: this.convertChild(node.right),
+            typeAnnotation: undefined,
           });
         }
+        return this.createNode<
+          | TSESTree.AssignmentExpression
+          | TSESTree.BinaryExpression
+          | TSESTree.LogicalExpression
+        >(node, {
+          ...expressionType,
+          left: this.converter(
+            node.left,
+            node,
+            expressionType.type === AST_NODE_TYPES.AssignmentExpression,
+          ),
+          right: this.convertChild(node.right),
+        });
       }
 
       case SyntaxKind.PropertyAccessExpression: {
@@ -2386,12 +2375,11 @@ export class Converter {
             type: AST_NODE_TYPES.JSXSpreadChild,
             expression,
           });
-        } else {
-          return this.createNode<TSESTree.JSXExpressionContainer>(node, {
-            type: AST_NODE_TYPES.JSXExpressionContainer,
-            expression,
-          });
         }
+        return this.createNode<TSESTree.JSXExpressionContainer>(node, {
+          type: AST_NODE_TYPES.JSXExpressionContainer,
+          expression,
+        });
       }
 
       case SyntaxKind.JsxAttribute: {
@@ -2993,12 +2981,12 @@ export class Converter {
               type: AST_NODE_TYPES.TSNullKeyword,
             },
           );
-        } else {
-          return this.createNode<TSESTree.TSLiteralType>(node, {
-            type: AST_NODE_TYPES.TSLiteralType,
-            literal: this.convertChild(node.literal),
-          });
         }
+
+        return this.createNode<TSESTree.TSLiteralType>(node, {
+          type: AST_NODE_TYPES.TSLiteralType,
+          literal: this.convertChild(node.literal),
+        });
       }
       case SyntaxKind.TypeAssertionExpression: {
         return this.createNode<TSESTree.TSTypeAssertion>(node, {

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -639,16 +639,15 @@ export function convertToken(
         flags: value.slice(value.lastIndexOf('/') + 1),
       },
     };
-  } else {
-    // @ts-expect-error TS is complaining about `value` not being the correct
-    // type but it is
-    return {
-      type: tokenType,
-      value,
-      range,
-      loc,
-    };
   }
+  // @ts-expect-error TS is complaining about `value` not being the correct
+  // type but it is
+  return {
+    type: tokenType,
+    value,
+    range,
+    loc,
+  };
 }
 
 /**

--- a/packages/typescript-estree/src/parseSettings/ExpiringCache.ts
+++ b/packages/typescript-estree/src/parseSettings/ExpiringCache.ts
@@ -49,10 +49,9 @@ export class ExpiringCache<TKey, TValue> implements CacheLike<TKey, TValue> {
       if (ageSeconds < this.#cacheDurationSeconds) {
         // cache hit woo!
         return entry.value;
-      } else {
-        // key has expired - clean it up to free up memory
-        this.#map.delete(key);
       }
+      // key has expired - clean it up to free up memory
+      this.#map.delete(key);
     }
     // no hit :'(
     return undefined;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6822
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Enables the rule and runs `yarn lint --fix`.

In retrospect, I probably could have labeled the issue as `good first issue`. Ah well.