### PR TITLE
docs: getting started guide should reference tsconfig allowJs if it recommends a JS eslint config file

### DIFF
--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -39,7 +39,7 @@ For more information on migrating from a "legacy" config setup, see [ESLint's Co
 
 ## Usage
 
-The simplest usage of this package would be:
+Assuming that your tsconfig.json has "allowJs" set to true, the simplest usage of this package would be:
 
 ```js title="eslint.config.js"
 // @ts-check


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

TypeScript_ESLint.mdx recommends using a JavaScript eslint.config file. The documentation should reference that a tsconfig.json needs to allow JS files for this setup to work