### PR TITLE
docs: flip the flag of skipCompoundAssignments in the example

### DIFF
--- a/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
+++ b/packages/eslint-plugin/docs/rules/restrict-plus-operands.md
@@ -170,7 +170,7 @@ let fn = (a: string, b: RegExp) => a + b;
 
 ### `skipCompoundAssignments`
 
-Examples of code for this rule with `{ skipCompoundAssignments: true }`:
+Examples of code for this rule with `{ skipCompoundAssignments: false }`:
 
 <!--tabs-->
 


### PR DESCRIPTION
Fixed https://github.com/typescript-eslint/typescript-eslint/issues/7867.