### PR TITLE
chore(eslint-plugin): remove unused `natural-compare-lite` from dependencies

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -65,7 +65,6 @@
     "graphemer": "^1.4.0",
     "ignore": "^5.2.4",
     "natural-compare": "^1.4.0",
-    "natural-compare-lite": "^1.4.0",
     "semver": "^7.5.4",
     "ts-api-utils": "^1.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10974,11 +10974,6 @@ nanoid@^3.3.6:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
-natural-compare-lite@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
-  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes N/A
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

[natural-compare-lite](https://www.npmjs.com/package/natural-compare-lite) and [natural-compare](https://www.npmjs.com/package/natural-compare-lite) are two identical packages on the npm (They have the same tarball sha256).

`@typescript-eslint/eslint-plugin` has both `natural-compare` and `natural-compare-lite` in the `package.json`'s `dependencies`, but only `natural-compare` is actually used:

<img width="417" alt="image" src="https://github.com/typescript-eslint/typescript-eslint/assets/40715044/cb05dbd6-30e0-4d8b-88ef-d7ca5629ec4f">

<img width="429" alt="image" src="https://github.com/typescript-eslint/typescript-eslint/assets/40715044/d63e2e32-b982-48e1-b7d8-ad3cef143efb">

The PR removes the unused `natural-compare-lite`.