### PR TITLE
chore(eslint-plugin): fix typos in schema definitions

### DIFF
--- a/packages/eslint-plugin/src/rules/class-methods-use-this.ts
+++ b/packages/eslint-plugin/src/rules/class-methods-use-this.ts
@@ -50,7 +50,7 @@ export default createRule<Options, MessageIds>({
           },
           ignoreOverrideMethods: {
             type: 'boolean',
-            description: 'Ingore members marked with the `override` modifier',
+            description: 'Ignore members marked with the `override` modifier',
           },
           ignoreClassesThatImplementAnInterface: {
             oneOf: [

--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -81,7 +81,7 @@ export default createRule<Options, MessageIds>({
           },
           allowTypedFunctionExpressions: {
             description:
-              'Whether to ignore type annotations on the variable of a function expresion.',
+              'Whether to ignore type annotations on the variable of a function expression.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/tests/schema-snapshots/class-methods-use-this.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/class-methods-use-this.shot
@@ -35,7 +35,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         ]
       },
       "ignoreOverrideMethods": {
-        "description": "Ingore members marked with the \`override\` modifier",
+        "description": "Ignore members marked with the \`override\` modifier",
         "type": "boolean"
       }
     },
@@ -60,7 +60,7 @@ type Options = [
     | boolean
       /** Ignore only the public fields of classes that implement an interface */
       | 'public-fields';
-    /** Ingore members marked with the \`override\` modifier */
+    /** Ignore members marked with the \`override\` modifier */
     ignoreOverrideMethods?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/explicit-module-boundary-types.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/explicit-module-boundary-types.shot
@@ -28,7 +28,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "type": "boolean"
       },
       "allowTypedFunctionExpressions": {
-        "description": "Whether to ignore type annotations on the variable of a function expresion.",
+        "description": "Whether to ignore type annotations on the variable of a function expression.",
         "type": "boolean"
       }
     },
@@ -53,7 +53,7 @@ type Options = [
      * You must still type the parameters of the function.
      */
     allowHigherOrderFunctions?: boolean;
-    /** Whether to ignore type annotations on the variable of a function expresion. */
+    /** Whether to ignore type annotations on the variable of a function expression. */
     allowTypedFunctionExpressions?: boolean;
     /** An array of function/method names that will not have their arguments or return values checked. */
     allowedNames?: string[];


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [-] Addresses an existing open issue: fixes #000
- [-] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This fixes typos in the schema definitions.

I've been extracting the schemas from `typescript-eslint` (using [jsonschema-extractor](https://github.com/fox-projects/jsonschema-extractor)), and submitting them upstream to [SchemaStore](https://github.com/SchemaStore/schemastore) to improve autocompletion of `.eslintrc.(json|yml|yaml)` files (at least until people switch to flat config). Typos run into build errors over there.

💖