### PR TITLE
chore: hide user-facing MDX comment in Releases docs

### DIFF
--- a/docs/maintenance/Releases.mdx
+++ b/docs/maintenance/Releases.mdx
@@ -3,7 +3,7 @@ id: releases
 title: Releases
 ---
 
-{/* TODO: update references to lerna to be `nx release instead` */}
+<!-- TODO: update references to lerna to be `nx release instead` -->
 
 [Users > Releases](../users/Releases.mdx) describes how our automatic releases are done.
 There is generally no maintenance activity we need to take for the weekly releases.


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

It's currently displayed as plain text: https://typescript-eslint.io/maintenance/releases

![rendered mdx comment](https://github.com/typescript-eslint/typescript-eslint/assets/61150013/48e373a1-c1f4-4a8e-bb07-e84c53c5a4b8)

