### PR TITLE
fix(eslint-plugin): [no-floating-promises] revert disable of ignoreVoid in strict config

### DIFF
--- a/packages/eslint-plugin/src/configs/strict-type-checked-only.ts
+++ b/packages/eslint-plugin/src/configs/strict-type-checked-only.ts
@@ -15,7 +15,7 @@ export = {
     '@typescript-eslint/no-base-to-string': 'error',
     '@typescript-eslint/no-confusing-void-expression': 'error',
     '@typescript-eslint/no-duplicate-type-constituents': 'error',
-    '@typescript-eslint/no-floating-promises': ['error', { ignoreVoid: false }],
+    '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-for-in-array': 'error',
     'no-implied-eval': 'off',
     '@typescript-eslint/no-implied-eval': 'error',

--- a/packages/eslint-plugin/src/configs/strict-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/strict-type-checked.ts
@@ -27,7 +27,7 @@ export = {
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-extra-non-null-assertion': 'error',
     '@typescript-eslint/no-extraneous-class': 'error',
-    '@typescript-eslint/no-floating-promises': ['error', { ignoreVoid: false }],
+    '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-for-in-array': 'error',
     'no-implied-eval': 'off',
     '@typescript-eslint/no-implied-eval': 'error',

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -50,10 +50,7 @@ export default createRule<Options, MessageId>({
     docs: {
       description:
         'Require Promise-like statements to be handled appropriately',
-      recommended: {
-        recommended: true,
-        strict: [{ ignoreVoid: false }],
-      },
+      recommended: 'recommended',
       requiresTypeChecking: true,
     },
     hasSuggestions: true,

--- a/packages/repo-tools/src/postinstall.mts
+++ b/packages/repo-tools/src/postinstall.mts
@@ -20,8 +20,7 @@ if (process.env.SKIP_POSTINSTALL) {
   process.exit(0);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-(async function (): Promise<void> {
+void (async function (): Promise<void> {
   // make sure we're running from the workspace root
   const {
     default: { workspaceRoot },

--- a/packages/rule-tester/src/utils/config-validator.ts
+++ b/packages/rule-tester/src/utils/config-validator.ts
@@ -78,8 +78,7 @@ function validateRuleSchema(
   const validateRule = ruleValidators.get(rule);
 
   if (validateRule) {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    validateRule(localOptions);
+    void validateRule(localOptions);
     if (validateRule.errors) {
       throw new Error(
         validateRule.errors

--- a/packages/typescript-eslint/src/configs/strict-type-checked-only.ts
+++ b/packages/typescript-eslint/src/configs/strict-type-checked-only.ts
@@ -23,10 +23,7 @@ export default (
       '@typescript-eslint/no-base-to-string': 'error',
       '@typescript-eslint/no-confusing-void-expression': 'error',
       '@typescript-eslint/no-duplicate-type-constituents': 'error',
-      '@typescript-eslint/no-floating-promises': [
-        'error',
-        { ignoreVoid: false },
-      ],
+      '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-for-in-array': 'error',
       'no-implied-eval': 'off',
       '@typescript-eslint/no-implied-eval': 'error',

--- a/packages/typescript-eslint/src/configs/strict-type-checked.ts
+++ b/packages/typescript-eslint/src/configs/strict-type-checked.ts
@@ -35,10 +35,7 @@ export default (
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-extra-non-null-assertion': 'error',
       '@typescript-eslint/no-extraneous-class': 'error',
-      '@typescript-eslint/no-floating-promises': [
-        'error',
-        { ignoreVoid: false },
-      ],
+      '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-for-in-array': 'error',
       'no-implied-eval': 'off',
       '@typescript-eslint/no-implied-eval': 'error',

--- a/packages/website/src/hooks/useClipboard.ts
+++ b/packages/website/src/hooks/useClipboard.ts
@@ -9,7 +9,7 @@ export function useClipboard(code: () => string): useClipboardResult {
 
   const copy = useCallback(() => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    navigator.clipboard.writeText(code()).then(() => {
+    void navigator.clipboard.writeText(code()).then(() => {
       setCopied(true);
     });
   }, [setCopied, code]);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8712
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Reverts specifically the part of #8364 that had `no-floating-promises` disable allowing `void` in the `strict-type-checked` config.
