### PR TITLE
chore(website): only min-height code blocks with playground buttons

### DIFF
--- a/packages/website/src/theme/CodeBlock/Content/styles.module.css
+++ b/packages/website/src/theme/CodeBlock/Content/styles.module.css
@@ -6,6 +6,9 @@
   /* rtl:ignore */
   direction: ltr;
   border-radius: inherit;
+}
+
+.codeBlockContent:has(.playgroundButton) {
   min-height: 5.5rem;
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8110
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

What good timing that [Firefox supports `:has:` now](https://www.mozilla.org/en-US/firefox/121.0/releasenotes). https://caniuse.com/css-has shows we can use it. This fix was a bit easier for it!

For testing:

* Docs page that doesn't apply min-height: /linting/troubleshooting/performance-troubleshooting#eslint-plugin-prettier
* Rule page that still applies min-height: /rules/array-type