### PR TITLE
feat(eslint-plugin): [await-thenable] added suggestion fixer

### DIFF
--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -1,3 +1,4 @@
+import type { TSESLint } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 
 import * as util from '../util';
@@ -10,8 +11,10 @@ export default util.createRule({
       recommended: 'recommended',
       requiresTypeChecking: true,
     },
+    hasSuggestions: true,
     messages: {
       await: 'Unexpected `await` of a non-Promise (non-"Thenable") value.',
+      removeAwait: 'Remove unnecessary `await`.',
     },
     schema: [],
     type: 'problem',
@@ -35,6 +38,17 @@ export default util.createRule({
           context.report({
             messageId: 'await',
             node,
+            suggest: [
+              {
+                messageId: 'removeAwait',
+                fix(fixer): TSESLint.RuleFix {
+                  return fixer.removeRange([
+                    node.range[0],
+                    node.range[0] + 'await'.length,
+                  ]);
+                },
+              },
+            ],
           });
         }
       },

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -42,10 +42,16 @@ export default util.createRule({
               {
                 messageId: 'removeAwait',
                 fix(fixer): TSESLint.RuleFix {
-                  return fixer.removeRange([
-                    node.range[0],
-                    node.range[0] + 'await'.length,
-                  ]);
+                  const sourceCode = context.getSourceCode();
+                  const awaitKeyword = util.nullThrows(
+                    sourceCode.getFirstToken(node, util.isAwaitKeyword),
+                    util.NullThrowsReasons.MissingToken(
+                      'await',
+                      'await expression',
+                    ),
+                  );
+
+                  return fixer.remove(awaitKeyword);
                 },
               },
             ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6235
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a `suggestion` fixer to remove `await` from the beginning of the AwaitExpression.

While I was in the area, split up the `invalid` test cases (#6887).