### PR TITLE
feat(typescript-estree): add debug logs for useProgramFromProjectService

### DIFF
--- a/packages/typescript-estree/src/useProgramFromProjectService.ts
+++ b/packages/typescript-estree/src/useProgramFromProjectService.ts
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import { minimatch } from 'minimatch';
 
 import { createProjectProgram } from './create-program/createProjectProgram';
@@ -9,12 +10,17 @@ import {
 } from './create-program/shared';
 import type { MutableParseSettings } from './parseSettings';
 
+const log = debug(
+  'typescript-eslint:typescript-estree:useProgramFromProjectService',
+);
+
 export function useProgramFromProjectService(
   { allowDefaultProjectForFiles, service }: ProjectServiceSettings,
   parseSettings: Readonly<MutableParseSettings>,
   hasFullTypeInformation: boolean,
 ): ASTAndDefiniteProgram | undefined {
   const filePath = getCanonicalFileName(parseSettings.filePath);
+  log('Opening project service file for: %s', filePath);
 
   const opened = service.openClientFile(
     ensureAbsolutePath(filePath, service.host.getCurrentDirectory()),
@@ -22,6 +28,8 @@ export function useProgramFromProjectService(
     /* scriptKind */ undefined,
     parseSettings.tsconfigRootDir,
   );
+
+  log('Opened project service file: %o', opened);
 
   if (hasFullTypeInformation) {
     if (opened.configFileName) {
@@ -44,8 +52,11 @@ export function useProgramFromProjectService(
     .getProgram();
 
   if (!program) {
+    log('Could not find project service program for: %s', filePath);
     return undefined;
   }
+
+  log('Found project service program for: %s', filePath);
 
   return createProjectProgram(parseSettings, [program]);
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8425
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a few choice `debug` logs to `useProgramFromProjectService`.