### PR TITLE
fix(eslint-plugin): [no-restricted-imports] prevent crash when `patterns` or `paths` in options are empty

### DIFF
--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -216,7 +216,7 @@ function shouldCreateRule(
   baseRules: RuleListener,
   options: Options,
 ): baseRules is Exclude<RuleListener, Record<string, never>> {
-  if (!Object.keys(baseRules).length || options.length === 0) {
+  if (Object.keys(baseRules).length === 0 || options.length === 0) {
     return false;
   }
 

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -221,7 +221,7 @@ function shouldCreateRule(
   }
 
   if (!isOptionsArrayOfStringOrObject(options)) {
-    return !!(options[0].paths?.length || options[0].patterns?.length);
+    return options[0].paths?.length !== 0 || options[0].patterns?.length !== 0;
   }
 
   return true;

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -8,6 +8,7 @@ import type {
 import type {
   ArrayOfStringOrObject,
   ArrayOfStringOrObjectPatterns,
+  RuleListener,
 } from 'eslint/lib/rules/no-restricted-imports';
 import type { Ignore } from 'ignore';
 import ignore from 'ignore';
@@ -211,6 +212,21 @@ function getRestrictedPatterns(
   return [];
 }
 
+function shouldCreateRule(
+  baseRules: RuleListener,
+  options: Options,
+): baseRules is Exclude<RuleListener, Record<string, never>> {
+  if (!Object.keys(baseRules).length || options.length === 0) {
+    return false;
+  }
+
+  if (!isOptionsArrayOfStringOrObject(options)) {
+    return !!(options[0].paths?.length || options[0].patterns?.length);
+  }
+
+  return true;
+}
+
 export default createRule<Options, MessageIds>({
   name: 'no-restricted-imports',
   meta: {
@@ -228,7 +244,7 @@ export default createRule<Options, MessageIds>({
     const rules = baseRule.create(context);
     const { options } = context;
 
-    if (options.length === 0) {
+    if (!shouldCreateRule(rules, options)) {
       return {};
     }
 

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -221,7 +221,7 @@ function shouldCreateRule(
   }
 
   if (!isOptionsArrayOfStringOrObject(options)) {
-    return options[0].paths?.length !== 0 || options[0].patterns?.length !== 0;
+    return !!(options[0].paths?.length || options[0].patterns?.length);
   }
 
   return true;

--- a/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-restricted-imports.test.ts
@@ -322,6 +322,35 @@ import type { foo } from 'import2/private/bar';
         },
       ],
     },
+    {
+      code: "import foo from 'foo';",
+      options: [],
+    },
+    {
+      code: "import foo from 'foo';",
+      options: [
+        {
+          paths: [],
+        },
+      ],
+    },
+    {
+      code: "import foo from 'foo';",
+      options: [
+        {
+          patterns: [],
+        },
+      ],
+    },
+    {
+      code: "import foo from 'foo';",
+      options: [
+        {
+          paths: [],
+          patterns: [],
+        },
+      ],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -1057,6 +1057,13 @@ declare module 'eslint/lib/rules/no-restricted-imports' {
           allowTypeImports?: boolean;
         }[]
       | string[];
+    export type RuleListener =
+      | Record<string, never>
+      | {
+          ImportDeclaration(node: TSESTree.ImportDeclaration): void;
+          ExportNamedDeclaration(node: TSESTree.ExportNamedDeclaration): void;
+          ExportAllDeclaration(node: TSESTree.ExportAllDeclaration): void;
+        };
   }
 
   interface ObjectOfPathsAndPatterns {
@@ -1074,11 +1081,7 @@ declare module 'eslint/lib/rules/no-restricted-imports' {
     | 'patterns'
     | 'patternWithCustomMessage',
     rule.ArrayOfStringOrObject | [ObjectOfPathsAndPatterns],
-    {
-      ImportDeclaration(node: TSESTree.ImportDeclaration): void;
-      ExportNamedDeclaration(node: TSESTree.ExportNamedDeclaration): void;
-      ExportAllDeclaration(node: TSESTree.ExportAllDeclaration): void;
-    }
+    rule.RuleListener
   >;
   export = rule;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8103
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Thanks to @mdziekon for investigation made in #8103!

Basically the extension rule didn't check if the base rule returned listeners or not (its typing was wrong, base rule may return empty object https://github.com/eslint/eslint/blob/5aa9c499da48b2d3187270d5d8ece71ad7521f56/lib/rules/no-restricted-imports.js#L192-L195)
