### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] avoid remove const casting on template literals with expressions inside

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -277,9 +277,25 @@ function bar(items: string[]) {
       `,
       parserOptions: optionsWithOnUncheckedIndexedAccess,
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/8737
+    `
+const myString = 'foo';
+const templateLiteral = \`\${myString}-somethingElse\` as const;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/8737
+    `
+const myString = 'foo';
+const templateLiteral = <const>\`\${myString}-somethingElse\`;
+    `,
   ],
 
   invalid: [
+    // https://github.com/typescript-eslint/typescript-eslint/issues/8737
+    {
+      code: 'const a = `a` as const;',
+      output: 'const a = `a`;',
+      errors: [{ messageId: 'unnecessaryAssertion', line: 1 }],
+    },
     {
       code: "const a = 'a' as const;",
       output: "const a = 'a';",


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8737
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`no-unnecessary-type-assertion` now avoids to remove `const` casting from template literals when they are containing expressions.

This scenario is handled inside `isConstVariableDeclaration` which has been renamed to `isLiteralVariableDeclarationChangingTypeWithConst` to better reflect its purpose.

Edit: missed appreciation note... sorry
😅
 