### PR TITLE
fix(eslint-plugin): [prefer-optional-chain] properly disambiguate between `boolean` and `false`

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
@@ -84,8 +84,10 @@ function isValidFalseBooleanCheckType(
     narrows out the non-nullish falsy cases - so converting the chain to `x?.a`
     would introduce a build error
     */
+    const booleanLiteralTypes = types.filter(isBooleanLiteralType);
     if (
-      types.some(t => isBooleanLiteralType(t) && t.intrinsicName === 'false') ||
+      (booleanLiteralTypes.length === 1 &&
+        booleanLiteralTypes[0].intrinsicName === 'false') ||
       types.some(t => isStringLiteralType(t) && t.value === '') ||
       types.some(t => isNumberLiteralType(t) && t.value === 0) ||
       types.some(t => isBigIntLiteralType(t) && t.value.base10Value === '0')

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
@@ -61,17 +61,13 @@ type Operand = ValidOperand | InvalidOperand;
 const NULLISH_FLAGS = ts.TypeFlags.Null | ts.TypeFlags.Undefined;
 function isValidFalseBooleanCheckType(
   node: TSESTree.Node,
-  operator: TSESTree.LogicalExpression['operator'],
-  checkType: 'true' | 'false',
+  disallowFalseyLiteral: boolean,
   parserServices: ParserServicesWithTypeInformation,
   options: PreferOptionalChainOptions,
 ): boolean {
   const type = parserServices.getTypeAtLocation(node);
   const types = unionTypeParts(type);
 
-  const disallowFalseyLiteral =
-    (operator === '||' && checkType === 'false') ||
-    (operator === '&&' && checkType === 'true');
   if (disallowFalseyLiteral) {
     /*
     ```
@@ -133,6 +129,7 @@ export function gatherLogicalOperands(
   const { operands, newlySeenLogicals } = flattenLogicalOperands(node);
 
   for (const operand of operands) {
+    const areMoreOperands = operand !== operands.at(-1);
     switch (operand.type) {
       case AST_NODE_TYPES.BinaryExpression: {
         // check for "yoda" style logical: null != x
@@ -258,8 +255,7 @@ export function gatherLogicalOperands(
           operand.operator === '!' &&
           isValidFalseBooleanCheckType(
             operand.argument,
-            node.operator,
-            'false',
+            areMoreOperands && node.operator === '||',
             parserServices,
             options,
           )
@@ -285,8 +281,7 @@ export function gatherLogicalOperands(
         if (
           isValidFalseBooleanCheckType(
             operand,
-            node.operator,
-            'true',
+            areMoreOperands && node.operator === '&&',
             parserServices,
             options,
           )

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
@@ -84,10 +84,8 @@ function isValidFalseBooleanCheckType(
     narrows out the non-nullish falsy cases - so converting the chain to `x?.a`
     would introduce a build error
     */
-    const booleanLiteralTypes = types.filter(isBooleanLiteralType);
     if (
-      (booleanLiteralTypes.length === 1 &&
-        booleanLiteralTypes[0].intrinsicName === 'false') ||
+      types.some(t => isBooleanLiteralType(t) && t.intrinsicName === 'false') ||
       types.some(t => isStringLiteralType(t) && t.value === '') ||
       types.some(t => isNumberLiteralType(t) && t.value === 0) ||
       types.some(t => isBigIntLiteralType(t) && t.value.base10Value === '0')

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -1918,6 +1918,25 @@ describe('hand-crafted cases', () => {
       },
       {
         code: `
+          declare const foo: { bar: boolean } | null | undefined;
+          declare function acceptsBoolean(arg: boolean): void;
+          acceptsBoolean(foo != null && foo.bar);
+        `,
+        output: `
+          declare const foo: { bar: boolean } | null | undefined;
+          declare function acceptsBoolean(arg: boolean): void;
+          acceptsBoolean(foo?.bar);
+        `,
+        options: [
+          {
+            allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing:
+              true,
+          },
+        ],
+        errors: [{ messageId: 'preferOptionalChain' }],
+      },
+      {
+        code: `
           function foo(globalThis?: { Array: Function }) {
             typeof globalThis !== 'undefined' && globalThis.Array();
           }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8659
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
In #8659, we see that [the example in the docs](https://typescript-eslint.io/rules/prefer-optional-chain/#allowpotentiallyunsafefixesthatmodifythereturntypeiknowwhatimdoing) for `prefer-optional-chain`: `allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing` is not reporting an error.

The root cause is actually _unrelated_ to `allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing` — it is because `foo.bar` is of type `boolean`.

In the rule, there is a bypass to avoid flagging unions with falsy members, such as
```
declare const foo: { bar: boolean } | boolean | null | undefined;
foo && foo.bar;
```
since changing that to an optional chain would cause a TS error.

However, if the falsy literal is the last operand, then we _should_ report it. This is the change made by this PR.
```
declare const foo: { bar: boolean } | null | undefined;
foo && foo.bar;
```