### PR TITLE
chore: correct nx/(release/)changelog-renderer require path

### DIFF
--- a/tools/release/changelog-renderer.js
+++ b/tools/release/changelog-renderer.js
@@ -1,4 +1,6 @@
-const { default: defaultChangelogRenderer } = require('nx/changelog-renderer');
+const {
+  default: defaultChangelogRenderer,
+} = require('nx/release/changelog-renderer');
 
 const changelogRenderer = async ({
   projectGraph,

--- a/tools/release/changelog-renderer.js
+++ b/tools/release/changelog-renderer.js
@@ -24,3 +24,4 @@ const changelogRenderer = async ({
 };
 
 module.exports = changelogRenderer;
+module.exports.default = changelogRenderer;

--- a/tools/release/changelog-renderer.js
+++ b/tools/release/changelog-renderer.js
@@ -26,4 +26,3 @@ const changelogRenderer = async ({
 };
 
 module.exports = changelogRenderer;
-module.exports.default = changelogRenderer;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "eslint.config.mjs",
     "jest.config.base.js",
     "jest.config.js",
-    "jest.preset.js"
+    "jest.preset.js",
+    "tools/release/changelog-renderer.js"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "eslint.config.mjs",
     "jest.config.base.js",
     "jest.config.js",
-    "jest.preset.js",
-    "tools/release/changelog-renderer.js"
+    "jest.preset.js"
   ]
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8437
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

```plaintext
/typescript-eslint/node_modules/nx/src/command-line/release/changelog.js:367
    let contents = await changelogRenderer({
                         ^
TypeError: changelogRenderer is not a function
```

I think `nx` might be trying to import the module, but since it's authored like CJS, it's not able to see the `default` export?

If that's not it then it might be a swallowed exception on the Nx side...