### PR TITLE
feat(website): add ESQuery filter to URL state

### DIFF
--- a/packages/website/src/components/ESQueryFilter.tsx
+++ b/packages/website/src/components/ESQueryFilter.tsx
@@ -5,20 +5,22 @@ import styles from './ESQueryFilter.module.css';
 import Text from './inputs/Text';
 
 export interface ESQueryFilterProps {
-  readonly onChange: (value: Selector) => void;
+  readonly onChange: (filter: string, selector: Selector) => void;
   readonly onError: (value?: Error) => void;
+  defaultValue?: string;
 }
 
 export function ESQueryFilter({
   onChange,
   onError,
+  defaultValue,
 }: ESQueryFilterProps): React.JSX.Element {
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(defaultValue ?? '');
   const changeEvent = (value: string): void => {
     setValue(value);
     try {
       const queryParsed = window.esquery.parse(value);
-      onChange(queryParsed);
+      onChange(value, queryParsed);
       onError(undefined);
     } catch (e: unknown) {
       onError(e instanceof Error ? e : new Error(String(e)));

--- a/packages/website/src/components/Playground.tsx
+++ b/packages/website/src/components/Playground.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import { useWindowSize } from '@docusaurus/theme-common';
 import clsx from 'clsx';
-import type * as ESQuery from 'esquery';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   type ImperativePanelHandle,
@@ -39,7 +38,6 @@ function Playground(): React.JSX.Element {
   const [selectedRange, setSelectedRange] = useState<SelectedRange>();
   const [position, setPosition] = useState<number>();
   const [activeTab, setTab] = useState<TabType>('code');
-  const [esQueryFilter, setEsQueryFilter] = useState<ESQuery.Selector>();
   const [esQueryError, setEsQueryError] = useState<Error>();
   const [visualEslintRc, setVisualEslintRc] = useState(false);
   const [visualTSConfig, setVisualTSConfig] = useState(false);
@@ -178,7 +176,13 @@ function Playground(): React.JSX.Element {
             />
             {state.showAST === 'es' && (
               <ESQueryFilter
-                onChange={setEsQueryFilter}
+                defaultValue={state.esQueryFilter}
+                onChange={(filter, selector) =>
+                  setState({
+                    esQueryFilter: filter,
+                    esQuerySelector: selector,
+                  })
+                }
                 onError={setEsQueryError}
               />
             )}
@@ -202,7 +206,9 @@ function Playground(): React.JSX.Element {
               (state.showAST && astModel && (
                 <ASTViewer
                   key={String(state.showAST)}
-                  filter={state.showAST === 'es' ? esQueryFilter : undefined}
+                  filter={
+                    state.showAST === 'es' ? state.esQuerySelector : undefined
+                  }
                   value={
                     state.showAST === 'ts'
                       ? astModel.storedTsAST

--- a/packages/website/src/components/Playground.tsx
+++ b/packages/website/src/components/Playground.tsx
@@ -176,11 +176,10 @@ function Playground(): React.JSX.Element {
             />
             {state.showAST === 'es' && (
               <ESQueryFilter
-                defaultValue={state.esQueryFilter}
+                defaultValue={state.esQuery?.filter}
                 onChange={(filter, selector) =>
                   setState({
-                    esQueryFilter: filter,
-                    esQuerySelector: selector,
+                    esQuery: { filter, selector },
                   })
                 }
                 onError={setEsQueryError}
@@ -207,7 +206,7 @@ function Playground(): React.JSX.Element {
                 <ASTViewer
                   key={String(state.showAST)}
                   filter={
-                    state.showAST === 'es' ? state.esQuerySelector : undefined
+                    state.showAST === 'es' ? state.esQuery?.selector : undefined
                   }
                   value={
                     state.showAST === 'ts'

--- a/packages/website/src/components/hooks/useHashState.ts
+++ b/packages/website/src/components/hooks/useHashState.ts
@@ -71,6 +71,13 @@ const parseStateFromUrl = (hash: string): Partial<ConfigModel> | undefined => {
       );
     }
 
+    let esQuerySelector: ConfigModel['esQuerySelector'] | undefined;
+    if (searchParams.has('esQuerySelector')) {
+      esQuerySelector = JSON.parse(
+        readQueryParam(searchParams.get('esQuerySelector'), ''),
+      ) as ConfigModel['esQuerySelector'];
+    }
+
     const fileType =
       searchParams.get('jsx') === 'true'
         ? '.tsx'
@@ -90,6 +97,8 @@ const parseStateFromUrl = (hash: string): Partial<ConfigModel> | undefined => {
       eslintrc: eslintrc ?? '',
       tsconfig: tsconfig ?? '',
       showTokens: searchParams.get('tokens') === 'true',
+      esQuerySelector,
+      esQueryFilter: searchParams.get('esQueryFilter') ?? '',
     };
   } catch (e) {
     console.warn(e);
@@ -110,9 +119,16 @@ const writeStateToUrl = (newState: ConfigModel): string | undefined => {
     if (newState.fileType) {
       searchParams.set('fileType', newState.fileType);
     }
+    if (newState.esQuerySelector) {
+      searchParams.set(
+        'esQuerySelector',
+        writeQueryParam(JSON.stringify(newState.esQuerySelector)),
+      );
+    }
     searchParams.set('code', writeQueryParam(newState.code));
     searchParams.set('eslintrc', writeQueryParam(newState.eslintrc));
     searchParams.set('tsconfig', writeQueryParam(newState.tsconfig));
+    searchParams.set('esQueryFilter', newState.esQueryFilter ?? '');
     searchParams.set('tokens', String(!!newState.showTokens));
     return searchParams.toString();
   } catch (e) {

--- a/packages/website/src/components/hooks/useHashState.ts
+++ b/packages/website/src/components/hooks/useHashState.ts
@@ -71,11 +71,11 @@ const parseStateFromUrl = (hash: string): Partial<ConfigModel> | undefined => {
       );
     }
 
-    let esQuerySelector: ConfigModel['esQuerySelector'] | undefined;
-    if (searchParams.has('esQuerySelector')) {
-      esQuerySelector = JSON.parse(
-        readQueryParam(searchParams.get('esQuerySelector'), ''),
-      ) as ConfigModel['esQuerySelector'];
+    let esQuery: ConfigModel['esQuery'] | undefined;
+    if (searchParams.has('esQuery')) {
+      esQuery = JSON.parse(
+        readQueryParam(searchParams.get('esQuery'), ''),
+      ) as ConfigModel['esQuery'];
     }
 
     const fileType =
@@ -97,8 +97,7 @@ const parseStateFromUrl = (hash: string): Partial<ConfigModel> | undefined => {
       eslintrc: eslintrc ?? '',
       tsconfig: tsconfig ?? '',
       showTokens: searchParams.get('tokens') === 'true',
-      esQuerySelector,
-      esQueryFilter: searchParams.get('esQueryFilter') ?? '',
+      esQuery,
     };
   } catch (e) {
     console.warn(e);
@@ -119,16 +118,15 @@ const writeStateToUrl = (newState: ConfigModel): string | undefined => {
     if (newState.fileType) {
       searchParams.set('fileType', newState.fileType);
     }
-    if (newState.esQuerySelector) {
+    if (newState.esQuery) {
       searchParams.set(
-        'esQuerySelector',
-        writeQueryParam(JSON.stringify(newState.esQuerySelector)),
+        'esQuery',
+        writeQueryParam(JSON.stringify(newState.esQuery)),
       );
     }
     searchParams.set('code', writeQueryParam(newState.code));
     searchParams.set('eslintrc', writeQueryParam(newState.eslintrc));
     searchParams.set('tsconfig', writeQueryParam(newState.tsconfig));
-    searchParams.set('esQueryFilter', newState.esQueryFilter ?? '');
     searchParams.set('tokens', String(!!newState.showTokens));
     return searchParams.toString();
   } catch (e) {

--- a/packages/website/src/components/options.ts
+++ b/packages/website/src/components/options.ts
@@ -44,6 +44,4 @@ export const defaultConfig: ConfigModel = {
   }),
   scroll: true,
   showTokens: false,
-  esQueryFilter: '',
-  esQuerySelector: undefined,
 };

--- a/packages/website/src/components/options.ts
+++ b/packages/website/src/components/options.ts
@@ -44,4 +44,6 @@ export const defaultConfig: ConfigModel = {
   }),
   scroll: true,
   showTokens: false,
+  esQueryFilter: '',
+  esQuerySelector: undefined,
 };

--- a/packages/website/src/components/types.ts
+++ b/packages/website/src/components/types.ts
@@ -1,4 +1,5 @@
 import type { TSESLint } from '@typescript-eslint/utils';
+import type * as ESQuery from 'esquery';
 import type * as ts from 'typescript';
 
 export type CompilerFlags = Record<string, unknown>;
@@ -29,6 +30,8 @@ export interface ConfigModel {
   showAST?: ConfigShowAst;
   scroll?: boolean;
   showTokens?: boolean;
+  esQueryFilter?: string;
+  esQuerySelector?: ESQuery.Selector;
 }
 
 export type SelectedRange = [number, number];

--- a/packages/website/src/components/types.ts
+++ b/packages/website/src/components/types.ts
@@ -30,8 +30,10 @@ export interface ConfigModel {
   showAST?: ConfigShowAst;
   scroll?: boolean;
   showTokens?: boolean;
-  esQueryFilter?: string;
-  esQuerySelector?: ESQuery.Selector;
+  esQuery?: {
+    selector: ESQuery.Selector;
+    filter?: string;
+  };
 }
 
 export type SelectedRange = [number, number];


### PR DESCRIPTION
Closes #8174

Here us [a working example](https://deploy-preview-8297--typescript-eslint.netlify.app/play/#ts=5.3.3&showAST=es&fileType=.tsx&esQuerySelector=N4IgLgngDgpiBcIDGB7AtlFBXAdgExABoQBnGAGxiTBQCcSEBtUSWBEASzxhzA4DMOMWkRAA3AIbkscRAFkYYABYo8AERiCcHPihwgAvoRbRZICWDC0OAIyxg4xHBLRnJ0mADpWMAAoTaF0VhBgMAXQMgA&code=FAEwpgxgNghgTmABNGBnViDCAeAagPkQG9hFEBbMAFwAsB7EbAFQBpEBVfACgAd4ZyALkRMAlMPYBuUoh5w6PYdgAK3UYgC8hZdIC%2BQA&eslintrc=N4KABGBEBOCuA2BTAzpAXGYBfEWg&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&esQueryFilter=MethodDefinition%5Bvalue.typeParameters%5D&tokens=false)