### PR TITLE
fix(eslint-plugin): [prefer-optional-chain] address multipart nullish checks false positive

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -485,23 +485,26 @@ export function analyzeChain(
     }
   })();
 
-  let subChain: ValidOperand[] = [];
+  // Things like x !== null && x !== undefined have two nodes, but they are
+  // one logical unit here, so we'll allow them to be grouped.
+  let subChain: (ValidOperand | readonly ValidOperand[])[] = [];
   const maybeReportThenReset = (
-    newChainSeed?: readonly ValidOperand[],
+    newChainSeed?: readonly [ValidOperand, ...ValidOperand[]],
   ): void => {
     if (subChain.length > 1) {
+      const subChainFlat = subChain.flat();
       context.report({
         messageId: 'preferOptionalChain',
         loc: {
-          start: subChain[0].node.loc.start,
-          end: subChain[subChain.length - 1].node.loc.end,
+          start: subChainFlat[0].node.loc.start,
+          end: subChainFlat[subChainFlat.length - 1].node.loc.end,
         },
         ...getFixer(
           context.sourceCode,
           parserServices,
           operator,
           options,
-          subChain,
+          subChainFlat,
         ),
       });
     }
@@ -518,13 +521,11 @@ export function analyzeChain(
     //     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ first "chain"
     //                          ^^^^^^^^^^^ newChainSeed
     //                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ second chain
-    subChain = newChainSeed ? [...newChainSeed] : [];
+    subChain = newChainSeed ? [newChainSeed] : [];
   };
 
   for (let i = 0; i < chain.length; i += 1) {
-    const lastOperand = subChain[subChain.length - 1] as
-      | ValidOperand
-      | undefined;
+    const lastOperand = subChain.flat().at(-1);
     const operand = chain[i];
 
     const validatedOperands = analyzeOperand(parserServices, operand, i, chain);

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -28,6 +28,35 @@ describe('|| {}', () => {
       'foo ?? {};',
       '(foo ?? {})?.bar;',
       'foo ||= bar ?? {};',
+      // https://github.com/typescript-eslint/typescript-eslint/issues/8380
+      `
+        const a = null;
+        const b = 0;
+        a === undefined || b === null || b === undefined;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/8380
+      `
+        const a = 0;
+        const b = 0;
+        a === undefined || b === undefined || b === null;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/8380
+      `
+        const a = 0;
+        const b = 0;
+        b === null || a === undefined || b === undefined;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/8380
+      `
+        const b = 0;
+        b === null || b === undefined;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/8380
+      `
+        const a = 0;
+        const b = 0;
+        b != null && a !== null && a !== undefined;
+      `,
     ],
     invalid: [
       {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8380 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Basically the trouble is that the rule checks "am I in a subsequence of logical operands that are candidates for optional chaining that is _more than one unit long_?", assuming that a nullish check will be the first element in that chain and subsequent elements will be chainable expressions. However, a nullish check such as `a !== null && a !== undefined` takes up more than one element in that subsequence, since it is two comparisons. When checking if the length is greater than 1, we get a false positive. 

The code change groups the subsequence so that `a !== null && a !== undefined` get treated as a single unit when checking whether to report.

my brain hurts.