### PR TITLE
docs: warn against progressive type enhancement in rules

### DIFF
--- a/docs/developers/Custom_Rules.mdx
+++ b/docs/developers/Custom_Rules.mdx
@@ -273,10 +273,10 @@ This can be necessary for TypeScript APIs not wrapped by the parser services.
 :::
 
 :::caution
-We recommend against changing rule logic based on whether `services.program` exists.
+We recommend against changing rule logic based solely on whether `services.program` exists.
 In our experience, users are generally surprised when rules behave differently with or without type information.
 Additionally, if they misconfigure their ESLint config, they may not realize why the rule started behaving differently.
-Consider creating two versions of the rule instead, or only creating a type checked version.
+Consider either gating type checking behind an explicit option for the rule or creating two versions of the rule instead.
 :::
 
 ## Testing

--- a/docs/developers/Custom_Rules.mdx
+++ b/docs/developers/Custom_Rules.mdx
@@ -276,6 +276,7 @@ This can be necessary for TypeScript APIs not wrapped by the parser services.
 We recommend against changing rule logic based on whether `services.program` exists.
 In our experience, users are generally surprised when rules behave differently with or without type information.
 Additionally, if they misconfigure their ESLint config, they may not realize why the rule started behaving differently.
+Consider creating two versions of the rule instead, or only creating a type checked version.
 :::
 
 ## Testing

--- a/docs/developers/Custom_Rules.mdx
+++ b/docs/developers/Custom_Rules.mdx
@@ -272,6 +272,12 @@ Rules can retrieve their full backing TypeScript type checker with `services.pro
 This can be necessary for TypeScript APIs not wrapped by the parser services.
 :::
 
+:::caution
+We recommend against changing rule logic on whether `services.program` exists.
+In our experience, users are generally surprised when rules behave differently with or without type information.
+Additionally, if they misconfigure their ESLint config, they may not realize why the rule started behaving differently.
+:::
+
 ## Testing
 
 `@typescript-eslint/rule-tester` exports a `RuleTester` with a similar API to the built-in ESLint `RuleTester`.

--- a/docs/developers/Custom_Rules.mdx
+++ b/docs/developers/Custom_Rules.mdx
@@ -273,7 +273,7 @@ This can be necessary for TypeScript APIs not wrapped by the parser services.
 :::
 
 :::caution
-We recommend against changing rule logic on whether `services.program` exists.
+We recommend against changing rule logic based on whether `services.program` exists.
 In our experience, users are generally surprised when rules behave differently with or without type information.
 Additionally, if they misconfigure their ESLint config, they may not realize why the rule started behaving differently.
 :::


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7158
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a caution to the docs.

I wonder if this is overkill...?