### PR TITLE
fix(eslint-plugin): [consistent-type-imports] dont report on types used in export assignment expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -183,12 +183,15 @@ export default createRule<Options, MessageIds>({
                        * keep origin import kind when export
                        * export { Type }
                        * export default Type;
+                       * export = Type;
                        */
                       if (
                         ref.identifier.parent.type ===
                           AST_NODE_TYPES.ExportSpecifier ||
                         ref.identifier.parent.type ===
-                          AST_NODE_TYPES.ExportDefaultDeclaration
+                          AST_NODE_TYPES.ExportDefaultDeclaration ||
+                        ref.identifier.parent.type ===
+                          AST_NODE_TYPES.TSExportAssignment
                       ) {
                         if (ref.isValueReference && ref.isTypeReference) {
                           return node.importKind === 'type';

--- a/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-imports.test.ts
@@ -566,6 +566,22 @@ export type Y = {
   [constants.X]: ReadonlyArray<string>;
 };
     `,
+    `
+      import A from 'foo';
+      export = A;
+    `,
+    `
+      import type A from 'foo';
+      export = A;
+    `,
+    `
+      import type A from 'foo';
+      export = {} as A;
+    `,
+    `
+      import { type A } from 'foo';
+      export = {} as A;
+    `,
   ],
   invalid: [
     {
@@ -2225,6 +2241,42 @@ let baz: D;
       errors: [
         {
           messageId: 'aImportIsOnlyTypes',
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+import A from 'foo';
+export = {} as A;
+      `,
+      output: `
+import type A from 'foo';
+export = {} as A;
+      `,
+      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
+      errors: [
+        {
+          messageId: 'typeOverValue',
+          line: 2,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: `
+import { A } from 'foo';
+export = {} as A;
+      `,
+      output: `
+import { type A } from 'foo';
+export = {} as A;
+      `,
+      options: [{ prefer: 'type-imports', fixStyle: 'inline-type-imports' }],
+      errors: [
+        {
+          messageId: 'typeOverValue',
           line: 2,
           column: 1,
         },

--- a/packages/scope-manager/src/referencer/ExportVisitor.ts
+++ b/packages/scope-manager/src/referencer/ExportVisitor.ts
@@ -7,8 +7,7 @@ import { Visitor } from './Visitor';
 type ExportNode =
   | TSESTree.ExportAllDeclaration
   | TSESTree.ExportDefaultDeclaration
-  | TSESTree.ExportNamedDeclaration
-  | TSESTree.TSExportAssignment;
+  | TSESTree.ExportNamedDeclaration;
 
 class ExportVisitor extends Visitor {
   readonly #referencer: Referencer;
@@ -26,10 +25,7 @@ class ExportVisitor extends Visitor {
   }
 
   protected Identifier(node: TSESTree.Identifier): void {
-    if (
-      this.#exportNode.type !== AST_NODE_TYPES.TSExportAssignment &&
-      this.#exportNode.exportKind === 'type'
-    ) {
+    if (this.#exportNode.exportKind === 'type') {
       // export type { T };
       // type exports can only reference types
       this.#referencer.currentScope().referenceType(node);
@@ -51,10 +47,6 @@ class ExportVisitor extends Visitor {
       // etc
       // these not included in the scope of this visitor as they are all guaranteed to be values or declare variables
     }
-  }
-
-  protected TSExportAssignment(node: TSESTree.TSExportAssignment): void {
-    this.visit(node.expression);
   }
 
   protected ExportNamedDeclaration(

--- a/packages/scope-manager/src/referencer/Referencer.ts
+++ b/packages/scope-manager/src/referencer/Referencer.ts
@@ -444,7 +444,11 @@ class Referencer extends Visitor {
   }
 
   protected TSExportAssignment(node: TSESTree.TSExportAssignment): void {
-    ExportVisitor.visit(this, node);
+    if (node.expression.type === AST_NODE_TYPES.Identifier) {
+      ExportVisitor.visit(this, node);
+    } else {
+      this.visit(node.expression);
+    }
   }
 
   protected ExportNamedDeclaration(

--- a/packages/scope-manager/src/referencer/Referencer.ts
+++ b/packages/scope-manager/src/referencer/Referencer.ts
@@ -445,7 +445,7 @@ class Referencer extends Visitor {
 
   protected TSExportAssignment(node: TSESTree.TSExportAssignment): void {
     if (node.expression.type === AST_NODE_TYPES.Identifier) {
-      ExportVisitor.visit(this, node);
+      this.currentScope().referenceDualValueType(node.expression);
     } else {
       this.visit(node.expression);
     }

--- a/packages/scope-manager/tests/fixtures/export/equals4-type.ts
+++ b/packages/scope-manager/tests/fixtures/export/equals4-type.ts
@@ -1,0 +1,3 @@
+type T = 1;
+
+export = {} as T;

--- a/packages/scope-manager/tests/fixtures/export/equals4-type.ts.shot
+++ b/packages/scope-manager/tests/fixtures/export/equals4-type.ts.shot
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`export equals4-type 1`] = `
+ScopeManager {
+  variables: [
+    ImplicitGlobalConstTypeVariable,
+    Variable$2 {
+      defs: [
+        TypeDefinition$1 {
+          name: Identifier<"T">,
+          node: TSTypeAliasDeclaration$1,
+        },
+      ],
+      name: "T",
+      references: [
+        Reference$1 {
+          identifier: Identifier<"T">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: Variable$2,
+        },
+      ],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
+  ],
+  scopes: [
+    GlobalScope$1 {
+      block: Program$2,
+      isStrict: false,
+      references: [
+        Reference$1,
+      ],
+      set: Map {
+        "const" => ImplicitGlobalConstTypeVariable,
+        "T" => Variable$2,
+      },
+      type: "global",
+      upper: null,
+      variables: [
+        ImplicitGlobalConstTypeVariable,
+        Variable$2,
+      ],
+    },
+  ],
+}
+`;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8330
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I missed that in https://github.com/typescript-eslint/typescript-eslint/pull/8265 :

In cases like `export = {} as T`, T was referenced as `isTypeReference: true` and `isValueReference: true`. Now it's only referenced as a type