### PR TITLE
fix(eslint-plugin): check possibly undefined ancestor.parent

### DIFF
--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -95,6 +95,7 @@ export default util.createRule({
 
       while (ancestor && !ts.isFunctionLike(ancestor)) {
         if (
+          ancestor.parent &&
           ts.isTryStatement(ancestor.parent) &&
           ts.isBlock(ancestor) &&
           ancestor.parent.end === ancestor.end


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Check if `ancestor.parent` is defined before passing it to typescript which will otherwise crash with:
`TypeError: Cannot read properties of undefined (reading 'kind')` on an undefined value.


