### PR TITLE
chore: resolve internal lint issues with new no-useless-template-literals rule

### DIFF
--- a/packages/rule-schema-to-typescript-types/src/printAST.ts
+++ b/packages/rule-schema-to-typescript-types/src/printAST.ts
@@ -162,7 +162,7 @@ function printAndMaybeParenthesise(ast: AST): CodeWithComments {
     };
   }
   return {
-    code: `${printed.code}`,
+    code: printed.code,
     commentLines: printed.commentLines,
   };
 }

--- a/packages/scope-manager/tests/util/serializers/TSESTreeNode.ts
+++ b/packages/scope-manager/tests/util/serializers/TSESTreeNode.ts
@@ -37,7 +37,7 @@ const serializer: NewPlugin = {
 
     const keys = Object.keys(node).filter(k => !EXCLUDED_KEYS.has(k));
     if (keys.length === 0) {
-      return `${node.type}`;
+      return node.type;
     }
 
     if (SEEN_NODES.has(node)) {

--- a/packages/scope-manager/tests/util/serializers/baseSerializer.ts
+++ b/packages/scope-manager/tests/util/serializers/baseSerializer.ts
@@ -45,7 +45,7 @@ function createSerializer<TConstructor extends ConstructorSignature>(
 
       if (thing.$id) {
         if (SEEN_THINGS.has(thing)) {
-          return `${name}`;
+          return name;
         }
         SEEN_THINGS.add(thing);
       }

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -133,7 +133,7 @@ function Feature({ title, description }: FeatureItem): React.JSX.Element {
 function Home(): React.JSX.Element {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <Layout description={`${siteConfig.tagline}`}>
+    <Layout description={siteConfig.tagline}>
       <main>
         <div className={clsx('hero hero--dark', styles.hero)}>
           <div className="container">


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Follow up of https://github.com/typescript-eslint/typescript-eslint/pull/7957
