### PR TITLE
fix(type-utils): preventing isUnsafeAssignment infinite recursive calls

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts
@@ -92,6 +92,19 @@ toHaveBeenCalledWith(1 as any);
 declare function acceptsMap(arg: Map<string, string>): void;
 acceptsMap(new Map());
     `,
+    `
+type T = [number, T[]];
+declare function foo(t: T): void;
+declare const t: T;
+
+foo(t);
+    `,
+    `
+type T = Array<T>;
+declare function foo<T>(t: T): T;
+const t: T = [];
+foo(t);
+    `,
   ],
   invalid: [
     {
@@ -348,6 +361,26 @@ foo('a', 1 as any, 'a' as any, 1 as any);
           data: {
             sender: 'any',
             receiver: 'string',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+type T = [number, T[]];
+declare function foo(t: T): void;
+declare const t: T;
+foo(t as any);
+      `,
+      errors: [
+        {
+          messageId: 'unsafeArgument',
+          line: 5,
+          column: 5,
+          endColumn: 13,
+          data: {
+            sender: 'any',
+            receiver: 'T',
           },
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-unsafe-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-assignment.test.ts
@@ -114,6 +114,10 @@ class Foo {
     'const x: { y: number } = { y: 1 };',
     'const x = [...[1, 2, 3]];',
     'const [{ [`x${1}`]: x }] = [{ [`x`]: 1 }] as [{ [`x`]: any }];',
+    `
+type T = [string, T[]];
+const test: T = ['string', []] as T;
+    `,
     {
       code: `
 type Props = { a: string };
@@ -368,6 +372,20 @@ function foo() {
           line: 3,
           column: 9,
           endColumn: 19,
+        },
+      ],
+    },
+    {
+      code: `
+type T = [string, T[]];
+const test: T = ['string', []] as any;
+      `,
+      errors: [
+        {
+          messageId: 'anyAssignment',
+          line: 3,
+          column: 7,
+          endColumn: 38,
         },
       ],
     },

--- a/packages/type-utils/src/isUnsafeAssignment.ts
+++ b/packages/type-utils/src/isUnsafeAssignment.ts
@@ -20,7 +20,22 @@ export function isUnsafeAssignment(
   receiver: ts.Type,
   checker: ts.TypeChecker,
   senderNode: TSESTree.Node | null,
-  visited = new Map<ts.Type, Set<ts.Type>>(),
+): false | { sender: ts.Type; receiver: ts.Type } {
+  return isUnsafeAssignmentWorker(
+    type,
+    receiver,
+    checker,
+    senderNode,
+    new Map(),
+  );
+}
+
+function isUnsafeAssignmentWorker(
+  type: ts.Type,
+  receiver: ts.Type,
+  checker: ts.TypeChecker,
+  senderNode: TSESTree.Node | null,
+  visited: Map<ts.Type, Set<ts.Type>>,
 ): false | { sender: ts.Type; receiver: ts.Type } {
   if (isTypeAnyType(type)) {
     // Allow assignment of any ==> unknown.
@@ -84,7 +99,7 @@ export function isUnsafeAssignment(
       const arg = typeArguments[i];
       const receiverArg = receiverTypeArguments[i];
 
-      const unsafe = isUnsafeAssignment(
+      const unsafe = isUnsafeAssignmentWorker(
         arg,
         receiverArg,
         checker,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7298, fixes #5014
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR prevents infinite recursive calls to `isUnsafeAssignment` for code with circular references.

`no-unsafe-argument` ( #7298, #5014)

[playground](https://typescript-eslint.io/play/#ts=5.1.6&fileType=.tsx&code=C4TwDgpgBAKlC8UDaA7ArgWwEYQE4BpYkBdYgbgCgATCAYwBsBDXaAMzRVuAEsB7FKK168AFMABcsAJSSAbr25VKNBs2i1%2BAZ2BQJsShSGjgUykA&eslintrc=N4KABGBEAOCGBOBnApvSAuKABALgT2mUQGN4BLaHAWiIBsyA7HAejiVUgBpwp4BXWkQxhQECJFwEipCtTqMWDAPZU%2BDRLABmyKggDmfALbImwyKnhK0PAL4gbQA&tsconfig=N4XyA&tokens=false)
```ts
type T = [number, T[]];
declare function foo(t: T): void;
declare const t: T;

foo(t);
```
```
RangeError: Maximum call stack size exceeded
...
```

`no-unsafe-assignment` (unreported issue)

[playground](https://typescript-eslint.io/play/#ts=5.1.6&fileType=.tsx&code=C4TwDgpgBAKlC8UDaBnYAnAlgOwOYBpYkBdYgbgCgBjAe2zSmAjQC5YFkByNLPTwksSgBDFLEpA&eslintrc=N4KABGBEAOCGBOBnApvSAuKABALgT2mUQGN4BLaHAWiIBsyA7HAejiVUgBpwp4BXWkQxhQECJFwEipCtTqMWDAPZU%2BDRLABmyKrESIyAcwYBbZE2GRU8JWh4BfEPaA&tsconfig=N4XyA&tokens=false)
```ts
type T = [string, T[]];
const test: T = ['string', []] as T;
```

```
RangeError: Maximum call stack size exceeded
..
```



<!-- Description of what is changed and how the code change does that. -->
