### PR TITLE
fix(website): fix infinite rendering when hash changed

### DIFF
--- a/packages/website/src/components/hooks/useHashState.ts
+++ b/packages/website/src/components/hooks/useHashState.ts
@@ -1,4 +1,3 @@
-import { useHistory } from '@docusaurus/router';
 import * as lz from 'lz-string';
 import { useCallback, useState } from 'react';
 
@@ -189,7 +188,6 @@ const writeStateToLocalStorage = (newState: ConfigModel): void => {
 function useHashState(
   initialState: ConfigModel,
 ): [ConfigModel, (cfg: Partial<ConfigModel>) => void] {
-  const history = useHistory();
   const [state, setState] = useState<ConfigModel>(() => ({
     ...initialState,
     ...retrieveStateFromLocalStorage(),
@@ -208,11 +206,7 @@ function useHashState(
         }
 
         writeStateToLocalStorage(newState);
-
-        history.replace({
-          ...history.location,
-          hash: writeStateToUrl(newState),
-        });
+        window.history.replaceState(null, '', `#${writeStateToUrl(newState)}`);
 
         if (cfg.ts) {
           window.location.reload();
@@ -220,7 +214,7 @@ function useHashState(
         return newState;
       });
     },
-    [setState, history],
+    [setState],
   );
 
   return [state, updateState];

--- a/packages/website/src/components/hooks/useHashState.ts
+++ b/packages/website/src/components/hooks/useHashState.ts
@@ -208,6 +208,7 @@ function useHashState(
         }
 
         writeStateToLocalStorage(newState);
+
         history.replace({
           ...history.location,
           hash: writeStateToUrl(newState),

--- a/packages/website/src/components/hooks/useHashState.ts
+++ b/packages/website/src/components/hooks/useHashState.ts
@@ -1,3 +1,4 @@
+import { useHistory } from '@docusaurus/router';
 import * as lz from 'lz-string';
 import { useCallback, useState } from 'react';
 
@@ -188,6 +189,7 @@ const writeStateToLocalStorage = (newState: ConfigModel): void => {
 function useHashState(
   initialState: ConfigModel,
 ): [ConfigModel, (cfg: Partial<ConfigModel>) => void] {
+  const history = useHistory();
   const [state, setState] = useState<ConfigModel>(() => ({
     ...initialState,
     ...retrieveStateFromLocalStorage(),
@@ -206,7 +208,10 @@ function useHashState(
         }
 
         writeStateToLocalStorage(newState);
-        window.history.replaceState(null, '', `#${writeStateToUrl(newState)}`);
+        history.replace({
+          ...history.location,
+          hash: writeStateToUrl(newState),
+        });
 
         if (cfg.ts) {
           window.location.reload();
@@ -214,7 +219,7 @@ function useHashState(
         return newState;
       });
     },
-    [setState],
+    [setState, history],
   );
 
   return [state, updateState];

--- a/packages/website/src/pages/play.tsx
+++ b/packages/website/src/pages/play.tsx
@@ -3,18 +3,17 @@ import Loader from '@site/src/components/layout/Loader';
 import Layout from '@theme/Layout';
 import React, { lazy, Suspense } from 'react';
 
+const Playground = lazy(
+  () =>
+    // @ts-expect-error: This does not follow Node resolution
+    import('../components/Playground') as Promise<() => React.JSX.Element>,
+);
+
 function Play(): React.JSX.Element {
   return (
     <Layout title="Playground" description="Playground" noFooter={true}>
       <BrowserOnly fallback={<Loader />}>
         {(): React.JSX.Element => {
-          const Playground = lazy(
-            () =>
-              // @ts-expect-error: This does not follow Node resolution
-              import('../components/Playground') as Promise<
-                () => React.JSX.Element
-              >,
-          );
           return (
             <Suspense fallback={<Loader />}>
               <Playground />


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8731
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The docusaurus's `PendingNavigation` component rendered infinitely when the url hash changed using `useHistory`.
This causes the resize handle to not work as described in the [issue](https://github.com/typescript-eslint/typescript-eslint/issues/8731).
- PendingNavigation: `node_modules/@docusaurus/core/lib/client/PendingNavigation.js`

```ts
 history.replace({
          ...history.location,
          hash: writeStateToUrl(newState),
        });
```

Here is a performance profile, which recording before and after entering the code in the editor. After entering the code, small tasks continue to come in to the main thread.
<img width="499" alt="스크린샷 2024-03-20 오후 8 27 40" src="https://github.com/typescript-eslint/typescript-eslint/assets/41323220/0095cfe7-cc8b-411d-be98-56b298ddf891">



I think it's a bug in docusaurus. This PR uses the HTML5 history api to avoid this behavior.