### PR TITLE
chore(eslint-plugin): [no-invalid-void-type] fix `Options` typing to reflect `minItems: 1`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
@@ -5,7 +5,7 @@ import { getSourceCode } from '@typescript-eslint/utils/eslint-utils';
 import { createRule } from '../util';
 
 interface Options {
-  allowInGenericTypeArguments?: string[] | boolean;
+  allowInGenericTypeArguments?: [string, ...string[]] | boolean;
   allowAsThisParameter?: boolean;
 }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR fixes the `Options` typing for the `no-invalid-void-type` rule so that it reflects
https://github.com/typescript-eslint/typescript-eslint/blob/70505e45bee0c2b05777a3f9e5b886a1a607d349/packages/eslint-plugin/src/rules/no-invalid-void-type.ts#L51
and also [its documentation](https://typescript-eslint.io/rules/no-invalid-void-type/#options). I think this should be considered an extremely minor typo even though it doesn't involve documentation.

:sweat_smile: