### PR TITLE
chore: add discord and stackoverflow as links to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,9 @@ contact_links:
   - name: Getting Started Guide
     about: If you're looking for help setting up check out our getting started guide
     url: https://typescript-eslint.io
+  - name: Ask a question on Discord
+    about: If you just want to ask a question, consider asking it on Discord!
+    url: https://discord.gg/FSxKq8Tdyg
+  - name: Ask a question on StackOverflow
+    about: If you just want to ask a question, consider asking it on StackOverflow!
+    url: https://stackoverflow.com/questions/tagged/typescript-eslint 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,4 +11,4 @@ contact_links:
     url: https://discord.gg/FSxKq8Tdyg
   - name: Ask a question on StackOverflow
     about: If you just want to ask a question, consider asking it on StackOverflow!
-    url: https://stackoverflow.com/questions/tagged/typescript-eslint 
+    url: https://stackoverflow.com/questions/tagged/typescript-eslint


### PR DESCRIPTION
IDK if this is the best as it adds more noise
But people can't easily find these options right now without jumping through some hoops.
