### PR TITLE
chore(eslint-plugin): [no-confusing-void-expression] explicitly state default options in rule doc

### DIFF
--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -79,7 +79,7 @@ export default createRule<Options, MessageId>({
     fixable: 'code',
     hasSuggestions: true,
   },
-  defaultOptions: [{}],
+  defaultOptions: [{ ignoreArrowShorthand: false, ignoreVoidOperator: false }],
 
   create(context, [options]) {
     return {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The `defaultOptions` object in the `no-confusing-void-expression` rule documentation is currently empty:

![no-confusing-void-expression-empty-defaults](https://github.com/typescript-eslint/typescript-eslint/assets/12002672/15a63059-4adb-4197-a170-cb686921424a)
(https://typescript-eslint.io/rules/no-confusing-void-expression/#options)

even though the rule has 2 options. Afaik, this PR makes that `defaultOptions` object explicitly state the options' default values.

Admittedly, I didn't actually generate the website locally, but
https://github.com/typescript-eslint/typescript-eslint/blob/b636baa1972e63f161cef3603d285eba128806d6/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts#L100-L122
strongly suggests this PR will work.

This should be considered as an extremely minor documentation fix, even though changing the documentation actually requires changing code.

💖

----

<a name="update-1">__Update__</a>

I have run Docusaurus (it was easier than I thought) and this fix works as expected.

💖💖
