### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] fix false positive for type variable

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -271,7 +271,10 @@ export default createRule<Options, MessageId>({
       if (
         isTypeFlagSet(
           type,
-          ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.TypeParameter,
+          ts.TypeFlags.Any |
+            ts.TypeFlags.Unknown |
+            ts.TypeFlags.TypeParameter |
+            ts.TypeFlags.TypeVariable,
         )
       ) {
         return;
@@ -345,7 +348,8 @@ export default createRule<Options, MessageId>({
           flag |=
             ts.TypeFlags.Any |
             ts.TypeFlags.Unknown |
-            ts.TypeFlags.TypeParameter;
+            ts.TypeFlags.TypeParameter |
+            ts.TypeFlags.TypeVariable;
 
           // Allow loose comparison to nullish values.
           if (node.operator === '==' || node.operator === '!=') {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -253,6 +253,26 @@ function test<T>(a: T) {
   const t16 = undefined !== a;
 }
     `,
+    `
+function foo<T extends object>(arg: T, key: keyof T): void {
+  const t1 = arg[key] == null;
+  const t2 = null == arg[key];
+  const t3 = arg[key] != null;
+  const t4 = null != arg[key];
+  const t5 = arg[key] == undefined;
+  const t6 = undefined == arg[key];
+  const t7 = arg[key] != undefined;
+  const t8 = undefined != arg[key];
+  const t9 = arg[key] === null;
+  const t10 = null === arg[key];
+  const t11 = arg[key] !== null;
+  const t12 = null !== arg[key];
+  const t13 = arg[key] === undefined;
+  const t14 = undefined === arg[key];
+  const t15 = arg[key] !== undefined;
+  const t16 = undefined !== arg[key];
+}
+    `,
 
     // Predicate functions
     `
@@ -317,6 +337,11 @@ function test<T>(a: T) {
     `
 function test<T extends string | null>(a: T) {
   return a ?? 'default';
+}
+    `,
+    `
+function foo<T extends object>(arg: T, key: keyof T): void {
+  arg[key] ?? 'default';
 }
     `,
     // Indexing cases
@@ -741,6 +766,13 @@ foo ||= 1;
 declare let foo: number;
 foo &&= 1;
     `,
+    `
+function foo<T extends object>(arg: T, key: keyof T): void {
+  arg[key] ??= 'default';
+  arg[key] ||= 'default';
+  arg[key] &&= 'default';
+}
+    `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/6264
     `
 function get<Obj, Key extends keyof Obj>(obj: Obj, key: Key) {
@@ -1084,7 +1116,14 @@ function test(a: never) {
       `,
       errors: [ruleError(3, 10, 'never')],
     },
-
+    {
+      code: `
+function test<T extends { foo: number }, K extends 'foo'>(num: T[K]) {
+  num ?? 'default';
+}
+      `,
+      errors: [ruleError(3, 3, 'neverNullish')],
+    },
     // Predicate functions
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -255,22 +255,7 @@ function test<T>(a: T) {
     `,
     `
 function foo<T extends object>(arg: T, key: keyof T): void {
-  const t1 = arg[key] == null;
-  const t2 = null == arg[key];
-  const t3 = arg[key] != null;
-  const t4 = null != arg[key];
-  const t5 = arg[key] == undefined;
-  const t6 = undefined == arg[key];
-  const t7 = arg[key] != undefined;
-  const t8 = undefined != arg[key];
-  const t9 = arg[key] === null;
-  const t10 = null === arg[key];
-  const t11 = arg[key] !== null;
-  const t12 = null !== arg[key];
-  const t13 = arg[key] === undefined;
-  const t14 = undefined === arg[key];
-  const t15 = arg[key] !== undefined;
-  const t16 = undefined !== arg[key];
+  arg[key] == null;
 }
     `,
 
@@ -769,8 +754,6 @@ foo &&= 1;
     `
 function foo<T extends object>(arg: T, key: keyof T): void {
   arg[key] ??= 'default';
-  arg[key] ||= 'default';
-  arg[key] &&= 'default';
 }
     `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/6264


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7850
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
Fix the following false positive cases.
- [demo](https://typescript-eslint.io/play/#ts=5.2.2&showAST=types&fileType=.ts&code=GYVwdgxgLglg9mABMOcA8AVRBTAHlbMAEwGdE4AjAK22gD4AKAKEUQEMAnAcwC5EMANC0QBrbAE8%2BY8XGD8mASj4A3ODCKIA3sIgISURFACMiALztuAbWkBdM%2BbAgANk4DcOvQagAmM4kcu9hZc1hI27qy6YPqGAMx%2BnCG2iACEDs5uHtFeACx%2BAU6p5omh4uFZMVAArAlWyabm4ETYwDBg2EQRiFGVAGx%2BTS1tHUEltl09XgDstUlhRYiDre2dFV4AHAPEQysLY2ETnoYAnLOldg3pLofZhkYADPkZ9sV1B2t3Jq9zZUVXmZEjsZfP8-sFzjdKkZ4t9zi9Fttlh1IV4jHlGojhhpLuDxh9jDVYck0hjmkjVoDbsZ%2BqSdiMSbj3qx9r8APysxAAcjJbGcUE5XRZdnZ5m5LV5Tn5grevwAPrLRTy%2BQKmABfJhAA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1tiacTJTIAhtEK0yHJgBNK%2BSpPRRE0aB2iRwYAL4gtQA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eFYDArugDTg10NM8AOXapUAYQAW6aAGsylDt160isAKpF2JdABMACgENMh%2BOjxYFYAGaHUOnjShrN2vQBlY0O1dv3lTpAuRNDScnoAkkS66AAeegCC0NDoJFZKvAC%2BIJlAA&tokens=false)

```ts
function foo<T extends object>(
  arg: T,
  key: keyof T
): void {
  const t1 = arg[key] == null;
  const t2 = null == arg[key];
  const t3 = arg[key] != null;
  const t4 = null != arg[key];
  const t5 = arg[key] == undefined;
  const t6 = undefined == arg[key];
  const t7 = arg[key] != undefined;
  const t8 = undefined != arg[key];
  const t9 = arg[key] === null;
  const t10 = null === arg[key];
  const t11 = arg[key] !== null;
  const t12 = null !== arg[key];
  const t13 = arg[key] === undefined;
  const t14 = undefined === arg[key];
  const t15 = arg[key] !== undefined;
  const t16 = undefined !== arg[key];
  arg[key] ?? 'default';
  arg[key] ??= 'default';
  arg[key] ||= 'default';
}

```

<!-- Description of what is changed and how the code change does that. -->

