### PR TITLE
fix(eslint-plugin): expose *-type-checked-only configs for extension

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -6,10 +6,13 @@ import disableTypeChecked from './configs/disable-type-checked';
 import eslintRecommended from './configs/eslint-recommended';
 import recommended from './configs/recommended';
 import recommendedTypeChecked from './configs/recommended-type-checked';
+import recommendedTypeCheckedOnly from './configs/recommended-type-checked-only';
 import strict from './configs/strict';
 import strictTypeChecked from './configs/strict-type-checked';
+import strictTypeCheckedOnly from './configs/strict-type-checked-only';
 import stylistic from './configs/stylistic';
 import stylisticTypeChecked from './configs/stylistic-type-checked';
+import stylisticTypeCheckedOnly from './configs/stylistic-type-checked-only';
 import rules from './rules';
 
 // note - cannot migrate this to an import statement because it will make TSC copy the package.json to the dist folder
@@ -28,10 +31,13 @@ export = {
     /** @deprecated - please use "recommended-type-checked" instead. */
     'recommended-requiring-type-checking': recommendedTypeChecked,
     'recommended-type-checked': recommendedTypeChecked,
+    'recommended-type-checked-only': recommendedTypeCheckedOnly,
     strict,
     'strict-type-checked': strictTypeChecked,
+    'strict-type-checked-only': strictTypeCheckedOnly,
     stylistic,
     'stylistic-type-checked': stylisticTypeChecked,
+    'stylistic-type-checked-only': stylisticTypeCheckedOnly,
   },
   meta: {
     name,

--- a/packages/eslint-plugin/tests/configs.test.ts
+++ b/packages/eslint-plugin/tests/configs.test.ts
@@ -31,7 +31,7 @@ function filterRules(values: Record<string, string>): [string, string][] {
 
 interface FilterAndMapRuleConfigsSettings {
   excludeDeprecated?: boolean;
-  typeChecked?: 'exclude' | 'only';
+  typeChecked?: 'exclude' | 'include-only';
   recommendations?: (RuleRecommendation | undefined)[];
 }
 
@@ -51,7 +51,7 @@ function filterAndMapRuleConfigs({
       result = result.filter(
         ([, rule]) => !rule.meta.docs?.requiresTypeChecking,
       );
-    } else if (typeChecked === 'only') {
+    } else if (typeChecked === 'include-only') {
       result = result.filter(
         ([, rule]) => rule.meta.docs?.requiresTypeChecking,
       );
@@ -159,7 +159,7 @@ describe('recommended-type-checked-only.ts', () => {
     const configRules = filterRules(unfilteredConfigRules);
     // note: include deprecated rules so that the config doesn't change between major bumps
     const ruleConfigs = filterAndMapRuleConfigs({
-      typeChecked: 'only',
+      typeChecked: 'include-only',
       recommendations: ['recommended'],
     }).filter(([ruleName]) => ruleName);
 
@@ -214,7 +214,7 @@ describe('strict-type-checked-only.ts', () => {
     // note: exclude deprecated rules, this config is allowed to change between minor versions
     const ruleConfigs = filterAndMapRuleConfigs({
       excludeDeprecated: true,
-      typeChecked: 'only',
+      typeChecked: 'include-only',
       recommendations: ['recommended', 'strict'],
     }).filter(([ruleName]) => ruleName);
 
@@ -266,7 +266,7 @@ describe('stylistic-type-checked-only.ts', () => {
     const configRules = filterRules(unfilteredConfigRules);
     // note: include deprecated rules so that the config doesn't change between major bumps
     const ruleConfigs = filterAndMapRuleConfigs({
-      typeChecked: 'only',
+      typeChecked: 'include-only',
       recommendations: ['stylistic'],
     }).filter(([ruleName]) => ruleName);
 

--- a/packages/eslint-plugin/tests/configs.test.ts
+++ b/packages/eslint-plugin/tests/configs.test.ts
@@ -47,15 +47,11 @@ function filterAndMapRuleConfigs({
   }
 
   if (typeChecked) {
-    if (typeChecked === 'exclude') {
-      result = result.filter(
-        ([, rule]) => !rule.meta.docs?.requiresTypeChecking,
-      );
-    } else if (typeChecked === 'include-only') {
-      result = result.filter(
-        ([, rule]) => rule.meta.docs?.requiresTypeChecking,
-      );
-    }
+    result = result.filter(([, rule]) =>
+      typeChecked === 'exclude'
+        ? !rule.meta.docs?.requiresTypeChecking
+        : rule.meta.docs?.requiresTypeChecking,
+    );
   }
 
   if (recommendations) {

--- a/packages/eslint-plugin/tests/configs.test.ts
+++ b/packages/eslint-plugin/tests/configs.test.ts
@@ -31,13 +31,13 @@ function filterRules(values: Record<string, string>): [string, string][] {
 
 interface FilterAndMapRuleConfigsSettings {
   excludeDeprecated?: boolean;
-  excludeTypeChecked?: boolean;
+  typeChecked?: 'exclude' | 'only';
   recommendations?: (RuleRecommendation | undefined)[];
 }
 
 function filterAndMapRuleConfigs({
   excludeDeprecated,
-  excludeTypeChecked,
+  typeChecked,
   recommendations,
 }: FilterAndMapRuleConfigsSettings = {}): [string, string][] {
   let result = Object.entries(rules);
@@ -46,8 +46,16 @@ function filterAndMapRuleConfigs({
     result = result.filter(([, rule]) => !rule.meta.deprecated);
   }
 
-  if (excludeTypeChecked) {
-    result = result.filter(([, rule]) => !rule.meta.docs?.requiresTypeChecking);
+  if (typeChecked) {
+    if (typeChecked === 'exclude') {
+      result = result.filter(
+        ([, rule]) => !rule.meta.docs?.requiresTypeChecking,
+      );
+    } else if (typeChecked === 'only') {
+      result = result.filter(
+        ([, rule]) => rule.meta.docs?.requiresTypeChecking,
+      );
+    }
   }
 
   if (recommendations) {
@@ -116,7 +124,7 @@ describe('recommended.ts', () => {
     const configRules = filterRules(unfilteredConfigRules);
     // note: include deprecated rules so that the config doesn't change between major bumps
     const ruleConfigs = filterAndMapRuleConfigs({
-      excludeTypeChecked: true,
+      typeChecked: 'exclude',
       recommendations: ['recommended'],
     });
 
@@ -143,6 +151,24 @@ describe('recommended-type-checked.ts', () => {
   itHasBaseRulesOverriden(unfilteredConfigRules);
 });
 
+describe('recommended-type-checked-only.ts', () => {
+  const unfilteredConfigRules: Record<string, string> =
+    plugin.configs['recommended-type-checked-only'].rules;
+
+  it('contains only type-checked recommended rules', () => {
+    const configRules = filterRules(unfilteredConfigRules);
+    // note: include deprecated rules so that the config doesn't change between major bumps
+    const ruleConfigs = filterAndMapRuleConfigs({
+      typeChecked: 'only',
+      recommendations: ['recommended'],
+    }).filter(([ruleName]) => ruleName);
+
+    expect(entriesToObject(ruleConfigs)).toEqual(entriesToObject(configRules));
+  });
+
+  itHasBaseRulesOverriden(unfilteredConfigRules);
+});
+
 describe('strict.ts', () => {
   const unfilteredConfigRules: Record<string, string> =
     plugin.configs.strict.rules;
@@ -152,7 +178,7 @@ describe('strict.ts', () => {
     // note: exclude deprecated rules, this config is allowed to change between minor versions
     const ruleConfigs = filterAndMapRuleConfigs({
       excludeDeprecated: true,
-      excludeTypeChecked: true,
+      typeChecked: 'exclude',
       recommendations: ['recommended', 'strict'],
     });
 
@@ -179,6 +205,25 @@ describe('strict-type-checked.ts', () => {
   itHasBaseRulesOverriden(unfilteredConfigRules);
 });
 
+describe('strict-type-checked-only.ts', () => {
+  const unfilteredConfigRules: Record<string, string> =
+    plugin.configs['strict-type-checked-only'].rules;
+
+  it('contains only type-checked strict rules', () => {
+    const configRules = filterRules(unfilteredConfigRules);
+    // note: exclude deprecated rules, this config is allowed to change between minor versions
+    const ruleConfigs = filterAndMapRuleConfigs({
+      excludeDeprecated: true,
+      typeChecked: 'only',
+      recommendations: ['recommended', 'strict'],
+    }).filter(([ruleName]) => ruleName);
+
+    expect(entriesToObject(ruleConfigs)).toEqual(entriesToObject(configRules));
+  });
+
+  itHasBaseRulesOverriden(unfilteredConfigRules);
+});
+
 describe('stylistic.ts', () => {
   const unfilteredConfigRules: Record<string, string> =
     plugin.configs.stylistic.rules;
@@ -187,7 +232,7 @@ describe('stylistic.ts', () => {
     const configRules = filterRules(unfilteredConfigRules);
     // note: include deprecated rules so that the config doesn't change between major bumps
     const ruleConfigs = filterAndMapRuleConfigs({
-      excludeTypeChecked: true,
+      typeChecked: 'exclude',
       recommendations: ['stylistic'],
     });
 
@@ -207,6 +252,24 @@ describe('stylistic-type-checked.ts', () => {
   });
 
   it('contains all stylistic rules, excluding deprecated ones', () => {
+    expect(entriesToObject(ruleConfigs)).toEqual(entriesToObject(configRules));
+  });
+
+  itHasBaseRulesOverriden(unfilteredConfigRules);
+});
+
+describe('stylistic-type-checked-only.ts', () => {
+  const unfilteredConfigRules: Record<string, string> =
+    plugin.configs['stylistic-type-checked-only'].rules;
+
+  it('contains only type-checked stylistic rules', () => {
+    const configRules = filterRules(unfilteredConfigRules);
+    // note: include deprecated rules so that the config doesn't change between major bumps
+    const ruleConfigs = filterAndMapRuleConfigs({
+      typeChecked: 'only',
+      recommendations: ['stylistic'],
+    }).filter(([ruleName]) => ruleName);
+
     expect(entriesToObject(ruleConfigs)).toEqual(entriesToObject(configRules));
   });
 

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -10,10 +10,13 @@ import disableTypeCheckedConfig from './configs/disable-type-checked';
 import eslintRecommendedConfig from './configs/eslint-recommended';
 import recommendedConfig from './configs/recommended';
 import recommendedTypeCheckedConfig from './configs/recommended-type-checked';
+import recommendedTypeCheckedOnlyConfig from './configs/recommended-type-checked-only';
 import strictConfig from './configs/strict';
 import strictTypeCheckedConfig from './configs/strict-type-checked';
+import strictTypeCheckedOnlyConfig from './configs/strict-type-checked-only';
 import stylisticConfig from './configs/stylistic';
 import stylisticTypeCheckedConfig from './configs/stylistic-type-checked';
+import stylisticTypeCheckedOnlyConfig from './configs/stylistic-type-checked-only';
 
 const parser: TSESLint.FlatConfig.Parser = {
   meta: parserBase.meta,
@@ -32,10 +35,13 @@ const configs = {
   eslintRecommended: eslintRecommendedConfig(plugin, parser),
   recommended: recommendedConfig(plugin, parser),
   recommendedTypeChecked: recommendedTypeCheckedConfig(plugin, parser),
+  recommendedTypeCheckedOnly: recommendedTypeCheckedOnlyConfig(plugin, parser),
   strict: strictConfig(plugin, parser),
   strictTypeChecked: strictTypeCheckedConfig(plugin, parser),
+  strictTypeCheckedOnly: strictTypeCheckedOnlyConfig(plugin, parser),
   stylistic: stylisticConfig(plugin, parser),
   stylisticTypeChecked: stylisticTypeCheckedConfig(plugin, parser),
+  stylisticTypeCheckedOnly: stylisticTypeCheckedOnlyConfig(plugin, parser),
 };
 
 export type Config = TSESLint.FlatConfig.ConfigFile;

--- a/packages/typescript-eslint/tests/configs.test.ts
+++ b/packages/typescript-eslint/tests/configs.test.ts
@@ -37,13 +37,13 @@ function filterRules(
 
 interface FilterAndMapRuleConfigsSettings {
   excludeDeprecated?: boolean;
-  excludeTypeChecked?: boolean;
+  typeChecked?: 'exclude' | 'only';
   recommendations?: (RuleRecommendation | undefined)[];
 }
 
 function filterAndMapRuleConfigs({
   excludeDeprecated,
-  excludeTypeChecked,
+  typeChecked,
   recommendations,
 }: FilterAndMapRuleConfigsSettings = {}): [string, string][] {
   let result = Object.entries(rules);
@@ -52,8 +52,16 @@ function filterAndMapRuleConfigs({
     result = result.filter(([, rule]) => !rule.meta.deprecated);
   }
 
-  if (excludeTypeChecked) {
-    result = result.filter(([, rule]) => !rule.meta.docs?.requiresTypeChecking);
+  if (typeChecked) {
+    if (typeChecked === 'exclude') {
+      result = result.filter(
+        ([, rule]) => !rule.meta.docs?.requiresTypeChecking,
+      );
+    } else if (typeChecked === 'only') {
+      result = result.filter(
+        ([, rule]) => rule.meta.docs?.requiresTypeChecking,
+      );
+    }
   }
 
   if (recommendations) {
@@ -120,7 +128,7 @@ describe('recommended.ts', () => {
     const configRules = filterRules(unfilteredConfigRules);
     // note: include deprecated rules so that the config doesn't change between major bumps
     const ruleConfigs = filterAndMapRuleConfigs({
-      excludeTypeChecked: true,
+      typeChecked: 'exclude',
       recommendations: ['recommended'],
     });
 
@@ -146,6 +154,24 @@ describe('recommended-type-checked.ts', () => {
   itHasBaseRulesOverriden(unfilteredConfigRules);
 });
 
+describe('recommended-type-checked-only.ts', () => {
+  const unfilteredConfigRules =
+    plugin.configs.recommendedTypeCheckedOnly[2]?.rules;
+
+  it('contains only type-checked recommended rules', () => {
+    const configRules = filterRules(unfilteredConfigRules);
+    // note: include deprecated rules so that the config doesn't change between major bumps
+    const ruleConfigs = filterAndMapRuleConfigs({
+      typeChecked: 'only',
+      recommendations: ['recommended'],
+    }).filter(([ruleName]) => ruleName);
+
+    expect(entriesToObject(ruleConfigs)).toEqual(entriesToObject(configRules));
+  });
+
+  itHasBaseRulesOverriden(unfilteredConfigRules);
+});
+
 describe('strict.ts', () => {
   const unfilteredConfigRules = plugin.configs.strict[2]?.rules;
 
@@ -154,7 +180,7 @@ describe('strict.ts', () => {
     // note: exclude deprecated rules, this config is allowed to change between minor versions
     const ruleConfigs = filterAndMapRuleConfigs({
       excludeDeprecated: true,
-      excludeTypeChecked: true,
+      typeChecked: 'exclude',
       recommendations: ['recommended', 'strict'],
     });
 
@@ -180,6 +206,24 @@ describe('strict-type-checked.ts', () => {
   itHasBaseRulesOverriden(unfilteredConfigRules);
 });
 
+describe('strict-type-checked-only.ts', () => {
+  const unfilteredConfigRules = plugin.configs.strictTypeCheckedOnly[2]?.rules;
+
+  it('contains only type-checked strict rules', () => {
+    const configRules = filterRules(unfilteredConfigRules);
+    // note: exclude deprecated rules, this config is allowed to change between minor versions
+    const ruleConfigs = filterAndMapRuleConfigs({
+      excludeDeprecated: true,
+      typeChecked: 'only',
+      recommendations: ['recommended', 'strict'],
+    }).filter(([ruleName]) => ruleName);
+
+    expect(entriesToObject(ruleConfigs)).toEqual(entriesToObject(configRules));
+  });
+
+  itHasBaseRulesOverriden(unfilteredConfigRules);
+});
+
 describe('stylistic.ts', () => {
   const unfilteredConfigRules = plugin.configs.stylistic[2]?.rules;
 
@@ -187,7 +231,7 @@ describe('stylistic.ts', () => {
     const configRules = filterRules(unfilteredConfigRules);
     // note: include deprecated rules so that the config doesn't change between major bumps
     const ruleConfigs = filterAndMapRuleConfigs({
-      excludeTypeChecked: true,
+      typeChecked: 'exclude',
       recommendations: ['stylistic'],
     });
 
@@ -206,6 +250,24 @@ describe('stylistic-type-checked.ts', () => {
   });
 
   it('contains all stylistic rules, excluding deprecated ones', () => {
+    expect(entriesToObject(ruleConfigs)).toEqual(entriesToObject(configRules));
+  });
+
+  itHasBaseRulesOverriden(unfilteredConfigRules);
+});
+
+describe('stylistic-type-checked-only.ts', () => {
+  const unfilteredConfigRules =
+    plugin.configs.stylisticTypeCheckedOnly[2]?.rules;
+
+  it('contains only type-checked stylistic rules', () => {
+    const configRules = filterRules(unfilteredConfigRules);
+    // note: include deprecated rules so that the config doesn't change between major bumps
+    const ruleConfigs = filterAndMapRuleConfigs({
+      typeChecked: 'only',
+      recommendations: ['stylistic'],
+    }).filter(([ruleName]) => ruleName);
+
     expect(entriesToObject(ruleConfigs)).toEqual(entriesToObject(configRules));
   });
 

--- a/packages/typescript-eslint/tests/configs.test.ts
+++ b/packages/typescript-eslint/tests/configs.test.ts
@@ -37,7 +37,7 @@ function filterRules(
 
 interface FilterAndMapRuleConfigsSettings {
   excludeDeprecated?: boolean;
-  typeChecked?: 'exclude' | 'only';
+  typeChecked?: 'exclude' | 'include-only';
   recommendations?: (RuleRecommendation | undefined)[];
 }
 
@@ -57,7 +57,7 @@ function filterAndMapRuleConfigs({
       result = result.filter(
         ([, rule]) => !rule.meta.docs?.requiresTypeChecking,
       );
-    } else if (typeChecked === 'only') {
+    } else if (typeChecked === 'include-only') {
       result = result.filter(
         ([, rule]) => rule.meta.docs?.requiresTypeChecking,
       );
@@ -162,7 +162,7 @@ describe('recommended-type-checked-only.ts', () => {
     const configRules = filterRules(unfilteredConfigRules);
     // note: include deprecated rules so that the config doesn't change between major bumps
     const ruleConfigs = filterAndMapRuleConfigs({
-      typeChecked: 'only',
+      typeChecked: 'include-only',
       recommendations: ['recommended'],
     }).filter(([ruleName]) => ruleName);
 
@@ -214,7 +214,7 @@ describe('strict-type-checked-only.ts', () => {
     // note: exclude deprecated rules, this config is allowed to change between minor versions
     const ruleConfigs = filterAndMapRuleConfigs({
       excludeDeprecated: true,
-      typeChecked: 'only',
+      typeChecked: 'include-only',
       recommendations: ['recommended', 'strict'],
     }).filter(([ruleName]) => ruleName);
 
@@ -264,7 +264,7 @@ describe('stylistic-type-checked-only.ts', () => {
     const configRules = filterRules(unfilteredConfigRules);
     // note: include deprecated rules so that the config doesn't change between major bumps
     const ruleConfigs = filterAndMapRuleConfigs({
-      typeChecked: 'only',
+      typeChecked: 'include-only',
       recommendations: ['stylistic'],
     }).filter(([ruleName]) => ruleName);
 

--- a/packages/typescript-eslint/tests/configs.test.ts
+++ b/packages/typescript-eslint/tests/configs.test.ts
@@ -53,15 +53,11 @@ function filterAndMapRuleConfigs({
   }
 
   if (typeChecked) {
-    if (typeChecked === 'exclude') {
-      result = result.filter(
-        ([, rule]) => !rule.meta.docs?.requiresTypeChecking,
-      );
-    } else if (typeChecked === 'include-only') {
-      result = result.filter(
-        ([, rule]) => rule.meta.docs?.requiresTypeChecking,
-      );
-    }
+    result = result.filter(([, rule]) =>
+      typeChecked === 'exclude'
+        ? !rule.meta.docs?.requiresTypeChecking
+        : rule.meta.docs?.requiresTypeChecking,
+    );
   }
 
   if (recommendations) {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #8599
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR is a fix for #8599. I noticed that there were tests for asserting the shape of the different configs, so I extended those tests to account for `*-type-checked-only`.

I opened this PR because I believe we have some timezone differences, and it seemed nicer than just dropping an issue on your lap. If that is the wrong assumption, I apologise 😌 

Please let me know if there is any other information that I can provide!