### PR TITLE
docs: fix typo in switch-exhaustiveness-check

### DIFF
--- a/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.mdx
+++ b/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.mdx
@@ -34,7 +34,7 @@ If your project has many intentionally redundant `default` cases, you may want t
 
 ### `requireDefaultForNonUnion`
 
-Defaults to false. It set to true, this rule will also report when a `switch` statement switches over a non-union type (like a `number` or `string`, for example) and that `switch` statement does not have a `default` case. Thus, by setting this option to true, the rule becomes stricter.
+Defaults to false. If set to true, this rule will also report when a `switch` statement switches over a non-union type (like a `number` or `string`, for example) and that `switch` statement does not have a `default` case. Thus, by setting this option to true, the rule becomes stricter.
 
 This is generally desirable so that `number` and `string` switches will be subject to the same exhaustive checks that your other switches are.
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fix typo `It set to` -> `If set to`

<!-- Description of what is changed and how the code change does that. -->
