### PR TITLE
docs: fix broken link in getting started page details section

### DIFF
--- a/docs/Getting_Started.mdx
+++ b/docs/Getting_Started.mdx
@@ -72,7 +72,7 @@ The [`config`](./packages/TypeScript_ESLint.mdx) helper sets three parts of ESLi
 
 - [Parser](https://eslint.org/docs/latest/use/configure/parser): set to [`@typescript-eslint/parser`](./packages/Parser.mdx) so ESLint knows how to parse the new pieces of TypeScript syntax.
 - [Plugins](https://eslint.org/docs/latest/use/configure/plugins): set to [`@typescript-eslint/eslint-plugin`](./packages/ESLint_Plugin.mdx) to load [rules listed in our _Rules_ page](./Rules).
-- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](https://typescript-eslint.io/linting/configs/#recommended) to enable our most commonly useful lint rules.
+- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](./linting/configs/#recommended) to enable our most commonly useful lint rules.
 
 See [ESLint's Configuration Files docs](https://eslint.org/docs/user-guide/configuring/configuration-files) for more details on configuring ESLint.
 

--- a/docs/Getting_Started.mdx
+++ b/docs/Getting_Started.mdx
@@ -72,7 +72,7 @@ The [`config`](./packages/TypeScript_ESLint.mdx) helper sets three parts of ESLi
 
 - [Parser](https://eslint.org/docs/latest/use/configure/parser): set to [`@typescript-eslint/parser`](./packages/Parser.mdx) so ESLint knows how to parse the new pieces of TypeScript syntax.
 - [Plugins](https://eslint.org/docs/latest/use/configure/plugins): set to [`@typescript-eslint/eslint-plugin`](./packages/ESLint_Plugin.mdx) to load [rules listed in our _Rules_ page](./Rules).
-- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](http://localhost:3000/linting/configs#recommended) to enable our most commonly useful lint rules.
+- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](https://typescript-eslint.io/linting/configs/#recommended) to enable our most commonly useful lint rules.
 
 See [ESLint's Configuration Files docs](https://eslint.org/docs/user-guide/configuring/configuration-files) for more details on configuring ESLint.
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Hey! 👋

I noticed a broken link in the "Getting Started" page, specifically in the "Details" section under the recommended configurations link. It was pointing to localhost instead of the correct public domain.

I've updated the link to direct users to the correct destination.

As far as I can tell, there are no open issues related to this, and it's likely that no one has noticed the broken link yet.

This PR resolves the issue and ensures a smoother experience for users navigating the documentation.

Thanks for reviewing! 🚀