### PR TITLE
Revert "chore(deps): update dependency marked to v6"

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -82,7 +82,7 @@
     "jest-specific-snapshot": "*",
     "json-schema": "*",
     "markdown-table": "^3.0.3",
-    "marked": "^6.0.0",
+    "marked": "^5.1.1",
     "prettier": "*",
     "title-case": "^3.0.3",
     "typescript": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10469,10 +10469,10 @@ markdownlint@~0.29.0:
     markdown-it "13.0.1"
     markdownlint-micromark "0.1.5"
 
-marked@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-6.0.0.tgz#80cd7f51145437cffe9f541a318b9882f75601df"
-  integrity sha512-7E3m/xIlymrFL5gWswIT4CheIE3fDeh51NV09M4x8iOc7NDYlyERcQMLAIHcSlrvwliwbPQ4OGD+MpPSYiQcqw==
+marked@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-5.1.2.tgz#62b5ccfc75adf72ca3b64b2879b551d89e77677f"
+  integrity sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==
 
 mathml-tag-names@^2.1.3:
   version "2.1.3"


### PR DESCRIPTION
Reverts typescript-eslint/typescript-eslint#7422

In `packages/eslint-plugin/tests/docs.test.ts`:

```plaintext
The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("marked")' call instead.
  To convert this file to an ECMAScript module, change its file extension to '.mts' or create a local package.json file with `{ "type": "module" }`.ts(1479)
module "/Users/josh/repos/typescript-eslint/node_modules/marked/lib/marked"
```