### PR TITLE
docs: fix "are be"

### DIFF
--- a/docs/contributing/Local_Development.mdx
+++ b/docs/contributing/Local_Development.mdx
@@ -64,7 +64,7 @@ You can run `yarn test` in any package to run its tests.
 #### Code Coverage
 
 We aim for 100% code coverage in all PRs when possible, except in the `website/` package.
-Coverage reports are be generated locally whenever `yarn test` is run.
+Coverage reports are generated locally whenever `yarn test` is run.
 
 The `codecov` bot should also comment on your PR with the percentage, as well as links to the line-by-line coverage of each file touched by your PR.
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken - above two steps ignored due to exception for "extremely minor documentation typos"
