### PR TITLE
fix(eslint-plugin): [prefer-find] support ternary branches in prefer-find

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -60,13 +60,6 @@ export default createRule({
       // This is the only reason we're returning a list rather than a single value.
       if (expression.type === AST_NODE_TYPES.ConditionalExpression) {
         // Both branches of the ternary _must_ return results.
-        const alternateResult = parseArrayFilterExpressions(
-          expression.alternate,
-        );
-        if (alternateResult.length === 0) {
-          return [];
-        }
-
         const consequentResult = parseArrayFilterExpressions(
           expression.consequent,
         );
@@ -74,8 +67,15 @@ export default createRule({
           return [];
         }
 
+        const alternateResult = parseArrayFilterExpressions(
+          expression.alternate,
+        );
+        if (alternateResult.length === 0) {
+          return [];
+        }
+
         // Accumulate the results from both sides and pass up the chain.
-        return [...alternateResult, ...consequentResult];
+        return [...consequentResult, ...alternateResult];
       }
 
       // Check if it looks like <<stuff>>(...), but not <<stuff>>?.(...)

--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -41,20 +41,41 @@ export default createRule({
       filterNode: TSESTree.Node;
     }
 
-    function parseIfArrayFilterExpression(
+    function parseArrayFilterExpressions(
       expression: TSESTree.Expression,
-    ): FilterExpressionData | undefined {
+    ): FilterExpressionData[] {
       if (expression.type === AST_NODE_TYPES.SequenceExpression) {
         // Only the last expression in (a, b, [1, 2, 3].filter(condition))[0] matters
         const lastExpression = nullThrows(
           expression.expressions.at(-1),
           'Expected to have more than zero expressions in a sequence expression',
         );
-        return parseIfArrayFilterExpression(lastExpression);
+        return parseArrayFilterExpressions(lastExpression);
       }
 
       if (expression.type === AST_NODE_TYPES.ChainExpression) {
-        return parseIfArrayFilterExpression(expression.expression);
+        return parseArrayFilterExpressions(expression.expression);
+      }
+
+      // This is the only reason we're returning a list rather than a single value.
+      if (expression.type === AST_NODE_TYPES.ConditionalExpression) {
+        // Both branches of the ternary _must_ return results.
+        const alternateResult = parseArrayFilterExpressions(
+          expression.alternate,
+        );
+        if (alternateResult.length === 0) {
+          return [];
+        }
+
+        const consequentResult = parseArrayFilterExpressions(
+          expression.consequent,
+        );
+        if (consequentResult.length === 0) {
+          return [];
+        }
+
+        // Accumulate the results from both sides and pass up the chain.
+        return [...alternateResult, ...consequentResult];
       }
 
       // Check if it looks like <<stuff>>(...), but not <<stuff>>?.(...)
@@ -78,16 +99,19 @@ export default createRule({
             // As long as the object is a (possibly nullable) array,
             // this is an Array.prototype.filter expression.
             if (isArrayish(filteredObjectType)) {
-              return {
-                isBracketSyntaxForFilter,
-                filterNode,
-              };
+              return [
+                {
+                  isBracketSyntaxForFilter,
+                  filterNode,
+                },
+              ];
             }
           }
         }
       }
 
-      return undefined;
+      // not a filter expression.
+      return [];
     }
 
     /**
@@ -223,8 +247,8 @@ export default createRule({
       CallExpression(node): void {
         const object = getObjectIfArrayAtZeroExpression(node);
         if (object) {
-          const filterExpression = parseIfArrayFilterExpression(object);
-          if (filterExpression) {
+          const filterExpressions = parseArrayFilterExpressions(object);
+          if (filterExpressions.length !== 0) {
             context.report({
               node,
               messageId: 'preferFind',
@@ -233,9 +257,11 @@ export default createRule({
                   messageId: 'preferFindSuggestion',
                   fix: (fixer): TSESLint.RuleFix[] => {
                     return [
-                      generateFixToReplaceFilterWithFind(
-                        fixer,
-                        filterExpression,
+                      ...filterExpressions.map(filterExpression =>
+                        generateFixToReplaceFilterWithFind(
+                          fixer,
+                          filterExpression,
+                        ),
                       ),
                       // Get rid of the .at(0) or ['at'](0).
                       generateFixToRemoveArrayElementAccess(
@@ -261,8 +287,8 @@ export default createRule({
       ): void {
         if (isMemberAccessOfZero(node)) {
           const object = node.object;
-          const filterExpression = parseIfArrayFilterExpression(object);
-          if (filterExpression) {
+          const filterExpressions = parseArrayFilterExpressions(object);
+          if (filterExpressions.length !== 0) {
             context.report({
               node,
               messageId: 'preferFind',
@@ -271,9 +297,11 @@ export default createRule({
                   messageId: 'preferFindSuggestion',
                   fix: (fixer): TSESLint.RuleFix[] => {
                     return [
-                      generateFixToReplaceFilterWithFind(
-                        fixer,
-                        filterExpression,
+                      ...filterExpressions.map(filterExpression =>
+                        generateFixToReplaceFilterWithFind(
+                          fixer,
+                          filterExpression,
+                        ),
                       ),
                       // Get rid of the [0].
                       generateFixToRemoveArrayElementAccess(

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -71,7 +71,11 @@ ruleTester.run('prefer-find', rule, {
     "[1, 2, 3].filter(x => x)[Symbol('0')];",
     "[1, 2, 3].filter(x => x)[Symbol.for('0')];",
     '(Math.random < 0.5 ? [1, 2, 3].filter(x => true) : [1, 2, 3])[0];',
-    '(Math.random < 0.5 ? [1, 2, 3].find(x => true) : [1, 2, 3].filter(x => true))[0];',
+    `
+      (Math.random < 0.5
+        ? [1, 2, 3].find(x => true)
+        : [1, 2, 3].filter(x => true))[0];
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -71,6 +71,7 @@ ruleTester.run('prefer-find', rule, {
     "[1, 2, 3].filter(x => x)[Symbol('0')];",
     "[1, 2, 3].filter(x => x)[Symbol.for('0')];",
     '(Math.random < 0.5 ? [1, 2, 3].filter(x => true) : [1, 2, 3])[0];',
+    '(Math.random < 0.5 ? [1, 2, 3].find(x => true) : [1, 2, 3].filter(x => true))[0];',
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -70,9 +70,9 @@ ruleTester.run('prefer-find', rule, {
     `,
     "[1, 2, 3].filter(x => x)[Symbol('0')];",
     "[1, 2, 3].filter(x => x)[Symbol.for('0')];",
-    '(Math.random < 0.5 ? [1, 2, 3].filter(x => true) : [1, 2, 3])[0];',
+    '(Math.random() < 0.5 ? [1, 2, 3].filter(x => true) : [1, 2, 3])[0];',
     `
-      (Math.random < 0.5
+      (Math.random() < 0.5
         ? [1, 2, 3].find(x => true)
         : [1, 2, 3].filter(x => true))[0];
     `,

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -638,7 +638,7 @@ Math.random() < 0.5
     },
     {
       code: `
-declare const f: any, g: any;
+declare const f: (arg0: unknown) => boolean, g: (arg0: unknown) => boolean;
 const nestedTernaries = (
   Math.random() < 0.5
     ? Math.random() < 0.5
@@ -655,7 +655,7 @@ const nestedTernaries = (
             {
               messageId: 'preferFindSuggestion',
               output: `
-declare const f: any, g: any;
+declare const f: (arg0: unknown) => boolean, g: (arg0: unknown) => boolean;
 const nestedTernaries = (
   Math.random() < 0.5
     ? Math.random() < 0.5
@@ -672,7 +672,7 @@ const nestedTernaries = (
 
     {
       code: `
-declare const f: any, g: any;
+declare const f: (arg0: unknown) => boolean, g: (arg0: unknown) => boolean;
 const nestedTernariesWithSequenceExpression = (
   Math.random() < 0.5
     ? ('sequence',
@@ -689,7 +689,7 @@ const nestedTernariesWithSequenceExpression = (
             {
               messageId: 'preferFindSuggestion',
               output: `
-declare const f: any, g: any;
+declare const f: (arg0: unknown) => boolean, g: (arg0: unknown) => boolean;
 const nestedTernariesWithSequenceExpression = (
   Math.random() < 0.5
     ? ('sequence',

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -70,6 +70,7 @@ ruleTester.run('prefer-find', rule, {
     `,
     "[1, 2, 3].filter(x => x)[Symbol('0')];",
     "[1, 2, 3].filter(x => x)[Symbol.for('0')];",
+    '(Math.random < 0.5 ? [1, 2, 3].filter(x => true) : [1, 2, 3])[0];',
   ],
 
   invalid: [
@@ -578,6 +579,73 @@ arr.filter(f, thisArg)[0];
               output: `
 declare const arr: { a: 1 }[] & ({ b: 2 }[] | { c: 3 }[]);
 arr.find(f, thisArg);
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const f: any, g: any;
+const nestedTernaries = (
+  Math.random() < 0.5
+    ? Math.random() < 0.5
+      ? [1, 2, 3].filter(f)
+      : []?.filter(x => 'shrug')
+    : [2, 3, 4]['filter'](g)
+).at(0.2);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindSuggestion',
+              output: `
+declare const f: any, g: any;
+const nestedTernaries = (
+  Math.random() < 0.5
+    ? Math.random() < 0.5
+      ? [1, 2, 3].find(f)
+      : []?.find(x => 'shrug')
+    : [2, 3, 4]["find"](g)
+);
+      `,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      code: `
+declare const f: any, g: any;
+const nestedTernariesWithSequenceExpression = (
+  Math.random() < 0.5
+    ? ('sequence',
+      'expression',
+      Math.random() < 0.5 ? [1, 2, 3].filter(f) : []?.filter(x => 'shrug'))
+    : [2, 3, 4]['filter'](g)
+).at(0.2);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindSuggestion',
+              output: `
+declare const f: any, g: any;
+const nestedTernariesWithSequenceExpression = (
+  Math.random() < 0.5
+    ? ('sequence',
+      'expression',
+      Math.random() < 0.5 ? [1, 2, 3].find(f) : []?.find(x => 'shrug'))
+    : [2, 3, 4]["find"](g)
+);
       `,
             },
           ],

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -592,6 +592,52 @@ arr.find(f, thisArg);
     },
     {
       code: `
+(Math.random() < 0.5
+  ? [1, 2, 3].filter(x => false)
+  : [1, 2, 3].filter(x => true))[0];
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindSuggestion',
+              output: `
+(Math.random() < 0.5
+  ? [1, 2, 3].find(x => false)
+  : [1, 2, 3].find(x => true));
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+Math.random() < 0.5
+  ? [1, 2, 3].find(x => true)
+  : [1, 2, 3].filter(x => true)[0];
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindSuggestion',
+              output: `
+Math.random() < 0.5
+  ? [1, 2, 3].find(x => true)
+  : [1, 2, 3].find(x => true);
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
 declare const f: any, g: any;
 const nestedTernaries = (
   Math.random() < 0.5

--- a/packages/eslint-plugin/tests/rules/prefer-find.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-find.test.ts
@@ -638,7 +638,8 @@ Math.random() < 0.5
     },
     {
       code: `
-declare const f: (arg0: unknown) => boolean, g: (arg0: unknown) => boolean;
+declare const f: (arg0: unknown, arg1: number, arg2: Array<unknown>) => boolean,
+  g: (arg0: unknown) => boolean;
 const nestedTernaries = (
   Math.random() < 0.5
     ? Math.random() < 0.5
@@ -649,13 +650,14 @@ const nestedTernaries = (
       `,
       errors: [
         {
-          line: 3,
+          line: 4,
           messageId: 'preferFind',
           suggestions: [
             {
               messageId: 'preferFindSuggestion',
               output: `
-declare const f: (arg0: unknown) => boolean, g: (arg0: unknown) => boolean;
+declare const f: (arg0: unknown, arg1: number, arg2: Array<unknown>) => boolean,
+  g: (arg0: unknown) => boolean;
 const nestedTernaries = (
   Math.random() < 0.5
     ? Math.random() < 0.5
@@ -697,6 +699,28 @@ const nestedTernariesWithSequenceExpression = (
       Math.random() < 0.5 ? [1, 2, 3].find(f) : []?.find(x => 'shrug'))
     : [2, 3, 4]["find"](g)
 );
+      `,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      code: `
+declare const spreadArgs: [(x: unknown) => boolean];
+[1, 2, 3].filter(...spreadArgs).at(0);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'preferFind',
+          suggestions: [
+            {
+              messageId: 'preferFindSuggestion',
+              output: `
+declare const spreadArgs: [(x: unknown) => boolean];
+[1, 2, 3].find(...spreadArgs);
       `,
             },
           ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8379 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds support for recursively checking ternary branches.
