### PR TITLE
fix(typescript-estree): fix incorrect backwards-compat augmentation in TS 5.3

### DIFF
--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -244,7 +244,7 @@ function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
     options.filePath &&
     parseAndGenerateServicesCalls[options.filePath] > 1
       ? createIsolatedProgram(parseSettings)
-      : getProgramAndAST(parseSettings, hasFullTypeInformation)!;
+      : getProgramAndAST(parseSettings, hasFullTypeInformation);
 
   /**
    * Convert the TypeScript AST to an ESTree-compatible one, and optionally preserve

--- a/packages/typescript-estree/src/ts-estree/ts-nodes.ts
+++ b/packages/typescript-estree/src/ts-estree/ts-nodes.ts
@@ -2,12 +2,11 @@ import type * as ts from 'typescript';
 
 // Workaround to support new TS version features for consumers on old TS versions
 // Eg: https://github.com/typescript-eslint/typescript-eslint/issues/2388, https://github.com/typescript-eslint/typescript-eslint/issues/2784
-/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error, @typescript-eslint/no-empty-interface */
+/* eslint-disable @typescript-eslint/no-empty-interface */
 declare module 'typescript' {
-  /** @ts-ignore - added in TS 4.5, deprecated and converted to a type-alias in TS 5.3 */
-  export interface AssertClause extends ts.Node {}
-  /** @ts-ignore - added in TS 4.5, deprecated and converted to a type-alias in TS 5.3 */
-  export interface AssertEntry extends ts.Node {}
+  // added in TS 4.5, deprecated in TS 5.3
+  export interface AssertClause extends ts.ImportAttributes {}
+  export interface AssertEntry extends ts.ImportAttribute {}
   // added in TS 4.9
   export interface SatisfiesExpression extends ts.Node {}
   // added in TS 5.1
@@ -16,7 +15,7 @@ declare module 'typescript' {
   export interface ImportAttribute extends ts.Node {}
   export interface ImportAttributes extends ts.Node {}
 }
-/* eslint-enable @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error, @typescript-eslint/no-empty-interface */
+/* eslint-enable @typescript-eslint/no-empty-interface */
 
 export type TSToken = ts.Token<ts.SyntaxKind>;
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8047
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This doesn't work any better than before.
It fixes the error on >5.3, but it introduces an error on <TS5.3.