### PR TITLE
feat(rule-tester): allow to create empty tests

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -395,33 +395,37 @@ export class RuleTester extends TestFramework {
      * one of the templates above.
      */
     constructor.describe(ruleName, () => {
-      constructor.describe('valid', () => {
-        normalizedTests.valid.forEach(valid => {
-          const testName = ((): string => {
-            if (valid.name == null || valid.name.length === 0) {
-              return valid.code;
-            }
-            return valid.name;
-          })();
-          constructor[getTestMethod(valid)](sanitize(testName), () => {
-            this.#testValidTemplate(ruleName, rule, valid);
+      if (normalizedTests.valid.length) {
+        constructor.describe('valid', () => {
+          normalizedTests.valid.forEach(valid => {
+            const testName = ((): string => {
+              if (valid.name == null || valid.name.length === 0) {
+                return valid.code;
+              }
+              return valid.name;
+            })();
+            constructor[getTestMethod(valid)](sanitize(testName), () => {
+              this.#testValidTemplate(ruleName, rule, valid);
+            });
           });
         });
-      });
+      }
 
-      constructor.describe('invalid', () => {
-        normalizedTests.invalid.forEach(invalid => {
-          const name = ((): string => {
-            if (invalid.name == null || invalid.name.length === 0) {
-              return invalid.code;
-            }
-            return invalid.name;
-          })();
-          constructor[getTestMethod(invalid)](sanitize(name), () => {
-            this.#testInvalidTemplate(ruleName, rule, invalid);
+      if (normalizedTests.invalid.length) {
+        constructor.describe('invalid', () => {
+          normalizedTests.invalid.forEach(invalid => {
+            const name = ((): string => {
+              if (invalid.name == null || invalid.name.length === 0) {
+                return invalid.code;
+              }
+              return invalid.name;
+            })();
+            constructor[getTestMethod(invalid)](sanitize(name), () => {
+              this.#testInvalidTemplate(ruleName, rule, invalid);
+            });
           });
         });
-      });
+      }
     });
   }
 

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -833,7 +833,18 @@ describe('RuleTester', () => {
           ],
         });
 
-        expect(mockedDescribe.mock.calls).toHaveLength(2);
+        expect(mockedDescribe.mock.calls).toMatchInlineSnapshot(`
+          [
+            [
+              "my-rule",
+              [Function],
+            ],
+            [
+              "invalid",
+              [Function],
+            ],
+          ]
+        `);
       });
 
       it('does not call describe with invalid if no invalid tests are provided', () => {
@@ -848,7 +859,18 @@ describe('RuleTester', () => {
           invalid: [],
         });
 
-        expect(mockedDescribe.mock.calls).toHaveLength(2);
+        expect(mockedDescribe.mock.calls).toMatchInlineSnapshot(`
+          [
+            [
+              "my-rule",
+              [Function],
+            ],
+            [
+              "valid",
+              [Function],
+            ],
+          ]
+        `);
       });
     });
   });

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -819,6 +819,37 @@ describe('RuleTester', () => {
         expect(mockedDescribeSkip.mock.calls).toHaveLength(0);
         // expect(mockedIt.mock.lastCall).toMatchInlineSnapshot(`undefined`);
       });
+
+      it('does not call describe with valid if no valid tests are provided', () => {
+        const ruleTester = new RuleTester();
+
+        ruleTester.run('my-rule', NOOP_RULE, {
+          valid: [],
+          invalid: [
+            {
+              code: 'invalid',
+              errors: [{ messageId: 'error' }],
+            },
+          ],
+        });
+
+        expect(mockedDescribe.mock.calls).toHaveLength(2);
+      });
+
+      it('does not call describe with invalid if no invalid tests are provided', () => {
+        const ruleTester = new RuleTester();
+
+        ruleTester.run('my-rule', NOOP_RULE, {
+          valid: [
+            {
+              code: 'valid',
+            },
+          ],
+          invalid: [],
+        });
+
+        expect(mockedDescribe.mock.calls).toHaveLength(2);
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7481
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

In some cases I only need to test for valid or invalid scenarios.

For example, if I want to check that a rule for the ESLint plugin works with different code stylings. Or that a rule does not apply to a certain file extension.

Example:

```ts
ruleTester.run(
  `${RULE_NAME}: works consistently with an empty array or an array with one element`,
  rule,
  {
    valid: ['[].includes(person)', "['Decim'].includes(bartender)"],
    invalid: [],
  },
)
```

This test is currently crashing with an error: `Error: No test found in suite invalid`