### PR TITLE
fix(eslint-plugin): [require-await] add support for "await using"

### DIFF
--- a/packages/eslint-plugin/src/rules/require-await.ts
+++ b/packages/eslint-plugin/src/rules/require-await.ts
@@ -149,6 +149,7 @@ export default createRule({
       'ArrowFunctionExpression:exit': exitFunction,
 
       AwaitExpression: markAsHasAwait,
+      'VariableDeclaration[kind = "await using"]': markAsHasAwait,
       'ForOfStatement[await = true]': markAsHasAwait,
       'YieldExpression[delegate = true]': markAsHasDelegateGen,
 

--- a/packages/eslint-plugin/tests/rules/require-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-await.test.ts
@@ -232,6 +232,11 @@ async function* foo(): Promise<string> {
         yield* x;
       }
     `,
+    `
+      const fn = async () => {
+        await using foo = new Bar();
+      };
+    `,
   ],
 
   invalid: [
@@ -406,6 +411,21 @@ async function* asyncGenerator() {
           messageId: 'missingAwait',
           data: {
             name: "Async generator function 'asyncGenerator'",
+          },
+        },
+      ],
+    },
+    {
+      code: `
+        const fn = async () => {
+          using foo = new Bar();
+        };
+      `,
+      errors: [
+        {
+          messageId: 'missingAwait',
+          data: {
+            name: "Async arrow function 'fn'",
           },
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7865
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Just set `hasAwait = true` for the current scope where `await using` is used