### PR TITLE
docs(eslint-plugin): [require-array-sort-compare] generalize sort method names

### DIFF
--- a/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
+++ b/packages/eslint-plugin/docs/rules/require-array-sort-compare.md
@@ -15,11 +15,11 @@ For example, when sorting numbers, this results in a "10 before 2" order:
 [1, 2, 3, 10, 20, 30].sort(); //→ [1, 10, 2, 20, 3, 30]
 ```
 
-This rule reports on any call to the `Array#sort()` method that doesn't provide a `compare` argument.
+This rule reports on any call to the sort methods that do not provide a `compare` argument.
 
 ## Examples
 
-This rule aims to ensure all calls of the native `Array#sort` method provide a `compareFunction`, while ignoring calls to user-defined `sort` methods.
+This rule aims to ensure all calls of the native sort methods provide a `compareFunction`, while ignoring calls to user-defined methods.
 
 <!--tabs-->
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This is a follow-up to my previous PR to make the docs more consistent, since there are two sort methods now.
