### PR TITLE
chore: run yarn generate-configs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,22 @@ jobs:
       - name: Build
         uses: ./.github/actions/prepare-build
 
+  generate_configs:
+    name: Lint
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install
+        uses: ./.github/actions/prepare-install
+        with:
+          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+      - run: yarn generate-configs
+      - run: git status --porcelain
+      - if: failure()
+        run: echo "Outdated result detected from yarn generate-configs. Please check in any file changes."
+
   lint_without_build:
     name: Lint
     needs: [install]


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5925
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I think this is actually the only generation script we particularly need in CI?