### PR TITLE
chore: prevent a11y-alt-text-bot workflow when author is a bot

### DIFF
--- a/.github/workflows/a11y-alt-bot.yml
+++ b/.github/workflows/a11y-alt-bot.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   accessibility_alt_text_bot:
     name: Check alt text is set on images
-    if: ${{ ! endsWith(github.actor, '[bot]') }}
+    if: ${{ !endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Get action 'github/accessibility-alt-text-bot'

--- a/.github/workflows/a11y-alt-bot.yml
+++ b/.github/workflows/a11y-alt-bot.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   accessibility_alt_text_bot:
     name: Check alt text is set on images
+    if: ${{ ! endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Get action 'github/accessibility-alt-text-bot'


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8205 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR adds a condition for the `accessibility_alt_text_bot` job to prevent the job from running when the username of the user that triggers the workflow ends with "[bot]".
