### PR TITLE
fix(rule-tester): fix `parser` fallback logic

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -91,7 +91,7 @@ export class RuleTester extends TestFramework {
       // as of eslint 6 you have to provide an absolute path to the parser
       // but that's not as clean to type, this saves us trying to manually enforce
       // that contributors require.resolve everything
-      parser: require.resolve((testerConfig ?? defaultConfig).parser),
+      parser: require.resolve(testerConfig?.parser ?? defaultConfig.parser),
     });
 
     // make sure that the parser doesn't hold onto file handles between tests


### PR DESCRIPTION
The docs at https://typescript-eslint.io/packages/rule-tester/#type-aware-testing show that for type-aware rule testing `parserOptions` needs to be specified. However, like shown in the docs, when `parser` is omitted then an error: "The first argument to require.resolve must be a string. Received null or undefined" is thrown due to a bug in `parser` fallback behavior.

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
