### PR TITLE
docs: remove redundant `parser` property from examples

### DIFF
--- a/docs/packages/Rule_Tester.mdx
+++ b/docs/packages/Rule_Tester.mdx
@@ -19,9 +19,7 @@ For non-type-aware rules you can test them as follows:
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import rule from '../src/rules/my-rule.ts';
 
-const ruleTester = new RuleTester({
-  parser: '@typescript-eslint/parser',
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run('my-rule', rule, {
   valid: [
@@ -136,7 +134,6 @@ You can then test your rule by providing the type-aware config:
 
 ```ts
 const ruleTester = new RuleTester({
-  parser: '@typescript-eslint/parser',
   // Added lines start
   parserOptions: {
     tsconfigRootDir: './path/to/your/folder/fixture',
@@ -162,7 +159,6 @@ The `RuleTester` allows you to apply dependency constraints at either an individ
 
 ```ts
 const ruleTester = new RuleTester({
-  parser: '@typescript-eslint/parser',
   // Added lines start
   dependencyConstraints: {
     // none of the tests will run unless `my-dependency` matches the semver range `>=1.2.3`


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7304
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

### [Packages -> rule-tester](https://typescript-eslint.io/packages/rule-tester)

Removed `parser: '@typescript-eslint/parser'` from configurations passed to `RuleTester`'s constructor as `'@typescript-eslint/parser'` is already is the default value.

### [Developers -> Building Custom Rules](https://typescript-eslint.io/developers/custom-rules#testing)

Left untouched since I believe that referencing `parser` explicitly contributes nicely to the examples in this section.