### PR TITLE
chore: add rule-tester commit scope

### DIFF
--- a/.github/workflows/semantic-pr-titles.yml
+++ b/.github/workflows/semantic-pr-titles.yml
@@ -31,6 +31,7 @@ jobs:
             eslint-plugin-internal
             eslint-plugin-tslint
             parser
+            rule-tester
             scope-manager
             type-utils
             types


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

In version 6.0, a new rule-tester package was added.

It's worth adding this scope to the commit validator. My other PR crashed with an error because of it:
https://github.com/typescript-eslint/typescript-eslint/pull/7467