### PR TITLE
fix(eslint-plugin): [prefer-literal-enum-member] allows self-referential enums with allowBitwiseExpressions

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
+++ b/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
@@ -73,7 +73,6 @@ export default createRule({
           const rightIsLiteral =
             node.initializer.right.type === AST_NODE_TYPES.Literal;
 
-          // early branch, so gathering member identifiers only happens when needed
           if (leftIsLiteral && rightIsLiteral) {
             return;
           }

--- a/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
+++ b/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
@@ -78,12 +78,15 @@ export default createRule({
             return;
           }
 
-          const members = node.parent.members.reduce((names, member) => {
-            if ('name' in member.id) {
-              names.push(member.id.name);
-            }
-            return names;
-          }, new Array<string>());
+          const members = node.parent.members.reduce<string[]>(
+            (names, member) => {
+              if ('name' in member.id) {
+                names.push(member.id.name);
+              }
+              return names;
+            },
+            [],
+          );
 
           const leftIsValidIdentifier =
             node.initializer.left.type === AST_NODE_TYPES.Identifier &&

--- a/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
+++ b/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
@@ -79,7 +79,9 @@ export default createRule({
           }
 
           const members = node.parent.members.reduce((names, member) => {
-            if ('name' in member.id) names.push(member.id.name);
+            if ('name' in member.id) {
+              names.push(member.id.name);
+            }
             return names;
           }, new Array<string>());
 

--- a/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
+++ b/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/prefer-literal-enum-member */
 import type { TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';

--- a/packages/eslint-plugin/tests/rules/prefer-literal-enum-member.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-literal-enum-member.test.ts
@@ -73,6 +73,8 @@ enum Foo {
   E = 1 & 0,
   F = 1 ^ 0,
   G = ~1,
+  E = G | 1,
+  F = G | E,
 }
       `,
       options: [{ allowBitwiseExpressions: true }],
@@ -280,6 +282,8 @@ enum Foo {
   E = 1 & 0,
   F = 1 ^ 0,
   G = ~1,
+  E = G | 1,
+  F = G | E,
 }
       `,
       options: [{ allowBitwiseExpressions: false }],
@@ -317,6 +321,16 @@ enum Foo {
         {
           messageId: 'notLiteral',
           line: 9,
+          column: 3,
+        },
+        {
+          messageId: 'notLiteral',
+          line: 10,
+          column: 3,
+        },
+        {
+          messageId: 'notLiteral',
+          line: 11,
           column: 3,
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7763
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Allows enums with binary bitwise expressions if both operands are literals or reference members of own enum