### PR TITLE
docs: add 'include an emoji' note in contributing guides

### DIFF
--- a/docs/contributing/Issues.mdx
+++ b/docs/contributing/Issues.mdx
@@ -36,3 +36,11 @@ You can instead:
 - Publicly toot [@tseslint on Mastodon](https://fosstodon.org/@tseslint) or tweet [@tseslint on Twitter](https://twitter.com/tseslint)
 
 > Note that requests to add documentation _are_ allowed, even encouraged! 📝
+
+---
+
+:::note Appreciation Note
+Thanks for reading through this file in full!
+Please include your favorite emoji at the bottom of your issue to hint to us that you did in fact read this file.
+💖 is a good starter if you're not sure which to use.
+:::

--- a/docs/contributing/Pull_Requests.mdx
+++ b/docs/contributing/Pull_Requests.mdx
@@ -87,3 +87,11 @@ Once the feedback is addressed, and the PR is approved, we'll ensure the branch 
 If you need help and/or have a question, posting a comment in the PR is a great way to do so.
 There's no need to tag anybody individually.
 One of us will drop by and help when we can.
+
+---
+
+:::note Appreciation Note
+Thanks for reading through this file in full!
+Please include your favorite emoji at the bottom of your pull request to hint to us that you did in fact read this file.
+💖 is a good starter if you're not sure which to use.
+:::


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7216
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This was a little tricky because our contributing guide isn't one long page. It's separated into multiple pages. I figured folks will generally need to read through at least the issues and/or PR pages.
