### PR TITLE
Remove T from Internal Types - MessageIds, Options, Obj, Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1765,7 +1765,7 @@ You can read about our [versioning strategy](https://main--typescript-eslint.net
 ### Features
 
 - add RuleCreator.withoutDocs ([#4136](https://github.com/typescript-eslint/typescript-eslint/issues/4136)) ([87cfc6a](https://github.com/typescript-eslint/typescript-eslint/commit/87cfc6ad3e3312d7b6f98a592fb37e69d5d6880a))
-- **experimental-utils:** add default [] for RuleModule TOptions generic ([#4135](https://github.com/typescript-eslint/typescript-eslint/issues/4135)) ([62b8098](https://github.com/typescript-eslint/typescript-eslint/commit/62b8098fa7d361954c170ee6c190e47e95194b13))
+- **experimental-utils:** add default [] for RuleModule Options generic ([#4135](https://github.com/typescript-eslint/typescript-eslint/issues/4135)) ([62b8098](https://github.com/typescript-eslint/typescript-eslint/commit/62b8098fa7d361954c170ee6c190e47e95194b13))
 - **typescript-estree:** support Import Assertions ([#4074](https://github.com/typescript-eslint/typescript-eslint/issues/4074)) ([ae0fb5a](https://github.com/typescript-eslint/typescript-eslint/commit/ae0fb5a591958216b7df656e66b1dfe464898167))
 - **typescript-estree:** support private fields in-in syntax ([#4075](https://github.com/typescript-eslint/typescript-eslint/issues/4075)) ([939d8ea](https://github.com/typescript-eslint/typescript-eslint/commit/939d8eac547fb1734aa00f1ea01cc6eae0b4280a))
 - **typescript-estree:** support type-only module specifiers ([#4076](https://github.com/typescript-eslint/typescript-eslint/issues/4076)) ([77baa92](https://github.com/typescript-eslint/typescript-eslint/commit/77baa9203638e888a76e21003a278a8da386e133))

--- a/packages/eslint-plugin/rules.d.ts
+++ b/packages/eslint-plugin/rules.d.ts
@@ -17,7 +17,7 @@ TS wants to transpile each rule file to this `.d.ts` file:
 
 ```ts
 import type { TSESLint } from '@typescript-eslint/utils';
-declare const _default: TSESLint.RuleModule<TMessageIds, TOptions, TSESLint.RuleListener>;
+declare const _default: TSESLint.RuleModule<MessageIds, Options, TSESLint.RuleListener>;
 export default _default;
 ```
 

--- a/packages/eslint-plugin/tests/RuleTester.ts
+++ b/packages/eslint-plugin/tests/RuleTester.ts
@@ -18,9 +18,9 @@ export function getFixturesRootDir(): string {
  *
  * @deprecated - DO NOT USE THIS FOR NEW RULES
  */
-export function batchedSingleLineTests<TOptions extends readonly unknown[]>(
-  test: ValidTestCase<TOptions>,
-): ValidTestCase<TOptions>[];
+export function batchedSingleLineTests<Options extends readonly unknown[]>(
+  test: ValidTestCase<Options>,
+): ValidTestCase<Options>[];
 /**
  * Converts a batch of single line tests into a number of separate test cases.
  * This makes it easier to write tests which use the same options.
@@ -35,17 +35,17 @@ export function batchedSingleLineTests<TOptions extends readonly unknown[]>(
  * @deprecated - DO NOT USE THIS FOR NEW RULES
  */
 export function batchedSingleLineTests<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  test: InvalidTestCase<TMessageIds, TOptions>,
-): InvalidTestCase<TMessageIds, TOptions>[];
+  test: InvalidTestCase<MessageIds, Options>,
+): InvalidTestCase<MessageIds, Options>[];
 export function batchedSingleLineTests<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  options: InvalidTestCase<TMessageIds, TOptions> | ValidTestCase<TOptions>,
-): (InvalidTestCase<TMessageIds, TOptions> | ValidTestCase<TOptions>)[] {
+  options: InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>,
+): (InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>)[] {
   // -- eslint counts lines from 1
   const lineOffset = options.code.startsWith('\n') ? 2 : 1;
   const output =

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -869,20 +869,6 @@ describe('hand-crafted cases', () => {
           },
         ],
       },
-      {
-        code: `
-          const a = 0;
-          const b = 0;
-          a === undefined || b === null || b === undefined;
-        `,
-      },
-      {
-        code: `
-          const a = 0;
-          const b = 0;
-          a === undefined || b === undefined || b === null;
-        `,
-      },
       '(x = {}) && (x.y = true) != null && x.y.toString();',
       "('x' as `${'x'}`) && ('x' as `${'x'}`).length;",
       '`x` && `x`.length;',

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -869,6 +869,20 @@ describe('hand-crafted cases', () => {
           },
         ],
       },
+      {
+        code: `
+          const a = 0;
+          const b = 0;
+          a === undefined || b === null || b === undefined;
+        `,
+      },
+      {
+        code: `
+          const a = 0;
+          const b = 0;
+          a === undefined || b === undefined || b === null;
+        `,
+      },
       '(x = {}) && (x.y = true) != null && x.y.toString();',
       "('x' as `${'x'}`) && ('x' as `${'x'}`).length;",
       '`x` && `x`.length;',

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -146,21 +146,21 @@ export class RuleTester extends TestFramework {
   /**
    * Adds the `only` property to a test to run it in isolation.
    */
-  static only<TOptions extends Readonly<unknown[]>>(
-    item: ValidTestCase<TOptions> | string,
-  ): ValidTestCase<TOptions>;
+  static only<Options extends Readonly<unknown[]>>(
+    item: ValidTestCase<Options> | string,
+  ): ValidTestCase<Options>;
   /**
    * Adds the `only` property to a test to run it in isolation.
    */
-  static only<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
-    item: InvalidTestCase<TMessageIds, TOptions>,
-  ): InvalidTestCase<TMessageIds, TOptions>;
-  static only<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
+  static only<MessageIds extends string, Options extends Readonly<unknown[]>>(
+    item: InvalidTestCase<MessageIds, Options>,
+  ): InvalidTestCase<MessageIds, Options>;
+  static only<MessageIds extends string, Options extends Readonly<unknown[]>>(
     item:
-      | InvalidTestCase<TMessageIds, TOptions>
-      | ValidTestCase<TOptions>
+      | InvalidTestCase<MessageIds, Options>
+      | ValidTestCase<Options>
       | string,
-  ): InvalidTestCase<TMessageIds, TOptions> | ValidTestCase<TOptions> {
+  ): InvalidTestCase<MessageIds, Options> | ValidTestCase<Options> {
     if (typeof item === 'string') {
       return { code: item, only: true };
     }
@@ -176,11 +176,11 @@ export class RuleTester extends TestFramework {
   }
 
   #normalizeTests<
-    TMessageIds extends string,
-    TOptions extends readonly unknown[],
+    MessageIds extends string,
+    Options extends readonly unknown[],
   >(
-    rawTests: RunTests<TMessageIds, TOptions>,
-  ): NormalizedRunTests<TMessageIds, TOptions> {
+    rawTests: RunTests<MessageIds, Options>,
+  ): NormalizedRunTests<MessageIds, Options> {
     /*
     Automatically add a filename to the tests to enable type-aware tests to "just work".
     This saves users having to verbosely and manually add the filename to every
@@ -205,11 +205,9 @@ export class RuleTester extends TestFramework {
       return filename;
     };
     const normalizeTest = <
-      TMessageIds extends string,
-      TOptions extends readonly unknown[],
-      T extends
-        | InvalidTestCase<TMessageIds, TOptions>
-        | ValidTestCase<TOptions>,
+      MessageIds extends string,
+      Options extends readonly unknown[],
+      T extends InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>,
     >(
       test: T,
     ): T => {
@@ -239,7 +237,7 @@ export class RuleTester extends TestFramework {
 
     // convenience iterator to make it easy to loop all tests without a concat
     const allTestsIterator = {
-      *[Symbol.iterator](): Generator<ValidTestCase<TOptions>, void> {
+      *[Symbol.iterator](): Generator<ValidTestCase<Options>, void> {
         for (const testCase of normalizedTests.valid) {
           yield testCase;
         }
@@ -285,9 +283,7 @@ export class RuleTester extends TestFramework {
     just disappearing without a trace.
     */
     const maybeMarkAsOnly = <
-      T extends
-        | InvalidTestCase<TMessageIds, TOptions>
-        | ValidTestCase<TOptions>,
+      T extends InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>,
     >(
       test: T,
     ): T => {
@@ -305,10 +301,10 @@ export class RuleTester extends TestFramework {
   /**
    * Adds a new rule test to execute.
    */
-  run<TMessageIds extends string, TOptions extends readonly unknown[]>(
+  run<MessageIds extends string, Options extends readonly unknown[]>(
     ruleName: string,
-    rule: RuleModule<TMessageIds, TOptions>,
-    test: RunTests<TMessageIds, TOptions>,
+    rule: RuleModule<MessageIds, Options>,
+    test: RunTests<MessageIds, Options>,
   ): void {
     const constructor = this.constructor as typeof RuleTester;
 
@@ -366,7 +362,7 @@ export class RuleTester extends TestFramework {
       ruleName,
       Object.assign({}, rule, {
         // Create a wrapper rule that freezes the `context` properties.
-        create(context: RuleContext<TMessageIds, TOptions>) {
+        create(context: RuleContext<MessageIds, Options>) {
           freezeDeeply(context.options);
           freezeDeeply(context.settings);
           freezeDeeply(context.parserOptions);
@@ -381,7 +377,7 @@ export class RuleTester extends TestFramework {
     const normalizedTests = this.#normalizeTests(test);
 
     function getTestMethod(
-      test: ValidTestCase<TOptions>,
+      test: ValidTestCase<Options>,
     ): 'it' | 'itOnly' | 'itSkip' {
       if (test.skip) {
         return 'itSkip';
@@ -437,12 +433,12 @@ export class RuleTester extends TestFramework {
    * Use @private instead of #private to expose it for testing purposes
    */
   private runRuleForItem<
-    TMessageIds extends string,
-    TOptions extends readonly unknown[],
+    MessageIds extends string,
+    Options extends readonly unknown[],
   >(
     ruleName: string,
-    rule: RuleModule<TMessageIds, TOptions>,
-    item: InvalidTestCase<TMessageIds, TOptions> | ValidTestCase<TOptions>,
+    rule: RuleModule<MessageIds, Options>,
+    item: InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>,
   ): {
     messages: Linter.LintMessage[];
     output: string;
@@ -627,14 +623,14 @@ export class RuleTester extends TestFramework {
    * all valid cases go through this
    */
   #testValidTemplate<
-    TMessageIds extends string,
-    TOptions extends readonly unknown[],
+    MessageIds extends string,
+    Options extends readonly unknown[],
   >(
     ruleName: string,
-    rule: RuleModule<TMessageIds, TOptions>,
-    itemIn: ValidTestCase<TOptions> | string,
+    rule: RuleModule<MessageIds, Options>,
+    itemIn: ValidTestCase<Options> | string,
   ): void {
-    const item: ValidTestCase<TOptions> =
+    const item: ValidTestCase<Options> =
       typeof itemIn === 'object' ? itemIn : { code: itemIn };
 
     assert.ok(
@@ -669,12 +665,12 @@ export class RuleTester extends TestFramework {
    * all invalid cases go through this.
    */
   #testInvalidTemplate<
-    TMessageIds extends string,
-    TOptions extends readonly unknown[],
+    MessageIds extends string,
+    Options extends readonly unknown[],
   >(
     ruleName: string,
-    rule: RuleModule<TMessageIds, TOptions>,
-    item: InvalidTestCase<TMessageIds, TOptions>,
+    rule: RuleModule<MessageIds, Options>,
+    item: InvalidTestCase<MessageIds, Options>,
   ): void {
     assert.ok(
       typeof item.code === 'string',

--- a/packages/rule-tester/src/types/InvalidTestCase.ts
+++ b/packages/rule-tester/src/types/InvalidTestCase.ts
@@ -4,11 +4,11 @@ import type { ReportDescriptorMessageData } from '@typescript-eslint/utils/ts-es
 import type { DependencyConstraint } from './DependencyConstraint';
 import type { ValidTestCase } from './ValidTestCase';
 
-export interface SuggestionOutput<TMessageIds extends string> {
+export interface SuggestionOutput<MessageIds extends string> {
   /**
    * Reported message ID.
    */
-  readonly messageId: TMessageIds;
+  readonly messageId: MessageIds;
   /**
    * The data used to fill the message template.
    */
@@ -23,7 +23,7 @@ export interface SuggestionOutput<TMessageIds extends string> {
   // readonly desc?: string;
 }
 
-export interface TestCaseError<TMessageIds extends string> {
+export interface TestCaseError<MessageIds extends string> {
   /**
    * The 1-based column number of the reported start location.
    */
@@ -47,11 +47,11 @@ export interface TestCaseError<TMessageIds extends string> {
   /**
    * Reported message ID.
    */
-  readonly messageId: TMessageIds;
+  readonly messageId: MessageIds;
   /**
    * Reported suggestions.
    */
-  readonly suggestions?: readonly SuggestionOutput<TMessageIds>[] | null;
+  readonly suggestions?: readonly SuggestionOutput<MessageIds>[] | null;
   /**
    * The type of the reported AST node.
    */
@@ -62,13 +62,13 @@ export interface TestCaseError<TMessageIds extends string> {
 }
 
 export interface InvalidTestCase<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
-> extends ValidTestCase<TOptions> {
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
+> extends ValidTestCase<Options> {
   /**
    * Expected errors.
    */
-  readonly errors: readonly TestCaseError<TMessageIds>[];
+  readonly errors: readonly TestCaseError<MessageIds>[];
   /**
    * The expected code after autofixes are applied. If set to `null`, the test runner will assert that no autofix is suggested.
    */

--- a/packages/rule-tester/src/types/ValidTestCase.ts
+++ b/packages/rule-tester/src/types/ValidTestCase.ts
@@ -6,7 +6,7 @@ import type {
 
 import type { DependencyConstraint } from './DependencyConstraint';
 
-export interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
+export interface ValidTestCase<Options extends Readonly<unknown[]>> {
   /**
    * Name for the test case.
    */
@@ -30,7 +30,7 @@ export interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   /**
    * Options for the test case.
    */
-  readonly options?: Readonly<TOptions>;
+  readonly options?: Readonly<Options>;
   /**
    * The absolute path for the parser.
    */

--- a/packages/rule-tester/src/types/index.ts
+++ b/packages/rule-tester/src/types/index.ts
@@ -11,20 +11,20 @@ export type TesterConfigWithDefaults = Mutable<
 >;
 
 export interface RunTests<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
 > {
   // RuleTester.run also accepts strings for valid cases
-  readonly valid: readonly (ValidTestCase<TOptions> | string)[];
-  readonly invalid: readonly InvalidTestCase<TMessageIds, TOptions>[];
+  readonly valid: readonly (ValidTestCase<Options> | string)[];
+  readonly invalid: readonly InvalidTestCase<MessageIds, Options>[];
 }
 
 export interface NormalizedRunTests<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
 > {
-  readonly valid: readonly ValidTestCase<TOptions>[];
-  readonly invalid: readonly InvalidTestCase<TMessageIds, TOptions>[];
+  readonly valid: readonly ValidTestCase<Options>[];
+  readonly invalid: readonly InvalidTestCase<MessageIds, Options>[];
 }
 
 export type { ValidTestCase } from './ValidTestCase';

--- a/packages/utils/src/eslint-utils/InferTypesFromRule.ts
+++ b/packages/utils/src/eslint-utils/InferTypesFromRule.ts
@@ -1,23 +1,23 @@
 import type { RuleCreateFunction, RuleModule } from '../ts-eslint';
 
 /**
- * Uses type inference to fetch the TOptions type from the given RuleModule
+ * Uses type inference to fetch the Options type from the given RuleModule
  */
 type InferOptionsTypeFromRule<T> =
-  T extends RuleModule<infer _TMessageIds, infer TOptions>
-    ? TOptions
-    : T extends RuleCreateFunction<infer _TMessageIds, infer TOptions>
-      ? TOptions
+  T extends RuleModule<infer _MessageIds, infer Options>
+    ? Options
+    : T extends RuleCreateFunction<infer _MessageIds, infer Options>
+      ? Options
       : unknown;
 
 /**
- * Uses type inference to fetch the TMessageIds type from the given RuleModule
+ * Uses type inference to fetch the MessageIds type from the given RuleModule
  */
 type InferMessageIdsTypeFromRule<T> =
-  T extends RuleModule<infer TMessageIds, infer _TOptions>
-    ? TMessageIds
-    : T extends RuleCreateFunction<infer TMessageIds, infer _TOptions>
-      ? TMessageIds
+  T extends RuleModule<infer MessageIds, infer _TOptions>
+    ? MessageIds
+    : T extends RuleCreateFunction<infer MessageIds, infer _TOptions>
+      ? MessageIds
       : unknown;
 
 export { InferOptionsTypeFromRule, InferMessageIdsTypeFromRule };

--- a/packages/utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/utils/src/eslint-utils/RuleCreator.ts
@@ -11,36 +11,36 @@ export type { RuleListener, RuleModule };
 
 // we automatically add the url
 export type NamedCreateRuleMetaDocs = Omit<RuleMetaDataDocs, 'url'>;
-export type NamedCreateRuleMeta<TMessageIds extends string> = Omit<
-  RuleMetaData<TMessageIds>,
+export type NamedCreateRuleMeta<MessageIds extends string> = Omit<
+  RuleMetaData<MessageIds>,
   'docs'
 > & {
   docs: NamedCreateRuleMetaDocs;
 };
 
 export interface RuleCreateAndOptions<
-  TOptions extends readonly unknown[],
-  TMessageIds extends string,
+  Options extends readonly unknown[],
+  MessageIds extends string,
 > {
   create: (
-    context: Readonly<RuleContext<TMessageIds, TOptions>>,
-    optionsWithDefault: Readonly<TOptions>,
+    context: Readonly<RuleContext<MessageIds, Options>>,
+    optionsWithDefault: Readonly<Options>,
   ) => RuleListener;
-  defaultOptions: Readonly<TOptions>;
+  defaultOptions: Readonly<Options>;
 }
 
 export interface RuleWithMeta<
-  TOptions extends readonly unknown[],
-  TMessageIds extends string,
-> extends RuleCreateAndOptions<TOptions, TMessageIds> {
-  meta: RuleMetaData<TMessageIds>;
+  Options extends readonly unknown[],
+  MessageIds extends string,
+> extends RuleCreateAndOptions<Options, MessageIds> {
+  meta: RuleMetaData<MessageIds>;
 }
 
 export interface RuleWithMetaAndName<
-  TOptions extends readonly unknown[],
-  TMessageIds extends string,
-> extends RuleCreateAndOptions<TOptions, TMessageIds> {
-  meta: NamedCreateRuleMeta<TMessageIds>;
+  Options extends readonly unknown[],
+  MessageIds extends string,
+> extends RuleCreateAndOptions<Options, MessageIds> {
+  meta: NamedCreateRuleMeta<MessageIds>;
   name: string;
 }
 
@@ -54,17 +54,17 @@ export function RuleCreator(urlCreator: (ruleName: string) => string) {
   // This function will get much easier to call when this is merged https://github.com/Microsoft/TypeScript/pull/26349
   // TODO - when the above PR lands; add type checking for the context.report `data` property
   return function createNamedRule<
-    TOptions extends readonly unknown[],
-    TMessageIds extends string,
+    Options extends readonly unknown[],
+    MessageIds extends string,
   >({
     name,
     meta,
     ...rule
-  }: Readonly<RuleWithMetaAndName<TOptions, TMessageIds>>): RuleModule<
-    TMessageIds,
-    TOptions
+  }: Readonly<RuleWithMetaAndName<Options, MessageIds>>): RuleModule<
+    MessageIds,
+    Options
   > {
-    return createRule<TOptions, TMessageIds>({
+    return createRule<Options, MessageIds>({
       meta: {
         ...meta,
         docs: {
@@ -84,20 +84,18 @@ export function RuleCreator(urlCreator: (ruleName: string) => string) {
  * @remarks It is generally better to provide a docs URL function to RuleCreator.
  */
 function createRule<
-  TOptions extends readonly unknown[],
-  TMessageIds extends string,
+  Options extends readonly unknown[],
+  MessageIds extends string,
 >({
   create,
   defaultOptions,
   meta,
-}: Readonly<RuleWithMeta<TOptions, TMessageIds>>): RuleModule<
-  TMessageIds,
-  TOptions
+}: Readonly<RuleWithMeta<Options, MessageIds>>): RuleModule<
+  MessageIds,
+  Options
 > {
   return {
-    create(
-      context: Readonly<RuleContext<TMessageIds, TOptions>>,
-    ): RuleListener {
+    create(context: Readonly<RuleContext<MessageIds, Options>>): RuleListener {
       const optionsWithDefault = applyDefault(defaultOptions, context.options);
       return create(context, optionsWithDefault);
     },

--- a/packages/utils/src/eslint-utils/getParserServices.ts
+++ b/packages/utils/src/eslint-utils/getParserServices.ts
@@ -17,20 +17,20 @@ const ERROR_MESSAGE_UNKNOWN_PARSER =
  * This **_will_** throw if it is not available.
  */
 function getParserServices<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
+  context: Readonly<TSESLint.RuleContext<MessageIds, Options>>,
 ): ParserServicesWithTypeInformation;
 /**
  * Try to retrieve type-aware parser service from context.
  * This **_will_** throw if it is not available.
  */
 function getParserServices<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
+  context: Readonly<TSESLint.RuleContext<MessageIds, Options>>,
   allowWithoutFullTypeInformation: false,
 ): ParserServicesWithTypeInformation;
 /**
@@ -38,10 +38,10 @@ function getParserServices<
  * This **_will not_** throw if it is not available.
  */
 function getParserServices<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
+  context: Readonly<TSESLint.RuleContext<MessageIds, Options>>,
   allowWithoutFullTypeInformation: true,
 ): ParserServices;
 /**
@@ -49,10 +49,10 @@ function getParserServices<
  * This may or may not throw if it is not available, depending on if `allowWithoutFullTypeInformation` is `true`
  */
 function getParserServices<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
+  context: Readonly<TSESLint.RuleContext<MessageIds, Options>>,
   allowWithoutFullTypeInformation: boolean,
 ): ParserServices;
 

--- a/packages/utils/src/ts-eslint/Linter.ts
+++ b/packages/utils/src/ts-eslint/Linter.ts
@@ -15,10 +15,10 @@ import type {
 import type { SourceCode } from './SourceCode';
 
 export type MinimalRuleModule<
-  TMessageIds extends string = string,
-  TOptions extends readonly unknown[] = [],
-> = Partial<Omit<RuleModule<TMessageIds, TOptions>, 'create'>> &
-  Pick<RuleModule<TMessageIds, TOptions>, 'create'>;
+  MessageIds extends string = string,
+  Options extends readonly unknown[] = [],
+> = Partial<Omit<RuleModule<MessageIds, Options>, 'create'>> &
+  Pick<RuleModule<MessageIds, Options>, 'create'>;
 
 declare class LinterBase {
   /**
@@ -39,20 +39,20 @@ declare class LinterBase {
    * @param ruleId A unique rule identifier
    * @param ruleModule Function from context to object mapping AST node types to event handlers
    */
-  defineRule<TMessageIds extends string, TOptions extends readonly unknown[]>(
+  defineRule<MessageIds extends string, Options extends readonly unknown[]>(
     ruleId: string,
-    ruleModule: MinimalRuleModule<TMessageIds, TOptions> | RuleCreateFunction,
+    ruleModule: MinimalRuleModule<MessageIds, Options> | RuleCreateFunction,
   ): void;
 
   /**
    * Defines many new linting rules.
    * @param rulesToDefine map from unique rule identifier to rule
    */
-  defineRules<TMessageIds extends string, TOptions extends readonly unknown[]>(
+  defineRules<MessageIds extends string, Options extends readonly unknown[]>(
     rulesToDefine: Record<
       string,
-      | MinimalRuleModule<TMessageIds, TOptions>
-      | RuleCreateFunction<TMessageIds, TOptions>
+      | MinimalRuleModule<MessageIds, Options>
+      | RuleCreateFunction<MessageIds, Options>
     >,
   ): void;
 

--- a/packages/utils/src/ts-eslint/RuleTester.ts
+++ b/packages/utils/src/ts-eslint/RuleTester.ts
@@ -11,7 +11,7 @@ import type {
   SharedConfigurationSettings,
 } from './Rule';
 
-interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
+interface ValidTestCase<Options extends Readonly<unknown[]>> {
   /**
    * Name for the test case.
    */
@@ -35,7 +35,7 @@ interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   /**
    * Options for the test case.
    */
-  readonly options?: Readonly<TOptions>;
+  readonly options?: Readonly<Options>;
   /**
    * The absolute path for the parser.
    */
@@ -54,11 +54,11 @@ interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   readonly only?: boolean;
 }
 
-interface SuggestionOutput<TMessageIds extends string> {
+interface SuggestionOutput<MessageIds extends string> {
   /**
    * Reported message ID.
    */
-  readonly messageId: TMessageIds;
+  readonly messageId: MessageIds;
   /**
    * The data used to fill the message template.
    */
@@ -74,20 +74,20 @@ interface SuggestionOutput<TMessageIds extends string> {
 }
 
 interface InvalidTestCase<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
-> extends ValidTestCase<TOptions> {
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
+> extends ValidTestCase<Options> {
   /**
    * Expected errors.
    */
-  readonly errors: readonly TestCaseError<TMessageIds>[];
+  readonly errors: readonly TestCaseError<MessageIds>[];
   /**
    * The expected code after autofixes are applied. If set to `null`, the test runner will assert that no autofix is suggested.
    */
   readonly output?: string | null;
 }
 
-interface TestCaseError<TMessageIds extends string> {
+interface TestCaseError<MessageIds extends string> {
   /**
    * The 1-based column number of the reported start location.
    */
@@ -111,11 +111,11 @@ interface TestCaseError<TMessageIds extends string> {
   /**
    * Reported message ID.
    */
-  readonly messageId: TMessageIds;
+  readonly messageId: MessageIds;
   /**
    * Reported suggestions.
    */
-  readonly suggestions?: readonly SuggestionOutput<TMessageIds>[] | null;
+  readonly suggestions?: readonly SuggestionOutput<MessageIds>[] | null;
   /**
    * The type of the reported AST node.
    */
@@ -135,12 +135,12 @@ type RuleTesterTestFrameworkFunction = (
 ) => void;
 
 interface RunTests<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
 > {
   // RuleTester.run also accepts strings for valid cases
-  readonly valid: readonly (ValidTestCase<TOptions> | string)[];
-  readonly invalid: readonly InvalidTestCase<TMessageIds, TOptions>[];
+  readonly valid: readonly (ValidTestCase<Options> | string)[];
+  readonly invalid: readonly InvalidTestCase<MessageIds, Options>[];
 }
 interface RuleTesterConfig extends ClassicConfig.Config {
   // should be require.resolve(parserPackageName)
@@ -161,10 +161,10 @@ declare class RuleTesterBase {
    * @param rule The rule to test.
    * @param test The collection of tests to run.
    */
-  run<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
+  run<MessageIds extends string, Options extends Readonly<unknown[]>>(
     ruleName: string,
-    rule: RuleModule<TMessageIds, TOptions>,
-    tests: RunTests<TMessageIds, TOptions>,
+    rule: RuleModule<MessageIds, Options>,
+    tests: RunTests<MessageIds, Options>,
   ): void;
 
   /**
@@ -191,11 +191,11 @@ declare class RuleTesterBase {
   /**
    * Define a rule for one particular run of tests.
    */
-  defineRule<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
+  defineRule<MessageIds extends string, Options extends Readonly<unknown[]>>(
     name: string,
     rule:
-      | RuleCreateFunction<TMessageIds, TOptions>
-      | RuleModule<TMessageIds, TOptions>,
+      | RuleCreateFunction<MessageIds, Options>
+      | RuleModule<MessageIds, Options>,
   ): void;
 }
 

--- a/packages/utils/src/ts-eslint/SourceCode.ts
+++ b/packages/utils/src/ts-eslint/SourceCode.ts
@@ -404,10 +404,10 @@ namespace SourceCode {
     ) => token is infer U extends TSESTree.Token)
       ? U
       : TDefault;
-  export type GetFilterPredicateFromOptions<TOptions, TDefault> =
-    TOptions extends { filter?: FilterPredicate }
-      ? GetFilterPredicate<TOptions['filter'], TDefault>
-      : GetFilterPredicate<TOptions, TDefault>;
+  export type GetFilterPredicateFromOptions<Options, TDefault> =
+    Options extends { filter?: FilterPredicate }
+      ? GetFilterPredicate<Options['filter'], TDefault>
+      : GetFilterPredicate<Options, TDefault>;
 
   export type ReturnTypeFromOptions<T> = T extends { includeComments: true }
     ? GetFilterPredicateFromOptions<T, TSESTree.Token>


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8365 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I removed the T prefix from various places in the code base using VSC's find and replace regex. Let me know of any other places internal types to address.
