### PR TITLE
docs: mention issues being unassigned, not just open

### DIFF
--- a/docs/contributing/Pull_Requests.mdx
+++ b/docs/contributing/Pull_Requests.mdx
@@ -10,7 +10,7 @@ Fantastic!
 
 Please do:
 
-- Only send pull requests that resolve [open issues marked as `accepting prs`](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+is%3Aopen+label%3A%22accepting+prs%22)
+- Only send pull requests that resolve [open, unassigned issues marked as `accepting prs`](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+is%3Aopen+label%3A%22accepting+prs%22+no%3Aassignee)
   - One exception: extremely minor documentation typos
 - Fill out the pull request template in full
 - Validate your changes per [Development > Validating Changes](./Local_Development.mdx#validating-changes) before un-[drafting your PR](https://github.blog/2019-02-14-introducing-draft-pull-requests)


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8743
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a mention of assigning issues, and updates the search link.