### PR TITLE
docs(eslint-plugin): fix ignorePrimitives examples in prefer-nullish-coalescing docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.md
@@ -9,7 +9,7 @@ description: 'Enforce using the nullish coalescing operator instead of logical a
 The `??` nullish coalescing runtime operator allows providing a default value when dealing with `null` or `undefined`.
 Because the nullish coalescing operator _only_ coalesces when the original value is `null` or `undefined`, it is much safer than relying upon logical OR operator chaining `||`, which coalesces on any _falsy_ value.
 
-This rule reports when you can safely replace:
+This rule reports when you may consider replacing:
 
 - An `||` operator with `??`
 - An `||=` operator with `??=`
@@ -144,28 +144,28 @@ a ?? (b && c && d);
 
 ### `ignorePrimitives`
 
-If you would like to ignore certain primitive types that can be falsy then you may pass an object containing a boolean value for each primitive:
+If you would like to ignore expressions containing operands of certain primitive types that can be falsy then you may pass an object containing a boolean value for each primitive:
 
 - `string: true`, ignores `null` or `undefined` unions with `string` (default: false).
 - `number: true`, ignores `null` or `undefined` unions with `number` (default: false).
 - `bigint: true`, ignores `null` or `undefined` unions with `bigint` (default: false).
 - `boolean: true`, ignores `null` or `undefined` unions with `boolean` (default: false).
 
-Incorrect code for `ignorePrimitives: { string: true }`, and correct code for `ignorePrimitives: { string: false }`:
+Incorrect code for `ignorePrimitives: { string: false }`, and correct code for `ignorePrimitives: { string: true }`:
 
 ```ts
 const foo: string | undefined = 'bar';
 foo || 'a string';
 ```
 
-Correct code for `ignorePrimitives: { string: true }`:
+Correct code for both `ignorePrimitives: { string: false }` and `ignorePrimitives: { string: true }`:
 
 ```ts
 const foo: string | undefined = 'bar';
 foo ?? 'a string';
 ```
 
-Also, if you would like to ignore all primitives types, you can set `ignorePrimitives: true`. It would be equivalent to `ignorePrimitives: { string: true, number: true, bigint: true, boolean: true }`.
+Also, if you would like to ignore all primitives types, you can set `ignorePrimitives: true`. It is equivalent to `ignorePrimitives: { string: true, number: true, bigint: true, boolean: true }`.
 
 ## When Not To Use It
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: brought up in (but doesn't close) #7628
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The examples for the `ignorePrimitives` option were flipped. Setting `ignorePrimitives` to true means that any logical OR expression with a primitive operand is ignored by the lint rule.

I also made two other edits to this docs page. The first is to change "you can safely replace" to "you may consider replacing" in the lint rule's description. The reason for this change is that this lint rule suggests changes that alter the code's behavior in subtle cases where `x || y !== x ?? y`. My interpretation of "safe" for lint suggestions is they don't change the behavior of the code, please let me know if this expectation isn't correct!

There is also a small change to reword the tense in one of the sentences to help it read more smoothly.

