### PR TITLE
fix(eslint-plugin): [strict-boolean-expression] fix nullable object handling in LogicalExpression

### DIFF
--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -34,6 +34,7 @@ export type MessageId =
   | 'conditionErrorNullableEnum'
   | 'conditionErrorNullableNumber'
   | 'conditionErrorNullableObject'
+  | 'conditionErrorNullableObjectConvertToNullishCoalescing'
   | 'conditionErrorNullableString'
   | 'conditionErrorNullish'
   | 'conditionErrorNumber'
@@ -113,6 +114,9 @@ export default createRule<Options, MessageId>({
       conditionErrorNullableObject:
         'Unexpected nullable object value in conditional. ' +
         'An explicit null check is required.',
+      conditionErrorNullableObjectConvertToNullishCoalescing:
+        'Unexpected nullable object value in conditional with `||` or `&&`. ' +
+        'You should probably be using nullish coalescing instead.',
       conditionErrorNullableEnum:
         'Unexpected nullable enum value in conditional. ' +
         'Please handle the nullish/zero/NaN cases explicitly.',
@@ -721,6 +725,12 @@ export default createRule<Options, MessageId>({
                 },
               ],
             });
+          } else if (isLogicalExpressionNotNullishCoalescing(node.parent!)) {
+            context.report({
+              node,
+              messageId:
+                'conditionErrorNullableObjectConvertToNullishCoalescing',
+            });
           } else {
             // if (nullableObject)
             context.report({
@@ -935,6 +945,14 @@ function isLogicalNegationExpression(
   node: TSESTree.Node,
 ): node is TSESTree.UnaryExpression {
   return node.type === AST_NODE_TYPES.UnaryExpression && node.operator === '!';
+}
+
+function isLogicalExpressionNotNullishCoalescing(
+  node: TSESTree.Node,
+): node is TSESTree.LogicalExpression {
+  return (
+    node.type === AST_NODE_TYPES.LogicalExpression && node.operator !== '??'
+  );
 }
 
 function isArrayLengthExpression(

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -725,7 +725,7 @@ export default createRule<Options, MessageId>({
                 },
               ],
             });
-          } else if (isLogicalExpressionNotNullishCoalescing(node.parent!)) {
+          } else if (isLogicalExpression(node.parent!)) {
             context.report({
               node,
               messageId:
@@ -947,12 +947,10 @@ function isLogicalNegationExpression(
   return node.type === AST_NODE_TYPES.UnaryExpression && node.operator === '!';
 }
 
-function isLogicalExpressionNotNullishCoalescing(
+function isLogicalExpression(
   node: TSESTree.Node,
 ): node is TSESTree.LogicalExpression {
-  return (
-    node.type === AST_NODE_TYPES.LogicalExpression && node.operator !== '??'
-  );
+  return node.type === AST_NODE_TYPES.LogicalExpression;
 }
 
 function isArrayLengthExpression(

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -1643,6 +1643,7 @@ if (x) {
         !obj
         obj || 0
         obj && 1 || 0
+        obj ?? 1
       `,
       errors: [
         {
@@ -1658,6 +1659,7 @@ if (x) {
         !obj
         obj || 0
         obj && 1 || 0
+        obj ?? 1
       `,
             },
           ],
@@ -1675,6 +1677,7 @@ if (x) {
         obj == null
         obj || 0
         obj && 1 || 0
+        obj ?? 1
       `,
             },
           ],

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -1680,38 +1680,14 @@ if (x) {
           ],
         },
         {
-          messageId: 'conditionErrorNullableObject',
+          messageId: 'conditionErrorNullableObjectConvertToNullishCoalescing',
           line: 5,
           column: 9,
-          suggestions: [
-            {
-              messageId: 'conditionFixCompareNullish',
-              output: `
-        declare const obj: { x: number } | null;
-        !obj ? 1 : 0
-        !obj
-        ;(obj != null) || 0
-        obj && 1 || 0
-      `,
-            },
-          ],
         },
         {
-          messageId: 'conditionErrorNullableObject',
+          messageId: 'conditionErrorNullableObjectConvertToNullishCoalescing',
           line: 6,
           column: 9,
-          suggestions: [
-            {
-              messageId: 'conditionFixCompareNullish',
-              output: `
-        declare const obj: { x: number } | null;
-        !obj ? 1 : 0
-        !obj
-        obj || 0
-        ;(obj != null) && 1 || 0
-      `,
-            },
-          ],
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7743
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

When a nullable object appears in a logical expression other than nullish coalescing (so || or &&), there is a suggested fix, and it could be wrong and introduce a bug (as explained in the https://github.com/typescript-eslint/typescript-eslint/issues/7743). This MR removes the suggested fix for these cases, and gives a more explicit message.


## Note

This is the follow-up to https://github.com/typescript-eslint/typescript-eslint/pull/7895, as I discovered that checking that the operator was not a nullish coalescing operator was not necessary in the first place because no errors are raised when using nullish coalescing.
