### PR TITLE
docs: fix prefer-optional-chain example for the unsafe fixes option

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-optional-chain.md
+++ b/packages/eslint-plugin/docs/rules/prefer-optional-chain.md
@@ -76,7 +76,7 @@ declare function acceptsBoolean(arg: boolean): void;
 acceptsBoolean(foo != null && foo.bar);
 
 // ❌ typechecks UNSUCCESSFULLY as the expression returns `boolean | undefined`
-acceptsBoolean(foo != null && foo.bar);
+acceptsBoolean(foo?.bar);
 ```
 
 This style of code isn't super common - which means having this option set to `true` _should_ be safe in most codebases. However we default it to `false` due to its unsafe nature. We have provided this option for convenience because it increases the autofix cases covered by the rule. If you set option to `true` the onus is entirely on you and your team to ensure that each fix is correct and safe and that it does not break the build.


### PR DESCRIPTION
…odifyTheReturnTypeIKnowWhatImDoing in prefer-optional-chain

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7702
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
<!-- Description of what is changed and how the code change does that. -->
The example for the option allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing seems like a copy-paste error, which has two equal lines calling `acceptsBoolean`. The second line should be using optional chain.
