### PR TITLE
docs: fix "Alternatively" typo

### DIFF
--- a/docs/contributing/Local_Development.mdx
+++ b/docs/contributing/Local_Development.mdx
@@ -40,7 +40,7 @@ You can also perform them locally.
 
 We use [Prettier](https://prettier.io) to auto-format code.
 A Git pre-commit hook should apply it to all committed changes.
-ALternately, you can run `yarn format` in any package or in the root.
+Alternately, you can run `yarn format` in any package or in the root.
 
 ### Linting
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [-] Addresses an existing open issue: fixes #000
- [-] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fixes typo