### PR TITLE
docs: fix missing quotation mark in explicit-member-accessibility.md

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
+++ b/packages/eslint-plugin/docs/rules/explicit-member-accessibility.md
@@ -50,14 +50,14 @@ This rule in its default state requires no configuration and will enforce that e
 
 ```jsonc
 {
-  "accessibility: "explicit",
+  "accessibility": "explicit",
   "overrides": {
     "accessors": "explicit",
     "constructors": "no-public",
     "methods": "explicit",
     "properties": "off",
-    "parameterProperties": "explicit"
-  }
+    "parameterProperties": "explicit",
+  },
 }
 ```
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fix a missing quotation mark in docs

**Update**: The prettier linter made me add some trailing commas to the body. I suspect it didn't need them before b/c it wasn't valid JSON-C before.