### PR TITLE
fix(parser): disallow `errorOnTypeScriptSyntacticAndSemanticIssues`

### DIFF
--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -103,6 +103,12 @@ function parseForESLint(
     options.ecmaFeatures = {};
   }
 
+  /**
+   * Override errorOnTypeScriptSyntacticAndSemanticIssues and set it to false to prevent use from user config
+   * https://github.com/typescript-eslint/typescript-eslint/issues/8681#issuecomment-2000411834
+   */
+  options.errorOnTypeScriptSyntacticAndSemanticIssues = false;
+
   const parserOptions: TSESTreeOptions = {};
   Object.assign(parserOptions, options, {
     jsx: validateBoolean(options.ecmaFeatures.jsx),
@@ -123,6 +129,7 @@ function parseForESLint(
     options.warnOnUnsupportedTypeScriptVersion,
     true,
   );
+
   if (!warnOnUnsupportedTypeScriptVersion) {
     parserOptions.loggerFn = false;
   }

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -103,15 +103,14 @@ function parseForESLint(
     options.ecmaFeatures = {};
   }
 
-  /**
-   * Override errorOnTypeScriptSyntacticAndSemanticIssues and set it to false to prevent use from user config
-   * https://github.com/typescript-eslint/typescript-eslint/issues/8681#issuecomment-2000411834
-   */
-  options.errorOnTypeScriptSyntacticAndSemanticIssues = false;
-
   const parserOptions: TSESTreeOptions = {};
   Object.assign(parserOptions, options, {
     jsx: validateBoolean(options.ecmaFeatures.jsx),
+    /**
+     * Override errorOnTypeScriptSyntacticAndSemanticIssues and set it to false to prevent use from user config
+     * https://github.com/typescript-eslint/typescript-eslint/issues/8681#issuecomment-2000411834
+     */
+    errorOnTypeScriptSyntacticAndSemanticIssues: false,
   });
   const analyzeOptions: AnalyzeOptions = {
     globalReturn: options.ecmaFeatures.globalReturn,

--- a/packages/parser/tests/lib/parser.test.ts
+++ b/packages/parser/tests/lib/parser.test.ts
@@ -48,12 +48,42 @@ describe('parser', () => {
     });
   });
 
+  it('parseAndGenerateServices() should be called with options.errorOnTypeScriptSyntacticAndSemanticIssues overriden to false', () => {
+    const code = 'const valid = true;';
+    const spy = jest.spyOn(typescriptESTree, 'parseAndGenerateServices');
+    const config: ParserOptions = {
+      loc: false,
+      comment: false,
+      range: false,
+      tokens: false,
+      sourceType: 'module' as const,
+      ecmaFeatures: {
+        globalReturn: false,
+        jsx: false,
+      },
+      // ts-estree specific
+      filePath: './isolated-file.src.ts',
+      project: 'tsconfig.json',
+      errorOnTypeScriptSyntacticAndSemanticIssues: true,
+      tsconfigRootDir: path.resolve(__dirname, '../fixtures/services'),
+      extraFileExtensions: ['.foo'],
+    };
+    parseForESLint(code, config);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenLastCalledWith(code, {
+      jsx: false,
+      ...config,
+      errorOnTypeScriptSyntacticAndSemanticIssues: false,
+    });
+  });
+
   it('`warnOnUnsupportedTypeScriptVersion: false` should set `loggerFn: false` on typescript-estree', () => {
     const code = 'const valid = true;';
     const spy = jest.spyOn(typescriptESTree, 'parseAndGenerateServices');
     parseForESLint(code, { warnOnUnsupportedTypeScriptVersion: true });
     expect(spy).toHaveBeenCalledWith(code, {
       ecmaFeatures: {},
+      errorOnTypeScriptSyntacticAndSemanticIssues: false,
       jsx: false,
       sourceType: 'script',
       warnOnUnsupportedTypeScriptVersion: true,
@@ -64,6 +94,7 @@ describe('parser', () => {
       ecmaFeatures: {},
       jsx: false,
       sourceType: 'script',
+      errorOnTypeScriptSyntacticAndSemanticIssues: false,
       loggerFn: false,
       warnOnUnsupportedTypeScriptVersion: false,
     });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8681 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR overrides the above property to false in `parseForESLint` and adds, modifies relevant test cases.

Continuation of https://github.com/typescript-eslint/typescript-eslint/pull/8684
