### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] false positives with branded types

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -28,6 +28,9 @@ const isTruthyLiteral = (type: ts.Type): boolean =>
 const isPossiblyFalsy = (type: ts.Type): boolean =>
   tsutils
     .unionTypeParts(type)
+    // Intersections like `string & {}` can also be possibly falsy,
+    // requiring us to look into the intersection.
+    .flatMap(type => tsutils.intersectionTypeParts(type))
     // PossiblyFalsy flag includes literal values, so exclude ones that
     // are definitely truthy
     .filter(t => !isTruthyLiteral(t))

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -37,7 +37,14 @@ const isPossiblyFalsy = (type: ts.Type): boolean =>
     .some(type => isTypeFlagSet(type, ts.TypeFlags.PossiblyFalsy));
 
 const isPossiblyTruthy = (type: ts.Type): boolean =>
-  tsutils.unionTypeParts(type).some(type => !tsutils.isFalsyType(type));
+  tsutils
+    .unionTypeParts(type)
+    .map(type => tsutils.intersectionTypeParts(type))
+    .some(intersectionParts =>
+      // It is possible to define intersections that are always falsy,
+      // like `"" & { __brand: string }`.
+      intersectionParts.every(type => !tsutils.isFalsyType(type)),
+    );
 
 // Nullish utilities
 const nullishFlag = ts.TypeFlags.Undefined | ts.TypeFlags.Null;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -83,6 +83,11 @@ const result2 = foo() == null;
     necessaryConditionTest('null | object'),
     necessaryConditionTest('undefined | true'),
     necessaryConditionTest('void | true'),
+    // "branded" type
+    necessaryConditionTest('string & {}'),
+    necessaryConditionTest('string & { __brand: string }'),
+    necessaryConditionTest('number & {}'),
+    necessaryConditionTest('boolean & {}'),
 
     necessaryConditionTest('any'), // any
     necessaryConditionTest('unknown'), // unknown

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -86,8 +86,31 @@ const result2 = foo() == null;
     // "branded" type
     necessaryConditionTest('string & {}'),
     necessaryConditionTest('string & { __brand: string }'),
-    necessaryConditionTest('number & {}'),
-    necessaryConditionTest('boolean & {}'),
+    necessaryConditionTest('number & { __brand: string }'),
+    necessaryConditionTest('boolean & { __brand: string }'),
+    necessaryConditionTest('bigint & { __brand: string }'),
+    necessaryConditionTest('string & {} & { __brand: string }'),
+    necessaryConditionTest(
+      'string & { __brandA: string } & { __brandB: string }',
+    ),
+    necessaryConditionTest('string & { __brand: string } | number'),
+    necessaryConditionTest('(string | number) & { __brand: string }'),
+    necessaryConditionTest('string & ({ __brand: string } | number)'),
+    necessaryConditionTest('("" | "foo") & { __brand: string }'),
+    necessaryConditionTest(
+      '(string & { __brandA: string }) | (number & { __brandB: string })',
+    ),
+    necessaryConditionTest(
+      '((string & { __brandA: string }) | (number & { __brandB: string }) & ("" | "foo"))',
+    ),
+    necessaryConditionTest(
+      '{ __brandA: string} & (({ __brandB: string } & string) | ({ __brandC: string } & number))',
+    ),
+    necessaryConditionTest(
+      '(string | number) & ("foo" | 123 | { __brandA: string })',
+    ),
+
+    necessaryConditionTest('string & string'),
 
     necessaryConditionTest('any'), // any
     necessaryConditionTest('unknown'), // unknown
@@ -650,6 +673,7 @@ const t1 = b2 && b1 ? 'yes' : 'no';
     unnecessaryConditionTest('null', 'alwaysFalsy'),
     unnecessaryConditionTest('void', 'alwaysFalsy'),
     unnecessaryConditionTest('never', 'never'),
+    unnecessaryConditionTest('string & number', 'never'),
 
     // More complex logical expressions
     {
@@ -1826,5 +1850,37 @@ foo &&= null;
         },
       ],
     },
+
+    // "branded" types
+    unnecessaryConditionTest('"" & {}', 'alwaysFalsy'),
+    unnecessaryConditionTest('"" & { __brand: string }', 'alwaysFalsy'),
+    unnecessaryConditionTest(
+      '("" | false) & { __brand: string }',
+      'alwaysFalsy',
+    ),
+    unnecessaryConditionTest(
+      '((string & { __brandA: string }) | (number & { __brandB: string })) & ""',
+      'alwaysFalsy',
+    ),
+    unnecessaryConditionTest(
+      '("foo" | "bar") & { __brand: string }',
+      'alwaysTruthy',
+    ),
+    unnecessaryConditionTest(
+      '(123 | true) & { __brand: string }',
+      'alwaysTruthy',
+    ),
+    unnecessaryConditionTest(
+      '(string | number) & ("foo" | 123) & { __brand: string }',
+      'alwaysTruthy',
+    ),
+    unnecessaryConditionTest(
+      '((string & { __brandA: string }) | (number & { __brandB: string })) & "foo"',
+      'alwaysTruthy',
+    ),
+    unnecessaryConditionTest(
+      '((string & { __brandA: string }) | (number & { __brandB: string })) & ("foo" | 123)',
+      'alwaysTruthy',
+    ),
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7293
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR fixes false positives in rule `no-unnecessary-condition` caused by branded types, as described in #7293. 

Note: #7293 only talks about branded strings, but I noticed that the problem occurred for any type.

> Please include your favorite emoji at the bottom of your pull request to hint to us that you did in fact read this file.

💩 
