### PR TITLE
fix(eslint-plugin): [unbound-method] check method definition in object literal using longhand form

### DIFF
--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -64,6 +64,17 @@ ruleTester.run('unbound-method', rule, {
       };
       const f = o.f;
     `,
+    `
+      const { alert } = window;
+    `,
+    `
+      let b = window.blur;
+    `,
+    `
+      function foo() {}
+      const fooObject = { foo };
+      const { foo: bar } = fooObject;
+    `,
     ...[
       'instance.bound();',
       'instance.unbound();',

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -58,6 +58,12 @@ ruleTester.run('unbound-method', rule, {
     '[5.2, 7.1, 3.6].map(Math.floor);',
     'const x = console.log;',
     'const x = Object.defineProperty;',
+    `
+      const o = {
+        f: function (this: void) {},
+      };
+      const f = o.f;
+    `,
     ...[
       'instance.bound();',
       'instance.unbound();',
@@ -640,6 +646,21 @@ const { b, a } = values;
           line: 7,
           column: 12,
           endColumn: 13,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/8636
+    {
+      code: `
+const objectLiteral = {
+  f: function () {},
+};
+const f = objectLiteral.f;
+      `,
+      errors: [
+        {
+          line: 5,
           messageId: 'unboundWithoutThisAnnotation',
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8636 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Just added the same validation to the long form method syntax as already exists for the short form, i.e.
```typescript
{
   // this
   f: function() {},
   // is now scrutinized the same as 
   g() {}
}
```