### PR TITLE
docs: add dropping support for Node 14 in the breaking changes of v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,10 +604,10 @@ You can read about our [versioning strategy](https://main--typescript-eslint.net
 * Removes `experimental-utils` - we will no longer update this package and it will be forever frozen at v5.x
 * **eslint-plugin:** Adds an additional class of checks to the rule
 * drop support for ESLint v6
-* drops support for node v17
+* drops support for node v12, v14, and v17
 * **utils:** Removes `meta.docs.suggestion` property
 * Bumps the minimum supported range and removes handling for old versions
-* drops support for node v12
+
 
 You can read about our [versioning strategy](https://main--typescript-eslint.netlify.app/users/versioning) and [releases](https://main--typescript-eslint.netlify.app/users/releases) on our website.
 


### PR DESCRIPTION
Dropping support for Node v14 was missing in the breaking changes section of the changelog file.

None of the checklist items are applicable to this PR.

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
