### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] provide valid fixes for assertions with extra tokens before `as` keyword

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -1,4 +1,4 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
 import path from 'path';
 
 import rule from '../../src/rules/no-unnecessary-type-assertion';
@@ -657,6 +657,101 @@ const item = arr[0];
       errors: [
         {
           messageId: 'unnecessaryAssertion',
+        },
+      ],
+    },
+    {
+      code: noFormat`
+const foo = (  3 + 5  ) as number;
+      `,
+      output: `
+const foo = (  3 + 5  );
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+const foo = (  3 + 5  ) /*as*/ as number;
+      `,
+      output: `
+const foo = (  3 + 5  ) /*as*/;
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+const foo = (  3 + 5
+  ) /*as*/ as //as
+  (
+    number
+  );
+      `,
+      output: `
+const foo = (  3 + 5
+  ) /*as*/;
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+const foo = (3 + (5 as number) ) as number;
+      `,
+      output: `
+const foo = (3 + (5 as number) );
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+const foo = 3 + 5/*as*/ as number;
+      `,
+      output: `
+const foo = 3 + 5/*as*/;
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+const foo = 3 + 5/*a*/ /*b*/ as number;
+      `,
+      output: `
+const foo = 3 + 5/*a*/ /*b*/;
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 13,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -755,5 +755,65 @@ const foo = 3 + 5/*a*/ /*b*/;
         },
       ],
     },
+    {
+      code: noFormat`
+const foo = <(number)>(3 + 5);
+      `,
+      output: `
+const foo = (3 + 5);
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+const foo = < ( number ) >( 3 + 5 );
+      `,
+      output: `
+const foo = ( 3 + 5 );
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+const foo = <number> /* a */ (3 + 5);
+      `,
+      output: `
+const foo =  /* a */ (3 + 5);
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 13,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+const foo = <number /* a */>(3 + 5);
+      `,
+      output: `
+const foo = (3 + 5);
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+          column: 13,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8325
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I think the test cases and comments are a nice overview :)