### PR TITLE
feat(eslint-plugin): add rule prefer-find

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-find.md
+++ b/packages/eslint-plugin/docs/rules/prefer-find.md
@@ -1,0 +1,29 @@
+---
+description: 'Enforce the use of Array.prototype.find() over Array.prototype.filter() followed by [0] when looking for a single result.'
+---
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/prefer-find** for documentation.
+
+When searching for the first item in an array matching a condition, it may be tempting to use code like `arr.filter(x => x > 0)[0]`. However, it is simpler to use [Array.prototype.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) instead, `arr.find(x => x > 0)`, which also returns the first entry matching a condition.
+
+Beware that the two approaches are not quite identical, however! `.find()` will only execute the callback on array elements until it finds a match, whereas `.filter()` executes the callback for all array elements. Therefore, when fixing errors from this rule, be sure that your `.filter()` callbacks do not have side effects.
+
+<!--tabs-->
+
+### ❌ Incorrect
+
+```ts
+[1, 2, 3].filter(x => x > 1)[0];
+```
+
+### ✅ Correct
+
+```ts
+[1, 2, 3].find(x => x > 1);
+```
+
+## When Not To Use It
+
+If you don't mind `.filter(...)[0]`, you can avoid this rule.

--- a/packages/eslint-plugin/docs/rules/prefer-find.md
+++ b/packages/eslint-plugin/docs/rules/prefer-find.md
@@ -6,9 +6,17 @@ description: 'Enforce the use of Array.prototype.find() over Array.prototype.fil
 >
 > See **https://typescript-eslint.io/rules/prefer-find** for documentation.
 
-When searching for the first item in an array matching a condition, it may be tempting to use code like `arr.filter(x => x > 0)[0]`. However, it is simpler to use [Array.prototype.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) instead, `arr.find(x => x > 0)`, which also returns the first entry matching a condition.
+When searching for the first item in an array matching a condition, it may be tempting to use code like `arr.filter(x => x > 0)[0]`.
+However, it is simpler to use [Array.prototype.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) instead, `arr.find(x => x > 0)`, which also returns the first entry matching a condition.
+Because the `.find()` only needs to execute the callback until it finds a match, it's also more efficient.
 
-Beware that the two approaches are not quite identical, however! `.find()` will only execute the callback on array elements until it finds a match, whereas `.filter()` executes the callback for all array elements. Therefore, when fixing errors from this rule, be sure that your `.filter()` callbacks do not have side effects.
+:::info
+
+Beware the the difference in short-circuiting behavior between the approaches.
+`.find()` will only execute the callback on array elements until it finds a match, whereas `.filter()` executes the callback for all array elements.
+Therefore, when fixing errors from this rule, be sure that your `.filter()` callbacks do not have side effects.
+
+:::
 
 <!--tabs-->
 
@@ -16,6 +24,8 @@ Beware that the two approaches are not quite identical, however! `.find()` will 
 
 ```ts
 [1, 2, 3].filter(x => x > 1)[0];
+
+[1, 2, 3].filter(x => x > 1).at(0);
 ```
 
 ### ✅ Correct
@@ -26,4 +36,4 @@ Beware that the two approaches are not quite identical, however! `.find()` will 
 
 ## When Not To Use It
 
-If you don't mind `.filter(...)[0]`, you can avoid this rule.
+If you intentionally use patterns like `.filter(callback)[0]` to execute side effects in `callback` on all array elements, you will want to avoid this rule.

--- a/packages/eslint-plugin/docs/rules/prefer-find.md
+++ b/packages/eslint-plugin/docs/rules/prefer-find.md
@@ -12,7 +12,7 @@ Because the `.find()` only needs to execute the callback until it finds a match,
 
 :::info
 
-Beware the the difference in short-circuiting behavior between the approaches.
+Beware the difference in short-circuiting behavior between the approaches.
 `.find()` will only execute the callback on array elements until it finds a match, whereas `.filter()` executes the callback for all array elements.
 Therefore, when fixing errors from this rule, be sure that your `.filter()` callbacks do not have side effects.
 

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -118,6 +118,7 @@ export = {
     'prefer-destructuring': 'off',
     '@typescript-eslint/prefer-destructuring': 'error',
     '@typescript-eslint/prefer-enum-initializers': 'error',
+    '@typescript-eslint/prefer-find': 'error',
     '@typescript-eslint/prefer-for-of': 'error',
     '@typescript-eslint/prefer-function-type': 'error',
     '@typescript-eslint/prefer-includes': 'error',

--- a/packages/eslint-plugin/src/configs/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/disable-type-checked.ts
@@ -38,6 +38,7 @@ export = {
     '@typescript-eslint/no-useless-template-literals': 'off',
     '@typescript-eslint/non-nullable-type-assertion-style': 'off',
     '@typescript-eslint/prefer-destructuring': 'off',
+    '@typescript-eslint/prefer-find': 'off',
     '@typescript-eslint/prefer-includes': 'off',
     '@typescript-eslint/prefer-nullish-coalescing': 'off',
     '@typescript-eslint/prefer-optional-chain': 'off',

--- a/packages/eslint-plugin/src/configs/stylistic-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/stylistic-type-checked.ts
@@ -24,6 +24,7 @@ export = {
     '@typescript-eslint/no-empty-interface': 'error',
     '@typescript-eslint/no-inferrable-types': 'error',
     '@typescript-eslint/non-nullable-type-assertion-style': 'error',
+    '@typescript-eslint/prefer-find': 'error',
     '@typescript-eslint/prefer-for-of': 'error',
     '@typescript-eslint/prefer-function-type': 'error',
     '@typescript-eslint/prefer-namespace-keyword': 'error',

--- a/packages/eslint-plugin/src/configs/stylistic-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/stylistic-type-checked.ts
@@ -24,7 +24,6 @@ export = {
     '@typescript-eslint/no-empty-interface': 'error',
     '@typescript-eslint/no-inferrable-types': 'error',
     '@typescript-eslint/non-nullable-type-assertion-style': 'error',
-    '@typescript-eslint/prefer-find': 'error',
     '@typescript-eslint/prefer-for-of': 'error',
     '@typescript-eslint/prefer-function-type': 'error',
     '@typescript-eslint/prefer-namespace-keyword': 'error',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -102,6 +102,7 @@ import parameterProperties from './parameter-properties';
 import preferAsConst from './prefer-as-const';
 import preferDestructuring from './prefer-destructuring';
 import preferEnumInitializers from './prefer-enum-initializers';
+import preferFind from './prefer-find';
 import preferForOf from './prefer-for-of';
 import preferFunctionType from './prefer-function-type';
 import preferIncludes from './prefer-includes';
@@ -241,6 +242,7 @@ export default {
   'prefer-as-const': preferAsConst,
   'prefer-destructuring': preferDestructuring,
   'prefer-enum-initializers': preferEnumInitializers,
+  'prefer-find': preferFind,
   'prefer-for-of': preferForOf,
   'prefer-function-type': preferFunctionType,
   'prefer-includes': preferIncludes,

--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -1,0 +1,110 @@
+import type { TSESLint } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+
+import { createRule, getParserServices } from '../util';
+
+export default createRule({
+  name: 'prefer-find',
+  meta: {
+    docs: {
+      description:
+        'Enforce the use of Array.prototype.find() over Array.prototype.filter() followed by [0] when looking for a single result',
+      requiresTypeChecking: true,
+      recommended: 'stylistic',
+    },
+    fixable: 'code',
+    messages: {
+      preferFind: 'Use .filter(...)[0] instead of .find(...)',
+      preferFindFix: 'Use .filter(...)[0] instead of .find(...)',
+    },
+    schema: [],
+    type: 'suggestion',
+    hasSuggestions: true,
+  },
+
+  defaultOptions: [],
+
+  create(context) {
+    const services = getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    return {
+      MemberExpression(node): void {
+        // Check if it looks like <<stuff>>[0] or <<stuff>>['0'], but not <<stuff>>?.[0]
+        if (
+          node.computed &&
+          !node.optional &&
+          node.property.type === AST_NODE_TYPES.Literal &&
+          (node.property.value === 0 ||
+            node.property.value === '0' ||
+            node.property.value === 0n)
+        ) {
+          // Check if it looks like <<stuff>>(...)[0], but not <<stuff>>?.(...)[0]
+          if (
+            node.object.type === AST_NODE_TYPES.CallExpression &&
+            !node.object.optional
+          ) {
+            const objectCallee = node.object.callee;
+            // Check if it looks like <<stuff>>.filter(...)[0] or <<stuff>>['filter'](...)[0],
+            // or the optional chaining variants.
+            if (objectCallee.type === AST_NODE_TYPES.MemberExpression) {
+              const isBracketSyntaxForFilter = objectCallee.computed;
+              if (
+                isBracketSyntaxForFilter
+                  ? objectCallee.property.type === AST_NODE_TYPES.Literal &&
+                    objectCallee.property.value === 'filter'
+                  : objectCallee.property.name === 'filter'
+              ) {
+                const isOptionalAccessOfFilter = objectCallee.optional;
+
+                const filteredObjectType = checker.getTypeAtLocation(
+                  services.esTreeNodeToTSNodeMap.get(objectCallee.object),
+                );
+
+                // We can now report if the object is an array
+                // or if it's an optional chain on a nullable array.
+                if (
+                  checker.isArrayType(filteredObjectType) ||
+                  (isOptionalAccessOfFilter &&
+                    tsutils
+                      .unionTypeParts(filteredObjectType)
+                      .every(
+                        unionPart =>
+                          checker.isArrayType(unionPart) ||
+                          tsutils.isIntrinsicNullType(unionPart) ||
+                          tsutils.isIntrinsicUndefinedType(unionPart),
+                      ))
+                ) {
+                  context.report({
+                    node,
+                    messageId: 'preferFind',
+                    suggest: [
+                      {
+                        messageId: 'preferFindFix',
+                        fix(fixer): TSESLint.RuleFix[] {
+                          return [
+                            // Replace .filter with .find
+                            fixer.replaceText(
+                              objectCallee.property,
+                              isBracketSyntaxForFilter ? '"find"' : 'find',
+                            ),
+                            // Get rid of the [0]
+                            fixer.removeRange([
+                              node.object.range[1],
+                              node.range[1],
+                            ]),
+                          ];
+                        },
+                      },
+                    ],
+                  });
+                }
+              }
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -138,6 +138,10 @@ export default createRule({
       return undefined;
     }
 
+    /**
+     * Implements the algorithm for array indexing by `.at()` method.
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at#parameters
+     */
     function isTreatedAsZeroByArrayAt(value: unknown): boolean {
       const asNumber = Number(value);
 
@@ -160,6 +164,10 @@ export default createRule({
       );
     }
 
+    /**
+     * Implements the algorithm for array indexing by member operator.
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#array_indices
+     */
     function isTreatedAsZeroByMemberAccess(value: unknown): boolean {
       return String(value) === '0';
     }

--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -9,10 +9,6 @@ import type {
 import * as tsutils from 'ts-api-utils';
 import type { Type } from 'typescript';
 
-import type {
-  MemberExpressionComputedName,
-  MemberExpressionNonComputedName,
-} from '../../../types/src/generated/ast-spec';
 import {
   createRule,
   getConstrainedTypeAtLocation,
@@ -84,8 +80,8 @@ export default createRule({
               callee.object,
             );
 
-            // As long as the object is an array or an optional chain on a
-            // nullable array, this is an Array.prototype.filter expression.
+            // As long as the object is a (possibly nullable) array,
+            // this is an Array.prototype.filter expression.
             if (isArrayish(filteredObjectType)) {
               return {
                 isBracketSyntaxForFilter,
@@ -297,8 +293,8 @@ export default createRule({
  */
 function isStaticMemberAccessOfValue(
   memberExpression:
-    | MemberExpressionComputedName
-    | MemberExpressionNonComputedName,
+    | TSESTree.MemberExpressionComputedName
+    | TSESTree.MemberExpressionNonComputedName,
   value: string,
   scope?: Scope.Scope | undefined,
 ): boolean {

--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -179,11 +179,12 @@ export default createRule({
       sourceCode: SourceCode,
     ): RuleFix {
       const tokenToStartDeletingFrom = nullThrows(
-        sourceCode.getTokenAfter(arrayNode, {
-          // The next `.` or `[` is what we're looking for.
-          // think of (...).at(0) or (...)[0] or even (...)["at"](0).
-          filter: token => token.value === '.' || token.value === '[',
-        }),
+        // The next `.` or `[` is what we're looking for.
+        // think of (...).at(0) or (...)[0] or even (...)["at"](0).
+        sourceCode.getTokenAfter(
+          arrayNode,
+          token => token.value === '.' || token.value === '[',
+        ),
         'Expected to find a member access token!',
       );
       return fixer.removeRange([

--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -173,6 +173,19 @@ export default createRule({
       ]);
     }
 
+    function generateFixToReplaceFilterWithFind(
+      fixer: TSESLint.RuleFixer,
+      filterExpression: {
+        isBracketSyntaxForFilter: boolean;
+        filterNode: TSESTree.Node;
+      },
+    ): TSESLint.RuleFix {
+      return fixer.replaceText(
+        filterExpression.filterNode,
+        filterExpression.isBracketSyntaxForFilter ? '"find"' : 'find',
+      );
+    }
+
     return {
       CallExpression(node): void {
         const object = getObjectIfArrayAtExpression(node);
@@ -188,11 +201,9 @@ export default createRule({
                   fix(fixer): TSESLint.RuleFix[] {
                     const sourceCode = getSourceCode(context);
                     return [
-                      fixer.replaceText(
-                        filterExpression.filterNode,
-                        filterExpression.isBracketSyntaxForFilter
-                          ? '"find"'
-                          : 'find',
+                      generateFixToReplaceFilterWithFind(
+                        fixer,
+                        filterExpression,
                       ),
                       // get rid of the .at(0) or ['at'](0)
                       generateFixToRemoveArrayElementAccess(
@@ -217,8 +228,8 @@ export default createRule({
       ): void {
         if (isMemberAccessOfZero(node)) {
           const object = node.object;
-          const parsedFilterExpression = parseIfArrayFilterExpression(object);
-          if (parsedFilterExpression) {
+          const filterExpression = parseIfArrayFilterExpression(object);
+          if (filterExpression) {
             context.report({
               node,
               messageId: 'preferFind',
@@ -229,12 +240,9 @@ export default createRule({
                     const sourceCode = context.sourceCode;
 
                     return [
-                      // Replace .filter with .find
-                      fixer.replaceText(
-                        parsedFilterExpression.filterNode,
-                        parsedFilterExpression.isBracketSyntaxForFilter
-                          ? '"find"'
-                          : 'find',
+                      generateFixToReplaceFilterWithFind(
+                        fixer,
+                        filterExpression,
                       ),
                       // Get rid of the [0]
                       generateFixToRemoveArrayElementAccess(

--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -22,8 +22,8 @@ export default createRule({
       requiresTypeChecking: true,
     },
     messages: {
-      preferFind: 'Use .filter(...)[0] instead of .find(...)',
-      preferFindSuggestion: 'Use .filter(...)[0] instead of .find(...)',
+      preferFind: 'Use .find(...) instead of .filter(...)[0]',
+      preferFindSuggestion: 'Use .find(...) instead of .filter(...)[0]',
     },
     schema: [],
     type: 'suggestion',

--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -218,7 +218,7 @@ export default createRule({
               suggest: [
                 {
                   messageId: 'preferFindSuggestion',
-                  fix(fixer): TSESLint.RuleFix[] {
+                  fix: (fixer): TSESLint.RuleFix[] => {
                     const sourceCode = getSourceCode(context);
                     return [
                       generateFixToReplaceFilterWithFind(
@@ -256,9 +256,8 @@ export default createRule({
               suggest: [
                 {
                   messageId: 'preferFindSuggestion',
-                  fix(fixer): TSESLint.RuleFix[] {
+                  fix: (fixer): TSESLint.RuleFix[] => {
                     const sourceCode = context.sourceCode;
-
                     return [
                       generateFixToReplaceFilterWithFind(
                         fixer,

--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -77,8 +77,8 @@ export default createRule({
               callee.object,
             );
 
-            // We can now report if the object is an array
-            // or if it's an optional chain on a nullable array.
+            // As long as the object is an array or an optional chain on a
+            // nullable array, this is an Array.prototype.filter expression.
             if (
               checker.isArrayType(filteredObjectType) ||
               checker.isTupleType(filteredObjectType) ||
@@ -153,10 +153,10 @@ export default createRule({
       return String(value) === '0';
     }
 
-    function generateFixToRemoveArrayAccess(
+    function generateFixToRemoveArrayElementAccess(
       fixer: TSESLint.RuleFixer,
-      arrayNode: TSESTree.Node,
-      wholeExpressionBeingFlagged: TSESTree.Node,
+      arrayNode: TSESTree.Expression,
+      wholeExpressionBeingFlagged: TSESTree.Expression,
       sourceCode: SourceCode,
     ): RuleFix {
       const tokenToStartDeletingFrom = nullThrows(
@@ -195,7 +195,7 @@ export default createRule({
                           : 'find',
                       ),
                       // get rid of the .at(0) or ['at'](0)
-                      generateFixToRemoveArrayAccess(
+                      generateFixToRemoveArrayElementAccess(
                         fixer,
                         object,
                         node,
@@ -237,7 +237,7 @@ export default createRule({
                           : 'find',
                       ),
                       // Get rid of the [0]
-                      generateFixToRemoveArrayAccess(
+                      generateFixToRemoveArrayElementAccess(
                         fixer,
                         object,
                         node,

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -54,6 +54,8 @@ ruleTester.run('prefer-find', rule, {
     `,
     "['Just', 'a', 'filter'].filter(x => x.length > 4);",
     "['Just', 'a', 'find'].find(x => x.length > 4);",
+    'undefined.filter(x => x)[0];',
+    'null?.filter(x => x)[0];',
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -495,5 +495,38 @@ function actingOnArray<T extends string[]>(values: T) {
         },
       ],
     },
+    {
+      code: `
+const nestedSequenceAbomination =
+  (1,
+  2,
+  (1,
+  2,
+  3,
+  (1, 2, 3, 4),
+  (1, 2, 3, 4, 5, [1, 2, 3, 4, 5, 6].filter(x => x % 2 == 0)))['0']);
+      `,
+      errors: [
+        {
+          line: 5,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindSuggestion',
+              output: `
+const nestedSequenceAbomination =
+  (1,
+  2,
+  (1,
+  2,
+  3,
+  (1, 2, 3, 4),
+  (1, 2, 3, 4, 5, [1, 2, 3, 4, 5, 6].find(x => x % 2 == 0))));
+      `,
+            },
+          ],
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -22,7 +22,7 @@ ruleTester.run('prefer-find', rule, {
 
       declare const jerkCode: JerkCode<string>;
 
-      jerkCode.filter(item => item === 'aha');
+      jerkCode.filter(item => item === 'aha')[0];
     `,
     `
       declare const arr: readonly string[];

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -1,0 +1,176 @@
+import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
+
+import rule from '../../src/rules/prefer-find';
+import { getFixturesRootDir } from '../RuleTester';
+
+const rootDir = getFixturesRootDir();
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    tsconfigRootDir: rootDir,
+    project: './tsconfig.json',
+  },
+});
+
+ruleTester.run('prefer-find', rule, {
+  valid: [
+    `
+      interface JerkCode<T> {
+        filter(predicate: (item: T) => boolean): JerkCode<T>;
+      }
+
+      declare const jerkCode: JerkCode<string>;
+
+      jerkCode.filter(item => item === 'aha');
+    `,
+    `
+      declare const notNecessarilyAnArray: unknown[] | undefined | null | string;
+      notNecessarilyAnArray?.filter(item => true)[0];
+    `,
+    // Be sure that we don't try to mess with this case, where the member access
+    // is not directly occurring on the result of the filter call due to optional
+    // chaining.
+    '([]?.filter(f))[0];',
+    // Be sure that we don't try to mess with this case, since the member access
+    // should not need to be optional for the cases the rule is concerned with.
+    '[].filter(() => true)?.[0];',
+    // Be sure that we don't try to mess with this case, since the function call
+    // should not need to be optional for the cases the rule is concerned with.
+    '[].filter?.(() => true)[0];',
+  ],
+
+  invalid: [
+    {
+      code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha')[0];
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindFix',
+              output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha')['0'];
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindFix',
+              output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const arr: string[];
+arr.filter(item => item === 'aha')[0n];
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindFix',
+              output: `
+declare const arr: string[];
+arr.find(item => item === 'aha');
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'const two = [1, 2, 3].filter(item => item === 2)[0];',
+      errors: [
+        {
+          line: 1,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindFix',
+              output: `const two = [1, 2, 3].find(item => item === 2);`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: noFormat`(([] as unknown[]))["filter"] ((item) => { return item === 2 }  ) [ 0  ] ;`,
+      errors: [
+        {
+          line: 1,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindFix',
+              output:
+                '(([] as unknown[]))["find"] ((item) => { return item === 2 }  ) ;',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: noFormat`(([] as unknown[]))?.["filter"] ((item) => { return item === 2 }  ) [ 0  ] ;`,
+      errors: [
+        {
+          line: 1,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindFix',
+              output:
+                '(([] as unknown[]))?.["find"] ((item) => { return item === 2 }  ) ;',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const nullableArray: unknown[] | undefined | null;
+nullableArray?.filter(item => true)[0];
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindFix',
+              output: `
+declare const nullableArray: unknown[] | undefined | null;
+nullableArray?.find(item => true);
+      `,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -528,5 +528,47 @@ const nestedSequenceAbomination =
         },
       ],
     },
+    {
+      code: `
+declare const arr: { a: 1 }[] & { b: 2 }[];
+arr.filter(f, thisArg)[0];
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindSuggestion',
+              output: `
+declare const arr: { a: 1 }[] & { b: 2 }[];
+arr.find(f, thisArg);
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const arr: { a: 1 }[] & ({ b: 2 }[] | { c: 3 }[]);
+arr.filter(f, thisArg)[0];
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindSuggestion',
+              output: `
+declare const arr: { a: 1 }[] & ({ b: 2 }[] | { c: 3 }[]);
+arr.find(f, thisArg);
+      `,
+            },
+          ],
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -105,6 +105,52 @@ arr.find(item => item === 'aha');
     },
     {
       code: `
+declare const arr: Array<string>;
+const zero = 0n;
+arr.filter(item => item === 'aha')[zero];
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindSuggestion',
+              output: `
+declare const arr: Array<string>;
+const zero = 0n;
+arr.find(item => item === 'aha');
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const arr: Array<string>;
+const zero = -0n;
+arr.filter(item => item === 'aha')[zero];
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindSuggestion',
+              output: `
+declare const arr: Array<string>;
+const zero = -0n;
+arr.find(item => item === 'aha');
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
 declare const arr: readonly string[];
 arr.filter(item => item === 'aha').at(0);
       `,

--- a/packages/eslint-plugin/tests/schema-snapshots/prefer-find.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/prefer-find.shot
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rule schemas should be convertible to TS types for documentation purposes prefer-find 1`] = `
+"
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];"
+`;

--- a/packages/utils/src/eslint-utils/nullThrows.ts
+++ b/packages/utils/src/eslint-utils/nullThrows.ts
@@ -19,7 +19,6 @@ function nullThrows<T>(value: T, message: string): NonNullable<T> {
   // so ignore it in coverage metrics.
   /* istanbul ignore if */
   if (value == null) {
-    console.error(`Non-null Assertion Failed: ${message}`);
     throw new Error(`Non-null Assertion Failed: ${message}`);
   }
 

--- a/packages/utils/src/eslint-utils/nullThrows.ts
+++ b/packages/utils/src/eslint-utils/nullThrows.ts
@@ -11,7 +11,7 @@ const NullThrowsReasons = {
  * Assert that a value must not be null or undefined.
  * This is a nice explicit alternative to the non-null assertion operator.
  */
-function nullThrows<T>(value: T | null | undefined, message: string): T {
+function nullThrows<T>(value: T, message: string): NonNullable<T> {
   // this function is primarily used to keep types happy in a safe way
   // i.e. is used when we expect that a value is never nullish
   // this means that it's pretty much impossible to test the below if...
@@ -19,6 +19,7 @@ function nullThrows<T>(value: T | null | undefined, message: string): T {
   // so ignore it in coverage metrics.
   /* istanbul ignore if */
   if (value == null) {
+    console.error(`Non-null Assertion Failed: ${message}`);
     throw new Error(`Non-null Assertion Failed: ${message}`);
   }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6886 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a rule that prefers `arr.find(...)` over `arr.filter(...)[0]`. Also adds the corresponding autofix as suggestions.