### PR TITLE
fix(eslint-plugin): [consistent-type-imports] import assertion checks added

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -261,17 +261,25 @@ export default util.createRule<Options, MessageIds>({
                     report.unusedSpecifiers.length === 0 &&
                     report.node.importKind !== 'type'
                   ) {
-                    context.report({
-                      node: report.node,
-                      messageId: 'typeOverValue',
-                      *fix(fixer) {
-                        yield* fixToTypeImportDeclaration(
-                          fixer,
-                          report,
-                          sourceImports,
-                        );
-                      },
-                    });
+                    /** checks if import has type assertions
+                     * ```
+                     * import * as type from 'mod' assert { type: 'json' };
+                     * ```
+                     * https://github.com/typescript-eslint/typescript-eslint/issues/7527
+                     */
+                    if (report.node.assertions.length === 0) {
+                      context.report({
+                        node: report.node,
+                        messageId: 'typeOverValue',
+                        *fix(fixer) {
+                          yield* fixToTypeImportDeclaration(
+                            fixer,
+                            report,
+                            sourceImports,
+                          );
+                        },
+                      });
+                    }
                   } else {
                     const isTypeImport = report.node.importKind === 'type';
 
@@ -612,7 +620,11 @@ export default util.createRule<Options, MessageIds>({
 
       if (namespaceSpecifier && !defaultSpecifier) {
         // import * as types from 'foo'
-        yield* fixInsertTypeSpecifierForImportDeclaration(fixer, node, false);
+
+        // checks for presence of import assertions
+        if (node.assertions.length === 0) {
+          yield* fixInsertTypeSpecifierForImportDeclaration(fixer, node, false);
+        }
         return;
       } else if (defaultSpecifier) {
         if (

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -125,6 +125,16 @@ ruleTester.run('consistent-type-imports', rule, {
       `,
       options: [{ prefer: 'no-type-imports' }],
     },
+    {
+      code: `
+        import * as Type from 'foo' assert { type: 'json' };
+        const a: typeof Type = Type;
+      `,
+      options: [{ prefer: 'no-type-imports' }],
+      dependencyConstraints: {
+        typescript: '4.5',
+      },
+    },
     `
       import { type A } from 'foo';
       type T = A;


### PR DESCRIPTION
Added type assertion for json files

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7527
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

&nbsp;

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses the issue where `typescript-eslint/eslint-plugin` throws an error when an import statement with type imports includes an import assertions.

### Reproduction Code:

``` typescript
import * as aJson from './a.json' assert { type: 'json' }

const what: aJson.A;
```

### Actual Behaviour

`typescript-eslint` provides an invalid TypeScript code as a fix and hence had to be addressed by adding a rule that checks for such import type assertions.

### Expected Behaviour

Since typescript 4.5, import assertions are supported, so `No Error` or `All is Ok` is the expected output.

&nbsp;

## Changes made:

1. Modified rule in `consistent-type-imports.ts` for type only import. Now it checks for absence of assertions and only then suggests the fix.

``` typescript
// checks for presence of import assertions
if (node.assertions.length === 0) {
  yield * fixInsertTypeSpecifierForImportDeclaration(fixer, node, false);
}
```

2. Tweaked reporting conditions in `consistent-type-imports.ts` for type only imports. Now it checks for absence of import assertions and only then reports the error.

```` typescript
/** checks if import has type assertions
 * ```
 * import * as type from 'mod' assert { type: 'json' };
 * ```
 * https://github.com/typescript-eslint/typescript-eslint/issues/7527
 */
if (report.node.assertions.length === 0) {
  context.report({
    node: report.node,
    messageId: "typeOverValue",
    *fix(fixer) {
      yield* fixToTypeImportDeclaration(fixer, report, sourceImports);
    }
  });
}
````

3. Added a rule to `consistent-type-imports.test.ts` which considers import assertion for json files as a valid rule.

``` typescript
  {
    code: `
      import * as Type from 'foo' assert { type: 'json' };
      const a: typeof Type = Type;
    `,
    options: [{ prefer: 'no-type-imports' }],
    dependencyConstraints: {
      typescript: '4.5',
    },
  },
```
