### PR TITLE
fix(eslint-plugin): [class-methods-use-this] detect a problematic case for private/protected members if `ignoreClassesThatImplementAnInterface` is set

### DIFF
--- a/packages/eslint-plugin/docs/rules/class-methods-use-this.md
+++ b/packages/eslint-plugin/docs/rules/class-methods-use-this.md
@@ -16,7 +16,7 @@ This rule adds the following options:
 ```ts
 interface Options extends BaseClassMethodsUseThisOptions {
   ignoreOverrideMethods?: boolean;
-  ignoreClassesThatImplementAnInterface?: boolean;
+  ignoreClassesThatImplementAnInterface?: boolean | 'public-fields';
 }
 
 const defaultOptions: Options = {
@@ -41,13 +41,49 @@ class X {
 
 ### `ignoreClassesThatImplementAnInterface`
 
-Makes the rule ignore all class members that are defined within a class that `implements` a type.
+Makes the rule ignore class members that are defined within a class that `implements` a type.
+If specified, it can be either:
+
+- `true`: Ignore all classes that implement an interface
+- `'public-fields'`: Ignore only the public fields of classes that implement an interface
 
 It's important to note that this option does not only apply to members defined in the interface as that would require type information.
+
+#### `true`
 
 Example of a correct code when `ignoreClassesThatImplementAnInterface` is set to `true`:
 
 ```ts option='{ "ignoreClassesThatImplementAnInterface": true }' showPlaygroundButton
+class X implements Y {
+  method() {}
+  property = () => {};
+}
+```
+
+#### `'public-fields'`
+
+Example of a incorrect code when `ignoreClassesThatImplementAnInterface` is set to `'public-fields'`:
+
+<!--tabs-->
+
+##### ❌ Incorrect
+
+```ts
+class X implements Y {
+  method() {}
+  property = () => {};
+
+  private privateMethod() {}
+  private privateProperty = () => {};
+
+  protected privateMethod() {}
+  protected privateProperty = () => {};
+}
+```
+
+##### ✅ Correct
+
+```ts
 class X implements Y {
   method() {}
   property = () => {};

--- a/packages/eslint-plugin/tests/rules/class-methods-use-this/class-methods-use-this.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-methods-use-this/class-methods-use-this.test.ts
@@ -43,6 +43,22 @@ class Foo {
     {
       code: `
 class Foo {
+  private override method() {}
+}
+      `,
+      options: [{ ignoreOverrideMethods: true }],
+    },
+    {
+      code: `
+class Foo {
+  protected override method() {}
+}
+      `,
+      options: [{ ignoreOverrideMethods: true }],
+    },
+    {
+      code: `
+class Foo {
   override get getter(): number {}
 }
       `,
@@ -51,7 +67,39 @@ class Foo {
     {
       code: `
 class Foo {
+  private override get getter(): number {}
+}
+      `,
+      options: [{ ignoreOverrideMethods: true }],
+    },
+    {
+      code: `
+class Foo {
+  protected override get getter(): number {}
+}
+      `,
+      options: [{ ignoreOverrideMethods: true }],
+    },
+    {
+      code: `
+class Foo {
   override set setter(v: number) {}
+}
+      `,
+      options: [{ ignoreOverrideMethods: true }],
+    },
+    {
+      code: `
+class Foo {
+  private override set setter(v: number) {}
+}
+      `,
+      options: [{ ignoreOverrideMethods: true }],
+    },
+    {
+      code: `
+class Foo {
+  protected override set setter(v: number) {}
 }
       `,
       options: [{ ignoreOverrideMethods: true }],
@@ -72,12 +120,76 @@ class Foo implements Bar {
     {
       code: `
 class Foo implements Bar {
+  private override method() {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+          // But overridden properties should be ignored.
+          ignoreOverrideMethods: true,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  protected override method() {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+          // But overridden properties should be ignored.
+          ignoreOverrideMethods: true,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
   override get getter(): number {}
 }
       `,
       options: [
         {
           ignoreClassesThatImplementAnInterface: true,
+          ignoreOverrideMethods: true,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  private override get getter(): number {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+          // But overridden properties should be ignored.
+          ignoreOverrideMethods: true,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  protected override get getter(): number {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+          // But overridden properties should be ignored.
           ignoreOverrideMethods: true,
         },
       ],
@@ -98,6 +210,38 @@ class Foo implements Bar {
     {
       code: `
 class Foo implements Bar {
+  private override set setter(v: number) {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+          // But overridden properties should be ignored.
+          ignoreOverrideMethods: true,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  protected override set setter(v: number) {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+          // But overridden properties should be ignored.
+          ignoreOverrideMethods: true,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
   property = () => {};
 }
       `,
@@ -107,6 +251,22 @@ class Foo implements Bar {
       code: `
 class Foo {
   override property = () => {};
+}
+      `,
+      options: [{ ignoreOverrideMethods: true }],
+    },
+    {
+      code: `
+class Foo {
+  private override property = () => {};
+}
+      `,
+      options: [{ ignoreOverrideMethods: true }],
+    },
+    {
+      code: `
+class Foo {
+  protected override property = () => {};
 }
       `,
       options: [{ ignoreOverrideMethods: true }],
@@ -150,12 +310,70 @@ class Foo {
         },
       ],
     },
+    {
+      code: `
+class Foo implements Bar {
+  private override property = () => {};
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should check only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+          // But overridden properties should be ignored.
+          ignoreOverrideMethods: true,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  protected override property = () => {};
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should check only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+          // But overridden properties should be ignored.
+          ignoreOverrideMethods: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {
       code: `
 class Foo {
   method() {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  private method() {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  protected method() {}
 }
       `,
       options: [{}],
@@ -194,6 +412,32 @@ class Foo {
     {
       code: `
 class Foo {
+  private get getter(): number {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  protected get getter(): number {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
   get #getter(): number {}
 }
       `,
@@ -208,6 +452,37 @@ class Foo {
       code: `
 class Foo {
   set setter(b: number) {}
+}
+      `,
+      options: [
+        {
+          ignoreClassesThatImplementAnInterface: false,
+          ignoreOverrideMethods: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  private set setter(b: number) {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  protected set setter(b: number) {}
 }
       `,
       options: [{}],
@@ -259,6 +534,44 @@ class Foo implements Bar {
     {
       code: `
 class Foo implements Bar {
+  private method() {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  protected method() {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
   get getter(): number {}
 }
       `,
@@ -285,6 +598,44 @@ class Foo implements Bar {
     {
       code: `
 class Foo implements Bar {
+  private get getter(): number {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  protected get getter(): number {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
   set setter(v: number) {}
 }
       `,
@@ -302,6 +653,46 @@ class Foo implements Bar {
 }
       `,
       options: [{ ignoreClassesThatImplementAnInterface: false }],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  private set setter(v: number) {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+          ignoreOverrideMethods: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  protected set setter(v: number) {}
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+          ignoreOverrideMethods: false,
+        },
+      ],
       errors: [
         {
           messageId: 'missingThis',
@@ -450,6 +841,44 @@ class Foo implements Bar {
         {
           ignoreClassesThatImplementAnInterface: false,
           ignoreOverrideMethods: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  private property = () => {};
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  protected property = () => {};
+}
+      `,
+      options: [
+        {
+          // _interface_ cannot have `private`/`protected` modifier on members.
+          // We should ignore only public members.
+          ignoreClassesThatImplementAnInterface: 'public-fields',
         },
       ],
       errors: [

--- a/packages/eslint-plugin/tests/rules/class-methods-use-this/class-methods-use-this.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-methods-use-this/class-methods-use-this.test.ts
@@ -18,6 +18,22 @@ class Foo implements Bar {
     },
     {
       code: `
+class Foo implements Bar {
+  get getter() {}
+}
+      `,
+      options: [{ ignoreClassesThatImplementAnInterface: true }],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  set setter() {}
+}
+      `,
+      options: [{ ignoreClassesThatImplementAnInterface: true }],
+    },
+    {
+      code: `
 class Foo {
   override method() {}
 }
@@ -26,8 +42,50 @@ class Foo {
     },
     {
       code: `
+class Foo {
+  override get getter(): number {}
+}
+      `,
+      options: [{ ignoreOverrideMethods: true }],
+    },
+    {
+      code: `
+class Foo {
+  override set setter(v: number) {}
+}
+      `,
+      options: [{ ignoreOverrideMethods: true }],
+    },
+    {
+      code: `
 class Foo implements Bar {
   override method() {}
+}
+      `,
+      options: [
+        {
+          ignoreClassesThatImplementAnInterface: true,
+          ignoreOverrideMethods: true,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  override get getter(): number {}
+}
+      `,
+      options: [
+        {
+          ignoreClassesThatImplementAnInterface: true,
+          ignoreOverrideMethods: true,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  override set setter(v: number) {}
 }
       `,
       options: [
@@ -96,8 +154,73 @@ class Foo {
   invalid: [
     {
       code: `
+class Foo {
+  method() {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  get getter(): number {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  set setter(b: number) {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
 class Foo implements Bar {
   method() {}
+}
+      `,
+      options: [{ ignoreClassesThatImplementAnInterface: false }],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  get getter(): number {}
+}
+      `,
+      options: [{ ignoreClassesThatImplementAnInterface: false }],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  set setter(v: number) {}
 }
       `,
       options: [{ ignoreClassesThatImplementAnInterface: false }],
@@ -122,8 +245,70 @@ class Foo {
     },
     {
       code: `
+class Foo {
+  override get getter(): number {}
+}
+      `,
+      options: [{ ignoreOverrideMethods: false }],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  override set setter(v: number) {}
+}
+      `,
+      options: [{ ignoreOverrideMethods: false }],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
 class Foo implements Bar {
   override method() {}
+}
+      `,
+      options: [
+        {
+          ignoreClassesThatImplementAnInterface: false,
+          ignoreOverrideMethods: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  override get getter(): number {}
+}
+      `,
+      options: [
+        {
+          ignoreClassesThatImplementAnInterface: false,
+          ignoreOverrideMethods: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  override set setter(v: number) {}
 }
       `,
       options: [

--- a/packages/eslint-plugin/tests/rules/class-methods-use-this/class-methods-use-this.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-methods-use-this/class-methods-use-this.test.ts
@@ -168,6 +168,19 @@ class Foo {
     {
       code: `
 class Foo {
+  #method() {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
   get getter(): number {}
 }
       `,
@@ -181,7 +194,33 @@ class Foo {
     {
       code: `
 class Foo {
+  get #getter(): number {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
   set setter(b: number) {}
+}
+      `,
+      options: [{}],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  set #setter(b: number) {}
 }
       `,
       options: [{}],
@@ -207,6 +246,19 @@ class Foo implements Bar {
     {
       code: `
 class Foo implements Bar {
+  #method() {}
+}
+      `,
+      options: [{ ignoreClassesThatImplementAnInterface: false }],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
   get getter(): number {}
 }
       `,
@@ -220,7 +272,33 @@ class Foo implements Bar {
     {
       code: `
 class Foo implements Bar {
+  get #getter(): number {}
+}
+      `,
+      options: [{ ignoreClassesThatImplementAnInterface: false }],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
   set setter(v: number) {}
+}
+      `,
+      options: [{ ignoreClassesThatImplementAnInterface: false }],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  set #setter(v: number) {}
 }
       `,
       options: [{ ignoreClassesThatImplementAnInterface: false }],
@@ -327,6 +405,19 @@ class Foo implements Bar {
       code: `
 class Foo implements Bar {
   property = () => {};
+}
+      `,
+      options: [{ ignoreClassesThatImplementAnInterface: false }],
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo implements Bar {
+  #property = () => {};
 }
       `,
       options: [{ ignoreClassesThatImplementAnInterface: false }],

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -36,8 +36,8 @@ function foo<T extends (Args: any) => void>(arg: T) {}
 export type ArrayInput<Func> = Func extends (arg0: Array<infer T>) => any
   ? T[]
   : Func extends (...args: infer T) => any
-  ? T
-  : never;
+    ? T
+    : never;
     `,
     `
 function foo() {

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -36,8 +36,8 @@ function foo<T extends (Args: any) => void>(arg: T) {}
 export type ArrayInput<Func> = Func extends (arg0: Array<infer T>) => any
   ? T[]
   : Func extends (...args: infer T) => any
-    ? T
-    : never;
+  ? T
+  : never;
     `,
     `
 function foo() {

--- a/packages/eslint-plugin/tests/schema-snapshots/class-methods-use-this.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/class-methods-use-this.shot
@@ -22,7 +22,17 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
       },
       "ignoreClassesThatImplementAnInterface": {
         "description": "Ignore classes that specifically implement some interface",
-        "type": "boolean"
+        "oneOf": [
+          {
+            "description": "Ignore all classes that implement an interface",
+            "type": "boolean"
+          },
+          {
+            "description": "Ignore only the public fields of classes that implement an interface",
+            "enum": ["public-fields"],
+            "type": "string"
+          }
+        ]
       },
       "ignoreOverrideMethods": {
         "description": "Ingore members marked with the \`override\` modifier",
@@ -43,7 +53,13 @@ type Options = [
     /** Allows specified method names to be ignored with this rule */
     exceptMethods?: string[];
     /** Ignore classes that specifically implement some interface */
-    ignoreClassesThatImplementAnInterface?: boolean;
+    ignoreClassesThatImplementAnInterface?: /**
+     * Ignore classes that specifically implement some interface
+     * Ignore all classes that implement an interface
+     */
+    | boolean
+      /** Ignore only the public fields of classes that implement an interface */
+      | 'public-fields';
     /** Ingore members marked with the \`override\` modifier */
     ignoreOverrideMethods?: boolean;
   },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7704
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This fixes #7704.

TypeScript's interface feature does not have any private/protected member as a part of it.

So the rule `class-methods-use-this` enabling ignoreClassesThatImplementAnInterface=true should warn the case of that the implementation is not a part of interface.