### PR TITLE
feature: utils: context: add support of ESLint v9

### DIFF
--- a/packages/utils/src/eslint-utils/context.ts
+++ b/packages/utils/src/eslint-utils/context.ts
@@ -38,8 +38,7 @@ export function getFilename(
 export function getScope(
   context: Readonly<RuleContext<string, readonly unknown[]>>,
 ): Scope.Scope {
-  // TODO: Use `SourceCode#getScope` (we'll be forced to soon)
-  return context.getScope();
+  return context.sourceCode?.getScope() ?? context.getScope()
 }
 
 export function getSourceCode(


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Fixes no `context.getScope` function error for [ESLint v9](https://eslint.org/blog/2023/12/eslint-v9.0.0-alpha.0-released/)

```
TypeError: context.getScope is not a function
Occurred while linting /Users/coderaiser/putout/packages/eslint-plugin-putout/eslint-fixture/unused-type.ts:1
Rule: "@typescript-eslint/no-redeclare"
    at getScope (/Users/coderaiser/putout/node_modules/@typescript-eslint/utils/dist/eslint-utils/context.js:25:20)
    at Program (/Users/coderaiser/putout/node_modules/@typescript-eslint/eslint-plugin/dist/rules/no-redeclare.js:180:59)
    at ruleErrorHandler (/Users/coderaiser/putout/node_modules/eslint/lib/linter/linter.js:1059:28)
    at /Users/coderaiser/putout/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/coderaiser/putout/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/Users/coderaiser/putout/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (/Users/coderaiser/putout/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
    at NodeEventGenerator.enterNode (/Users/coderaiser/putout/node_modules/eslint/lib/linter/node-event-generator.js:340:14)
    at CodePathAnalyzer.enterNode (/Users/coderaiser/putout/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:803:23) {
  ruleId: '@typescript-eslint/no-redeclare',
```