### PR TITLE
chore: add a11y-alt-text-check bot

### DIFF
--- a/.github/workflows/a11y-alt-bot.yml
+++ b/.github/workflows/a11y-alt-bot.yml
@@ -1,0 +1,26 @@
+name: Accessibility-alt-text-bot
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+
+jobs:
+  accessibility_alt_text_bot:
+    name: Check alt text is set on issue or pull requests
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion }}
+    steps:
+      - name: Get action 'github/accessibility-alt-text-bot'
+        uses: github/accessibility-alt-text-bot@v1.4.0

--- a/.github/workflows/a11y-alt-bot.yml
+++ b/.github/workflows/a11y-alt-bot.yml
@@ -20,7 +20,6 @@ jobs:
   accessibility_alt_text_bot:
     name: Check alt text is set on issue or pull requests
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion }}
     steps:
       - name: Get action 'github/accessibility-alt-text-bot'
         uses: github/accessibility-alt-text-bot@v1.4.0

--- a/.github/workflows/a11y-alt-bot.yml
+++ b/.github/workflows/a11y-alt-bot.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   accessibility_alt_text_bot:
-    name: Check alt text is set on issue or pull requests
+    name: Check alt text is set on images
     runs-on: ubuntu-latest
     steps:
       - name: Get action 'github/accessibility-alt-text-bot'


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #7640
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR adds a new github action/bot that checks if images in comments in issues, PRs or discussion have an alt text.
The new file is very similar to the file provided at the [original bot repo](https://github.com/github/accessibility-alt-text-bot)