### PR TITLE
docs(eslint-plugin): [explicit-function-return-type] fix typo in option name

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -289,9 +289,9 @@ You may pass function/method names you would like this rule to ignore, like so:
 }
 ```
 
-### `allowIIFE`
+### `allowIIFEs`
 
-Examples of code for this rule with `{ allowIIFE: true }`:
+Examples of code for this rule with `{ allowIIFEs: true }`:
 
 #### ❌ Incorrect
 

--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -293,6 +293,8 @@ You may pass function/method names you would like this rule to ignore, like so:
 
 Examples of code for this rule with `{ allowIIFEs: true }`:
 
+<!--tabs-->
+
 #### ❌ Incorrect
 
 ```ts


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fix typo in docs for rule: `explicit-function-return-type` as per [source](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/explicit-function-return-type.ts#L20C5-L20C15)