### PR TITLE
fix(eslint-plugin): [prefer-find] stop throwing type errors when converting symbols to numbers

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -153,14 +153,13 @@ export default createRule({
      * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at#parameters
      */
     function isTreatedAsZeroByArrayAt(value: unknown): boolean {
-      let asNumber: number;
-
-      try {
-        asNumber = Number(value);
-      } catch (e) {
-        // This will happen if trying to convert a symbol.
+      // This would cause the number constructor coercion to throw. Other static
+      // values are safe.
+      if (typeof value === 'symbol') {
         return false;
       }
+
+      const asNumber = Number(value);
 
       if (isNaN(asNumber)) {
         return true;

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -56,6 +56,24 @@ ruleTester.run('prefer-find', rule, {
     "['Just', 'a', 'find'].find(x => x.length > 4);",
     'undefined.filter(x => x)[0];',
     'null?.filter(x => x)[0];',
+    // Should not throw. See https://github.com/typescript-eslint/typescript-eslint/issues/8386
+    `
+      declare function foo(param: any): any;
+      foo(Symbol.for('foo'));
+    `,
+    // Specifically need to test Symbol.for(), not just Symbol(), since only
+    // Symbol.for() creates a static value that the rule inspects.
+    `
+      declare const arr: string[];
+      const s = Symbol.for("Don't throw!");
+      arr.filter(item => item === 'aha').at(s);
+    `,
+    `
+      [1, 2, 3].filter(x => x)[Symbol('0')];
+    `,
+    `
+      [1, 2, 3].filter(x => x)[Symbol.for('0')];
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -68,12 +68,8 @@ ruleTester.run('prefer-find', rule, {
       const s = Symbol.for("Don't throw!");
       arr.filter(item => item === 'aha').at(s);
     `,
-    `
-      [1, 2, 3].filter(x => x)[Symbol('0')];
-    `,
-    `
-      [1, 2, 3].filter(x => x)[Symbol.for('0')];
-    `,
+    "[1, 2, 3].filter(x => x)[Symbol('0')];",
+    "[1, 2, 3].filter(x => x)[Symbol.for('0')];",
   ],
 
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8386 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds exception handling around Number conversion.
