### PR TITLE
docs: fix link to Node.js release schedule

### DIFF
--- a/docs/users/Dependency_Versions.mdx
+++ b/docs/users/Dependency_Versions.mdx
@@ -13,7 +13,7 @@ We generally support at least the latest two major versions of ESLint.
 
 ## Node
 
-This project makes an effort to support Active LTS and Maintenance LTS release statuses of Node according to [Node's release document](https://nodejs.org/en/about/releases).
+This project makes an effort to support Active LTS and Maintenance LTS release statuses of Node according to [Node's release document](https://github.com/nodejs/release#release-schedule).
 Support for specific Current status releases are considered periodically.
 
 ## TypeScript


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

There was a redirect from [`https://nodejs.org/en/about/releases`](https://nodejs.org/en/about/releases) to [`https://github.com/nodejs/release#release-schedule`](https://github.com/nodejs/release#release-schedule)

https://github.com/nodejs/nodejs.org/commit/703d66f70dabb5c4244b82fde65fd52205baff6e#diff-86afba6135d6b52234c22643d9d0395852e262279de5291e3a38b74bd9d0e1d8L31-L34

(Now https://nodejs.org/en/about/releases is 404)