### PR TITLE
fix(typescript-estree): fix invalid parsing error when use update expression on non-null assertion

### DIFF
--- a/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/fixture.ts
+++ b/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/fixture.ts
@@ -11,5 +11,6 @@ class F {
     (<number>this.#a)++;
     (this.#a satisfies number)++;
     (this.#a as number)++;
+    this.#a!++;
   }
 }

--- a/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/1-TSESTree-AST.shot
@@ -547,12 +547,71 @@ Program {
                       end: { column: 26, line: 13 },
                     },
                   },
+                  ExpressionStatement {
+                    type: "ExpressionStatement",
+                    expression: UpdateExpression {
+                      type: "UpdateExpression",
+                      argument: TSNonNullExpression {
+                        type: "TSNonNullExpression",
+                        expression: MemberExpression {
+                          type: "MemberExpression",
+                          computed: false,
+                          object: ThisExpression {
+                            type: "ThisExpression",
+
+                            range: [214, 218],
+                            loc: {
+                              start: { column: 4, line: 14 },
+                              end: { column: 8, line: 14 },
+                            },
+                          },
+                          optional: false,
+                          property: PrivateIdentifier {
+                            type: "PrivateIdentifier",
+                            name: "a",
+
+                            range: [219, 221],
+                            loc: {
+                              start: { column: 9, line: 14 },
+                              end: { column: 11, line: 14 },
+                            },
+                          },
+
+                          range: [214, 221],
+                          loc: {
+                            start: { column: 4, line: 14 },
+                            end: { column: 11, line: 14 },
+                          },
+                        },
+
+                        range: [214, 222],
+                        loc: {
+                          start: { column: 4, line: 14 },
+                          end: { column: 12, line: 14 },
+                        },
+                      },
+                      operator: "++",
+                      prefix: false,
+
+                      range: [214, 224],
+                      loc: {
+                        start: { column: 4, line: 14 },
+                        end: { column: 14, line: 14 },
+                      },
+                    },
+
+                    range: [214, 225],
+                    loc: {
+                      start: { column: 4, line: 14 },
+                      end: { column: 15, line: 14 },
+                    },
+                  },
                 ],
 
-                range: [23, 213],
+                range: [23, 229],
                 loc: {
                   start: { column: 6, line: 4 },
-                  end: { column: 3, line: 14 },
+                  end: { column: 3, line: 15 },
                 },
               },
               declare: false,
@@ -561,25 +620,25 @@ Program {
               id: null,
               params: [],
 
-              range: [20, 213],
+              range: [20, 229],
               loc: {
                 start: { column: 3, line: 4 },
-                end: { column: 3, line: 14 },
+                end: { column: 3, line: 15 },
               },
             },
 
-            range: [19, 213],
+            range: [19, 229],
             loc: {
               start: { column: 2, line: 4 },
-              end: { column: 3, line: 14 },
+              end: { column: 3, line: 15 },
             },
           },
         ],
 
-        range: [8, 215],
+        range: [8, 231],
         loc: {
           start: { column: 8, line: 1 },
-          end: { column: 1, line: 15 },
+          end: { column: 1, line: 16 },
         },
       },
       declare: false,
@@ -599,19 +658,19 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 215],
+      range: [0, 231],
       loc: {
         start: { column: 0, line: 1 },
-        end: { column: 1, line: 15 },
+        end: { column: 1, line: 16 },
       },
     },
   ],
   sourceType: "script",
 
-  range: [0, 216],
+  range: [0, 232],
   loc: {
     start: { column: 0, line: 1 },
-    end: { column: 0, line: 16 },
+    end: { column: 0, line: 17 },
   },
 }
 `;

--- a/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/2-TSESTree-Tokens.shot
@@ -682,24 +682,84 @@ exports[`AST Fixtures expression UpdateExpression valid-assignment TSESTree - To
       end: { column: 26, line: 13 },
     },
   },
+  Keyword {
+    type: "Keyword",
+    value: "this",
+
+    range: [214, 218],
+    loc: {
+      start: { column: 4, line: 14 },
+      end: { column: 8, line: 14 },
+    },
+  },
   Punctuator {
     type: "Punctuator",
-    value: "}",
+    value: ".",
 
-    range: [212, 213],
+    range: [218, 219],
     loc: {
-      start: { column: 2, line: 14 },
-      end: { column: 3, line: 14 },
+      start: { column: 8, line: 14 },
+      end: { column: 9, line: 14 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "#a",
+
+    range: [219, 221],
+    loc: {
+      start: { column: 9, line: 14 },
+      end: { column: 11, line: 14 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "!",
+
+    range: [221, 222],
+    loc: {
+      start: { column: 11, line: 14 },
+      end: { column: 12, line: 14 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "++",
+
+    range: [222, 224],
+    loc: {
+      start: { column: 12, line: 14 },
+      end: { column: 14, line: 14 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ";",
+
+    range: [224, 225],
+    loc: {
+      start: { column: 14, line: 14 },
+      end: { column: 15, line: 14 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: "}",
 
-    range: [214, 215],
+    range: [228, 229],
     loc: {
-      start: { column: 0, line: 15 },
-      end: { column: 1, line: 15 },
+      start: { column: 2, line: 15 },
+      end: { column: 3, line: 15 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [230, 231],
+    loc: {
+      start: { column: 0, line: 16 },
+      end: { column: 1, line: 16 },
     },
   },
 ]

--- a/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/3-Babel-AST.shot
@@ -529,12 +529,71 @@ Program {
                       end: { column: 26, line: 13 },
                     },
                   },
+                  ExpressionStatement {
+                    type: "ExpressionStatement",
+                    expression: UpdateExpression {
+                      type: "UpdateExpression",
+                      argument: TSNonNullExpression {
+                        type: "TSNonNullExpression",
+                        expression: MemberExpression {
+                          type: "MemberExpression",
+                          computed: false,
+                          object: ThisExpression {
+                            type: "ThisExpression",
+
+                            range: [214, 218],
+                            loc: {
+                              start: { column: 4, line: 14 },
+                              end: { column: 8, line: 14 },
+                            },
+                          },
+                          optional: false,
+                          property: PrivateIdentifier {
+                            type: "PrivateIdentifier",
+                            name: "a",
+
+                            range: [219, 221],
+                            loc: {
+                              start: { column: 9, line: 14 },
+                              end: { column: 11, line: 14 },
+                            },
+                          },
+
+                          range: [214, 221],
+                          loc: {
+                            start: { column: 4, line: 14 },
+                            end: { column: 11, line: 14 },
+                          },
+                        },
+
+                        range: [214, 222],
+                        loc: {
+                          start: { column: 4, line: 14 },
+                          end: { column: 12, line: 14 },
+                        },
+                      },
+                      operator: "++",
+                      prefix: false,
+
+                      range: [214, 224],
+                      loc: {
+                        start: { column: 4, line: 14 },
+                        end: { column: 14, line: 14 },
+                      },
+                    },
+
+                    range: [214, 225],
+                    loc: {
+                      start: { column: 4, line: 14 },
+                      end: { column: 15, line: 14 },
+                    },
+                  },
                 ],
 
-                range: [23, 213],
+                range: [23, 229],
                 loc: {
                   start: { column: 6, line: 4 },
-                  end: { column: 3, line: 14 },
+                  end: { column: 3, line: 15 },
                 },
               },
               expression: false,
@@ -542,25 +601,25 @@ Program {
               id: null,
               params: [],
 
-              range: [20, 213],
+              range: [20, 229],
               loc: {
                 start: { column: 3, line: 4 },
-                end: { column: 3, line: 14 },
+                end: { column: 3, line: 15 },
               },
             },
 
-            range: [19, 213],
+            range: [19, 229],
             loc: {
               start: { column: 2, line: 4 },
-              end: { column: 3, line: 14 },
+              end: { column: 3, line: 15 },
             },
           },
         ],
 
-        range: [8, 215],
+        range: [8, 231],
         loc: {
           start: { column: 8, line: 1 },
-          end: { column: 1, line: 15 },
+          end: { column: 1, line: 16 },
         },
       },
       id: Identifier {
@@ -575,19 +634,19 @@ Program {
       },
       superClass: null,
 
-      range: [0, 215],
+      range: [0, 231],
       loc: {
         start: { column: 0, line: 1 },
-        end: { column: 1, line: 15 },
+        end: { column: 1, line: 16 },
       },
     },
   ],
   sourceType: "script",
 
-  range: [0, 216],
+  range: [0, 232],
   loc: {
     start: { column: 0, line: 1 },
-    end: { column: 0, line: 16 },
+    end: { column: 0, line: 17 },
   },
 }
 `;

--- a/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/4-Babel-Tokens.shot
@@ -682,24 +682,84 @@ exports[`AST Fixtures expression UpdateExpression valid-assignment Babel - Token
       end: { column: 26, line: 13 },
     },
   },
+  Keyword {
+    type: "Keyword",
+    value: "this",
+
+    range: [214, 218],
+    loc: {
+      start: { column: 4, line: 14 },
+      end: { column: 8, line: 14 },
+    },
+  },
   Punctuator {
     type: "Punctuator",
-    value: "}",
+    value: ".",
 
-    range: [212, 213],
+    range: [218, 219],
     loc: {
-      start: { column: 2, line: 14 },
-      end: { column: 3, line: 14 },
+      start: { column: 8, line: 14 },
+      end: { column: 9, line: 14 },
+    },
+  },
+  PrivateIdentifier {
+    type: "PrivateIdentifier",
+    value: "a",
+
+    range: [219, 221],
+    loc: {
+      start: { column: 9, line: 14 },
+      end: { column: 11, line: 14 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "!",
+
+    range: [221, 222],
+    loc: {
+      start: { column: 11, line: 14 },
+      end: { column: 12, line: 14 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "++",
+
+    range: [222, 224],
+    loc: {
+      start: { column: 12, line: 14 },
+      end: { column: 14, line: 14 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ";",
+
+    range: [224, 225],
+    loc: {
+      start: { column: 14, line: 14 },
+      end: { column: 15, line: 14 },
     },
   },
   Punctuator {
     type: "Punctuator",
     value: "}",
 
-    range: [214, 215],
+    range: [228, 229],
     loc: {
-      start: { column: 0, line: 15 },
-      end: { column: 1, line: 15 },
+      start: { column: 2, line: 15 },
+      end: { column: 3, line: 15 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [230, 231],
+    loc: {
+      start: { column: 0, line: 16 },
+      end: { column: 1, line: 16 },
     },
   },
 ]

--- a/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/5-AST-Alignment-AST.shot
+++ b/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/5-AST-Alignment-AST.shot
@@ -551,12 +551,71 @@ exports[`AST Fixtures expression UpdateExpression valid-assignment AST Alignment
                         end: { column: 26, line: 13 },
                       },
                     },
+                    ExpressionStatement {
+                      type: 'ExpressionStatement',
+                      expression: UpdateExpression {
+                        type: 'UpdateExpression',
+                        argument: TSNonNullExpression {
+                          type: 'TSNonNullExpression',
+                          expression: MemberExpression {
+                            type: 'MemberExpression',
+                            computed: false,
+                            object: ThisExpression {
+                              type: 'ThisExpression',
+
+                              range: [214, 218],
+                              loc: {
+                                start: { column: 4, line: 14 },
+                                end: { column: 8, line: 14 },
+                              },
+                            },
+                            optional: false,
+                            property: PrivateIdentifier {
+                              type: 'PrivateIdentifier',
+                              name: 'a',
+
+                              range: [219, 221],
+                              loc: {
+                                start: { column: 9, line: 14 },
+                                end: { column: 11, line: 14 },
+                              },
+                            },
+
+                            range: [214, 221],
+                            loc: {
+                              start: { column: 4, line: 14 },
+                              end: { column: 11, line: 14 },
+                            },
+                          },
+
+                          range: [214, 222],
+                          loc: {
+                            start: { column: 4, line: 14 },
+                            end: { column: 12, line: 14 },
+                          },
+                        },
+                        operator: '++',
+                        prefix: false,
+
+                        range: [214, 224],
+                        loc: {
+                          start: { column: 4, line: 14 },
+                          end: { column: 14, line: 14 },
+                        },
+                      },
+
+                      range: [214, 225],
+                      loc: {
+                        start: { column: 4, line: 14 },
+                        end: { column: 15, line: 14 },
+                      },
+                    },
                   ],
 
-                  range: [23, 213],
+                  range: [23, 229],
                   loc: {
                     start: { column: 6, line: 4 },
-                    end: { column: 3, line: 14 },
+                    end: { column: 3, line: 15 },
                   },
                 },
 -               declare: false,
@@ -565,25 +624,25 @@ exports[`AST Fixtures expression UpdateExpression valid-assignment AST Alignment
                 id: null,
                 params: Array [],
 
-                range: [20, 213],
+                range: [20, 229],
                 loc: {
                   start: { column: 3, line: 4 },
-                  end: { column: 3, line: 14 },
+                  end: { column: 3, line: 15 },
                 },
               },
 
-              range: [19, 213],
+              range: [19, 229],
               loc: {
                 start: { column: 2, line: 4 },
-                end: { column: 3, line: 14 },
+                end: { column: 3, line: 15 },
               },
             },
           ],
 
-          range: [8, 215],
+          range: [8, 231],
           loc: {
             start: { column: 8, line: 1 },
-            end: { column: 1, line: 15 },
+            end: { column: 1, line: 16 },
           },
         },
 -       declare: false,
@@ -603,19 +662,19 @@ exports[`AST Fixtures expression UpdateExpression valid-assignment AST Alignment
 -       implements: Array [],
         superClass: null,
 
-        range: [0, 215],
+        range: [0, 231],
         loc: {
           start: { column: 0, line: 1 },
-          end: { column: 1, line: 15 },
+          end: { column: 1, line: 16 },
         },
       },
     ],
     sourceType: 'script',
 
-    range: [0, 216],
+    range: [0, 232],
     loc: {
       start: { column: 0, line: 1 },
-      end: { column: 0, line: 16 },
+      end: { column: 0, line: 17 },
     },
   }"
 `;

--- a/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/6-AST-Alignment-Tokens.shot
+++ b/packages/ast-spec/src/expression/UpdateExpression/fixtures/valid-assignment/snapshots/6-AST-Alignment-Tokens.shot
@@ -704,24 +704,87 @@ exports[`AST Fixtures expression UpdateExpression valid-assignment AST Alignment
         end: { column: 26, line: 13 },
       },
     },
+    Keyword {
+      type: 'Keyword',
+      value: 'this',
+
+      range: [214, 218],
+      loc: {
+        start: { column: 4, line: 14 },
+        end: { column: 8, line: 14 },
+      },
+    },
     Punctuator {
       type: 'Punctuator',
-      value: '}',
+      value: '.',
 
-      range: [212, 213],
+      range: [218, 219],
       loc: {
-        start: { column: 2, line: 14 },
-        end: { column: 3, line: 14 },
+        start: { column: 8, line: 14 },
+        end: { column: 9, line: 14 },
+      },
+    },
+-   Identifier {
+-     type: 'Identifier',
+-     value: '#a',
++   PrivateIdentifier {
++     type: 'PrivateIdentifier',
++     value: 'a',
+
+      range: [219, 221],
+      loc: {
+        start: { column: 9, line: 14 },
+        end: { column: 11, line: 14 },
+      },
+    },
+    Punctuator {
+      type: 'Punctuator',
+      value: '!',
+
+      range: [221, 222],
+      loc: {
+        start: { column: 11, line: 14 },
+        end: { column: 12, line: 14 },
+      },
+    },
+    Punctuator {
+      type: 'Punctuator',
+      value: '++',
+
+      range: [222, 224],
+      loc: {
+        start: { column: 12, line: 14 },
+        end: { column: 14, line: 14 },
+      },
+    },
+    Punctuator {
+      type: 'Punctuator',
+      value: ';',
+
+      range: [224, 225],
+      loc: {
+        start: { column: 14, line: 14 },
+        end: { column: 15, line: 14 },
       },
     },
     Punctuator {
       type: 'Punctuator',
       value: '}',
 
-      range: [214, 215],
+      range: [228, 229],
       loc: {
-        start: { column: 0, line: 15 },
-        end: { column: 1, line: 15 },
+        start: { column: 2, line: 15 },
+        end: { column: 3, line: 15 },
+      },
+    },
+    Punctuator {
+      type: 'Punctuator',
+      value: '}',
+
+      range: [230, 231],
+      loc: {
+        start: { column: 0, line: 16 },
+        end: { column: 1, line: 16 },
       },
     },
   ]"

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -944,12 +944,14 @@ export function isValidAssignmentTarget(node: ts.Node): boolean {
     case SyntaxKind.TypeAssertionExpression:
     case SyntaxKind.AsExpression:
     case SyntaxKind.SatisfiesExpression:
+    case SyntaxKind.NonNullExpression:
       return isValidAssignmentTarget(
         (
           node as
             | ts.ParenthesizedExpression
             | ts.AssertionExpression
             | ts.SatisfiesExpression
+            | ts.NonNullExpression
         ).expression,
       );
     default:


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8201
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

 I tried to report this issue, but the same issue was already created. #8201 doesn't have an accepting PRS label yet, but I'm raising a PR because I think it's definitely a bug and I want it fixed quickly.
