### PR TITLE
docs(eslint-plugin): [no-unsafe-member-access] correct example idx from const to let

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-member-access.md
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-member-access.md
@@ -54,7 +54,7 @@ properlyTyped.prop[key];
 
 const arr = [1, 2, 3];
 arr[1];
-const idx = 1;
+let idx = 1;
 arr[idx];
 arr[idx++];
 ```


### PR DESCRIPTION
Update variable declaration from const to let so that code can run. Fixes error: `Cannot assign to 'idx' because it is a constant.`

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
