### PR TITLE
chore: add `typescript-eslint` package scaffold

### DIFF
--- a/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
+++ b/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
@@ -38,6 +38,7 @@ body:
         - parser
         - rule-tester
         - scope-manager
+        - typescript-eslint
         - typescript-estree
         - utils
         - website

--- a/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
+++ b/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
@@ -28,6 +28,7 @@ body:
         - parser
         - scope-manager
         - type-utils
+        - typescript-eslint
         - typescript-estree
         - utils
         - website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
             'rule-schema-to-typescript-types',
             'scope-manager',
             'type-utils',
+            'typescript-eslint',
             'typescript-estree',
             'utils',
             'visitor-keys',

--- a/.github/workflows/semantic-pr-titles.yml
+++ b/.github/workflows/semantic-pr-titles.yml
@@ -35,6 +35,7 @@ jobs:
             scope-manager
             type-utils
             types
+            typescript-eslint
             typescript-estree
             utils
             visitor-keys

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/semver": "^7.5.0",
     "@types/tmp": "^0.2.3",
     "@types/yargs": "^17.0.32",
+    "@typescript-eslint/eslint-plugin-internal": "workspace:packages/eslint-plugin-internal",
     "console-fail-test": "^0.2.3",
     "cross-fetch": "^4.0.0",
     "cspell": "^7.0.0",
@@ -117,6 +118,7 @@
     "tslint": "^6.1.3",
     "tsx": "^4.6.2",
     "typescript": ">=4.3.5 <5.4.0",
+    "typescript-eslint": "workspace:packages/typescript-eslint",
     "yargs": "17.7.2"
   },
   "resolutions": {

--- a/packages/typescript-eslint/LICENCE
+++ b/packages/typescript-eslint/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 typescript-eslint and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/typescript-eslint/README.md
+++ b/packages/typescript-eslint/README.md
@@ -1,0 +1,12 @@
+# `typescript-eslint`
+
+> Tooling which enables you to use TypeScript with ESLint
+
+[![NPM Version](https://img.shields.io/npm/v/typescript-eslint.svg?style=flat-square)](https://www.npmjs.com/package/typescript-eslint)
+[![NPM Downloads](https://img.shields.io/npm/dm/typescript-eslint.svg?style=flat-square)](https://www.npmjs.com/package/typescript-eslint)
+
+👉 See **https://typescript-eslint.io/packages/typescript-eslint** for documentation on this package.
+
+> See https://typescript-eslint.io for general documentation on typescript-eslint, the tooling that allows you to run ESLint and Prettier on TypeScript code.
+
+<!-- Local path for docs: docs/packages/typescript-eslint.mdx -->

--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "typescript-eslint",
+  "version": "6.20.0",
+  "description": "Tooling which enables you to use TypeScript with ESLint",
+  "files": [
+    "dist",
+    "_ts4.3",
+    "README.md",
+    "LICENSE"
+  ],
+  "type": "commonjs",
+  "private": true,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "engines": {
+    "node": "^16.0.0 || >=18.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typescript-eslint/typescript-eslint.git",
+    "directory": "packages/typescript-eslint"
+  },
+  "bugs": {
+    "url": "https://github.com/typescript-eslint/typescript-eslint/issues"
+  },
+  "license": "MIT",
+  "keywords": [
+    "ast",
+    "ecmascript",
+    "javascript",
+    "typescript",
+    "parser",
+    "syntax",
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
+  "scripts": {
+    "build": "tsc -b tsconfig.build.json",
+    "postbuild": "downlevel-dts dist _ts4.3/dist --to=4.3",
+    "clean": "tsc -b tsconfig.build.json --clean",
+    "postclean": "rimraf dist && rimraf _ts4.3 && rimraf coverage",
+    "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
+    "lint": "nx lint",
+    "test": "jest --coverage --passWithNoTests",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "peerDependencies": {
+    "eslint": "^7.0.0 || ^8.0.0"
+  },
+  "dependencies": {
+    "@typescript-eslint/eslint-plugin": "6.20.0",
+    "@typescript-eslint/parser": "6.20.0"
+  },
+  "devDependencies": {
+    "downlevel-dts": "*",
+    "jest": "29.7.0",
+    "prettier": "^3.0.3",
+    "rimraf": "*",
+    "typescript": "*"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/typescript-eslint"
+  },
+  "typesVersions": {
+    "<4.7": {
+      "*": [
+        "_ts4.3/*"
+      ]
+    }
+  }
+}

--- a/packages/typescript-eslint/project.json
+++ b/packages/typescript-eslint/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "typescript-eslint",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "type": "library",
+  "implicitDependencies": [],
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "ignorePath": ".eslintignore"
+      }
+    }
+  }
+}

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -1,0 +1,2 @@
+// TODO(bradzacher) #7935
+export {};

--- a/packages/typescript-eslint/tsconfig.build.json
+++ b/packages/typescript-eslint/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "../parser/tsconfig.build.json" }]
+}

--- a/packages/typescript-eslint/tsconfig.json
+++ b/packages/typescript-eslint/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "composite": false,
+    "rootDir": "."
+  },
+  "include": ["src", "tests", "tools"],
+  "exclude": ["tests/fixtures"],
+  "references": [{ "path": "../parser/tsconfig.build.json" }]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5645,6 +5645,7 @@ __metadata:
     "@types/semver": ^7.5.0
     "@types/tmp": ^0.2.3
     "@types/yargs": ^17.0.32
+    "@typescript-eslint/eslint-plugin-internal": "workspace:packages/eslint-plugin-internal"
     console-fail-test: ^0.2.3
     cross-fetch: ^4.0.0
     cspell: ^7.0.0
@@ -5683,6 +5684,7 @@ __metadata:
     tslint: ^6.1.3
     tsx: ^4.6.2
     typescript: ">=4.3.5 <5.4.0"
+    typescript-eslint: "workspace:packages/typescript-eslint"
     yargs: 17.7.2
   languageName: unknown
   linkType: soft
@@ -18346,6 +18348,25 @@ __metadata:
   checksum: 99c11aaa8f45189fcfba6b8a4825fd684a321caa9bd7a76a27cf0c7732c174d198b99f449c52c3818107430b5f41c0ccbbfb75cb2ee3ca4a9451710986d61a60
   languageName: node
   linkType: hard
+
+"typescript-eslint@workspace:packages/typescript-eslint":
+  version: 0.0.0-use.local
+  resolution: "typescript-eslint@workspace:packages/typescript-eslint"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": 6.20.0
+    "@typescript-eslint/parser": 6.20.0
+    downlevel-dts: "*"
+    jest: 29.7.0
+    prettier: ^3.0.3
+    rimraf: "*"
+    typescript: "*"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  languageName: unknown
+  linkType: soft
 
 "typescript@npm:5.3.3":
   version: 5.3.3


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: #7694
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR just adds an private scaffold for the `typescript-eslint` package being added in #7935. I've split this out so that the automation will bump the versions with each release.

The most annoying part of the branch is every time I go back to it and rebase it on `main` I have to manually resolve and correct all of the versions or else things will use old releases from npm instead of the repo code.