### PR TITLE
fix(eslint-plugin): [no-floating-promises] handle TaggedTemplateExpression

### DIFF
--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -290,6 +290,8 @@ export default createRule<Options, MessageId>({
 
         // All other cases are unhandled.
         return { isUnhandled: true };
+      } else if (node.type === AST_NODE_TYPES.TaggedTemplateExpression) {
+        return { isUnhandled: true };
       } else if (node.type === AST_NODE_TYPES.ConditionalExpression) {
         // We must be getting the promise-like value from one of the branches of the
         // ternary. Check them directly.

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -504,6 +504,18 @@ void promiseArray;
 ['I', 'am', 'just', 'an', 'array'];
       `,
     },
+    {
+      code: `
+declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
+myTag\`abc\`.catch(() => {});
+      `,
+    },
+    {
+      code: `
+declare const myTag: (strings: TemplateStringsArray) => string;
+myTag\`abc\`;
+      `,
+    },
   ],
 
   invalid: [
@@ -596,27 +608,40 @@ doSomething();
     {
       code: `
 declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
-
 myTag\`abc\`;
-myTag\`abc\`.then(() => {});
-myTag\`abc\`.catch(() => {});
-myTag\`abc\`.finally(() => {});
       `,
       errors: [
         {
-          line: 4,
-          messageId: 'floatingVoid',
-        },
-        {
-          line: 5,
-          messageId: 'floatingVoid',
-        },
-        {
-          line: 7,
+          line: 3,
           messageId: 'floatingVoid',
         },
       ],
     },
+    {
+      code: `
+declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
+myTag\`abc\`.then(() => {});
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
+      code: `
+declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
+myTag\`abc\`.finally(() => {});
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+
     {
       options: [{ ignoreVoid: true }],
       code: `

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -594,6 +594,30 @@ doSomething();
       ],
     },
     {
+      code: `
+declare const myTag: (strings: TemplateStringsArray) => Promise<void>;
+
+myTag\`abc\`;
+myTag\`abc\`.then(() => {});
+myTag\`abc\`.catch(() => {});
+myTag\`abc\`.finally(() => {});
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 5,
+          messageId: 'floatingVoid',
+        },
+        {
+          line: 7,
+          messageId: 'floatingVoid',
+        },
+      ],
+    },
+    {
       options: [{ ignoreVoid: true }],
       code: `
 async function test() {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR makes "no-floating-promises" rule to raise error when floating promise is created from a tagged templates, which is essentially a function call in this context.
The motivating example is with [dax](https://github.com/dsherret/dax), which is a popular library to write shell script in TypeScript.
Its `$` API is a tagged template and it returns a Promise (with other methods on it) and we need to `await` on that.
If we forget to `await`, execution orders will be messed up and the main script might exit too early.

After this PR, "no-floating-promises" will be able to capture the mistake in the following snippet:

```typescript
import $ from 'dax-sh'

// Here we are forgetting `await` and , "no-floating-promises" cannot detect it without the PR
$`echo hello`
$`echo world`
```

I added the corresponding test cases in the PR and confirmed that the test fails before the implementation change in this PR.
