### PR TITLE
feat(utils): revert removal of backwards-compat functions

### DIFF
--- a/packages/utils/src/eslint-utils/context.ts
+++ b/packages/utils/src/eslint-utils/context.ts
@@ -1,0 +1,48 @@
+// Wrappers around ESLint's deprecation of existing methods
+/* eslint-disable deprecation/deprecation -- TODO - delete in the next major (v8) */
+import type { Scope, SourceCode } from '../ts-eslint';
+import type { RuleContext } from '../ts-eslint/Rule';
+import type { TSESTree } from '../ts-estree';
+
+/** @deprecated use `context.sourceCode.getAncestors(node)` */
+export function getAncestors(
+  context: Readonly<RuleContext<string, unknown[]>>,
+): TSESTree.Node[] {
+  return context.getAncestors();
+}
+
+/** @deprecated use `context.sourceCode.getCwd()` */
+export function getCwd(
+  context: Readonly<RuleContext<string, unknown[]>>,
+): string {
+  return context.getCwd();
+}
+
+/** @deprecated use `context.sourceCode.getDeclaredVariables(node)` */
+export function getDeclaredVariables(
+  context: Readonly<RuleContext<string, unknown[]>>,
+  node: TSESTree.Node,
+): readonly Scope.Variable[] {
+  return context.sourceCode.getDeclaredVariables(node);
+}
+
+/** @deprecated use `context.filename` */
+export function getFilename(
+  context: Readonly<RuleContext<string, unknown[]>>,
+): string {
+  return context.filename;
+}
+
+/** @deprecated use `context.sourceCode.getScope(node) */
+export function getScope(
+  context: Readonly<RuleContext<string, readonly unknown[]>>,
+): Scope.Scope {
+  return context.getScope();
+}
+
+/** @deprecated use `context.sourceCode` */
+export function getSourceCode(
+  context: Readonly<RuleContext<string, readonly unknown[]>>,
+): Readonly<SourceCode> {
+  return context.sourceCode;
+}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## Overview

<!-- Description of what is changed and how the code change does that. -->
Removed these in #8377 - but on second thought removing them is not good *right now*.

Our goal for this next major is that users just bump *our* peer dependencies (typescript and eslint). If we remove these functions then 3rd party plugins might break - meaning a user has to upgrade our peer deps AND 3rd party plugins. This isn't what we want - we want a isolated and painless major!

Adding them back and marking as `@deprecated` so that things keep working for now. We'll remove them in our next major.