### PR TITLE
fix(scope-manager): Complete optional chaining when range missing

### DIFF
--- a/packages/scope-manager/src/scope/FunctionScope.ts
+++ b/packages/scope-manager/src/scope/FunctionScope.ts
@@ -51,14 +51,14 @@ class FunctionScope extends ScopeBase<
       return true;
     }
 
-    const bodyStart = this.block.body?.range[0] ?? -1;
+    const bodyStart = this.block.body?.range?.[0] ?? -1;
 
     // It's invalid resolution in the following case:
     return !(
       (
         variable.scope === this &&
-        ref.identifier.range[0] < bodyStart && // the reference is in the parameter part.
-        variable.defs.every(d => d.name.range[0] >= bodyStart)
+        ref.identifier?.range?.[0] < bodyStart && // the reference is in the parameter part.
+        variable.defs.every(d => d.name?.range?.[0] >= bodyStart)
       ) // the variable is in the body.
     );
   }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7562
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
If the `range` option is set to `false`, the optional chaining in `FunctionScope.ts:isValidResolution` fails at:

```
const bodyStart = this.block.body?.range[0] ?? -1;
```

This is because the `range` prop is undefined and reading `[0]` throws an exception.

This change extends the optional chaining to the full path and adds optional chaining on property access on subsequent lines as well.
