### PR TITLE
Update no-explicit-any.md

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-explicit-any.md
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.md
@@ -161,7 +161,7 @@ interface Garply {
 **Difficult-to-represent TypeScript types**.
 Some code patterns can be difficult to represent exactly in the TypeScript type system. For example, functional programming concepts such as composing and piping sometimes necessitate using `any`.
 
-```TypeScript
+```ts
 // eslint-disable no-explicit-any
 type a2a = (x: any) => any;
 const pipe = (...fns: a2a[]) => (x: any) => fns.reduce((y, f) => f(y), x);

--- a/packages/eslint-plugin/docs/rules/no-explicit-any.md
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.md
@@ -158,7 +158,8 @@ interface Garply {
 
 ## When Not To Use It
 
-**Higher Order Functions**. If you're typing a higher order function such as `compose`, `pipe`, etc, you may need `any` because TypeScript types can't always fully represent functional JavaScript patterns. For example, functions like `compose` and `pipe` compose many different functions with many different types which TypeScript can't accurately represent. Instead, you can assign explicit types later to the returned functions, e.g.:
+**Difficult-to-represent TypeScript types**.
+Some code patterns can be difficult to represent exactly in the TypeScript type system, and/or expose legitimate edge cases for using `any`. For example, functional programming concepts such as composing and piping sometimes necessitate using `any`.
 
 ```TypeScript
 // eslint-disable no-explicit-any

--- a/packages/eslint-plugin/docs/rules/no-explicit-any.md
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.md
@@ -158,21 +158,23 @@ interface Garply {
 
 ## When Not To Use It
 
-**Higher Order Functions**. If you're typing a higher order function such as `compose`, `pipe`, etc, you may need `any` because TypeScript types are not fully co-expressive with idiomatic functional JavaScript. Such functions are intentionally generic, and you can assign explicit types later to the returned functions, e.g.:
+**Higher Order Functions**. If you're typing a higher order function such as `compose`, `pipe`, etc, you may need `any` because TypeScript types can't always fully represent functional JavaScript patterns. For example, functions like `compose` and `pipe` compose many different functions with many different types which TypeScript can't accurately represent. Instead, you can assign explicit types later to the returned functions, e.g.:
 
 ```TypeScript
-// eslint-disable-next-line no-explicit-any
+// eslint-disable no-explicit-any
 type a2a = (x: any) => any;
-type compose = (...fns: a2a[]) => a2a;
-const pipe: compose = (...fns) => x => fns.reduce((y, f) => f(y), x);
-const compose: compose = (...fns) => x => fns.reduceRight((y, f) => f(y), x);
+const pipe = (...fns: a2a[]) => (x: any) => fns.reduce((y, f) => f(y), x);
+const compose = (...fns: a2a[]) => (x: any) => fns.reduceRight((y, f) => f(y), x);
+// eslint-enable no-explicit-any
 
 type n2n = (n: number) => number;
 const g: n2n = n => n + 1;
 const f: n2n = n => n * 2;
+type n2s = (n: number) => string;
+const exclaim:n2s = (n) => `${n}!`;
 
-const h: n2n = pipe(g, f);
-const j: n2n = compose(f, g);
+const h: n2s = pipe(g, f, exclaim);
+const j: n2s = compose(exclaim, f, g);
 ```
 
 **Unknown Types**. If an unknown type or a library without typings is used

--- a/packages/eslint-plugin/docs/rules/no-explicit-any.md
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.md
@@ -6,8 +6,8 @@ description: 'Disallow the `any` type.'
 >
 > See **https://typescript-eslint.io/rules/no-explicit-any** for documentation.
 
-The `any` type in TypeScript is a dangerous "escape hatch" from the type system.
-Using `any` disables many type checking rules and is generally best used only as a last resort or when prototyping code.
+The `any` type in TypeScript is a potentially dangerous "escape hatch" from the type system.
+Using `any` disables many type checking rules and is generally best used only when it's required or when prototyping code.
 This rule reports on explicit uses of the `any` keyword as a type annotation.
 
 > TypeScript's `--noImplicitAny` compiler option prevents an implied `any`, but doesn't prevent `any` from being explicitly used the way this rule does.
@@ -158,7 +158,24 @@ interface Garply {
 
 ## When Not To Use It
 
-If an unknown type or a library without typings is used
+**Higher Order Functions**. If you're typing a higher order function such as `compose`, `pipe`, etc, you may need `any` because TypeScript types are not fully co-expressive with idiomatic functional JavaScript. Such functions are intentionally generic, and you can assign explicit types later to the returned functions, e.g.:
+
+```TypeScript
+// eslint-disable-next-line no-explicit-any
+type a2a = (x: any) => any;
+type compose = (...fns: a2a[]) => a2a;
+const pipe: compose = (...fns) => x => fns.reduce((y, f) => f(y), x);
+const compose: compose = (...fns) => x => fns.reduceRight((y, f) => f(y), x);
+
+type n2n = (n: number) => number;
+const g: n2n = n => n + 1;
+const f: n2n = n => n * 2;
+
+const h: n2n = pipe(g, f);
+const j: n2n = compose(f, g);
+```
+
+**Unknown Types**. If an unknown type or a library without typings is used
 and you want to be able to specify `any`.
 
 ## Related To

--- a/packages/eslint-plugin/docs/rules/no-explicit-any.md
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.md
@@ -7,7 +7,7 @@ description: 'Disallow the `any` type.'
 > See **https://typescript-eslint.io/rules/no-explicit-any** for documentation.
 
 The `any` type in TypeScript is a potentially dangerous "escape hatch" from the type system.
-Using `any` disables many type checking rules and is generally best used only when it's required or when prototyping code.
+Using `any` disables many type checking rules and is generally best used only as a last resort or when prototyping code.
 This rule reports on explicit uses of the `any` keyword as a type annotation.
 
 > TypeScript's `--noImplicitAny` compiler option prevents an implied `any`, but doesn't prevent `any` from being explicitly used the way this rule does.

--- a/packages/eslint-plugin/docs/rules/no-explicit-any.md
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.md
@@ -159,7 +159,7 @@ interface Garply {
 ## When Not To Use It
 
 **Difficult-to-represent TypeScript types**.
-Some code patterns can be difficult to represent exactly in the TypeScript type system, and/or expose legitimate edge cases for using `any`. For example, functional programming concepts such as composing and piping sometimes necessitate using `any`.
+Some code patterns can be difficult to represent exactly in the TypeScript type system. For example, functional programming concepts such as composing and piping sometimes necessitate using `any`.
 
 ```TypeScript
 // eslint-disable no-explicit-any


### PR DESCRIPTION
Fix potentially misleading statement about explicit `any` - which is sometimes required for functional code.

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

**Notes:**

This checklist discourages people from contributing PRs by trying to force us to wait around for "accepting prs". If you don't want to accept a PR, just close it. Bonus: It gives you one spot to decide whether to accept a PR, instead of 2.

- [x] Addresses an existing open issue: fixes #7354
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Provide an example of when explicit `any` may be needed, and how to disable the rule on an as-needed basis.
