### PR TITLE
docs: force space after await in no-floating-promises snippet

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-floating-promises.md
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.md
@@ -98,8 +98,9 @@ This allows you to skip checking of async IIFEs (Immediately Invoked function Ex
 
 Examples of **correct** code for this rule with `{ ignoreIIFE: true }`:
 
+<!-- prettier-ignore -->
 ```ts option='{ "ignoreIIFE": true }' showPlaygroundButton
-await(async function () {
+await (async function () {
   await res(1);
 })();
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: No - docs PR.
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22) - No - docs PR
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This just tweaks the formatting for a code snippet as it appears on the rule site. 
Addresses https://github.com/typescript-eslint/typescript-eslint/pull/1799/files#r399829282. 
Workaround for https://github.com/prettier/prettier/issues/6608.
