### PR TITLE
chore(website): properly align underline for children of `<a>` tag

### DIFF
--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -195,3 +195,7 @@ h6 {
 .markdown a {
   text-decoration: underline;
 }
+
+.markdown a * {
+  vertical-align: baseline;
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8469
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
