### PR TITLE
fix(eslint-plugin): [switch-exhaustiveness-check] better support for intersections, infinite types, non-union values

### DIFF
--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -123,30 +123,26 @@ export default createRule<Options, MessageIds>({
         caseTypes.add(caseType);
       }
 
-      function findMissingBranchTypes(): ts.Type[] {
-        const missingLiteralTypes: ts.Type[] = [];
+      const missingLiteralBranchTypes: ts.Type[] = [];
 
-        for (const unionPart of tsutils.unionTypeParts(discriminantType)) {
-          for (const intersectionPart of tsutils.intersectionTypeParts(
-            unionPart,
-          )) {
-            if (
-              caseTypes.has(intersectionPart) ||
-              !isTypeLiteralLikeType(intersectionPart)
-            ) {
-              continue;
-            }
-
-            missingLiteralTypes.push(intersectionPart);
+      for (const unionPart of tsutils.unionTypeParts(discriminantType)) {
+        for (const intersectionPart of tsutils.intersectionTypeParts(
+          unionPart,
+        )) {
+          if (
+            caseTypes.has(intersectionPart) ||
+            !isTypeLiteralLikeType(intersectionPart)
+          ) {
+            continue;
           }
-        }
 
-        return missingLiteralTypes;
+          missingLiteralBranchTypes.push(intersectionPart);
+        }
       }
 
       return {
         symbolName,
-        missingLiteralBranchTypes: findMissingBranchTypes(),
+        missingLiteralBranchTypes,
         defaultCase,
         containsNonLiteralType,
       };

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -926,7 +926,7 @@ default: { throw new Error('default case') }
 declare const value: string | number;
 switch (value) {
   case 1:
-    1;
+    break;
 }
       `,
       errors: [

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -786,6 +786,29 @@ switch (value) {
         },
       ],
     },
+    {
+      code: `
+enum Aaa {
+  Foo,
+  Bar,
+}
+declare const value: Aaa | 1;
+switch (value) {
+  case 1:
+    break;
+  case Aaa.Foo:
+    break;
+  case Aaa.Bar:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -1204,8 +1227,8 @@ switch (value) {
     },
     {
       code: `
-const a = Symbol('a');
-const b = Symbol('b');
+const a = Symbol('aa');
+const b = Symbol('bb');
 declare const value: typeof a | typeof b | 1;
 switch (value) {
   case 1:
@@ -1227,14 +1250,14 @@ switch (value) {
             {
               messageId: 'addMissingCases',
               output: `
-const a = Symbol('a');
-const b = Symbol('b');
+const a = Symbol('aa');
+const b = Symbol('bb');
 declare const value: typeof a | typeof b | 1;
 switch (value) {
   case 1:
     break;
-  case typeof a: { throw new Error('Not implemented yet: typeof a case') }
-  case typeof b: { throw new Error('Not implemented yet: typeof b case') }
+  case a: { throw new Error('Not implemented yet: a case') }
+  case b: { throw new Error('Not implemented yet: b case') }
 }
       `,
             },
@@ -1427,6 +1450,77 @@ switch (value) {
 declare const value: object;
 switch (value) {
   case 1:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+enum Aaa {
+  Foo,
+  Bar,
+}
+declare const value: Aaa | 1 | string;
+switch (value) {
+  case 1:
+    break;
+  case Aaa.Foo:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 7,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+enum Aaa {
+  Foo,
+  Bar,
+}
+declare const value: Aaa | 1 | string;
+switch (value) {
+  case 1:
+    break;
+  case Aaa.Foo:
+    break;
+  case Aaa.Bar: { throw new Error('Not implemented yet: Aaa.Bar case') }
+}
+      `,
+            },
+          ],
+        },
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 7,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+enum Aaa {
+  Foo,
+  Bar,
+}
+declare const value: Aaa | 1 | string;
+switch (value) {
+  case 1:
+    break;
+  case Aaa.Foo:
     break;
   default: { throw new Error('default case') }
 }

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -575,9 +575,9 @@ switch (value) {
     },
     {
       code: `
-declare const value: (string & { foo: void }) | 'bar';
+declare const value: (string & { foo: 'bar' }) | '1';
 switch (value) {
-  case 'bar':
+  case '1':
     break;
 }
       `,
@@ -651,6 +651,311 @@ switch (value) {
     },
   ],
   invalid: [
+    {
+      code: `
+declare const value: 'literal';
+switch (value) {
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: 'literal';
+switch (value) {
+case "literal": { throw new Error('Not implemented yet: "literal" case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: 'literal' & { _brand: true };
+switch (value) {
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: 'literal' & { _brand: true };
+switch (value) {
+case "literal": { throw new Error('Not implemented yet: "literal" case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: ('literal' & { _brand: true }) | 1;
+switch (value) {
+  case 'literal':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: ('literal' & { _brand: true }) | 1;
+switch (value) {
+  case 'literal':
+    break;
+  case 1: { throw new Error('Not implemented yet: 1 case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  case "2": { throw new Error('Not implemented yet: "2" case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  case "2": { throw new Error('Not implemented yet: "2" case') }
+}
+      `,
+            },
+          ],
+        },
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: (string & { foo: 'bar' }) | '1';
+switch (value) {
+  case '1':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: (string & { foo: 'bar' }) | '1';
+switch (value) {
+  case '1':
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: (string & { foo: 'bar' }) | '1' | 1 | null | undefined;
+switch (value) {
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: (string & { foo: 'bar' }) | '1' | 1 | null | undefined;
+switch (value) {
+case undefined: { throw new Error('Not implemented yet: undefined case') }
+case null: { throw new Error('Not implemented yet: null case') }
+case "1": { throw new Error('Not implemented yet: "1" case') }
+case 1: { throw new Error('Not implemented yet: 1 case') }
+}
+      `,
+            },
+          ],
+        },
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: (string & { foo: 'bar' }) | '1' | 1 | null | undefined;
+switch (value) {
+default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: string | number;
+switch (value) {
+  case 1:
+    1;
+}
+      `,
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: string | number;
+switch (value) {
+  case 1:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
     {
       // Matched only one branch out of seven.
       code: `
@@ -1335,311 +1640,6 @@ switch (myValue) {
       errors: [
         {
           messageId: 'dangerousDefaultCase',
-        },
-      ],
-    },
-    {
-      code: `
-declare const value: 'literal';
-switch (value) {
-}
-      `,
-      options: [
-        {
-          allowDefaultCaseForExhaustiveSwitch: false,
-          requireDefaultForNonUnion: true,
-        },
-      ],
-      errors: [
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 3,
-          column: 9,
-          suggestions: [
-            {
-              messageId: 'addMissingCases',
-              output: `
-declare const value: 'literal';
-switch (value) {
-case "literal": { throw new Error('Not implemented yet: "literal" case') }
-}
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-declare const value: 'literal' & { _brand: true };
-switch (value) {
-}
-      `,
-      options: [
-        {
-          allowDefaultCaseForExhaustiveSwitch: false,
-          requireDefaultForNonUnion: true,
-        },
-      ],
-      errors: [
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 3,
-          column: 9,
-          suggestions: [
-            {
-              messageId: 'addMissingCases',
-              output: `
-declare const value: 'literal' & { _brand: true };
-switch (value) {
-case "literal": { throw new Error('Not implemented yet: "literal" case') }
-}
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-declare const value: ('literal' & { _brand: true }) | 1;
-switch (value) {
-  case 'literal':
-    break;
-}
-      `,
-      options: [
-        {
-          allowDefaultCaseForExhaustiveSwitch: false,
-          requireDefaultForNonUnion: true,
-        },
-      ],
-      errors: [
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 3,
-          column: 9,
-          suggestions: [
-            {
-              messageId: 'addMissingCases',
-              output: `
-declare const value: ('literal' & { _brand: true }) | 1;
-switch (value) {
-  case 'literal':
-    break;
-  case 1: { throw new Error('Not implemented yet: 1 case') }
-}
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-declare const value: '1' | '2' | number;
-switch (value) {
-  case '1':
-    break;
-}
-      `,
-      options: [
-        {
-          allowDefaultCaseForExhaustiveSwitch: true,
-          requireDefaultForNonUnion: false,
-        },
-      ],
-      errors: [
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 3,
-          column: 9,
-          suggestions: [
-            {
-              messageId: 'addMissingCases',
-              output: `
-declare const value: '1' | '2' | number;
-switch (value) {
-  case '1':
-    break;
-  case "2": { throw new Error('Not implemented yet: "2" case') }
-}
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-declare const value: '1' | '2' | number;
-switch (value) {
-  case '1':
-    break;
-}
-      `,
-      options: [
-        {
-          allowDefaultCaseForExhaustiveSwitch: true,
-          requireDefaultForNonUnion: true,
-        },
-      ],
-      errors: [
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 3,
-          column: 9,
-          suggestions: [
-            {
-              messageId: 'addMissingCases',
-              output: `
-declare const value: '1' | '2' | number;
-switch (value) {
-  case '1':
-    break;
-  case "2": { throw new Error('Not implemented yet: "2" case') }
-}
-      `,
-            },
-          ],
-        },
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 3,
-          column: 9,
-          suggestions: [
-            {
-              messageId: 'addMissingCases',
-              output: `
-declare const value: '1' | '2' | number;
-switch (value) {
-  case '1':
-    break;
-  default: { throw new Error('default case') }
-}
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-declare const value: (string & { foo: void }) | 'bar';
-switch (value) {
-  case 'bar':
-    break;
-}
-      `,
-      options: [
-        {
-          allowDefaultCaseForExhaustiveSwitch: true,
-          requireDefaultForNonUnion: true,
-        },
-      ],
-      errors: [
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 3,
-          column: 9,
-          suggestions: [
-            {
-              messageId: 'addMissingCases',
-              output: `
-declare const value: (string & { foo: void }) | 'bar';
-switch (value) {
-  case 'bar':
-    break;
-  default: { throw new Error('default case') }
-}
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-declare const value: (string & { foo: void }) | 'bar' | 1 | null | undefined;
-switch (value) {
-}
-      `,
-      options: [
-        {
-          allowDefaultCaseForExhaustiveSwitch: false,
-          requireDefaultForNonUnion: true,
-        },
-      ],
-      errors: [
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 3,
-          column: 9,
-          suggestions: [
-            {
-              messageId: 'addMissingCases',
-              output: `
-declare const value: (string & { foo: void }) | 'bar' | 1 | null | undefined;
-switch (value) {
-case undefined: { throw new Error('Not implemented yet: undefined case') }
-case null: { throw new Error('Not implemented yet: null case') }
-case "bar": { throw new Error('Not implemented yet: "bar" case') }
-case 1: { throw new Error('Not implemented yet: 1 case') }
-}
-      `,
-            },
-          ],
-        },
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 3,
-          column: 9,
-          suggestions: [
-            {
-              messageId: 'addMissingCases',
-              output: `
-declare const value: (string & { foo: void }) | 'bar' | 1 | null | undefined;
-switch (value) {
-default: { throw new Error('default case') }
-}
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: `
-declare const value: string | number;
-switch (value) {
-  case 1:
-    break;
-}
-      `,
-      options: [
-        {
-          allowDefaultCaseForExhaustiveSwitch: false,
-          requireDefaultForNonUnion: true,
-        },
-      ],
-      errors: [
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 3,
-          column: 9,
-          suggestions: [
-            {
-              messageId: 'addMissingCases',
-              output: `
-declare const value: string | number;
-switch (value) {
-  case 1:
-    break;
-  default: { throw new Error('default case') }
-}
-      `,
-            },
-          ],
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -649,6 +649,143 @@ switch (value) {
         },
       ],
     },
+    {
+      code: `
+declare const value: number;
+declare const a: number;
+switch (value) {
+  case a:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: bigint;
+switch (value) {
+  case 10n:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: symbol;
+const a = Symbol('a');
+switch (value) {
+  case a:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: symbol;
+const a = Symbol('a');
+switch (value) {
+  case a:
+    break;
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+const a = Symbol('a');
+declare const value: typeof a | string;
+switch (value) {
+  case a:
+    break;
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+const a = Symbol('a');
+declare const value: typeof a | string;
+switch (value) {
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: boolean | 1;
+switch (value) {
+  case 1:
+    break;
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: boolean | 1;
+switch (value) {
+  case 1:
+    break;
+  case true:
+    break;
+  case false:
+    break;
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -929,6 +1066,12 @@ switch (value) {
     break;
 }
       `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
       errors: [
         {
           messageId: 'switchIsNotExhaustive',
@@ -949,10 +1092,347 @@ switch (value) {
           ],
         },
       ],
+    },
+    {
+      code: `
+declare const value: number;
+declare const a: number;
+switch (value) {
+  case a:
+    break;
+}
+      `,
       options: [
         {
           allowDefaultCaseForExhaustiveSwitch: false,
           requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 4,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: number;
+declare const a: number;
+switch (value) {
+  case a:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: bigint;
+switch (value) {
+  case 10n:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: bigint;
+switch (value) {
+  case 10n:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: symbol;
+const a = Symbol('a');
+switch (value) {
+  case a:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 4,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: symbol;
+const a = Symbol('a');
+switch (value) {
+  case a:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+const a = Symbol('a');
+const b = Symbol('b');
+declare const value: typeof a | typeof b | 1;
+switch (value) {
+  case 1:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 5,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+const a = Symbol('a');
+const b = Symbol('b');
+declare const value: typeof a | typeof b | 1;
+switch (value) {
+  case 1:
+    break;
+  case typeof a: { throw new Error('Not implemented yet: typeof a case') }
+  case typeof b: { throw new Error('Not implemented yet: typeof b case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+const a = Symbol('a');
+declare const value: typeof a | string;
+switch (value) {
+  case a:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 4,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+const a = Symbol('a');
+declare const value: typeof a | string;
+switch (value) {
+  case a:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: boolean;
+switch (value) {
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: boolean;
+switch (value) {
+case false: { throw new Error('Not implemented yet: false case') }
+case true: { throw new Error('Not implemented yet: true case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: boolean | 1;
+switch (value) {
+  case false:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: boolean | 1;
+switch (value) {
+  case false:
+    break;
+  case true: { throw new Error('Not implemented yet: true case') }
+  case 1: { throw new Error('Not implemented yet: 1 case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: boolean | number;
+switch (value) {
+  case 1:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: boolean | number;
+switch (value) {
+  case 1:
+    break;
+  case false: { throw new Error('Not implemented yet: false case') }
+  case true: { throw new Error('Not implemented yet: true case') }
+}
+      `,
+            },
+          ],
+        },
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: boolean | number;
+switch (value) {
+  case 1:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: object;
+switch (value) {
+  case 1:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: object;
+switch (value) {
+  case 1:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -333,6 +333,322 @@ switch (value) {
         },
       ],
     },
+    {
+      code: `
+declare const value: 'literal';
+switch (value) {
+  case 'literal':
+    return 0;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: null;
+switch (value) {
+  case null:
+    return 0;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: undefined;
+switch (value) {
+  case undefined:
+    return 0;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: null | undefined;
+switch (value) {
+  case null:
+    return 0;
+  case undefined:
+    return 0;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: 'literal' & { _brand: true };
+switch (value) {
+  case 'literal':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: ('literal' & { _brand: true }) | 1;
+switch (value) {
+  case 'literal':
+    break;
+  case 1:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: (1 & { _brand: true }) | 'literal' | null;
+switch (value) {
+  case 'literal':
+    break;
+  case 1:
+    break;
+  case null:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  case '2':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  case '2':
+    break;
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  case '2':
+    break;
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: '1' | '2' | (number & { foo: 'bar' });
+switch (value) {
+  case '1':
+    break;
+  case '2':
+    break;
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  case '2':
+    break;
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: number | null | undefined;
+switch (value) {
+  case null:
+    break;
+  case undefined:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: (string & { foo: void }) | 'bar';
+switch (value) {
+  case 'bar':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+const a = Symbol('a');
+declare const value: typeof a | 2;
+switch (value) {
+  case a:
+    break;
+  case 2:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: string | number;
+switch (value) {
+  case 1:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: string | number;
+switch (value) {
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: string | number;
+switch (value) {
+  default:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -493,32 +809,6 @@ switch (day) {
           data: {
             missingBranches:
               '"Monday" | "Tuesday" | "Wednesday" | "Thursday" | "Friday" | "Saturday" | "Sunday"',
-          },
-        },
-      ],
-    },
-    {
-      // Still complains with union intersection part
-      code: `
-type FooBar = (string & { foo: void }) | 'bar';
-
-const foobar = 'bar' as FooBar;
-let result = 0;
-
-switch (foobar) {
-  case 'bar': {
-    result = 42;
-    break;
-  }
-}
-      `,
-      errors: [
-        {
-          messageId: 'switchIsNotExhaustive',
-          line: 7,
-          column: 9,
-          data: {
-            missingBranches: 'string & { foo: void; }',
           },
         },
       ],
@@ -1045,6 +1335,311 @@ switch (myValue) {
       errors: [
         {
           messageId: 'dangerousDefaultCase',
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: 'literal';
+switch (value) {
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: 'literal';
+switch (value) {
+case "literal": { throw new Error('Not implemented yet: "literal" case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: 'literal' & { _brand: true };
+switch (value) {
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: 'literal' & { _brand: true };
+switch (value) {
+case "literal": { throw new Error('Not implemented yet: "literal" case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: ('literal' & { _brand: true }) | 1;
+switch (value) {
+  case 'literal':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: ('literal' & { _brand: true }) | 1;
+switch (value) {
+  case 'literal':
+    break;
+  case 1: { throw new Error('Not implemented yet: 1 case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: false,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  case "2": { throw new Error('Not implemented yet: "2" case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  case "2": { throw new Error('Not implemented yet: "2" case') }
+}
+      `,
+            },
+          ],
+        },
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: '1' | '2' | number;
+switch (value) {
+  case '1':
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: (string & { foo: void }) | 'bar';
+switch (value) {
+  case 'bar':
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: true,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: (string & { foo: void }) | 'bar';
+switch (value) {
+  case 'bar':
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: (string & { foo: void }) | 'bar' | 1 | null | undefined;
+switch (value) {
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: (string & { foo: void }) | 'bar' | 1 | null | undefined;
+switch (value) {
+case undefined: { throw new Error('Not implemented yet: undefined case') }
+case null: { throw new Error('Not implemented yet: null case') }
+case "bar": { throw new Error('Not implemented yet: "bar" case') }
+case 1: { throw new Error('Not implemented yet: 1 case') }
+}
+      `,
+            },
+          ],
+        },
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: (string & { foo: void }) | 'bar' | 1 | null | undefined;
+switch (value) {
+default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const value: string | number;
+switch (value) {
+  case 1:
+    break;
+}
+      `,
+      options: [
+        {
+          allowDefaultCaseForExhaustiveSwitch: false,
+          requireDefaultForNonUnion: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          line: 3,
+          column: 9,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+declare const value: string | number;
+switch (value) {
+  case 1:
+    break;
+  default: { throw new Error('default case') }
+}
+      `,
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8238, fixes #6682
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I decided to fix both issues in one pr, because it was really hard to fix the first one without fixing the second.

This PR introduces better support for all combinations of unions, intersections, infinite types. It also fix suggestions more accurate.

In addition, this PR also includes several fixes for bugs that were present on `main` but wasn't mentioned in issues:

#### 1. Provide correct fixes for missing `unique symbols`

Before ([playground](https://typescript-eslint.io/play/#ts=5.3.3&fileType=.ts&code=MYewdgzgLgBAhjAvDAygTwLYCMQBsAUA5HIQJQBQoksWSqmOBhWZ5AJgKbC5wBOHMKtBgA3OLgCuHAFwwoaAA4cQAM3gwAPnMXK1tGOXIQA7gEsowABYx8YyR1IwA3uRiC4EAXFlZ%2BcANYA3OQAvkA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6ZAd0vzIAt6AHrwCGsZPkoA3RExTJafRGQDW6MAG1w2HImjQA9tEhaIAXS0BfEBaA&tsconfig=&tokens=false)):
```diff
const a = Symbol('a')
const b = Symbol('b')
declare const value: typeof a | typeof b  

switch (value) {
  case a: break;
+ case unique symbol: { throw new Error('Not implemented yet: unique symbol case') }
}
```
After:
```diff
const a = Symbol('a')
const b = Symbol('b')
declare const value: typeof a | typeof b  

switch (value) {
  case a: break;
+ case b: { throw new Error('Not implemented yet: b case') }
}
```

#### 2. Support intersections that includes literals

Before ([playground](https://typescript-eslint.io/play/#ts=5.3.3&fileType=.ts&code=CYUwxgNghgTiAEYD2A7AzgF3gNyhAriAFzwAUA5FFOfAGTwDeURAjAL4CU8APvOQEb9yAKDQB3AJYYwACzK4CILg2HxEUNAkrUS-OFADWAblXrNfQeV37jwtkA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6ZAd0vzIAt6AHrwCGsZPkoA3RExTJafRGQDW6MAG1w2HImjQA9tEgAaLdqzbsMRAEdYlaIgAiiAGaj4%2BAGKGAcvqYAVSZKALV8OEQzbABfaIBdLTiYoA&tsconfig=&tokens=false)):
```ts
declare const value: ('aa' & {a:1}) | 'bb'
switch (value) {
//      ^ Switch is not exhaustive. Cases not matched: "aa" & { a: 1; }
  case 'aa': break;
  case 'bb': break;
}
```
After (no false positive):
```ts
declare const value: ('aa' & {a:1}) | 'bb'
switch (value) {
  case 'aa': break;
  case 'bb': break;
}
```

#### 3. Consistently add a default branch both for bare infinite types and unions of infinite types

Before ([playground](https://typescript-eslint.io/play/#ts=5.3.3&fileType=.ts&code=CYUwxgNghgTiAEYD2A7AzgF3gNyhAriAFzwr4C2ARiDAFBoDuAlhmABbwAUuBIAlPADeteIihoEARhKU4UANYBuWgF9a60JFgJk6LD0LTSFajHgAfeJhhMUAc3rNWHbnkMDhosOKky5S1SA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6ZAd0vzIAt6AHrwCGsZPkoA3RExTJafRGQDW6MAG1w2HImjQA9tEgAaLdqzbsMRAEdYlaIgAiiAGaj4%2BAGKGAcvqYAVSZKALV8OEQzbABfaIBdLTiYoA&tsconfig=&tokens=false)):
```diff
declare const value: number
switch (value) {
  case 1: break;
+ default: { throw new Error('default case') }
}


declare const value: number | string
switch (value) {
  case 1: break;
+ case string: { throw new Error('Not implemented yet: string case') }
+ case number: { throw new Error('Not implemented yet: number case') }
}
```
After:
```diff

declare const value: number
switch (value) {
  case 1: break;
+ default: { throw new Error('default case') }
}


declare const value: number | string
switch (value) {
  case 1: break;
+ default: { throw new Error('default case') }
}
```

---

I've removed `isUnion` from `SwitchMetadata` to avoid confusion: we shouldn't treat unions and non-unions differently. We should only care whether a type contains non-literal types or not