### PR TITLE
feat: no-unsafe-enum-comparison handles switch cases

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-enum-comparison.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-enum-comparison.md
@@ -6,21 +6,23 @@ description: 'Disallow comparing an enum value with a non-enum value.'
 >
 > See **https://typescript-eslint.io/rules/no-unsafe-enum-comparison** for documentation.
 
-The TypeScript compiler can be surprisingly lenient when working with enums.
-For example, it will allow you to compare enum values against numbers even though they might not have any type overlap:
+The TypeScript compiler can be surprisingly lenient when working with enums. String enums are widely considered to be safer than number enums, but even string enums have some pitfalls. For example, it is allowed to compare enum values against literals:
 
 ```ts
-enum Fruit {
-  Apple,
-  Banana,
+enum Vegetable {
+  Asparagus = 'asparagus',
 }
 
-declare let fruit: Fruit;
+declare const vegetable: Vegetable;
 
-fruit === 999; // No error
+vegetable === 'asparagus'; // No error
 ```
 
-This rule flags when an enum typed value is compared to a non-enum `number`.
+The above code snippet should instead be written as `vegetable === Vegetable.Asparagus`. Allowing literals in comparisons subverts the point of using enums in the first place. By enforcing comparisons with properly typed enums:
+
+- It makes a codebase more resilient to enum members swapping values.
+- It allows for code IDE's to use the "Rename Symbol" feature to quickly rename an enum throughout an entire codebase without anything breaking.
+- It makes enums more intuitive, similar to how they work in other strongly-typed languages like Rust.
 
 ## Examples
 
@@ -35,7 +37,7 @@ enum Fruit {
 
 declare let fruit: Fruit;
 
-fruit === 999;
+fruit === 0;
 ```
 
 ```ts
@@ -57,7 +59,7 @@ enum Fruit {
 
 declare let fruit: Fruit;
 
-fruit === Fruit.Banana;
+fruit === Fruit.Apple;
 ```
 
 ```ts

--- a/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
@@ -306,6 +306,32 @@ ruleTester.run('strict-enums-comparison', rule, {
 
       const bitShift = 1 >> Fruit.Apple;
     `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const fruit: Fruit;
+
+      switch (fruit) {
+        case Fruit.Apple: {
+          break;
+        }
+      }
+    `,
+    `
+      enum Vegetable {
+        Asparagus = 'asparagus',
+      }
+
+      declare const vegetable: Vegetable;
+
+      switch (vegetable) {
+        case Vegetable.Asparagus: {
+          break;
+        }
+      }
+    `,
   ],
   invalid: [
     {
@@ -564,6 +590,78 @@ ruleTester.run('strict-enums-comparison', rule, {
         weirdString === 'someArbitraryValue';
       `,
       errors: [{ messageId: 'mismatched' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare const fruit: Fruit;
+
+        switch (fruit) {
+          case 0: {
+            break;
+          }
+        }
+      `,
+      errors: [{ messageId: 'mismatchedCase' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+          Banana,
+        }
+
+        declare const fruit: Fruit;
+
+        switch (fruit) {
+          case Fruit.Apple: {
+            break;
+          }
+          case 1: {
+            break;
+          }
+        }
+      `,
+      errors: [{ messageId: 'mismatchedCase' }],
+    },
+    {
+      code: `
+        enum Vegetable {
+          Asparagus = 'asparagus',
+        }
+
+        declare const vegetable: Vegetable;
+
+        switch (vegetable) {
+          case 'asparagus': {
+            break;
+          }
+        }
+      `,
+      errors: [{ messageId: 'mismatchedCase' }],
+    },
+    {
+      code: `
+        enum Vegetable {
+          Asparagus = 'asparagus',
+          Beet = 'beet',
+        }
+
+        declare const vegetable: Vegetable;
+
+        switch (vegetable) {
+          case Vegetable.Asparagus: {
+            break;
+          }
+          case 'beet': {
+            break;
+          }
+        }
+      `,
+      errors: [{ messageId: 'mismatchedCase' }],
     },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [X] Addresses an existing open issue: fixes #7509
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Hello, co-author of the original `no-unsafe-enum-comparison` rule here.

Currently, he `no-unsafe-enum-comparison` rule handles comparisons (e.g. `BinaryExpression`) but it does not handle switch statements. My PR makes the rule handle both.

This was an oversight in my original design of this rule, and I consider this to be a bug. However, I have marked the PR as `feat` instead of `fix` to be more conservative; feel free to change it if you wish.

## Other Notes

I have reworked the documentation for this rule a bit, as the original text is now no longer accurate, because TypeScript has made number enums more safe in version 5.0. Thus, I rewrote the document to focus on the string case, adding a line to emphasize that simply using string enums against number enums does not make you safe (and that the rule is still useful if you choose to use string enums over number enums).