### PR TITLE
docs: no-unused-vars demonstrate TypeScript style exemptions

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unused-vars.md
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars.md
@@ -17,6 +17,25 @@ However:
 
 - These lint rules are more configurable than TypeScript's compiler options.
   - For example, the [`varsIgnorePattern` option](https://eslint.org/docs/latest/rules/no-unused-vars#varsignorepattern) can customize what names are always allowed to be exempted. TypeScript hardcodes its exemptions to names starting with `_`.
+    If you would like to emulate the TypeScript style of exempting names starting with `_`, you can use this configuration (this includes errors as well):
+    ```json
+    {
+      "rules": {
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            "args": "all",
+            "argsIgnorePattern": "^_",
+            "caughtErrors": "all",
+            "caughtErrorsIgnorePattern": "^_",
+            "destructuredArrayIgnorePattern": "^_",
+            "varsIgnorePattern": "^_",
+            "ignoreRestSiblings": true
+          }
+        ]
+      }
+    }
+    ```
 - [ESLint can be configured](https://eslint.org/docs/latest/use/configure/rules) within lines, files, and folders. TypeScript compiler options are linked to their TSConfig file.
 - Many projects configure TypeScript's reported errors to block builds more aggressively than ESLint complaints. Blocking builds on unused variables can be inconvenient.
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8464
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This is a docs PR that details `no-unused-vars` usage that emulates the TypeScript style of exempting where variables are prefixed with `_`.  This grew out of: https://johnnyreilly.com/typescript-eslint-no-unused-vars

The docs preview can be seen here: https://deploy-preview-8526--typescript-eslint.netlify.app/rules/no-unused-vars