### PR TITLE
feat(eslint-plugin): [explicit-function-return-type] add support for typed class property definitions

### DIFF
--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -336,6 +336,11 @@ function ancestorHasReturnType(node: FunctionNode): boolean {
           return true;
         }
         break;
+      case AST_NODE_TYPES.PropertyDefinition:
+        if (ancestor.typeAnnotation) {
+          return true;
+        }
+        break;
     }
 
     ancestor = ancestor.parent;

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -713,6 +713,26 @@ let foo = (() => (() => {})())();
         },
       ],
     },
+    {
+      code: `
+class Bar {
+  bar: Foo = {
+    foo: x => x + 1,
+  };
+}
+      `,
+    },
+    {
+      code: `
+class Bar {
+  bar: Foo[] = [
+    {
+      foo: x => x + 1,
+    },
+  ];
+}
+      `,
+    },
   ],
   invalid: [
     {
@@ -1646,6 +1666,26 @@ class Foo {
           endLine: 4,
           column: 3,
           endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `
+class Bar {
+  bar = [
+    {
+      foo: x => x + 1,
+    },
+  ];
+}
+      `,
+      errors: [
+        {
+          messageId: 'missingReturnType',
+          line: 5,
+          endLine: 5,
+          column: 7,
+          endColumn: 12,
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8023
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Check also the `PropertyDefinition` nodes, not just the `VariableDeclarator`