### PR TITLE
feat(eslint-plugin): [explicit-function-return-type] support patterns in `allowedNames`

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
@@ -276,14 +276,18 @@ const allowedArrow = (x: string) => x;
 
 ### `allowedNames`
 
-You may pass function/method names you would like this rule to ignore, like so:
+You may pass function/method names and/or regular expressions you would like this rule to ignore, like so:
 
 ```json
 {
   "@typescript-eslint/explicit-function-return-type": [
     "error",
     {
-      "allowedNames": ["ignoredFunctionName", "ignoredMethodName"]
+      "allowedNames": [
+        "ignoredFunctionName",
+        "ignoredMethodName",
+        ".*endsWithSuffix$"
+      ]
     }
   ]
 }

--- a/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
+++ b/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
@@ -69,7 +69,7 @@ export default createRule<Options, MessageIds>({
           },
           allowedNames: {
             description:
-              'An array of function/method names that will not have their arguments or return values checked.',
+              'An array of function/method names and/or name patterns that will not have their arguments or return values checked.',
             items: {
               type: 'string',
             },
@@ -117,6 +117,13 @@ export default createRule<Options, MessageIds>({
         return false;
       }
 
+      const allowedNames = options.allowedNames.map(
+        allowedName => new RegExp(allowedName, 'u'),
+      );
+      function doesMatchAnyAllowedName(funcName: string): boolean {
+        return allowedNames.some(allowedName => allowedName.test(funcName));
+      }
+
       if (
         node.type === AST_NODE_TYPES.ArrowFunctionExpression ||
         node.type === AST_NODE_TYPES.FunctionExpression
@@ -146,7 +153,7 @@ export default createRule<Options, MessageIds>({
             }
           }
         }
-        if (!!funcName && !!options.allowedNames.includes(funcName)) {
+        if (!!funcName && !!doesMatchAnyAllowedName(funcName)) {
           return true;
         }
       }
@@ -154,7 +161,7 @@ export default createRule<Options, MessageIds>({
         node.type === AST_NODE_TYPES.FunctionDeclaration &&
         node.id &&
         node.id.type === AST_NODE_TYPES.Identifier &&
-        !!options.allowedNames.includes(node.id.name)
+        !!doesMatchAnyAllowedName(node.id.name)
       ) {
         return true;
       }

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -494,6 +494,42 @@ const x = {
     },
     {
       code: `
+function pattern() {
+  return { a: 123 } as const;
+}
+
+function foo(): number {
+  return 123;
+}
+
+const foo = function patttttern() {
+  return;
+};
+      `,
+      options: [
+        {
+          allowedNames: ['.*pa(t)+ern$'],
+        },
+      ],
+    },
+    {
+      code: `
+function pattern() {
+  return;
+}
+
+const foo = function stringFuncName() {
+  return;
+};
+      `,
+      options: [
+        {
+          allowedNames: ['.*pa(t)+ern$', 'stringFuncName'],
+        },
+      ],
+    },
+    {
+      code: `
 type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
 const x: HigherOrderType = () => arg1 => arg2 => 'foo';
       `,
@@ -1509,6 +1545,26 @@ class Foo {
           endLine: 4,
           column: 3,
           endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `
+function pattern() {
+  return 2;
+}
+function patttern() {
+  return 3;
+}
+      `,
+      options: [{ allowedNames: ['.*pa(t){3,5}ern$'] }],
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 2,
+          endLine: 2,
+          column: 1,
+          endColumn: 17,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/schema-snapshots/explicit-function-return-type.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/explicit-function-return-type.shot
@@ -17,7 +17,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "type": "boolean"
       },
       "allowedNames": {
-        "description": "An array of function/method names that will not have their arguments or return values checked.",
+        "description": "An array of function/method names and/or name patterns that will not have their arguments or return values checked.",
         "items": {
           "type": "string"
         },
@@ -67,7 +67,7 @@ type Options = [
     allowIIFEs?: boolean;
     /** Whether to ignore type annotations on the variable of function expressions. */
     allowTypedFunctionExpressions?: boolean;
-    /** An array of function/method names that will not have their arguments or return values checked. */
+    /** An array of function/method names and/or name patterns that will not have their arguments or return values checked. */
     allowedNames?: string[];
   },
 ];


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7876
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This is a proposal to use regular expressions in `allowedNames` for `explicit-function-return-type`.
