### PR TITLE
fix(utils): type portability with `RuleCreator`, fix #7605

### DIFF
--- a/packages/utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/utils/src/eslint-utils/RuleCreator.ts
@@ -7,6 +7,8 @@ import type {
 } from '../ts-eslint/Rule';
 import { applyDefault } from './applyDefault';
 
+export type { RuleListener, RuleModule };
+
 // we automatically add the url
 export type NamedCreateRuleMetaDocs = Omit<RuleMetaDataDocs, 'url'>;
 export type NamedCreateRuleMeta<TMessageIds extends string> = Omit<


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7605
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Reproduction: https://github.com/antfu/repro-ts-eslint-utils-dts - fails on both tsup and unbuild

Reproduction with patch: https://github.com/antfu/repro-ts-eslint-utils-dts/tree/patched (the `patched` branch) - both tsup and unbuild work correctly and generated the following dts:

```ts
import { ESLintUtils } from '@typescript-eslint/utils';

declare const _default: ESLintUtils.RuleModule<"missingIfNewline", [], ESLintUtils.RuleListener>;

export { _default as default };
```

<!-- Description of what is changed and how the code change does that. -->
