### PR TITLE
docs: underline URLs

### DIFF
--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -191,3 +191,17 @@ h6 {
 [data-theme='dark'] .code-block-added-line {
   background-color: #00ff9510;
 }
+
+a {
+  text-decoration: underline;
+}
+
+/*Removes underlines from table of contents, menu (left hand sidebar),
+edit this page button, and footer links (github, twitter, etc) respectfully*/
+a.table-of-contents__link,
+a.pagination-nav__link,
+a.menu__link,
+a.theme-edit-this-page,
+footer * {
+  text-decoration: none;
+}

--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -196,8 +196,9 @@ a {
   text-decoration: underline;
 }
 
-/*Removes underlines from table of contents, menu (left hand sidebar),
-edit this page button, and footer links (github, twitter, etc) respectfully*/
+/*Removes underlines from table of contents, next page button,
+menu (left hand sidebar), edit this page button,
+and footer links (github, twitter, etc) respectfully*/
 a.table-of-contents__link,
 a.pagination-nav__link,
 a.menu__link,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8214 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
Updated CSS to add underlines to URLs and added another rule to remove underlines from the table of contents, next page buttons, edit page button, and menu sidebars along with the social media links in the footer (as they can be distinguished with the external link icon).