### PR TITLE
fix(eslint-plugin): correct message for `no-unsafe-unary-minus`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-unary-minus.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-unary-minus.ts
@@ -15,7 +15,8 @@ export default util.createRule<Options, MessageIds>({
       requiresTypeChecking: true,
     },
     messages: {
-      unaryMinus: 'Invalid type "{{type}}" of template literal expression.',
+      unaryMinus:
+        'Argument of unary negation should be assignable to number | bigint but is {{type}} instead.',
     },
     schema: [],
   },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

Followup to #7390 since I realized that the error message is wrong.

## PR Checklist

- [ ] ~Addresses an existing open issue~
- [ ] ~That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR corrects the error message for the `no-unsafe-unary-minus` rule.