### PR TITLE
docs(eslint-plugin): deduplicate examples for no-explicit-any

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-explicit-any.md
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.md
@@ -98,39 +98,10 @@ function greet(param: Array<string>): Array<string> {}
 
 A boolean to specify if arrays from the rest operator are considered okay. `false` by default.
 
-Examples of **incorrect** code for the `{ "ignoreRestArgs": false }` option:
+The examples below are **incorrect** when `{ignoreRestArgs: false}`, but **correct** when `{ignoreRestArgs: true}`.
 
 ```ts
 /*eslint @typescript-eslint/no-explicit-any: ["error", { "ignoreRestArgs": false }]*/
-
-function foo1(...args: any[]): void {}
-function foo2(...args: readonly any[]): void {}
-function foo3(...args: Array<any>): void {}
-function foo4(...args: ReadonlyArray<any>): void {}
-
-declare function bar(...args: any[]): void;
-
-const baz = (...args: any[]) => {};
-const qux = function (...args: any[]) {};
-
-type Quux = (...args: any[]) => void;
-type Quuz = new (...args: any[]) => void;
-
-interface Grault {
-  (...args: any[]): void;
-}
-interface Corge {
-  new (...args: any[]): void;
-}
-interface Garply {
-  f(...args: any[]): void;
-}
-```
-
-Examples of **correct** code for the `{ "ignoreRestArgs": true }` option:
-
-```ts
-/*eslint @typescript-eslint/no-explicit-any: ["error", { "ignoreRestArgs": true }]*/
 
 function foo1(...args: any[]): void {}
 function foo2(...args: readonly any[]): void {}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6461
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The two code blocks are exactly equivalent, and including both of them seems wasteful and causes confusion. Deduplicating it makes the logical relationship clearer.