### PR TITLE
fix(eslint-plugin): [sort-type-constituents] prevent formatting differences in complex types from affecting sort order

### DIFF
--- a/packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts
@@ -31,10 +31,31 @@ const valid = (operator: '&' | '|'): TSESLint.ValidTestCase<Options>[] => [
     code: `type T = { a: string } ${operator} { b: string };`,
   },
   {
+    code: noFormat`
+type T = { a: string } ${operator} {
+  b: string
+};`,
+  },
+  {
     code: `type T = [1, 2, 3] ${operator} [1, 2, 4];`,
   },
   {
+    code: noFormat`
+type T = [1, 2, 3] ${operator} [
+  1,
+  2,
+  4
+];`,
+  },
+  {
     code: `type T = (() => string) ${operator} (() => void);`,
+  },
+  {
+    code: noFormat`
+type T = ((a: string) => string) ${operator} (
+  (b: string) => string
+);
+`,
   },
   {
     code: `type T = () => string ${operator} void;`,
@@ -156,6 +177,25 @@ const invalid = (
       ],
     },
     {
+      code: noFormat`
+type T = {
+  b: string
+} ${operator} { a: string };`,
+      output: noFormat`
+type T = { a: string } ${operator} {
+  b: string
+};`,
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+          data: {
+            type,
+            name: 'T',
+          },
+        },
+      ],
+    },
+    {
       code: `type T = [1, 2, 4] ${operator} [1, 2, 3];`,
       output: `type T = [1, 2, 3] ${operator} [1, 2, 4];`,
       errors: [
@@ -169,8 +209,52 @@ const invalid = (
       ],
     },
     {
+      code: noFormat`
+type T = [
+  2,
+  3,
+  4
+] ${operator} [1, 2, 3];
+`,
+      output: noFormat`
+type T = [1, 2, 3] ${operator} [
+  2,
+  3,
+  4
+];
+`,
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+          data: {
+            type,
+            name: 'T',
+          },
+        },
+      ],
+    },
+    {
       code: `type T = (() => void) ${operator} (() => string);`,
       output: `type T = (() => string) ${operator} (() => void);`,
+      errors: [
+        {
+          messageId: 'notSortedNamed',
+          data: {
+            type,
+            name: 'T',
+          },
+        },
+      ],
+    },
+    {
+      code: noFormat`
+type T = ((b: string) => string) ${operator} (
+  (a: string) => string
+);
+`,
+      output: noFormat`
+type T = ((a: string) => string) ${operator} ((b: string) => string);
+`,
       errors: [
         {
           messageId: 'notSortedNamed',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #3639
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Currently, `sort-type-constituents` compares all source text for a given "constituent". This means that whitespace can affect the sort order unexpectedly. Particularly when paired with a formatter like Prettier, the addition or removal of a line break can end up violating this lint rule.

Considering these two examples, the first results in a lint error and the second does not, even though you'd assume they'd be sorted the same.

```tsx
type T = { a: string } & {
  b: string
};
```

```tsx
type T = { a: string } & { b: string };
```

I've tried to address these differences without completely changing how the rule works by determining a separate text value on which the sort operates, and this value has normalization to better ignore formatting differences between constituents.