### PR TITLE
docs(eslint-plugin): remove `fixable` and `hasSuggestions` from rules that don't provide them

### DIFF
--- a/packages/eslint-plugin/src/rules/class-methods-use-this.ts
+++ b/packages/eslint-plugin/src/rules/class-methods-use-this.ts
@@ -28,8 +28,6 @@ export default createRule<Options, MessageIds>({
       extendsBaseRule: true,
       requiresTypeChecking: false,
     },
-    fixable: 'code',
-    hasSuggestions: false,
     schema: [
       {
         type: 'object',

--- a/packages/eslint-plugin/src/rules/no-confusing-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-non-null-assertion.ts
@@ -13,7 +13,6 @@ export default createRule({
         'Disallow non-null assertion in locations that may be confusing',
       recommended: 'stylistic',
     },
-    fixable: 'code',
     hasSuggestions: true,
     messages: {
       confusingEqual:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8151
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

For now, I just manually remove these properties, without checking it on RuleTester level because I can't find a solution to the problem described here https://github.com/typescript-eslint/typescript-eslint/issues/8151#issuecomment-1877330302