### PR TITLE
docs(eslint-plugin): add missing quotes for examples in no-duplicate-type-constituents

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-duplicate-type-constituents.md
+++ b/packages/eslint-plugin/docs/rules/no-duplicate-type-constituents.md
@@ -21,7 +21,7 @@ For example, given `type A = string` and `type T = string | A`, this rule would 
 ```ts
 type T1 = 'A' | 'A';
 
-type T2 = A | A | B;
+type T2 = 'A' | 'A' | 'B';
 
 type T3 = { a: string } & { a: string };
 
@@ -37,7 +37,7 @@ type T5 = StringA | StringB;
 ```ts
 type T1 = 'A' | 'B';
 
-type T2 = A | B | C;
+type T2 = 'A' | 'B' | 'C';
 
 type T3 = { a: string } & { b: string };
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes 
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The examples in "[no-duplicate-type-constituents](https://typescript-eslint.io/rules/no-duplicate-type-constituents)" are missing quotes, causing this code to compile with errors.

<img width="557" alt="Screenshot 2023-09-15 at 19 55 19" src="https://github.com/typescript-eslint/typescript-eslint/assets/22116465/0a2b62dc-260d-424d-acc8-92228d47f4fa">

```ts
type T1 = 'A' | 'A';

// 2304: Cannot find name 'A'. 3:11 - 3:12
type T2 = A | A | B;

type T3 = { a: string } & { a: string };

type T4 = [1, 2, 3] | [1, 2, 3];

type StringA = string;
type StringB = string;
type T5 = StringA | StringB;
```

https://typescript-eslint.io/play/#ts=5.2.2&fileType=.tsx&code=C4TwDgpgBAKgjFAvFA5AQRVAPqjBuAKANElgCYko1sqaAhQ48aGAZkoG8oBDALigDOwAE4BLAHYBzKAF8oAMihc%2BgkROkzGJFgBZKAbTgAaKGROsAujUMmzUS1uZQAymqnVkQsVMLaXbyTpKL3VfJxgAVkpXb0lqHBj1BiA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1oBNZjGyAQ3yJaRUrTIcmyfJXyxELVBkiJo0DtEjgwAXxB6gA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false
