### PR TITLE
feat(utils): use mergeable interface for `settings` property (again)

### DIFF
--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -171,7 +171,9 @@ export type ReportDescriptor<TMessageIds extends string> =
  * Plugins can add their settings using declaration
  * merging against this interface.
  */
-export type SharedConfigurationSettings = Record<string, unknown>;
+export interface SharedConfigurationSettings {
+  [name: string]: unknown;
+}
 
 export interface RuleContext<
   TMessageIds extends string,

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -171,6 +171,7 @@ export type ReportDescriptor<TMessageIds extends string> =
  * Plugins can add their settings using declaration
  * merging against this interface.
  */
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 export interface SharedConfigurationSettings {
   [name: string]: unknown;
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] ~Addresses an existing open issue: fixes #000~
- [x] ~That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

It looks like #3556 got "undone" at some point - its now a `type` which can't be merged with; sadly I only noticed this after the next next major came out so I'll still need to use a type-cast 😞 