### PR TITLE
fix(eslint-plugin): [prefer-readonly] disable checking accessors

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly.ts
@@ -299,7 +299,10 @@ class ClassScope {
         tsutils.isModifierFlagSet(node, ts.ModifierFlags.Private) ||
         node.name.kind === ts.SyntaxKind.PrivateIdentifier
       ) ||
-      tsutils.isModifierFlagSet(node, ts.ModifierFlags.Accessor | ts.ModifierFlags.Readonly)
+      tsutils.isModifierFlagSet(
+        node,
+        ts.ModifierFlags.Accessor | ts.ModifierFlags.Readonly,
+      ) ||
       ts.isComputedPropertyName(node.name)
     ) {
       return;

--- a/packages/eslint-plugin/src/rules/prefer-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly.ts
@@ -299,8 +299,7 @@ class ClassScope {
         tsutils.isModifierFlagSet(node, ts.ModifierFlags.Private) ||
         node.name.kind === ts.SyntaxKind.PrivateIdentifier
       ) ||
-      tsutils.isModifierFlagSet(node, ts.ModifierFlags.Readonly) ||
-      tsutils.isModifierFlagSet(node, ts.ModifierFlags.Accessor) ||
+      tsutils.isModifierFlagSet(node, ts.ModifierFlags.Accessor | ts.ModifierFlags.Readonly)
       ts.isComputedPropertyName(node.name)
     ) {
       return;

--- a/packages/eslint-plugin/src/rules/prefer-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly.ts
@@ -300,6 +300,7 @@ class ClassScope {
         node.name.kind === ts.SyntaxKind.PrivateIdentifier
       ) ||
       tsutils.isModifierFlagSet(node, ts.ModifierFlags.Readonly) ||
+      tsutils.isModifierFlagSet(node, ts.ModifierFlags.Accessor) ||
       ts.isComputedPropertyName(node.name)
     ) {
       return;

--- a/packages/eslint-plugin/tests/rules/prefer-readonly.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly.test.ts
@@ -718,11 +718,22 @@ class Foo {
       }
     `,
     `
-      class TestAccessors {
+      class TestStaticPrivateAccessor {
         private static accessor staticAcc = 1;
+      }
+    `,
+    `
+      class TestStaticPrivateFieldAccessor {
         static accessor #staticAcc = 1;
-
+      }
+    `,
+    `
+      class TestPrivateAccessor {
         private accessor acc = 3;
+      }
+    `,
+    `
+      class TestPrivateFieldAccessor {
         accessor #acc = 3;
       }
     `,

--- a/packages/eslint-plugin/tests/rules/prefer-readonly.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly.test.ts
@@ -717,6 +717,15 @@ class Foo {
         }
       }
     `,
+    `
+      class TestAccessors {
+        private static accessor staticAcc = 1;
+        static accessor #staticAcc = 1;
+
+        private accessor acc = 3;
+        accessor #acc = 3;
+      }
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8299
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Accessors don't support `readonly`, so having `prefer-readonly` apply to them doesn't make sense. The current behaviour also generates an invalid fix, as such this PR simply removes accessors from being considered in the rule.