### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] handle exactOptionalPropertyTypes compiler option

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -131,7 +131,9 @@ export default createRule<Options, MessageIds>({
     function isTypeUnchanged(uncast: ts.Type, cast: ts.Type): boolean {
       if (uncast === cast) {
         return true;
-      } else if (
+      }
+
+      if (
         isTypeFlagSet(uncast, ts.TypeFlags.Undefined) &&
         isTypeFlagSet(cast, ts.TypeFlags.Undefined) &&
         tsutils.isCompilerOptionEnabled(
@@ -151,10 +153,10 @@ export default createRule<Options, MessageIds>({
           return false;
         }
 
-        const castPartsSet = new Set(castParts);
-        uncastParts.forEach(part => castPartsSet.delete(part));
-        return castPartsSet.size === 0;
+        const uncastPartsSet = new Set(uncastParts);
+        return castParts.every(part => uncastPartsSet.has(part));
       }
+
       return false;
     }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -128,7 +128,7 @@ export default createRule<Options, MessageIds>({
       );
     }
 
-    function isTypeChanged(uncast: ts.Type, cast: ts.Type): boolean {
+    function isTypeUnchanged(uncast: ts.Type, cast: ts.Type): boolean {
       if (uncast === cast) {
         return true;
       } else if (
@@ -262,7 +262,7 @@ export default createRule<Options, MessageIds>({
 
         const castType = services.getTypeAtLocation(node);
         const uncastType = services.getTypeAtLocation(node.expression);
-        const typeIsUnchanged = isTypeChanged(uncastType, castType);
+        const typeIsUnchanged = isTypeUnchanged(uncastType, castType);
 
         const wouldSameTypeBeInferred = castType.isLiteral()
           ? isLiteralVariableDeclarationChangingTypeWithConst(node)

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -19,6 +19,11 @@ const optionsWithOnUncheckedIndexedAccess = {
   project: './tsconfig.noUncheckedIndexedAccess.json',
 };
 
+const optionsWithExactOptionalPropertyTypes = {
+  tsconfigRootDir: rootDir,
+  project: './tsconfig.exactOptionalPropertyTypes.json',
+};
+
 ruleTester.run('no-unnecessary-type-assertion', rule, {
   valid: [
     `
@@ -287,6 +292,42 @@ const templateLiteral = \`\${myString}-somethingElse\` as const;
 const myString = 'foo';
 const templateLiteral = <const>\`\${myString}-somethingElse\`;
     `,
+    {
+      code: `
+declare const foo: {
+  a?: string;
+};
+const bar = foo.a as string;
+      `,
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+    },
+    {
+      code: `
+declare const foo: {
+  a?: string | undefined;
+};
+const bar = foo.a as string;
+      `,
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+    },
+    {
+      code: `
+declare const foo: {
+  a: string;
+};
+const bar = foo.a as string | undefined;
+      `,
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+    },
+    {
+      code: `
+declare const foo: {
+  a: string | null | number;
+};
+const bar = foo.a as string | undefined;
+      `,
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+    },
   ],
 
   invalid: [
@@ -933,6 +974,51 @@ function bar(items: string[]) {
           column: 9,
         },
       ],
+    },
+    // exactOptionalPropertyTypes = true
+    {
+      code: `
+declare const foo: {
+  a?: string;
+};
+const bar = foo.a as string | undefined;
+      `,
+      output: `
+declare const foo: {
+  a?: string;
+};
+const bar = foo.a;
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 5,
+          column: 13,
+        },
+      ],
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+    },
+    {
+      code: `
+declare const foo: {
+  a?: string | undefined;
+};
+const bar = foo.a as string | undefined;
+      `,
+      output: `
+declare const foo: {
+  a?: string | undefined;
+};
+const bar = foo.a;
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 5,
+          column: 13,
+        },
+      ],
+      parserOptions: optionsWithExactOptionalPropertyTypes,
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -328,6 +328,15 @@ const bar = foo.a as string | undefined;
       `,
       parserOptions: optionsWithExactOptionalPropertyTypes,
     },
+    {
+      code: `
+declare const foo: {
+  a?: string | number;
+};
+const bar = foo.a as string | undefined | bigint;
+      `,
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -322,7 +322,7 @@ const bar = foo.a as string | undefined;
     {
       code: `
 declare const foo: {
-  a: string | null | number;
+  a?: string | null | number;
 };
 const bar = foo.a as string | undefined;
       `,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5344
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
