### PR TITLE
chore(website): add preview of compiled code

### DIFF
--- a/packages/website/src/components/Playground.tsx
+++ b/packages/website/src/components/Playground.tsx
@@ -98,7 +98,7 @@ function Playground(): React.JSX.Element {
             <div className={clsx(styles.sourceCode)}>
               {isLoading && <Loader />}
               <EditorTabs
-                tabs={['code', 'tsconfig', 'eslintrc']}
+                tabs={['code', 'tsconfig', 'eslintrc', 'compiled']}
                 active={activeTab}
                 change={setTab}
                 showVisualEditor={activeTab !== 'code'}

--- a/packages/website/src/components/Playground.tsx
+++ b/packages/website/src/components/Playground.tsx
@@ -101,7 +101,9 @@ function Playground(): React.JSX.Element {
                 tabs={['code', 'tsconfig', 'eslintrc', 'compiled']}
                 active={activeTab}
                 change={setTab}
-                showVisualEditor={activeTab !== 'code'}
+                showVisualEditor={
+                  activeTab !== 'code' && activeTab !== 'compiled'
+                }
                 showModal={onVisualEditor}
               />
               {(activeVisualEditor === 'eslintrc' && (

--- a/packages/website/src/components/linter/createParser.ts
+++ b/packages/website/src/components/linter/createParser.ts
@@ -85,6 +85,17 @@ export function createParser(
         typeChecker: checker,
       });
 
+      const compiledFiles =
+        compilerHost.languageService.getEmitOutput(filePath);
+
+      const fileSep = '// --------------------------';
+      compilerHost.createFile(
+        '/compiled',
+        compiledFiles.outputFiles
+          .map(file => `${fileSep}\n// ${file.name}\n${fileSep}\n` + file.text)
+          .join(`\n`),
+      );
+
       return {
         ast: converted.estree,
         services: {

--- a/packages/website/src/components/types.ts
+++ b/packages/website/src/components/types.ts
@@ -13,7 +13,7 @@ export interface RuleDetails {
   url?: string;
 }
 
-export type TabType = 'code' | 'eslintrc' | 'tsconfig';
+export type TabType = 'code' | 'eslintrc' | 'tsconfig' | 'compiled';
 
 export type ConfigFileType = `${ts.Extension}`;
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I'm not really sure if we even need/want this but there was some discussions about adding this option when we added playground to website some time ago :)

[playground](https://deploy-preview-7622--typescript-eslint.netlify.app/play/#ts=5.2.2&fileType=.tsx&code=CYUwxgNghgTiAEAzArgOzAFwJYHtX1DBwAoA6cgfQAdYoBbALnilQE8BKJl1gbgFgAUIJAAPKjhgZ4kKAGdZ8AMLQAXivgBvQfHgABQjm3w6IDAAscwADwAVELIwA%2BYnYdNXGdpsFGAvoP8BIA&eslintrc=N4KABGBEBOCuA2BTAzpAXGYBfEWg&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3QAacDTqw2maOgCyAQ0QUwoiVNoATfqmWZlBYus2SaUPIYDm6POsjoSANkhSAviA9A&tokens=false)

TODO: 
- [x] hide visaul editor
- [ ] maybe improve sync between vfs and editor

### default
![image](https://github.com/typescript-eslint/typescript-eslint/assets/625469/f394ab9f-993a-403e-97ac-f896354a95a9)

### with declarations
![image](https://github.com/typescript-eslint/typescript-eslint/assets/625469/cccdd7e3-c918-47ae-9e3c-99a7cb5340c7)

### target: "es2015"
![image](https://github.com/typescript-eslint/typescript-eslint/assets/625469/42161e03-32d2-4a18-9f29-276df8d7f247)

