### PR TITLE
docs: getting started guide should reference allowJs

### DIFF
--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -30,7 +30,7 @@ npm install --save-dev eslint typescript typescript-eslint
 
 ### Step 2: Configuration
 
-Next, Assuming that your tsconfig.json has "allowJs" set to true, create an `eslint.config.js` config file in the root of your project, and populate it with the following:
+Next, assuming that your tsconfig.json has "allowJs" set to true, create an `eslint.config.js` config file in the root of your project, and populate it with the following:
 
 ```js title="eslint.config.js"
 // @ts-check

--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -30,7 +30,7 @@ npm install --save-dev eslint typescript typescript-eslint
 
 ### Step 2: Configuration
 
-Next, create an `eslint.config.js` config file in the root of your project, and populate it with the following:
+Next, Assuming that your tsconfig.json has "allowJs" set to true, create an `eslint.config.js` config file in the root of your project, and populate it with the following:
 
 ```js title="eslint.config.js"
 // @ts-check


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Quickstart.mdx recommends using a JavaScript eslint.config file. The documentation should reference that a tsconfig.json needs to allow JS files for this setup to work
