### PR TITLE
chore: make lint use eslint-plugin outputs as inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -38,11 +38,16 @@
       "cache": true
     },
     "lint": {
+      "dependsOn": ["eslint-plugin:build"],
       "inputs": [
         "default",
         "{workspaceRoot}/.eslintrc.js",
         "{workspaceRoot}/yarn.lock",
-        "{workspaceRoot}/.eslintignore"
+        "{workspaceRoot}/.eslintignore",
+        {
+          "dependentTasksOutputFiles": "**/*.js",
+          "transitive": false
+        }
       ],
       "cache": true
     },

--- a/packages/integration-tests/tools/integration-test-base.ts
+++ b/packages/integration-tests/tools/integration-test-base.ts
@@ -94,6 +94,8 @@ export function integrationTest(testFilename: string, filesGlob: string): void {
               if (stderr.length > 0) {
                 console.error(stderr);
               }
+              // childProcess.ExecFileException is an extension of Error
+              // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
               reject(err);
             } else {
               resolve();

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -49,25 +49,17 @@
     "targets": {
       "copy-ast-spec": {
         "dependsOn": [
-          {
-            "target": "build",
-            "projects": "dependencies"
-          }
+          "^build"
         ],
         "outputs": [
           "{projectRoot}/src/generated"
-        ]
+        ],
+        "cache": true
       },
       "build": {
         "dependsOn": [
-          {
-            "target": "build",
-            "projects": "dependencies"
-          },
-          {
-            "target": "copy-ast-spec",
-            "projects": "self"
-          }
+          "^build",
+          "copy-ast-spec"
         ]
       }
     }


### PR DESCRIPTION
- Adds the `build` of `eslint-plugin` as a dependency of the lint target
- Configures the `inputs` of lint to take the `.js` files of that dependency into account when hashing for cache hits (https://nx.dev/reference/project-configuration#dependent-tasks-output)
- Also makes the `copy-ast-spec` target cacheable and makes its config more succinct