### PR TITLE
fix(typescript-estree): only create project service from env setting if project is enabled

### DIFF
--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -80,10 +80,10 @@ export function createParseSettings(
     errorOnTypeScriptSyntacticAndSemanticIssues: false,
     errorOnUnknownASTType: options.errorOnUnknownASTType === true,
     EXPERIMENTAL_projectService:
-      (options.EXPERIMENTAL_useProjectService &&
-        process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER !== 'false') ||
-      (process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER === 'true' &&
-        options.EXPERIMENTAL_useProjectService !== false)
+      options.EXPERIMENTAL_useProjectService ||
+      (options.project &&
+        options.EXPERIMENTAL_useProjectService !== false &&
+        process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER === 'true')
         ? (TSSERVER_PROJECT_SERVICE ??= createProjectService(
             options.EXPERIMENTAL_useProjectService,
             jsDocParsingMode,

--- a/packages/typescript-estree/tests/lib/createParseSettings.test.ts
+++ b/packages/typescript-estree/tests/lib/createParseSettings.test.ts
@@ -1,6 +1,56 @@
 import { createParseSettings } from '../../src/parseSettings/createParseSettings';
 
+const projectService = { service: true };
+
+jest.mock('../../src/create-program/createProjectService', () => ({
+  createProjectService: () => projectService,
+}));
+
 describe('createParseSettings', () => {
+  describe('EXPERIMENTAL_projectService', () => {
+    it('is created when options.EXPERIMENTAL_useProjectService is enabled', () => {
+      process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER = 'false';
+
+      const parseSettings = createParseSettings('', {
+        EXPERIMENTAL_useProjectService: true,
+      });
+
+      expect(parseSettings.EXPERIMENTAL_projectService).toBe(projectService);
+    });
+
+    it('is created when options.EXPERIMENTAL_useProjectService is undefined, options.project is true, and process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER is true', () => {
+      process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER = 'true';
+
+      const parseSettings = createParseSettings('', {
+        EXPERIMENTAL_useProjectService: undefined,
+        project: true,
+      });
+
+      expect(parseSettings.EXPERIMENTAL_projectService).toBe(projectService);
+    });
+
+    it('is not created when options.EXPERIMENTAL_useProjectService is undefined, options.project is falsy, and process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER is true', () => {
+      process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER = 'true';
+
+      const parseSettings = createParseSettings('', {
+        EXPERIMENTAL_useProjectService: undefined,
+      });
+
+      expect(parseSettings.EXPERIMENTAL_projectService).toBeUndefined();
+    });
+
+    it('is not created when options.EXPERIMENTAL_useProjectService is false, options.project is true, and process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER is true', () => {
+      process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER = 'true';
+
+      const parseSettings = createParseSettings('', {
+        EXPERIMENTAL_useProjectService: false,
+        project: true,
+      });
+
+      expect(parseSettings.EXPERIMENTAL_projectService).toBeUndefined();
+    });
+  });
+
   describe('tsconfigMatchCache', () => {
     it('reuses the TSConfig match cache when called a subsequent time', () => {
       const parseSettings1 = createParseSettings('input.ts');

--- a/packages/typescript-estree/tests/lib/createParseSettings.test.ts
+++ b/packages/typescript-estree/tests/lib/createParseSettings.test.ts
@@ -3,7 +3,7 @@ import { createParseSettings } from '../../src/parseSettings/createParseSettings
 const projectService = { service: true };
 
 jest.mock('../../src/create-program/createProjectService', () => ({
-  createProjectService: () => projectService,
+  createProjectService: (): typeof projectService => projectService,
 }));
 
 describe('createParseSettings', () => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7348; fixes #8131
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I spent some time trying to investigate #8131's unit test failures. I made a bit of progress and then realized... wait, why is the project service enabled for either of these rules? We don't normally enable `parserOptions.project` for un-typed lint rules. Therefore, I don't think we'd want the presence of the environment variable to enable the project service unless `options.project` was also set.