### PR TITLE
feat(eslint-plugin): [ban-ts-comments] suggest ts-expect-error over ts-ignore

### DIFF
--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -137,9 +137,8 @@ export default createRule<[Options], MessageIds>({
 
           const option = options[fullDirective];
           if (option === true) {
-            if (directive === 'ignore' && options['ts-expect-error'] !== true) {
-              // Special case to suggest @ts-expect-error instead of @ts-ignore,
-              // as long as @ts-expect-error is banned outright.
+            if (directive === 'ignore') {
+              // Special case to suggest @ts-expect-error instead of @ts-ignore
               context.report({
                 node: comment,
                 messageId: 'tsIgnoreInsteadOfExpectError',

--- a/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
@@ -306,10 +306,15 @@ ruleTester.run('ts-ignore', rule, {
       options: [{ 'ts-ignore': true, 'ts-expect-error': true }],
       errors: [
         {
-          data: { directive: 'ignore' },
-          messageId: 'tsDirectiveComment',
+          messageId: 'tsIgnoreInsteadOfExpectError',
           line: 1,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'replaceTsIgnoreWithTsExpectError',
+              output: '// @ts-expect-error',
+            },
+          ],
         },
       ],
     },
@@ -339,24 +344,18 @@ ruleTester.run('ts-ignore', rule, {
           messageId: 'tsIgnoreInsteadOfExpectError',
           line: 1,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'replaceTsIgnoreWithTsExpectError',
+              output: '// @ts-expect-error',
+            },
+          ],
         },
       ],
     },
     {
       code: '/* @ts-ignore */',
-      options: [{ 'ts-ignore': true, 'ts-expect-error': true }],
-      errors: [
-        {
-          data: { directive: 'ignore' },
-          messageId: 'tsDirectiveComment',
-          line: 1,
-          column: 1,
-        },
-      ],
-    },
-    {
-      code: '/* @ts-ignore */',
-      options: [{ 'ts-ignore': true, 'ts-expect-error': false }],
+      options: [{ 'ts-ignore': true }],
       errors: [
         {
           messageId: 'tsIgnoreInsteadOfExpectError',
@@ -368,22 +367,6 @@ ruleTester.run('ts-ignore', rule, {
               output: '/* @ts-expect-error */',
             },
           ],
-        },
-      ],
-    },
-    {
-      code: `
-/*
- @ts-ignore
-*/
-      `,
-      options: [{ 'ts-ignore': true, 'ts-expect-error': true }],
-      errors: [
-        {
-          data: { directive: 'ignore' },
-          messageId: 'tsDirectiveComment',
-          line: 2,
-          column: 1,
         },
       ],
     },
@@ -414,13 +397,18 @@ ruleTester.run('ts-ignore', rule, {
     },
     {
       code: '/** @ts-ignore */',
-      options: [{ 'ts-ignore': true, 'ts-expect-error': true }],
+      options: [{ 'ts-ignore': true, 'ts-expect-error': false }],
       errors: [
         {
-          data: { directive: 'ignore' },
-          messageId: 'tsDirectiveComment',
+          messageId: 'tsIgnoreInsteadOfExpectError',
           line: 1,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'replaceTsIgnoreWithTsExpectError',
+              output: '/** @ts-expect-error */',
+            },
+          ],
         },
       ],
     },
@@ -437,18 +425,6 @@ ruleTester.run('ts-ignore', rule, {
               output: '// @ts-expect-error: Suppress next line',
             },
           ],
-        },
-      ],
-    },
-    {
-      code: '// @ts-ignore: Suppress next line',
-      options: [{ 'ts-ignore': true, 'ts-expect-error': true }],
-      errors: [
-        {
-          data: { directive: 'ignore' },
-          messageId: 'tsDirectiveComment',
-          line: 1,
-          column: 1,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
@@ -303,7 +303,7 @@ ruleTester.run('ts-ignore', rule, {
   invalid: [
     {
       code: '// @ts-ignore',
-      options: [{ 'ts-ignore': true }],
+      options: [{ 'ts-ignore': true, 'ts-expect-error': true }],
       errors: [
         {
           data: { directive: 'ignore' },
@@ -315,6 +315,36 @@ ruleTester.run('ts-ignore', rule, {
     },
     {
       code: '// @ts-ignore',
+      options: [
+        { 'ts-ignore': true, 'ts-expect-error': 'allow-with-description' },
+      ],
+      errors: [
+        {
+          messageId: 'tsIgnoreInsteadOfExpectError',
+          line: 1,
+          column: 1,
+          suggestions: [
+            {
+              messageId: 'replaceTsIgnoreWithTsExpectError',
+              output: '// @ts-expect-error',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: '// @ts-ignore',
+      errors: [
+        {
+          messageId: 'tsIgnoreInsteadOfExpectError',
+          line: 1,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: '/* @ts-ignore */',
+      options: [{ 'ts-ignore': true, 'ts-expect-error': true }],
       errors: [
         {
           data: { directive: 'ignore' },
@@ -326,12 +356,33 @@ ruleTester.run('ts-ignore', rule, {
     },
     {
       code: '/* @ts-ignore */',
-      options: [{ 'ts-ignore': true }],
+      options: [{ 'ts-ignore': true, 'ts-expect-error': false }],
+      errors: [
+        {
+          messageId: 'tsIgnoreInsteadOfExpectError',
+          line: 1,
+          column: 1,
+          suggestions: [
+            {
+              messageId: 'replaceTsIgnoreWithTsExpectError',
+              output: '/* @ts-expect-error */',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+/*
+ @ts-ignore
+*/
+      `,
+      options: [{ 'ts-ignore': true, 'ts-expect-error': true }],
       errors: [
         {
           data: { directive: 'ignore' },
           messageId: 'tsDirectiveComment',
-          line: 1,
+          line: 2,
           column: 1,
         },
       ],
@@ -345,16 +396,25 @@ ruleTester.run('ts-ignore', rule, {
       options: [{ 'ts-ignore': true }],
       errors: [
         {
-          data: { directive: 'ignore' },
-          messageId: 'tsDirectiveComment',
+          messageId: 'tsIgnoreInsteadOfExpectError',
           line: 2,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'replaceTsIgnoreWithTsExpectError',
+              output: `
+/*
+ @ts-expect-error
+*/
+      `,
+            },
+          ],
         },
       ],
     },
     {
       code: '/** @ts-ignore */',
-      options: [{ 'ts-ignore': true }],
+      options: [{ 'ts-ignore': true, 'ts-expect-error': true }],
       errors: [
         {
           data: { directive: 'ignore' },
@@ -368,6 +428,23 @@ ruleTester.run('ts-ignore', rule, {
       code: '// @ts-ignore: Suppress next line',
       errors: [
         {
+          messageId: 'tsIgnoreInsteadOfExpectError',
+          line: 1,
+          column: 1,
+          suggestions: [
+            {
+              messageId: 'replaceTsIgnoreWithTsExpectError',
+              output: '// @ts-expect-error: Suppress next line',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: '// @ts-ignore: Suppress next line',
+      options: [{ 'ts-ignore': true, 'ts-expect-error': true }],
+      errors: [
+        {
           data: { directive: 'ignore' },
           messageId: 'tsDirectiveComment',
           line: 1,
@@ -379,10 +456,15 @@ ruleTester.run('ts-ignore', rule, {
       code: '/////@ts-ignore: Suppress next line',
       errors: [
         {
-          data: { directive: 'ignore' },
-          messageId: 'tsDirectiveComment',
+          messageId: 'tsIgnoreInsteadOfExpectError',
           line: 1,
           column: 1,
+          suggestions: [
+            {
+              messageId: 'replaceTsIgnoreWithTsExpectError',
+              output: '/////@ts-expect-error: Suppress next line',
+            },
+          ],
         },
       ],
     },
@@ -395,10 +477,20 @@ if (false) {
       `,
       errors: [
         {
-          data: { directive: 'ignore' },
-          messageId: 'tsDirectiveComment',
+          messageId: 'tsIgnoreInsteadOfExpectError',
           line: 3,
           column: 3,
+          suggestions: [
+            {
+              messageId: 'replaceTsIgnoreWithTsExpectError',
+              output: `
+if (false) {
+  // @ts-expect-error: Unreachable code error
+  console.log('hello');
+}
+      `,
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7843
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Updates error message and adds a suggestion to replace ts-ignore with ts-expect-error, as long as the option for banning ts-expect-error is not set to true.