### PR TITLE
feat(typescript-estree): add defaultProject for project service

### DIFF
--- a/docs/packages/TypeScript_ESTree.mdx
+++ b/docs/packages/TypeScript_ESTree.mdx
@@ -277,9 +277,14 @@ interface ParseAndGenerateServicesOptions extends ParseOptions {
  */
 interface ProjectServiceOptions {
   /**
-   * Globs of files to allow running with the default inferred project settings.
+   * Globs of files to allow running with the default project compiler options.
    */
   allowDefaultProjectForFiles?: string[];
+
+  /**
+   * Path to a TSConfig to use instead of TypeScript's default project configuration.
+   */
+  defaultProject?: string;
 }
 
 interface ParserServices {

--- a/packages/typescript-estree/src/create-program/createProjectService.ts
+++ b/packages/typescript-estree/src/create-program/createProjectService.ts
@@ -61,37 +61,39 @@ export function createProjectService(
   });
 
   if (typeof options === 'object' && options.defaultProject) {
+    let configRead;
+
     try {
-      const configRead = tsserver.readConfigFile(
+      configRead = tsserver.readConfigFile(
         options.defaultProject,
         system.readFile,
-      );
-
-      if (configRead.error) {
-        throw new Error(
-          `Could not read default project '${options.defaultProject}': ${tsserver.formatDiagnostic(
-            configRead.error,
-            {
-              getCurrentDirectory: system.getCurrentDirectory,
-              getCanonicalFileName: (fileName: string) => fileName,
-              getNewLine: () => os.EOL,
-            },
-          )}`,
-        );
-      }
-
-      type ProjectCompilerOptions =
-        ts.server.protocol.InferredProjectCompilerOptions;
-
-      service.setCompilerOptionsForInferredProjects(
-        (configRead.config as { compilerOptions: ProjectCompilerOptions })
-          .compilerOptions,
       );
     } catch (error) {
       throw new Error(
         `Could not parse default project '${options.defaultProject}': ${(error as Error).message}`,
       );
     }
+
+    if (configRead.error) {
+      throw new Error(
+        `Could not read default project '${options.defaultProject}': ${tsserver.formatDiagnostic(
+          configRead.error,
+          {
+            getCurrentDirectory: system.getCurrentDirectory,
+            getCanonicalFileName: fileName => fileName,
+            getNewLine: () => os.EOL,
+          },
+        )}`,
+      );
+    }
+
+    service.setCompilerOptionsForInferredProjects(
+      (
+        configRead.config as {
+          compilerOptions: ts.server.protocol.InferredProjectCompilerOptions;
+        }
+      ).compilerOptions,
+    );
   }
 
   return {

--- a/packages/typescript-estree/src/create-program/createProjectService.ts
+++ b/packages/typescript-estree/src/create-program/createProjectService.ts
@@ -56,6 +56,7 @@ export function createProjectService(
     },
     session: undefined,
     jsDocParsingMode,
+    // TODO: Use options.defaultProject?
   });
 
   return {

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -109,6 +109,11 @@ export interface ProjectServiceOptions {
    * Globs of files to allow running with the default inferred project settings.
    */
   allowDefaultProjectForFiles?: string[];
+
+  /**
+   * Path to a TSConfig to use instead of TypeScript's default project configuration.
+   */
+  defaultProject?: string;
 }
 
 interface ParseAndGenerateServicesOptions extends ParseOptions {

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -106,7 +106,7 @@ interface ParseOptions {
  */
 export interface ProjectServiceOptions {
   /**
-   * Globs of files to allow running with the default inferred project settings.
+   * Globs of files to allow running with the default project compiler options.
    */
   allowDefaultProjectForFiles?: string[];
 

--- a/packages/typescript-estree/tests/lib/createProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/createProjectService.test.ts
@@ -1,4 +1,13 @@
+import * as ts from 'typescript';
+
 import { createProjectService } from '../../src/create-program/createProjectService';
+
+const mockReadConfigFile = jest.fn();
+
+jest.mock('typescript/lib/tsserverlibrary', () => ({
+  ...jest.requireActual('typescript/lib/tsserverlibrary'),
+  readConfigFile: mockReadConfigFile,
+}));
 
 describe('createProjectService', () => {
   it('sets allowDefaultProjectForFiles when options.allowDefaultProjectForFiles is defined', () => {
@@ -17,5 +26,42 @@ describe('createProjectService', () => {
     const settings = createProjectService(undefined, undefined);
 
     expect(settings.allowDefaultProjectForFiles).toBeUndefined();
+  });
+
+  it('throws an error when options.defaultProject is set and the readConfigFile returns an error', () => {
+    mockReadConfigFile.mockReturnValue({
+      error: {
+        category: ts.DiagnosticCategory.Error,
+        code: 1000,
+      },
+    });
+
+    expect(() =>
+      createProjectService(
+        {
+          allowDefaultProjectForFiles: ['file.js'],
+          defaultProject: './tsconfig.json',
+        },
+        undefined,
+      ),
+    ).toThrow(
+      /Could not read default project '\.\/tsconfig.json': error TS1000/,
+    );
+  });
+
+  it('throws an error when options.defaultProject is set and the readConfigFile throws an error', () => {
+    mockReadConfigFile.mockImplementation(() => {
+      throw new Error('Oh no!');
+    });
+
+    expect(() =>
+      createProjectService(
+        {
+          allowDefaultProjectForFiles: ['file.js'],
+          defaultProject: './tsconfig.json',
+        },
+        undefined,
+      ),
+    ).toThrow("Could not parse default project './tsconfig.json': Oh no!");
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8206
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a `defaultProject` property to the existing `ProjectServiceOptions` config object. Folks should be able to use it like:

```js
EXPERIMENTAL_useProjectService: {
  allowDefaultProjectForFiles: ["./*.js"],
  defaultProject: "./tsconfig.json"
}
```

~...except, I can't find an API to use the default project in the project service. Filing as a draft for reference while I ask about it.~ Chatted with @jakebailey and @sandersn [in the TypeScript Discord](https://discord.com/channels/508357248330760243/640177429775777792/1224400225658212492). `service.setCompilerOptionsForInferredProjects` is the right API. Thanks!

❤️‍🔥