### PR TITLE
feat: allow `parserOptions.project: false`

### DIFF
--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -45,8 +45,8 @@ interface ParserOptions {
   jsxFragmentName?: string | null;
   jsxPragma?: string | null;
   lib?: string[];
-  programs?: import('typescript').Program;
-  project?: string | string[] | true;
+  programs?: import('typescript').Program[];
+  project?: string | string[] | true | boolean | null;
   projectFolderIgnoreList?: string[];
   tsconfigRootDir?: string;
   warnOnUnsupportedTypeScriptVersion?: boolean;
@@ -212,13 +212,17 @@ This option allows you to provide a path to your project's `tsconfig.json`. **Th
 
   // array of paths and/or glob patterns
   project: ['./packages/**/tsconfig.json', './separate-package/tsconfig.json'];
+
+  // ways to disable type-aware linting (useful for overrides configs)
+  project: false;
+  project: null;
   ```
 
 - If `true`, each source file's parse will find the nearest `tsconfig.json` file to that source file.
 
   - This is done by checking that source file's directory tree for the nearest `tsconfig.json`.
 
-- If you use project references, TypeScript will not automatically use project references to resolve files. This means that you will have to add each referenced tsconfig to the `project` field either separately, or via a glob.
+- If you use project references, TypeScript will **not** automatically use project references to resolve files. This means that you will have to add each referenced tsconfig to the `project` field either separately, or via a glob.
 
 - Note that using wide globs `**` in your `parserOptions.project` may cause performance implications. Instead of globs that use `**` to recursively check all folders, prefer paths that use a single `*` at a time. For more info see [#2611](https://github.com/typescript-eslint/typescript-eslint/issues/2611).
 

--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -46,7 +46,7 @@ interface ParserOptions {
   jsxPragma?: string | null;
   lib?: string[];
   programs?: import('typescript').Program[];
-  project?: string | string[] | true | boolean | null;
+  project?: string | string[] | boolean | null;
   projectFolderIgnoreList?: string[];
   tsconfigRootDir?: string;
   warnOnUnsupportedTypeScriptVersion?: boolean;

--- a/docs/packages/TypeScript_ESTree.mdx
+++ b/docs/packages/TypeScript_ESTree.mdx
@@ -209,8 +209,10 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
    * Absolute (or relative to `tsconfigRootDir`) paths to the tsconfig(s),
    * or `true` to find the nearest tsconfig.json to the file.
    * If this is provided, type information will be returned.
+   *
+   * If set to `false`, `null` or `undefined` type information will not be returned.
    */
-  project?: string | string[] | true;
+  project?: string[] | string | boolean | null;
 
   /**
    * If you provide a glob (or globs) to the project option, you can use this option to ignore certain folders from

--- a/docs/packages/TypeScript_ESTree.mdx
+++ b/docs/packages/TypeScript_ESTree.mdx
@@ -210,7 +210,7 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
    * or `true` to find the nearest tsconfig.json to the file.
    * If this is provided, type information will be returned.
    *
-   * If set to `false`, `null` or `undefined` type information will not be returned.
+   * If set to `false`, `null`, or `undefined`, type information will not be returned.
    */
   project?: string[] | string | boolean | null;
 

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -63,7 +63,7 @@ interface ParserOptions {
   jsDocParsingMode?: JSDocParsingMode;
   loc?: boolean;
   programs?: Program | null;
-  project?: string[] | string | true | null;
+  project?: string[] | string | boolean | null;
   projectFolderIgnoreList?: (RegExp | string)[];
   range?: boolean;
   sourceType?: SourceType;

--- a/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
+++ b/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
@@ -2,7 +2,8 @@ import debug from 'debug';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import type { ParseSettings } from '.';
+import type { TSESTreeOptions } from '../parser-options';
+import type { ParseSettings } from './index';
 
 const log = debug('typescript-eslint:typescript-estree:getProjectConfigFiles');
 
@@ -20,10 +21,10 @@ export function getProjectConfigFiles(
     ParseSettings,
     'filePath' | 'tsconfigMatchCache' | 'tsconfigRootDir'
   >,
-  project: string[] | string | true | null | undefined,
+  project: TSESTreeOptions['project'],
 ): string[] | null {
   if (project !== true) {
-    if (project == null) {
+    if (project == null || project === false) {
       return null;
     }
     if (Array.isArray(project)) {

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -166,8 +166,10 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
    * Absolute (or relative to `tsconfigRootDir`) paths to the tsconfig(s),
    * or `true` to find the nearest tsconfig.json to the file.
    * If this is provided, type information will be returned.
+   *
+   * If set to `false`, `null` or `undefined` type information will not be returned.
    */
-  project?: string[] | string | true | null;
+  project?: string[] | string | boolean | null;
 
   /**
    * If you provide a glob (or globs) to the project option, you can use this option to ignore certain folders from

--- a/packages/typescript-estree/tests/lib/getProjectConfigFiles.test.ts
+++ b/packages/typescript-estree/tests/lib/getProjectConfigFiles.test.ts
@@ -38,12 +38,14 @@ describe('getProjectConfigFiles', () => {
     expect(actual).toEqual(project);
   });
 
-  it('returns the project when given as undefined', () => {
-    const project = undefined;
+  describe('it does not enable type-aware linting when given as', () => {
+    for (const project of [undefined, null, false]) {
+      it(`${project}`, () => {
+        const actual = getProjectConfigFiles(parseSettings, project);
 
-    const actual = getProjectConfigFiles(parseSettings, project);
-
-    expect(actual).toBeNull();
+        expect(actual).toBeNull();
+      });
+    }
   });
 
   describe('when caching hits', () => {


### PR DESCRIPTION
## Overview

<!-- Description of what is changed and how the code change does that. -->
More splitting out of #7935.
This change allows us to pass `false` to `parserOptions.project`.
This allows us to work-around eslint/eslint#17820 not being in ESLint v8