### PR TITLE
feat: require-array-sort-compare + toSorted

### DIFF
--- a/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
+++ b/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
@@ -6,7 +6,7 @@ description: 'Require `Array#sort` calls to always provide a `compareFunction`.'
 >
 > See **https://typescript-eslint.io/rules/require-array-sort-compare** for documentation.
 
-When called without a compare function, `Array#sort()` converts all non-undefined array elements into strings and then compares said strings based off their UTF-16 code units [[ECMA specification](https://www.ecma-international.org/ecma-262/9.0/#sec-sortcompare)].
+When called without a compare function, `Array#sort()` and `Array#toSorted()` converts all non-undefined array elements into strings and then compares said strings based off their UTF-16 code units [[ECMA specification](https://www.ecma-international.org/ecma-262/9.0/#sec-sortcompare)].
 
 The result is that elements are sorted alphabetically, regardless of their type.
 For example, when sorting numbers, this results in a "10 before 2" order:

--- a/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
+++ b/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
@@ -27,7 +27,7 @@ export default createRule<Options, MessageIds>({
     type: 'problem',
     docs: {
       description:
-        'Require `Array#sort` calls to always provide a `compareFunction`',
+        'Require `Array#sort` and `Array#toSorted` calls to always provide a `compareFunction`',
       requiresTypeChecking: true,
     },
     messages: {
@@ -66,23 +66,26 @@ export default createRule<Options, MessageIds>({
       return false;
     }
 
+    function checkSortArgument(callee: TSESTree.MemberExpression): void {
+      const calleeObjType = getConstrainedTypeAtLocation(
+        services,
+        callee.object,
+      );
+
+      if (options.ignoreStringArrays && isStringArrayNode(callee.object)) {
+        return;
+      }
+
+      if (isTypeArrayTypeOrUnionOfArrayTypes(calleeObjType, checker)) {
+        context.report({ node: callee.parent, messageId: 'requireCompare' });
+      }
+    }
+
     return {
-      "CallExpression[arguments.length=0] > MemberExpression[property.name='sort'][computed=false]"(
-        callee: TSESTree.MemberExpression,
-      ): void {
-        const calleeObjType = getConstrainedTypeAtLocation(
-          services,
-          callee.object,
-        );
-
-        if (options.ignoreStringArrays && isStringArrayNode(callee.object)) {
-          return;
-        }
-
-        if (isTypeArrayTypeOrUnionOfArrayTypes(calleeObjType, checker)) {
-          context.report({ node: callee.parent, messageId: 'requireCompare' });
-        }
-      },
+      "CallExpression[arguments.length=0] > MemberExpression[property.name='sort'][computed=false]":
+        checkSortArgument,
+      "CallExpression[arguments.length=0] > MemberExpression[property.name='toSorted'][computed=false]":
+        checkSortArgument,
     };
   },
 });

--- a/packages/eslint-plugin/tests/rules/require-array-sort-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-array-sort-compare.test.ts
@@ -126,6 +126,13 @@ ruleTester.run('require-array-sort-compare', rule, {
       `,
       options: [{ ignoreStringArrays: true }],
     },
+    {
+      code: `
+        function f(a: number[]) {
+          a.toSorted((a, b) => a - b);
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/require-array-sort-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-array-sort-compare.test.ts
@@ -254,5 +254,13 @@ ruleTester.run('require-array-sort-compare', rule, {
       errors: [{ messageId: 'requireCompare' }],
       options: [{ ignoreStringArrays: true }],
     },
+    {
+      code: `
+        function f(a: number[]) {
+          a.toSorted();
+        }
+      `,
+      errors: [{ messageId: 'requireCompare' }],
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [X] Addresses an existing open issue: fixes #8051
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

A simple PR that just expands the rule to check for both `sort` and `toSorted` (instead of just checking for `sort`).
For context, when the rule was originally created, `toSorted` didn't exist, as this is a new array method.