### PR TITLE
chore: streamline issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
@@ -1,5 +1,5 @@
 name: '🐛 Rule Bug'
-description: 'Report a bug you encountered with a lint rule'
+description: 'An issue with a single lint rule'
 title: 'Bug: [rule name here] <short description of the issue>'
 labels:
   - bug
@@ -7,7 +7,7 @@ labels:
   - triage
 body:
   - type: checkboxes
-    id: sanity-checks
+    id: preliminary-checks
     attributes:
       label: Before You File a Bug Report Please Confirm You Have Done The Following...
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -41,7 +41,7 @@ body:
     attributes:
       label: Repro Code
       description: A ***minimal*** code sample which reproduces the issue
-      render: typescript
+      render: TypeScript
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/02-enhancement-rule-option.yaml
+++ b/.github/ISSUE_TEMPLATE/02-enhancement-rule-option.yaml
@@ -1,5 +1,5 @@
 name: '✨ New Rule Option or Additional Check'
-description: 'Propose a new lint rule option or propose that a lint rule checks more cases'
+description: 'Propose a new lint rule option or that a lint rule checks more cases'
 title: 'Enhancement: [rule-name] <a short description of my proposal>'
 labels:
   - 'enhancement: plugin rule option'
@@ -7,7 +7,7 @@ labels:
   - triage
 body:
   - type: checkboxes
-    id: sanity-checks
+    id: preliminary-checks
     attributes:
       label: Before You File a Proposal Please Confirm You Have Done The Following...
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Fail
       description: Specify an example of code that should be detected and errored on.
-      render: typescript
+      render: TypeScript
       value: |
         var replace = 'me';
     validations:
@@ -56,7 +56,7 @@ body:
     attributes:
       label: Pass
       description: Specify an example of code that would be accepted in its place
-      render: typescript
+      render: TypeScript
       value: |
         const replace = 'me';
     validations:

--- a/.github/ISSUE_TEMPLATE/03-enhancement-new-rule.yaml
+++ b/.github/ISSUE_TEMPLATE/03-enhancement-new-rule.yaml
@@ -7,7 +7,7 @@ labels:
   - triage
 body:
   - type: checkboxes
-    id: sanity-checks
+    id: preliminary-checks
     attributes:
       label: Before You File a Proposal Please Confirm You Have Done The Following...
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -48,7 +48,7 @@ body:
     attributes:
       label: Fail Cases
       description: Specify an example of code that should be detected and errored on.
-      render: typescript
+      render: TypeScript
       value: |
         var replace = 'me';
     validations:
@@ -58,7 +58,7 @@ body:
     attributes:
       label: Pass Cases
       description: Specify an example of code that would be accepted in its place
-      render: typescript
+      render: TypeScript
       value: |
         const replace = 'me';
     validations:

--- a/.github/ISSUE_TEMPLATE/04-enhancement-new-base-rule-extension.yaml
+++ b/.github/ISSUE_TEMPLATE/04-enhancement-new-base-rule-extension.yaml
@@ -14,7 +14,7 @@ body:
         In some cases, ESLint provides a rule itself, but it doesn't support TypeScript syntax; either it crashes, or it ignores the syntax, or it falsely reports against it.
         In these cases, we create what we call an extension rule; a rule within our plugin that has the same functionality, but also supports TypeScript.
   - type: checkboxes
-    id: sanity-checks
+    id: preliminary-checks
     attributes:
       label: Before You File a Proposal Please Confirm You Have Done The Following...
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -55,7 +55,7 @@ body:
     attributes:
       label: Fail
       description: Specify an example of code that should be detected and errored on.
-      render: typescript
+      render: TypeScript
       value: |
         var replace = 'me';
     validations:
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Pass
       description: Specify an example of code that would be accepted in its place
-      render: typescript
+      render: TypeScript
       value: |
         const replace = 'me';
     validations:

--- a/.github/ISSUE_TEMPLATE/05-documentation-request.yml
+++ b/.github/ISSUE_TEMPLATE/05-documentation-request.yml
@@ -1,12 +1,12 @@
 name: '📝 Documentation'
-description: 'Request a change in documentation'
+description: 'Adding or improving in docs'
 title: 'Docs: <a short description of my proposal>'
 labels:
   - documentation
   - triage
 body:
   - type: checkboxes
-    id: sanity-checks
+    id: preliminary-checks
     attributes:
       label: Before You File a Documentation Request Please Confirm You Have Done The Following...
       options:

--- a/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
+++ b/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
@@ -1,12 +1,12 @@
 name: '🐛 Bug With Another Package'
-description: 'Report a bug you encountered with another one of our packages (parser, util, scope-manager, etc)'
+description: 'An issue with another one of our packages (parser, utils, etc)'
 title: 'Bug: <short description of the issue>'
 labels:
   - bug
   - triage
 body:
   - type: checkboxes
-    id: sanity-checks
+    id: preliminary-checks
     attributes:
       label: Before You File a Bug Report Please Confirm You Have Done The Following...
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -54,7 +54,7 @@ body:
     attributes:
       label: Repro Code
       description: A ***minimal*** code sample which reproduces the issue
-      render: typescript
+      render: TypeScript
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
+++ b/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
@@ -1,12 +1,12 @@
 name: '✨ Enhance Another Package'
-description: 'Report an enhancement to another one of our packages (parser, util, scope-manager, etc)'
+description: 'Request a change to another one of our packages (parser, utils, etc)'
 title: 'Enhancement: <a short description of my proposal>'
 labels:
   - enhancement
   - triage
 body:
   - type: checkboxes
-    id: sanity-checks
+    id: preliminary-checks
     attributes:
       label: Before You File a Proposal Please Confirm You Have Done The Following...
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
@@ -46,26 +46,6 @@ body:
       label: Description
       description: Explain what your proposal would do and why this is useful.
       placeholder: I propose that the foo rule should also check for when bars are force to be a baz.
-    validations:
-      required: true
-  - type: textarea
-    id: fail-cases
-    attributes:
-      label: Fail
-      description: Specify an example of code that should be detected and errored on.
-      render: typescript
-      value: |
-        var replace = 'me';
-    validations:
-      required: true
-  - type: textarea
-    id: pass-cases
-    attributes:
-      label: Pass
-      description: Specify an example of code that would be accepted in its place
-      render: typescript
-      value: |
-        const replace = 'me';
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/08-bug-report-complex.yaml
+++ b/.github/ISSUE_TEMPLATE/08-bug-report-complex.yaml
@@ -1,17 +1,16 @@
-name: '🐛 Complex Bug With a Reproduction Repository'
-description: Report a complex bug you encountered by providing an isolated reproduction repository
+name: '🐛 Complex Bug With a Reproduction'
+description: Report a complex bug with an isolated reproduction
 title: 'Bug: <short description of the issue>'
 labels:
   - bug
   - triage
 body:
   - type: markdown
-    id: preamble
     attributes:
       value: |
         An isolated reproduction is one we can clone locally and get running without other projects or existing knowledge of your project. If we cannot reproduce your bug quickly with the provided steps, we may not be able to take action on this issue. Help us to help you!
   - type: checkboxes
-    id: sanity-checks
+    id: preliminary-checks
     attributes:
       label: Before You File a Bug Report Please Confirm You Have Done The Following...
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!

--- a/.github/ISSUE_TEMPLATE/09-config-change.yaml
+++ b/.github/ISSUE_TEMPLATE/09-config-change.yaml
@@ -7,7 +7,7 @@ labels:
   - triage
 body:
   - type: checkboxes
-    id: sanity-checks
+    id: preliminary-checks
     attributes:
       label: Before You File a Proposal Please Confirm You Have Done The Following...
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!

--- a/.github/ISSUE_TEMPLATE/10-repo-maintenance.yaml
+++ b/.github/ISSUE_TEMPLATE/10-repo-maintenance.yaml
@@ -1,5 +1,5 @@
 name: '🏗 Improve Repository Maintenance'
-description: Report a bug or request a feature related to developing the typescript-eslint monorepo
+description: Improve the development experience for the typescript-eslint monorepo
 title: 'Repo: <short description of the issue>'
 labels:
   - 'repo maintenance'

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: FAQ
-    about: Please check out our FAQ before filing new issues
+    about: Please read our FAQ before filing new issues
     url: https://typescript-eslint.io/linting/troubleshooting
   - name: Getting Started Guide
-    about: If you're looking for help setting up check out our getting started guide
+    about: If you're looking for help setting up, check out our getting started guide
     url: https://typescript-eslint.io
   - name: Ask a question on Discord
     about: If you just want to ask a question, consider asking it on Discord!


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7856; fixes #7818
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Goes mostly with the descriptions suggested in #7856 and applies the removal of before/after from #7818 as suggested there.

Also touches up some markdown that was counted as invalid locally (`typescript` isn't a supported language name; `TypeScript` is).