### PR TITLE
docs: remove -W yarn flag in Dependency_Version_Upgrades.mdx

### DIFF
--- a/docs/maintenance/Dependency_Version_Upgrades.mdx
+++ b/docs/maintenance/Dependency_Version_Upgrades.mdx
@@ -8,7 +8,7 @@ title: Dependency Version Upgrades
 Our published packages only depend on `@babel/*` packages as devDependencies.
 You can generally upgrade those dependencies with:
 
-1. `yarn add -DW @babel/code-frame @babel/core @babel/eslint-parser @babel/parser @babel/types`
+1. `yarn add -D @babel/code-frame @babel/core @babel/eslint-parser @babel/parser @babel/types`
 2. `npx nx run ast-spec:test -u`
 
 The fixtures under `packages/ast-spec/` describe how the files are parsed under both Babel and our (TSESTree) parser.


### PR DESCRIPTION
## Overview

Tried the command today. -W isn't needed in our post-classic versions of Yarn.

Spotted while making #7922.