### PR TITLE
fix(typescript-estree): ensure backwards compat with pre-5.3 import attributes

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -3180,6 +3180,8 @@ export class Converter {
         });
       }
 
+      // eslint-disable-next-line deprecation/deprecation -- required for backwards-compatibility
+      case SyntaxKind.AssertEntry:
       case SyntaxKind.ImportAttribute: {
         return this.createNode<TSESTree.ImportAttribute>(node, {
           type: AST_NODE_TYPES.ImportAttribute,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7960
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
We don't have old TS version regression tests so this is a bit of a "trust me bro".
Manual test steps:
1) checkout branch
1) `yarn && yarn build`
1) copy folder `packages/typescript-estree/dist`
1) open a new folder
1) `yarn add @typescript-eslint/typescript-estree`
1) run `node` and use the repl from the issue (`require('@typescript-eslint/typescript-estree').parse('import json from "./foo.json" assert { type: "json", type: "bar" };').body[0].attributes`) --> observe the broken AST is printed.
1) paste the copied dist folder to `node_modules/@typescript-eslint/typescript-estree/`
1) run `node` and use the repl from the issue --> observe the correct AST is printed.

![screenshot of console showing output of the above steps](https://github.com/typescript-eslint/typescript-eslint/assets/7462525/1b11cb67-9b1f-4100-aa77-b8dadaaeaa07)
