### PR TITLE
fix(eslint-plugin): [prefer-regexp-exec] fix heuristic to check whether regex may contain global flag

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
+++ b/packages/eslint-plugin/src/rules/prefer-regexp-exec.ts
@@ -72,7 +72,12 @@ export default createRule({
       return result;
     }
 
-    function provablyDoesNotContainGlobalFlag(
+    /**
+     * Returns true if and only if we have syntactic proof that the /g flag is
+     * absent. Returns false in all other cases (i.e. it still might or might
+     * not contain the global flag).
+     */
+    function definitelyDoesNotContainGlobalFlag(
       node: TSESTree.CallExpressionArgument,
     ): boolean {
       if (
@@ -107,7 +112,8 @@ export default createRule({
 
         // Don't report regular expressions with global flag.
         if (
-          (!argumentValue && !provablyDoesNotContainGlobalFlag(argumentNode)) ||
+          (!argumentValue &&
+            !definitelyDoesNotContainGlobalFlag(argumentNode)) ||
           (argumentValue &&
             argumentValue.value instanceof RegExp &&
             argumentValue.value.flags.includes('g'))

--- a/packages/eslint-plugin/tests/rules/prefer-regexp-exec.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-regexp-exec.test.ts
@@ -82,6 +82,28 @@ function test(str: string) {
   str.match('[a-z');
 }
     `,
+    {
+      code: `
+const text = 'something';
+declare const search: RegExp;
+text.match(search);
+      `,
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/8614
+    {
+      code: `
+const text = 'something';
+declare const obj: { search: RegExp };
+text.match(obj.search);
+      `,
+    },
+    {
+      code: `
+const text = 'something';
+declare function returnsRegexp(): RegExp;
+text.match(returnsRegexp());
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8614 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Changes the heuristic to say "if we don't know what it is, it could have the global flag". Note that it could also be tricked into falsely flagging on factory functions that return a regexp, since the heuristic inspects the second argument without checking what function it's inspecting. That has been made more strict.

See [examples in the playground](https://typescript-eslint.io/play/#ts=5.4.2&fileType=.tsx&code=CYUwxgNghgTiAEYD2A7AzgF3hkAPDAXPJjAJYoDmA3AFA0D09xGArgGZvYAWCMLECYEhBp4ZCl0J0c%2BAHQBbKBjBcAFPTRck-YPDbQKAGngokWChCQAjKBHoBKWjIwKlK9Zu0RgKAORZ9KCN4UlELa1t6CkdpPBdFZTUAJRAKAFFcAAdVX08dPQNjU3NLGwhfY19fe3saZ1dE1RT0rJy87xQAHX8CoONQ%2BHCyivhfCmramlBIWARkdCx2nwwAMQMAQQA1WFIoKwEiZozMpziG9yWUVY3tsj2BScZuAYGAdx44bgQ2FhR4K1S5DQBDo02gn3mmDEIEOqWOtCeABUeIgoGhvjAkPIviE0GgWCA6mcEu4AN7ELQ6K5rIJET4AX1kl2uQRiU3A4O%2BvzAGFIqGhrBg6GaeFUuCIKBY8gBMGMAE8iCRyNFYS0TnQnpceoEKPAALRifiCYRoPxYADWple8CgKDlGC4yptVm0WAd3wMaFkRLkJLUcEFwtSooALAAmSoTBFMLUBAz6m0oXTuw0CG1gMCkUBXWwQOWDEAYUQOgbiSQAQngACFwFAWOiQlghCIzQwmHBbKQAF4IUgYXImMzwSxIc1OpQ4uAUPCZRCoEgsHlIGA%2B%2BJuf2FlhCtAi3CqcOVcY1WhAA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Y6RAM0Wls4DmiAB7F6wxGXRRe0APbRI4MAF8QKoA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)
