### PR TITLE
fix(eslint-plugin): [no-restricted-imports] disallow side effect imports when allowTypeImports is enabled

### DIFF
--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -273,7 +273,7 @@ export default createRule<Options, MessageIds>({
       ImportDeclaration(node: TSESTree.ImportDeclaration): void {
         if (
           node.importKind === 'type' ||
-          (node.specifiers.length &&
+          (node.specifiers.length > 0 &&
             node.specifiers.every(
               specifier =>
                 specifier.type === AST_NODE_TYPES.ImportSpecifier &&
@@ -298,7 +298,7 @@ export default createRule<Options, MessageIds>({
       ): void {
         if (
           node.exportKind === 'type' ||
-          (node.specifiers.length &&
+          (node.specifiers.length > 0 &&
             node.specifiers.every(specifier => specifier.exportKind === 'type'))
         ) {
           const importSource = node.source.value.trim();

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -273,11 +273,12 @@ export default createRule<Options, MessageIds>({
       ImportDeclaration(node: TSESTree.ImportDeclaration): void {
         if (
           node.importKind === 'type' ||
-          node.specifiers.every(
-            specifier =>
-              specifier.type === AST_NODE_TYPES.ImportSpecifier &&
-              specifier.importKind === 'type',
-          )
+          (node.specifiers.length &&
+            node.specifiers.every(
+              specifier =>
+                specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+                specifier.importKind === 'type',
+            ))
         ) {
           const importSource = node.source.value.trim();
           if (
@@ -297,7 +298,8 @@ export default createRule<Options, MessageIds>({
       ): void {
         if (
           node.exportKind === 'type' ||
-          node.specifiers.every(specifier => specifier.exportKind === 'type')
+          (node.specifiers.length &&
+            node.specifiers.every(specifier => specifier.exportKind === 'type'))
         ) {
           const importSource = node.source.value.trim();
           if (

--- a/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
@@ -491,6 +491,43 @@ import type { foo } from 'import2/private/bar';
       ],
     },
     {
+      code: "import 'import-foo';",
+      options: [
+        {
+          paths: [
+            {
+              name: 'import-foo',
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'path',
+          type: AST_NODE_TYPES.ImportDeclaration,
+        },
+      ],
+    },
+    {
+      code: "import 'import-foo';",
+      options: [
+        {
+          paths: [
+            {
+              name: 'import-foo',
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'path',
+          type: AST_NODE_TYPES.ImportDeclaration,
+        },
+      ],
+    },
+    {
       code: "import foo from 'import-foo';",
       options: [
         {

--- a/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
@@ -10,6 +10,7 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-restricted-imports', rule, {
   valid: [
     "import foo from 'foo';",
+    "import 'foo';",
     {
       code: "import foo from 'foo';",
       options: ['import1', 'import2'],
@@ -25,6 +26,10 @@ ruleTester.run('no-restricted-imports', rule, {
     {
       code: "export { foo } from 'foo';",
       options: [{ paths: ['import1', 'import2'] }],
+    },
+    {
+      code: "import 'foo';",
+      options: ['import1', 'import2'],
     },
     {
       code: "import foo from 'foo';",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #7559
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fixes #7559 by changing the logic from #7379 from "allow imports if all specifiers are types (or if no specifiers exist)" to "allow imports if specifiers exist and all specifiers are types."

✨ 
<!-- Description of what is changed and how the code change does that. -->
