### PR TITLE
docs(eslint-plugin): [no-throw-literal] fix typo in example

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-throw-literal.md
+++ b/packages/eslint-plugin/docs/rules/no-throw-literal.md
@@ -77,7 +77,7 @@ function err() {
 throw err();
 
 const foo = {
-  bar: new Error();
+  bar: new Error(),
 }
 throw foo.bar;
 

--- a/packages/eslint-plugin/docs/rules/no-throw-literal.md
+++ b/packages/eslint-plugin/docs/rules/no-throw-literal.md
@@ -20,8 +20,6 @@ This rule is aimed at maintaining consistency when throwing exception by disallo
 ### ❌ Incorrect
 
 ```ts
-/*eslint @typescript-eslint/no-throw-literal: "error"*/
-
 throw 'error';
 
 throw 0;
@@ -53,19 +51,17 @@ throw foo.bar;
 ### ✅ Correct
 
 ```ts
-/*eslint @typescript-eslint/no-throw-literal: "error"*/
-
 throw new Error();
 
-throw new Error("error");
+throw new Error('error');
 
-const e = new Error("error");
+const e = new Error('error');
 throw e;
 
 try {
-    throw new Error("error");
+  throw new Error('error');
 } catch (e) {
-    throw e;
+  throw e;
 }
 
 const err = new Error();
@@ -78,12 +74,12 @@ throw err();
 
 const foo = {
   bar: new Error(),
-}
+};
 throw foo.bar;
 
 class CustomError extends Error {
   // ...
-};
+}
 throw new CustomError();
 ```
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I just accidentally opened example in the playground and noticed that there is an extra semicolon
