### PR TITLE
fix(typescript-estree): fix the issue of single run inferring in the pnpm repo (#3811)

### DIFF
--- a/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
+++ b/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
@@ -35,11 +35,17 @@ export function inferSingleRun(options: TSESTreeOptions | undefined): boolean {
 
   // Currently behind a flag while we gather real-world feedback
   if (options.allowAutomaticSingleRunInference) {
+    const possibleEslintBinPaths = [
+      'node_modules/.bin/eslint', // npm or yarn repo
+      'node_modules/eslint/bin/eslint.js', // pnpm repo
+    ];
     if (
       // Default to single runs for CI processes. CI=true is set by most CI providers by default.
       process.env.CI === 'true' ||
       // This will be true for invocations such as `npx eslint ...` and `./node_modules/.bin/eslint ...`
-      process.argv[1].endsWith(normalize('node_modules/.bin/eslint'))
+      possibleEslintBinPaths.some(path =>
+        process.argv[1].endsWith(normalize(path)),
+      )
     ) {
       return true;
     }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #3811
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Add a check for the eslint bin path in the `inferSingleRun` method within the pnpm repository.
