### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] detect unnecessary non-null-assertion on a call expression

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -436,7 +436,7 @@ export default createRule<Options, MessageId>({
     function checkCallExpression(node: TSESTree.CallExpression): void {
       // If this is something like arr.filter(x => /*condition*/), check `condition`
       if (isArrayPredicateFunction(node) && node.arguments.length) {
-        const callback = node.arguments[0]!;
+        const callback = node.arguments[0];
         // Inline defined functions
         if (
           callback.type === AST_NODE_TYPES.ArrowFunctionExpression ||

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -180,10 +180,7 @@ export default createRule<Options, MessageIds>({
             node,
             messageId: 'unnecessaryAssertion',
             fix(fixer) {
-              return fixer.removeRange([
-                node.expression.range[1],
-                node.range[1],
-              ]);
+              return fixer.removeRange([node.range[1] - 1, node.range[1]]);
             },
           });
         } else {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -169,7 +169,10 @@ export default createRule<Options, MessageIds>({
         const type = getConstrainedTypeAtLocation(services, node.expression);
 
         if (!isNullableType(type)) {
-          if (isPossiblyUsedBeforeAssigned(node.expression)) {
+          if (
+            node.expression.type === AST_NODE_TYPES.Identifier &&
+            isPossiblyUsedBeforeAssigned(node.expression)
+          ) {
             return;
           }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -277,7 +277,10 @@ export default createRule<Options, MessageIds>({
                   : null;
               }
               return fixer.removeRange([
-                node.expression.range[1] + 1,
+                node.expression.range[1] +
+                  (node.expression.type === AST_NODE_TYPES.CallExpression
+                    ? 0
+                    : 1),
                 node.range[1],
               ]);
             },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -225,6 +225,18 @@ const a = foo() as number;
 declare function foo(): number | undefined;
 const a = <number>foo();
     `,
+    `
+declare const arr: (object | undefined)[];
+const item = arr[0]!;
+    `,
+    `
+declare const arr: (object | undefined)[];
+const item = arr[0] as object;
+    `,
+    `
+declare const arr: (object | undefined)[];
+const item = <object>arr[0];
+    `,
   ],
 
   invalid: [
@@ -622,6 +634,20 @@ type RT = { log: () => void };
 declare function foo(): RT;
 (foo()).log;
       `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+    },
+    {
+      code: `
+declare const arr: object[];
+const item = arr[0]!;
+      `,
+      output: `
+      declare const arr: object[]
+const item = arr[0]`,
       errors: [
         {
           messageId: 'unnecessaryAssertion',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -213,6 +213,10 @@ let values: number[] = [];
 
 value = values.pop()!;
     `,
+    `
+declare function foo(): number | undefined;
+const a = foo()!;
+    `,
   ],
 
   invalid: [
@@ -515,6 +519,22 @@ y = 0;
         {
           messageId: 'contextuallyUnnecessary',
           line: 5,
+        },
+      ],
+    },
+    {
+      code: `
+declare function foo(): number;
+const a = foo()!;
+      `,
+      output: `
+declare function foo(): number;
+const a = foo();
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 3,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -535,6 +535,38 @@ const a = foo();
         {
           messageId: 'unnecessaryAssertion',
           line: 3,
+          column: 11,
+          endColumn: 17,
+        },
+      ],
+    },
+    {
+      code: `
+const b = new Date()!;
+      `,
+      output: `
+const b = new Date();
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
+const b = (1 + 1)!;
+      `,
+      output: `
+const b = (1 + 1);
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 11,
+          endColumn: 19,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -538,5 +538,38 @@ const a = foo();
         },
       ],
     },
+    {
+      code: `
+declare function foo(): number;
+const a = foo() as number;
+      `,
+      output: `
+declare function foo(): number;
+const a = foo();
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 3,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: `
+declare function foo(): number;
+const a = <number>foo();
+      `,
+      output: `
+declare function foo(): number;
+const a = foo();
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 3,
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -571,5 +571,22 @@ const a = foo();
         },
       ],
     },
+    {
+      code: `
+type RT = { log: () => void };
+declare function foo(): RT;
+(foo() as RT).log;
+      `,
+      output: `
+type RT = { log: () => void };
+declare function foo(): RT;
+(foo()).log;
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -646,8 +646,9 @@ declare const arr: object[];
 const item = arr[0]!;
       `,
       output: `
-      declare const arr: object[]
-const item = arr[0]`,
+declare const arr: object[];
+const item = arr[0];
+      `,
       errors: [
         {
           messageId: 'unnecessaryAssertion',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -217,6 +217,14 @@ value = values.pop()!;
 declare function foo(): number | undefined;
 const a = foo()!;
     `,
+    `
+declare function foo(): number | undefined;
+const a = foo() as number;
+    `,
+    `
+declare function foo(): number | undefined;
+const a = <number>foo();
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8141
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
