### PR TITLE
chore(eslint-plugin): fix post-merge issue around util namespace import

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-return.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-return.ts
@@ -12,6 +12,7 @@ import {
   getThisExpression,
   isAnyOrAnyArrayTypeDiscriminated,
   isTypeAnyType,
+  isTypeFlagSet,
   isTypeUnknownArrayType,
   isTypeUnknownType,
   isUnsafeAssignment,
@@ -106,7 +107,7 @@ export default createRule({
         for (const signature of functionType.getCallSignatures()) {
           if (
             returnNodeType === signature.getReturnType() ||
-            util.isTypeFlagSet(
+            isTypeFlagSet(
               signature.getReturnType(),
               ts.TypeFlags.Any | ts.TypeFlags.Unknown,
             )


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7766
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Switches the old namespace import style to a named one.