### PR TITLE
fix(eslint-plugin): [no-confusing-void-expression] handle unfixable cases

### DIFF
--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -347,14 +347,14 @@ export default createRule<Options, MessageId>({
     function canFix(
       node: TSESTree.ReturnStatement | TSESTree.ArrowFunctionExpression,
     ): boolean {
-      const services = util.getParserServices(context);
+      const services = getParserServices(context);
 
       const targetNode =
         node.type === AST_NODE_TYPES.ReturnStatement
           ? node.argument!
           : node.body;
 
-      const type = util.getConstrainedTypeAtLocation(services, targetNode);
+      const type = getConstrainedTypeAtLocation(services, targetNode);
       return tsutils.isTypeFlagSet(type, ts.TypeFlags.VoidLike);
     }
   },

--- a/packages/eslint-plugin/tests/rules/no-confusing-void-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-confusing-void-expression.test.ts
@@ -199,12 +199,25 @@ function notcool(input: string) {
     {
       code: 'foo => foo && console.log(foo);',
       errors: [{ line: 1, column: 15, messageId: 'invalidVoidExprArrow' }],
-      output: `foo => { foo && console.log(foo); };`,
+    },
+    {
+      code: '(foo: undefined) => foo && console.log(foo);',
+      errors: [{ line: 1, column: 28, messageId: 'invalidVoidExprArrow' }],
+      output: `(foo: undefined) => { foo && console.log(foo); };`,
     },
     {
       code: 'foo => foo || console.log(foo);',
       errors: [{ line: 1, column: 15, messageId: 'invalidVoidExprArrow' }],
-      output: `foo => { foo || console.log(foo); };`,
+    },
+    {
+      code: '(foo: undefined) => foo || console.log(foo);',
+      errors: [{ line: 1, column: 28, messageId: 'invalidVoidExprArrow' }],
+      output: `(foo: undefined) => { foo || console.log(foo); };`,
+    },
+    {
+      code: '(foo: void) => foo || console.log(foo);',
+      errors: [{ line: 1, column: 23, messageId: 'invalidVoidExprArrow' }],
+      output: `(foo: void) => { foo || console.log(foo); };`,
     },
     {
       code: 'foo => (foo ? console.log(true) : console.log(false));',
@@ -310,7 +323,72 @@ function notcool(input: string) {
         };
       `,
     },
-
+    {
+      code: `
+        const f = function () {
+          let num = 1;
+          return num ? console.log('foo') : num;
+        };
+      `,
+      errors: [{ line: 4, column: 24, messageId: 'invalidVoidExprReturnLast' }],
+    },
+    {
+      code: `
+        const f = function () {
+          let undef = undefined;
+          return undef ? console.log('foo') : undef;
+        };
+      `,
+      errors: [{ line: 4, column: 26, messageId: 'invalidVoidExprReturnLast' }],
+      output: `
+        const f = function () {
+          let undef = undefined;
+          undef ? console.log('foo') : undef;
+        };
+      `,
+    },
+    {
+      code: `
+        const f = function () {
+          let num = 1;
+          return num || console.log('foo');
+        };
+      `,
+      errors: [{ line: 4, column: 25, messageId: 'invalidVoidExprReturnLast' }],
+    },
+    {
+      code: `
+        const f = function () {
+          let bar = void 0;
+          return bar || console.log('foo');
+        };
+      `,
+      errors: [{ line: 4, column: 25, messageId: 'invalidVoidExprReturnLast' }],
+      output: `
+        const f = function () {
+          let bar = void 0;
+          bar || console.log('foo');
+        };
+      `,
+    },
+    {
+      code: `
+        let num = 1;
+        const foo = () => (num ? console.log('foo') : num);
+      `,
+      errors: [{ line: 3, column: 34, messageId: 'invalidVoidExprArrow' }],
+    },
+    {
+      code: `
+        let bar = void 0;
+        const foo = () => (bar ? console.log('foo') : bar);
+      `,
+      errors: [{ line: 3, column: 34, messageId: 'invalidVoidExprArrow' }],
+      output: `
+        let bar = void 0;
+        const foo = () => { bar ? console.log('foo') : bar; };
+      `,
+    },
     {
       options: [{ ignoreVoidOperator: true }],
       code: "return console.log('foo');",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6187
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This change will prevent autofixes in certain cases. Before the change, it worked like this
```ts
  const f = function () {
          let num = 1;
          return num ? console.log('foo') : num;
  };

// after fix
  const f = function () {
          let num = 1;
          num ? console.log('foo') : num;
  };
```

I changed to not apply fix to node which can be conditionally void.

```ts
let num = 1;
const foo = () => num ? console.log('foo') : num;

const f = function () {
     let num = 1;
     return num ? console.log('foo') : num;
};
```


<!-- Description of what is changed and how the code change does that. -->
