### PR TITLE
chore: add performance package with a project service hyperfine comparison

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,7 @@ coverage
 __snapshots__
 .docusaurus
 build
+packages/performance/generated
 
 # Files copied as part of the build
 packages/types/src/generated/**/*.ts

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,17 @@
+name: 'Performance Testing'
+
+on: workflow_dispatch
+
+jobs:
+  performance:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare-install
+      - run: brew install hyperfine
+      - run: PERFORMANCE_FILE_COUNT=${{ matrix.file-count }} yarn workspace @typescript-eslint/performance run generate
+      - run: hyperfine yarn workspace @typescript-eslint/performance run test:${{ matrix.test}}
+    strategy:
+      matrix:
+        file-count: [50, 100, 150, 200]
+        test: ['project', 'service']

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -3,7 +3,7 @@ name: 'Performance Testing'
 on: workflow_dispatch
 
 jobs:
-  performance:
+  comparison:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,3 +15,9 @@ jobs:
       matrix:
         file-count: [50, 100, 150, 200]
         test: ['project', 'service']
+  summary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare-install
+      - run: yarn workspace @typescript-eslint/performance run test:summary

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Performance testing
+packages/performance/generated
+
 # Website
 packages/website/.docusaurus
 packages/website/.cache-loader

--- a/packages/performance/.eslintrc.cjs
+++ b/packages/performance/.eslintrc.cjs
@@ -1,0 +1,15 @@
+/* eslint-env node */
+module.exports = {
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/strict-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
+  ],
+  plugins: ['@typescript-eslint'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: true,
+    tsconfigRootDir: __dirname,
+  },
+  root: true,
+};

--- a/packages/performance/README.md
+++ b/packages/performance/README.md
@@ -1,0 +1,27 @@
+# Performance Testing
+
+A quick internal utility for testing lint performance.
+
+## Generating a Summary
+
+`test:summary` runs the three performance scenarios under different file counts, then prints a summary table:
+
+```shell
+yarn test:summary
+```
+
+For each of those file counts, the generated code is 50% `.js` and 50% `.ts`.
+
+## Running Tests Manually
+
+First generate the number of files you'd like to test:
+
+```shell
+PERFORMANCE_FILE_COUNT=123 yarn generate
+```
+
+Then run one or more of the test types:
+
+- `yarn test:project`: Traditional `project: true`
+- `yarn test:service` `EXPERIMENTAL_useProjectService`
+- `yarn test:service:seeded`: `EXPERIMENTAL_useProjectService`, with `allowDefaultProjectFallbackFilesGlobs`

--- a/packages/performance/generate.ts
+++ b/packages/performance/generate.ts
@@ -1,0 +1,47 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+import {
+  generateESLintConfig,
+  generateJsFile,
+  generateTSConfig,
+  generateTsFile,
+} from './generating.js';
+import { directory, writeFile } from './writing.js';
+
+const fileCount = Number(process.env.PERFORMANCE_FILE_COUNT ?? 100);
+
+await fs.rm(directory, { force: true, recursive: true });
+await fs.mkdir(path.join(directory, 'src'), { recursive: true });
+
+// The root-level TSConfig is used for the project service, which intentionally
+// uses the default/inferred project for non-included JS files.
+await writeFile(`tsconfig.json`, generateTSConfig(false));
+
+// The explicit project allows JS, akin to the common tsconfig.eslint.json.
+await writeFile(`tsconfig.project.json`, generateTSConfig(true));
+
+for (const [alias, parserOptions] of [
+  ['project', `project: "./tsconfig.project.json"`],
+  ['service', `EXPERIMENTAL_useProjectService: true`],
+] as const) {
+  await writeFile(
+    `.eslintrc.${alias}.cjs`,
+    generateESLintConfig(parserOptions),
+  );
+}
+
+for (let i = 0; i < fileCount; i += 1) {
+  const [extension, generator] =
+    i % 2 ? ['js', generateJsFile] : ['ts', generateTsFile];
+
+  await writeFile(`src/example${i}.${extension}`, generator(i));
+}
+
+await writeFile(
+  'src/index.ts',
+  new Array(fileCount)
+    .fill(undefined)
+    .map((_, i) => `export { example${i} } from "./example${i}.js";`)
+    .join('\n'),
+);

--- a/packages/performance/generate.ts
+++ b/packages/performance/generate.ts
@@ -9,7 +9,7 @@ import {
 } from './generating.js';
 import { directory, writeFile } from './writing.js';
 
-const fileCount = Number(process.env.PERFORMANCE_FILE_COUNT ?? 100);
+const fileCount = Number(process.env.PERFORMANCE_FILE_COUNT);
 
 await fs.rm(directory, { force: true, recursive: true });
 await fs.mkdir(path.join(directory, 'src'), { recursive: true });

--- a/packages/performance/generate.ts
+++ b/packages/performance/generate.ts
@@ -10,6 +10,11 @@ import {
 import { directory, writeFile } from './writing.js';
 
 const fileCount = Number(process.env.PERFORMANCE_FILE_COUNT);
+if (!fileCount) {
+  throw new Error(
+    `Invalid process.env.PERFORMANCE_FILE_COUNT: ${process.env.PERFORMANCE_FILE_COUNT}`,
+  );
+}
 
 await fs.rm(directory, { force: true, recursive: true });
 await fs.mkdir(path.join(directory, 'src'), { recursive: true });
@@ -24,6 +29,10 @@ await writeFile(`tsconfig.project.json`, generateTSConfig(true));
 for (const [alias, parserOptions] of [
   ['project', `project: "./tsconfig.project.json"`],
   ['service', `EXPERIMENTAL_useProjectService: true`],
+  [
+    'service.seeded',
+    `allowDefaultProjectFallbackFilesGlobs: ["./src/*.js"],\n    EXPERIMENTAL_useProjectService: true`,
+  ],
 ] as const) {
   await writeFile(
     `.eslintrc.${alias}.cjs`,

--- a/packages/performance/generating.ts
+++ b/packages/performance/generating.ts
@@ -1,0 +1,48 @@
+export function generateESLintConfig(parserOptions: string) {
+  return `
+/* eslint-env node */
+module.exports = {
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/strict-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
+  ],
+  plugins: ['@typescript-eslint'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ${parserOptions},
+    tsconfigRootDir: __dirname
+  },
+  root: true,
+};
+`.trimStart();
+}
+
+export function generateJsFile(i: number) {
+  return `
+export async function example${i}(input) {
+  return typeof input === 'number' ? input.toPrecision(1) : input.toUpperCase();
+}
+`.trimStart();
+}
+
+export function generateTsFile(i: number) {
+  return `
+export async function example${i}<T extends number | string>(input: T) {
+  return typeof input === 'number' ? input.toPrecision(1) : input.toUpperCase();
+}
+`.trimStart();
+}
+
+export function generateTSConfig(allowJs: boolean) {
+  return `
+{
+  "compilerOptions": {
+    "allowJs": ${allowJs},
+    "module": "ESNext",
+    "strict": true,
+    "target": "ESNext"
+  }
+}
+`.trimStart();
+}

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@typescript-eslint/performance",
+  "version": "6.9.1",
+  "private": true,
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint.git",
+    "directory": "packages/performance"
+  },
+  "scripts": {
+    "generate": "tsx ./generate.ts",
+    "generate:watch": "tsx --watch ./generate.ts",
+    "test:project": "time eslint --config ./generated/.eslintrc.project.cjs ./generated",
+    "test:service": "time eslint --config ./generated/.eslintrc.service.cjs ./generated"
+  },
+  "dependencies": {
+    "@typescript-eslint/eslint-plugin": "6.9.1",
+    "@typescript-eslint/parser": "6.9.1"
+  },
+  "devDependencies": {
+    "eslint": "*",
+    "tsx": "*"
+  }
+}

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -11,8 +11,9 @@
   "scripts": {
     "generate": "tsx ./generate.ts",
     "generate:watch": "tsx --watch ./generate.ts",
-    "test:project": "time eslint --config ./generated/.eslintrc.project.cjs ./generated",
-    "test:service": "time eslint --config ./generated/.eslintrc.service.cjs ./generated"
+    "test:project": "time eslint --config ./generated/.eslintrc.project.cjs ./generated || true",
+    "test:service": "time eslint --config ./generated/.eslintrc.service.cjs ./generated || true",
+    "test:summary": "tsx ./test-summary.ts"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "6.9.1",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "eslint": "*",
+    "execa": "*",
     "tsx": "*"
   }
 }

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -13,7 +13,8 @@
     "generate:watch": "tsx --watch ./generate.ts",
     "test:project": "time eslint --config ./generated/.eslintrc.project.cjs ./generated || true",
     "test:service": "time eslint --config ./generated/.eslintrc.service.cjs ./generated || true",
-    "test:summary": "tsx ./test-summary.ts"
+    "test:service:seeded": "time eslint --config ./generated/.eslintrc.service.seeded.cjs ./generated || true",
+    "test:summary": "tsx ./summary.ts"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "6.9.1",

--- a/packages/performance/summary.ts
+++ b/packages/performance/summary.ts
@@ -9,8 +9,9 @@ for (const fileCount of [5, 10, 25, 50, 75, 100, 125, 150, 175, 200]) {
   await $({ env: { PERFORMANCE_FILE_COUNT: `${fileCount}` } })`yarn generate`;
   const project = getTiming(await $`yarn test:project`);
   const service = getTiming(await $`yarn test:service`);
+  const serviceSeeded = getTiming(await $`yarn test:service:seeded`);
 
-  counts[fileCount] = { project, service };
+  counts[fileCount] = { project, service, 'service (seeded)': serviceSeeded };
 }
 
 console.table(counts);

--- a/packages/performance/summary.ts
+++ b/packages/performance/summary.ts
@@ -1,0 +1,16 @@
+import { $ } from 'execa';
+
+const getTiming = ({ stderr }: { stderr: string }) =>
+  stderr.trim().replace(/ +/g, ' ');
+
+const counts: Record<string, unknown> = {};
+
+for (const fileCount of [5, 10, 25, 50, 75, 100, 125, 150, 175, 200]) {
+  await $({ env: { PERFORMANCE_FILE_COUNT: `${fileCount}` } })`yarn generate`;
+  const project = getTiming(await $`yarn test:project`);
+  const service = getTiming(await $`yarn test:service`);
+
+  counts[fileCount] = { project, service };
+}
+
+console.table(counts);

--- a/packages/performance/tsconfig.json
+++ b/packages/performance/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "strict": true,
+    "target": "ESNext"
+  }
+}

--- a/packages/performance/tsconfig.json
+++ b/packages/performance/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "target": "ESNext"
   }

--- a/packages/performance/writing.ts
+++ b/packages/performance/writing.ts
@@ -1,0 +1,8 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+export const directory = 'generated';
+
+export async function writeFile(fileName: string, data: string) {
+  await fs.writeFile(path.join(directory, fileName), data);
+}

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -23,16 +23,10 @@ const log = debug(
 let TSCONFIG_MATCH_CACHE: ExpiringCache<string, string> | null;
 let TSSERVER_PROJECT_SERVICE: TypeScriptProjectService | null = null;
 
-console.log('Instantiating module createParseSettings');
-
 export function createParseSettings(
   code: ts.SourceFile | string,
   options: Partial<TSESTreeOptions> = {},
 ): MutableParseSettings {
-  console.log(
-    '\nCalling createParseSettings',
-    (code as ts.SourceFile).fileName || code,
-  );
   const codeFullText = enforceCodeString(code);
   const singleRun = inferSingleRun(options);
   const tsconfigRootDir =

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -23,10 +23,16 @@ const log = debug(
 let TSCONFIG_MATCH_CACHE: ExpiringCache<string, string> | null;
 let TSSERVER_PROJECT_SERVICE: TypeScriptProjectService | null = null;
 
+console.log('Instantiating module createParseSettings');
+
 export function createParseSettings(
   code: ts.SourceFile | string,
   options: Partial<TSESTreeOptions> = {},
 ): MutableParseSettings {
+  console.log(
+    '\nCalling createParseSettings',
+    (code as ts.SourceFile).fileName || code,
+  );
   const codeFullText = enforceCodeString(code);
   const singleRun = inferSingleRun(options);
   const tsconfigRootDir =
@@ -55,7 +61,9 @@ export function createParseSettings(
         process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER !== 'false') ||
       (process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER === 'true' &&
         options.EXPERIMENTAL_useProjectService !== false)
-        ? (TSSERVER_PROJECT_SERVICE ??= createProjectService())
+        ? (TSSERVER_PROJECT_SERVICE ??= createProjectService(
+            options.allowDefaultProjectFallbackFilesGlobs,
+          ))
         : undefined,
     EXPERIMENTAL_useSourceOfProjectReferenceRedirect:
       options.EXPERIMENTAL_useSourceOfProjectReferenceRedirect === true,

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -106,6 +106,16 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
   /**
    * ***EXPERIMENTAL FLAG*** - Use this at your own risk.
    *
+   * If `EXPERIMENTAL_useProjectService` is true, which files to load into the service immediately.
+   * Intentionally an annoyingly long name for now. We'll think of a better one if we need.
+   *
+   * @see https://github.com/typescript-eslint/typescript-eslint/pull/7870
+   */
+  allowDefaultProjectFallbackFilesGlobs?: string[];
+
+  /**
+   * ***EXPERIMENTAL FLAG*** - Use this at your own risk.
+   *
    * Causes TS to use the source files for referenced projects instead of the compiled .d.ts files.
    * This feature is not yet optimized, and is likely to cause OOMs for medium to large projects.
    *

--- a/packages/typescript-estree/src/useProgramFromProjectService.ts
+++ b/packages/typescript-estree/src/useProgramFromProjectService.ts
@@ -10,15 +10,12 @@ export function useProgramFromProjectService(
   projectService: server.ProjectService,
   parseSettings: Readonly<MutableParseSettings>,
 ): ASTAndDefiniteProgram | undefined {
-  const opened = projectService.openClientFile(
+  projectService.openClientFile(
     absolutify(parseSettings.filePath),
     parseSettings.codeFullText,
     /* scriptKind */ undefined,
     parseSettings.tsconfigRootDir,
   );
-  if (!opened.configFileName) {
-    return undefined;
-  }
 
   const scriptInfo = projectService.getScriptInfo(parseSettings.filePath);
   const program = projectService

--- a/packages/typescript-estree/tests/lib/semanticInfo.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo.test.ts
@@ -335,33 +335,76 @@ describe('semanticInfo', () => {
       const parseResult = parseAndGenerateServices(code, optionsProjectString);
       expect(parseResult.services.program).toBe(program1);
     });
+
+    it('file not in single provided program instance should throw', () => {
+      const filename = 'non-existent-file.ts';
+      const program = createProgram(path.join(FIXTURES_DIR, 'tsconfig.json'));
+      const options = createOptions(filename);
+      const optionsWithSingleProgram = {
+        ...options,
+        programs: [program],
+      };
+      expect(() =>
+        parseAndGenerateServices('const foo = 5;', optionsWithSingleProgram),
+      ).toThrow(
+        `The file was not found in any of the provided program instance(s): ${filename}`,
+      );
+    });
+
+    it('file not in multiple provided program instances should throw', () => {
+      const filename = 'non-existent-file.ts';
+      const program1 = createProgram(path.join(FIXTURES_DIR, 'tsconfig.json'));
+      const options = createOptions(filename);
+      const optionsWithSingleProgram = {
+        ...options,
+        programs: [program1],
+      };
+      expect(() =>
+        parseAndGenerateServices('const foo = 5;', optionsWithSingleProgram),
+      ).toThrow(
+        `The file was not found in any of the provided program instance(s): ${filename}`,
+      );
+
+      const program2 = createProgram(path.join(FIXTURES_DIR, 'tsconfig.json'));
+      const optionsWithMultiplePrograms = {
+        ...options,
+        programs: [program1, program2],
+      };
+      expect(() =>
+        parseAndGenerateServices('const foo = 5;', optionsWithMultiplePrograms),
+      ).toThrow(
+        `The file was not found in any of the provided program instance(s): ${filename}`,
+      );
+    });
+  } else {
+    it('file not in single provided program instance should not throw', () => {
+      const filename = 'non-existent-file.ts';
+      const program = createProgram(path.join(FIXTURES_DIR, 'tsconfig.json'));
+      const options = createOptions(filename);
+      const optionsWithSingleProgram = {
+        ...options,
+        programs: [program],
+      };
+      expect(() =>
+        parseAndGenerateServices('const foo = 5;', optionsWithSingleProgram),
+      ).not.toThrow();
+    });
+
+    it('file not in multiple provided program instances should not throw', () => {
+      const filename = 'non-existent-file.ts';
+      const program1 = createProgram(path.join(FIXTURES_DIR, 'tsconfig.json'));
+      const options = createOptions(filename);
+
+      const program2 = createProgram(path.join(FIXTURES_DIR, 'tsconfig.json'));
+      const optionsWithMultiplePrograms = {
+        ...options,
+        programs: [program1, program2],
+      };
+      expect(() =>
+        parseAndGenerateServices('const foo = 5;', optionsWithMultiplePrograms),
+      ).not.toThrow();
+    });
   }
-
-  it('file not in provided program instance(s)', () => {
-    const filename = 'non-existent-file.ts';
-    const program1 = createProgram(path.join(FIXTURES_DIR, 'tsconfig.json'));
-    const options = createOptions(filename);
-    const optionsWithSingleProgram = {
-      ...options,
-      programs: [program1],
-    };
-    expect(() =>
-      parseAndGenerateServices('const foo = 5;', optionsWithSingleProgram),
-    ).toThrow(
-      `The file was not found in any of the provided program instance(s): ${filename}`,
-    );
-
-    const program2 = createProgram(path.join(FIXTURES_DIR, 'tsconfig.json'));
-    const optionsWithMultiplePrograms = {
-      ...options,
-      programs: [program1, program2],
-    };
-    expect(() =>
-      parseAndGenerateServices('const foo = 5;', optionsWithMultiplePrograms),
-    ).toThrow(
-      `The file was not found in any of the provided program instance(s): ${filename}`,
-    );
-  });
 
   it('createProgram fails on non-existent file', () => {
     expect(() => createProgram('tsconfig.non-existent.json')).toThrow();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5904,6 +5904,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@typescript-eslint/performance@workspace:packages/performance":
+  version: 0.0.0-use.local
+  resolution: "@typescript-eslint/performance@workspace:packages/performance"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": 6.9.1
+    "@typescript-eslint/parser": 6.9.1
+    eslint: "*"
+    tsx: "*"
+  languageName: unknown
+  linkType: soft
+
 "@typescript-eslint/repo-tools@workspace:packages/repo-tools":
   version: 0.0.0-use.local
   resolution: "@typescript-eslint/repo-tools@workspace:packages/repo-tools"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5911,6 +5911,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": 6.9.1
     "@typescript-eslint/parser": 6.9.1
     eslint: "*"
+    execa: "*"
     tsx: "*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: starts on #6218
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds two forms of very rudimentary performance testing:

* `comparison` job: . Runs a matrix of commands on generated code with my old favorite https://github.com/sharkdp/hyperfine. Uses the Mac runner purely so that `brew install` can be used.
    * The generated code is 50% `.js` files that aren't included in the TSConfig and 50% `.ts` files that are included.
* `summary` job: runs a direct `console.table` showing the results of running the two kinds of linting once
    - `yarn test:project`: Traditional `project: true`
    - `yarn test:service` `EXPERIMENTAL_useProjectService`
    - `yarn test:service:seeded`: `EXPERIMENTAL_useProjectService`, with `allowDefaultProjectFallbackFilesGlobs`


Example output from `yarn test:summary` on my M1 Max Mac (`(index)` is generated file count):

```plaintext
┌─────────┬────────────────────────────────┬────────────────────────────────┬────────────────────────────────┐
│ (index) │            project             │            service             │        service (seeded)        │
├─────────┼────────────────────────────────┼────────────────────────────────┼────────────────────────────────┤
│    5    │ '1.10 real 2.07 user 0.12 sys' │ '1.91 real 3.53 user 0.22 sys' │ '1.74 real 3.31 user 0.20 sys' │
│   10    │ '1.12 real 2.07 user 0.11 sys' │ '1.90 real 3.62 user 0.23 sys' │ '1.94 real 3.62 user 0.24 sys' │
│   25    │ '1.14 real 2.17 user 0.12 sys' │ '2.32 real 4.12 user 0.32 sys' │ '2.33 real 4.15 user 0.33 sys' │
│   50    │ '1.22 real 2.27 user 0.13 sys' │ '3.12 real 5.03 user 0.50 sys' │ '3.12 real 5.03 user 0.49 sys' │
│   75    │ '1.41 real 2.65 user 0.14 sys' │ '3.85 real 5.76 user 0.63 sys' │ '3.84 real 5.76 user 0.65 sys' │
│   100   │ '1.37 real 2.70 user 0.13 sys' │ '4.71 real 6.55 user 0.83 sys' │ '4.59 real 6.42 user 0.81 sys' │
│   125   │ '1.43 real 2.74 user 0.14 sys' │ '5.31 real 7.15 user 0.99 sys' │ '5.28 real 7.10 user 0.98 sys' │
│   150   │ '1.49 real 2.82 user 0.14 sys' │ '6.12 real 7.93 user 1.15 sys' │ '6.10 real 7.92 user 1.13 sys' │
│   175   │ '1.59 real 3.05 user 0.15 sys' │ '6.98 real 8.75 user 1.28 sys' │ '6.92 real 8.74 user 1.28 sys' │
│   200   │ '1.58 real 3.08 user 0.15 sys' │ '7.57 real 9.25 user 1.38 sys' │ '7.56 real 9.21 user 1.43 sys' │
└─────────┴────────────────────────────────┴────────────────────────────────┴────────────────────────────────┘
```

Includes roughly the changes from #7752 for testing purposes. But an earlier, scrappier version of them.