### PR TITLE
fix(typescript-eslint): set `sourceType: "module"` in base shared config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,7 +83,6 @@ export default tseslint.config(
           // in the rare case that we do - just need to manually restart their IDE.
           glob: 'Infinity',
         },
-        sourceType: 'module',
         project: [
           'tsconfig.json',
           'packages/*/tsconfig.json',

--- a/packages/typescript-eslint/src/configs/base.ts
+++ b/packages/typescript-eslint/src/configs/base.ts
@@ -6,7 +6,7 @@ export default (
 ): FlatConfig.Config => ({
   languageOptions: {
     parser,
-    parserOptions: { sourceType: 'module' },
+    sourceType: 'module',
   },
   plugins: {
     '@typescript-eslint': plugin,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8518
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview