### PR TITLE
chore: playwright test: ignore sponsor logo returning 404

### DIFF
--- a/packages/website/tests/index.spec.ts
+++ b/packages/website/tests/index.spec.ts
@@ -2,6 +2,16 @@ import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
 test.describe('Website', () => {
+  test.beforeEach(async ({ context }) => {
+    // Sponsor logos are sometimes changed or removed between deploys
+    await context.route('https://images.opencollective.com/**/*.png', route =>
+      route.fulfill({
+        status: 200,
+        body: '',
+      }),
+    );
+  });
+
   test('Axe', async ({ page }) => {
     await page.goto('/');
     await new AxeBuilder({ page }).analyze();
@@ -21,7 +31,8 @@ test.describe('Website', () => {
       }
       errorMessages.push(`[${type}] ${text}`);
     });
-    await page.goto('/');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page).toHaveTitle('typescript-eslint');
     expect(errorMessages).toStrictEqual([]);
   });
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7332
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

One of the sponsor's logo is returning 404 (due to rebranding). This ignores that kind of errors in test setup.

Website test will fail on this branch because they fail for all non-maintainers. The same change works in this PR https://github.com/typescript-eslint/typescript-eslint/pull/7247 but submitting this as separate issue which was preferred by maintainers :) 