### PR TITLE
feat(eslint-plugin): [no-unused-var] handle implicit exports in declaration files

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,6 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "neverConnectToCloud": true,
   "nxCloudAccessToken": "YjIzMmMxMWItMjhiMS00NWY2LTk1NWYtYWU3YWQ0YjE4YjBlfHJlYWQ=",
   "release": {
     "changelog": {

--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,5 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "neverConnectToCloud": true,
   "nxCloudAccessToken": "YjIzMmMxMWItMjhiMS00NWY2LTk1NWYtYWU3YWQ0YjE4YjBlfHJlYWQ=",
   "release": {
     "changelog": {

--- a/packages/eslint-plugin/src/util/collectUnusedVariables.ts
+++ b/packages/eslint-plugin/src/util/collectUnusedVariables.ts
@@ -70,7 +70,6 @@ class UnusedVarsVisitor<
       this.#isDefinitionFile,
     );
 
-    // TODO: do this better than the ternary
     for (const variable of implicitlyExported ? [] : scope.variables) {
       if (
         // skip function expression names,
@@ -454,9 +453,19 @@ function allVariablesImplicitlyExported(
   isDefinitionFile: boolean,
 ): boolean {
   // TODO: does this also happen in ambient module declarations?
-  if (!isDefinitionFile || scope.type !== ScopeType.tsModule) {
+  if (
+    !isDefinitionFile ||
+    !(
+      scope.type === ScopeType.tsModule ||
+      scope.type === ScopeType.module ||
+      scope.type === ScopeType.global
+    )
+  ) {
     return false;
   }
+
+  // TODO: test modules, globals
+  // TODO: look for `export {}`
 
   function isExportImportEquals(variable: Variable): boolean {
     for (const def of variable.defs) {

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -1180,6 +1180,15 @@ export namespace Foo {
       `,
       filename: 'foo.d.ts',
     },
+    {
+      code: `
+declare module 'foo' {
+  export import Bar = Something.Bar;
+  const foo: 1234;
+}
+      `,
+      filename: 'foo.d.ts',
+    },
   ],
 
   invalid: [
@@ -2035,6 +2044,31 @@ export namespace Foo {
     {
       code: `
 export namespace Foo {
+  export import Bar = Something.Bar;
+  const foo: 1234;
+  export const bar: string;
+  export namespace NS {
+    const baz: 1234;
+  }
+}
+      `,
+      filename: 'foo.d.ts',
+      errors: [
+        {
+          messageId: 'unusedVar',
+          line: 4,
+          column: 9,
+          data: {
+            varName: 'foo',
+            action: 'defined',
+            additional: '',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+declare module 'foo' {
   export import Bar = Something.Bar;
   const foo: 1234;
   export const bar: string;

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -1123,6 +1123,63 @@ export namespace Bar {
   export import TheFoo = Foo;
 }
     `,
+    `
+const foo = 1;
+export = foo;
+    `,
+    `
+const Foo = 1;
+interface Foo {
+  bar: string;
+}
+export = Foo;
+    `,
+    `
+interface Foo {
+  bar: string;
+}
+export = Foo;
+    `,
+    `
+type Foo = 1;
+export = Foo;
+    `,
+    `
+type Foo = 1;
+export = {} as Foo;
+    `,
+    `
+declare module 'foo' {
+  type Foo = 1;
+  export = Foo;
+}
+    `,
+    `
+namespace Foo {
+  export const foo = 1;
+}
+export namespace Bar {
+  export import TheFoo = Foo;
+}
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2867
+    {
+      code: `
+export namespace Foo {
+  const foo: 1234;
+}
+      `,
+      filename: 'foo.d.ts',
+    },
+    {
+      code: `
+export namespace Foo {
+  export import Bar = Something.Bar;
+  const foo: 1234;
+}
+      `,
+      filename: 'foo.d.ts',
+    },
   ],
 
   invalid: [
@@ -1944,6 +2001,56 @@ export namespace Bar {
           column: 10,
           data: {
             varName: 'TheFoo',
+            action: 'defined',
+            additional: '',
+          },
+        },
+      ],
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/2867
+    {
+      code: `
+export namespace Foo {
+  const foo: 1234;
+  export const bar: string;
+  export namespace NS {
+    const baz: 1234;
+  }
+}
+      `,
+      filename: 'foo.d.ts',
+      errors: [
+        {
+          messageId: 'unusedVar',
+          line: 3,
+          column: 9,
+          data: {
+            varName: 'foo',
+            action: 'defined',
+            additional: '',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+export namespace Foo {
+  export import Bar = Something.Bar;
+  const foo: 1234;
+  export const bar: string;
+  export namespace NS {
+    const baz: 1234;
+  }
+}
+      `,
+      filename: 'foo.d.ts',
+      errors: [
+        {
+          messageId: 'unusedVar',
+          line: 4,
+          column: 9,
+          data: {
+            varName: 'foo',
             action: 'defined',
             additional: '',
           },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2867
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This modifies the unused variable analysis to ignore declarations that are "implicitly" exported. Roughly, this means declaration files which do not contain any exports, recursively into namespaces, excluding `export import ... = ...` which doesn't count.

This PR is not yet complete; I'm missing:

- [ ] Look for `export {}` blocks, including empty ones (which probably don't show up in scope)
- [ ] Check other ambient contexts like globals (need to query for that, and figure out the rules)
- [ ] Consider whether I should actually move this into the rule and do things like those which use `ambientDeclarationSelector`
- [ ] Consider whether this analysis can actually replace `ambientDeclarationSelector` entirely (if not vice versa)

I'm mainly having trouble at the moment debugging a single test; adding `only` to the test doesn't seem to really work and one of my tests fails for a reason I haven't figured out yet.

That and my continued issues with `nx`, where it always tells me that the tests pass, so I have to disable it, which can only be done via the checked in config file ☹️ 