### PR TITLE
build: fix website test command start

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -11,7 +11,7 @@
     "stylelint:fix": "stylelint \"src/**/*.css\" --fix",
     "lint": "nx lint",
     "serve": "docusaurus serve",
-    "start": "nx start",
+    "start": "npx nx start",
     "swizzle": "docusaurus swizzle",
     "test": "playwright test",
     "typecheck": "tsc -b ./tsconfig.json"


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7698
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I'm not confident this is the best/right canonical way to get scoping to work, but `yarn start`  in the `website` package is fixed by it on my machine.