### PR TITLE
chore: tmp skip cache for eslint-plugin lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/prepare-build
 
   generate_configs:
-    name: Lint
+    name: Generate Configs
     needs: [build]
     runs-on: ubuntu-latest
     steps:
@@ -78,7 +78,7 @@ jobs:
         run: echo "Outdated result detected from yarn generate-configs. Please check in any file changes."
 
   lint_without_build:
-    name: Lint
+    name: Lint without build
     needs: [install]
     runs-on: ubuntu-latest
     strategy:
@@ -96,7 +96,7 @@ jobs:
         run: yarn ${{ matrix.lint-task }}
 
   lint_with_build:
-    name: Lint
+    name: Lint with build
     # because we lint with our own tooling, we need to build
     needs: [build]
     runs-on: ubuntu-latest

--- a/nx.json
+++ b/nx.json
@@ -56,7 +56,7 @@
         }
       }
     },
-    "@nx/eslint:lint": {
+    "lint": {
       "dependsOn": ["eslint-plugin:build"],
       "inputs": [
         "default",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint-fix": "yarn lint --fix",
     "lint-markdown-fix": "yarn lint-markdown --fix",
     "lint-markdown": "markdownlint \"**/*.md\" --config=.markdownlint.json --ignore-path=.markdownlintignore",
-    "lint": "npx nx run-many --target=lint --parallel",
+    "lint": "npx nx lint eslint-plugin --skip-nx-cache && npx nx run-many --target=lint --parallel --exclude eslint-plugin",
     "postinstall": "npx nx run repo-tools:postinstall-script",
     "pre-commit": "yarn lint-staged",
     "release": "tsx tools/release/release.mts",

--- a/packages/typescript-eslint/src/configs/all.ts
+++ b/packages/typescript-eslint/src/configs/all.ts
@@ -29,6 +29,8 @@ export default (
       '@typescript-eslint/class-methods-use-this': 'error',
       '@typescript-eslint/consistent-generic-constructors': 'error',
       '@typescript-eslint/consistent-indexed-object-style': 'error',
+      'consistent-return': 'off',
+      '@typescript-eslint/consistent-return': 'error',
       '@typescript-eslint/consistent-type-assertions': 'error',
       '@typescript-eslint/consistent-type-definitions': 'error',
       '@typescript-eslint/consistent-type-exports': 'error',

--- a/packages/typescript-eslint/src/configs/disable-type-checked.ts
+++ b/packages/typescript-eslint/src/configs/disable-type-checked.ts
@@ -13,6 +13,7 @@ export default (
 ): FlatConfig.Config => ({
   rules: {
     '@typescript-eslint/await-thenable': 'off',
+    '@typescript-eslint/consistent-return': 'off',
     '@typescript-eslint/consistent-type-exports': 'off',
     '@typescript-eslint/dot-notation': 'off',
     '@typescript-eslint/naming-convention': 'off',


### PR DESCRIPTION
- Fixes an existing issue with stale rule configs
- Updates duplicate CI job names
- Disables the cache for linting eslint-plugin to see if the prettier sync flakiness goes away