### PR TITLE
fix(typescript-eslint): fix type errors when using `exactOptionalPropertyTypes`

### DIFF
--- a/packages/integration-tests/tests/flat-config-types.test.ts
+++ b/packages/integration-tests/tests/flat-config-types.test.ts
@@ -3,19 +3,25 @@ import {
   typescriptIntegrationTest,
 } from '../tools/integration-test-base';
 
-typescriptIntegrationTest(
-  __filename,
-  ['--allowJs', '--esModuleInterop', 'eslint.config.js'],
-  out => {
-    const lines = out.split('\n').filter(
-      line =>
-        // error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
-        // this is fine for us to ignore in this context
-        line && !line.includes('error TS18028'),
-    );
+for (const additionalFlags of [
+  [],
+  ['--strictNullChecks'],
+  ['--strictNullChecks', '--exactOptionalPropertyTypes'],
+]) {
+  typescriptIntegrationTest(
+    __filename,
+    ['--allowJs', '--esModuleInterop', ...additionalFlags, 'eslint.config.js'],
+    out => {
+      const lines = out.split('\n').filter(
+        line =>
+          // error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
+          // this is fine for us to ignore in this context
+          line && !line.includes('error TS18028'),
+      );
 
-    // The types should not error (e.g. https://github.com/eslint-stylistic/eslint-stylistic/issues/276)
-    expect(lines).toHaveLength(0);
-  },
-);
+      // The types should not error (e.g. https://github.com/eslint-stylistic/eslint-stylistic/issues/276)
+      expect(lines).toHaveLength(0);
+    },
+  );
+}
 eslintIntegrationTest(__filename, 'eslint.config.js', true);

--- a/packages/integration-tests/tests/flat-config-types.test.ts
+++ b/packages/integration-tests/tests/flat-config-types.test.ts
@@ -9,6 +9,7 @@ for (const additionalFlags of [
   ['--strictNullChecks', '--exactOptionalPropertyTypes'],
 ]) {
   typescriptIntegrationTest(
+    `typescript${additionalFlags.length ? ` with ${additionalFlags.join(', ')}` : ''}`,
     __filename,
     ['--allowJs', '--esModuleInterop', ...additionalFlags, 'eslint.config.js'],
     out => {

--- a/packages/integration-tests/tools/integration-test-base.ts
+++ b/packages/integration-tests/tools/integration-test-base.ts
@@ -182,11 +182,12 @@ export function eslintIntegrationTest(
 }
 
 export function typescriptIntegrationTest(
+  testName: string,
   testFilename: string,
   tscArgs: string[],
   assertOutput: (out: string) => void,
 ): void {
-  integrationTest('typescript', testFilename, async testFolder => {
+  integrationTest(testName, testFilename, async testFolder => {
     const [result] = await Promise.allSettled([
       execFile('yarn', ['tsc', '--noEmit', ...tscArgs], {
         cwd: testFolder,

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -28,7 +28,8 @@ type EcmaVersion =
   | 2022
   | 2023
   | 2024
-  | 'latest';
+  | 'latest'
+  | undefined;
 
 type SourceTypeClassic = 'module' | 'script';
 type SourceType = SourceTypeClassic | 'commonjs';
@@ -37,11 +38,13 @@ type JSDocParsingMode = 'all' | 'none' | 'type-info';
 
 // If you add publicly visible options here, make sure they're also documented in `docs/packages/Parser.mdx`
 interface ParserOptions {
-  ecmaFeatures?: {
-    globalReturn?: boolean;
-    jsx?: boolean;
-    [key: string]: unknown;
-  };
+  ecmaFeatures?:
+    | {
+        globalReturn?: boolean | undefined;
+        jsx?: boolean | undefined;
+        [key: string]: unknown;
+      }
+    | undefined;
   ecmaVersion?: EcmaVersion;
 
   // scope-manager specific
@@ -69,7 +72,7 @@ interface ParserOptions {
   project?: string[] | string | boolean | null;
   projectFolderIgnoreList?: (RegExp | string)[];
   range?: boolean;
-  sourceType?: SourceType;
+  sourceType?: SourceType | undefined;
   tokens?: boolean;
   tsconfigRootDir?: string;
   warnOnUnsupportedTypeScriptVersion?: boolean;

--- a/packages/utils/src/ts-eslint/Config.ts
+++ b/packages/utils/src/ts-eslint/Config.ts
@@ -151,19 +151,19 @@ export namespace FlatConfig {
     /**
      * Metadata about your plugin for easier debugging and more effective caching of plugins.
      */
-    meta?: Partial<PluginMeta>;
+    meta?: { [K in keyof PluginMeta]?: PluginMeta[K] | undefined };
     /**
      * The definition of plugin processors.
      * Users can stringly reference the processor using the key in their config (i.e., `"pluginName/processorName"`).
      */
-    processors?: Record<string, Processor>;
+    processors?: Partial<Record<string, Processor>> | undefined;
     /**
      * The definition of plugin rules.
      * The key must be the name of the rule that users will use
      * Users can stringly reference the rule using the key they registered the plugin under combined with the rule name.
      * i.e. for the user config `plugins: { foo: pluginReference }` - the reference would be `"foo/ruleName"`.
      */
-    rules?: Record<string, LooseRuleDefinition>;
+    rules?: Record<string, LooseRuleDefinition> | undefined;
   }
   export interface Plugins {
     /**
@@ -203,7 +203,7 @@ export namespace FlatConfig {
     /**
      * An object specifying additional objects that should be added to the global scope during linting.
      */
-    globals?: GlobalsConfig;
+    globals?: GlobalsConfig | undefined;
     /**
      * An object containing a `parse()` method or a `parseForESLint()` method.
      * @default
@@ -217,7 +217,7 @@ export namespace FlatConfig {
      * An object specifying additional options that are passed directly to the parser.
      * The available options are parser-dependent.
      */
-    parserOptions?: ParserOptions;
+    parserOptions?: ParserOptions | undefined;
     /**
      * The type of JavaScript source code.
      * Possible values are `"script"` for traditional script files, `"module"` for ECMAScript modules (ESM), and `"commonjs"` for CommonJS files.

--- a/packages/utils/src/ts-eslint/Parser.ts
+++ b/packages/utils/src/ts-eslint/Parser.ts
@@ -28,7 +28,7 @@ export namespace Parser {
         /**
          * Information about the parser to uniquely identify it when serializing.
          */
-        meta?: Partial<ParserMeta>;
+        meta?: { [K in keyof ParserMeta]?: ParserMeta[K] | undefined };
         /**
          * Parses the given text into an ESTree AST
          */
@@ -38,7 +38,7 @@ export namespace Parser {
         /**
          * Information about the parser to uniquely identify it when serializing.
          */
-        meta?: Partial<ParserMeta>;
+        meta?: { [K in keyof ParserMeta]?: ParserMeta[K] | undefined };
         /**
          * Parses the given text into an AST
          */

--- a/packages/utils/src/ts-eslint/Processor.ts
+++ b/packages/utils/src/ts-eslint/Processor.ts
@@ -57,7 +57,7 @@ export namespace Processor {
     /**
      * Information about the processor to uniquely identify it when serializing.
      */
-    meta?: Partial<ProcessorMeta>;
+    meta?: { [K in keyof ProcessorMeta]?: ProcessorMeta[K] | undefined };
 
     /**
      * The function to extract code blocks.
@@ -82,6 +82,6 @@ export namespace Processor {
     /**
      * If `true` then it means the processor supports autofix.
      */
-    supportsAutofix?: boolean;
+    supportsAutofix?: boolean | undefined;
   }
 }

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -668,7 +668,7 @@ export type LooseRuleDefinition =
   // TODO - ESLint v9 will remove support for RuleCreateFunction
   | LooseRuleCreateFunction
   | {
-      meta?: object;
+      meta?: object | undefined;
       create: LooseRuleCreateFunction;
     };
 /*


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8782 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
Support `exactOptionalPropertyTypes: true`
