### PR TITLE
docs: remove /ts prefix from eslint-stylistic replacement rule link

### DIFF
--- a/packages/website/plugins/generated-rule-docs/insertions/insertFormattingNotice.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertFormattingNotice.ts
@@ -12,7 +12,7 @@ export function insertFormattingNotice(page: RuleDocsPage): void {
 
   const url =
     replacement &&
-    `https://eslint.style/rules/ts/${replacement.replace('@stylistic/', '')}`;
+    `https://eslint.style/rules/${replacement.replace('@stylistic/', '')}`;
 
   page.spliceChildren(0, 0, {
     value: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8387 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This pull request fixes stylistic rules deprecation links by removing the extra `/ts` prefix for redirection links. 
