### PR TITLE
feat(utils): improve eslint types

### DIFF
--- a/packages/utils/src/ts-eslint/Config.ts
+++ b/packages/utils/src/ts-eslint/Config.ts
@@ -119,7 +119,7 @@ export namespace ClassicConfig {
 export namespace FlatConfig {
   export type EcmaVersion = ParserOptionsTypes.EcmaVersion;
   export type GlobalsConfig = SharedConfig.GlobalsConfig;
-  export type Parser = ParserType.ParserModule;
+  export type Parser = ParserType.LooseParserModule;
   export type ParserOptions = SharedConfig.ParserOptions;
   export type Processor = ProcessorType.ProcessorModule;
   export type RuleEntry = SharedConfig.RuleEntry;
@@ -131,6 +131,9 @@ export namespace FlatConfig {
   export type SeverityString = SharedConfig.SeverityString;
   export type SourceType = ParserOptionsTypes.SourceType | 'commonjs';
 
+  export interface SharedConfigs {
+    [key: string]: Config;
+  }
   export interface PluginMeta {
     /**
      * The meta.name property should match the npm package name for your plugin.
@@ -146,7 +149,7 @@ export namespace FlatConfig {
      * Shared configurations bundled with the plugin.
      * Users will reference these directly in their config (i.e. `plugin.configs.recommended`).
      */
-    configs?: Record<string, Config>;
+    configs?: SharedConfigs;
     /**
      * Metadata about your plugin for easier debugging and more effective caching of plugins.
      */
@@ -165,7 +168,13 @@ export namespace FlatConfig {
     rules?: Record<string, RuleCreateFunction | AnyRuleModule>;
   }
   export interface Plugins {
-    [pluginAlias: string]: Plugin;
+    /**
+     * We intentionally omit the `configs` key from this object because it avoids
+     * type conflicts with old plugins that haven't updated their configs to flat configs yet.
+     * It's valid to reference these old plugins because ESLint won't access the
+     * `.config` property of a plugin when evaluating a flat config.
+     */
+    [pluginAlias: string]: Omit<Plugin, 'configs'>;
   }
 
   export interface LinterOptions {
@@ -174,9 +183,17 @@ export namespace FlatConfig {
      */
     noInlineConfig?: boolean;
     /**
-     * A Boolean value indicating if unused disable directives should be tracked and reported.
+     * A severity string indicating if and how unused disable and enable
+     * directives should be tracked and reported. For legacy compatibility, `true`
+     * is equivalent to `"warn"` and `false` is equivalent to `"off"`.
+     * @default "off"
+     *
+     * non-boolean values @since 8.56.0
      */
-    reportUnusedDisableDirectives?: boolean;
+    reportUnusedDisableDirectives?:
+      | SharedConfig.Severity
+      | SharedConfig.SeverityString
+      | boolean;
   }
 
   export interface LanguageOptions {
@@ -262,5 +279,6 @@ export namespace FlatConfig {
     settings?: Settings;
   }
   export type ConfigArray = Config[];
-  export type ConfigFile = ConfigArray | (() => Promise<ConfigArray>);
+  export type ConfigPromise = Promise<ConfigArray>;
+  export type ConfigFile = ConfigArray | ConfigPromise;
 }

--- a/packages/utils/src/ts-eslint/Linter.ts
+++ b/packages/utils/src/ts-eslint/Linter.ts
@@ -26,7 +26,7 @@ declare class LinterBase {
    * @param parserId Name of the parser
    * @param parserModule The parser object
    */
-  defineParser(parserId: string, parserModule: Parser.ParserModule): void;
+  defineParser(parserId: string, parserModule: Parser.LooseParserModule): void;
 
   /**
    * Defines a new linting rule.
@@ -243,7 +243,7 @@ namespace Linter {
   }
 
   /** @deprecated use Parser.ParserModule */
-  export type ParserModule = Parser.ParserModule;
+  export type ParserModule = Parser.LooseParserModule;
 
   /** @deprecated use Parser.ParseResult */
   export type ESLintParseResult = Parser.ParseResult;

--- a/packages/utils/src/ts-eslint/Parser.ts
+++ b/packages/utils/src/ts-eslint/Parser.ts
@@ -16,6 +16,39 @@ export namespace Parser {
     version?: string;
   }
 
+  /**
+   * A loose definition of the ParserModule type for use with configs
+   * This type intended to relax validation of configs so that parsers that have
+   * different AST types or scope managers can still be passed to configs
+   */
+  export type LooseParserModule =
+    | {
+        /**
+         * Information about the parser to uniquely identify it when serializing.
+         */
+        meta?: ParserMeta;
+        /**
+         * Parses the given text into an ESTree AST
+         */
+        parse(text: string, options?: unknown): unknown;
+      }
+    | {
+        /**
+         * Information about the parser to uniquely identify it when serializing.
+         */
+        meta?: ParserMeta;
+        /**
+         * Parses the given text into an AST
+         */
+        parseForESLint(
+          text: string,
+          options?: unknown,
+        ): {
+          // intentionally not using a Record to preserve optionals
+          [k in keyof ParseResult]: unknown;
+        };
+      };
+
   export type ParserModule =
     | {
         /**
@@ -66,6 +99,6 @@ export namespace Parser {
 
   // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
   export interface VisitorKeys {
-    [nodeType: string]: string[];
+    [nodeType: string]: readonly string[];
   }
 }

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -1,6 +1,7 @@
 import type { JSONSchema4 } from '../json-schema';
 import type { ParserServices, TSESTree } from '../ts-estree';
 import type { AST } from './AST';
+import type { FlatConfig } from './Config';
 import type { Linter } from './Linter';
 import type { Scope } from './Scope';
 import type { SourceCode } from './SourceCode';
@@ -189,6 +190,11 @@ interface RuleContext<
    * The name of the parser from configuration.
    */
   parserPath: string;
+  /**
+   * The language options configured for this run
+   * @since 8.4.0
+   */
+  languageOptions?: FlatConfig.LanguageOptions;
   /**
    * The parser options configured for this run
    */


### PR DESCRIPTION
## Overview

<!-- Description of what is changed and how the code change does that. -->
More splitting out of https://github.com/typescript-eslint/typescript-eslint/pull/7935.

- Loosen parser types in flat configs to allow for non-typescript-estree parsers
- Loosen plugin types to allow for not-yet-updated plugins to be passed to flat configs
- Add some missing features added in newer v8 versions