### PR TITLE
feat(eslint-plugin): [no-floating-promises] flag result of .map(async)

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-floating-promises.md
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.md
@@ -17,6 +17,13 @@ Valid ways of handling a Promise-valued statement include:
 - Calling its `.then()` with two arguments
 - Calling its `.catch()` with one argument
 
+This rule also reports when an array of Promises is created and not properly handled. The main way to resolve this is by using one of the Promise concurrency methods to create a single promise, then handling that according to the procedure above. These methods include:
+
+- `Promise.all()`,
+- `Promise.allSettled()`,
+- `Promise.any()`
+- `Promise.race()`
+
 :::tip
 `no-floating-promises` only detects unhandled Promise _statements_.
 See [`no-misused-promises`](./no-misused-promises.md) for detecting code that provides Promises to _logical_ locations such as if statements.
@@ -40,6 +47,8 @@ returnsPromise().then(() => {});
 Promise.reject('value').catch();
 
 Promise.reject('value').finally();
+
+[1, 2, 3].map(async x => x + 1);
 ```
 
 ### ✅ Correct
@@ -59,6 +68,8 @@ returnsPromise().then(
 Promise.reject('value').catch(() => {});
 
 await Promise.reject('value').finally(() => {});
+
+await Promise.all([1, 2, 3].map(async x => x + 1));
 ```
 
 ## Options

--- a/packages/eslint-plugin/docs/rules/no-floating-promises.md
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.md
@@ -17,7 +17,7 @@ Valid ways of handling a Promise-valued statement include:
 - Calling its `.then()` with two arguments
 - Calling its `.catch()` with one argument
 
-This rule also reports when an array of Promises is created and not properly handled. The main way to resolve this is by using one of the Promise concurrency methods to create a single promise, then handling that according to the procedure above. These methods include:
+This rule also reports when an Array containing Promises is created and not properly handled. The main way to resolve this is by using one of the Promise concurrency methods to create a single Promise, then handling that according to the procedure above. These methods include:
 
 - `Promise.all()`,
 - `Promise.allSettled()`,
@@ -115,3 +115,7 @@ If you do not use Promise-like values in your codebase, or want to allow them to
 ## Related To
 
 - [`no-misused-promises`](./no-misused-promises.md)
+
+## Further Reading
+
+- ["Using Promises" MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises). Note especially the sections on [Promise rejection events](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#promise_rejection_events) and [Composition](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises#composition).

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -120,71 +120,69 @@ export default createRule<Options, MessageId>({
                 ? 'floatingPromiseArrayVoid'
                 : 'floatingPromiseArray',
             });
+          } else if (options.ignoreVoid) {
+            context.report({
+              node,
+              messageId: nonFunctionHandler
+                ? 'floatingUselessRejectionHandlerVoid'
+                : 'floatingVoid',
+              suggest: [
+                {
+                  messageId: 'floatingFixVoid',
+                  fix(fixer): TSESLint.RuleFix | TSESLint.RuleFix[] {
+                    const tsNode = services.esTreeNodeToTSNodeMap.get(
+                      node.expression,
+                    );
+                    if (isHigherPrecedenceThanUnary(tsNode)) {
+                      return fixer.insertTextBefore(node, 'void ');
+                    }
+                    return [
+                      fixer.insertTextBefore(node, 'void ('),
+                      fixer.insertTextAfterRange(
+                        [expression.range[1], expression.range[1]],
+                        ')',
+                      ),
+                    ];
+                  },
+                },
+              ],
+            });
           } else {
-            if (options.ignoreVoid) {
-              context.report({
-                node,
-                messageId: nonFunctionHandler
-                  ? 'floatingUselessRejectionHandlerVoid'
-                  : 'floatingVoid',
-                suggest: [
-                  {
-                    messageId: 'floatingFixVoid',
-                    fix(fixer): TSESLint.RuleFix | TSESLint.RuleFix[] {
-                      const tsNode = services.esTreeNodeToTSNodeMap.get(
-                        node.expression,
+            context.report({
+              node,
+              messageId: nonFunctionHandler
+                ? 'floatingUselessRejectionHandler'
+                : 'floating',
+              suggest: [
+                {
+                  messageId: 'floatingFixAwait',
+                  fix(fixer): TSESLint.RuleFix | TSESLint.RuleFix[] {
+                    if (
+                      expression.type === AST_NODE_TYPES.UnaryExpression &&
+                      expression.operator === 'void'
+                    ) {
+                      return fixer.replaceTextRange(
+                        [expression.range[0], expression.range[0] + 4],
+                        'await',
                       );
-                      if (isHigherPrecedenceThanUnary(tsNode)) {
-                        return fixer.insertTextBefore(node, 'void ');
-                      }
-                      return [
-                        fixer.insertTextBefore(node, 'void ('),
-                        fixer.insertTextAfterRange(
-                          [expression.range[1], expression.range[1]],
-                          ')',
-                        ),
-                      ];
-                    },
+                    }
+                    const tsNode = services.esTreeNodeToTSNodeMap.get(
+                      node.expression,
+                    );
+                    if (isHigherPrecedenceThanUnary(tsNode)) {
+                      return fixer.insertTextBefore(node, 'await ');
+                    }
+                    return [
+                      fixer.insertTextBefore(node, 'await ('),
+                      fixer.insertTextAfterRange(
+                        [expression.range[1], expression.range[1]],
+                        ')',
+                      ),
+                    ];
                   },
-                ],
-              });
-            } else {
-              context.report({
-                node,
-                messageId: nonFunctionHandler
-                  ? 'floatingUselessRejectionHandler'
-                  : 'floating',
-                suggest: [
-                  {
-                    messageId: 'floatingFixAwait',
-                    fix(fixer): TSESLint.RuleFix | TSESLint.RuleFix[] {
-                      if (
-                        expression.type === AST_NODE_TYPES.UnaryExpression &&
-                        expression.operator === 'void'
-                      ) {
-                        return fixer.replaceTextRange(
-                          [expression.range[0], expression.range[0] + 4],
-                          'await',
-                        );
-                      }
-                      const tsNode = services.esTreeNodeToTSNodeMap.get(
-                        node.expression,
-                      );
-                      if (isHigherPrecedenceThanUnary(tsNode)) {
-                        return fixer.insertTextBefore(node, 'await ');
-                      }
-                      return [
-                        fixer.insertTextBefore(node, 'await ('),
-                        fixer.insertTextAfterRange(
-                          [expression.range[1], expression.range[1]],
-                          ')',
-                        ),
-                      ];
-                    },
-                  },
-                ],
-              });
-            }
+                },
+              ],
+            });
           }
         }
       },

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -63,7 +63,6 @@ export default createRule<Options, MessageId>({
         messageBase + ' ' + messageRejectionHandler,
       floatingUselessRejectionHandlerVoid:
         messageBaseVoid + ' ' + messageRejectionHandler,
-
       floatingPromiseArray: messagePromiseArray,
       floatingPromiseArrayVoid: messagePromiseArrayVoid,
     },

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -113,7 +113,14 @@ export default createRule<Options, MessageId>({
           isUnhandledPromise(checker, expression);
 
         if (isUnhandled) {
-          if (!promiseArray) {
+          if (promiseArray) {
+            context.report({
+              node,
+              messageId: options.ignoreVoid
+                ? 'floatingPromiseArrayVoid'
+                : 'floatingPromiseArray',
+            });
+          } else {
             if (options.ignoreVoid) {
               context.report({
                 node,
@@ -178,13 +185,6 @@ export default createRule<Options, MessageId>({
                 ],
               });
             }
-          } else {
-            context.report({
-              node,
-              messageId: options.ignoreVoid
-                ? 'floatingPromiseArrayVoid'
-                : 'floatingPromiseArray',
-            });
           }
         }
       },

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -327,11 +327,6 @@ export default createRule<Options, MessageId>({
 
 function isPromiseArray(checker: ts.TypeChecker, node: ts.Node): boolean {
   const type = checker.getTypeAtLocation(node);
-
-  // NOTE - I've chosen isArrayType rather than isArrayLikeType because the
-  // main real use case here is to catch the result of `.map(f)`,
-  // which should always be a native array type.
-  // PR QUESTION - should we be using isArrayLikeType instead?
   if (checker.isArrayType(type)) {
     const arrayType = checker.getTypeArguments(type)[0];
     if (isPromiseLikeType(checker, arrayType)) {

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -332,7 +332,7 @@ function isPromiseArray(checker: ts.TypeChecker, node: ts.Node): boolean {
   for (const ty of tsutils
     .unionTypeParts(type)
     .map(t => checker.getApparentType(t))) {
-    if (checker.isArrayLikeType(ty)) {
+    if (checker.isArrayType(ty)) {
       const arrayType = checker.getTypeArguments(ty)[0];
       if (isPromiseLike(checker, node, arrayType)) {
         return true;

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -332,7 +332,7 @@ function isPromiseArray(checker: ts.TypeChecker, node: ts.Node): boolean {
   for (const ty of tsutils
     .unionTypeParts(type)
     .map(t => checker.getApparentType(t))) {
-    if (checker.isArrayType(ty)) {
+    if (checker.isArrayLikeType(ty)) {
       const arrayType = checker.getTypeArguments(ty)[0];
       if (isPromiseLike(checker, node, arrayType)) {
         return true;

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -338,6 +338,14 @@ function isPromiseArray(checker: ts.TypeChecker, node: ts.Node): boolean {
         return true;
       }
     }
+
+    if (checker.isTupleType(ty)) {
+      for (const tupleElementType of checker.getTypeArguments(ty)) {
+        if (isPromiseLike(checker, node, tupleElementType)) {
+          return true;
+        }
+      }
+    }
   }
   return false;
 }

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -500,9 +500,12 @@ void promiseArray;
       `,
     },
     {
+      // Expressions aren't checked by this rule, so this just becomes an array
+      // of number | undefined, which is fine regardless of the ignoreVoid setting.
       code: `
 [1, 2, void Promise.reject(), 3];
       `,
+      options: [{ ignoreVoid: false }],
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -487,14 +487,6 @@ void promiseArray;
       `,
     },
     {
-      // This one is a bit of a head-scratcher, knowing that the rule recursively
-      // checks .finally() expressions. However, ultimately, the whole expression
-      // is not a promise (it's invalid TS), so it's not a floating promise.
-      code: `
-[Promise.reject(), Promise.reject()].finally(() => {});
-      `,
-    },
-    {
       code: `
 [Promise.reject(), Promise.reject()].then(() => {});
       `,

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -504,6 +504,11 @@ void promiseArray;
 [1, 2, void Promise.reject(), 3];
       `,
     },
+    {
+      code: `
+['I', 'am', 'just', 'an', 'array'];
+      `,
+    },
   ],
 
   invalid: [
@@ -1682,8 +1687,8 @@ Promise.reject(new Error('message')).finally(() => {});
     },
     {
       code: `
-function _<T extends Array<Promise<number>>>(
-  maybePromiseArray: T | undefined,
+function _<T, S extends Array<T | Promise<T>>>(
+  maybePromiseArray: S | undefined,
 ): void {
   maybePromiseArray?.[0];
 }
@@ -1731,6 +1736,16 @@ data.map(async () => {
 });
       `,
       errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
+    },
+    {
+      code: `
+function _<T, S extends Array<T | Array<T | Promise<T>>>>(
+  maybePromiseArrayArray: S | undefined,
+): void {
+  maybePromiseArrayArray?.[0];
+}
+      `,
+      errors: [{ line: 5, messageId: 'floatingPromiseArrayVoid' }],
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -1773,11 +1773,5 @@ function f<T extends Array<Promise<number>>>(a: T | undefined): void {
       `,
       errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
     },
-    {
-      code: `
-[Promise.reject()] as const;
-      `,
-      errors: [{ line: 2, messageId: 'floatingPromiseArrayVoid' }],
-    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -1682,6 +1682,16 @@ Promise.reject(new Error('message')).finally(() => {});
     },
     {
       code: `
+function _<T extends Array<Promise<number>>>(
+  maybePromiseArray: T | undefined,
+): void {
+  maybePromiseArray?.[0];
+}
+      `,
+      errors: [{ line: 5, messageId: 'floatingVoid' }],
+    },
+    {
+      code: `
 [1, 2, 3].map(() => Promise.reject());
       `,
       errors: [{ line: 2, messageId: 'floatingPromiseArrayVoid' }],
@@ -1719,6 +1729,29 @@ const data = ['test'];
 data.map(async () => {
   await new Promise((_res, rej) => setTimeout(rej, 1000));
 });
+      `,
+      errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
+    },
+    {
+      code: `
+function f<T extends Array<Promise<number>>>(a: T): void {
+  a;
+}
+      `,
+      errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
+    },
+    {
+      code: `
+declare const a: Array<Promise<number>> | undefined;
+a;
+      `,
+      errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
+    },
+    {
+      code: `
+function f<T extends Array<Promise<number>>>(a: T | undefined): void {
+  a;
+}
       `,
       errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
     },

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -222,7 +222,7 @@ async function test() {
     `
 async function test() {
   class Thenable {
-    then(callback: () => {}): Thenable {
+    then(callback: () => void): Thenable {
       return new Thenable();
     }
   }
@@ -264,7 +264,7 @@ async function test() {
     `
 async function test() {
   class CatchableThenable {
-    then(callback: () => {}, callback: () => {}): CatchableThenable {
+    then(callback: () => void, callback: () => void): CatchableThenable {
       return new CatchableThenable();
     }
   }
@@ -473,6 +473,35 @@ Promise.reject()
   .finally(() => {})
   .finally(() => {})
   .finally(() => {});
+      `,
+    },
+    {
+      code: `
+await Promise.all([Promise.resolve(), Promise.resolve()]);
+      `,
+    },
+    {
+      code: `
+declare const promiseArray: Array<Promise<unknown>>;
+void promiseArray;
+      `,
+    },
+    {
+      // This one is a bit of a head-scratcher, knowing that the rule recursively
+      // checks .finally() expressions. However, ultimately, the whole expression
+      // is not a promise (it's invalid TS), so it's not a floating promise.
+      code: `
+[Promise.reject(), Promise.reject()].finally(() => {});
+      `,
+    },
+    {
+      code: `
+[Promise.reject(), Promise.reject()].then(() => {});
+      `,
+    },
+    {
+      code: `
+[1, 2, void Promise.reject(), 3];
       `,
     },
   ],
@@ -997,7 +1026,7 @@ async function test() {
       code: `
 async function test() {
   class CatchableThenable {
-    then(callback: () => {}, callback: () => {}): CatchableThenable {
+    then(callback: () => void, callback: () => void): CatchableThenable {
       return new CatchableThenable();
     }
   }
@@ -1650,6 +1679,48 @@ Promise.resolve().finally(() => {}), 123;
 Promise.reject(new Error('message')).finally(() => {});
       `,
       errors: [{ line: 2, messageId: 'floatingVoid' }],
+    },
+    {
+      code: `
+[1, 2, 3].map(() => Promise.reject());
+      `,
+      errors: [{ line: 2, messageId: 'floatingPromiseArrayVoid' }],
+    },
+    {
+      code: `
+declare const array: unknown[];
+array.map(() => Promise.reject());
+      `,
+      errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
+    },
+    {
+      code: `
+declare const promiseArray: Array<Promise<unknown>>;
+void promiseArray;
+      `,
+      options: [{ ignoreVoid: false }],
+      errors: [{ line: 3, messageId: 'floatingPromiseArray' }],
+    },
+    {
+      code: `
+[1, 2, Promise.reject(), 3];
+      `,
+      errors: [{ line: 2, messageId: 'floatingPromiseArrayVoid' }],
+    },
+    {
+      code: `
+[1, 2, Promise.reject().catch(() => {}), 3];
+      `,
+      errors: [{ line: 2, messageId: 'floatingPromiseArrayVoid' }],
+    },
+    {
+      code: `
+const data = ['test'];
+data.map(async () => {
+  await new Promise((_res, rej) => setTimeout(rej, 1000));
+});
+      `,
+      errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -1786,5 +1786,17 @@ cursed();
       `,
       errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
     },
+    {
+      code: `
+[
+  'Type Argument number ',
+  1,
+  'is not',
+  Promise.resolve(),
+  'but it still is flagged',
+] as const;
+      `,
+      errors: [{ line: 2, messageId: 'floatingPromiseArrayVoid' }],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -1790,5 +1790,21 @@ cursed();
       `,
       errors: [{ line: 2, messageId: 'floatingPromiseArrayVoid' }],
     },
+    {
+      code: `
+        declare const arrayOrPromiseTuple:
+          | Array<number>
+          | [number, number, Promise<unknown>, string];
+        arrayOrPromiseTuple;
+      `,
+      errors: [{ line: 5, messageId: 'floatingPromiseArrayVoid' }],
+    },
+    {
+      code: `
+        declare const okArrayOrPromiseArray: Array<number> | Array<Promise<unknown>>;
+        okArrayOrPromiseArray;
+      `,
+      errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -1773,5 +1773,11 @@ function f<T extends Array<Promise<number>>>(a: T | undefined): void {
       `,
       errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
     },
+    {
+      code: `
+[Promise.reject()] as const;
+      `,
+      errors: [{ line: 2, messageId: 'floatingPromiseArrayVoid' }],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -1773,5 +1773,18 @@ function f<T extends Array<Promise<number>>>(a: T | undefined): void {
       `,
       errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
     },
+    {
+      code: `
+[Promise.reject()] as const;
+      `,
+      errors: [{ line: 2, messageId: 'floatingPromiseArrayVoid' }],
+    },
+    {
+      code: `
+declare function cursed(): [Promise<number>, Promise<string>];
+cursed();
+      `,
+      errors: [{ line: 3, messageId: 'floatingPromiseArrayVoid' }],
+    },
   ],
 });

--- a/packages/eslint-plugin/typings/typescript.d.ts
+++ b/packages/eslint-plugin/typings/typescript.d.ts
@@ -15,6 +15,10 @@ declare module 'typescript' {
      */
     isArrayType(type: Type): type is TypeReference;
     /**
+     * True if this type is assignable to `ReadonlyArray<any>`.
+     */
+    isArrayLikeType(type: Type): type is TypeReference;
+    /**
      * @returns `true` if the given type is a tuple type:
      * - `[foo]`
      * - `readonly [foo]`

--- a/packages/eslint-plugin/typings/typescript.d.ts
+++ b/packages/eslint-plugin/typings/typescript.d.ts
@@ -15,10 +15,6 @@ declare module 'typescript' {
      */
     isArrayType(type: Type): type is TypeReference;
     /**
-     * True if this type is assignable to `ReadonlyArray<any>`.
-     */
-    isArrayLikeType(type: Type): type is TypeReference;
-    /**
      * @returns `true` if the given type is a tuple type:
      * - `[foo]`
      * - `readonly [foo]`


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5958 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR adds functionality to the rule to check for unawaited arrays of promises, where we might expect to use Promise.all/Promise.allSettled, etc to handle the result.

```
async function rejectIn(t: number) {
  new Promise<void>((resolve) => {
    setTimeout(() => {
      resolve();
    }, t);
  });

  throw new Error();
}

// Unhandled rejections. Will now flag.
[1, 2, 3].map(async (t) => {
  await rejectIn(t);
});
```

I haven't attempted to add editor suggestions for fixes because the fixes seem rather complicated, depending on how you ended up with an array of promises and what you want to do with it. For example, we might fix the above code with 

```
// should we use Promise.all(), Promise.allSettled(), Promise.race(), etc? 
// it's unclear to me that picking one for the user is a good idea.
// Plus, they will still have to handle the resulting promise with catch or something.
Promise.all(
  [1, 2, 3].map(async (t) => {
    await rejectIn(t);
  }),
).catch(() => {});

// This fix would seem plausible but actually violates no-misused-promises with checksVoidReturn: true.
// Also, seems like it would be challenging to implement since it involves inspecting how we got to the
// floating promise in the first place.
[1, 2, 3].forEach(async (t) => {
  await rejectIn(t);
});

// This one should be easy to implement.
void [1, 2, 3].map(async (t) => {
  await rejectIn(t);
});
```

This seems like enough of an edge case that maybe the user should be responsible for manually resolving it. Please advise if adding editor suggestion would be a requirement for this PR.