### PR TITLE
fix(eslint-plugin): [prefer-string-starts-ends-with] only report slice/substring with correct range

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -161,23 +161,22 @@ export default createRule({
     }
 
     /**
-     * Check if a given node is a negative index expression
-     *
-     * E.g. `s.slice(- <expr>)`, `s.substring(s.length - <expr>)`
-     *
-     * @param node The node to check.
-     * @param expectedIndexedNode The node which is expected as the receiver of index expression.
+     * Returns true if `node` is `-substring.length` or
+     * `parentString.length - substring.length`
      */
-    function isNegativeIndexExpression(
+    function isLengthAheadOfEnd(
       node: TSESTree.Node,
-      expectedIndexedNode: TSESTree.Node,
+      substring: TSESTree.Node,
+      parentString: TSESTree.Node,
     ): boolean {
       return (
         (node.type === AST_NODE_TYPES.UnaryExpression &&
-          node.operator === '-') ||
+          node.operator === '-' &&
+          isLengthExpression(node.argument, substring)) ||
         (node.type === AST_NODE_TYPES.BinaryExpression &&
           node.operator === '-' &&
-          isLengthExpression(node.left, expectedIndexedNode))
+          isLengthExpression(node.left, parentString) &&
+          isLengthExpression(node.right, substring))
       );
     }
 
@@ -567,16 +566,44 @@ export default createRule({
           return;
         }
 
-        const isEndsWith =
-          (callNode.arguments.length === 1 ||
-            (callNode.arguments.length === 2 &&
-              isLengthExpression(callNode.arguments[1], node.object))) &&
-          isNegativeIndexExpression(callNode.arguments[0], node.object);
-        const isStartsWith =
-          !isEndsWith &&
-          callNode.arguments.length === 2 &&
-          isNumber(callNode.arguments[0], 0) &&
-          !isNegativeIndexExpression(callNode.arguments[1], node.object);
+        let isEndsWith = false;
+        let isStartsWith = false;
+        if (callNode.arguments.length === 1) {
+          if (
+            // foo.slice(-bar.length) === bar
+            // foo.slice(foo.length - bar.length) === bar
+            isLengthAheadOfEnd(
+              callNode.arguments[0],
+              parentNode.right,
+              node.object,
+            )
+          ) {
+            isEndsWith = true;
+          }
+        } else if (callNode.arguments.length === 2) {
+          if (
+            // foo.slice(0, bar.length) === bar
+            isNumber(callNode.arguments[0], 0) &&
+            isLengthExpression(callNode.arguments[1], parentNode.right)
+          ) {
+            isStartsWith = true;
+          } else if (
+            // foo.slice(foo.length - bar.length, foo.length) === bar
+            // foo.slice(foo.length - bar.length, 0) === bar
+            // foo.slice(-bar.length, foo.length) === bar
+            // foo.slice(-bar.length, 0) === bar
+            (isLengthExpression(callNode.arguments[1], node.object) ||
+              isNumber(callNode.arguments[1], 0)) &&
+            isLengthAheadOfEnd(
+              callNode.arguments[0],
+              parentNode.right,
+              node.object,
+            )
+          ) {
+            isEndsWith = true;
+          }
+        }
+
         if (!isStartsWith && !isEndsWith) {
           return;
         }

--- a/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
@@ -242,6 +242,21 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
         x.endsWith('foo') && x.slice(0, -4) === 'bar'
       }
     `,
+    `
+      function f(s: string) {
+        s.slice(0, length) === needle // the 'length' can be different to 'needle.length'
+      }
+    `,
+    `
+      function f(s: string) {
+        s.slice(-length) === needle // 'length' can be different
+      }
+    `,
+    `
+      function f(s: string) {
+        s.slice(0, 3) === needle
+      }
+    `,
   ]),
   invalid: addOptional([
     // String indexing.
@@ -820,15 +835,6 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
     {
       code: `
         function f(s: string) {
-          s.slice(0, length) === needle // the 'length' can be different to 'needle.length'
-        }
-      `,
-      output: null,
-      errors: [{ messageId: 'preferStartsWith' }],
-    },
-    {
-      code: `
-        function f(s: string) {
           s.slice(0, needle.length) == needle // hating implicit type conversion
         }
       `,
@@ -885,15 +891,6 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
           s.endsWith(needle)
         }
       `,
-      errors: [{ messageId: 'preferEndsWith' }],
-    },
-    {
-      code: `
-        function f(s: string) {
-          s.slice(-length) === needle // 'length' can be different
-        }
-      `,
-      output: null,
       errors: [{ messageId: 'preferEndsWith' }],
     },
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #4181
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Avoids reporting `slice`/`substring` where the sliced range does not match the expected substring's. This may lead to false negatives, but is "safe" in the general sense.