### PR TITLE
chore(ast-spec): exclude tsx fixtures from type-check

### DIFF
--- a/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/fixture.tsx
+++ b/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/fixture.tsx
@@ -5,7 +5,5 @@ declare namespace JSX {
   }
 }
 
-// @ts-expect-error -- https://github.com/typescript-eslint/typescript-eslint/issues/7166
 const componentBasic = <foo />;
-// @ts-expect-error -- https://github.com/typescript-eslint/typescript-eslint/issues/7166
 const componentDashed = <foo-bar:baz-bam />;

--- a/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/1-TSESTree-AST.shot
@@ -170,10 +170,10 @@ Program {
             name: "componentBasic",
             optional: false,
 
-            range: [201, 215],
+            range: [111, 125],
             loc: {
-              start: { column: 6, line: 9 },
-              end: { column: 20, line: 9 },
+              start: { column: 6, line: 8 },
+              end: { column: 20, line: 8 },
             },
           },
           init: JSXElement {
@@ -187,42 +187,42 @@ Program {
                 type: "JSXIdentifier",
                 name: "foo",
 
-                range: [219, 222],
+                range: [129, 132],
                 loc: {
-                  start: { column: 24, line: 9 },
-                  end: { column: 27, line: 9 },
+                  start: { column: 24, line: 8 },
+                  end: { column: 27, line: 8 },
                 },
               },
               selfClosing: true,
 
-              range: [218, 225],
+              range: [128, 135],
               loc: {
-                start: { column: 23, line: 9 },
-                end: { column: 30, line: 9 },
+                start: { column: 23, line: 8 },
+                end: { column: 30, line: 8 },
               },
             },
 
-            range: [218, 225],
+            range: [128, 135],
             loc: {
-              start: { column: 23, line: 9 },
-              end: { column: 30, line: 9 },
+              start: { column: 23, line: 8 },
+              end: { column: 30, line: 8 },
             },
           },
 
-          range: [201, 225],
+          range: [111, 135],
           loc: {
-            start: { column: 6, line: 9 },
-            end: { column: 30, line: 9 },
+            start: { column: 6, line: 8 },
+            end: { column: 30, line: 8 },
           },
         },
       ],
       declare: false,
       kind: "const",
 
-      range: [195, 226],
+      range: [105, 136],
       loc: {
-        start: { column: 0, line: 9 },
-        end: { column: 31, line: 9 },
+        start: { column: 0, line: 8 },
+        end: { column: 31, line: 8 },
       },
     },
     VariableDeclaration {
@@ -237,10 +237,10 @@ Program {
             name: "componentDashed",
             optional: false,
 
-            range: [323, 338],
+            range: [143, 158],
             loc: {
-              start: { column: 6, line: 11 },
-              end: { column: 21, line: 11 },
+              start: { column: 6, line: 9 },
+              end: { column: 21, line: 9 },
             },
           },
           init: JSXElement {
@@ -256,68 +256,68 @@ Program {
                   type: "JSXIdentifier",
                   name: "baz-bam",
 
-                  range: [350, 357],
+                  range: [170, 177],
                   loc: {
-                    start: { column: 33, line: 11 },
-                    end: { column: 40, line: 11 },
+                    start: { column: 33, line: 9 },
+                    end: { column: 40, line: 9 },
                   },
                 },
                 namespace: JSXIdentifier {
                   type: "JSXIdentifier",
                   name: "foo-bar",
 
-                  range: [342, 349],
+                  range: [162, 169],
                   loc: {
-                    start: { column: 25, line: 11 },
-                    end: { column: 32, line: 11 },
+                    start: { column: 25, line: 9 },
+                    end: { column: 32, line: 9 },
                   },
                 },
 
-                range: [342, 357],
+                range: [162, 177],
                 loc: {
-                  start: { column: 25, line: 11 },
-                  end: { column: 40, line: 11 },
+                  start: { column: 25, line: 9 },
+                  end: { column: 40, line: 9 },
                 },
               },
               selfClosing: true,
 
-              range: [341, 360],
+              range: [161, 180],
               loc: {
-                start: { column: 24, line: 11 },
-                end: { column: 43, line: 11 },
+                start: { column: 24, line: 9 },
+                end: { column: 43, line: 9 },
               },
             },
 
-            range: [341, 360],
+            range: [161, 180],
             loc: {
-              start: { column: 24, line: 11 },
-              end: { column: 43, line: 11 },
+              start: { column: 24, line: 9 },
+              end: { column: 43, line: 9 },
             },
           },
 
-          range: [323, 360],
+          range: [143, 180],
           loc: {
-            start: { column: 6, line: 11 },
-            end: { column: 43, line: 11 },
+            start: { column: 6, line: 9 },
+            end: { column: 43, line: 9 },
           },
         },
       ],
       declare: false,
       kind: "const",
 
-      range: [317, 361],
+      range: [137, 181],
       loc: {
-        start: { column: 0, line: 11 },
-        end: { column: 44, line: 11 },
+        start: { column: 0, line: 9 },
+        end: { column: 44, line: 9 },
       },
     },
   ],
   sourceType: "script",
 
-  range: [0, 362],
+  range: [0, 182],
   loc: {
     start: { column: 0, line: 1 },
-    end: { column: 0, line: 12 },
+    end: { column: 0, line: 10 },
   },
 }
 `;

--- a/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/2-TSESTree-Tokens.shot
@@ -176,7 +176,87 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed TSESTree - Tokens 1
     type: "Keyword",
     value: "const",
 
-    range: [195, 200],
+    range: [105, 110],
+    loc: {
+      start: { column: 0, line: 8 },
+      end: { column: 5, line: 8 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "componentBasic",
+
+    range: [111, 125],
+    loc: {
+      start: { column: 6, line: 8 },
+      end: { column: 20, line: 8 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=",
+
+    range: [126, 127],
+    loc: {
+      start: { column: 21, line: 8 },
+      end: { column: 22, line: 8 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [128, 129],
+    loc: {
+      start: { column: 23, line: 8 },
+      end: { column: 24, line: 8 },
+    },
+  },
+  JSXIdentifier {
+    type: "JSXIdentifier",
+    value: "foo",
+
+    range: [129, 132],
+    loc: {
+      start: { column: 24, line: 8 },
+      end: { column: 27, line: 8 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "/",
+
+    range: [133, 134],
+    loc: {
+      start: { column: 28, line: 8 },
+      end: { column: 29, line: 8 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [134, 135],
+    loc: {
+      start: { column: 29, line: 8 },
+      end: { column: 30, line: 8 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ";",
+
+    range: [135, 136],
+    loc: {
+      start: { column: 30, line: 8 },
+      end: { column: 31, line: 8 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "const",
+
+    range: [137, 142],
     loc: {
       start: { column: 0, line: 9 },
       end: { column: 5, line: 9 },
@@ -184,172 +264,92 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed TSESTree - Tokens 1
   },
   Identifier {
     type: "Identifier",
-    value: "componentBasic",
-
-    range: [201, 215],
-    loc: {
-      start: { column: 6, line: 9 },
-      end: { column: 20, line: 9 },
-    },
-  },
-  Punctuator {
-    type: "Punctuator",
-    value: "=",
-
-    range: [216, 217],
-    loc: {
-      start: { column: 21, line: 9 },
-      end: { column: 22, line: 9 },
-    },
-  },
-  Punctuator {
-    type: "Punctuator",
-    value: "<",
-
-    range: [218, 219],
-    loc: {
-      start: { column: 23, line: 9 },
-      end: { column: 24, line: 9 },
-    },
-  },
-  JSXIdentifier {
-    type: "JSXIdentifier",
-    value: "foo",
-
-    range: [219, 222],
-    loc: {
-      start: { column: 24, line: 9 },
-      end: { column: 27, line: 9 },
-    },
-  },
-  Punctuator {
-    type: "Punctuator",
-    value: "/",
-
-    range: [223, 224],
-    loc: {
-      start: { column: 28, line: 9 },
-      end: { column: 29, line: 9 },
-    },
-  },
-  Punctuator {
-    type: "Punctuator",
-    value: ">",
-
-    range: [224, 225],
-    loc: {
-      start: { column: 29, line: 9 },
-      end: { column: 30, line: 9 },
-    },
-  },
-  Punctuator {
-    type: "Punctuator",
-    value: ";",
-
-    range: [225, 226],
-    loc: {
-      start: { column: 30, line: 9 },
-      end: { column: 31, line: 9 },
-    },
-  },
-  Keyword {
-    type: "Keyword",
-    value: "const",
-
-    range: [317, 322],
-    loc: {
-      start: { column: 0, line: 11 },
-      end: { column: 5, line: 11 },
-    },
-  },
-  Identifier {
-    type: "Identifier",
     value: "componentDashed",
 
-    range: [323, 338],
+    range: [143, 158],
     loc: {
-      start: { column: 6, line: 11 },
-      end: { column: 21, line: 11 },
+      start: { column: 6, line: 9 },
+      end: { column: 21, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: "=",
 
-    range: [339, 340],
+    range: [159, 160],
     loc: {
-      start: { column: 22, line: 11 },
-      end: { column: 23, line: 11 },
+      start: { column: 22, line: 9 },
+      end: { column: 23, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: "<",
 
-    range: [341, 342],
+    range: [161, 162],
     loc: {
-      start: { column: 24, line: 11 },
-      end: { column: 25, line: 11 },
+      start: { column: 24, line: 9 },
+      end: { column: 25, line: 9 },
     },
   },
   Identifier {
     type: "Identifier",
     value: "foo-bar",
 
-    range: [342, 349],
+    range: [162, 169],
     loc: {
-      start: { column: 25, line: 11 },
-      end: { column: 32, line: 11 },
+      start: { column: 25, line: 9 },
+      end: { column: 32, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: ":",
 
-    range: [349, 350],
+    range: [169, 170],
     loc: {
-      start: { column: 32, line: 11 },
-      end: { column: 33, line: 11 },
+      start: { column: 32, line: 9 },
+      end: { column: 33, line: 9 },
     },
   },
   Identifier {
     type: "Identifier",
     value: "baz-bam",
 
-    range: [350, 357],
+    range: [170, 177],
     loc: {
-      start: { column: 33, line: 11 },
-      end: { column: 40, line: 11 },
+      start: { column: 33, line: 9 },
+      end: { column: 40, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: "/",
 
-    range: [358, 359],
+    range: [178, 179],
     loc: {
-      start: { column: 41, line: 11 },
-      end: { column: 42, line: 11 },
+      start: { column: 41, line: 9 },
+      end: { column: 42, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: ">",
 
-    range: [359, 360],
+    range: [179, 180],
     loc: {
-      start: { column: 42, line: 11 },
-      end: { column: 43, line: 11 },
+      start: { column: 42, line: 9 },
+      end: { column: 43, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: ";",
 
-    range: [360, 361],
+    range: [180, 181],
     loc: {
-      start: { column: 43, line: 11 },
-      end: { column: 44, line: 11 },
+      start: { column: 43, line: 9 },
+      end: { column: 44, line: 9 },
     },
   },
 ]

--- a/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/3-Babel-AST.shot
@@ -151,10 +151,10 @@ Program {
             type: "Identifier",
             name: "componentBasic",
 
-            range: [201, 215],
+            range: [111, 125],
             loc: {
-              start: { column: 6, line: 9 },
-              end: { column: 20, line: 9 },
+              start: { column: 6, line: 8 },
+              end: { column: 20, line: 8 },
             },
           },
           init: JSXElement {
@@ -168,41 +168,41 @@ Program {
                 type: "JSXIdentifier",
                 name: "foo",
 
-                range: [219, 222],
+                range: [129, 132],
                 loc: {
-                  start: { column: 24, line: 9 },
-                  end: { column: 27, line: 9 },
+                  start: { column: 24, line: 8 },
+                  end: { column: 27, line: 8 },
                 },
               },
               selfClosing: true,
 
-              range: [218, 225],
+              range: [128, 135],
               loc: {
-                start: { column: 23, line: 9 },
-                end: { column: 30, line: 9 },
+                start: { column: 23, line: 8 },
+                end: { column: 30, line: 8 },
               },
             },
 
-            range: [218, 225],
+            range: [128, 135],
             loc: {
-              start: { column: 23, line: 9 },
-              end: { column: 30, line: 9 },
+              start: { column: 23, line: 8 },
+              end: { column: 30, line: 8 },
             },
           },
 
-          range: [201, 225],
+          range: [111, 135],
           loc: {
-            start: { column: 6, line: 9 },
-            end: { column: 30, line: 9 },
+            start: { column: 6, line: 8 },
+            end: { column: 30, line: 8 },
           },
         },
       ],
       kind: "const",
 
-      range: [195, 226],
+      range: [105, 136],
       loc: {
-        start: { column: 0, line: 9 },
-        end: { column: 31, line: 9 },
+        start: { column: 0, line: 8 },
+        end: { column: 31, line: 8 },
       },
     },
     VariableDeclaration {
@@ -214,10 +214,10 @@ Program {
             type: "Identifier",
             name: "componentDashed",
 
-            range: [323, 338],
+            range: [143, 158],
             loc: {
-              start: { column: 6, line: 11 },
-              end: { column: 21, line: 11 },
+              start: { column: 6, line: 9 },
+              end: { column: 21, line: 9 },
             },
           },
           init: JSXElement {
@@ -233,67 +233,67 @@ Program {
                   type: "JSXIdentifier",
                   name: "baz-bam",
 
-                  range: [350, 357],
+                  range: [170, 177],
                   loc: {
-                    start: { column: 33, line: 11 },
-                    end: { column: 40, line: 11 },
+                    start: { column: 33, line: 9 },
+                    end: { column: 40, line: 9 },
                   },
                 },
                 namespace: JSXIdentifier {
                   type: "JSXIdentifier",
                   name: "foo-bar",
 
-                  range: [342, 349],
+                  range: [162, 169],
                   loc: {
-                    start: { column: 25, line: 11 },
-                    end: { column: 32, line: 11 },
+                    start: { column: 25, line: 9 },
+                    end: { column: 32, line: 9 },
                   },
                 },
 
-                range: [342, 357],
+                range: [162, 177],
                 loc: {
-                  start: { column: 25, line: 11 },
-                  end: { column: 40, line: 11 },
+                  start: { column: 25, line: 9 },
+                  end: { column: 40, line: 9 },
                 },
               },
               selfClosing: true,
 
-              range: [341, 360],
+              range: [161, 180],
               loc: {
-                start: { column: 24, line: 11 },
-                end: { column: 43, line: 11 },
+                start: { column: 24, line: 9 },
+                end: { column: 43, line: 9 },
               },
             },
 
-            range: [341, 360],
+            range: [161, 180],
             loc: {
-              start: { column: 24, line: 11 },
-              end: { column: 43, line: 11 },
+              start: { column: 24, line: 9 },
+              end: { column: 43, line: 9 },
             },
           },
 
-          range: [323, 360],
+          range: [143, 180],
           loc: {
-            start: { column: 6, line: 11 },
-            end: { column: 43, line: 11 },
+            start: { column: 6, line: 9 },
+            end: { column: 43, line: 9 },
           },
         },
       ],
       kind: "const",
 
-      range: [317, 361],
+      range: [137, 181],
       loc: {
-        start: { column: 0, line: 11 },
-        end: { column: 44, line: 11 },
+        start: { column: 0, line: 9 },
+        end: { column: 44, line: 9 },
       },
     },
   ],
   sourceType: "script",
 
-  range: [0, 362],
+  range: [0, 182],
   loc: {
     start: { column: 0, line: 1 },
-    end: { column: 0, line: 12 },
+    end: { column: 0, line: 10 },
   },
 }
 `;

--- a/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/4-Babel-Tokens.shot
@@ -176,7 +176,87 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed Babel - Tokens 1`] 
     type: "Keyword",
     value: "const",
 
-    range: [195, 200],
+    range: [105, 110],
+    loc: {
+      start: { column: 0, line: 8 },
+      end: { column: 5, line: 8 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "componentBasic",
+
+    range: [111, 125],
+    loc: {
+      start: { column: 6, line: 8 },
+      end: { column: 20, line: 8 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=",
+
+    range: [126, 127],
+    loc: {
+      start: { column: 21, line: 8 },
+      end: { column: 22, line: 8 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [128, 129],
+    loc: {
+      start: { column: 23, line: 8 },
+      end: { column: 24, line: 8 },
+    },
+  },
+  JSXIdentifier {
+    type: "JSXIdentifier",
+    value: "foo",
+
+    range: [129, 132],
+    loc: {
+      start: { column: 24, line: 8 },
+      end: { column: 27, line: 8 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "/",
+
+    range: [133, 134],
+    loc: {
+      start: { column: 28, line: 8 },
+      end: { column: 29, line: 8 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [134, 135],
+    loc: {
+      start: { column: 29, line: 8 },
+      end: { column: 30, line: 8 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ";",
+
+    range: [135, 136],
+    loc: {
+      start: { column: 30, line: 8 },
+      end: { column: 31, line: 8 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "const",
+
+    range: [137, 142],
     loc: {
       start: { column: 0, line: 9 },
       end: { column: 5, line: 9 },
@@ -184,172 +264,92 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed Babel - Tokens 1`] 
   },
   Identifier {
     type: "Identifier",
-    value: "componentBasic",
-
-    range: [201, 215],
-    loc: {
-      start: { column: 6, line: 9 },
-      end: { column: 20, line: 9 },
-    },
-  },
-  Punctuator {
-    type: "Punctuator",
-    value: "=",
-
-    range: [216, 217],
-    loc: {
-      start: { column: 21, line: 9 },
-      end: { column: 22, line: 9 },
-    },
-  },
-  Punctuator {
-    type: "Punctuator",
-    value: "<",
-
-    range: [218, 219],
-    loc: {
-      start: { column: 23, line: 9 },
-      end: { column: 24, line: 9 },
-    },
-  },
-  JSXIdentifier {
-    type: "JSXIdentifier",
-    value: "foo",
-
-    range: [219, 222],
-    loc: {
-      start: { column: 24, line: 9 },
-      end: { column: 27, line: 9 },
-    },
-  },
-  Punctuator {
-    type: "Punctuator",
-    value: "/",
-
-    range: [223, 224],
-    loc: {
-      start: { column: 28, line: 9 },
-      end: { column: 29, line: 9 },
-    },
-  },
-  Punctuator {
-    type: "Punctuator",
-    value: ">",
-
-    range: [224, 225],
-    loc: {
-      start: { column: 29, line: 9 },
-      end: { column: 30, line: 9 },
-    },
-  },
-  Punctuator {
-    type: "Punctuator",
-    value: ";",
-
-    range: [225, 226],
-    loc: {
-      start: { column: 30, line: 9 },
-      end: { column: 31, line: 9 },
-    },
-  },
-  Keyword {
-    type: "Keyword",
-    value: "const",
-
-    range: [317, 322],
-    loc: {
-      start: { column: 0, line: 11 },
-      end: { column: 5, line: 11 },
-    },
-  },
-  Identifier {
-    type: "Identifier",
     value: "componentDashed",
 
-    range: [323, 338],
+    range: [143, 158],
     loc: {
-      start: { column: 6, line: 11 },
-      end: { column: 21, line: 11 },
+      start: { column: 6, line: 9 },
+      end: { column: 21, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: "=",
 
-    range: [339, 340],
+    range: [159, 160],
     loc: {
-      start: { column: 22, line: 11 },
-      end: { column: 23, line: 11 },
+      start: { column: 22, line: 9 },
+      end: { column: 23, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: "<",
 
-    range: [341, 342],
+    range: [161, 162],
     loc: {
-      start: { column: 24, line: 11 },
-      end: { column: 25, line: 11 },
+      start: { column: 24, line: 9 },
+      end: { column: 25, line: 9 },
     },
   },
   JSXIdentifier {
     type: "JSXIdentifier",
     value: "foo-bar",
 
-    range: [342, 349],
+    range: [162, 169],
     loc: {
-      start: { column: 25, line: 11 },
-      end: { column: 32, line: 11 },
+      start: { column: 25, line: 9 },
+      end: { column: 32, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: ":",
 
-    range: [349, 350],
+    range: [169, 170],
     loc: {
-      start: { column: 32, line: 11 },
-      end: { column: 33, line: 11 },
+      start: { column: 32, line: 9 },
+      end: { column: 33, line: 9 },
     },
   },
   JSXIdentifier {
     type: "JSXIdentifier",
     value: "baz-bam",
 
-    range: [350, 357],
+    range: [170, 177],
     loc: {
-      start: { column: 33, line: 11 },
-      end: { column: 40, line: 11 },
+      start: { column: 33, line: 9 },
+      end: { column: 40, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: "/",
 
-    range: [358, 359],
+    range: [178, 179],
     loc: {
-      start: { column: 41, line: 11 },
-      end: { column: 42, line: 11 },
+      start: { column: 41, line: 9 },
+      end: { column: 42, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: ">",
 
-    range: [359, 360],
+    range: [179, 180],
     loc: {
-      start: { column: 42, line: 11 },
-      end: { column: 43, line: 11 },
+      start: { column: 42, line: 9 },
+      end: { column: 43, line: 9 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: ";",
 
-    range: [360, 361],
+    range: [180, 181],
     loc: {
-      start: { column: 43, line: 11 },
-      end: { column: 44, line: 11 },
+      start: { column: 43, line: 9 },
+      end: { column: 44, line: 9 },
     },
   },
 ]

--- a/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/5-AST-Alignment-AST.shot
+++ b/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/5-AST-Alignment-AST.shot
@@ -174,10 +174,10 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed AST Alignment - AST
               name: 'componentBasic',
 -             optional: false,
 
-              range: [201, 215],
+              range: [111, 125],
               loc: {
-                start: { column: 6, line: 9 },
-                end: { column: 20, line: 9 },
+                start: { column: 6, line: 8 },
+                end: { column: 20, line: 8 },
               },
             },
             init: JSXElement {
@@ -191,42 +191,42 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed AST Alignment - AST
                   type: 'JSXIdentifier',
                   name: 'foo',
 
-                  range: [219, 222],
+                  range: [129, 132],
                   loc: {
-                    start: { column: 24, line: 9 },
-                    end: { column: 27, line: 9 },
+                    start: { column: 24, line: 8 },
+                    end: { column: 27, line: 8 },
                   },
                 },
                 selfClosing: true,
 
-                range: [218, 225],
+                range: [128, 135],
                 loc: {
-                  start: { column: 23, line: 9 },
-                  end: { column: 30, line: 9 },
+                  start: { column: 23, line: 8 },
+                  end: { column: 30, line: 8 },
                 },
               },
 
-              range: [218, 225],
+              range: [128, 135],
               loc: {
-                start: { column: 23, line: 9 },
-                end: { column: 30, line: 9 },
+                start: { column: 23, line: 8 },
+                end: { column: 30, line: 8 },
               },
             },
 
-            range: [201, 225],
+            range: [111, 135],
             loc: {
-              start: { column: 6, line: 9 },
-              end: { column: 30, line: 9 },
+              start: { column: 6, line: 8 },
+              end: { column: 30, line: 8 },
             },
           },
         ],
 -       declare: false,
         kind: 'const',
 
-        range: [195, 226],
+        range: [105, 136],
         loc: {
-          start: { column: 0, line: 9 },
-          end: { column: 31, line: 9 },
+          start: { column: 0, line: 8 },
+          end: { column: 31, line: 8 },
         },
       },
       VariableDeclaration {
@@ -241,10 +241,10 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed AST Alignment - AST
               name: 'componentDashed',
 -             optional: false,
 
-              range: [323, 338],
+              range: [143, 158],
               loc: {
-                start: { column: 6, line: 11 },
-                end: { column: 21, line: 11 },
+                start: { column: 6, line: 9 },
+                end: { column: 21, line: 9 },
               },
             },
             init: JSXElement {
@@ -260,68 +260,68 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed AST Alignment - AST
                     type: 'JSXIdentifier',
                     name: 'baz-bam',
 
-                    range: [350, 357],
+                    range: [170, 177],
                     loc: {
-                      start: { column: 33, line: 11 },
-                      end: { column: 40, line: 11 },
+                      start: { column: 33, line: 9 },
+                      end: { column: 40, line: 9 },
                     },
                   },
                   namespace: JSXIdentifier {
                     type: 'JSXIdentifier',
                     name: 'foo-bar',
 
-                    range: [342, 349],
+                    range: [162, 169],
                     loc: {
-                      start: { column: 25, line: 11 },
-                      end: { column: 32, line: 11 },
+                      start: { column: 25, line: 9 },
+                      end: { column: 32, line: 9 },
                     },
                   },
 
-                  range: [342, 357],
+                  range: [162, 177],
                   loc: {
-                    start: { column: 25, line: 11 },
-                    end: { column: 40, line: 11 },
+                    start: { column: 25, line: 9 },
+                    end: { column: 40, line: 9 },
                   },
                 },
                 selfClosing: true,
 
-                range: [341, 360],
+                range: [161, 180],
                 loc: {
-                  start: { column: 24, line: 11 },
-                  end: { column: 43, line: 11 },
+                  start: { column: 24, line: 9 },
+                  end: { column: 43, line: 9 },
                 },
               },
 
-              range: [341, 360],
+              range: [161, 180],
               loc: {
-                start: { column: 24, line: 11 },
-                end: { column: 43, line: 11 },
+                start: { column: 24, line: 9 },
+                end: { column: 43, line: 9 },
               },
             },
 
-            range: [323, 360],
+            range: [143, 180],
             loc: {
-              start: { column: 6, line: 11 },
-              end: { column: 43, line: 11 },
+              start: { column: 6, line: 9 },
+              end: { column: 43, line: 9 },
             },
           },
         ],
 -       declare: false,
         kind: 'const',
 
-        range: [317, 361],
+        range: [137, 181],
         loc: {
-          start: { column: 0, line: 11 },
-          end: { column: 44, line: 11 },
+          start: { column: 0, line: 9 },
+          end: { column: 44, line: 9 },
         },
       },
     ],
     sourceType: 'script',
 
-    range: [0, 362],
+    range: [0, 182],
     loc: {
       start: { column: 0, line: 1 },
-      end: { column: 0, line: 12 },
+      end: { column: 0, line: 10 },
     },
   }"
 `;

--- a/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/6-AST-Alignment-Tokens.shot
+++ b/packages/ast-spec/src/jsx/JSXNamespacedName/fixtures/component-dashed/snapshots/6-AST-Alignment-Tokens.shot
@@ -182,7 +182,87 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed AST Alignment - Tok
       type: 'Keyword',
       value: 'const',
 
-      range: [195, 200],
+      range: [105, 110],
+      loc: {
+        start: { column: 0, line: 8 },
+        end: { column: 5, line: 8 },
+      },
+    },
+    Identifier {
+      type: 'Identifier',
+      value: 'componentBasic',
+
+      range: [111, 125],
+      loc: {
+        start: { column: 6, line: 8 },
+        end: { column: 20, line: 8 },
+      },
+    },
+    Punctuator {
+      type: 'Punctuator',
+      value: '=',
+
+      range: [126, 127],
+      loc: {
+        start: { column: 21, line: 8 },
+        end: { column: 22, line: 8 },
+      },
+    },
+    Punctuator {
+      type: 'Punctuator',
+      value: '<',
+
+      range: [128, 129],
+      loc: {
+        start: { column: 23, line: 8 },
+        end: { column: 24, line: 8 },
+      },
+    },
+    JSXIdentifier {
+      type: 'JSXIdentifier',
+      value: 'foo',
+
+      range: [129, 132],
+      loc: {
+        start: { column: 24, line: 8 },
+        end: { column: 27, line: 8 },
+      },
+    },
+    Punctuator {
+      type: 'Punctuator',
+      value: '/',
+
+      range: [133, 134],
+      loc: {
+        start: { column: 28, line: 8 },
+        end: { column: 29, line: 8 },
+      },
+    },
+    Punctuator {
+      type: 'Punctuator',
+      value: '>',
+
+      range: [134, 135],
+      loc: {
+        start: { column: 29, line: 8 },
+        end: { column: 30, line: 8 },
+      },
+    },
+    Punctuator {
+      type: 'Punctuator',
+      value: ';',
+
+      range: [135, 136],
+      loc: {
+        start: { column: 30, line: 8 },
+        end: { column: 31, line: 8 },
+      },
+    },
+    Keyword {
+      type: 'Keyword',
+      value: 'const',
+
+      range: [137, 142],
       loc: {
         start: { column: 0, line: 9 },
         end: { column: 5, line: 9 },
@@ -190,112 +270,32 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed AST Alignment - Tok
     },
     Identifier {
       type: 'Identifier',
-      value: 'componentBasic',
-
-      range: [201, 215],
-      loc: {
-        start: { column: 6, line: 9 },
-        end: { column: 20, line: 9 },
-      },
-    },
-    Punctuator {
-      type: 'Punctuator',
-      value: '=',
-
-      range: [216, 217],
-      loc: {
-        start: { column: 21, line: 9 },
-        end: { column: 22, line: 9 },
-      },
-    },
-    Punctuator {
-      type: 'Punctuator',
-      value: '<',
-
-      range: [218, 219],
-      loc: {
-        start: { column: 23, line: 9 },
-        end: { column: 24, line: 9 },
-      },
-    },
-    JSXIdentifier {
-      type: 'JSXIdentifier',
-      value: 'foo',
-
-      range: [219, 222],
-      loc: {
-        start: { column: 24, line: 9 },
-        end: { column: 27, line: 9 },
-      },
-    },
-    Punctuator {
-      type: 'Punctuator',
-      value: '/',
-
-      range: [223, 224],
-      loc: {
-        start: { column: 28, line: 9 },
-        end: { column: 29, line: 9 },
-      },
-    },
-    Punctuator {
-      type: 'Punctuator',
-      value: '>',
-
-      range: [224, 225],
-      loc: {
-        start: { column: 29, line: 9 },
-        end: { column: 30, line: 9 },
-      },
-    },
-    Punctuator {
-      type: 'Punctuator',
-      value: ';',
-
-      range: [225, 226],
-      loc: {
-        start: { column: 30, line: 9 },
-        end: { column: 31, line: 9 },
-      },
-    },
-    Keyword {
-      type: 'Keyword',
-      value: 'const',
-
-      range: [317, 322],
-      loc: {
-        start: { column: 0, line: 11 },
-        end: { column: 5, line: 11 },
-      },
-    },
-    Identifier {
-      type: 'Identifier',
       value: 'componentDashed',
 
-      range: [323, 338],
+      range: [143, 158],
       loc: {
-        start: { column: 6, line: 11 },
-        end: { column: 21, line: 11 },
+        start: { column: 6, line: 9 },
+        end: { column: 21, line: 9 },
       },
     },
     Punctuator {
       type: 'Punctuator',
       value: '=',
 
-      range: [339, 340],
+      range: [159, 160],
       loc: {
-        start: { column: 22, line: 11 },
-        end: { column: 23, line: 11 },
+        start: { column: 22, line: 9 },
+        end: { column: 23, line: 9 },
       },
     },
     Punctuator {
       type: 'Punctuator',
       value: '<',
 
-      range: [341, 342],
+      range: [161, 162],
       loc: {
-        start: { column: 24, line: 11 },
-        end: { column: 25, line: 11 },
+        start: { column: 24, line: 9 },
+        end: { column: 25, line: 9 },
       },
     },
 -   Identifier {
@@ -304,20 +304,20 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed AST Alignment - Tok
 +     type: 'JSXIdentifier',
       value: 'foo-bar',
 
-      range: [342, 349],
+      range: [162, 169],
       loc: {
-        start: { column: 25, line: 11 },
-        end: { column: 32, line: 11 },
+        start: { column: 25, line: 9 },
+        end: { column: 32, line: 9 },
       },
     },
     Punctuator {
       type: 'Punctuator',
       value: ':',
 
-      range: [349, 350],
+      range: [169, 170],
       loc: {
-        start: { column: 32, line: 11 },
-        end: { column: 33, line: 11 },
+        start: { column: 32, line: 9 },
+        end: { column: 33, line: 9 },
       },
     },
 -   Identifier {
@@ -326,40 +326,40 @@ exports[`AST Fixtures jsx JSXNamespacedName component-dashed AST Alignment - Tok
 +     type: 'JSXIdentifier',
       value: 'baz-bam',
 
-      range: [350, 357],
+      range: [170, 177],
       loc: {
-        start: { column: 33, line: 11 },
-        end: { column: 40, line: 11 },
+        start: { column: 33, line: 9 },
+        end: { column: 40, line: 9 },
       },
     },
     Punctuator {
       type: 'Punctuator',
       value: '/',
 
-      range: [358, 359],
+      range: [178, 179],
       loc: {
-        start: { column: 41, line: 11 },
-        end: { column: 42, line: 11 },
+        start: { column: 41, line: 9 },
+        end: { column: 42, line: 9 },
       },
     },
     Punctuator {
       type: 'Punctuator',
       value: '>',
 
-      range: [359, 360],
+      range: [179, 180],
       loc: {
-        start: { column: 42, line: 11 },
-        end: { column: 43, line: 11 },
+        start: { column: 42, line: 9 },
+        end: { column: 43, line: 9 },
       },
     },
     Punctuator {
       type: 'Punctuator',
       value: ';',
 
-      range: [360, 361],
+      range: [180, 181],
       loc: {
-        start: { column: 43, line: 11 },
-        end: { column: 44, line: 11 },
+        start: { column: 43, line: 9 },
+        end: { column: 44, line: 9 },
       },
     },
   ]"

--- a/packages/ast-spec/tests/fixtures.test.ts
+++ b/packages/ast-spec/tests/fixtures.test.ts
@@ -72,7 +72,7 @@ const FIXTURES: readonly Fixture[] = [...VALID_FIXTURES, ...ERROR_FIXTURES].map(
         }
       })(),
       ext,
-      isError: absolute.includes('/_error_/'),
+      isError: /[\\/]_error_[\\/]/.test(absolute),
       isJSX: ext.endsWith('x'),
       name,
       relative: path.relative(SRC_DIR, absolute).replace(/\\/g, '/'),

--- a/packages/ast-spec/tsconfig.json
+++ b/packages/ast-spec/tsconfig.json
@@ -5,6 +5,6 @@
     "rootDir": "."
   },
   "include": ["src", "typings", "tests", "tools", "**/fixtures/**/config.ts"],
-  "exclude": ["**/fixtures/**/fixture.ts"],
+  "exclude": ["**/fixtures/**/fixture.ts", "**/fixtures/**/fixture.tsx"],
   "references": [{ "path": "../typescript-estree/tsconfig.build.json" }]
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7166
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- exclude tsx files from type-check
- allow tests to be executed on windows
