### PR TITLE
chore(website): have start depend on website-eslint:build

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -11,7 +11,7 @@
     "stylelint:fix": "stylelint \"src/**/*.css\" --fix",
     "lint": "nx lint",
     "serve": "docusaurus serve",
-    "start": "docusaurus start",
+    "start": "nx start",
     "swizzle": "docusaurus swizzle",
     "test": "playwright test",
     "typecheck": "tsc -b ./tsconfig.json"

--- a/packages/website/project.json
+++ b/packages/website/project.json
@@ -4,6 +4,14 @@
   "type": "library",
   "implicitDependencies": [],
   "targets": {
+    "start": {
+      "dependsOn": ["website-eslint:build"],
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/website",
+        "command": "docusaurus start"
+      }
+    },
     "lint": {
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7417
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Uses an Nx target so that we can indicate it depends on `website-eslint`'s `build`.

Locally it seemed to run build for other packages - which is probably good? To make sure they're up-to-date for `website-eslint`?