### PR TITLE
feat(eslint-plugin-internal): add internal lint rule no-relative-paths-to-internal-packages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -177,6 +177,8 @@ export default tseslint.config(
       //
 
       '@typescript-eslint/internal/no-poorly-typed-ts-props': 'error',
+      '@typescript-eslint/internal/no-relative-paths-to-internal-packages':
+        'error',
       '@typescript-eslint/internal/no-typescript-default-import': 'error',
       '@typescript-eslint/internal/prefer-ast-types-enum': 'error',
 

--- a/packages/eslint-plugin-internal/src/rules/index.ts
+++ b/packages/eslint-plugin-internal/src/rules/index.ts
@@ -1,6 +1,7 @@
 import type { Linter } from '@typescript-eslint/utils/ts-eslint';
 
 import noPoorlyTypedTsProps from './no-poorly-typed-ts-props';
+import noRelativePathsToInternalPackages from './no-relative-paths-to-internal-packages';
 import noTypescriptDefaultImport from './no-typescript-default-import';
 import noTypescriptEstreeImport from './no-typescript-estree-import';
 import pluginTestFormatting from './plugin-test-formatting';
@@ -8,6 +9,7 @@ import preferASTTypesEnum from './prefer-ast-types-enum';
 
 export default {
   'no-poorly-typed-ts-props': noPoorlyTypedTsProps,
+  'no-relative-paths-to-internal-packages': noRelativePathsToInternalPackages,
   'no-typescript-default-import': noTypescriptDefaultImport,
   'no-typescript-estree-import': noTypescriptEstreeImport,
   'plugin-test-formatting': pluginTestFormatting,

--- a/packages/eslint-plugin-internal/src/rules/no-relative-paths-to-internal-packages.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-relative-paths-to-internal-packages.ts
@@ -1,0 +1,76 @@
+import path from 'path';
+
+import { createRule } from '../util';
+
+export const REPO_ROOT = path.resolve(__dirname, '../../../..');
+export const PACKAGES_DIR = path.join(REPO_ROOT, 'packages');
+
+export default createRule({
+  name: __filename,
+  meta: {
+    type: 'problem',
+    docs: {
+      recommended: 'recommended',
+      description: 'Disallow relative paths to internal packages',
+    },
+    messages: {
+      noRelativePathsToInternalPackages:
+        'Use absolute paths instead of relative paths to import modules in other internal packages.',
+    },
+    schema: [],
+    fixable: 'code',
+  },
+
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      ImportDeclaration(node): void {
+        const importSource = node.source;
+        if (
+          importSource.value.startsWith('@typescript-eslint') ||
+          !importSource.value.startsWith('.')
+        ) {
+          return;
+        }
+
+        // The idea here is to check if the import source resolves to a different
+        // package than the package the file is currently in. This lets us not flag
+        // relative paths to modules inside a package called 'utils' but still flag
+        // if importing the '@typescript-eslint/utils' package with a relative path.
+
+        const pathOfFileFromPackagesDir = path.relative(
+          PACKAGES_DIR,
+          context.physicalFilename,
+        );
+        const packageOfFile = pathOfFileFromPackagesDir.split(path.sep)[0];
+        const absolutePathOfImport = path.resolve(
+          path.dirname(context.physicalFilename),
+          importSource.value,
+        );
+        const pathOfImportFromPackagesDir = path.relative(
+          PACKAGES_DIR,
+          absolutePathOfImport,
+        );
+        const packageOfImport = pathOfImportFromPackagesDir.split(path.sep)[0];
+
+        if (packageOfImport !== packageOfFile) {
+          context.report({
+            node: importSource,
+            messageId: 'noRelativePathsToInternalPackages',
+            fix: fixer => {
+              // Force the output path to be separated with '/' to get consistent
+              // results on windows.
+              const platformIndependentRelativePathOfImportFromPackagesDir =
+                pathOfImportFromPackagesDir.split(path.sep).join('/');
+              return fixer.replaceText(
+                importSource,
+                `'@typescript-eslint/${platformIndependentRelativePathOfImportFromPackagesDir}'`,
+              );
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-internal/tests/rules/no-relative-paths-to-internal-packages.test.ts
+++ b/packages/eslint-plugin-internal/tests/rules/no-relative-paths-to-internal-packages.test.ts
@@ -1,0 +1,113 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import path from 'path';
+
+import rule, {
+  PACKAGES_DIR,
+} from '../../src/rules/no-relative-paths-to-internal-packages';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('no-relative-paths-to-internal-packages', rule, {
+  valid: [
+    "import { parse } from '@typescript-eslint/typescript-estree';",
+    "import { something } from 'not/a/relative/path';",
+    {
+      filename: path.resolve(
+        PACKAGES_DIR,
+        'eslint-plugin/src/rules/my-awesome-rule.ts',
+      ),
+      code: "import { something } from './utils';",
+    },
+    {
+      code: "import type { ValueOf } from './utils';",
+      filename: path.resolve(
+        PACKAGES_DIR,
+        'ast-spec/src/expression/AssignmentExpression/spec.ts',
+      ),
+    },
+    {
+      code: "import type { ValueOf } from '../../utils';",
+      filename: path.resolve(
+        PACKAGES_DIR,
+        'ast-spec/src/expression/AssignmentExpression/spec.ts',
+      ),
+    },
+    {
+      code: "import type { ValueOf } from '../../../utils';",
+      filename: path.resolve(
+        PACKAGES_DIR,
+        'ast-spec/src/expression/AssignmentExpression/spec.ts',
+      ),
+    },
+  ],
+  invalid: [
+    {
+      code: "import { parse } from '../../../typescript-estree';",
+      filename: path.resolve(
+        PACKAGES_DIR,
+        'eslint-plugin/src/rules/my-awesome-rule.ts',
+      ),
+      output: `import { parse } from '@typescript-eslint/typescript-estree';`,
+      errors: [
+        {
+          messageId: 'noRelativePathsToInternalPackages',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "import { parse } from '../../../typescript-estree/inner-module';",
+      filename: path.resolve(
+        PACKAGES_DIR,
+        'eslint-plugin/src/rules/my-awesome-rule.ts',
+      ),
+      output: `import { parse } from '@typescript-eslint/typescript-estree/inner-module';`,
+      errors: [
+        {
+          messageId: 'noRelativePathsToInternalPackages',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "import type { ValueOf } from '../../../../utils';",
+      output: "import type { ValueOf } from '@typescript-eslint/utils';",
+      filename: path.resolve(
+        PACKAGES_DIR,
+        'ast-spec/src/expression/AssignmentExpression/spec.ts',
+      ),
+      errors: [
+        {
+          messageId: 'noRelativePathsToInternalPackages',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: `
+import type {
+  MemberExpressionComputedName,
+  MemberExpressionNonComputedName,
+} from '../../../types/src/generated/ast-spec';
+      `,
+      output: `
+import type {
+  MemberExpressionComputedName,
+  MemberExpressionNonComputedName,
+} from '@typescript-eslint/types/src/generated/ast-spec';
+      `,
+      filename: path.resolve(
+        PACKAGES_DIR,
+        'eslint-plugin/src/rules/prefer-find.ts',
+      ),
+      errors: [
+        {
+          messageId: 'noRelativePathsToInternalPackages',
+          line: 5,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8345 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds internal lint rule to look for flag relative imports that import code from other packages.

Found no existing violations! :)