### PR TITLE
feat!(utils): call getParserServices before create() in typed rules

### DIFF
--- a/packages/utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/utils/src/eslint-utils/RuleCreator.ts
@@ -6,6 +6,7 @@ import type {
   RuleModule,
 } from '../ts-eslint/Rule';
 import { applyDefault } from './applyDefault';
+import { getParserServices } from './getParserServices';
 
 export type { RuleListener, RuleModule };
 
@@ -73,6 +74,13 @@ export function RuleCreator(urlCreator: (ruleName: string) => string) {
         },
       },
       ...rule,
+      create(context, optionsWithDefault): RuleListener {
+        if (meta.docs.requiresTypeChecking) {
+          getParserServices(context);
+        }
+
+        return rule.create(context, optionsWithDefault);
+      },
     });
   };
 }
@@ -98,8 +106,11 @@ function createRule<
     create(
       context: Readonly<RuleContext<TMessageIds, TOptions>>,
     ): RuleListener {
-      const optionsWithDefault = applyDefault(defaultOptions, context.options);
-      return create(context, optionsWithDefault);
+      if (meta.docs?.requiresTypeChecking) {
+        getParserServices(context);
+      }
+
+      return create(context, applyDefault(defaultOptions, context.options));
     },
     defaultOptions,
     meta,

--- a/packages/utils/tests/eslint-utils/RuleCreator.test.ts
+++ b/packages/utils/tests/eslint-utils/RuleCreator.test.ts
@@ -1,44 +1,143 @@
 import { ESLintUtils } from '../../src';
+import {
+  type NamedCreateRuleMeta,
+  RuleCreator,
+} from '../../src/eslint-utils/RuleCreator';
+import type { RuleContext } from '../../src/ts-eslint/Rule';
+
+const mockGetParserServices = jest.fn();
+
+jest.mock('../../src/eslint-utils/getParserServices', () => ({
+  get getParserServices(): typeof mockGetParserServices {
+    return mockGetParserServices;
+  },
+}));
 
 describe('RuleCreator', () => {
-  const createRule = ESLintUtils.RuleCreator(name => `test/${name}`);
-
-  it('createRule should be a function', () => {
-    expect(typeof createRule).toBe('function');
+  afterEach(() => {
+    mockGetParserServices.mockReset();
   });
 
-  it('should create rule correctly', () => {
-    const rule = createRule({
-      name: 'test',
-      meta: {
-        docs: {
-          description: 'some description',
-          recommended: 'recommended',
-          requiresTypeChecking: true,
-        },
-        messages: {
-          foo: 'some message',
-        },
-        schema: [],
-        type: 'problem',
-      },
-      defaultOptions: [],
-      create() {
-        return {};
-      },
-    });
-    expect(rule.meta).toEqual({
+  describe('factory usage', () => {
+    const createRule = ESLintUtils.RuleCreator(name => `test/${name}`);
+
+    const meta = {
       docs: {
         description: 'some description',
-        url: 'test/test',
         recommended: 'recommended',
-        requiresTypeChecking: true,
       },
       messages: {
-        foo: 'some message',
+        example: 'some message',
       },
       schema: [],
       type: 'problem',
+    } satisfies NamedCreateRuleMeta<'example'>;
+
+    it('populates rule meta', () => {
+      const rule = createRule({
+        name: 'test',
+        meta,
+        defaultOptions: [],
+        create: jest.fn(),
+      });
+
+      expect(rule.meta).toEqual({
+        ...meta,
+        docs: {
+          ...meta.docs,
+          url: 'test/test',
+        },
+      });
+    });
+
+    it('does not enforce parserServices in create when the rule is untyped', () => {
+      const create = jest.fn();
+      const rule = createRule({
+        name: 'test',
+        meta,
+        defaultOptions: [],
+        create,
+      });
+
+      rule.create({} as unknown as Readonly<RuleContext<'example', never[]>>);
+
+      expect(mockGetParserServices).not.toHaveBeenCalled();
+    });
+
+    it('enforces parserServices in create when the rule is typed', () => {
+      const create = jest.fn();
+      const rule = createRule({
+        name: 'test',
+        meta: {
+          ...meta,
+          docs: {
+            ...meta.docs,
+            requiresTypeChecking: true,
+          },
+        },
+        defaultOptions: [],
+        create,
+      });
+
+      rule.create({} as unknown as Readonly<RuleContext<'example', never[]>>);
+
+      expect(mockGetParserServices).toHaveBeenCalled();
+    });
+  });
+
+  describe('withoutDocs', () => {
+    const meta = {
+      docs: {
+        description: 'some description',
+        recommended: 'recommended',
+      },
+      messages: {
+        example: 'some message',
+      },
+      schema: [],
+      type: 'problem',
+    } satisfies NamedCreateRuleMeta<'example'>;
+
+    it('populates rule meta with added docs.url', () => {
+      const rule = RuleCreator.withoutDocs({
+        meta,
+        defaultOptions: [],
+        create: jest.fn(),
+      });
+
+      expect(rule.meta).toEqual(meta);
+    });
+
+    it('does not enforce parserServices in create when the rule is untyped', () => {
+      const create = jest.fn();
+      const rule = RuleCreator.withoutDocs({
+        meta,
+        defaultOptions: [],
+        create,
+      });
+
+      rule.create({} as unknown as Readonly<RuleContext<'example', never[]>>);
+
+      expect(mockGetParserServices).not.toHaveBeenCalled();
+    });
+
+    it('enforces parserServices in create when the rule is typed', () => {
+      const create = jest.fn();
+      const rule = RuleCreator.withoutDocs({
+        meta: {
+          ...meta,
+          docs: {
+            ...meta.docs,
+            requiresTypeChecking: true,
+          },
+        },
+        defaultOptions: [],
+        create,
+      });
+
+      rule.create({} as unknown as Readonly<RuleContext<'example', never[]>>);
+
+      expect(mockGetParserServices).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8150
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Throwing up as a draft for reference in triaging #8150.