### PR TITLE
chore: fix yargs call in release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@types/node": "^20.0.0",
     "@types/semver": "^7.5.0",
     "@types/tmp": "^0.2.3",
+    "@types/yargs": "^17.0.32",
     "console-fail-test": "^0.2.3",
     "cross-fetch": "^4.0.0",
     "cspell": "^7.0.0",

--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -6,7 +6,7 @@ import {
 } from 'nx/src/command-line/release';
 import yargs from 'yargs';
 
-const options = await yargs
+const options = await yargs(process.argv.slice(2))
   .version(false)
   .option('version', {
     description:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5185,12 +5185,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.8":
-  version: 17.0.24
-  resolution: "@types/yargs@npm:17.0.24"
+"@types/yargs@npm:^17.0.32, @types/yargs@npm:^17.0.8":
+  version: 17.0.32
+  resolution: "@types/yargs@npm:17.0.32"
   dependencies:
     "@types/yargs-parser": "*"
-  checksum: 5f3ac4dc4f6e211c1627340160fbe2fd247ceba002190da6cf9155af1798450501d628c9165a183f30a224fc68fa5e700490d740ff4c73e2cdef95bc4e8ba7bf
+  checksum: 4505bdebe8716ff383640c6e928f855b5d337cb3c68c81f7249fc6b983d0aa48de3eee26062b84f37e0d75a5797bc745e0c6e76f42f81771252a758c638f36ba
   languageName: node
   linkType: hard
 
@@ -5472,6 +5472,7 @@ __metadata:
     "@types/node": ^20.0.0
     "@types/semver": ^7.5.0
     "@types/tmp": ^0.2.3
+    "@types/yargs": ^17.0.32
     console-fail-test: ^0.2.3
     cross-fetch: ^4.0.0
     cspell: ^7.0.0


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8220
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Switches it to `yargs(process.argv.slice(2)` per https://yargs.js.org/docs/#api-reference.