### PR TITLE
fix(eslint-plugin): [no-useless-template-literals] detect TemplateLiteral

### DIFF
--- a/packages/eslint-plugin/src/rules/no-useless-template-literals.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-template-literals.ts
@@ -56,7 +56,9 @@ export default createRule<[], MessageId>({
     function isLiteral(expression: TSESTree.Expression): boolean {
       return (
         expression.type === AST_NODE_TYPES.Literal ||
-        expression.type === AST_NODE_TYPES.TemplateLiteral
+        (expression.type === AST_NODE_TYPES.TemplateLiteral &&
+          expression.expressions.length === 0 &&
+          expression.quasis.length === 1)
       );
     }
 

--- a/packages/eslint-plugin/src/rules/no-useless-template-literals.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-template-literals.ts
@@ -54,7 +54,10 @@ export default createRule<[], MessageId>({
     }
 
     function isLiteral(expression: TSESTree.Expression): boolean {
-      return expression.type === AST_NODE_TYPES.Literal;
+      return (
+        expression.type === AST_NODE_TYPES.Literal ||
+        expression.type === AST_NODE_TYPES.TemplateLiteral
+      );
     }
 
     function isInfinityIdentifier(expression: TSESTree.Expression): boolean {
@@ -110,7 +113,12 @@ export default createRule<[], MessageId>({
         }
 
         const fixableExpressions = node.expressions.filter(
-          (expression): expression is TSESTree.Literal | TSESTree.Identifier =>
+          (
+            expression,
+          ): expression is
+            | TSESTree.Literal
+            | TSESTree.TemplateLiteral
+            | TSESTree.Identifier =>
             isLiteral(expression) ||
             isUndefinedIdentifier(expression) ||
             isInfinityIdentifier(expression) ||

--- a/packages/eslint-plugin/tests/rules/no-useless-template-literals.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-template-literals.test.ts
@@ -61,11 +61,6 @@ ruleTester.run('no-useless-template-literals', rule, {
       \`\${left}\${center}\${right}\`;
     `,
 
-    `
-      declare const num: 1;
-      \`a\${\`b\${num}\`}c\`;
-    `,
-
     '`1 + 1 = ${1 + 1}`;',
 
     '`true && false = ${true && false}`;',
@@ -135,6 +130,10 @@ ruleTester.run('no-useless-template-literals', rule, {
 
     noFormat`
       \`with windows \r new line\`;
+    `,
+
+    `
+\`not a useless \${String.raw\`nested interpolation \${a}\`}\`;
     `,
   ],
 
@@ -363,39 +362,91 @@ ruleTester.run('no-useless-template-literals', rule, {
     },
 
     {
-      code: "`a${'b'}`;",
-      output: '`ab`;',
+      code: "`use${'less'}`;",
+      output: '`useless`;',
       errors: [
         {
           messageId: 'noUselessTemplateLiteral',
           line: 1,
-          column: 5,
-          endColumn: 8,
         },
       ],
     },
 
     {
-      code: '`a${`${`b`}c`}`;',
-      output: '`a${`bc`}`;',
+      code: '`use${`less`}`;',
+      output: '`useless`;',
       errors: [
         {
           messageId: 'noUselessTemplateLiteral',
           line: 1,
-          column: 8,
-          endColumn: 11,
         },
       ],
     },
 
     {
-      code: '`a${`bc`}`;',
-      output: '`abc`;',
+      code: `
+declare const nested: string, interpolation: string;
+\`use\${\`less\${nested}\${interpolation}\`}\`;
+      `,
+      output: `
+declare const nested: string, interpolation: string;
+\`useless\${nested}\${interpolation}\`;
+      `,
       errors: [
         {
           messageId: 'noUselessTemplateLiteral',
-          line: 1,
-          column: 5,
+        },
+      ],
+    },
+
+    {
+      code: noFormat`
+\`u\${
+  // hopefully this comment is not needed.
+  'se'
+
+}\${
+  \`le\${  \`ss\`  }\`
+}\`;
+      `,
+      output: `
+\`use\${
+  \`less\`
+}\`;
+      `,
+      errors: [
+        {
+          messageId: 'noUselessTemplateLiteral',
+          line: 4,
+        },
+        {
+          messageId: 'noUselessTemplateLiteral',
+          line: 7,
+          column: 3,
+          endLine: 7,
+        },
+        {
+          messageId: 'noUselessTemplateLiteral',
+          line: 7,
+          column: 10,
+          endLine: 7,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+\`use\${
+  \`less\`
+}\`;
+      `,
+      output: `
+\`useless\`;
+      `,
+      errors: [
+        {
+          messageId: 'noUselessTemplateLiteral',
+          line: 3,
+          column: 3,
           endColumn: 9,
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-useless-template-literals.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-template-literals.test.ts
@@ -371,6 +371,19 @@ ruleTester.run('no-useless-template-literals', rule, {
     },
 
     {
+      code: '`a${`b`}`;',
+      output: '`ab`;',
+      errors: [
+        {
+          messageId: 'noUselessTemplateLiteral',
+          line: 1,
+          column: 5,
+          endColumn: 8,
+        },
+      ],
+    },
+
+    {
       code: "`${'1 + 1 ='} ${2}`;",
       output: '`1 + 1 = 2`;',
       errors: [

--- a/packages/eslint-plugin/tests/rules/no-useless-template-literals.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-template-literals.test.ts
@@ -61,6 +61,11 @@ ruleTester.run('no-useless-template-literals', rule, {
       \`\${left}\${center}\${right}\`;
     `,
 
+    `
+      declare const num: 1;
+      \`a\${\`b\${num}\`}c\`;
+    `,
+
     '`1 + 1 = ${1 + 1}`;',
 
     '`true && false = ${true && false}`;',
@@ -371,14 +376,27 @@ ruleTester.run('no-useless-template-literals', rule, {
     },
 
     {
-      code: '`a${`b`}`;',
-      output: '`ab`;',
+      code: '`a${`${`b`}c`}`;',
+      output: '`a${`bc`}`;',
+      errors: [
+        {
+          messageId: 'noUselessTemplateLiteral',
+          line: 1,
+          column: 8,
+          endColumn: 11,
+        },
+      ],
+    },
+
+    {
+      code: '`a${`bc`}`;',
+      output: '`abc`;',
       errors: [
         {
           messageId: 'noUselessTemplateLiteral',
           line: 1,
           column: 5,
-          endColumn: 8,
+          endColumn: 9,
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8545 fixes #8584
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Add detect for TemplateLiteral