### PR TITLE
docs: add `import/no-unresolved` to perf troubleshooting docs

### DIFF
--- a/docs/linting/troubleshooting/Performance.mdx
+++ b/docs/linting/troubleshooting/Performance.mdx
@@ -81,7 +81,6 @@ There are many rules that do single file static analysis, but we provide the fol
 
 We recommend you do not use the following rules, as TypeScript provides the same checks as part of standard type checking:
 
-- `import/extensions`
 - `import/named`
 - `import/namespace`
 - `import/default`

--- a/docs/linting/troubleshooting/Performance.mdx
+++ b/docs/linting/troubleshooting/Performance.mdx
@@ -86,7 +86,6 @@ We recommend you do not use the following rules, as TypeScript provides the same
 - `import/default`
 - `import/no-named-as-default-member`
 - `import/no-unresolved`
-- `import/unambiguous`
 
 The following rules do not have equivalent checks in TypeScript, so we recommend that you only run them at CI/push time, to lessen the local performance burden.
 

--- a/docs/linting/troubleshooting/Performance.mdx
+++ b/docs/linting/troubleshooting/Performance.mdx
@@ -81,10 +81,13 @@ There are many rules that do single file static analysis, but we provide the fol
 
 We recommend you do not use the following rules, as TypeScript provides the same checks as part of standard type checking:
 
+- `import/extensions`
 - `import/named`
 - `import/namespace`
 - `import/default`
 - `import/no-named-as-default-member`
+- `import/no-unresolved`
+- `import/unambiguous`
 
 The following rules do not have equivalent checks in TypeScript, so we recommend that you only run them at CI/push time, to lessen the local performance burden.
 

--- a/docs/linting/troubleshooting/Performance.mdx
+++ b/docs/linting/troubleshooting/Performance.mdx
@@ -101,7 +101,7 @@ The following rules do not have equivalent checks in TypeScript, so we recommend
 
 If you want to enforce file extensions are always used and you're **NOT** using `moduleResolution` `node16` or `nodenext`, then there's not really a good alternative for you, and you should continue using the `import/extensions` lint rule.
 
-If you want to enforce file extensions are always used and you **ARE** using `moduleResolution` `node16` or `nodenext`, then you don't need to use the lint rule at all because TypeScript will automatically enforce that you include extensions! (However, the lint rule is still extremely useful as a one-time project-wide autofixer if you are switching from no file extensions --> file extensions, or vice versa.)
+If you want to enforce file extensions are always used and you **ARE** using `moduleResolution` `node16` or `nodenext`, then you don't need to use the lint rule at all because TypeScript will automatically enforce that you include extensions! (However, the lint rule is still extremely useful as a one-time project-wide fixer if you are switching from no file extensions --> file extensions, or vice versa.)
 
 #### Enforcing extensions are not used
 

--- a/docs/linting/troubleshooting/Performance.mdx
+++ b/docs/linting/troubleshooting/Performance.mdx
@@ -85,7 +85,7 @@ We recommend you do not use the following rules, as TypeScript provides the same
 - `import/namespace`
 - `import/default`
 - `import/no-named-as-default-member`
-- `import/no-unresolved`
+- `import/no-unresolved` (as long as you are using [`import` over `require`](https://typescript-eslint.io/rules/no-var-requires/))
 
 The following rules do not have equivalent checks in TypeScript, so we recommend that you only run them at CI/push time, to lessen the local performance burden.
 

--- a/docs/linting/troubleshooting/Performance.mdx
+++ b/docs/linting/troubleshooting/Performance.mdx
@@ -101,7 +101,7 @@ The following rules do not have equivalent checks in TypeScript, so we recommend
 
 If you want to enforce file extensions are always used and you're **NOT** using `moduleResolution` `node16` or `nodenext`, then there's not really a good alternative for you, and you should continue using the `import/extensions` lint rule.
 
-If you want to enforce file extensions are always used and you **ARE** using `moduleResolution` `node16` or `nodenext`, then you don't need to use the lint rule at all because TypeScript will automatically enforce that you include extensions!
+If you want to enforce file extensions are always used and you **ARE** using `moduleResolution` `node16` or `nodenext`, then you don't need to use the lint rule at all because TypeScript will automatically enforce that you include extensions! (However, the lint rule is still extremely useful as a one-time project-wide autofixer if you are switching from no file extensions --> file extensions, or vice versa.)
 
 #### Enforcing extensions are not used
 

--- a/docs/linting/troubleshooting/Performance.mdx
+++ b/docs/linting/troubleshooting/Performance.mdx
@@ -101,7 +101,7 @@ The following rules do not have equivalent checks in TypeScript, so we recommend
 
 If you want to enforce file extensions are always used and you're **NOT** using `moduleResolution` `node16` or `nodenext`, then there's not really a good alternative for you, and you should continue using the `import/extensions` lint rule.
 
-If you want to enforce file extensions are always used and you **ARE** using `moduleResolution` `node16` or `nodenext`, then you don't need to use the lint rule at all because TypeScript will automatically enforce that you include extensions! (However, the lint rule is still extremely useful as a one-time project-wide fixer if you are switching from no file extensions --> file extensions, or vice versa.)
+If you want to enforce file extensions are always used and you **ARE** using `moduleResolution` `node16` or `nodenext`, then you don't need to use the lint rule at all because TypeScript will automatically enforce that you include extensions!
 
 #### Enforcing extensions are not used
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: n/a
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I added 2 rules to the page, which are the following:

- `import/no-unresolved`
- `import/unambiguous`

I believe that these are correctly handled by the TypeScript compiler, correct me if I am wrong.
