### PR TITLE
chore: properly checkout repo in prettier-update workflow

### DIFF
--- a/.github/workflows/prettier-update.yml
+++ b/.github/workflows/prettier-update.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
 
       - name: Check if prettier was changed as part of the latest commit on the PR
         id: prettier-package-check


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7480
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

There are two issues in this workflow:
1) By default `actions/checkout@v3` switches to detached HEAD, we need to explicitly specify `ref: ${{ github.event.pull_request.head.ref }}`
  https://github.com/actions/checkout/issues/317#issuecomment-737107262
2) `actions/checkout@v3` sets `http.https://github.com/.extraheader=AUTHORIZATION: basic ***` in the git config. This prevents workflow to push to remote using `$GITHUB_TOKEN`. 
  https://github.com/actions/checkout/issues/162
  `persist-credentials: false` is designed to turn off this behavior