### PR TITLE
fix(eslint-plugin): [naming-convention] allow PascalCase for imports

### DIFF
--- a/packages/eslint-plugin/docs/rules/naming-convention.md
+++ b/packages/eslint-plugin/docs/rules/naming-convention.md
@@ -81,6 +81,11 @@ const defaultOptions: Options = [
   },
 
   {
+    selector: 'import',
+    format: ['camelCase', 'PascalCase'],
+  },
+
+  {
     selector: 'variable',
     format: ['camelCase', 'UPPER_CASE'],
     leadingUnderscore: 'allow',

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -40,6 +40,11 @@ const defaultCamelCaseAllTheThingsConfig: Options = [
   },
 
   {
+    selector: 'import',
+    format: ['camelCase', 'PascalCase'],
+  },
+
+  {
     selector: 'variable',
     format: ['camelCase', 'UPPER_CASE'],
     leadingUnderscore: 'allow',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7838
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds `'PascalCase'` alongside `'camelCase'` to the allowed formats for imports. This should allow the majority of community standards, such as `import * as React from "react"`.

Funny that out of the >15,000 (!) generated unit tests for this rule, none were impacted by this change to defaults.