### PR TITLE
docs: restrict-template-expressions - remove mention of numbers being allowed

### DIFF
--- a/packages/eslint-plugin/docs/rules/restrict-template-expressions.mdx
+++ b/packages/eslint-plugin/docs/rules/restrict-template-expressions.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 JavaScript automatically [converts an object to a string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#string_coercion) in a string context, such as when concatenating it with a string using `+` or embedding it in a template literal using `${}`.
 The default `toString()` method of objects returns `"[object Object]"`, which is often not what was intended.
-This rule reports on values used in a template literal string that aren't strings, numbers, or BigInts, optionally allowing other data types that provide useful stringification results.
+This rule reports on values used in a template literal string that aren't strings, optionally allowing other data types that provide useful stringification results.
 
 :::note
 


### PR DESCRIPTION
In the `recommended` config, numbers are allowed, but so are several other types. In the `strict` config, numbers are not allowed (#8364). Either way, "string and number" might not be the right documentation for what's allowed.

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

N/A - small docs edit

## Overview

small docs edit