### PR TITLE
fix(eslint-plugin): [no-useless-template-literals] incorrect bigint autofix result

### DIFF
--- a/packages/eslint-plugin/src/rules/no-useless-template-literals.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-template-literals.ts
@@ -6,6 +6,7 @@ import {
   createRule,
   getConstrainedTypeAtLocation,
   getParserServices,
+  getStaticStringValue,
   isTypeFlagSet,
   isUndefinedIdentifier,
 } from '../util';
@@ -118,16 +119,10 @@ export default createRule<[], MessageId>({
                 ]),
               ];
 
-              // Remove quotes for string literals (i.e. `'a'` will become `a`).
-              const isStringLiteral =
-                isUnderlyingTypeString(expression) &&
-                expression.type === AST_NODE_TYPES.Literal;
+              const stringValue = getStaticStringValue(expression);
 
-              if (isStringLiteral) {
-                const escapedValue = expression.value.replace(
-                  /([`$\\])/g,
-                  '\\$1',
-                );
+              if (stringValue != null) {
+                const escapedValue = stringValue.replace(/([`$\\])/g, '\\$1');
 
                 fixes.push(fixer.replaceText(expression, escapedValue));
               }

--- a/packages/eslint-plugin/tests/rules/no-useless-template-literals.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-template-literals.test.ts
@@ -17,7 +17,6 @@ ruleTester.run('no-useless-template-literals', rule, {
   valid: [
     "const string = 'a';",
     'const string = `a`;',
-
     `
       declare const string: 'a';
       \`\${string}b\`;
@@ -144,6 +143,30 @@ ruleTester.run('no-useless-template-literals', rule, {
           line: 1,
           column: 4,
           endColumn: 5,
+        },
+      ],
+    },
+    {
+      code: '`${1n}`;',
+      output: '`1`;',
+      errors: [
+        {
+          messageId: 'noUselessTemplateLiteral',
+          line: 1,
+          column: 4,
+          endColumn: 6,
+        },
+      ],
+    },
+    {
+      code: '`${/a/}`;',
+      output: '`/a/`;',
+      errors: [
+        {
+          messageId: 'noUselessTemplateLiteral',
+          line: 1,
+          column: 4,
+          endColumn: 7,
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8284
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview



<!-- Description of what is changed and how the code change does that. -->
