### PR TITLE
chore: add MDX files to precommit hook

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-  "*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}": ["prettier --write"]
+  "*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,mdx,css}": ["prettier --write"]
 }


### PR DESCRIPTION
`.mdx` is not formatted in pre-commit and may cause CI to fail.