### PR TITLE
docs: fix incorrect example command

### DIFF
--- a/docs/linting/Troubleshooting.mdx
+++ b/docs/linting/Troubleshooting.mdx
@@ -335,7 +335,7 @@ Make sure you're using the latest versions of each of your ESLint plugins (and o
 
 If you've using many ESLint plugins, have updated each to their latest version, and you're not sure which one this complaint is coming from, try either or both of:
 
-- Running with [`--trace-deprecation`](https://nodejs.org/api/cli.html#--trace-deprecation) (e.g. `npx crossenv NODE_OPTIONS=--trace-deprecation npm lint`)
+- Running with [`--trace-deprecation`](https://nodejs.org/api/cli.html#--trace-deprecation) (e.g. `npx cross-env NODE_OPTIONS=--trace-deprecation npm run lint`)
 - Disabling half of them at a time to narrow down which plugin it is
 
 Then make sure each of those plugins has a GitHub issue asking that they release a version supporting typescript-eslint v6.


### PR DESCRIPTION
- the package name crossenv is parked by NPM (https://www.npmjs.com/package/crossenv). cross-env is the intended one

- there's no npm command "lint" (https://docs.npmjs.com/cli/v6/commands)

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #7975
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
