### PR TITLE
chore(website): use less text for type checked filter

### DIFF
--- a/packages/website/src/components/RulesTable/index.tsx
+++ b/packages/website/src/components/RulesTable/index.tsx
@@ -231,7 +231,7 @@ export default function RulesTable(): React.JSX.Element {
             setMode={(newMode): void =>
               changeFilter('typeInformation', newMode)
             }
-            label={`${TYPE_INFORMATION_EMOJI} requires type information`}
+            label={`${TYPE_INFORMATION_EMOJI} type checked`}
           />
           <RuleFilterCheckBox
             mode={filters.extension}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7992
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Uses slightly smaller text for the biggest button on the page.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="923" alt="Before screenshot showing all buttons on one line, with 'requires type information' as the type checking label" src="https://github.com/typescript-eslint/typescript-eslint/assets/3335181/b2515dd4-bf3e-4a8e-bc41-bca57b3a3f5a">
</td>
<td>
<img width="923" alt="After screenshot showing all buttons on one line, with 'type checked' as the type checking label" src="https://github.com/typescript-eslint/typescript-eslint/assets/3335181/243f6018-4c36-4200-9b59-964845ccdf3b">
</td>
</tr>
</tbody>
</table>