### PR TITLE
chore: don't clear TSServer Project Service between repo tests

### DIFF
--- a/packages/typescript-estree/src/clear-caches.ts
+++ b/packages/typescript-estree/src/clear-caches.ts
@@ -1,9 +1,6 @@
 import { clearWatchCaches } from './create-program/getWatchProgramsForProjects';
 import { clearProgramCache as clearProgramCacheOriginal } from './parser';
-import {
-  clearTSConfigMatchCache,
-  clearTSServerProjectService,
-} from './parseSettings/createParseSettings';
+import { clearTSConfigMatchCache } from './parseSettings/createParseSettings';
 import { clearGlobCache } from './parseSettings/resolveProjectList';
 
 /**
@@ -17,7 +14,6 @@ export function clearCaches(): void {
   clearProgramCacheOriginal();
   clearWatchCaches();
   clearTSConfigMatchCache();
-  clearTSServerProjectService();
   clearGlobCache();
 }
 

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -144,10 +144,6 @@ export function clearTSConfigMatchCache(): void {
   TSCONFIG_MATCH_CACHE?.clear();
 }
 
-export function clearTSServerProjectService(): void {
-  TSSERVER_PROJECT_SERVICE = null;
-}
-
 /**
  * Ensures source code is a string.
  */


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7348
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`createProjectService()` has no parameters. So I'm hopeful it can just ... stick around between tests, regardless of what physical or virtual file system names they use? If not, we'll have to look into using its APIs to clear files...