### PR TITLE
docs: fix example of binding unbound method

### DIFF
--- a/packages/eslint-plugin/docs/rules/unbound-method.mdx
+++ b/packages/eslint-plugin/docs/rules/unbound-method.mdx
@@ -68,8 +68,8 @@ const { logBound } = instance;
 logBound();
 
 // .bind and lambdas will also add a correct scope
-const dotBindLog = instance.logBound.bind(instance);
-const innerLog = () => instance.logBound();
+const dotBindLog = instance.logUnbound.bind(instance);
+const innerLog = () => instance.logUnbound();
 
 // arith.double explicitly declares that it does not refer to `this` internally
 const arith = {


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This fixes the  "Correct usage" example of the `unbound-method` rule.

My understanding is that the example tries to show how to bind the correct scope to the method. So the method that should be used is `logUnbound`.

Using `.bind` or an arrow function on `logBound` is useless, as it is already bound with the correct scope.

:sauropod: 