### PR TITLE
docs: tip should point to the right sidebar in playground

### DIFF
--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -21,7 +21,7 @@ TS's AST is optimized for its use case of parsing incomplete code and typechecki
 ESTree is unoptimized and intended for "general purpose" use-cases of traversing the AST.
 
 :::tip
-You can select `@typescript-eslint/parser` on the [typescript-eslint playground](/play#showAST=es)'s left sidebar under _Options_ > _AST Explorer_ by selecting _ESTree_.
+You can select `@typescript-eslint/parser` on the [typescript-eslint playground](/play#showAST=es)'s right sidebar by selecting _ESTree_.
 :::
 
 ## Configuration


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7322
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22) (exception: extremely minor documentation typos)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I've updated the _TIP_ on the parser package [documentation page](https://typescript-eslint.io/packages/parser). It now points to the correct sidebar in [typescript-eslint _playground_](https://typescript-eslint.io/play#showAST=es)

_TIP_
<img width="790" alt="image" src="https://github.com/typescript-eslint/typescript-eslint/assets/57752566/e7e72b74-b130-4faa-b3a4-cfe7838b7691">

_playground_
<img width="1364" alt="image" src="https://github.com/typescript-eslint/typescript-eslint/assets/57752566/9d12e956-d934-47ff-ba66-d3650c0e720a">

