### PR TITLE
fix(eslint-plugin): [member-ordering] report alphabetical sorting for all groups instead of just the first failing group

### DIFF
--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -621,25 +621,25 @@ function getRank(
  * ```
  * interface Foo {
       [a: string]: number;
-
+ 
       a: x;
       B: x;
       c: x;
-
+ 
       c(): void;
       B(): void;
       a(): void;
-
+ 
       (): Baz;
-
+ 
       new (): Bar;
     }
  * ```
   The resulting array will look like this - [[a, B, c], [c, B, a]].
  * @param memberSet The members in the class of the source code on which the grouping operation will be performed.
  * @param memberType The member type order listed in the eslint config file.
- * @param supportsModifiers
- * @returns
+ * @param supportsModifiers it'll get passed to getRank()
+ * @returns the array of groups of members
  */
 function groupMembersByType(
   memberSet: Member[],
@@ -997,7 +997,7 @@ export default createRule<Options, MessageIds>({
 
       /**
        * It runs an alphabetic sort on the groups of the members of the class in the source code.
-       * @param memberSet
+       * @param memberSet The members in the class of the source code on which the grouping operation will be performed.
        */
       const checkAlphaSortForAllMembers = (memberSet: Member[]): undefined => {
         const hasAlphaSort = !!(order && order !== 'as-written');

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -643,27 +643,26 @@ function getRank(
  * @returns The array of groups of members.
  */
 function groupMembersByType(
-  memberSet: Member[],
-  memberType: MemberType[],
+  members: Member[],
+  memberTypes: MemberType[],
   supportsModifiers: boolean,
 ): Member[][] {
   const groupedMembers: Member[][] = [];
+  const memberRanks = members.map(member =>
+    getRank(member, memberTypes, supportsModifiers),
+  );
   let previousRank: number | undefined = undefined;
-  memberSet.forEach((member, index) => {
-    if (index === memberSet.length - 1) {
+  members.forEach((member, index) => {
+    if (index === members.length - 1) {
       return;
     }
-    const rankOfcurrentMember = getRank(member, memberType, supportsModifiers);
-    const rankOfNextMember = getRank(
-      memberSet[index + 1],
-      memberType,
-      supportsModifiers,
-    );
-    if (rankOfcurrentMember === previousRank) {
+    const rankOfCurrentMember = memberRanks[index];
+    const rankOfNextMember = memberRanks[index + 1];
+    if (rankOfCurrentMember === previousRank) {
       groupedMembers.at(-1)?.push(member);
-    } else if (rankOfcurrentMember === rankOfNextMember) {
+    } else if (rankOfCurrentMember === rankOfNextMember) {
       groupedMembers.push([member]);
-      previousRank = rankOfcurrentMember;
+      previousRank = rankOfCurrentMember;
     }
   });
   return groupedMembers;
@@ -996,8 +995,8 @@ export default createRule<Options, MessageIds>({
         const hasAlphaSort = !!(order && order !== 'as-written');
         if (hasAlphaSort && Array.isArray(memberTypes)) {
           groupMembersByType(memberSet, memberTypes, supportsModifiers).forEach(
-            groupMember => {
-              checkAlphaSort(groupMember, order as AlphabeticalOrder);
+            groupMembers => {
+              checkAlphaSort(groupMembers, order as AlphabeticalOrder);
             },
           );
         }

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -621,17 +621,17 @@ function getRank(
  * ```
  * interface Foo {
       [a: string]: number;
- 
+
       a: x;
       B: x;
       c: x;
- 
+
       c(): void;
       B(): void;
       a(): void;
- 
+
       (): Baz;
- 
+
       new (): Bar;
     }
  * ```
@@ -647,16 +647,7 @@ function groupMembersByType(
   supportsModifiers: boolean,
 ): Member[][] {
   const groupedMembers: Member[][] = [];
-  const getPreviousRank = (): number | undefined => {
-    if (groupedMembers.at(-1)?.at(0) === undefined) {
-      return undefined;
-    }
-    return getRank(
-      groupedMembers[groupedMembers.length - 1][0],
-      memberType,
-      supportsModifiers,
-    );
-  };
+  let previousRank: number | undefined = undefined;
   memberSet.forEach((member, index) => {
     if (index === memberSet.length - 1) {
       return;
@@ -667,10 +658,11 @@ function groupMembersByType(
       memberType,
       supportsModifiers,
     );
-    if (rankOfcurrentMember === getPreviousRank()) {
+    if (rankOfcurrentMember === previousRank) {
       groupedMembers.at(-1)?.push(member);
     } else if (rankOfcurrentMember === rankOfNextMember) {
       groupedMembers.push([member]);
+      previousRank = rankOfcurrentMember;
     }
   });
   return groupedMembers;

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -658,15 +658,15 @@ function groupMembersByType(
     );
   };
   memberSet.forEach((member, index) => {
+    if (index === memberSet.length - 1) {
+      return;
+    }
     const rankOfcurrentMember = getRank(member, memberType, supportsModifiers);
     const rankOfNextMember = getRank(
       memberSet[index + 1],
       memberType,
       supportsModifiers,
     );
-    if (index === memberSet.length - 1) {
-      return;
-    }
     if (rankOfcurrentMember === getPreviousRank()) {
       groupedMembers.at(-1)?.push(member);
     } else if (rankOfcurrentMember === rankOfNextMember) {

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -616,30 +616,31 @@ function getRank(
 }
 
 /**
- * If there are more than 1 consecutive same ranked member in 1 class, those members are put in an array & an array of these members' array is returned as a result. If, for example, the memberSet parameter looks like the below example - (contd. after the example tag)
+ * Groups members into arrays of consecutive members with the same rank.
+ * If, for example, the memberSet parameter looks like the following...
  * @example
  * ```
  * interface Foo {
-      [a: string]: number;
- 
-      a: x;
-      B: x;
-      c: x;
- 
-      c(): void;
-      B(): void;
-      a(): void;
- 
-      (): Baz;
- 
-      new (): Bar;
-    }
+ *   [a: string]: number;
+ *
+ *   a: x;
+ *   B: x;
+ *   c: x;
+ *
+ *   c(): void;
+ *   B(): void;
+ *   a(): void;
+ *
+ *   (): Baz;
+ *
+ *   new (): Bar;
+ * }
  * ```
-  The resulting array will look like this - [[a, B, c], [c, B, a]].
- * @param memberSet The members in the class of the source code on which the grouping operation will be performed.
- * @param memberType The member type order listed in the eslint config file.
- * @param supportsModifiers it'll get passed to getRank()
- * @returns the array of groups of members
+ * ...the resulting array will look like: [[a, B, c], [c, B, a]].
+ * @param memberSet The members to be grouped.
+ * @param memberType The configured order of member types.
+ * @param supportsModifiers It'll get passed to getRank().
+ * @returns The array of groups of members.
  */
 function groupMembersByType(
   memberSet: Member[],

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -1020,11 +1020,9 @@ export default createRule<Options, MessageIds>({
           }
 
           if (hasAlphaSort) {
-            return grouped
-              .map(groupMember =>
-                checkAlphaSort(groupMember, order as AlphabeticalOrder),
-              )
-              .some(result => !result);
+            grouped.map(groupMember =>
+              checkAlphaSort(groupMember, order as AlphabeticalOrder),
+            );
           }
         } else if (hasAlphaSort) {
           return checkAlphaSort(memberSet, order as AlphabeticalOrder);

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -995,8 +995,8 @@ export default createRule<Options, MessageIds>({
         const hasAlphaSort = !!(order && order !== 'as-written');
         if (hasAlphaSort && Array.isArray(memberTypes)) {
           groupMembersByType(memberSet, memberTypes, supportsModifiers).forEach(
-            groupMembers => {
-              checkAlphaSort(groupMembers, order as AlphabeticalOrder);
+            members => {
+              checkAlphaSort(members, order as AlphabeticalOrder);
             },
           );
         }

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -621,17 +621,17 @@ function getRank(
  * ```
  * interface Foo {
       [a: string]: number;
-
+ 
       a: x;
       B: x;
       c: x;
-
+ 
       c(): void;
       B(): void;
       a(): void;
-
+ 
       (): Baz;
-
+ 
       new (): Bar;
     }
  * ```

--- a/packages/eslint-plugin/src/rules/member-ordering.ts
+++ b/packages/eslint-plugin/src/rules/member-ordering.ts
@@ -619,19 +619,18 @@ function changeToGroups(
   memberSet: Member[],
   memberType: MemberType[],
   supportsModifiers: boolean,
-) {
-  let groupedMembers: Member[][] = [];
+): Member[][] {
+  const groupedMembers: Member[][] = [];
 
-  const getPreviousRank = () => {
-    if (groupedMembers[groupedMembers.length - 1]?.[0] === undefined) {
+  const getPreviousRank = (): number | undefined => {
+    if (groupedMembers.at(-1)?.at(0) === undefined) {
       return undefined;
-    } else {
-      return getRank(
-        groupedMembers[groupedMembers.length - 1][0],
-        memberType,
-        supportsModifiers,
-      );
     }
+    return getRank(
+      groupedMembers[groupedMembers.length - 1][0],
+      memberType,
+      supportsModifiers,
+    );
   };
 
   memberSet.forEach((member, index) => {
@@ -641,7 +640,7 @@ function changeToGroups(
       return;
     } else if (
       getRank(member, memberType, supportsModifiers) ===
-      getRank(memberSet.at(index + 1) as Member, memberType, supportsModifiers)
+      getRank(memberSet.at(index + 1)!, memberType, supportsModifiers)
     ) {
       groupedMembers.push([member]);
     }
@@ -968,7 +967,7 @@ export default createRule<Options, MessageIds>({
       let memberTypes: MemberType[] | string | undefined;
       let optionalityOrder: OptionalityOrder | undefined;
 
-      const runSort = (memberSet: Member[]) => {
+      const runSort = (memberSet: Member[]): undefined => {
         const hasAlphaSort = !!(order && order !== 'as-written');
         if (hasAlphaSort && Array.isArray(memberTypes)) {
           changeToGroups(memberSet, memberTypes, supportsModifiers).forEach(
@@ -997,13 +996,13 @@ export default createRule<Options, MessageIds>({
           }
 
           if (hasAlphaSort) {
-            let sortResults: boolean[] = [];
+            const sortResults: boolean[] = [];
             grouped.forEach(groupMember => {
               sortResults.push(
                 checkAlphaSort(groupMember, order as AlphabeticalOrder),
               );
             });
-            return sortResults.some(result => result === false);
+            return sortResults.some(result => !result);
           }
         } else if (hasAlphaSort) {
           return checkAlphaSort(memberSet, order as AlphabeticalOrder);

--- a/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-case-insensitive-order.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-case-insensitive-order.test.ts
@@ -543,6 +543,20 @@ interface Foo {
       ],
       errors: [
         {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'B',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'B',
+          },
+        },
+        {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'call',
@@ -588,6 +602,20 @@ type Foo = {
       ],
       errors: [
         {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'B',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'B',
+          },
+        },
+        {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'call',
@@ -627,6 +655,20 @@ class Foo {
       ],
       errors: [
         {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'B',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'B',
+          },
+        },
+        {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'd',
@@ -658,6 +700,20 @@ const foo = class Foo {
         },
       ],
       errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'B',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'B',
+          },
+        },
         {
           messageId: 'incorrectGroupOrder',
           data: {

--- a/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-order.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-order.test.ts
@@ -1857,6 +1857,20 @@ interface Foo {
       ],
       errors: [
         {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'call',
@@ -1897,6 +1911,20 @@ type Foo = {
       ],
       errors: [
         {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'call',
@@ -1931,6 +1959,20 @@ class Foo {
       ],
       errors: [
         {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'd',
@@ -1957,6 +1999,20 @@ const foo = class Foo {
         { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
       ],
       errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
         {
           messageId: 'incorrectGroupOrder',
           data: {
@@ -1999,6 +2055,13 @@ class Foo {
         },
       ],
       errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a2',
+            beforeMember: 'a3',
+          },
+        },
         {
           messageId: 'incorrectGroupOrder',
           data: {
@@ -2146,6 +2209,20 @@ class Foo {
       ],
       errors: [
         {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
+        {
           messageId: 'incorrectGroupOrder',
           data: {
             name: 'd',
@@ -2290,6 +2367,20 @@ const foo = class Foo {
           { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
         ],
         errors: [
+          {
+            messageId: 'incorrectOrder',
+            data: {
+              member: 'b',
+              beforeMember: 'c',
+            },
+          },
+          {
+            messageId: 'incorrectOrder',
+            data: {
+              member: 'a',
+              beforeMember: 'b',
+            },
+          },
           {
             messageId: 'incorrectGroupOrder',
             data: {
@@ -2443,6 +2534,20 @@ interface Foo {
         { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
       ],
       errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
         {
           messageId: 'incorrectGroupOrder',
           data: {
@@ -2603,6 +2708,20 @@ type Foo = {
         { default: { memberTypes: defaultOrder, order: 'alphabetically' } },
       ],
       errors: [
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'b',
+            beforeMember: 'c',
+          },
+        },
+        {
+          messageId: 'incorrectOrder',
+          data: {
+            member: 'a',
+            beforeMember: 'b',
+          },
+        },
         {
           messageId: 'incorrectGroupOrder',
           data: {

--- a/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-natural-case-insensitive-order.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-natural-case-insensitive-order.test.ts
@@ -122,6 +122,15 @@ interface Example {
           line: 10,
           messageId: 'incorrectOrder',
         },
+        {
+          column: 3,
+          data: {
+            beforeMember: 'B1',
+            member: 'a1',
+          },
+          line: 15,
+          messageId: 'incorrectOrder',
+        },
       ],
       options: [
         {

--- a/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-natural-order.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-natural-order.test.ts
@@ -131,6 +131,24 @@ interface Example {
           line: 10,
           messageId: 'incorrectOrder',
         },
+        {
+          column: 3,
+          data: {
+            beforeMember: 'a10',
+            member: 'B1',
+          },
+          line: 14,
+          messageId: 'incorrectOrder',
+        },
+        {
+          column: 3,
+          data: {
+            beforeMember: 'a1',
+            member: 'B5',
+          },
+          line: 16,
+          messageId: 'incorrectOrder',
+        },
       ],
       options: [
         {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8100 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
1. Previously, if a group of MemberType was unsorted, then it was reported ignoring the rest of the MemberTypes, now all of them are reported.
2. Previously, if the MemberTypes weren't in order wrt config, alphabetic sort was avoided, now both takes place.