### PR TITLE
feat(eslint-plugin): [require-await] allow yielding Promise in async generators

### DIFF
--- a/packages/eslint-plugin/src/rules/require-await.ts
+++ b/packages/eslint-plugin/src/rules/require-await.ts
@@ -112,32 +112,40 @@ export default createRule({
     }
 
     /**
-     * mark `scopeInfo.isAsyncYield` to `true` if its a generator
-     * function and the delegate is `true`
+     * Mark `scopeInfo.isAsyncYield` to `true` if it
+     *  1) delegates async generator function
+     *    or
+     *  2) yields thenable type
      */
-    function markAsHasDelegateGen(node: TSESTree.YieldExpression): void {
+    function visitYieldExpression(node: TSESTree.YieldExpression): void {
       if (!scopeInfo?.isGen || !node.argument) {
         return;
       }
 
       if (node.argument.type === AST_NODE_TYPES.Literal) {
-        // making this `false` as for literals we don't need to check the definition
+        // ignoring this as for literals we don't need to check the definition
         // eg : async function* run() { yield* 1 }
-        scopeInfo.isAsyncYield ||= false;
+        return;
       }
 
-      const type = services.getTypeAtLocation(node.argument);
-      const typesToCheck = expandUnionOrIntersectionType(type);
-      for (const type of typesToCheck) {
-        const asyncIterator = tsutils.getWellKnownSymbolPropertyOfType(
-          type,
-          'asyncIterator',
-          checker,
-        );
-        if (asyncIterator !== undefined) {
-          scopeInfo.isAsyncYield = true;
-          break;
+      if (node.delegate) {
+        const type = services.getTypeAtLocation(node.argument);
+        const typesToCheck = expandUnionOrIntersectionType(type);
+        for (const type of typesToCheck) {
+          const asyncIterator = tsutils.getWellKnownSymbolPropertyOfType(
+            type,
+            'asyncIterator',
+            checker,
+          );
+          if (asyncIterator !== undefined) {
+            scopeInfo.isAsyncYield = true;
+            break;
+          }
         }
+      } else if (
+        isThenableType(services.esTreeNodeToTSNodeMap.get(node.argument))
+      ) {
+        scopeInfo.isAsyncYield = true;
       }
     }
 
@@ -152,7 +160,7 @@ export default createRule({
       AwaitExpression: markAsHasAwait,
       'VariableDeclaration[kind = "await using"]': markAsHasAwait,
       'ForOfStatement[await = true]': markAsHasAwait,
-      'YieldExpression[delegate = true]': markAsHasDelegateGen,
+      YieldExpression: visitYieldExpression,
 
       // check body-less async arrow function.
       // ignore `async () => await foo` because it's obviously correct

--- a/packages/eslint-plugin/src/rules/require-await.ts
+++ b/packages/eslint-plugin/src/rules/require-await.ts
@@ -128,24 +128,25 @@ export default createRule({
         return;
       }
 
-      if (node.delegate) {
-        const type = services.getTypeAtLocation(node.argument);
-        const typesToCheck = expandUnionOrIntersectionType(type);
-        for (const type of typesToCheck) {
-          const asyncIterator = tsutils.getWellKnownSymbolPropertyOfType(
-            type,
-            'asyncIterator',
-            checker,
-          );
-          if (asyncIterator !== undefined) {
-            scopeInfo.isAsyncYield = true;
-            break;
-          }
+      if (!node.delegate) {
+        if (isThenableType(services.esTreeNodeToTSNodeMap.get(node.argument))) {
+          scopeInfo.isAsyncYield = true;
         }
-      } else if (
-        isThenableType(services.esTreeNodeToTSNodeMap.get(node.argument))
-      ) {
-        scopeInfo.isAsyncYield = true;
+        return;
+      }
+
+      const type = services.getTypeAtLocation(node.argument);
+      const typesToCheck = expandUnionOrIntersectionType(type);
+      for (const type of typesToCheck) {
+        const asyncIterator = tsutils.getWellKnownSymbolPropertyOfType(
+          type,
+          'asyncIterator',
+          checker,
+        );
+        if (asyncIterator !== undefined) {
+          scopeInfo.isAsyncYield = true;
+          break;
+        }
       }
     }
 

--- a/packages/eslint-plugin/tests/rules/require-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-await.test.ts
@@ -237,6 +237,30 @@ async function* foo(): Promise<string> {
         await using foo = new Bar();
       };
     `,
+    `
+      async function* test1() {
+        yield Promise.resolve(1);
+      }
+    `,
+    `
+      function asyncFunction() {
+        return Promise.resolve(1);
+      }
+      async function* test1() {
+        yield asyncFunction();
+      }
+    `,
+    `
+      declare const asyncFunction: () => Promise<void>;
+      async function* test1() {
+        yield asyncFunction();
+      }
+    `,
+    `
+      async function* test1() {
+        yield new Promise(() => {});
+      }
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7995
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I had to slightly refactor `markAsHasDelegateGen`:
1) Early return from `if (node.argument.type === AST_NODE_TYPES.Literal)` since `scopeInfo.isAsyncYield ||= false;` is meaningless
2) Now function accepts both nodes with `delegate=true` and `delegate=false`

