### PR TITLE
chore: revert "chore(deps): update dependency react-resizable-panels to ^0.0.57"

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -36,7 +36,7 @@
     "prism-react-renderer": "^1.3.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-resizable-panels": "^0.0.57",
+    "react-resizable-panels": "^0.0.55",
     "remark-docusaurus-tabs": "^0.2.0",
     "semver": "^7.5.4",
     "ts-node": "*",

--- a/packages/website/src/components/Playground.tsx
+++ b/packages/website/src/components/Playground.tsx
@@ -92,7 +92,7 @@ function Playground(): React.JSX.Element {
         <Panel
           id="playgroundMenu"
           className={styles.PanelColumn}
-          defaultSizePercentage={windowSize === 'mobile' ? 0 : optionsSize}
+          defaultSize={windowSize === 'mobile' ? 0 : optionsSize}
           collapsible={true}
           ref={playgroundMenuRef}
         >

--- a/packages/website/src/components/typeDetails/TypesDetails.tsx
+++ b/packages/website/src/components/typeDetails/TypesDetails.tsx
@@ -37,7 +37,7 @@ export function TypesDetails({
     <PanelGroup autoSaveId="playground-types" direction="horizontal">
       <Panel
         id="simplifiedTree"
-        defaultSizePercentage={35}
+        defaultSize={35}
         collapsible={true}
         className={styles.PanelColumn}
       >

--- a/yarn.lock
+++ b/yarn.lock
@@ -17494,13 +17494,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable-panels@npm:^0.0.57":
-  version: 0.0.57
-  resolution: "react-resizable-panels@npm:0.0.57"
+"react-resizable-panels@npm:^0.0.55":
+  version: 0.0.55
+  resolution: "react-resizable-panels@npm:0.0.55"
   peerDependencies:
     react: ^16.14.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
-  checksum: 3b2d12dd19317d0473a14e02dadd16c997bbf845fb1e6bc569bb5c0ef5e0bb9ccb53272eeb221af1514c0527dd9eae37a8d2def209c2df8d10689d19a68f8605
+  checksum: a7cb938403b57d2489638eb2cf93fddcb420fbd51b8af2b959881ada83ba052f79f51610d650019e577f0e6018542e9195e4bfe45e4e884b4821744c45837646
   languageName: node
   linkType: hard
 
@@ -21008,7 +21008,7 @@ __metadata:
     raw-loader: ^4.0.2
     react: ^18.2.0
     react-dom: ^18.2.0
-    react-resizable-panels: ^0.0.57
+    react-resizable-panels: ^0.0.55
     remark-docusaurus-tabs: ^0.2.0
     rimraf: "*"
     semver: ^7.5.4


### PR DESCRIPTION
Reverts typescript-eslint/typescript-eslint#7937. Fixes #7962.