### PR TITLE
fix(eslint-plugin): [consistent-type-imports] do not add new semicolons

### DIFF
--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -749,6 +749,29 @@ let bar: B;
       ],
     },
     {
+      // Since the source does not end with a semicolon, the fixer should not add a semicolon, as that would be the job of the formatter.
+      // Otherwise, this would conflict with the semi: false option of prettier.
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
+      code: `
+import A, { B } from 'foo'
+let foo: A;
+let bar: B;
+      `,
+      output: `
+import type { B } from 'foo'
+import type A from 'foo'
+let foo: A;
+let bar: B;
+      `,
+      errors: [
+        {
+          messageId: 'typeOverValue',
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
       code: noFormat`
         import A, {} from 'foo';
         let foo: A;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: I have not opened an issue for this
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Previously, the consistent-type-imports rule would add new semicolons at the end of some import even though the original code did not end with a semicolon.

This conflicted with the "semi: false" option in prettier, which I used in my project.

In this PR, I have set it to only add this semicolon if the original code has a semicolon as well. This resolves the conflict without adding a new property to this eslint rule.
