### PR TITLE
chore - drop T from internal types

### DIFF
--- a/packages/eslint-plugin/rules.d.ts
+++ b/packages/eslint-plugin/rules.d.ts
@@ -17,7 +17,7 @@ TS wants to transpile each rule file to this `.d.ts` file:
 
 ```ts
 import type { TSESLint } from '@typescript-eslint/utils';
-declare const _default: TSESLint.RuleModule<TMessageIds, TOptions, TSESLint.RuleListener>;
+declare const _default: TSESLint.RuleModule<MessageIds, Options, TSESLint.RuleListener>;
 export default _default;
 ```
 

--- a/packages/eslint-plugin/src/util/collectUnusedVariables.ts
+++ b/packages/eslint-plugin/src/util/collectUnusedVariables.ts
@@ -12,8 +12,8 @@ import {
 } from '@typescript-eslint/utils';
 
 class UnusedVarsVisitor<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 > extends Visitor {
   private static readonly RESULTS_CACHE = new WeakMap<
     TSESTree.Program,
@@ -23,7 +23,7 @@ class UnusedVarsVisitor<
   readonly #scopeManager: TSESLint.Scope.ScopeManager;
   // readonly #unusedVariables = new Set<TSESLint.Scope.Variable>();
 
-  private constructor(context: TSESLint.RuleContext<TMessageIds, TOptions>) {
+  private constructor(context: TSESLint.RuleContext<MessageIds, Options>) {
     super({
       visitChildrenEvenIfSelectorExists: true,
     });
@@ -35,10 +35,10 @@ class UnusedVarsVisitor<
   }
 
   public static collectUnusedVariables<
-    TMessageIds extends string,
-    TOptions extends readonly unknown[],
+    MessageIds extends string,
+    Options extends readonly unknown[],
   >(
-    context: TSESLint.RuleContext<TMessageIds, TOptions>,
+    context: TSESLint.RuleContext<MessageIds, Options>,
   ): ReadonlySet<TSESLint.Scope.Variable> {
     const program = context.sourceCode.ast;
     const cached = this.RESULTS_CACHE.get(program);
@@ -749,10 +749,10 @@ function isUsedVariable(variable: TSESLint.Scope.Variable): boolean {
  * - variables within ambient module declarations
  */
 function collectUnusedVariables<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
+  context: Readonly<TSESLint.RuleContext<MessageIds, Options>>,
 ): ReadonlySet<TSESLint.Scope.Variable> {
   return UnusedVarsVisitor.collectUnusedVariables(context);
 }

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -149,9 +149,9 @@ function getNameFromMember(
 }
 
 type ExcludeKeys<
-  TObj extends Record<string, unknown>,
-  TKeys extends keyof TObj,
-> = { [k in Exclude<keyof TObj, TKeys>]: TObj[k] };
+  Obj extends Record<string, unknown>,
+  Keys extends keyof Obj,
+> = { [k in Exclude<keyof Obj, Keys>]: Obj[k] };
 type RequireKeys<
   Obj extends Record<string, unknown>,
   Keys extends keyof Obj,

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -153,9 +153,9 @@ type ExcludeKeys<
   TKeys extends keyof TObj,
 > = { [k in Exclude<keyof TObj, TKeys>]: TObj[k] };
 type RequireKeys<
-  TObj extends Record<string, unknown>,
-  TKeys extends keyof TObj,
-> = ExcludeKeys<TObj, TKeys> & { [k in TKeys]-?: Exclude<TObj[k], undefined> };
+  Obj extends Record<string, unknown>,
+  Keys extends keyof Obj,
+> = ExcludeKeys<Obj, Keys> & { [k in Keys]-?: Exclude<Obj[k], undefined> };
 
 function getEnumNames<T extends string>(myEnum: Record<T, unknown>): T[] {
   return Object.keys(myEnum).filter(x => isNaN(parseInt(x))) as T[];

--- a/packages/eslint-plugin/src/util/objectIterators.ts
+++ b/packages/eslint-plugin/src/util/objectIterators.ts
@@ -8,22 +8,22 @@ function objectForEachKey<T extends Record<string, unknown>>(
   }
 }
 
-function objectMapKey<T extends Record<string, unknown>, TReturn>(
+function objectMapKey<T extends Record<string, unknown>, Return>(
   obj: T,
-  callback: (key: keyof T) => TReturn,
-): TReturn[] {
-  const values: TReturn[] = [];
+  callback: (key: keyof T) => Return,
+): Return[] {
+  const values: Return[] = [];
   objectForEachKey(obj, key => {
     values.push(callback(key));
   });
   return values;
 }
 
-function objectReduceKey<T extends Record<string, unknown>, TAccumulator>(
+function objectReduceKey<T extends Record<string, unknown>, Accumulator>(
   obj: T,
-  callback: (acc: TAccumulator, key: keyof T) => TAccumulator,
-  initial: TAccumulator,
-): TAccumulator {
+  callback: (acc: Accumulator, key: keyof T) => Accumulator,
+  initial: Accumulator,
+): Accumulator {
   let accumulator = initial;
   objectForEachKey(obj, key => {
     accumulator = callback(accumulator, key);

--- a/packages/eslint-plugin/tests/RuleTester.ts
+++ b/packages/eslint-plugin/tests/RuleTester.ts
@@ -18,9 +18,9 @@ export function getFixturesRootDir(): string {
  *
  * @deprecated - DO NOT USE THIS FOR NEW RULES
  */
-export function batchedSingleLineTests<TOptions extends readonly unknown[]>(
-  test: ValidTestCase<TOptions>,
-): ValidTestCase<TOptions>[];
+export function batchedSingleLineTests<Options extends readonly unknown[]>(
+  test: ValidTestCase<Options>,
+): ValidTestCase<Options>[];
 /**
  * Converts a batch of single line tests into a number of separate test cases.
  * This makes it easier to write tests which use the same options.
@@ -35,17 +35,17 @@ export function batchedSingleLineTests<TOptions extends readonly unknown[]>(
  * @deprecated - DO NOT USE THIS FOR NEW RULES
  */
 export function batchedSingleLineTests<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  test: InvalidTestCase<TMessageIds, TOptions>,
-): InvalidTestCase<TMessageIds, TOptions>[];
+  test: InvalidTestCase<MessageIds, Options>,
+): InvalidTestCase<MessageIds, Options>[];
 export function batchedSingleLineTests<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  options: InvalidTestCase<TMessageIds, TOptions> | ValidTestCase<TOptions>,
-): (InvalidTestCase<TMessageIds, TOptions> | ValidTestCase<TOptions>)[] {
+  options: InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>,
+): (InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>)[] {
   // -- eslint counts lines from 1
   const lineOffset = options.code.startsWith('\n') ? 2 : 1;
   const output =

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -869,20 +869,6 @@ describe('hand-crafted cases', () => {
           },
         ],
       },
-      {
-        code: `
-          const a = 0;
-          const b = 0;
-          a === undefined || b === null || b === undefined;
-        `,
-      },
-      {
-        code: `
-          const a = 0;
-          const b = 0;
-          a === undefined || b === undefined || b === null;
-        `,
-      },
       '(x = {}) && (x.y = true) != null && x.y.toString();',
       "('x' as `${'x'}`) && ('x' as `${'x'}`).length;",
       '`x` && `x`.length;',

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -869,6 +869,20 @@ describe('hand-crafted cases', () => {
           },
         ],
       },
+      {
+        code: `
+          const a = 0;
+          const b = 0;
+          a === undefined || b === null || b === undefined;
+        `,
+      },
+      {
+        code: `
+          const a = 0;
+          const b = 0;
+          a === undefined || b === undefined || b === null;
+        `,
+      },
       '(x = {}) && (x.y = true) != null && x.y.toString();',
       "('x' as `${'x'}`) && ('x' as `${'x'}`).length;",
       '`x` && `x`.length;',

--- a/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
@@ -1060,24 +1060,22 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
   ]),
 });
 
-type Case<TMessageIds extends string, TOptions extends Readonly<unknown[]>> =
-  | TSESLint.InvalidTestCase<TMessageIds, TOptions>
-  | TSESLint.ValidTestCase<TOptions>;
-function addOptional<TOptions extends Readonly<unknown[]>>(
-  cases: (TSESLint.ValidTestCase<TOptions> | string)[],
-): TSESLint.ValidTestCase<TOptions>[];
+type Case<MessageIds extends string, Options extends Readonly<unknown[]>> =
+  | TSESLint.InvalidTestCase<MessageIds, Options>
+  | TSESLint.ValidTestCase<Options>;
+function addOptional<Options extends Readonly<unknown[]>>(
+  cases: (TSESLint.ValidTestCase<Options> | string)[],
+): TSESLint.ValidTestCase<Options>[];
 function addOptional<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
 >(
-  cases: TSESLint.InvalidTestCase<TMessageIds, TOptions>[],
-): TSESLint.InvalidTestCase<TMessageIds, TOptions>[];
+  cases: TSESLint.InvalidTestCase<MessageIds, Options>[],
+): TSESLint.InvalidTestCase<MessageIds, Options>[];
 function addOptional<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
->(
-  cases: (Case<TMessageIds, TOptions> | string)[],
-): Case<TMessageIds, TOptions>[] {
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
+>(cases: (Case<MessageIds, Options> | string)[]): Case<MessageIds, Options>[] {
   function makeOptional(code: string): string;
   function makeOptional(code: string | null | undefined): string | null;
   function makeOptional(code: string | null | undefined): string | null {
@@ -1093,7 +1091,7 @@ function addOptional<
     );
   }
 
-  return cases.reduce<Case<TMessageIds, TOptions>[]>((acc, c) => {
+  return cases.reduce<Case<MessageIds, Options>[]>((acc, c) => {
     if (typeof c === 'string') {
       acc.push({
         code: c,

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -146,21 +146,21 @@ export class RuleTester extends TestFramework {
   /**
    * Adds the `only` property to a test to run it in isolation.
    */
-  static only<TOptions extends Readonly<unknown[]>>(
-    item: ValidTestCase<TOptions> | string,
-  ): ValidTestCase<TOptions>;
+  static only<Options extends Readonly<unknown[]>>(
+    item: ValidTestCase<Options> | string,
+  ): ValidTestCase<Options>;
   /**
    * Adds the `only` property to a test to run it in isolation.
    */
-  static only<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
-    item: InvalidTestCase<TMessageIds, TOptions>,
-  ): InvalidTestCase<TMessageIds, TOptions>;
-  static only<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
+  static only<MessageIds extends string, Options extends Readonly<unknown[]>>(
+    item: InvalidTestCase<MessageIds, Options>,
+  ): InvalidTestCase<MessageIds, Options>;
+  static only<MessageIds extends string, Options extends Readonly<unknown[]>>(
     item:
-      | InvalidTestCase<TMessageIds, TOptions>
-      | ValidTestCase<TOptions>
+      | InvalidTestCase<MessageIds, Options>
+      | ValidTestCase<Options>
       | string,
-  ): InvalidTestCase<TMessageIds, TOptions> | ValidTestCase<TOptions> {
+  ): InvalidTestCase<MessageIds, Options> | ValidTestCase<Options> {
     if (typeof item === 'string') {
       return { code: item, only: true };
     }
@@ -176,11 +176,11 @@ export class RuleTester extends TestFramework {
   }
 
   #normalizeTests<
-    TMessageIds extends string,
-    TOptions extends readonly unknown[],
+    MessageIds extends string,
+    Options extends readonly unknown[],
   >(
-    rawTests: RunTests<TMessageIds, TOptions>,
-  ): NormalizedRunTests<TMessageIds, TOptions> {
+    rawTests: RunTests<MessageIds, Options>,
+  ): NormalizedRunTests<MessageIds, Options> {
     /*
     Automatically add a filename to the tests to enable type-aware tests to "just work".
     This saves users having to verbosely and manually add the filename to every
@@ -205,11 +205,9 @@ export class RuleTester extends TestFramework {
       return filename;
     };
     const normalizeTest = <
-      TMessageIds extends string,
-      TOptions extends readonly unknown[],
-      T extends
-        | InvalidTestCase<TMessageIds, TOptions>
-        | ValidTestCase<TOptions>,
+      MessageIds extends string,
+      Options extends readonly unknown[],
+      T extends InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>,
     >(
       test: T,
     ): T => {
@@ -239,7 +237,7 @@ export class RuleTester extends TestFramework {
 
     // convenience iterator to make it easy to loop all tests without a concat
     const allTestsIterator = {
-      *[Symbol.iterator](): Generator<ValidTestCase<TOptions>, void> {
+      *[Symbol.iterator](): Generator<ValidTestCase<Options>, void> {
         for (const testCase of normalizedTests.valid) {
           yield testCase;
         }
@@ -285,9 +283,7 @@ export class RuleTester extends TestFramework {
     just disappearing without a trace.
     */
     const maybeMarkAsOnly = <
-      T extends
-        | InvalidTestCase<TMessageIds, TOptions>
-        | ValidTestCase<TOptions>,
+      T extends InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>,
     >(
       test: T,
     ): T => {
@@ -305,10 +301,10 @@ export class RuleTester extends TestFramework {
   /**
    * Adds a new rule test to execute.
    */
-  run<TMessageIds extends string, TOptions extends readonly unknown[]>(
+  run<MessageIds extends string, Options extends readonly unknown[]>(
     ruleName: string,
-    rule: RuleModule<TMessageIds, TOptions>,
-    test: RunTests<TMessageIds, TOptions>,
+    rule: RuleModule<MessageIds, Options>,
+    test: RunTests<MessageIds, Options>,
   ): void {
     const constructor = this.constructor as typeof RuleTester;
 
@@ -366,7 +362,7 @@ export class RuleTester extends TestFramework {
       ruleName,
       Object.assign({}, rule, {
         // Create a wrapper rule that freezes the `context` properties.
-        create(context: RuleContext<TMessageIds, TOptions>) {
+        create(context: RuleContext<MessageIds, Options>) {
           freezeDeeply(context.options);
           freezeDeeply(context.settings);
           freezeDeeply(context.parserOptions);
@@ -381,7 +377,7 @@ export class RuleTester extends TestFramework {
     const normalizedTests = this.#normalizeTests(test);
 
     function getTestMethod(
-      test: ValidTestCase<TOptions>,
+      test: ValidTestCase<Options>,
     ): 'it' | 'itOnly' | 'itSkip' {
       if (test.skip) {
         return 'itSkip';
@@ -437,12 +433,12 @@ export class RuleTester extends TestFramework {
    * Use @private instead of #private to expose it for testing purposes
    */
   private runRuleForItem<
-    TMessageIds extends string,
-    TOptions extends readonly unknown[],
+    MessageIds extends string,
+    Options extends readonly unknown[],
   >(
     ruleName: string,
-    rule: RuleModule<TMessageIds, TOptions>,
-    item: InvalidTestCase<TMessageIds, TOptions> | ValidTestCase<TOptions>,
+    rule: RuleModule<MessageIds, Options>,
+    item: InvalidTestCase<MessageIds, Options> | ValidTestCase<Options>,
   ): {
     messages: Linter.LintMessage[];
     output: string;
@@ -627,14 +623,14 @@ export class RuleTester extends TestFramework {
    * all valid cases go through this
    */
   #testValidTemplate<
-    TMessageIds extends string,
-    TOptions extends readonly unknown[],
+    MessageIds extends string,
+    Options extends readonly unknown[],
   >(
     ruleName: string,
-    rule: RuleModule<TMessageIds, TOptions>,
-    itemIn: ValidTestCase<TOptions> | string,
+    rule: RuleModule<MessageIds, Options>,
+    itemIn: ValidTestCase<Options> | string,
   ): void {
-    const item: ValidTestCase<TOptions> =
+    const item: ValidTestCase<Options> =
       typeof itemIn === 'object' ? itemIn : { code: itemIn };
 
     assert.ok(
@@ -669,12 +665,12 @@ export class RuleTester extends TestFramework {
    * all invalid cases go through this.
    */
   #testInvalidTemplate<
-    TMessageIds extends string,
-    TOptions extends readonly unknown[],
+    MessageIds extends string,
+    Options extends readonly unknown[],
   >(
     ruleName: string,
-    rule: RuleModule<TMessageIds, TOptions>,
-    item: InvalidTestCase<TMessageIds, TOptions>,
+    rule: RuleModule<MessageIds, Options>,
+    item: InvalidTestCase<MessageIds, Options>,
   ): void {
     assert.ok(
       typeof item.code === 'string',

--- a/packages/rule-tester/src/types/InvalidTestCase.ts
+++ b/packages/rule-tester/src/types/InvalidTestCase.ts
@@ -4,11 +4,11 @@ import type { ReportDescriptorMessageData } from '@typescript-eslint/utils/ts-es
 import type { DependencyConstraint } from './DependencyConstraint';
 import type { ValidTestCase } from './ValidTestCase';
 
-export interface SuggestionOutput<TMessageIds extends string> {
+export interface SuggestionOutput<MessageIds extends string> {
   /**
    * Reported message ID.
    */
-  readonly messageId: TMessageIds;
+  readonly messageId: MessageIds;
   /**
    * The data used to fill the message template.
    */
@@ -23,7 +23,7 @@ export interface SuggestionOutput<TMessageIds extends string> {
   // readonly desc?: string;
 }
 
-export interface TestCaseError<TMessageIds extends string> {
+export interface TestCaseError<MessageIds extends string> {
   /**
    * The 1-based column number of the reported start location.
    */
@@ -47,11 +47,11 @@ export interface TestCaseError<TMessageIds extends string> {
   /**
    * Reported message ID.
    */
-  readonly messageId: TMessageIds;
+  readonly messageId: MessageIds;
   /**
    * Reported suggestions.
    */
-  readonly suggestions?: readonly SuggestionOutput<TMessageIds>[] | null;
+  readonly suggestions?: readonly SuggestionOutput<MessageIds>[] | null;
   /**
    * The type of the reported AST node.
    */
@@ -62,13 +62,13 @@ export interface TestCaseError<TMessageIds extends string> {
 }
 
 export interface InvalidTestCase<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
-> extends ValidTestCase<TOptions> {
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
+> extends ValidTestCase<Options> {
   /**
    * Expected errors.
    */
-  readonly errors: readonly TestCaseError<TMessageIds>[];
+  readonly errors: readonly TestCaseError<MessageIds>[];
   /**
    * The expected code after autofixes are applied. If set to `null`, the test runner will assert that no autofix is suggested.
    */

--- a/packages/rule-tester/src/types/ValidTestCase.ts
+++ b/packages/rule-tester/src/types/ValidTestCase.ts
@@ -6,7 +6,7 @@ import type {
 
 import type { DependencyConstraint } from './DependencyConstraint';
 
-export interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
+export interface ValidTestCase<Options extends Readonly<unknown[]>> {
   /**
    * Name for the test case.
    */
@@ -30,7 +30,7 @@ export interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   /**
    * Options for the test case.
    */
-  readonly options?: Readonly<TOptions>;
+  readonly options?: Readonly<Options>;
   /**
    * The absolute path for the parser.
    */

--- a/packages/rule-tester/src/types/index.ts
+++ b/packages/rule-tester/src/types/index.ts
@@ -11,20 +11,20 @@ export type TesterConfigWithDefaults = Mutable<
 >;
 
 export interface RunTests<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
 > {
   // RuleTester.run also accepts strings for valid cases
-  readonly valid: readonly (ValidTestCase<TOptions> | string)[];
-  readonly invalid: readonly InvalidTestCase<TMessageIds, TOptions>[];
+  readonly valid: readonly (ValidTestCase<Options> | string)[];
+  readonly invalid: readonly InvalidTestCase<MessageIds, Options>[];
 }
 
 export interface NormalizedRunTests<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
 > {
-  readonly valid: readonly ValidTestCase<TOptions>[];
-  readonly invalid: readonly InvalidTestCase<TMessageIds, TOptions>[];
+  readonly valid: readonly ValidTestCase<Options>[];
+  readonly invalid: readonly InvalidTestCase<MessageIds, Options>[];
 }
 
 export type { ValidTestCase } from './ValidTestCase';

--- a/packages/rule-tester/src/utils/hasOwnProperty.ts
+++ b/packages/rule-tester/src/utils/hasOwnProperty.ts
@@ -1,8 +1,8 @@
 // typed so that TS can remove optionality
 export const hasOwnProperty = Function.call.bind(Object.hasOwnProperty) as <
-  TObj extends object,
-  TK extends keyof TObj,
+  Obj extends object,
+  K extends keyof Obj,
 >(
-  obj: TObj,
-  key: TK,
-) => obj is TObj & { [key in TK]-?: TObj[key] };
+  obj: Obj,
+  key: K,
+) => obj is Obj & { [key in K]-?: Obj[key] };

--- a/packages/scope-manager/src/definition/DefinitionBase.ts
+++ b/packages/scope-manager/src/definition/DefinitionBase.ts
@@ -6,10 +6,10 @@ import type { DefinitionType } from './DefinitionType';
 const generator = createIdGenerator();
 
 abstract class DefinitionBase<
-  TType extends DefinitionType,
-  TNode extends TSESTree.Node,
-  TParent extends TSESTree.Node | null,
-  TName extends TSESTree.Node,
+  Type extends DefinitionType,
+  Node extends TSESTree.Node,
+  Parent extends TSESTree.Node | null,
+  Name extends TSESTree.Node,
 > {
   /**
    * A unique ID for this instance - primarily used to help debugging and testing
@@ -20,27 +20,27 @@ abstract class DefinitionBase<
    * The type of the definition
    * @public
    */
-  public readonly type: TType;
+  public readonly type: Type;
 
   /**
    * The `Identifier` node of this definition
    * @public
    */
-  public readonly name: TName;
+  public readonly name: Name;
 
   /**
    * The enclosing node of the name.
    * @public
    */
-  public readonly node: TNode;
+  public readonly node: Node;
 
   /**
    * the enclosing statement node of the identifier.
    * @public
    */
-  public readonly parent: TParent;
+  public readonly parent: Parent;
 
-  constructor(type: TType, name: TName, node: TNode, parent: TParent) {
+  constructor(type: Type, name: Name, node: Node, parent: Parent) {
     this.type = type;
     this.name = name;
     this.node = node;

--- a/packages/scope-manager/src/scope/ScopeBase.ts
+++ b/packages/scope-manager/src/scope/ScopeBase.ts
@@ -136,9 +136,9 @@ const VARIABLE_SCOPE_TYPES = new Set([
 
 type AnyScope = ScopeBase<ScopeType, TSESTree.Node, Scope | null>;
 abstract class ScopeBase<
-  TType extends ScopeType,
-  TBlock extends TSESTree.Node,
-  TUpper extends Scope | null,
+  Type extends ScopeType,
+  Block extends TSESTree.Node,
+  Upper extends Scope | null,
 > {
   /**
    * A unique ID for this instance - primarily used to help debugging and testing
@@ -149,7 +149,7 @@ abstract class ScopeBase<
    * The AST node which created this scope.
    * @public
    */
-  public readonly block: TBlock;
+  public readonly block: Block;
   /**
    * The array of child scopes. This does not include grandchild scopes.
    * @public
@@ -204,12 +204,12 @@ abstract class ScopeBase<
    * The type of scope
    * @public
    */
-  public readonly type: TType;
+  public readonly type: Type;
   /**
    * Reference to the parent {@link Scope}.
    * @public
    */
-  public readonly upper: TUpper;
+  public readonly upper: Upper;
   /**
    * The scoped {@link Variable}s of this scope.
    * In the case of a 'function' scope this includes the automatic argument `arguments` as its first element, as well
@@ -227,9 +227,9 @@ abstract class ScopeBase<
 
   constructor(
     scopeManager: ScopeManager,
-    type: TType,
-    upperScope: TUpper,
-    block: TBlock,
+    type: Type,
+    upperScope: Upper,
+    block: Block,
     isMethodDefinition: boolean,
   ) {
     const upperScopeAsScopeBase = upperScope;

--- a/packages/scope-manager/tests/test-utils/getSpecificNode.ts
+++ b/packages/scope-manager/tests/test-utils/getSpecificNode.ts
@@ -2,22 +2,22 @@ import type { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/types';
 import { simpleTraverse } from '@typescript-eslint/typescript-estree';
 
 function getSpecificNode<
-  TSelector extends AST_NODE_TYPES,
-  TNode extends Extract<TSESTree.Node, { type: TSelector }>,
+  Selector extends AST_NODE_TYPES,
+  Node extends Extract<TSESTree.Node, { type: Selector }>,
 >(
   ast: TSESTree.Node,
-  selector: TSelector,
-  cb?: (node: TNode) => boolean | null | undefined,
-): TNode;
+  selector: Selector,
+  cb?: (node: Node) => boolean | null | undefined,
+): Node;
 function getSpecificNode<
-  TSelector extends AST_NODE_TYPES,
-  TNode extends Extract<TSESTree.Node, { type: TSelector }>,
-  TReturnType extends TSESTree.Node,
+  Selector extends AST_NODE_TYPES,
+  Node extends Extract<TSESTree.Node, { type: Selector }>,
+  ReturnType extends TSESTree.Node,
 >(
   ast: TSESTree.Node,
-  selector: TSelector,
-  cb: (node: TNode) => TReturnType | null | undefined,
-): TReturnType;
+  selector: Selector,
+  cb: (node: Node) => ReturnType | null | undefined,
+): ReturnType;
 
 function getSpecificNode(
   ast: TSESTree.Node,

--- a/packages/scope-manager/tests/test-utils/serializers/baseSerializer.ts
+++ b/packages/scope-manager/tests/test-utils/serializers/baseSerializer.ts
@@ -2,20 +2,20 @@ import type { NewPlugin } from 'pretty-format';
 
 type ConstructorSignature = new (...args: never) => unknown;
 
-function createSerializer<TConstructor extends ConstructorSignature>(
-  type: TConstructor,
-  keys: (keyof InstanceType<TConstructor>)[],
+function createSerializer<Constructor extends ConstructorSignature>(
+  type: Constructor,
+  keys: (keyof InstanceType<Constructor>)[],
 ): NewPlugin;
 // A hack of signature to enable this to work with abstract classes
-function createSerializer<TConstructor extends ConstructorSignature>(
+function createSerializer<Constructor extends ConstructorSignature>(
   abstractConstructor: unknown,
-  keys: (keyof InstanceType<TConstructor>)[],
-  instanceConstructorThatsNeverUsed: TConstructor,
+  keys: (keyof InstanceType<Constructor>)[],
+  instanceConstructorThatsNeverUsed: Constructor,
 ): NewPlugin;
 
-function createSerializer<TConstructor extends ConstructorSignature>(
-  type: TConstructor,
-  keys: (keyof InstanceType<TConstructor>)[],
+function createSerializer<Constructor extends ConstructorSignature>(
+  type: Constructor,
+  keys: (keyof InstanceType<Constructor>)[],
 ): NewPlugin {
   const SEEN_THINGS = new Set<unknown>();
 

--- a/packages/typescript-estree/src/parseSettings/ExpiringCache.ts
+++ b/packages/typescript-estree/src/parseSettings/ExpiringCache.ts
@@ -11,13 +11,13 @@ export interface CacheLike<Key, Value> {
 /**
  * A map with key-level expiration.
  */
-export class ExpiringCache<TKey, TValue> implements CacheLike<TKey, TValue> {
+export class ExpiringCache<Key, Value> implements CacheLike<Key, Value> {
   readonly #cacheDurationSeconds: CacheDurationSeconds;
 
   readonly #map = new Map<
-    TKey,
+    Key,
     Readonly<{
-      value: TValue;
+      value: Value;
       lastSeen: [number, number];
     }>
   >();
@@ -26,7 +26,7 @@ export class ExpiringCache<TKey, TValue> implements CacheLike<TKey, TValue> {
     this.#cacheDurationSeconds = cacheDurationSeconds;
   }
 
-  set(key: TKey, value: TValue): this {
+  set(key: Key, value: Value): this {
     this.#map.set(key, {
       value,
       lastSeen:
@@ -38,7 +38,7 @@ export class ExpiringCache<TKey, TValue> implements CacheLike<TKey, TValue> {
     return this;
   }
 
-  get(key: TKey): TValue | undefined {
+  get(key: Key): Value | undefined {
     const entry = this.#map.get(key);
     if (entry?.value != null) {
       if (this.#cacheDurationSeconds === 'Infinity') {

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -233,8 +233,8 @@ export type TSESTreeOptions = ParseAndGenerateServicesOptions;
 
 // This lets us use generics to type the return value, and removes the need to
 // handle the undefined type in the get method
-export interface ParserWeakMap<TKey, TValueBase> {
-  get<TValue extends TValueBase>(key: TKey): TValue;
+export interface ParserWeakMap<Key, ValueBase> {
+  get<Value extends ValueBase>(key: Key): Value;
   has(key: unknown): boolean;
 }
 

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -239,9 +239,9 @@ export interface ParserWeakMap<Key, ValueBase> {
 }
 
 export interface ParserWeakMapESTreeToTSNode<
-  TKey extends TSESTree.Node = TSESTree.Node,
+  Key extends TSESTree.Node = TSESTree.Node,
 > {
-  get<TKeyBase extends TKey>(key: TKeyBase): TSESTreeToTSNode<TKeyBase>;
+  get<KeyBase extends Key>(key: KeyBase): TSESTreeToTSNode<KeyBase>;
   has(key: unknown): boolean;
 }
 

--- a/packages/utils/src/eslint-utils/InferTypesFromRule.ts
+++ b/packages/utils/src/eslint-utils/InferTypesFromRule.ts
@@ -1,23 +1,23 @@
 import type { RuleCreateFunction, RuleModule } from '../ts-eslint';
 
 /**
- * Uses type inference to fetch the TOptions type from the given RuleModule
+ * Uses type inference to fetch the Options type from the given RuleModule
  */
 type InferOptionsTypeFromRule<T> =
-  T extends RuleModule<infer _TMessageIds, infer TOptions>
-    ? TOptions
-    : T extends RuleCreateFunction<infer _TMessageIds, infer TOptions>
-      ? TOptions
+  T extends RuleModule<infer _MessageIds, infer Options>
+    ? Options
+    : T extends RuleCreateFunction<infer _MessageIds, infer Options>
+      ? Options
       : unknown;
 
 /**
- * Uses type inference to fetch the TMessageIds type from the given RuleModule
+ * Uses type inference to fetch the MessageIds type from the given RuleModule
  */
 type InferMessageIdsTypeFromRule<T> =
-  T extends RuleModule<infer TMessageIds, infer _TOptions>
-    ? TMessageIds
-    : T extends RuleCreateFunction<infer TMessageIds, infer _TOptions>
-      ? TMessageIds
+  T extends RuleModule<infer MessageIds, infer _TOptions>
+    ? MessageIds
+    : T extends RuleCreateFunction<infer MessageIds, infer _TOptions>
+      ? MessageIds
       : unknown;
 
 export { InferOptionsTypeFromRule, InferMessageIdsTypeFromRule };

--- a/packages/utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/utils/src/eslint-utils/RuleCreator.ts
@@ -11,36 +11,36 @@ export type { RuleListener, RuleModule };
 
 // we automatically add the url
 export type NamedCreateRuleMetaDocs = Omit<RuleMetaDataDocs, 'url'>;
-export type NamedCreateRuleMeta<TMessageIds extends string> = Omit<
-  RuleMetaData<TMessageIds>,
+export type NamedCreateRuleMeta<MessageIds extends string> = Omit<
+  RuleMetaData<MessageIds>,
   'docs'
 > & {
   docs: NamedCreateRuleMetaDocs;
 };
 
 export interface RuleCreateAndOptions<
-  TOptions extends readonly unknown[],
-  TMessageIds extends string,
+  Options extends readonly unknown[],
+  MessageIds extends string,
 > {
   create: (
-    context: Readonly<RuleContext<TMessageIds, TOptions>>,
-    optionsWithDefault: Readonly<TOptions>,
+    context: Readonly<RuleContext<MessageIds, Options>>,
+    optionsWithDefault: Readonly<Options>,
   ) => RuleListener;
-  defaultOptions: Readonly<TOptions>;
+  defaultOptions: Readonly<Options>;
 }
 
 export interface RuleWithMeta<
-  TOptions extends readonly unknown[],
-  TMessageIds extends string,
-> extends RuleCreateAndOptions<TOptions, TMessageIds> {
-  meta: RuleMetaData<TMessageIds>;
+  Options extends readonly unknown[],
+  MessageIds extends string,
+> extends RuleCreateAndOptions<Options, MessageIds> {
+  meta: RuleMetaData<MessageIds>;
 }
 
 export interface RuleWithMetaAndName<
-  TOptions extends readonly unknown[],
-  TMessageIds extends string,
-> extends RuleCreateAndOptions<TOptions, TMessageIds> {
-  meta: NamedCreateRuleMeta<TMessageIds>;
+  Options extends readonly unknown[],
+  MessageIds extends string,
+> extends RuleCreateAndOptions<Options, MessageIds> {
+  meta: NamedCreateRuleMeta<MessageIds>;
   name: string;
 }
 
@@ -54,17 +54,17 @@ export function RuleCreator(urlCreator: (ruleName: string) => string) {
   // This function will get much easier to call when this is merged https://github.com/Microsoft/TypeScript/pull/26349
   // TODO - when the above PR lands; add type checking for the context.report `data` property
   return function createNamedRule<
-    TOptions extends readonly unknown[],
-    TMessageIds extends string,
+    Options extends readonly unknown[],
+    MessageIds extends string,
   >({
     name,
     meta,
     ...rule
-  }: Readonly<RuleWithMetaAndName<TOptions, TMessageIds>>): RuleModule<
-    TMessageIds,
-    TOptions
+  }: Readonly<RuleWithMetaAndName<Options, MessageIds>>): RuleModule<
+    MessageIds,
+    Options
   > {
-    return createRule<TOptions, TMessageIds>({
+    return createRule<Options, MessageIds>({
       meta: {
         ...meta,
         docs: {
@@ -84,20 +84,18 @@ export function RuleCreator(urlCreator: (ruleName: string) => string) {
  * @remarks It is generally better to provide a docs URL function to RuleCreator.
  */
 function createRule<
-  TOptions extends readonly unknown[],
-  TMessageIds extends string,
+  Options extends readonly unknown[],
+  MessageIds extends string,
 >({
   create,
   defaultOptions,
   meta,
-}: Readonly<RuleWithMeta<TOptions, TMessageIds>>): RuleModule<
-  TMessageIds,
-  TOptions
+}: Readonly<RuleWithMeta<Options, MessageIds>>): RuleModule<
+  MessageIds,
+  Options
 > {
   return {
-    create(
-      context: Readonly<RuleContext<TMessageIds, TOptions>>,
-    ): RuleListener {
+    create(context: Readonly<RuleContext<MessageIds, Options>>): RuleListener {
       const optionsWithDefault = applyDefault(defaultOptions, context.options);
       return create(context, optionsWithDefault);
     },

--- a/packages/utils/src/eslint-utils/applyDefault.ts
+++ b/packages/utils/src/eslint-utils/applyDefault.ts
@@ -7,14 +7,14 @@ import { deepMerge, isObjectNotArray } from './deepMerge';
  * @param userOptions the user opts
  * @returns the options with defaults
  */
-function applyDefault<TUser extends readonly unknown[], TDefault extends TUser>(
-  defaultOptions: Readonly<TDefault>,
-  userOptions: Readonly<TUser> | null,
-): TDefault {
+function applyDefault<User extends readonly unknown[], Default extends User>(
+  defaultOptions: Readonly<Default>,
+  userOptions: Readonly<User> | null,
+): Default {
   // clone defaults
   const options = JSON.parse(
     JSON.stringify(defaultOptions),
-  ) as AsMutable<TDefault>;
+  ) as AsMutable<Default>;
 
   if (userOptions == null) {
     return options;
@@ -38,7 +38,7 @@ function applyDefault<TUser extends readonly unknown[], TDefault extends TUser>(
 }
 
 type AsMutable<T extends readonly unknown[]> = {
-  -readonly [TKey in keyof T]: T[TKey];
+  -readonly [Key in keyof T]: T[Key];
 };
 
 export { applyDefault };

--- a/packages/utils/src/eslint-utils/getParserServices.ts
+++ b/packages/utils/src/eslint-utils/getParserServices.ts
@@ -17,20 +17,20 @@ const ERROR_MESSAGE_UNKNOWN_PARSER =
  * This **_will_** throw if it is not available.
  */
 function getParserServices<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
+  context: Readonly<TSESLint.RuleContext<MessageIds, Options>>,
 ): ParserServicesWithTypeInformation;
 /**
  * Try to retrieve type-aware parser service from context.
  * This **_will_** throw if it is not available.
  */
 function getParserServices<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
+  context: Readonly<TSESLint.RuleContext<MessageIds, Options>>,
   allowWithoutFullTypeInformation: false,
 ): ParserServicesWithTypeInformation;
 /**
@@ -38,10 +38,10 @@ function getParserServices<
  * This **_will not_** throw if it is not available.
  */
 function getParserServices<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
+  context: Readonly<TSESLint.RuleContext<MessageIds, Options>>,
   allowWithoutFullTypeInformation: true,
 ): ParserServices;
 /**
@@ -49,10 +49,10 @@ function getParserServices<
  * This may or may not throw if it is not available, depending on if `allowWithoutFullTypeInformation` is `true`
  */
 function getParserServices<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 >(
-  context: Readonly<TSESLint.RuleContext<TMessageIds, TOptions>>,
+  context: Readonly<TSESLint.RuleContext<MessageIds, Options>>,
   allowWithoutFullTypeInformation: boolean,
 ): ParserServices;
 

--- a/packages/utils/src/ts-eslint/Linter.ts
+++ b/packages/utils/src/ts-eslint/Linter.ts
@@ -15,10 +15,10 @@ import type {
 import type { SourceCode } from './SourceCode';
 
 export type MinimalRuleModule<
-  TMessageIds extends string = string,
-  TOptions extends readonly unknown[] = [],
-> = Partial<Omit<RuleModule<TMessageIds, TOptions>, 'create'>> &
-  Pick<RuleModule<TMessageIds, TOptions>, 'create'>;
+  MessageIds extends string = string,
+  Options extends readonly unknown[] = [],
+> = Partial<Omit<RuleModule<MessageIds, Options>, 'create'>> &
+  Pick<RuleModule<MessageIds, Options>, 'create'>;
 
 declare class LinterBase {
   /**
@@ -39,20 +39,20 @@ declare class LinterBase {
    * @param ruleId A unique rule identifier
    * @param ruleModule Function from context to object mapping AST node types to event handlers
    */
-  defineRule<TMessageIds extends string, TOptions extends readonly unknown[]>(
+  defineRule<MessageIds extends string, Options extends readonly unknown[]>(
     ruleId: string,
-    ruleModule: MinimalRuleModule<TMessageIds, TOptions> | RuleCreateFunction,
+    ruleModule: MinimalRuleModule<MessageIds, Options> | RuleCreateFunction,
   ): void;
 
   /**
    * Defines many new linting rules.
    * @param rulesToDefine map from unique rule identifier to rule
    */
-  defineRules<TMessageIds extends string, TOptions extends readonly unknown[]>(
+  defineRules<MessageIds extends string, Options extends readonly unknown[]>(
     rulesToDefine: Record<
       string,
-      | MinimalRuleModule<TMessageIds, TOptions>
-      | RuleCreateFunction<TMessageIds, TOptions>
+      | MinimalRuleModule<MessageIds, Options>
+      | RuleCreateFunction<MessageIds, Options>
     >,
   ): void;
 

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -614,26 +614,28 @@ export type RuleListener = RuleListenerBaseSelectors &
   RuleListenerExitSelectors;
 
 export interface RuleModule<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[] = [],
+  MessageIds extends string,
+  Options extends readonly unknown[] = [],
   // for extending base rules
-  TRuleListener extends RuleListener = RuleListener,
+  ExtendedRuleListener extends RuleListener = RuleListener,
 > {
   /**
    * Default options the rule will be run with
    */
-  defaultOptions: TOptions;
+  defaultOptions: Options;
 
   /**
    * Metadata about the rule
    */
-  meta: RuleMetaData<TMessageIds>;
+  meta: RuleMetaData<MessageIds>;
 
   /**
    * Function which returns an object with methods that ESLint calls to “visit”
    * nodes while traversing the abstract syntax tree.
    */
-  create(context: Readonly<RuleContext<TMessageIds, TOptions>>): TRuleListener;
+  create(
+    context: Readonly<RuleContext<MessageIds, Options>>,
+  ): ExtendedRuleListener;
 }
 export type AnyRuleModule = RuleModule<string, readonly unknown[]>;
 

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -35,7 +35,8 @@ export interface RuleMetaDataDocs {
    */
   extendsBaseRule?: boolean | string;
 }
-export interface RuleMetaData<TMessageIds extends string> {
+
+export interface RuleMetaData<MessageIds extends string> {
   /**
    * True if the rule is deprecated, false otherwise
    */
@@ -57,7 +58,7 @@ export interface RuleMetaData<TMessageIds extends string> {
    * The key is the messageId, and the string is the parameterised error string.
    * See: https://eslint.org/docs/developer-guide/working-with-rules#messageids
    */
-  messages: Record<TMessageIds, string>;
+  messages: Record<MessageIds, string>;
   /**
    * The type of rule.
    * - `"problem"` means the rule is identifying code that either will cause an error or may cause a confusing behavior. Developers should consider this a high priority to resolve.
@@ -107,20 +108,21 @@ export interface RuleFixer {
   replaceTextRange(range: Readonly<AST.Range>, text: string): RuleFix;
 }
 
-export interface SuggestionReportDescriptor<TMessageIds extends string>
-  extends Omit<ReportDescriptorBase<TMessageIds>, 'fix'> {
+export interface SuggestionReportDescriptor<MessageIds extends string>
+  extends Omit<ReportDescriptorBase<MessageIds>, 'fix'> {
   readonly fix: ReportFixFunction;
 }
 
 export type ReportFixFunction = (
   fixer: RuleFixer,
 ) => IterableIterator<RuleFix> | RuleFix | readonly RuleFix[] | null;
-export type ReportSuggestionArray<TMessageIds extends string> =
-  SuggestionReportDescriptor<TMessageIds>[];
+
+export type ReportSuggestionArray<MessageIds extends string> =
+  SuggestionReportDescriptor<MessageIds>[];
 
 export type ReportDescriptorMessageData = Readonly<Record<string, unknown>>;
 
-interface ReportDescriptorBase<TMessageIds extends string> {
+interface ReportDescriptorBase<MessageIds extends string> {
   /**
    * The parameters for the message string associated with `messageId`.
    */
@@ -132,17 +134,17 @@ interface ReportDescriptorBase<TMessageIds extends string> {
   /**
    * The messageId which is being reported.
    */
-  readonly messageId: TMessageIds;
+  readonly messageId: MessageIds;
 
   // we disallow this because it's much better to use messageIds for reusable errors that are easily testable
   // readonly desc?: string;
 }
-interface ReportDescriptorWithSuggestion<TMessageIds extends string>
-  extends ReportDescriptorBase<TMessageIds> {
+interface ReportDescriptorWithSuggestion<MessageIds extends string>
+  extends ReportDescriptorBase<MessageIds> {
   /**
    * 6.7's Suggestions API
    */
-  readonly suggest?: Readonly<ReportSuggestionArray<TMessageIds>> | null;
+  readonly suggest?: Readonly<ReportSuggestionArray<MessageIds>> | null;
 }
 
 interface ReportDescriptorNodeOptionalLoc {
@@ -163,8 +165,9 @@ interface ReportDescriptorLocOnly {
    */
   loc: Readonly<TSESTree.Position> | Readonly<TSESTree.SourceLocation>;
 }
-export type ReportDescriptor<TMessageIds extends string> =
-  ReportDescriptorWithSuggestion<TMessageIds> &
+
+export type ReportDescriptor<MessageIds extends string> =
+  ReportDescriptorWithSuggestion<MessageIds> &
     (ReportDescriptorLocOnly | ReportDescriptorNodeOptionalLoc);
 
 /**
@@ -177,8 +180,8 @@ export interface SharedConfigurationSettings {
 }
 
 export interface RuleContext<
-  TMessageIds extends string,
-  TOptions extends readonly unknown[],
+  MessageIds extends string,
+  Options extends readonly unknown[],
 > {
   /**
    * The rule ID.
@@ -188,7 +191,7 @@ export interface RuleContext<
    * An array of the configured options for this rule.
    * This array does not include the rule severity.
    */
-  options: TOptions;
+  options: Options;
   /**
    * The name of the parser from configuration.
    */
@@ -299,7 +302,7 @@ export interface RuleContext<
   /**
    * Reports a problem in the code.
    */
-  report(descriptor: ReportDescriptor<TMessageIds>): void;
+  report(descriptor: ReportDescriptor<MessageIds>): void;
 }
 
 /**

--- a/packages/utils/src/ts-eslint/RuleTester.ts
+++ b/packages/utils/src/ts-eslint/RuleTester.ts
@@ -11,7 +11,7 @@ import type {
   SharedConfigurationSettings,
 } from './Rule';
 
-interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
+interface ValidTestCase<Options extends Readonly<unknown[]>> {
   /**
    * Name for the test case.
    */
@@ -35,7 +35,7 @@ interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   /**
    * Options for the test case.
    */
-  readonly options?: Readonly<TOptions>;
+  readonly options?: Readonly<Options>;
   /**
    * The absolute path for the parser.
    */
@@ -54,11 +54,11 @@ interface ValidTestCase<TOptions extends Readonly<unknown[]>> {
   readonly only?: boolean;
 }
 
-interface SuggestionOutput<TMessageIds extends string> {
+interface SuggestionOutput<MessageIds extends string> {
   /**
    * Reported message ID.
    */
-  readonly messageId: TMessageIds;
+  readonly messageId: MessageIds;
   /**
    * The data used to fill the message template.
    */
@@ -74,20 +74,20 @@ interface SuggestionOutput<TMessageIds extends string> {
 }
 
 interface InvalidTestCase<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
-> extends ValidTestCase<TOptions> {
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
+> extends ValidTestCase<Options> {
   /**
    * Expected errors.
    */
-  readonly errors: readonly TestCaseError<TMessageIds>[];
+  readonly errors: readonly TestCaseError<MessageIds>[];
   /**
    * The expected code after autofixes are applied. If set to `null`, the test runner will assert that no autofix is suggested.
    */
   readonly output?: string | null;
 }
 
-interface TestCaseError<TMessageIds extends string> {
+interface TestCaseError<MessageIds extends string> {
   /**
    * The 1-based column number of the reported start location.
    */
@@ -111,11 +111,11 @@ interface TestCaseError<TMessageIds extends string> {
   /**
    * Reported message ID.
    */
-  readonly messageId: TMessageIds;
+  readonly messageId: MessageIds;
   /**
    * Reported suggestions.
    */
-  readonly suggestions?: readonly SuggestionOutput<TMessageIds>[] | null;
+  readonly suggestions?: readonly SuggestionOutput<MessageIds>[] | null;
   /**
    * The type of the reported AST node.
    */
@@ -135,12 +135,12 @@ type RuleTesterTestFrameworkFunction = (
 ) => void;
 
 interface RunTests<
-  TMessageIds extends string,
-  TOptions extends Readonly<unknown[]>,
+  MessageIds extends string,
+  Options extends Readonly<unknown[]>,
 > {
   // RuleTester.run also accepts strings for valid cases
-  readonly valid: readonly (ValidTestCase<TOptions> | string)[];
-  readonly invalid: readonly InvalidTestCase<TMessageIds, TOptions>[];
+  readonly valid: readonly (ValidTestCase<Options> | string)[];
+  readonly invalid: readonly InvalidTestCase<MessageIds, Options>[];
 }
 interface RuleTesterConfig extends ClassicConfig.Config {
   // should be require.resolve(parserPackageName)
@@ -161,10 +161,10 @@ declare class RuleTesterBase {
    * @param rule The rule to test.
    * @param test The collection of tests to run.
    */
-  run<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
+  run<MessageIds extends string, Options extends Readonly<unknown[]>>(
     ruleName: string,
-    rule: RuleModule<TMessageIds, TOptions>,
-    tests: RunTests<TMessageIds, TOptions>,
+    rule: RuleModule<MessageIds, Options>,
+    tests: RunTests<MessageIds, Options>,
   ): void;
 
   /**
@@ -191,11 +191,11 @@ declare class RuleTesterBase {
   /**
    * Define a rule for one particular run of tests.
    */
-  defineRule<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
+  defineRule<MessageIds extends string, Options extends Readonly<unknown[]>>(
     name: string,
     rule:
-      | RuleCreateFunction<TMessageIds, TOptions>
-      | RuleModule<TMessageIds, TOptions>,
+      | RuleCreateFunction<MessageIds, Options>
+      | RuleModule<MessageIds, Options>,
   ): void;
 }
 

--- a/packages/utils/src/ts-eslint/SourceCode.ts
+++ b/packages/utils/src/ts-eslint/SourceCode.ts
@@ -408,7 +408,6 @@ namespace SourceCode {
     Options extends { filter?: FilterPredicate }
       ? GetFilterPredicate<Options['filter'], Default>
       : GetFilterPredicate<Options, Default>;
-
   export type ReturnTypeFromOptions<T> = T extends { includeComments: true }
     ? GetFilterPredicateFromOptions<T, TSESTree.Token>
     : GetFilterPredicateFromOptions<

--- a/packages/utils/src/ts-eslint/SourceCode.ts
+++ b/packages/utils/src/ts-eslint/SourceCode.ts
@@ -396,18 +396,18 @@ namespace SourceCode {
   export type VisitorKeys = Parser.VisitorKeys;
 
   export type FilterPredicate = (token: TSESTree.Token) => boolean;
-  export type GetFilterPredicate<TFilter, TDefault> =
+  export type GetFilterPredicate<Filter, Default> =
     // https://github.com/prettier/prettier/issues/14275
     // prettier-ignore
-    TFilter extends ((
+    Filter extends ((
       token: TSESTree.Token,
     ) => token is infer U extends TSESTree.Token)
       ? U
-      : TDefault;
-  export type GetFilterPredicateFromOptions<TOptions, TDefault> =
-    TOptions extends { filter?: FilterPredicate }
-      ? GetFilterPredicate<TOptions['filter'], TDefault>
-      : GetFilterPredicate<TOptions, TDefault>;
+      : Default;
+  export type GetFilterPredicateFromOptions<Options, Default> =
+    Options extends { filter?: FilterPredicate }
+      ? GetFilterPredicate<Options['filter'], Default>
+      : GetFilterPredicate<Options, Default>;
 
   export type ReturnTypeFromOptions<T> = T extends { includeComments: true }
     ? GetFilterPredicateFromOptions<T, TSESTree.Token>


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8365 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR removes T from T-prefixed internal variables.

See https://github.com/typescript-eslint/typescript-eslint/pull/8447 for previous discussion.
