### PR TITLE
docs: fix invalid relative link in getting started page details section

### DIFF
--- a/docs/Getting_Started.mdx
+++ b/docs/Getting_Started.mdx
@@ -71,8 +71,8 @@ ESLint will lint all TypeScript compatible files within the current folder, and 
 The [`config`](./packages/TypeScript_ESLint.mdx) helper sets three parts of ESLint:
 
 - [Parser](https://eslint.org/docs/latest/use/configure/parser): set to [`@typescript-eslint/parser`](./packages/Parser.mdx) so ESLint knows how to parse the new pieces of TypeScript syntax.
-- [Plugins](https://eslint.org/docs/latest/use/configure/plugins): set to [`@typescript-eslint/eslint-plugin`](./packages/ESLint_Plugin.mdx) to load [rules listed in our _Rules_ page](./Rules).
-- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](../linting/configs/#recommended) to enable our most commonly useful lint rules.
+- [Plugins](https://eslint.org/docs/latest/use/configure/plugins): set to [`@typescript-eslint/eslint-plugin`](./packages/ESLint_Plugin.mdx) to load [rules listed in our _Rules_ page](/rules).
+- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](./linting/Configurations.mdx#recommended) to enable our most commonly useful lint rules.
 
 See [ESLint's Configuration Files docs](https://eslint.org/docs/user-guide/configuring/configuration-files) for more details on configuring ESLint.
 

--- a/docs/Getting_Started.mdx
+++ b/docs/Getting_Started.mdx
@@ -72,7 +72,7 @@ The [`config`](./packages/TypeScript_ESLint.mdx) helper sets three parts of ESLi
 
 - [Parser](https://eslint.org/docs/latest/use/configure/parser): set to [`@typescript-eslint/parser`](./packages/Parser.mdx) so ESLint knows how to parse the new pieces of TypeScript syntax.
 - [Plugins](https://eslint.org/docs/latest/use/configure/plugins): set to [`@typescript-eslint/eslint-plugin`](./packages/ESLint_Plugin.mdx) to load [rules listed in our _Rules_ page](./Rules).
-- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](https://typescript-eslint.io/linting/configs/#recommended) to enable our most commonly useful lint rules.
+- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](./linting/configs/#recommended) to enable our most commonly useful lint rules.
 
 See [ESLint's Configuration Files docs](https://eslint.org/docs/user-guide/configuring/configuration-files) for more details on configuring ESLint.
 

--- a/docs/Getting_Started.mdx
+++ b/docs/Getting_Started.mdx
@@ -72,7 +72,7 @@ The [`config`](./packages/TypeScript_ESLint.mdx) helper sets three parts of ESLi
 
 - [Parser](https://eslint.org/docs/latest/use/configure/parser): set to [`@typescript-eslint/parser`](./packages/Parser.mdx) so ESLint knows how to parse the new pieces of TypeScript syntax.
 - [Plugins](https://eslint.org/docs/latest/use/configure/plugins): set to [`@typescript-eslint/eslint-plugin`](./packages/ESLint_Plugin.mdx) to load [rules listed in our _Rules_ page](./Rules).
-- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](./linting/configs/#recommended) to enable our most commonly useful lint rules.
+- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](../linting/configs/#recommended) to enable our most commonly useful lint rules.
 
 See [ESLint's Configuration Files docs](https://eslint.org/docs/user-guide/configuring/configuration-files) for more details on configuring ESLint.
 

--- a/docs/Getting_Started.mdx
+++ b/docs/Getting_Started.mdx
@@ -72,7 +72,7 @@ The [`config`](./packages/TypeScript_ESLint.mdx) helper sets three parts of ESLi
 
 - [Parser](https://eslint.org/docs/latest/use/configure/parser): set to [`@typescript-eslint/parser`](./packages/Parser.mdx) so ESLint knows how to parse the new pieces of TypeScript syntax.
 - [Plugins](https://eslint.org/docs/latest/use/configure/plugins): set to [`@typescript-eslint/eslint-plugin`](./packages/ESLint_Plugin.mdx) to load [rules listed in our _Rules_ page](./Rules).
-- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](http://localhost:3000/linting/configs#recommended) to enable our most commonly useful lint rules.
+- [Rules](https://eslint.org/docs/latest/use/configure/rules): extends from our [recommended configuration](https://typescript-eslint.io/linting/configs/#recommended) to enable our most commonly useful lint rules.
 
 See [ESLint's Configuration Files docs](https://eslint.org/docs/user-guide/configuring/configuration-files) for more details on configuring ESLint.
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Hey there! 👋

In the previous update to the link in the "Getting Started" page, it was pointing from the current directory, but it actually needed to go one directory up. My apologies for the mistake.

This PR fixes that issue by adjusting the link appropriately.

Thanks for reviewing! 🚀
