### PR TITLE
chore: fix configuration link to recommended prettier usage

### DIFF
--- a/docs/linting/Configurations.mdx
+++ b/docs/linting/Configurations.mdx
@@ -229,4 +229,4 @@ If you feel strongly that a specific rule should (or should not) be one of these
 
 None of the preset configs provided by typescript-eslint enable formatting rules (rules that only serve to enforce code whitespace and other trivia).
 We strongly recommend you use Prettier or an equivalent for formatting your code, not ESLint formatting rules.
-See [What About Formatting? > Suggested Usage](./troubleshooting/formatting#suggested-usage).
+See [What About Formatting? > Suggested Usage](./troubleshooting/Formatting.mdx#suggested-usage---prettier).


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR fixes the link to point to the Prettier section of the Formatting page in the Troubleshooting category. The previously referenced 'Suggested Usage' header no longer exists, the closest equivalent is the current 'Suggested Usage - Prettier' header.
