### PR TITLE
fix(docs): fix typo in member-ordering

### DIFF
--- a/packages/eslint-plugin/docs/rules/member-ordering.md
+++ b/packages/eslint-plugin/docs/rules/member-ordering.md
@@ -814,7 +814,7 @@ interface Foo {
 
 #### Sorting Alphabetically Case Insensitive Within Member Groups
 
-This config specifies that within each `memberTypes` group, members are in an alphabetic case-sensitive order.
+This config specifies that within each `memberTypes` group, members are in an alphabetic case-insensitive order.
 You can copy and paste the default order from [Default Configuration](#default-configuration).
 
 ```jsonc


### PR DESCRIPTION
fixes: #7477

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7477 
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Fixed typo in [Sorting Alphabetically Case Insensitive Within Member Groups](https://typescript-eslint.io/rules/member-ordering/#sorting-alphabetically-case-insensitive-within-member-groups): members are in an alphabetic case-sensitive order -> members are in an alphabetic case-insensitive order

Affected URL(s)
https://typescript-eslint.io/rules/member-ordering
