### PR TITLE
fix(typescript-eslint): declare peer dependency on `utils` to ensure npm correctly installs dependencies

### DIFF
--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -51,12 +51,12 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "@typescript-eslint/utils": "7.3.1",
     "eslint": "^8.56.0"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "7.3.1",
-    "@typescript-eslint/parser": "7.3.1"
+    "@typescript-eslint/parser": "7.3.1",
+    "@typescript-eslint/utils": "7.3.1"
   },
   "devDependencies": {
     "downlevel-dts": "*",
@@ -66,9 +66,6 @@
     "typescript": "*"
   },
   "peerDependenciesMeta": {
-    "@typescript-eslint/utils": {
-      "optional": true
-    },
     "typescript": {
       "optional": true
     }

--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -51,6 +51,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "peerDependencies": {
+    "@typescript-eslint/utils": "7.3.1",
     "eslint": "^8.56.0"
   },
   "dependencies": {
@@ -65,6 +66,9 @@
     "typescript": "*"
   },
   "peerDependenciesMeta": {
+    "@typescript-eslint/utils": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19331,6 +19331,7 @@ __metadata:
   dependencies:
     "@typescript-eslint/eslint-plugin": 7.3.1
     "@typescript-eslint/parser": 7.3.1
+    "@typescript-eslint/utils": 7.3.1
     downlevel-dts: "*"
     jest: 29.7.0
     prettier: ^3.0.3


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing issue: fixes #8732

## Overview

<!-- Description of what is changed and how the code change does that. -->
`typescript-eslint` is currently "naughty" and accesses types from `/utils` via a transitive dependency.
This means that the types we receive depend on how the package manager installs things.

pnpm and npm both do a bad job of installing dependencies in the most sane way (https://github.com/npm/cli/issues/7300) and given the current ecosystem it's possible to get an old major for `/utils` installed at the root instead of v7. This means TS will get the incorrect types for `/utils` and then the config types break.

This adds a hard dep on `/utils` to force the relationship so that all package managers do the same thing and either hoist the `/utils` dependency to the root, or at least ensure that `/utils` is nested within `typescript-eslint`.

I considered making this a peer dep - but considering `/eslint-plugin` already depends on `/utils` - it's always installed (i.e. we're not adding an extra dep) - so no need to do anything complicated that might be misinterpreted by package managers.