### PR TITLE
chore: group jest versions in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -74,9 +74,8 @@
       groupName: 'babel',
     },
     {
-      extends: ['monorepo:jest'],
       matchPackageNames: ['ts-jest', 'pretty-format'],
-      matchPackagePrefixes: ['@types/jest', 'jest-', '@jest'],
+      matchPackagePrefixes: ['@types/jest', 'jest', '@jest'],
       groupName: 'jest',
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,7 +76,7 @@
     {
       extends: ['monorepo:jest'],
       matchPackageNames: ['ts-jest', 'pretty-format'],
-      matchPackagePrefixes: ['@types/jest', 'jest-', '@jest/'],
+      matchPackagePrefixes: ['@types/jest', 'jest-', '@jest'],
       groupName: 'jest',
     },
   ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7537 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I updated the jest config to match the babel config, as suggested here: https://github.com/typescript-eslint/typescript-eslint/issues/7537#issuecomment-1693273153
