### PR TITLE
feat(eslint-plugin): [thenable-in-promise-aggregators] disallow non-Thenables to promise aggregators

### DIFF
--- a/packages/eslint-plugin/docs/rules/thenable-in-promise-aggregators.md
+++ b/packages/eslint-plugin/docs/rules/thenable-in-promise-aggregators.md
@@ -9,7 +9,7 @@ description: 'Disallow passing non-Thenable values to promise aggregators.'
 A "Thenable" value is an object which has a `then` method, such as a Promise.
 The `await` keyword is generally used to retrieve the result of calling a Thenable's `then` method.
 
-When multiple Thenable's are running at the same time, it is sometimes desirable to wait until any one of them resolves (`Promise.race`), all of them resolve or any of them reject (`Promise.all`), or all of them resolve or reject (`Promise.allSettled`).
+When multiple Thenables are running at the same time, it is sometimes desirable to wait until any one of them resolves (`Promise.race`), all of them resolve or any of them reject (`Promise.all`), or all of them resolve or reject (`Promise.allSettled`).
 
 Each of these functions accept an iterable of promises as input and return a single Promise.
 If a non-Thenable is passed, it is ignored.
@@ -43,6 +43,6 @@ await Promise.race([
 
 ## When Not To Use It
 
-If you want to allow code to use `Promise.race`, `Promise.all`, or `Promise.allSettled` on arrays of non-promise values.
+If you want to allow code to use `Promise.race`, `Promise.all`, or `Promise.allSettled` on arrays of non-Thenable values.
 This is generally not preferred but can sometimes be useful for visual consistency.
 You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/thenable-in-promise-aggregators.md
+++ b/packages/eslint-plugin/docs/rules/thenable-in-promise-aggregators.md
@@ -1,0 +1,49 @@
+---
+description: 'Disallow passing non-Thenable values to promise aggregators.'
+---
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/thenable-in-promise-aggregators** for documentation.
+
+A "Thenable" value is an object which has a `then` method, such as a Promise.
+The `await` keyword is generally used to retrieve the result of calling a Thenable's `then` method.
+
+When multiple Thenable's are running at the same time, it is sometimes desirable to wait until any one of them resolves (`Promise.race`), all of them resolve or any of them reject (`Promise.all`), or all of them resolve or reject (`Promise.allSettled`).
+
+Each of these functions accept an iterable of promises as input and return a single
+Promise.
+If a non-Thenable is passed, it is ignored.
+While doing so is valid JavaScript, it is often a programmer error, such as forgetting to unwrap a wrapped promise, or using the `await` keyword on the individual promises, which defeats the purpose of using one of these Promise aggregators.
+
+## Examples
+
+<!--tabs-->
+
+### ❌ Incorrect
+
+```ts
+await Promise.race(['value1', 'value2']);
+
+await Promise.race([
+  await new Promise(resolve => setTimeout(resolve, 3000)),
+  await new Promise(resolve => setTimeout(resolve, 6000)),
+]);
+```
+
+### ✅ Correct
+
+```ts
+await Promise.race([Promise.resolve('value1'), Promise.resolve('value2')]);
+
+await Promise.race([
+  new Promise(resolve => setTimeout(resolve, 3000)),
+  new Promise(resolve => setTimeout(resolve, 6000)),
+]);
+```
+
+## When Not To Use It
+
+If you want to allow code to use `Promise.race`, `Promise.all`, or `Promise.allSettled` on arrays of non-promise values.
+This is generally not preferred but can sometimes be useful for visual consistency.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/thenable-in-promise-aggregators.md
+++ b/packages/eslint-plugin/docs/rules/thenable-in-promise-aggregators.md
@@ -11,8 +11,7 @@ The `await` keyword is generally used to retrieve the result of calling a Thenab
 
 When multiple Thenable's are running at the same time, it is sometimes desirable to wait until any one of them resolves (`Promise.race`), all of them resolve or any of them reject (`Promise.all`), or all of them resolve or reject (`Promise.allSettled`).
 
-Each of these functions accept an iterable of promises as input and return a single
-Promise.
+Each of these functions accept an iterable of promises as input and return a single Promise.
 If a non-Thenable is passed, it is ignored.
 While doing so is valid JavaScript, it is often a programmer error, such as forgetting to unwrap a wrapped promise, or using the `await` keyword on the individual promises, which defeats the purpose of using one of these Promise aggregators.
 

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -146,6 +146,7 @@ export = {
     '@typescript-eslint/sort-type-constituents': 'error',
     '@typescript-eslint/strict-boolean-expressions': 'error',
     '@typescript-eslint/switch-exhaustiveness-check': 'error',
+    '@typescript-eslint/thenable-in-promise-aggregators': 'error',
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/typedef': 'error',
     '@typescript-eslint/unbound-method': 'error',

--- a/packages/eslint-plugin/src/configs/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/disable-type-checked.ts
@@ -57,6 +57,7 @@ export = {
     '@typescript-eslint/return-await': 'off',
     '@typescript-eslint/strict-boolean-expressions': 'off',
     '@typescript-eslint/switch-exhaustiveness-check': 'off',
+    '@typescript-eslint/thenable-in-promise-aggregators': 'off',
     '@typescript-eslint/unbound-method': 'off',
   },
 };

--- a/packages/eslint-plugin/src/configs/recommended-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/recommended-type-checked.ts
@@ -47,6 +47,7 @@ export = {
     '@typescript-eslint/require-await': 'error',
     '@typescript-eslint/restrict-plus-operands': 'error',
     '@typescript-eslint/restrict-template-expressions': 'error',
+    '@typescript-eslint/thenable-in-promise-aggregators': 'error',
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/unbound-method': 'error',
   },

--- a/packages/eslint-plugin/src/configs/recommended-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/recommended-type-checked.ts
@@ -47,7 +47,6 @@ export = {
     '@typescript-eslint/require-await': 'error',
     '@typescript-eslint/restrict-plus-operands': 'error',
     '@typescript-eslint/restrict-template-expressions': 'error',
-    '@typescript-eslint/thenable-in-promise-aggregators': 'error',
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/unbound-method': 'error',
   },

--- a/packages/eslint-plugin/src/configs/strict-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/strict-type-checked.ts
@@ -71,6 +71,7 @@ export = {
     '@typescript-eslint/require-await': 'error',
     '@typescript-eslint/restrict-plus-operands': 'error',
     '@typescript-eslint/restrict-template-expressions': 'error',
+    '@typescript-eslint/thenable-in-promise-aggregators': 'error',
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/unbound-method': 'error',
     '@typescript-eslint/unified-signatures': 'error',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -132,6 +132,7 @@ import spaceBeforeFunctionParen from './space-before-function-paren';
 import spaceInfixOps from './space-infix-ops';
 import strictBooleanExpressions from './strict-boolean-expressions';
 import switchExhaustivenessCheck from './switch-exhaustiveness-check';
+import thenableInPromiseAggregators from './thenable-in-promise-aggregators';
 import tripleSlashReference from './triple-slash-reference';
 import typeAnnotationSpacing from './type-annotation-spacing';
 import typedef from './typedef';
@@ -273,6 +274,7 @@ export default {
   'space-infix-ops': spaceInfixOps,
   'strict-boolean-expressions': strictBooleanExpressions,
   'switch-exhaustiveness-check': switchExhaustivenessCheck,
+  'thenable-in-promise-aggregators': thenableInPromiseAggregators,
   'triple-slash-reference': tripleSlashReference,
   'type-annotation-spacing': typeAnnotationSpacing,
   typedef: typedef,

--- a/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
+++ b/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
@@ -1,8 +1,11 @@
-import * as tsutils from 'ts-api-utils';
 import {
   isTypeAnyType,
   isTypeUnknownType,
 } from '@typescript-eslint/type-utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+
 import { createRule, getParserServices } from '../util';
 
 export default createRule({
@@ -31,17 +34,17 @@ export default createRule({
     const checker = services.program.getTypeChecker();
 
     return {
-      CallExpression(node): void {
-        if (node.callee.type !== 'MemberExpression') {
+      CallExpression(node: TSESTree.CallExpression): void {
+        if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
           return;
         }
-        if (node.callee.object.type !== 'Identifier') {
+        if (node.callee.object.type !== AST_NODE_TYPES.Identifier) {
           return;
         }
         if (node.callee.object.name !== 'Promise') {
           return;
         }
-        if (node.callee.property.type !== 'Identifier') {
+        if (node.callee.property.type !== AST_NODE_TYPES.Identifier) {
           return;
         }
 
@@ -56,14 +59,14 @@ export default createRule({
         }
 
         const arg = args[0];
-        if (arg.type === 'ArrayExpression') {
+        if (arg.type === AST_NODE_TYPES.ArrayExpression) {
           const { elements } = arg;
           if (elements.length === 0) {
             return;
           }
 
           for (const element of elements) {
-            if (element === null) {
+            if (element == null) {
               continue;
             }
             const elementType = services.getTypeAtLocation(element);

--- a/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
+++ b/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
@@ -5,7 +5,8 @@ import {
 import type { TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
-import ts from 'typescript';
+import * as ts from 'typescript';
+
 import { createRule, getParserServices } from '../util';
 
 export default createRule({

--- a/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
+++ b/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
@@ -198,12 +198,11 @@ export default createRule({
         }
 
         if (checker.isArrayType(argType)) {
-          if (argType.typeArguments === undefined) {
-            return;
-          }
-
-          if (argType.typeArguments.length < 1) {
-            return;
+          if (
+            argType.typeArguments == null ||
+            argType.typeArguments.length < 1
+          ) {
+            throw new Error('Expected to find type arguments for an array.');
           }
 
           const typeArg = argType.typeArguments[0];

--- a/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
+++ b/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
@@ -33,7 +33,7 @@ export default createRule({
     const services = getParserServices(context);
     const checker = services.program.getTypeChecker();
 
-    const aggregateFunctionNames = ['all', 'race', 'allSettled'];
+    const aggregateFunctionNames = ['all', 'race', 'allSettled', 'any'];
 
     function skipChainExpression<T extends TSESTree.Node>(
       node: T,

--- a/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
+++ b/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
@@ -14,7 +14,7 @@ export default createRule({
     docs: {
       description:
         'Disallow passing non-Thenable values to promise aggregators',
-      recommended: 'recommended',
+      recommended: 'strict',
       requiresTypeChecking: true,
     },
     messages: {

--- a/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
+++ b/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
@@ -168,7 +168,11 @@ export default createRule({
 
           for (const element of elements) {
             if (element == null) {
-              continue;
+              context.report({
+                messageId: 'inArray',
+                node: arg,
+              });
+              return;
             }
             const elementType = services.getTypeAtLocation(element);
             if (isTypeAnyType(elementType) || isTypeUnknownType(elementType)) {

--- a/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
+++ b/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
@@ -1,0 +1,124 @@
+import * as tsutils from 'ts-api-utils';
+import {
+  isTypeAnyType,
+  isTypeUnknownType,
+} from '@typescript-eslint/type-utils';
+import { createRule, getParserServices } from '../util';
+
+export default createRule({
+  name: 'thenable-in-promise-aggregators',
+  meta: {
+    docs: {
+      description:
+        'Disallow passing non-Thenable values to promise aggregators',
+      recommended: 'recommended',
+      requiresTypeChecking: true,
+    },
+    messages: {
+      inArray:
+        'Unexpected non-Thenable value in array passed to promise aggregator.',
+      arrayArg:
+        'Unexpected array of non-Thenable values passed to promise aggregator.',
+      nonArrayArg: 'Unexpected non-array passed to promise aggregator.',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const services = getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    return {
+      CallExpression(node): void {
+        if (node.callee.type !== 'MemberExpression') {
+          return;
+        }
+        if (node.callee.object.type !== 'Identifier') {
+          return;
+        }
+        if (node.callee.object.name !== 'Promise') {
+          return;
+        }
+        if (node.callee.property.type !== 'Identifier') {
+          return;
+        }
+
+        const { name } = node.callee.property;
+        if (!['race', 'all', 'allSettled'].includes(name)) {
+          return;
+        }
+
+        const { arguments: args } = node;
+        if (args.length !== 1) {
+          return;
+        }
+
+        const arg = args[0];
+        if (arg.type === 'ArrayExpression') {
+          const { elements } = arg;
+          if (elements.length === 0) {
+            return;
+          }
+
+          for (const element of elements) {
+            if (element === null) {
+              continue;
+            }
+            const elementType = services.getTypeAtLocation(element);
+            if (isTypeAnyType(elementType) || isTypeUnknownType(elementType)) {
+              continue;
+            }
+
+            const originalNode = services.esTreeNodeToTSNodeMap.get(element);
+            if (tsutils.isThenableType(checker, originalNode, elementType)) {
+              continue;
+            }
+
+            context.report({
+              messageId: 'inArray',
+              node: element,
+            });
+          }
+        } else {
+          const argType = services.getTypeAtLocation(arg);
+          if (isTypeAnyType(argType) || isTypeUnknownType(argType)) {
+            return;
+          }
+
+          if (!checker.isArrayType(argType)) {
+            context.report({
+              messageId: 'nonArrayArg',
+              node: arg,
+            });
+            return;
+          }
+
+          if (argType.typeArguments === undefined) {
+            return;
+          }
+
+          if (argType.typeArguments.length < 1) {
+            return;
+          }
+
+          const typeArg = argType.typeArguments[0];
+          if (isTypeAnyType(typeArg) || isTypeUnknownType(typeArg)) {
+            return;
+          }
+
+          const originalNode = services.esTreeNodeToTSNodeMap.get(arg);
+          if (tsutils.isThenableType(checker, originalNode, typeArg)) {
+            return;
+          }
+
+          context.report({
+            messageId: 'arrayArg',
+            node: arg,
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
+++ b/packages/eslint-plugin/src/rules/thenable-in-promise-aggregators.ts
@@ -179,10 +179,10 @@ export default createRule({
           return;
         }
 
-        const callerType = services.getTypeAtLocation(callee.object);
+        const calleeType = services.getTypeAtLocation(callee.object);
         if (
-          !isPromiseConstructorLike(services.program, callerType) &&
-          !isPromiseLike(services.program, callerType)
+          !isPromiseConstructorLike(services.program, calleeType) &&
+          !isPromiseLike(services.program, calleeType)
         ) {
           return;
         }

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -38,6 +38,16 @@ async function test() {
     `,
     `
 async function test() {
+  await Promise['all']([Promise.resolve(3)]);
+}
+    `,
+    `
+async function test() {
+  await Promise.all([Promise['resolve'](3)]);
+}
+    `,
+    `
+async function test() {
   await Promise.race([(async () => true)()]);
 }
     `,
@@ -446,6 +456,33 @@ await foo.all([0]);
       ],
     },
     {
+      code: "await Promise['all']([3]);",
+      errors: [
+        {
+          line: 1,
+          messageId: 'inArray',
+        },
+      ],
+    },
+    {
+      code: "await Promise['race']([3]);",
+      errors: [
+        {
+          line: 1,
+          messageId: 'inArray',
+        },
+      ],
+    },
+    {
+      code: "await Promise['allSettled']([3]);",
+      errors: [
+        {
+          line: 1,
+          messageId: 'inArray',
+        },
+      ],
+    },
+    {
       code: 'await Promise.race(3);',
       errors: [
         {
@@ -483,6 +520,15 @@ await foo.all([0]);
     },
     {
       code: 'await Promise.race?.(undefined);',
+      errors: [
+        {
+          line: 1,
+          messageId: 'nonArrayArg',
+        },
+      ],
+    },
+    {
+      code: "await Promise['all'](3);",
       errors: [
         {
           line: 1,
@@ -549,6 +595,15 @@ await Promise.race(foo);
     },
     {
       code: 'await Promise.race([0] as const);',
+      errors: [
+        {
+          line: 1,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: "await Promise['all']([0, 1].map(v => v));",
       errors: [
         {
           line: 1,

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -202,6 +202,17 @@ async function test() {
   await foo.resolve?.([foo.resolve(3)]);
 }
     `,
+    `
+async function test() {
+  const promisesTuple: [Promise<number>] = [Promise.resolve(3)];
+  await Promise.all(promisesTuple);
+}
+    `,
+    `
+async function test() {
+  await Promise.all([Promise.resolve(6)] as const);
+}
+    `,
   ],
 
   invalid: [
@@ -488,6 +499,27 @@ await Promise.all?.(arr);
       errors: [
         {
           line: 3,
+          messageId: messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: [number];
+await Promise.race(foo);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.race([0] as const);',
+      errors: [
+        {
+          line: 1,
           messageId: messageIdArrayArg,
         },
       ],

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -1,6 +1,6 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 
-import rule from '../../src/rules/await-thenable';
+import rule from '../../src/rules/thenable-in-promise-aggregators';
 import { getFixturesRootDir } from '../RuleTester';
 
 const rootDir = getFixturesRootDir();
@@ -84,9 +84,9 @@ async function test() {
     `,
     `
 async function test() {
-  await Promise.race([(Math.random() > 0.5 ? numberPromise : 0)]);
-  await Promise.race([(Math.random() > 0.5 ? foo : 0)]);
-  await Promise.race([(Math.random() > 0.5 ? bar : 0)]);
+  await Promise.race([Math.random() > 0.5 ? numberPromise : 0]);
+  await Promise.race([Math.random() > 0.5 ? foo : 0]);
+  await Promise.race([Math.random() > 0.5 ? bar : 0]);
 
   const intersectionPromise: Promise<number> & number;
   await Promise.race([intersectionPromise]);
@@ -118,7 +118,7 @@ const doSomething = async (
     obj3.a?.b.c?.(),
     obj4.a.b.c?.(),
     obj5.a?.().b?.c?.(),
-    obj6?.a.b.c?.()
+    obj6?.a.b.c?.(),
   ]);
 
   await Promise.allSettled([callback?.()]);
@@ -126,26 +126,26 @@ const doSomething = async (
     `,
     `
 async function test() {
-    const promiseArr: Promise<number>[];
-    await Promise.all(promiseArr);
+  const promiseArr: Promise<number>[];
+  await Promise.all(promiseArr);
 }
     `,
     `
 async function test() {
-    const intersectionArr: (Promise<number> & number)[];
-    await Promise.all(intersectionArr);
+  const intersectionArr: (Promise<number> & number)[];
+  await Promise.all(intersectionArr);
 }
     `,
     `
 async function test() {
-    const values = [1, 2, 3];
-    await Promise.all(values.map(value => Promise.resolve(value)));
+  const values = [1, 2, 3];
+  await Promise.all(values.map(value => Promise.resolve(value)));
 }
     `,
     `
 async function test() {
-    const values = [1, 2, 3];
-    await Promise.all(values.map(async (value) => {}));
+  const values = [1, 2, 3];
+  await Promise.all(values.map(async value => {}));
 }
     `,
   ],
@@ -156,7 +156,7 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
         },
       ],
     },
@@ -165,7 +165,7 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
         },
       ],
     },
@@ -174,7 +174,7 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
         },
       ],
     },
@@ -183,7 +183,7 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
         },
       ],
     },
@@ -192,16 +192,16 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
         },
       ],
     },
     {
-      code: `async () => await Promise.race([Math.random() > 0.5 ? '' : 0]);`,
+      code: "async () => await Promise.race([Math.random() > 0.5 ? '' : 0]);",
       errors: [
         {
           line: 1,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
         },
       ],
     },
@@ -213,7 +213,7 @@ await Promise.race([new NonPromise()]);
       errors: [
         {
           line: 3,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
           suggestions: [],
         },
       ],
@@ -232,7 +232,7 @@ async function test() {
       errors: [
         {
           line: 8,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
         },
       ],
     },
@@ -244,7 +244,7 @@ await Promise.race([callback?.()]);
       errors: [
         {
           line: 3,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
         },
       ],
     },
@@ -256,7 +256,7 @@ await Promise.race([obj.a?.b?.()]);
       errors: [
         {
           line: 3,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
         },
       ],
     },
@@ -268,7 +268,7 @@ await Promise.race([obj?.a.b.c?.()]);
       errors: [
         {
           line: 3,
-          messageIdArrayArg,
+          messageId: messageIdInArray,
         },
       ],
     },
@@ -280,8 +280,8 @@ await Promise.all([wrappedPromise, stdPromise]);
       `,
       errors: [
         {
-          line: 3,
-          messageIdInArray,
+          line: 4,
+          messageId: messageIdInArray,
         },
       ],
     },
@@ -290,7 +290,7 @@ await Promise.all([wrappedPromise, stdPromise]);
       errors: [
         {
           line: 1,
-          messageIdNonArrayArg,
+          messageId: messageIdNonArrayArg,
         },
       ],
     },
@@ -299,7 +299,7 @@ await Promise.all([wrappedPromise, stdPromise]);
       errors: [
         {
           line: 1,
-          messageIdNonArrayArg,
+          messageId: messageIdNonArrayArg,
         },
       ],
     },
@@ -308,7 +308,7 @@ await Promise.all([wrappedPromise, stdPromise]);
       errors: [
         {
           line: 1,
-          messageIdNonArrayArg,
+          messageId: messageIdNonArrayArg,
         },
       ],
     },
@@ -317,7 +317,7 @@ await Promise.all([wrappedPromise, stdPromise]);
       errors: [
         {
           line: 1,
-          messageIdNonArrayArg,
+          messageId: messageIdNonArrayArg,
         },
       ],
     },
@@ -329,28 +329,28 @@ await Promise.all(promiseArr);
       errors: [
         {
           line: 3,
-          messageIdNonArrayArg,
+          messageId: messageIdNonArrayArg,
         },
       ],
     },
     {
-      code: 'await Promise.all([0, 1].map((v) => v)',
+      code: 'await Promise.all([0, 1].map(v => v));',
       errors: [
         {
           line: 1,
-          messageIdArrayArg,
+          messageId: messageIdArrayArg,
         },
       ],
     },
     {
       code: `
 declare const promiseArr: Promise<number>[];
-await Promise.all(promiseArr.map((v) => await v));
+await Promise.all(promiseArr.map(v => await v));
       `,
       errors: [
         {
           line: 3,
-          messageIdArrayArg,
+          messageId: messageIdArrayArg,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -21,7 +21,9 @@ ruleTester.run('thenable-in-promise-aggregators', rule, {
     'await Promise.allSettled([Promise.resolve(3)]);',
     'await Promise.any([Promise.resolve(3)]);',
     'await Promise.all([]);',
+    'await Promise.race([Promise.reject(3)]);',
     "await Promise['all']([Promise.resolve(3)]);",
+    'await Promise[`all`]([Promise.resolve(3)]);',
     "await Promise.all([Promise['resolve'](3)]);",
     'await Promise.race([(async () => true)()]);',
     `
@@ -37,6 +39,30 @@ await Promise.race([returnsPromiseAsync()]);
     `
 declare const anyValue: any;
 await Promise.race([anyValue]);
+    `,
+    `
+const key = 'all';
+await Promise[key]([Promise.resolve(3)]);
+    `,
+    `
+declare const key: 'race';
+await Promise[key]([Promise.resolve(3)]);
+    `,
+    `
+declare const key: 'race' | 'any';
+await Promise[key]([Promise.resolve(3)]);
+    `,
+    `
+declare const key: any;
+await Promise[key]([3]);
+    `,
+    `
+declare const key: 'all' | 'unrelated';
+await Promise[key]([3]);
+    `,
+    `
+declare const key: [string] & 'all';
+await Promise[key]([Promise.resolve(3)]);
     `,
     `
 declare const unknownValue: unknown;
@@ -467,11 +493,23 @@ await foo.all([0]);
       ],
     },
     {
+      code: `
+declare const foo: never;
+await Promise.all([foo]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'inArray',
+        },
+      ],
+    },
+    {
       code: 'await Promise.all([,]);',
       errors: [
         {
           line: 1,
-          messageId: 'inArray',
+          messageId: 'emptyArrayElement',
         },
       ],
     },
@@ -498,6 +536,54 @@ await foo.all([0]);
       errors: [
         {
           line: 1,
+          messageId: 'inArray',
+        },
+      ],
+    },
+    {
+      code: `
+const key = 'all';
+await Promise[key]([3]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'inArray',
+        },
+      ],
+    },
+    {
+      code: `
+declare const key: 'all';
+await Promise[key]([3]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'inArray',
+        },
+      ],
+    },
+    {
+      code: `
+declare const key: 'all' | 'race';
+await Promise[key]([3]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'inArray',
+        },
+      ],
+    },
+    {
+      code: `
+declare const key: 'all' & Promise<number>;
+await Promise[key]([3]);
+      `,
+      errors: [
+        {
+          line: 3,
           messageId: 'inArray',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -158,15 +158,15 @@ declare const arrOfAny: any[];
 await Promise.all(arrOfAny);
     `,
     `
-declare const arrOfUnknown: unknown[] = [];
+declare const arrOfUnknown: unknown[];
 await Promise.all(arrOfAny);
     `,
     `
-declare const arrOfIntersection: (Promise<number> & number)[] = [];
+declare const arrOfIntersection: (Promise<number> & number)[];
 await Promise.all(arrOfIntersection);
     `,
     `
-declare const arrOfUnion: (Promise<number> | number)[] = [];
+declare const arrOfUnion: (Promise<number> | number)[];
 await Promise.all(arrOfUnion);
     `,
   ],

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -111,6 +111,12 @@ async function test() {
     `,
     `
 async function test() {
+  const unionPromise: Promise<number> | number;
+  await Promise.race([unionPromise]);
+}
+    `,
+    `
+async function test() {
   class Thenable {
     then(callback: () => {}) {}
   }
@@ -245,6 +251,18 @@ async function test() {
 async function test() {
   const arrOfUnknown: unknown[] = [];
   await Promise.all(arrOfAny);
+}
+    `,
+    `
+async function test() {
+  const arrOfIntersection: (Promise<number> & number)[] = [];
+  await Promise.all(arrOfIntersection);
+}
+    `,
+    `
+async function test() {
+  const arrOfUnion: (Promise<number> | number)[] = [];
+  await Promise.all(arrOfUnion);
 }
     `,
   ],
@@ -483,6 +501,18 @@ await foo.all([0]);
       ],
     },
     {
+      code: `
+declare const badUnion: number | string;
+await Promise.all([badUnion]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'inArray',
+        },
+      ],
+    },
+    {
       code: 'await Promise.race(3);',
       errors: [
         {
@@ -607,6 +637,18 @@ await Promise.race(foo);
       errors: [
         {
           line: 1,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: `
+declare const badUnionArr: (number | string)[];
+await Promise.all(badUnionArr);
+      `,
+      errors: [
+        {
+          line: 3,
           messageId: 'arrayArg',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -1,0 +1,358 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import rule from '../../src/rules/await-thenable';
+import { getFixturesRootDir } from '../RuleTester';
+
+const rootDir = getFixturesRootDir();
+const messageIdInArray = 'inArray';
+const messageIdArrayArg = 'arrayArg';
+const messageIdNonArrayArg = 'nonArrayArg';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    tsconfigRootDir: rootDir,
+    project: './tsconfig.json',
+  },
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('thenable-in-promise-aggregators', rule, {
+  valid: [
+    `
+async function test() {
+  await Promise.race([Promise.resolve(3)]);
+}
+    `,
+    `
+async function test() {
+  await Promise.all([Promise.resolve(3)]);
+}
+    `,
+    `
+async function test() {
+  await Promise.allSettled([Promise.resolve(3)]);
+}
+    `,
+    `
+async function test() {
+  await Promise.race([(async () => true)()]);
+}
+    `,
+    `
+async function test() {
+  function returnsPromise() {
+    return Promise.resolve('value');
+  }
+  await Promise.race([returnsPromise()]);
+}
+    `,
+    `
+async function test() {
+  async function returnsPromiseAsync() {}
+  await Promise.race([returnsPromiseAsync()]);
+}
+    `,
+    `
+async function test() {
+  let anyValue: any;
+  await Promise.race([anyValue]);
+}
+    `,
+    `
+async function test() {
+  let unknownValue: unknown;
+  await Promise.race([unknownValue]);
+}
+    `,
+    `
+async function test() {
+  const numberPromise: Promise<number>;
+  await Promise.race([numberPromise]);
+}
+    `,
+    `
+async function test() {
+  class Foo extends Promise<number> {}
+  const foo: Foo = Foo.resolve(2);
+  await Promise.race([foo]);
+
+  class Bar extends Foo {}
+  const bar: Bar = Bar.resolve(2);
+  await Promise.race([bar]);
+}
+    `,
+    `
+async function test() {
+  await Promise.race([(Math.random() > 0.5 ? numberPromise : 0)]);
+  await Promise.race([(Math.random() > 0.5 ? foo : 0)]);
+  await Promise.race([(Math.random() > 0.5 ? bar : 0)]);
+
+  const intersectionPromise: Promise<number> & number;
+  await Promise.race([intersectionPromise]);
+}
+    `,
+    `
+async function test() {
+  class Thenable {
+    then(callback: () => {}) {}
+  }
+  const thenable = new Thenable();
+
+  await Promise.race([thenable]);
+}
+    `,
+    `
+const doSomething = async (
+  obj1: { a?: { b?: { c?: () => Promise<void> } } },
+  obj2: { a?: { b?: { c: () => Promise<void> } } },
+  obj3: { a?: { b: { c?: () => Promise<void> } } },
+  obj4: { a: { b: { c?: () => Promise<void> } } },
+  obj5: { a?: () => { b?: { c?: () => Promise<void> } } },
+  obj6?: { a: { b: { c?: () => Promise<void> } } },
+  callback?: () => Promise<void>,
+): Promise<void> => {
+  await Promise.all([
+    obj1.a?.b?.c?.(),
+    obj2.a?.b?.c(),
+    obj3.a?.b.c?.(),
+    obj4.a.b.c?.(),
+    obj5.a?.().b?.c?.(),
+    obj6?.a.b.c?.()
+  ]);
+
+  await Promise.allSettled([callback?.()]);
+};
+    `,
+    `
+async function test() {
+    const promiseArr: Promise<number>[];
+    await Promise.all(promiseArr);
+}
+    `,
+    `
+async function test() {
+    const intersectionArr: (Promise<number> & number)[];
+    await Promise.all(intersectionArr);
+}
+    `,
+    `
+async function test() {
+    const values = [1, 2, 3];
+    await Promise.all(values.map(value => Promise.resolve(value)));
+}
+    `,
+    `
+async function test() {
+    const values = [1, 2, 3];
+    await Promise.all(values.map(async (value) => {}));
+}
+    `,
+  ],
+
+  invalid: [
+    {
+      code: 'await Promise.race([0]);',
+      errors: [
+        {
+          line: 1,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.all([0]);',
+      errors: [
+        {
+          line: 1,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.allSettled([0]);',
+      errors: [
+        {
+          line: 1,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.race([Promise.resolve(3), 0]);',
+      errors: [
+        {
+          line: 1,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: 'async () => await Promise.race([await Promise.resolve(3)]);',
+      errors: [
+        {
+          line: 1,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: `async () => await Promise.race([Math.random() > 0.5 ? '' : 0]);`,
+      errors: [
+        {
+          line: 1,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: `
+class NonPromise extends Array {}
+await Promise.race([new NonPromise()]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageIdArrayArg,
+          suggestions: [],
+        },
+      ],
+    },
+    {
+      code: `
+async function test() {
+  class IncorrectThenable {
+    then() {}
+  }
+  const thenable = new IncorrectThenable();
+
+  await Promise.race([thenable]);
+}
+      `,
+      errors: [
+        {
+          line: 8,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: `
+declare const callback: (() => void) | undefined;
+await Promise.race([callback?.()]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: `
+declare const obj: { a?: { b?: () => void } };
+await Promise.race([obj.a?.b?.()]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: `
+declare const obj: { a: { b: { c?: () => void } } } | undefined;
+await Promise.race([obj?.a.b.c?.()]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: `
+declare const wrappedPromise: { promise: Promise<number> };
+declare const stdPromise: Promise<number>;
+await Promise.all([wrappedPromise, stdPromise]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageIdInArray,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.race(3);',
+      errors: [
+        {
+          line: 1,
+          messageIdNonArrayArg,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.all(3);',
+      errors: [
+        {
+          line: 1,
+          messageIdNonArrayArg,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.allSettled({ foo: 3 });',
+      errors: [
+        {
+          line: 1,
+          messageIdNonArrayArg,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.race(undefined);',
+      errors: [
+        {
+          line: 1,
+          messageIdNonArrayArg,
+        },
+      ],
+    },
+    {
+      code: `
+declare const promiseArr: Promise<number[]>;
+await Promise.all(promiseArr);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageIdNonArrayArg,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.all([0, 1].map((v) => v)',
+      errors: [
+        {
+          line: 1,
+          messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: `
+declare const promiseArr: Promise<number>[];
+await Promise.all(promiseArr.map((v) => await v));
+      `,
+      errors: [
+        {
+          line: 3,
+          messageIdArrayArg,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -302,7 +302,6 @@ await Promise.race([new NonPromise()]);
         {
           line: 3,
           messageId: messageIdInArray,
-          suggestions: [],
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -227,13 +227,13 @@ async function test() {
     `
 async function test() {
   const arrOfAny: any[] = [];
-  await Promise.all(arrOfAny)
+  await Promise.all(arrOfAny);
 }
     `,
     `
 async function test() {
   const arrOfUnknown: unknown[] = [];
-  await Promise.all(arrOfAny)
+  await Promise.all(arrOfAny);
 }
     `,
   ],
@@ -418,7 +418,7 @@ await foo.all([0]);
       ],
     },
     {
-      code: 'await Promise?.race?.([0]);',
+      code: 'await Promise?.race([0]);',
       errors: [
         {
           line: 1,

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -148,6 +148,60 @@ async function test() {
   await Promise.all(values.map(async value => {}));
 }
     `,
+    `
+async function test() {
+  const foo = Promise;
+  await foo.all([Promise.resolve(3)]);
+}
+    `,
+    `
+async function test() {
+  const foo = Promise;
+  await Promise.all([foo.resolve(3)]);
+}
+    `,
+    `
+async function test() {
+  class Foo extends Promise<number> {}
+  await Foo.all([Foo.resolve(3)]);
+}
+    `,
+    `
+async function test() {
+  const foo = Promise;
+  await Promise.all([
+    new foo(resolve => {
+      resolve();
+    }),
+  ]);
+}
+    `,
+    `
+async function test() {
+  class Foo extends Promise<number> {}
+  const myfn = () =>
+    new Foo(resolve => {
+      resolve(3);
+    });
+  await Promise.all([myfn()]);
+}
+    `,
+    `
+async function test() {
+  await Promise.resolve?.([Promise.resolve(3)]);
+}
+    `,
+    `
+async function test() {
+  await Promise?.resolve?.([Promise.resolve(3)]);
+}
+    `,
+    `
+async function test() {
+  const foo = Promise;
+  await foo.resolve?.([foo.resolve(3)]);
+}
+    `,
   ],
 
   invalid: [
@@ -286,6 +340,69 @@ await Promise.all([wrappedPromise, stdPromise]);
       ],
     },
     {
+      code: `
+const foo = Promise;
+await foo.race([0]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: messageIdInArray,
+        },
+      ],
+    },
+    {
+      code: `
+class Foo extends Promise<number> {}
+await Foo.all([0]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: messageIdInArray,
+        },
+      ],
+    },
+    {
+      code: `
+const foo = (() => Promise)();
+await foo.all([0]);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: messageIdInArray,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.race?.([0]);',
+      errors: [
+        {
+          line: 1,
+          messageId: messageIdInArray,
+        },
+      ],
+    },
+    {
+      code: 'await Promise?.race?.([0]);',
+      errors: [
+        {
+          line: 1,
+          messageId: messageIdInArray,
+        },
+      ],
+    },
+    {
+      code: 'await Promise?.race?.([0]);',
+      errors: [
+        {
+          line: 1,
+          messageId: messageIdInArray,
+        },
+      ],
+    },
+    {
       code: 'await Promise.race(3);',
       errors: [
         {
@@ -322,6 +439,15 @@ await Promise.all([wrappedPromise, stdPromise]);
       ],
     },
     {
+      code: 'await Promise.race?.(undefined);',
+      errors: [
+        {
+          line: 1,
+          messageId: messageIdNonArrayArg,
+        },
+      ],
+    },
+    {
       code: `
 declare const promiseArr: Promise<number[]>;
 await Promise.all(promiseArr);
@@ -346,6 +472,18 @@ await Promise.all(promiseArr);
       code: `
 declare const promiseArr: Promise<number>[];
 await Promise.all(promiseArr.map(v => await v));
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: messageIdArrayArg,
+        },
+      ],
+    },
+    {
+      code: `
+declare const arr: number[];
+await Promise.all?.(arr);
       `,
       errors: [
         {

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -78,7 +78,11 @@ async function test() {
   class Foo extends Promise<number> {}
   const foo: Foo = Foo.resolve(2);
   await Promise.race([foo]);
-
+}
+    `,
+    `
+async function test() {
+  class Foo extends Promise<number> {}
   class Bar extends Foo {}
   const bar: Bar = Bar.resolve(2);
   await Promise.race([bar]);
@@ -86,10 +90,11 @@ async function test() {
     `,
     `
 async function test() {
-  await Promise.race([Math.random() > 0.5 ? numberPromise : 0]);
-  await Promise.race([Math.random() > 0.5 ? foo : 0]);
-  await Promise.race([Math.random() > 0.5 ? bar : 0]);
-
+  await Promise.race([Math.random() > 0.5 ? nonExistentSymbol : 0]);
+}
+    `,
+    `
+async function test() {
   const intersectionPromise: Promise<number> & number;
   await Promise.race([intersectionPromise]);
 }
@@ -121,9 +126,8 @@ const doSomething = async (
     obj4.a.b.c?.(),
     obj5.a?.().b?.c?.(),
     obj6?.a.b.c?.(),
+    callback(),
   ]);
-
-  await Promise.allSettled([callback?.()]);
 };
     `,
     `

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -36,6 +36,11 @@ async function test() {
     `,
     `
 async function test() {
+  await Promise.all([]);
+}
+    `,
+    `
+async function test() {
   await Promise.race([(async () => true)()]);
 }
     `,
@@ -211,6 +216,12 @@ async function test() {
     `
 async function test() {
   await Promise.all([Promise.resolve(6)] as const);
+}
+    `,
+    `
+async function test() {
+  const foo = Array();
+  await Promise.all(foo);
 }
     `,
   ],
@@ -406,6 +417,15 @@ await foo.all([0]);
     },
     {
       code: 'await Promise?.race?.([0]);',
+      errors: [
+        {
+          line: 1,
+          messageId: messageIdInArray,
+        },
+      ],
+    },
+    {
+      code: 'await Promise.all([,]);',
       errors: [
         {
           line: 1,

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -169,6 +169,94 @@ await Promise.all(arrOfIntersection);
 declare const arrOfUnion: (Promise<number> | number)[];
 await Promise.all(arrOfUnion);
     `,
+    `
+declare const unionOfArr: Promise<string>[] | Promise<number>[];
+await Promise.all(unionOfArr);
+    `,
+    `
+declare const unionOfTuple: [Promise<number>] | [Promise<string>];
+await Promise.all(unionOfTuple);
+    `,
+    `
+declare const intersectionOfArr: Promise<string>[] & Promise<number>[];
+await Promise.all(intersectionOfArr);
+    `,
+    `
+declare const intersectionOfTuple: [Promise<number>] & [Promise<string>];
+await Promise.all(intersectionOfTuple);
+    `,
+    `
+declare const readonlyArr: ReadonlyArray<Promise<number>>;
+await Promise.all(readonlyArr);
+    `,
+    `
+declare const unionOfPromiseArrAndArr: Promise<number>[] | number[];
+await Promise.all(unionOfPromiseArrAndArr);
+    `,
+    `
+declare const readonlyTuple: readonly [Promise<number>];
+await Promise.all(readonlyTuple);
+    `,
+    `
+declare const readonlyTupleWithOneValid: readonly [number, Promise<number>];
+await Promise.all(readonlyTupleWithOneValid);
+    `,
+    `
+declare const unionOfReadonlyTuples:
+  | readonly [number]
+  | readonly [Promise<number>];
+await Promise.all(unionOfReadonlyTuples);
+    `,
+    `
+declare const readonlyTupleOfUnion: readonly [Promise<number> | number];
+await Promise.all(readonlyTupleOfUnion);
+    `,
+    `
+class Foo extends Array<Promise<number>> {}
+declare const foo: Foo;
+await Promise.all(foo);
+    `,
+    `
+class Foo extends Array {}
+declare const foo: Foo;
+await Promise.all(foo);
+    `,
+    `
+class Foo extends Array<any> {}
+declare const foo: Foo;
+await Promise.all(foo);
+    `,
+    `
+class Foo extends Array<unknown> {}
+declare const foo: Foo;
+await Promise.all(foo);
+    `,
+    `
+class Foo extends Array<number | Promise<number>> {}
+declare const foo: Foo;
+await Promise.all(foo);
+    `,
+    `
+type Foo = { new (): ReadonlyArray<Promise<number>> };
+declare const foo: Foo;
+class Baz extends foo {}
+declare const baz: Baz;
+await Promise.all(baz);
+    `,
+    `
+type Foo = { new (): [Promise<number>] };
+declare const foo: Foo;
+class Baz extends foo {}
+declare const baz: Baz;
+await Promise.all(baz);
+    `,
+    `
+type Foo = { new (): [number | Promise<number>] };
+declare const foo: Foo;
+class Baz extends foo {}
+declare const baz: Baz;
+await Promise.all(baz);
+    `,
   ],
 
   invalid: [
@@ -417,72 +505,6 @@ await Promise.all([badUnion]);
       ],
     },
     {
-      code: 'await Promise.race(3);',
-      errors: [
-        {
-          line: 1,
-          messageId: 'nonArrayArg',
-        },
-      ],
-    },
-    {
-      code: 'await Promise.all(3);',
-      errors: [
-        {
-          line: 1,
-          messageId: 'nonArrayArg',
-        },
-      ],
-    },
-    {
-      code: 'await Promise.allSettled({ foo: 3 });',
-      errors: [
-        {
-          line: 1,
-          messageId: 'nonArrayArg',
-        },
-      ],
-    },
-    {
-      code: 'await Promise.race(undefined);',
-      errors: [
-        {
-          line: 1,
-          messageId: 'nonArrayArg',
-        },
-      ],
-    },
-    {
-      code: 'await Promise.race?.(undefined);',
-      errors: [
-        {
-          line: 1,
-          messageId: 'nonArrayArg',
-        },
-      ],
-    },
-    {
-      code: "await Promise['all'](3);",
-      errors: [
-        {
-          line: 1,
-          messageId: 'nonArrayArg',
-        },
-      ],
-    },
-    {
-      code: `
-declare const promiseArr: Promise<number[]>;
-await Promise.all(promiseArr);
-      `,
-      errors: [
-        {
-          line: 3,
-          messageId: 'nonArrayArg',
-        },
-      ],
-    },
-    {
       code: 'await Promise.all([0, 1].map(v => v));',
       errors: [
         {
@@ -553,6 +575,124 @@ await Promise.all(badUnionArr);
       errors: [
         {
           line: 3,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: `
+declare const badArrUnion: number[] | string[];
+await Promise.all(badArrUnion);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: `
+declare const badReadonlyArr: ReadonlyArray<number>;
+await Promise.all(badReadonlyArr);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: `
+declare const badArrIntersection: number[] & string[];
+await Promise.all(badArrIntersection);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: `
+declare const badReadonlyTuple: readonly [number, string];
+await Promise.all(badReadonlyTuple);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo extends Array<number> {}
+declare const foo: Foo;
+await Promise.all(foo);
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo extends Array<string | number> {}
+declare const foo: Foo;
+await Promise.all(foo);
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = [number];
+declare const foo: Foo;
+await Promise.all(foo);
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: `
+class Bar {}
+type Foo = { new (): Bar & [number] };
+declare const foo: Foo;
+class Baz extends foo {}
+declare const baz: Baz;
+await Promise.all(baz);
+      `,
+      errors: [
+        {
+          line: 7,
+          messageId: 'arrayArg',
+        },
+      ],
+    },
+    {
+      code: `
+type Foo = { new (): ReadonlyArray<number> };
+declare const foo: Foo;
+class Baz extends foo {}
+declare const baz: Baz;
+await Promise.all(baz);
+      `,
+      errors: [
+        {
+          line: 6,
           messageId: 'arrayArg',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -224,6 +224,18 @@ async function test() {
   await Promise.all(foo);
 }
     `,
+    `
+async function test() {
+  const arrOfAny: any[] = [];
+  await Promise.all(arrOfAny)
+}
+    `,
+    `
+async function test() {
+  const arrOfUnknown: unknown[] = [];
+  await Promise.all(arrOfAny)
+}
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -4,9 +4,6 @@ import rule from '../../src/rules/thenable-in-promise-aggregators';
 import { getFixturesRootDir } from '../RuleTester';
 
 const rootDir = getFixturesRootDir();
-const messageIdInArray = 'inArray';
-const messageIdArrayArg = 'arrayArg';
-const messageIdNonArrayArg = 'nonArrayArg';
 
 const ruleTester = new RuleTester({
   parserOptions: {
@@ -244,7 +241,7 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -253,7 +250,7 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -262,7 +259,7 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -271,7 +268,7 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -280,7 +277,7 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -289,7 +286,7 @@ async function test() {
       errors: [
         {
           line: 1,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -301,7 +298,7 @@ await Promise.race([new NonPromise()]);
       errors: [
         {
           line: 3,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -319,7 +316,7 @@ async function test() {
       errors: [
         {
           line: 8,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -331,7 +328,7 @@ await Promise.race([callback?.()]);
       errors: [
         {
           line: 3,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -343,7 +340,7 @@ await Promise.race([obj.a?.b?.()]);
       errors: [
         {
           line: 3,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -355,7 +352,7 @@ await Promise.race([obj?.a.b.c?.()]);
       errors: [
         {
           line: 3,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -368,7 +365,7 @@ await Promise.all([wrappedPromise, stdPromise]);
       errors: [
         {
           line: 4,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -380,7 +377,7 @@ await foo.race([0]);
       errors: [
         {
           line: 3,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -392,7 +389,7 @@ await Foo.all([0]);
       errors: [
         {
           line: 3,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -404,7 +401,7 @@ await foo.all([0]);
       errors: [
         {
           line: 3,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -413,7 +410,7 @@ await foo.all([0]);
       errors: [
         {
           line: 1,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -422,7 +419,7 @@ await foo.all([0]);
       errors: [
         {
           line: 1,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -431,7 +428,7 @@ await foo.all([0]);
       errors: [
         {
           line: 1,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -440,7 +437,7 @@ await foo.all([0]);
       errors: [
         {
           line: 1,
-          messageId: messageIdInArray,
+          messageId: 'inArray',
         },
       ],
     },
@@ -449,7 +446,7 @@ await foo.all([0]);
       errors: [
         {
           line: 1,
-          messageId: messageIdNonArrayArg,
+          messageId: 'nonArrayArg',
         },
       ],
     },
@@ -458,7 +455,7 @@ await foo.all([0]);
       errors: [
         {
           line: 1,
-          messageId: messageIdNonArrayArg,
+          messageId: 'nonArrayArg',
         },
       ],
     },
@@ -467,7 +464,7 @@ await foo.all([0]);
       errors: [
         {
           line: 1,
-          messageId: messageIdNonArrayArg,
+          messageId: 'nonArrayArg',
         },
       ],
     },
@@ -476,7 +473,7 @@ await foo.all([0]);
       errors: [
         {
           line: 1,
-          messageId: messageIdNonArrayArg,
+          messageId: 'nonArrayArg',
         },
       ],
     },
@@ -485,7 +482,7 @@ await foo.all([0]);
       errors: [
         {
           line: 1,
-          messageId: messageIdNonArrayArg,
+          messageId: 'nonArrayArg',
         },
       ],
     },
@@ -497,7 +494,7 @@ await Promise.all(promiseArr);
       errors: [
         {
           line: 3,
-          messageId: messageIdNonArrayArg,
+          messageId: 'nonArrayArg',
         },
       ],
     },
@@ -506,7 +503,7 @@ await Promise.all(promiseArr);
       errors: [
         {
           line: 1,
-          messageId: messageIdArrayArg,
+          messageId: 'arrayArg',
         },
       ],
     },
@@ -518,7 +515,7 @@ await Promise.all(promiseArr.map(v => await v));
       errors: [
         {
           line: 3,
-          messageId: messageIdArrayArg,
+          messageId: 'arrayArg',
         },
       ],
     },
@@ -530,7 +527,7 @@ await Promise.all?.(arr);
       errors: [
         {
           line: 3,
-          messageId: messageIdArrayArg,
+          messageId: 'arrayArg',
         },
       ],
     },
@@ -542,7 +539,7 @@ await Promise.race(foo);
       errors: [
         {
           line: 3,
-          messageId: messageIdArrayArg,
+          messageId: 'arrayArg',
         },
       ],
     },
@@ -551,7 +548,7 @@ await Promise.race(foo);
       errors: [
         {
           line: 1,
-          messageId: messageIdArrayArg,
+          messageId: 'arrayArg',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
+++ b/packages/eslint-plugin/tests/rules/thenable-in-promise-aggregators.test.ts
@@ -19,6 +19,7 @@ ruleTester.run('thenable-in-promise-aggregators', rule, {
     'await Promise.race([Promise.resolve(3)]);',
     'await Promise.all([Promise.resolve(3)]);',
     'await Promise.allSettled([Promise.resolve(3)]);',
+    'await Promise.any([Promise.resolve(3)]);',
     'await Promise.all([]);',
     "await Promise['all']([Promise.resolve(3)]);",
     "await Promise.all([Promise['resolve'](3)]);",
@@ -280,6 +281,15 @@ await Promise.all(baz);
     },
     {
       code: 'await Promise.allSettled([0]);',
+      errors: [
+        {
+          line: 1,
+          messageId: 'inArray',
+        },
+      ],
+    },
+    {
+      code: 'await Promise.any([0]);',
       errors: [
         {
           line: 1,

--- a/packages/eslint-plugin/tests/schema-snapshots/thenable-in-promise-aggregators.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/thenable-in-promise-aggregators.shot
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rule schemas should be convertible to TS types for documentation purposes thenable-in-promise-aggregators 1`] = `
+"
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];"
+`;

--- a/packages/type-utils/src/builtinSymbolLikes.ts
+++ b/packages/type-utils/src/builtinSymbolLikes.ts
@@ -114,11 +114,30 @@ export function isBuiltinTypeAliasLike(
   });
 }
 
+/**
+ * Checks if the given type is an instance of a built-in type whose name matches
+ * the given predicate, i.e., it either is that type or extends it.
+ *
+ * This will return false if the type is _potentially_ an instance of the given
+ * type but might not be, e.g., if it's a union type where only some of the
+ * members are instances of a built-in type matching the predicate, this returns
+ * false.
+ *
+ * @param program The program the type is defined in
+ * @param type The type
+ * @param predicateOrSymbolName A predicate which returns true if the name of a
+ *   symbol is a match and false otherwise, or the name of the symbol to match
+ */
 export function isBuiltinSymbolLike(
   program: ts.Program,
   type: ts.Type,
-  predicate: (symbolName: string) => boolean,
+  predicateOrSymbolName: string | ((symbolName: string) => boolean),
 ): boolean {
+  const predicate =
+    typeof predicateOrSymbolName === 'string'
+      ? (symbolName: string) => symbolName === predicateOrSymbolName
+      : predicateOrSymbolName;
+
   return isBuiltinSymbolLikeRecurser(program, type, subType => {
     const symbol = subType.getSymbol();
     if (!symbol) {

--- a/packages/type-utils/src/builtinSymbolLikes.ts
+++ b/packages/type-utils/src/builtinSymbolLikes.ts
@@ -8,7 +8,11 @@ import { isSymbolFromDefaultLibrary } from './isSymbolFromDefaultLibrary';
  *  ^ PromiseLike
  */
 export function isPromiseLike(program: ts.Program, type: ts.Type): boolean {
-  return isBuiltinSymbolLike(program, type, 'Promise');
+  return isBuiltinSymbolLike(
+    program,
+    type,
+    symbolName => symbolName === 'Promise',
+  );
 }
 
 /**
@@ -20,7 +24,11 @@ export function isPromiseConstructorLike(
   program: ts.Program,
   type: ts.Type,
 ): boolean {
-  return isBuiltinSymbolLike(program, type, 'PromiseConstructor');
+  return isBuiltinSymbolLike(
+    program,
+    type,
+    symbolName => symbolName === 'PromiseConstructor',
+  );
 }
 
 /**
@@ -29,7 +37,11 @@ export function isPromiseConstructorLike(
  *      ^ ErrorLike
  */
 export function isErrorLike(program: ts.Program, type: ts.Type): boolean {
-  return isBuiltinSymbolLike(program, type, 'Error');
+  return isBuiltinSymbolLike(
+    program,
+    type,
+    symbolName => symbolName === 'Error',
+  );
 }
 
 /**
@@ -105,7 +117,7 @@ export function isBuiltinTypeAliasLike(
 export function isBuiltinSymbolLike(
   program: ts.Program,
   type: ts.Type,
-  symbolName: string,
+  predicate: (symbolName: string) => boolean,
 ): boolean {
   return isBuiltinSymbolLikeRecurser(program, type, subType => {
     const symbol = subType.getSymbol();
@@ -114,7 +126,7 @@ export function isBuiltinSymbolLike(
     }
 
     if (
-      symbol.getName() === symbolName &&
+      predicate(symbol.getName()) &&
       isSymbolFromDefaultLibrary(program, symbol)
     ) {
       return true;

--- a/packages/type-utils/src/builtinSymbolLikes.ts
+++ b/packages/type-utils/src/builtinSymbolLikes.ts
@@ -135,7 +135,7 @@ export function isBuiltinSymbolLike(
 ): boolean {
   const predicate =
     typeof predicateOrSymbolName === 'string'
-      ? (symbolName: string) => symbolName === predicateOrSymbolName
+      ? (symbolName: string): boolean => symbolName === predicateOrSymbolName
       : predicateOrSymbolName;
 
   return isBuiltinSymbolLikeRecurser(program, type, subType => {


### PR DESCRIPTION
## PR Checklist

- [X] Addresses an existing open issue: adds requested feature #1804
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a new rule, `thenable-in-promise-aggregators`, which verifies that array arguments of `Promise.all`, `Promise.allSettled`, and `Promise.race` are all Thenable. The purpose behind this PR is discussed in the issue; for me, I often wrap promises to make them cancelable, but it still makes sense to name the object e.g. `fooPromise`, and when mixed with regular promises (or even without), I will type `Promise.race([stdPromise, fooPromise])`, which will look correct and appear to behave correctly for a long time, before getting non-responsive if one of the promises is unexpectedly slow.
