### PR TITLE
docs(eslint-plugin): add Deprecating Formatting Rules blog post

### DIFF
--- a/packages/eslint-plugin/src/rules/block-spacing.ts
+++ b/packages/eslint-plugin/src/rules/block-spacing.ts
@@ -18,7 +18,7 @@ export default createRule<Options, MessageIds>({
   name: 'block-spacing',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/block-spacing'],
+    replacedBy: ['@stylistic/ts/block-spacing'],
     type: 'layout',
     docs: {
       description:

--- a/packages/eslint-plugin/src/rules/brace-style.ts
+++ b/packages/eslint-plugin/src/rules/brace-style.ts
@@ -17,7 +17,7 @@ export default createRule<Options, MessageIds>({
   name: 'brace-style',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/brace-style'],
+    replacedBy: ['@stylistic/ts/brace-style'],
     type: 'layout',
     docs: {
       description: 'Enforce consistent brace style for blocks',

--- a/packages/eslint-plugin/src/rules/comma-dangle.ts
+++ b/packages/eslint-plugin/src/rules/comma-dangle.ts
@@ -47,7 +47,7 @@ export default createRule<Options, MessageIds>({
   name: 'comma-dangle',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/comma-dangle'],
+    replacedBy: ['@stylistic/ts/comma-dangle'],
     type: 'layout',
     docs: {
       description: 'Require or disallow trailing commas',

--- a/packages/eslint-plugin/src/rules/comma-spacing.ts
+++ b/packages/eslint-plugin/src/rules/comma-spacing.ts
@@ -23,7 +23,7 @@ export default createRule<Options, MessageIds>({
   name: 'comma-spacing',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/comma-spacing'],
+    replacedBy: ['@stylistic/ts/comma-spacing'],
     type: 'layout',
     docs: {
       description: 'Enforce consistent spacing before and after commas',

--- a/packages/eslint-plugin/src/rules/func-call-spacing.ts
+++ b/packages/eslint-plugin/src/rules/func-call-spacing.ts
@@ -24,7 +24,7 @@ export default createRule<Options, MessageIds>({
   name: 'func-call-spacing',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/func-call-spacing'],
+    replacedBy: ['@stylistic/ts/func-call-spacing'],
     type: 'layout',
     docs: {
       description:

--- a/packages/eslint-plugin/src/rules/indent.ts
+++ b/packages/eslint-plugin/src/rules/indent.ts
@@ -93,7 +93,7 @@ export default createRule<Options, MessageIds>({
   name: 'indent',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/indent'],
+    replacedBy: ['@stylistic/ts/indent'],
     type: 'layout',
     docs: {
       description: 'Enforce consistent indentation',

--- a/packages/eslint-plugin/src/rules/key-spacing.ts
+++ b/packages/eslint-plugin/src/rules/key-spacing.ts
@@ -28,7 +28,7 @@ export default createRule<Options, MessageIds>({
   name: 'key-spacing',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/key-spacing'],
+    replacedBy: ['@stylistic/ts/key-spacing'],
     type: 'layout',
     docs: {
       description:

--- a/packages/eslint-plugin/src/rules/keyword-spacing.ts
+++ b/packages/eslint-plugin/src/rules/keyword-spacing.ts
@@ -38,7 +38,7 @@ export default createRule<Options, MessageIds>({
   name: 'keyword-spacing',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/keyword-spacing'],
+    replacedBy: ['@stylistic/ts/keyword-spacing'],
     type: 'layout',
     docs: {
       description: 'Enforce consistent spacing before and after keywords',

--- a/packages/eslint-plugin/src/rules/lines-around-comment.ts
+++ b/packages/eslint-plugin/src/rules/lines-around-comment.ts
@@ -51,7 +51,7 @@ export default createRule<Options, MessageIds>({
   name: 'lines-around-comment',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/lines-around-comment'],
+    replacedBy: ['@stylistic/ts/lines-around-comment'],
     type: 'layout',
     docs: {
       description: 'Require empty lines around comments',

--- a/packages/eslint-plugin/src/rules/lines-between-class-members.ts
+++ b/packages/eslint-plugin/src/rules/lines-between-class-members.ts
@@ -34,7 +34,7 @@ export default createRule<Options, MessageIds>({
   name: 'lines-between-class-members',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/ts/line-between-class-members'],
+    replacedBy: ['@stylistic/ts/lines-between-class-members'],
     type: 'layout',
     docs: {
       description: 'Require or disallow an empty line between class members',

--- a/packages/eslint-plugin/src/rules/lines-between-class-members.ts
+++ b/packages/eslint-plugin/src/rules/lines-between-class-members.ts
@@ -34,7 +34,7 @@ export default createRule<Options, MessageIds>({
   name: 'lines-between-class-members',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/line-between-class-members'],
+    replacedBy: ['@stylistic/ts/line-between-class-members'],
     type: 'layout',
     docs: {
       description: 'Require or disallow an empty line between class members',

--- a/packages/eslint-plugin/src/rules/member-delimiter-style.ts
+++ b/packages/eslint-plugin/src/rules/member-delimiter-style.ts
@@ -137,7 +137,7 @@ export default createRule<Options, MessageIds>({
   name: 'member-delimiter-style',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/member-delimiter-style'],
+    replacedBy: ['@stylistic/ts/member-delimiter-style'],
     type: 'layout',
     docs: {
       description:

--- a/packages/eslint-plugin/src/rules/no-extra-parens.ts
+++ b/packages/eslint-plugin/src/rules/no-extra-parens.ts
@@ -21,7 +21,7 @@ export default createRule<Options, MessageIds>({
   name: 'no-extra-parens',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/no-extra-parens'],
+    replacedBy: ['@stylistic/ts/no-extra-parens'],
     type: 'layout',
     docs: {
       description: 'Disallow unnecessary parentheses',

--- a/packages/eslint-plugin/src/rules/object-curly-spacing.ts
+++ b/packages/eslint-plugin/src/rules/object-curly-spacing.ts
@@ -29,7 +29,7 @@ export default createRule<Options, MessageIds>({
       description: 'Enforce consistent spacing inside braces',
       extendsBaseRule: true,
     },
-    replacedBy: ['@stylistic/object-curly-spacing'],
+    replacedBy: ['@stylistic/ts/object-curly-spacing'],
   },
   defaultOptions: ['never'],
   create(context) {

--- a/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
+++ b/packages/eslint-plugin/src/rules/padding-line-between-statements.ts
@@ -591,7 +591,7 @@ export default createRule<Options, MessageIds>({
   name: 'padding-line-between-statements',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/padding-line-between-statements'],
+    replacedBy: ['@stylistic/ts/padding-line-between-statements'],
     type: 'layout',
     docs: {
       description: 'Require or disallow padding lines between statements',

--- a/packages/eslint-plugin/src/rules/quotes.ts
+++ b/packages/eslint-plugin/src/rules/quotes.ts
@@ -17,7 +17,7 @@ export default createRule<Options, MessageIds>({
   name: 'quotes',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/quotes'],
+    replacedBy: ['@stylistic/ts/quotes'],
     type: 'layout',
     docs: {
       description:

--- a/packages/eslint-plugin/src/rules/semi.ts
+++ b/packages/eslint-plugin/src/rules/semi.ts
@@ -17,7 +17,7 @@ export default createRule<Options, MessageIds>({
   name: 'semi',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/semi'],
+    replacedBy: ['@stylistic/ts/semi'],
     type: 'layout',
     docs: {
       description: 'Require or disallow semicolons instead of ASI',

--- a/packages/eslint-plugin/src/rules/space-before-blocks.ts
+++ b/packages/eslint-plugin/src/rules/space-before-blocks.ts
@@ -17,7 +17,7 @@ export default createRule<Options, MessageIds>({
   name: 'space-before-blocks',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/space-before-blocks'],
+    replacedBy: ['@stylistic/ts/space-before-blocks'],
     type: 'layout',
     docs: {
       description: 'Enforce consistent spacing before blocks',

--- a/packages/eslint-plugin/src/rules/space-before-function-paren.ts
+++ b/packages/eslint-plugin/src/rules/space-before-function-paren.ts
@@ -21,7 +21,7 @@ export default createRule<Options, MessageIds>({
   name: 'space-before-function-paren',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/space-before-function-paren'],
+    replacedBy: ['@stylistic/ts/space-before-function-paren'],
     type: 'layout',
     docs: {
       description: 'Enforce consistent spacing before function parenthesis',

--- a/packages/eslint-plugin/src/rules/space-infix-ops.ts
+++ b/packages/eslint-plugin/src/rules/space-infix-ops.ts
@@ -19,7 +19,7 @@ export default createRule<Options, MessageIds>({
   name: 'space-infix-ops',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/space-infix-ops'],
+    replacedBy: ['@stylistic/ts/space-infix-ops'],
     type: 'layout',
     docs: {
       description: 'Require spacing around infix operators',

--- a/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
+++ b/packages/eslint-plugin/src/rules/type-annotation-spacing.ts
@@ -103,7 +103,7 @@ export default createRule<Options, MessageIds>({
   name: 'type-annotation-spacing',
   meta: {
     deprecated: true,
-    replacedBy: ['@stylistic/type-annotation-spacing'],
+    replacedBy: ['@stylistic/ts/type-annotation-spacing'],
     type: 'layout',
     docs: {
       description: 'Require consistent spacing around type annotations',

--- a/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
+++ b/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
@@ -54,6 +54,7 @@ The equivalent stylistic rules for deprecated typescript-eslint rules are summar
 | [`@typescript-eslint/lines-between-class-members`](/rules/lines-between-class-members)         | [`@stylistic/lines-between-class-members`](https://eslint.style/rules/ts/lines-between-class-members)         |
 | [`@typescript-eslint/member-delimiter-style`](/rules/member-delimiter-style)                   | [`@stylistic/member-delimiter-style`](https://eslint.style/rules/ts/member-delimiter-style)                   |
 | [`@typescript-eslint/no-extra-parens`](/rules/no-extra-parens)                                 | [`@stylistic/no-extra-parens`](https://eslint.style/rules/ts/no-extra-parens)                                 |
+| [`@typescript-eslint/no-extra-semi`](/rules/no-extra-semi)                                     | [`@stylistic/no-extra-semi`](https://eslint.style/rules/ts/no-extra-semi)                                     |
 | [`@typescript-eslint/padding-line-between-statements`](/rules/padding-line-between-statements) | [`@stylistic/padding-line-between-statements`](https://eslint.style/rules/ts/padding-line-between-statements) |
 | [`@typescript-eslint/quotes`](/rules/quotes)                                                   | [`@stylistic/quotes`](https://eslint.style/rules/ts/quotes)                                                   |
 | [`@typescript-eslint/semi`](/rules/semi)                                                       | [`@stylistic/semi`](https://eslint.style/rules/ts/semi)                                                       |

--- a/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
+++ b/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
@@ -40,27 +40,27 @@ You'll want to switch to using their equivalents from [ESLint Stylistic](https:/
 See the [ESLint Stylistic > Getting Started](https://eslint.style/guide/getting-started) guide for how to switch formatting rules to that project.
 The equivalent stylistic rules for deprecated typescript-eslint rules are summarized in this table:
 
-| typescript-eslint Rule                                                                        | ESLint Stylistic Rule                                                                                 |
-| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| [`@typescript-eslint/block-spacing`](/rules/block-spacing)                                    | [`@stylistic/block-spacing`](https://eslint.style/rules/ts/block-spacing)                             |
-| [`@typescript-eslint/brace-style`](/rules/brace-style)                                        | [`@stylistic/brace-style`](https://eslint.style/rules/ts/brace-style)                                 |
-| [`@typescript-eslint/comma-dangle`](/rules/comma-dangle)                                      | [`@stylistic/comma-dangle`](https://eslint.style/rules/ts/comma-dangle)                               |
-| [`@typescript-eslint/comma-spacing`](/rules/comma-spacing)                                    | [`@stylistic/comma-spacing`](https://eslint.style/rules/ts/comma-spacing)                             |
-| [`@typescript-eslint/func-call-spacing`](/rules/func-call-spacing)                            | [`@stylistic/func-call-spacing`](https://eslint.style/rules/ts/func-call-spacing)                     |
-| [`@typescript-eslint/indent`](/rules/indent)                                                  | [`@stylistic/indent`](https://eslint.style/rules/ts/indent)                                           |
-| [`@typescript-eslint/key-spacing`](/rules/key-spacing)                                        | [`@stylistic/key-spacing`](https://eslint.style/rules/ts/key-spacing)                                 |
-| [`@typescript-eslint/keyword-spacing`](/rules/keyword-spacing)                                | [`@stylistic/keyword-spacing`](https://eslint.style/rules/ts/keyword-spacing)                         |
-| [`@typescript-eslint/lines-around-comment`](/rules/lines-around-comment)                      | [`@stylistic/lines-around-comment`](https://eslint.style/rules/ts/lines-around-comment)               |
-| [`@typescript-eslint/lines-between-class-members`](/rules/lines-between-class-members)        | [`@stylistic/lines-between-class-members`](https://eslint.style/rules/ts/lines-between-class-members)        |
-| [`@typescript-eslint/member-delimiter-style`](/rules/member-delimiter-style)                  | [`@stylistic/member-delimiter-style`](https://eslint.style/rules/ts/member-delimiter-style)           |
-| [`@typescript-eslint/no-extra-parens`](/rules/no-extra-parens)                                | [`@stylistic/no-extra-parens`](https://eslint.style/rules/ts/no-extra-parens)                         |
+| typescript-eslint Rule                                                                         | ESLint Stylistic Rule                                                                                         |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| [`@typescript-eslint/block-spacing`](/rules/block-spacing)                                     | [`@stylistic/block-spacing`](https://eslint.style/rules/ts/block-spacing)                                     |
+| [`@typescript-eslint/brace-style`](/rules/brace-style)                                         | [`@stylistic/brace-style`](https://eslint.style/rules/ts/brace-style)                                         |
+| [`@typescript-eslint/comma-dangle`](/rules/comma-dangle)                                       | [`@stylistic/comma-dangle`](https://eslint.style/rules/ts/comma-dangle)                                       |
+| [`@typescript-eslint/comma-spacing`](/rules/comma-spacing)                                     | [`@stylistic/comma-spacing`](https://eslint.style/rules/ts/comma-spacing)                                     |
+| [`@typescript-eslint/func-call-spacing`](/rules/func-call-spacing)                             | [`@stylistic/func-call-spacing`](https://eslint.style/rules/ts/func-call-spacing)                             |
+| [`@typescript-eslint/indent`](/rules/indent)                                                   | [`@stylistic/indent`](https://eslint.style/rules/ts/indent)                                                   |
+| [`@typescript-eslint/key-spacing`](/rules/key-spacing)                                         | [`@stylistic/key-spacing`](https://eslint.style/rules/ts/key-spacing)                                         |
+| [`@typescript-eslint/keyword-spacing`](/rules/keyword-spacing)                                 | [`@stylistic/keyword-spacing`](https://eslint.style/rules/ts/keyword-spacing)                                 |
+| [`@typescript-eslint/lines-around-comment`](/rules/lines-around-comment)                       | [`@stylistic/lines-around-comment`](https://eslint.style/rules/ts/lines-around-comment)                       |
+| [`@typescript-eslint/lines-between-class-members`](/rules/lines-between-class-members)         | [`@stylistic/lines-between-class-members`](https://eslint.style/rules/ts/lines-between-class-members)         |
+| [`@typescript-eslint/member-delimiter-style`](/rules/member-delimiter-style)                   | [`@stylistic/member-delimiter-style`](https://eslint.style/rules/ts/member-delimiter-style)                   |
+| [`@typescript-eslint/no-extra-parens`](/rules/no-extra-parens)                                 | [`@stylistic/no-extra-parens`](https://eslint.style/rules/ts/no-extra-parens)                                 |
 | [`@typescript-eslint/padding-line-between-statements`](/rules/padding-line-between-statements) | [`@stylistic/padding-line-between-statements`](https://eslint.style/rules/ts/padding-line-between-statements) |
-| [`@typescript-eslint/quotes`](/rules/quotes)                                                  | [`@stylistic/quotes`](https://eslint.style/rules/ts/quotes)                                           |
-| [`@typescript-eslint/semi`](/rules/semi)                                                      | [`@stylistic/semi`](https://eslint.style/rules/ts/semi)                                               |
-| [`@typescript-eslint/space-before-blocks`](/rules/space-before-blocks)                        | [`@stylistic/space-before-blocks`](https://eslint.style/rules/ts/space-before-blocks)                 |
-| [`@typescript-eslint/space-before-function-paren`](/rules/space-before-function-paren)        | [`@stylistic/space-before-function-paren`](https://eslint.style/rules/ts/space-before-function-paren)       |
-| [`@typescript-eslint/space-infix-ops`](/rules/space-infix-ops)                                | [`@stylistic/space-infix-ops`](https://eslint.style/rules/ts/space-infix-ops)                         |
-| [`@typescript-eslint/type-annotation-spacing`](/rules/type-annotation-spacing)                | [`@stylistic/type-annotation-spacing`](https://eslint.style/rules/ts/type-annotation-spacing)         |
+| [`@typescript-eslint/quotes`](/rules/quotes)                                                   | [`@stylistic/quotes`](https://eslint.style/rules/ts/quotes)                                                   |
+| [`@typescript-eslint/semi`](/rules/semi)                                                       | [`@stylistic/semi`](https://eslint.style/rules/ts/semi)                                                       |
+| [`@typescript-eslint/space-before-blocks`](/rules/space-before-blocks)                         | [`@stylistic/space-before-blocks`](https://eslint.style/rules/ts/space-before-blocks)                         |
+| [`@typescript-eslint/space-before-function-paren`](/rules/space-before-function-paren)         | [`@stylistic/space-before-function-paren`](https://eslint.style/rules/ts/space-before-function-paren)         |
+| [`@typescript-eslint/space-infix-ops`](/rules/space-infix-ops)                                 | [`@stylistic/space-infix-ops`](https://eslint.style/rules/ts/space-infix-ops)                                 |
+| [`@typescript-eslint/type-annotation-spacing`](/rules/type-annotation-spacing)                 | [`@stylistic/type-annotation-spacing`](https://eslint.style/rules/ts/type-annotation-spacing)                 |
 
 ## Supporting typescript-eslint
 

--- a/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
+++ b/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
@@ -1,0 +1,69 @@
+---
+authors:
+  - image_url: https://www.joshuakgoldberg.com/img/josh.jpg
+    name: Josh Goldberg
+    title: typescript-eslint Maintainer
+    url: https://github.com/JoshuaKGoldberg
+description: We're following ESLint's lead in moving our formatting lint rules to the ESLint Stylistic project.
+slug: deprecating-formatting-rules
+tags: [formatter, formatting, prettier, style, stylistic]
+title: Deprecating Formatting Rules
+---
+
+[ESLint recently announced their plan to deprecate their core formatting rules](https://eslint.org/blog/2023/10/deprecating-formatting-rules).
+The [ESLint Stylistic](https://eslint.style) project has taken over maintenance of formatting rules.
+
+As a result, we in typescript-eslint are now able to deprecate our formatting rules as well.
+We'll keep these deprecated rules available until our next major version.
+
+<!--truncate-->
+
+## Context: Formatting Rules
+
+The ESLint blog post thoroughly explains the history and tradeoffs of formatting rules.
+See also [ESLint's 2020 Changes to Rule Policies blog post](https://eslint.org/blog/2020/05/changes-to-rules-policies/#what-are-the-changes) and our _[What About Formatting?](/linting/troubleshooting/formatting)_ docs.
+The performance downsides of formatting rules are heightened when [linting with type information](/linting/typed-linting).
+
+## Timelines
+
+[v6.16.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v6.16.0), released December 25th, 2023, marks the rules as deprecated.
+Deprecation is only a documentation change.
+Per semantic versioning, formatting-related rules will remain available for all releases of typescript-eslint in the current major version, v6.
+
+**Our next major version, v7, will remove all deprecated rules.**
+
+## Upgrading to ESLint Stylistic
+
+Although you can continue to use formatting rules in typescript-eslint for now, we don't plan on adding any new features or fixes to the rules.
+You'll want to switch to using their equivalents from [ESLint Stylistic](https://eslint.style).
+
+See the [ESLint Stylistic > Getting Started](https://eslint.style/guide/getting-started) guide for how to switch formatting rules to that project.
+The equivalent stylistic rules for deprecated typescript-eslint rules are summarized in this table:
+
+| typescript-eslint Rule                                                                        | ESLint Stylistic Rule                                                                                 |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [`@typescript-eslint/block-spacing`](/rules/block-spacing)                                    | [`@stylistic/block-spacing`](https://eslint.style/rules/ts/block-spacing)                             |
+| [`@typescript-eslint/brace-style`](/rules/brace-style)                                        | [`@stylistic/brace-style`](https://eslint.style/rules/ts/brace-style)                                 |
+| [`@typescript-eslint/comma-dangle`](/rules/comma-dangle)                                      | [`@stylistic/comma-dangle`](https://eslint.style/rules/ts/comma-dangle)                               |
+| [`@typescript-eslint/comma-spacing`](/rules/comma-spacing)                                    | [`@stylistic/comma-spacing`](https://eslint.style/rules/ts/comma-spacing)                             |
+| [`@typescript-eslint/func-call-spacing`](/rules/func-call-spacing)                            | [`@stylistic/func-call-spacing`](https://eslint.style/rules/ts/func-call-spacing)                     |
+| [`@typescript-eslint/indent`](/rules/indent)                                                  | [`@stylistic/indent`](https://eslint.style/rules/ts/indent)                                           |
+| [`@typescript-eslint/key-spacing`](/rules/key-spacing)                                        | [`@stylistic/key-spacing`](https://eslint.style/rules/ts/key-spacing)                                 |
+| [`@typescript-eslint/keyword-spacing`](/rules/keyword-spacing)                                | [`@stylistic/keyword-spacing`](https://eslint.style/rules/ts/keyword-spacing)                         |
+| [`@typescript-eslint/lines-around-comment`](/rules/lines-around-comment)                      | [`@stylistic/lines-around-comment`](https://eslint.style/rules/ts/lines-around-comment)               |
+| [`@typescript-eslint/lines-between-class-members`](/rules/lines-between-class-members)        | [`@stylistic/line-between-class-members`](https://eslint.style/rules/ts/between-class-members)        |
+| [`@typescript-eslint/member-delimiter-style`](/rules/member-delimiter-style)                  | [`@stylistic/member-delimiter-style`](https://eslint.style/rules/ts/member-delimiter-style)           |
+| [`@typescript-eslint/no-extra-parens`](/rules/no-extra-parens)                                | [`@stylistic/no-extra-parens`](https://eslint.style/rules/ts/no-extra-parens)                         |
+| [`@typescript-eslint/padding-line-between-statements`](/rules/padding-line-between-statement) | [`@stylistic/padding-line-between-statements`](https://eslint.style/rules/ts/line-between-statements) |
+| [`@typescript-eslint/quotes`](/rules/quotes)                                                  | [`@stylistic/quotes`](https://eslint.style/rules/ts/quotes)                                           |
+| [`@typescript-eslint/semi`](/rules/semi)                                                      | [`@stylistic/semi`](https://eslint.style/rules/ts/semi)                                               |
+| [`@typescript-eslint/space-before-blocks`](/rules/space-before-blocks)                        | [`@stylistic/space-before-blocks`](https://eslint.style/rules/ts/space-before-blocks)                 |
+| [`@typescript-eslint/space-before-function-paren`](/rules/space-before-function-paren)        | [`@stylistic/space-before-function-paren`](https://eslint.style/rules/ts/before-function-paren)       |
+| [`@typescript-eslint/space-infix-ops`](/rules/space-infix-ops)                                | [`@stylistic/space-infix-ops`](https://eslint.style/rules/ts/space-infix-ops)                         |
+| [`@typescript-eslint/type-annotation-spacing`](/rules/type-annotation-spacing)                | [`@stylistic/type-annotation-spacing`](https://eslint.style/rules/ts/type-annotation-spacing)         |
+
+## Supporting typescript-eslint
+
+If you enjoyed this blog post and/or use typescript-eslint, please consider [supporting us on Open Collective](https://opencollective.com/typescript-eslint).
+We're a small volunteer team and could use your support to make the ESLint experience on TypeScript great.
+Thanks! 💖

--- a/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
+++ b/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
@@ -51,7 +51,7 @@ The equivalent stylistic rules for deprecated typescript-eslint rules are summar
 | [`@typescript-eslint/key-spacing`](/rules/key-spacing)                                        | [`@stylistic/key-spacing`](https://eslint.style/rules/ts/key-spacing)                                 |
 | [`@typescript-eslint/keyword-spacing`](/rules/keyword-spacing)                                | [`@stylistic/keyword-spacing`](https://eslint.style/rules/ts/keyword-spacing)                         |
 | [`@typescript-eslint/lines-around-comment`](/rules/lines-around-comment)                      | [`@stylistic/lines-around-comment`](https://eslint.style/rules/ts/lines-around-comment)               |
-| [`@typescript-eslint/lines-between-class-members`](/rules/lines-between-class-members)        | [`@stylistic/line-between-class-members`](https://eslint.style/rules/ts/between-class-members)        |
+| [`@typescript-eslint/lines-between-class-members`](/rules/lines-between-class-members)        | [`@stylistic/lines-between-class-members`](https://eslint.style/rules/ts/lines-between-class-members)        |
 | [`@typescript-eslint/member-delimiter-style`](/rules/member-delimiter-style)                  | [`@stylistic/member-delimiter-style`](https://eslint.style/rules/ts/member-delimiter-style)           |
 | [`@typescript-eslint/no-extra-parens`](/rules/no-extra-parens)                                | [`@stylistic/no-extra-parens`](https://eslint.style/rules/ts/no-extra-parens)                         |
 | [`@typescript-eslint/padding-line-between-statements`](/rules/padding-line-between-statement) | [`@stylistic/padding-line-between-statements`](https://eslint.style/rules/ts/line-between-statements) |

--- a/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
+++ b/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
@@ -58,7 +58,7 @@ The equivalent stylistic rules for deprecated typescript-eslint rules are summar
 | [`@typescript-eslint/quotes`](/rules/quotes)                                                  | [`@stylistic/quotes`](https://eslint.style/rules/ts/quotes)                                           |
 | [`@typescript-eslint/semi`](/rules/semi)                                                      | [`@stylistic/semi`](https://eslint.style/rules/ts/semi)                                               |
 | [`@typescript-eslint/space-before-blocks`](/rules/space-before-blocks)                        | [`@stylistic/space-before-blocks`](https://eslint.style/rules/ts/space-before-blocks)                 |
-| [`@typescript-eslint/space-before-function-paren`](/rules/space-before-function-paren)        | [`@stylistic/space-before-function-paren`](https://eslint.style/rules/ts/before-function-paren)       |
+| [`@typescript-eslint/space-before-function-paren`](/rules/space-before-function-paren)        | [`@stylistic/space-before-function-paren`](https://eslint.style/rules/ts/space-before-function-paren)       |
 | [`@typescript-eslint/space-infix-ops`](/rules/space-infix-ops)                                | [`@stylistic/space-infix-ops`](https://eslint.style/rules/ts/space-infix-ops)                         |
 | [`@typescript-eslint/type-annotation-spacing`](/rules/type-annotation-spacing)                | [`@stylistic/type-annotation-spacing`](https://eslint.style/rules/ts/type-annotation-spacing)         |
 

--- a/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
+++ b/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
@@ -54,7 +54,7 @@ The equivalent stylistic rules for deprecated typescript-eslint rules are summar
 | [`@typescript-eslint/lines-between-class-members`](/rules/lines-between-class-members)        | [`@stylistic/lines-between-class-members`](https://eslint.style/rules/ts/lines-between-class-members)        |
 | [`@typescript-eslint/member-delimiter-style`](/rules/member-delimiter-style)                  | [`@stylistic/member-delimiter-style`](https://eslint.style/rules/ts/member-delimiter-style)           |
 | [`@typescript-eslint/no-extra-parens`](/rules/no-extra-parens)                                | [`@stylistic/no-extra-parens`](https://eslint.style/rules/ts/no-extra-parens)                         |
-| [`@typescript-eslint/padding-line-between-statements`](/rules/padding-line-between-statement) | [`@stylistic/padding-line-between-statements`](https://eslint.style/rules/ts/line-between-statements) |
+| [`@typescript-eslint/padding-line-between-statements`](/rules/padding-line-between-statements) | [`@stylistic/padding-line-between-statements`](https://eslint.style/rules/ts/padding-line-between-statements) |
 | [`@typescript-eslint/quotes`](/rules/quotes)                                                  | [`@stylistic/quotes`](https://eslint.style/rules/ts/quotes)                                           |
 | [`@typescript-eslint/semi`](/rules/semi)                                                      | [`@stylistic/semi`](https://eslint.style/rules/ts/semi)                                               |
 | [`@typescript-eslint/space-before-blocks`](/rules/space-before-blocks)                        | [`@stylistic/space-before-blocks`](https://eslint.style/rules/ts/space-before-blocks)                 |

--- a/packages/website/plugins/generated-rule-docs/insertions/insertFormattingNotice.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertFormattingNotice.ts
@@ -12,10 +12,7 @@ export function insertFormattingNotice(page: RuleDocsPage): void {
   );
   const url =
     replacement &&
-    `https://eslint.style/rules/default/${replacement.replace(
-      '@stylistic/',
-      '',
-    )}`;
+    `https://eslint.style/rules/ts/${replacement.replace('@stylistic/', '')}`;
 
   page.spliceChildren(0, 0, {
     value: `
@@ -26,7 +23,7 @@ Formatting rules now live in <a href="https://eslint.style">eslint-stylistic</a>
         : ''
     }
 <br />
-See <a href="/linting/troubleshooting/formatting">What About Formatting?</a> for more information.
+See <a href="/blog/deprecating-formatting-rules">Deprecating Formatting Rules</a> for more information.
 </admonition>
 `,
     type: 'jsx',

--- a/packages/website/plugins/generated-rule-docs/insertions/insertFormattingNotice.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertFormattingNotice.ts
@@ -3,13 +3,13 @@ import type * as unist from 'unist';
 import type { RuleDocsPage } from '../RuleDocsPage';
 
 export function insertFormattingNotice(page: RuleDocsPage): void {
-  if (page.rule.meta.type !== 'layout') {
+  const replacement = page.rule.meta.replacedBy?.find(e =>
+    e.startsWith('@stylistic/'),
+  );
+  if (!replacement) {
     return;
   }
 
-  const replacement = page.rule.meta.replacedBy!.find(e =>
-    e.startsWith('@stylistic/'),
-  );
   const url =
     replacement &&
     `https://eslint.style/rules/ts/${replacement.replace('@stylistic/', '')}`;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8115
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Summarizes why we're doing this and links to the ESLint blog post + ESLint Stylistic docs as well.

Also includes a fix to the rule replacements: I'd forgotten `ts/` exists as a separate namespace from `default/`.