### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] improve checking optional callee

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -547,7 +547,7 @@ export default createRule<Options, MessageId>({
     //  declare const foo: { bar : { baz: string } } | null
     //  foo?.bar;
     //  ```
-    function isNullableOriginFromPrev(
+    function isMemberExpressionNullableOriginFromObject(
       node: TSESTree.MemberExpression,
     ): boolean {
       const prevType = getConstrainedTypeAtLocation(services, node.object);
@@ -580,12 +580,35 @@ export default createRule<Options, MessageId>({
       return false;
     }
 
+    function isCallExpressionNullableOriginFromCallee(
+      node: TSESTree.CallExpression,
+    ): boolean {
+      const prevType = getConstrainedTypeAtLocation(services, node.callee);
+
+      if (prevType.isUnion()) {
+        const isOwnNullable = prevType.types.some(type => {
+          const signatures = type.getCallSignatures();
+          return signatures.some(sig =>
+            isNullableType(sig.getReturnType(), { allowUndefined: true }),
+          );
+        });
+        return (
+          !isOwnNullable && isNullableType(prevType, { allowUndefined: true })
+        );
+      }
+
+      return false;
+    }
+
     function isOptionableExpression(node: TSESTree.Expression): boolean {
       const type = getConstrainedTypeAtLocation(services, node);
       const isOwnNullable =
         node.type === AST_NODE_TYPES.MemberExpression
-          ? !isNullableOriginFromPrev(node)
-          : true;
+          ? !isMemberExpressionNullableOriginFromObject(node)
+          : node.type === AST_NODE_TYPES.CallExpression
+            ? !isCallExpressionNullableOriginFromCallee(node)
+            : true;
+
       const possiblyVoid = isTypeFlagSet(type, ts.TypeFlags.Void);
       return (
         isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown) ||

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -774,6 +774,28 @@ function getElem(dict: Record<string, { foo: string }>, key: string) {
         typescript: '4.1',
       },
     },
+    `
+type Foo = { bar: () => number | undefined } | null;
+declare const foo: Foo;
+foo?.bar()?.toExponential();
+    `,
+    `
+type Foo = (() => number | undefined) | null;
+declare const foo: Foo;
+foo?.()?.toExponential();
+    `,
+    `
+type FooUndef = () => undefined;
+type FooNum = () => number;
+type Foo = FooUndef | FooNum | null;
+declare const foo: Foo;
+foo?.()?.toExponential();
+    `,
+    `
+type Foo = { [key: string]: () => number | undefined } | null;
+declare const foo: Foo;
+foo?.['bar']()?.toExponential();
+    `,
   ],
   invalid: [
     // Ensure that it's checking in all the right places
@@ -1990,6 +2012,118 @@ foo &&= null;
           endLine: 3,
           column: 1,
           endColumn: 4,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+type Foo = { bar: () => number } | null;
+declare const foo: Foo;
+foo?.bar()?.toExponential();
+      `,
+      output: noFormat`
+type Foo = { bar: () => number } | null;
+declare const foo: Foo;
+foo?.bar().toExponential();
+      `,
+      errors: [
+        {
+          messageId: 'neverOptionalChain',
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+type Foo = { bar: null | { baz: () => { qux: number } } } | null;
+declare const foo: Foo;
+foo?.bar?.baz()?.qux?.toExponential();
+      `,
+      output: noFormat`
+type Foo = { bar: null | { baz: () => { qux: number } } } | null;
+declare const foo: Foo;
+foo?.bar?.baz().qux.toExponential();
+      `,
+      errors: [
+        {
+          messageId: 'neverOptionalChain',
+          line: 4,
+          column: 16,
+          endLine: 4,
+          endColumn: 18,
+        },
+        {
+          messageId: 'neverOptionalChain',
+          line: 4,
+          column: 21,
+          endLine: 4,
+          endColumn: 23,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+type Foo = (() => number) | null;
+declare const foo: Foo;
+foo?.()?.toExponential();
+      `,
+      output: noFormat`
+type Foo = (() => number) | null;
+declare const foo: Foo;
+foo?.().toExponential();
+      `,
+      errors: [
+        {
+          messageId: 'neverOptionalChain',
+          line: 4,
+          column: 8,
+          endLine: 4,
+          endColumn: 10,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+type Foo = { [key: string]: () => number } | null;
+declare const foo: Foo;
+foo?.['bar']()?.toExponential();
+      `,
+      output: noFormat`
+type Foo = { [key: string]: () => number } | null;
+declare const foo: Foo;
+foo?.['bar']().toExponential();
+      `,
+      errors: [
+        {
+          messageId: 'neverOptionalChain',
+          line: 4,
+          column: 15,
+          endLine: 4,
+          endColumn: 17,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+type Foo = { [key: string]: () => number } | null;
+declare const foo: Foo;
+foo?.['bar']?.()?.toExponential();
+      `,
+      output: noFormat`
+type Foo = { [key: string]: () => number } | null;
+declare const foo: Foo;
+foo?.['bar']?.().toExponential();
+      `,
+      errors: [
+        {
+          messageId: 'neverOptionalChain',
+          line: 4,
+          column: 17,
+          endLine: 4,
+          endColumn: 19,
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7912
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This pr improves unnecessary optional chaining checking of  `no-unnecessary-condition`.
In below example, optional chain in `y()?.` is unnecessary because `y` does not return nullable value.
As described in #7912, the current `no-unnecessary-condition` does not check for the following case.
```ts
type T1 = { y: () => number } | null;
declare const x1: T1;
x1?.y()?.toExponential();
```

I added `isCallExpressionNullableOriginFromCallee` function.
This function takes a CallExpression node as an argument. It returns `true` if the call expression's nullable type is origin from callee otherwise returns `false`.

```ts
// isCallExpressionNullableOriginFromCallee will return true for given call expression `y()`
type T1 = { y: () => number } | null;
declare const x1: T1;
x1?.y()?.toExponential();
//    ^^^ y()'s nullable type is origin from T1's nullable type

// isCallExpressionNullableOriginFromCallee will return false for given call expression `y()`
type T1 = { y: () => number | null } | null;
declare const x1: T1;
x1?.y()?.toExponential();
//    ^^^ y()'s nullable type is origin from it's own definition. (() => number | null)
```

<!-- Description of what is changed and how the code change does that. -->
