### PR TITLE
feat: add rule type for `meta.defaultOptions`

### DIFF
--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -37,6 +37,11 @@ interface RuleMetaDataDocs {
 }
 interface RuleMetaData<TMessageIds extends string> {
   /**
+   * Specifies default options for the rule.
+   * If present, ESLint will recursively merge any user-provided options with these default options.
+   */
+  defaultOptions?: unknown[];
+  /**
    * True if the rule is deprecated, false otherwise
    */
   deprecated?: boolean;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This new property will soon be supported by ESLint rules. Providing the type for it will be useful for third-party tooling like [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator) that gets types from here.

Context:
* https://github.com/eslint/eslint/pull/17656
* https://github.com/eslint/rfcs/pull/113

@JoshuaKGoldberg is this a good level of documentation and typing for this new property?

As a follow-up, we'll also want to add this type to [@types/eslint](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/eslint).