### PR TITLE
docs: fix CJS/ESM

### DIFF
--- a/docs/Getting_Started.mdx
+++ b/docs/Getting_Started.mdx
@@ -22,9 +22,9 @@ npm install --save-dev eslint typescript typescript-eslint
 
 ### Step 2: Configuration
 
-Next, create a `eslint.config.js` config file in the root of your project, and populate it with the following:
+Next, create a `eslint.config.mjs` config file in the root of your project, and populate it with the following:
 
-```js title="eslint.config.js"
+```js title="eslint.config.mjs"
 // @ts-check
 
 import eslint from '@eslint/js';


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8455
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This edit is necessary because the Node.js currently defaults to CJS.
i.e. you have to manually add an extra field to package.json if you want to use ESM.

Furthermore, I propose that the ecosystem should standardize around an eslint config file named "eslint.config.mjs", regardless of whether or not the project is using ESM, because it will always just work.