### PR TITLE
fix(eslint-plugin): refactor lint script to run all projects without running eslint-plugin separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint-fix": "yarn lint --fix",
     "lint-markdown-fix": "yarn lint-markdown --fix",
     "lint-markdown": "markdownlint \"**/*.md\" --config=.markdownlint.json --ignore-path=.markdownlintignore",
-    "lint": "npx nx lint eslint-plugin --skip-nx-cache && npx nx run-many --target=lint --parallel --exclude eslint-plugin",
+    "lint": "npx nx run-many --target=lint --parallel",
     "postinstall": "npx nx run repo-tools:postinstall-script",
     "pre-commit": "yarn lint-staged",
     "release": "tsx tools/release/release.mts",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8733
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The current lint script sequence includes a direct linting command followed by additional linting tasks executed through NX CLI. However, this approach has led to unintended consequences due to how Yarn forwards arguments at the end of the called script, particularly when attempting to pass options such as --fix.

By removing the direct linting command and focusing solely on executing linting tasks through NX CLI, we can avoid the issue altogether. This simplification streamlines the script and eliminates potential conflicts arising from Yarn's argument forwarding behavior.


