### PR TITLE
fix(eslint-plugin): [no-shadow] fix static class generics for class expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -199,7 +199,7 @@ export default util.createRule<Options, MessageIds>({
       return methodDefinition.static;
     }
 
-    function isGenericOfClassDecl(variable: TSESLint.Scope.Variable): boolean {
+    function isGenericOfClass(variable: TSESLint.Scope.Variable): boolean {
       if (!('isTypeVariable' in variable)) {
         // this shouldn't happen...
         return false;
@@ -224,16 +224,17 @@ export default util.createRule<Options, MessageIds>({
         return false;
       }
       const classDecl = typeParameterDecl.parent;
-      return classDecl?.type === AST_NODE_TYPES.ClassDeclaration;
+      return (
+        classDecl?.type === AST_NODE_TYPES.ClassDeclaration ||
+        classDecl?.type === AST_NODE_TYPES.ClassExpression
+      );
     }
 
     function isGenericOfAStaticMethodShadow(
       variable: TSESLint.Scope.Variable,
       shadowed: TSESLint.Scope.Variable,
     ): boolean {
-      return (
-        isGenericOfStaticMethod(variable) && isGenericOfClassDecl(shadowed)
-      );
+      return isGenericOfStaticMethod(variable) && isGenericOfClass(shadowed);
     }
 
     function isImportDeclaration(

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -225,12 +225,12 @@ export class Wrapper<Wrapped> {
     `
 function makeA() {
   return class A<T> {
-    constructor(public value: T) { }
+    constructor(public value: T) {}
 
     static make<T>(value: T) {
       return new A<T>(value);
     }
-  }
+  };
 }
     `,
     {

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -223,15 +223,15 @@ export class Wrapper<Wrapped> {
 }
     `,
     `
-    function makeA() {
-      return class A<T> {
-        constructor(public value: T) { }
+function makeA() {
+  return class A<T> {
+    constructor(public value: T) { }
 
-        static make<T>(value: T) {
-          return new A<T>(value);
-        }
-      }
+    static make<T>(value: T) {
+      return new A<T>(value);
     }
+  }
+}
     `,
     {
       // https://github.com/typescript-eslint/typescript-eslint/issues/3862

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -222,6 +222,17 @@ export class Wrapper<Wrapped> {
   }
 }
     `,
+    `
+    function makeA() {
+      return class A<T> {
+        constructor(public value: T) { }
+
+        static make<T>(value: T) {
+          return new A<T>(value);
+        }
+      }
+    }
+    `,
     {
       // https://github.com/typescript-eslint/typescript-eslint/issues/3862
       code: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7664 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR adds an extra check for whether the parent of a type parameter declaration is a Class Expression
