### PR TITLE
fix(eslint-plugin): [no-unsafe-return] allow returning anything if explicitly returning any

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-return.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-return.ts
@@ -96,7 +96,13 @@ export default util.createRule({
       // function return type, we shouldn't complain (it's intentional, even if unsafe)
       if (functionTSNode.type) {
         for (const signature of functionType.getCallSignatures()) {
-          if (returnNodeType === signature.getReturnType()) {
+          if (
+            returnNodeType === signature.getReturnType() ||
+            util.isTypeFlagSet(
+              signature.getReturnType(),
+              ts.TypeFlags.Any | ts.TypeFlags.Unknown,
+            )
+          ) {
             return;
           }
         }

--- a/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
@@ -114,6 +114,11 @@ function foo(): Set<number> {
         return [] as any[];
       }
     `,
+    `
+      function foo(): unknown {
+        return [] as any[];
+      }
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-return.test.ts
@@ -108,6 +108,12 @@ function foo(): Set<number> {
         return new Map();
       }
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/3549
+    `
+      function foo(): any {
+        return [] as any[];
+      }
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #3549
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I'm not sure if we should handle the following case: `const x: () => any = () => [] as any[];`

Overall the docs does not make it clear which cases are exempted, so I guess we have some room for interpretation.