### PR TITLE
chore: fix integration tests for ESLint formatting deprecations

### DIFF
--- a/packages/integration-tests/tests/__snapshots__/recommended-does-not-require-program.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/recommended-does-not-require-program.test.ts.snap
@@ -24,7 +24,16 @@ exports[`recommended-does-not-require-program should lint successfully 1`] = `
     "output": "const foo: unknown = true;
 ",
     "suppressedMessages": [],
-    "usedDeprecatedRules": [],
+    "usedDeprecatedRules": [
+      {
+        "replacedBy": [],
+        "ruleId": "no-extra-semi",
+      },
+      {
+        "replacedBy": [],
+        "ruleId": "no-mixed-spaces-and-tabs",
+      },
+    ],
     "warningCount": 0,
   },
 ]

--- a/packages/integration-tests/tests/__snapshots__/vue-sfc.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/vue-sfc.test.ts.snap
@@ -58,7 +58,12 @@ export default Vue.extend({
 </script>
 ",
     "suppressedMessages": [],
-    "usedDeprecatedRules": [],
+    "usedDeprecatedRules": [
+      {
+        "replacedBy": [],
+        "ruleId": "semi-spacing",
+      },
+    ],
     "warningCount": 0,
   },
   {
@@ -93,7 +98,12 @@ export default class Utility {
 </script>
 ",
     "suppressedMessages": [],
-    "usedDeprecatedRules": [],
+    "usedDeprecatedRules": [
+      {
+        "replacedBy": [],
+        "ruleId": "semi-spacing",
+      },
+    ],
     "warningCount": 0,
   },
   {
@@ -145,7 +155,12 @@ export default Vue.extend({
 </script>
 ",
     "suppressedMessages": [],
-    "usedDeprecatedRules": [],
+    "usedDeprecatedRules": [
+      {
+        "replacedBy": [],
+        "ruleId": "semi-spacing",
+      },
+    ],
     "warningCount": 0,
   },
 ]


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7890
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Updates snapshots for the latest ESLint version deprecating formatting rules (https://github.com/eslint/eslint/issues/17522).