### PR TITLE
docs: mention strict configs' stricter default rule options

### DIFF
--- a/docs/users/Shared_Configurations.mdx
+++ b/docs/users/Shared_Configurations.mdx
@@ -178,6 +178,7 @@ module.exports = {
 </TabItem>
 </Tabs>
 
+Some rules also enabled in `recommended` default to more strict settings in this configuration.
 See [`configs/strict.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/strict.ts) for the exact contents of this config.
 
 :::caution
@@ -208,6 +209,7 @@ module.exports = {
 </TabItem>
 </Tabs>
 
+Some rules also enabled in `recommended-type-checked` default to more strict settings in this configuration.
 See [`configs/strict-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/strict-type-checked.ts) for the exact contents of this config.
 
 :::caution

--- a/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
@@ -198,7 +198,9 @@ function getRuleDefaultOptions(page: RuleDocsPage): string {
   return typeof recommended === 'object'
     ? [
         `const defaultOptionsRecommended: Options = ${defaults};`,
+        '',
+        '// These options are merged on top of the recommended defaults',
         `const defaultOptionsStrict: Options = ${JSON.stringify(recommended.strict)};`,
-      ].join('\n\n')
+      ].join('\n')
     : `const defaultOptions: Options = ${defaults};`;
 }

--- a/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
@@ -113,20 +113,34 @@ export async function insertNewRuleReferences(
       type: 'paragraph',
     } as mdast.Paragraph);
   } else if (!COMPLICATED_RULE_OPTIONS.has(page.file.stem)) {
-    const defaults =
-      SPECIAL_CASE_DEFAULTS.get(page.file.stem) ??
-      JSON.stringify(page.rule.defaultOptions);
-
     page.spliceChildren(
       page.headingIndices.options + 1,
       0,
       {
-        children: [
-          {
-            type: 'text',
-            value: 'This rule accepts the following options:',
-          } as mdast.Text,
-        ],
+        children:
+          typeof page.rule.meta.docs.recommended === 'object'
+            ? [
+                {
+                  type: 'text',
+                  value:
+                    'This rule accepts the following options, and has more strict settings in the ',
+                } as mdast.Text,
+                ...linkToConfigs(
+                  page.rule.meta.docs.requiresTypeChecking
+                    ? ['strict', 'strict-type-checked']
+                    : ['strict'],
+                ),
+                {
+                  type: 'text',
+                  value: ` config${page.rule.meta.docs.requiresTypeChecking ? 's' : ''}.`,
+                } as mdast.Text,
+              ]
+            : [
+                {
+                  type: 'text',
+                  value: 'This rule accepts the following options:',
+                } as mdast.Text,
+              ],
         type: 'paragraph',
       } as mdast.Paragraph,
       {
@@ -135,7 +149,7 @@ export async function insertNewRuleReferences(
         value: [
           await compile(page.rule.meta.schema, prettierConfig),
           await prettier.format(
-            `const defaultOptions: Options = ${defaults};`,
+            getRuleDefaultOptions(page),
             await prettierConfig,
           ),
         ]
@@ -146,4 +160,45 @@ export async function insertNewRuleReferences(
   }
 
   return eslintrc;
+}
+
+function linkToConfigs(configs: string[]): mdast.Node[] {
+  const links = configs.map(
+    (config): mdast.Link => ({
+      children: [
+        {
+          type: 'inlineCode',
+          value: config,
+        } as mdast.InlineCode,
+      ],
+      type: 'link',
+      url: `/users/configs#${config})`,
+    }),
+  );
+
+  return links.length === 1
+    ? links
+    : [
+        links[0],
+        {
+          type: 'text',
+          value: ' and ',
+        } as mdast.Text,
+        links[1],
+      ];
+}
+
+function getRuleDefaultOptions(page: RuleDocsPage): string {
+  const defaults =
+    SPECIAL_CASE_DEFAULTS.get(page.file.stem) ??
+    JSON.stringify(page.rule.defaultOptions);
+
+  const recommended = page.rule.meta.docs.recommended;
+
+  return typeof recommended === 'object'
+    ? [
+        `const defaultOptionsRecommended: Options = ${defaults};`,
+        `const defaultOptionsStrict: Options = ${JSON.stringify(recommended.strict)};`,
+      ].join('\n\n')
+    : `const defaultOptions: Options = ${defaults};`;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8712
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Mentions the differences in configs in two ways:

* In the _Shared Configs_ page as plain text
* In relevant rules' docs under _Options_ with two `defaultOptions*` variables

![Screenshot of no-floating-promises' Options docs showing different rule options in strict and strict-type-checked](https://github.com/typescript-eslint/typescript-eslint/assets/3335181/2c669fd9-ba47-4c75-9f12-4568cf561ed6)
