### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] false positives with optional chaining

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -852,6 +852,28 @@ type Foo = { [key: string]: () => number | undefined } | null;
 declare const foo: Foo;
 foo?.['bar']()?.toExponential();
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/8652
+    `
+declare const x: (<T>(x: T) => T) | null;
+declare const y: (() => void) | null
+
+x?.(y)?.()
+    `,
+    `
+declare const x: (<T>(x: T) => T) | null;
+declare const y: (() => void) | void
+
+x?.(y)?.()
+    `,
+    // TODO(#8652): The following should be valid, but currently fails.
+    /*
+    `
+declare const x: (<T>(x: T) => T) | null;
+declare const y: (() => void) | undefined
+
+x?.(y)?.()
+    `,
+    */
   ],
   invalid: [
     // Ensure that it's checking in all the right places


### PR DESCRIPTION
Partial mitigation for #8652.

Avoids some false positives with nested optional chaining, e.g.

```ts
declare const x: (<T>(x: T) => T) | null;
declare const y: (() => void) | null

x?.(y)?.()
```

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: #8652
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR changes the way an expression `a` is tested for nullability, inside an optional chain such as `a?.b`, as follows:

- if TypeScript says `a` is either `any`, `unknown`,  `null` or `void`, then `a` is considered nullable,
- otherwise, the previous logic is used as-is.

The reason why we cannot test for `undefined` as well (possibly replacing the second step entirely), is that `undefined` is always present if the expression is part of a nested optional chain, such as `a?.b` in `a?.b?.c`.

Ideally, in this case, we would like to ask TypeScript the type of `a?.b` _after any narrowing resulting from optional chain short-circuit_, which would exclude `undefined` (unless the member `b` itself can be `undefined`), and solve all false positives. This is not (yet) covered by this PR.

Note that the following still results in a false positive (with a `null` replaced with `undefined`):

```ts
declare const x: (<T>(x: T) => T) | null;
declare const y: (() => void) | undefined

x?.(y)?.()
```