### PR TITLE
docs: fix link to What About Formatting article

### DIFF
--- a/docs/linting/Configurations.mdx
+++ b/docs/linting/Configurations.mdx
@@ -229,4 +229,4 @@ If you feel strongly that a specific rule should (or should not) be one of these
 
 None of the preset configs provided by typescript-eslint enable formatting rules (rules that only serve to enforce code whitespace and other trivia).
 We strongly recommend you use Prettier or an equivalent for formatting your code, not ESLint formatting rules.
-See [What About Formatting? > Suggested Usage](./troubleshooting/formatting#suggested-usage).
+See [What About Formatting? > Suggested Usage](../troubleshooting/formatting#suggested-usage---prettier).


### PR DESCRIPTION
In the [Formatting section of the Configurations article](https://typescript-eslint.io/linting/configs/#formatting), there is a link to the **What About Formatting** article which currently goes to a **404 Page Not Found** error page.

| Before | After |
| :--- | :--- |
| ![Screenshot of "Page Not Found" error](https://github.com/paulshryock/typescript-eslint/assets/7530507/7cb06f5f-522b-4ec7-a5f2-a149ab842d52) | ![Screenshot of "What About Formatting?" article scrolled to "Suggested Usage - Prettier" heading](https://github.com/typescript-eslint/typescript-eslint/assets/7530507/12117241-cc68-47cc-ad9f-e94a51ba9958) |