### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] handle left-hand optional with exactOptionalPropertyTypes option

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -197,6 +197,28 @@ export default createRule<Options, MessageId>({
       );
     }
 
+    function isNullablesMemberExpression(
+      node: TSESTree.MemberExpression,
+    ): boolean {
+      const objectType = services.getTypeAtLocation(node.object);
+      if (node.computed) {
+        const propertyType = services.getTypeAtLocation(node.property);
+        return isNullablePropertyType(objectType, propertyType);
+      }
+      const property = node.property;
+
+      if (property.type === AST_NODE_TYPES.Identifier) {
+        const propertyType = objectType.getProperty(property.name);
+        if (
+          propertyType &&
+          tsutils.isSymbolFlagSet(propertyType, ts.SymbolFlags.Optional)
+        ) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     /**
      * Checks if a conditional node is necessary:
      * if the type of the node is always true or always false, it's not necessary.
@@ -283,7 +305,13 @@ export default createRule<Options, MessageId>({
       let messageId: MessageId | null = null;
       if (isTypeFlagSet(type, ts.TypeFlags.Never)) {
         messageId = 'never';
-      } else if (!isPossiblyNullish(type)) {
+      } else if (
+        !isPossiblyNullish(type) &&
+        !(
+          node.type === AST_NODE_TYPES.MemberExpression &&
+          isNullablesMemberExpression(node)
+        )
+      ) {
         // Since typescript array index signature types don't represent the
         //  possibility of out-of-bounds access, if we're indexing into an array
         //  just skip the check, to avoid false positives

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -197,7 +197,7 @@ export default createRule<Options, MessageId>({
       );
     }
 
-    function isNullablesMemberExpression(
+    function isNullableMemberExpression(
       node: TSESTree.MemberExpression,
     ): boolean {
       const objectType = services.getTypeAtLocation(node.object);
@@ -309,7 +309,7 @@ export default createRule<Options, MessageId>({
         !isPossiblyNullish(type) &&
         !(
           node.type === AST_NODE_TYPES.MemberExpression &&
-          isNullablesMemberExpression(node)
+          isNullableMemberExpression(node)
         )
       ) {
         // Since typescript array index signature types don't represent the

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.exactOptionalPropertyTypes.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.exactOptionalPropertyTypes.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  }
+}

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -22,6 +22,11 @@ const ruleTester = new RuleTester({
   },
 });
 
+const optionsWithExactOptionalPropertyTypes = {
+  tsconfigRootDir: rootPath,
+  project: './tsconfig.exactOptionalPropertyTypes.json',
+};
+
 const ruleError = (
   line: number,
   column: number,
@@ -747,6 +752,48 @@ foo ??= 1;
 declare let foo: number;
 foo ||= 1;
     `,
+    `
+declare const foo: { bar: { baz?: number; qux: number } };
+type Key = 'baz' | 'qux';
+declare const key: Key;
+foo.bar[key] ??= 1;
+    `,
+    `
+enum Keys {
+  A = 'A',
+  B = 'B',
+}
+type Foo = {
+  [Keys.A]: number | null;
+  [Keys.B]: number;
+};
+declare const foo: Foo;
+declare const key: Keys;
+foo[key] ??= 1;
+    `,
+    {
+      code: `
+declare const foo: { bar?: number };
+foo.bar ??= 1;
+      `,
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+    },
+    {
+      code: `
+declare const foo: { bar: { baz?: number } };
+foo['bar'].baz ??= 1;
+      `,
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+    },
+    {
+      code: `
+declare const foo: { bar: { baz?: number; qux: number } };
+type Key = 'baz' | 'qux';
+declare const key: Key;
+foo.bar[key] ??= 1;
+      `,
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+    },
     `
 declare let foo: number;
 foo &&= 1;
@@ -2032,6 +2079,22 @@ foo &&= null;
           endLine: 3,
           column: 1,
           endColumn: 4,
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: { bar: number };
+foo.bar ??= 1;
+      `,
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+      errors: [
+        {
+          messageId: 'neverNullish',
+          line: 3,
+          endLine: 3,
+          column: 1,
+          endColumn: 8,
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6635
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR fixes a false positive issue that occurs when using the exactOptionalPropertyTypes option.

[Playground](https://typescript-eslint.io/play/#ts=4.9.5&fileType=.ts&code=CYUwxgNghgTiAEYD2A7AzgF3gMyUgXPAN7wBGsA-ISgK4C2pIM8AvgNwBQuSAdOcxQoBeeAEY2QA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1tiacTJTIAhtEK0yHJgBNK%2BSpPRRE0aB2iRwYAL4gtQA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoAkNZOgB4CG0euBxTqACprIljwBPACpCBZSnkwBXdABpwEKCWnJWAORmpUAYQAW6aAGtJYaXKUBfEFaA&tokens=false)

tsconfig.json
```json
{
  "compilerOptions": {
    "exactOptionalPropertyTypes": true,
    "strictNullChecks": true
  }
}
```

code.ts
```ts
declare const foo: { bar?: number };
foo.bar ??= 1;
```

 When the exactOptionalPropertyTypes option is true, typescript removes `undefined` type of the expression on the left-hand side in assignment. This seems to be the way typescript is intended to provide the functionality of [exactOptionalPropertyTypes](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes).

[Playground](https://typescript-eslint.io/play/#ts=4.9.5&showAST=types&fileType=.ts&code=CYUwxgNghgTiAEYD2A7AzgF3gMyUgXPAN7wBGsA-ISgK4C2pIM8AvgNwBQuSAdOcxQrwAjG3gB6cfAwBPAA4Ik2eAHJufWCvgBLNPAAGtBk3gAfeDRShs2lCGD6ueDQIoBeEWMnT5i5Wud%2BLV0DI0YYfSA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1tiacTJTIAhtEK0yHJgBNK%2BSpPRRE0aB2iRwYAL4gtQA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoAkNZOgB4CG0euBxTqACprIljwBPACpCBZSnkwBXdABpwEKCWnJWAORmpUAYQAW6aAGtJYaXKUBfEFaA&tokens=false)
```ts
declare const foo: { bar?: number };
foo.bar ?? 1; // type of 'foo.bar' is `number | undefined`
foo.bar ??= 1; // type of 'foo.bar' is `number`
```

In this PR, I added code to get the property's Symbol from the member expression's object type and check if whether it's optional.

This implementation has a limitation in that it cannot handle well for using computed key. If it should be handled, I'll need to modify the code a bit more, and I'd love to hear feedback.

```ts
 declare const foo: { bar: { baz?: number }; };
 declare const baz: 'baz';
 foo.bar[baz] ??= 1;
```

<!-- Description of what is changed and how the code change does that. -->
