### PR TITLE
fix(typescript-eslint): apply `ignores` to all extended configs passed to `config` helper function

### DIFF
--- a/packages/typescript-eslint/src/config-helper.ts
+++ b/packages/typescript-eslint/src/config-helper.ts
@@ -91,14 +91,17 @@ export function config(
       return config;
     }
 
-    if (config.files) {
-      const files = config.files;
-      return [
-        ...extendsArr.map(conf => ({ ...conf, files: [...files] })),
-        config,
-      ];
-    }
+    const extension = {
+      ...(config.files && { files: config.files }),
+      ...(config.ignores && { ignores: config.ignores }),
+    };
 
-    return [...extendsArr, config];
+    return [
+      ...extendsArr.map(conf => ({
+        ...conf,
+        ...extension,
+      })),
+      config,
+    ];
   });
 }

--- a/packages/typescript-eslint/tests/configs.test.ts
+++ b/packages/typescript-eslint/tests/configs.test.ts
@@ -211,3 +211,61 @@ describe('stylistic-type-checked.ts', () => {
 
   itHasBaseRulesOverriden(unfilteredConfigRules);
 });
+
+describe('config helper', () => {
+  it('works without extends', () => {
+    expect(
+      plugin.config({
+        files: ['file'],
+        rules: { rule: 'error' },
+        ignores: ['ignored'],
+      }),
+    ).toEqual([
+      {
+        files: ['file'],
+        rules: { rule: 'error' },
+        ignores: ['ignored'],
+      },
+    ]);
+  });
+
+  it('flattens extended configs', () => {
+    expect(
+      plugin.config({
+        rules: { rule: 'error' },
+        extends: [{ rules: { rule1: 'error' } }, { rules: { rule2: 'error' } }],
+      }),
+    ).toEqual([
+      { rules: { rule1: 'error' } },
+      { rules: { rule2: 'error' } },
+      { rules: { rule: 'error' } },
+    ]);
+  });
+
+  it('flattens extended configs with files and ignores', () => {
+    expect(
+      plugin.config({
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        rules: { rule: 'error' },
+        extends: [{ rules: { rule1: 'error' } }, { rules: { rule2: 'error' } }],
+      }),
+    ).toEqual([
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        rules: { rule1: 'error' },
+      },
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        rules: { rule2: 'error' },
+      },
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        rules: { rule: 'error' },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8511
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
