### PR TITLE
feat(utils): define `SourceCode#getScope` and deprecate `Context#getScope`

### DIFF
--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -256,6 +256,7 @@ interface RuleContext<
   /**
    * Returns the scope of the currently-traversed node.
    * This information can be used track references to variables.
+   * @deprecated in favor of `context.getSourceCode().getScope(node)`
    */
   getScope(): Scope.Scope;
 

--- a/packages/utils/src/ts-eslint/SourceCode.ts
+++ b/packages/utils/src/ts-eslint/SourceCode.ts
@@ -300,6 +300,12 @@ declare class SourceCodeBase extends TokenStore {
    */
   isSpaceBetweenTokens(first: TSESTree.Token, second: TSESTree.Token): boolean;
   /**
+   * Returns the scope of the given node.
+   * This information can be used track references to variables.
+   * @since 8.37.0
+   */
+  getScope(node: TSESTree.Node): Scope.Scope;
+  /**
    * The source code split into lines according to ECMA-262 specification.
    * This is done to avoid each rule needing to do so separately.
    */


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] ~Addresses an existing open issue: fixes #000~
- [x] ~That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

I'm still triaging the implications of this over in `eslint-plugin-jest`, but for now we can at least get the types added - it's a bit annoying it was added in such a late minor and will be removed in the next immediate major but that's for us to deal with I guess 🤷

I assume updates will be needed throughout this codebase but have not actually looked - I know that `unbound-method` needs updating as our fork of it is omitting deprecation warnings; maybe it would be worth shipping a new util that handles falling back if needed to avoid being a breaking change 🤔 

(I also can't remember if you prefer using `feat`, `fix`, or `chore` for type-only changes - no offense will be taken if you change the title)

References:
  - https://github.com/eslint/eslint/commit/10022b1f4bda1ad89193512ecf18c2ee61db8202
  - https://github.com/eslint/eslint/commit/1ea4cfb585dcb52ac3cb1522a32f25cfe507121b