### PR TITLE
docs(eslint-plugin): fix typo in prefer-ts-expect-error

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.md
+++ b/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.md
@@ -9,7 +9,7 @@ description: 'Enforce using `@ts-expect-error` over `@ts-ignore`.'
 TypeScript allows you to suppress all errors on a line by placing a comment starting with `@ts-ignore` or `@ts-expect-error` immediately before the erroring line.
 The two directives work the same, except `@ts-expect-error` causes a type error if placed before a line that's not erroring in the first place.
 
-This means its easy for `@ts-ignore`s to be forgotten about, and remain in code even after the error they were suppressing is fixed.
+This means it's easy for `@ts-ignore`s to be forgotten about, and remain in code even after the error they were suppressing is fixed.
 This is dangerous, as if a new error arises on that line it'll be suppressed by the forgotten about `@ts-ignore`, and so be missed.
 
 ## Examples


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8505
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Typo in prefer-ts-expect-error docs fixed.
