### PR TITLE
chore: shorten issue template naming

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
@@ -1,4 +1,4 @@
-name: '🐛 Report a Bug With a Rule'
+name: '🐛 Rule Bug'
 description: 'Report a bug you encountered with a lint rule'
 title: 'Bug: [rule name here] <short description of the issue>'
 labels:

--- a/.github/ISSUE_TEMPLATE/02-enhancement-rule-option.yaml
+++ b/.github/ISSUE_TEMPLATE/02-enhancement-rule-option.yaml
@@ -1,4 +1,4 @@
-name: '✨ Propose a New Rule Option or Additional Checks'
+name: '✨ New Rule Option or Additional Check'
 description: 'Propose a new lint rule option or propose that a lint rule checks more cases'
 title: 'Enhancement: [rule-name] <a short description of my proposal>'
 labels:

--- a/.github/ISSUE_TEMPLATE/03-enhancement-new-rule.yaml
+++ b/.github/ISSUE_TEMPLATE/03-enhancement-new-rule.yaml
@@ -1,4 +1,4 @@
-name: '✨ Propose a New Rule'
+name: '✨ New Rule'
 description: 'Propose a new lint rule'
 title: 'Rule proposal: <a short description of my proposal>'
 labels:

--- a/.github/ISSUE_TEMPLATE/04-enhancement-new-base-rule-extension.yaml
+++ b/.github/ISSUE_TEMPLATE/04-enhancement-new-base-rule-extension.yaml
@@ -1,4 +1,4 @@
-name: '✨ Propose a New Base Rule Extension'
+name: '✨ New Base Rule Extension'
 description: 'Propose a new base lint rule extension'
 title: 'Base rule extension: [rule-name] <a short description of my proposal>'
 labels:

--- a/.github/ISSUE_TEMPLATE/05-documentation-request.yml
+++ b/.github/ISSUE_TEMPLATE/05-documentation-request.yml
@@ -1,4 +1,4 @@
-name: '📝 Documentation Request'
+name: '📝 Documentation'
 description: 'Request a change in documentation'
 title: 'Docs: <a short description of my proposal>'
 labels:

--- a/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
+++ b/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
@@ -1,4 +1,4 @@
-name: '🐛 Report a Bug With Another Package'
+name: '🐛 Bug With Another Package'
 description: 'Report a bug you encountered with another one of our packages (parser, util, scope-manager, etc)'
 title: 'Bug: <short description of the issue>'
 labels:

--- a/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
+++ b/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
@@ -1,4 +1,4 @@
-name: '✨ Propose an Enhancement With Another Package'
+name: '✨ Enhance Another Package'
 description: 'Report an enhancement to another one of our packages (parser, util, scope-manager, etc)'
 title: 'Enhancement: <a short description of my proposal>'
 labels:

--- a/.github/ISSUE_TEMPLATE/08-bug-report-complex.yaml
+++ b/.github/ISSUE_TEMPLATE/08-bug-report-complex.yaml
@@ -1,4 +1,4 @@
-name: '🐛 Report a Complex Bug With a Reproduction Repository'
+name: '🐛 Complex Bug With a Reproduction Repository'
 description: Report a complex bug you encountered by providing an isolated reproduction repository
 title: 'Bug: <short description of the issue>'
 labels:

--- a/.github/ISSUE_TEMPLATE/09-config-change.yaml
+++ b/.github/ISSUE_TEMPLATE/09-config-change.yaml
@@ -1,4 +1,4 @@
-name: '♻ Propose a Change to Preset Configurations'
+name: '♻ Preset Configurations Change'
 description: 'Propose an addition, removal, or general change to a preset config'
 title: 'Configs: <a short description of my proposal>'
 labels:

--- a/.github/ISSUE_TEMPLATE/10-repo-maintenance.yaml
+++ b/.github/ISSUE_TEMPLATE/10-repo-maintenance.yaml
@@ -1,4 +1,4 @@
-name: '🏗 Suggest an Improvement with Repository Maintenance'
+name: '🏗 Improve Repository Maintenance'
 description: Report a bug or request a feature related to developing the typescript-eslint monorepo
 title: 'Repo: <short description of the issue>'
 labels:


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: starts on #7856
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Shortens the title names - Security should still be changed, however.