### PR TITLE
fix(eslint-plugin): [prefer-nullish-coalescing] treat any/unknown as non-nullable

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -334,7 +334,6 @@ export default createRule<Options, MessageIds>({
         ]
           .filter((flag): flag is number => typeof flag === 'number')
           .reduce((previous, flag) => previous | flag, 0);
-
         if (
           type.flags !== ts.TypeFlags.Null &&
           type.flags !== ts.TypeFlags.Undefined &&

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -10,8 +10,8 @@ import {
   getTypeFlags,
   isLogicalOrOperator,
   isNodeEqual,
-  isNullableType,
   isNullLiteral,
+  isTypeFlagSet,
   isUndefinedIdentifier,
   nullThrows,
   NullThrowsReasons,
@@ -309,7 +309,7 @@ export default createRule<Options, MessageIds>({
       ): void {
         const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
         const type = checker.getTypeAtLocation(tsNode.left);
-        if (!isNullableType(type)) {
+        if (!isTypeFlagSet(type, ts.TypeFlags.Null | ts.TypeFlags.Undefined)) {
           return;
         }
 
@@ -334,6 +334,7 @@ export default createRule<Options, MessageIds>({
         ]
           .filter((flag): flag is number => typeof flag === 'number')
           .reduce((previous, flag) => previous | flag, 0);
+
         if (
           type.flags !== ts.TypeFlags.Null &&
           type.flags !== ts.TypeFlags.Undefined &&

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -222,6 +222,18 @@ x || y;
       `,
       options: [{ ignorePrimitives: true }],
     })),
+    `
+      declare const x: any;
+      x || y;
+    `,
+    `
+      declare const x: unknown;
+      x || y;
+    `,
+    `
+      declare const x: never;
+      x || y;
+    `,
   ],
   invalid: [
     ...nullishTypeInvalidTest((nullish, type) => ({

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -224,14 +224,17 @@ x || y;
     })),
     `
       declare const x: any;
+      declare const y: number;
       x || y;
     `,
     `
       declare const x: unknown;
+      declare const y: number;
       x || y;
     `,
     `
       declare const x: never;
+      declare const y: number;
       x || y;
     `,
   ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8261
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

https://github.com/typescript-eslint/typescript-eslint/pull/8089 introduced change in the `isNullableType` function. It started treating `any` and `unknown` as nullables, it worked for `no-unnecesary-type-assertion`, but not for `prefer-nullish-coalescing`. `prefer-nullish-coalescing` expects `isNullableType` to return true only for `null` and `undefined`