### PR TITLE
docs(eslint-plugin): [consistent-return] add warning section use noImplicitReturns instead

### DIFF
--- a/packages/eslint-plugin/docs/rules/consistent-return.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-return.mdx
@@ -12,6 +12,10 @@ import TabItem from '@theme/TabItem';
 This rule extends the base [`eslint/consistent-return`](https://eslint.org/docs/rules/consistent-return) rule.
 This version adds support for functions that return `void` or `Promise<void>`.
 
+:::danger warning
+If possible, it is recommended to use tsconfig's noImplicitReturns option rather than this rule. This is because the rule has missing cases, but the noImplicitReturns option does not.:::
+:::
+
 <Tabs>
 <TabItem value="❌ Incorrect">
 

--- a/packages/eslint-plugin/docs/rules/consistent-return.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-return.mdx
@@ -13,7 +13,7 @@ This rule extends the base [`eslint/consistent-return`](https://eslint.org/docs/
 This version adds support for functions that return `void` or `Promise<void>`.
 
 :::danger warning
-If possible, it is recommended to use tsconfig's noImplicitReturns option rather than this rule. This is because the rule has missing cases, but the noImplicitReturns option does not.:::
+If possible, it is recommended to use tsconfig's `noImplicitReturns` option rather than this rule. `noImplicitReturns` is powered by TS's type information and control-flow analysis so it has better coverage than this rule.
 :::
 
 <Tabs>

--- a/yarn.lock
+++ b/yarn.lock
@@ -19330,11 +19330,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>":
   version: 5.4.2
-  resolution: "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>::version=5.4.2&hash=f3b441"
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>::version=5.4.2&hash=5adc0c"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: c1b669146bca5529873aae60870e243fa8140c85f57ca32c42f898f586d73ce4a6b4f6bb02ae312729e214d7f5859a0c70da3e527a116fdf5ad00c9fc733ecc6
+  checksum: 797ac213c03a19749181c745647b4cab03d13bf4b6b738b05a3426f46c6b540f908989e839d9b0c89d7a4ee2bdb50493b4d4898d4ef1c897c3e9d0b082e78a67
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19330,11 +19330,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>":
   version: 5.4.2
-  resolution: "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>::version=5.4.2&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>::version=5.4.2&hash=f3b441"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 797ac213c03a19749181c745647b4cab03d13bf4b6b738b05a3426f46c6b540f908989e839d9b0c89d7a4ee2bdb50493b4d4898d4ef1c897c3e9d0b082e78a67
+  checksum: c1b669146bca5529873aae60870e243fa8140c85f57ca32c42f898f586d73ce4a6b4f6bb02ae312729e214d7f5859a0c70da3e527a116fdf5ad00c9fc733ecc6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8657
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I have created an item in the documentation recommending the use of the noImplicitReturns option.

<img width="1045" alt="스크린샷 2024-03-24 오후 7 45 43" src="https://github.com/typescript-eslint/typescript-eslint/assets/102564722/6e9022f7-1964-412b-833d-6188f79875a6">
