### PR TITLE
fix(typescript-estree): enable dot globs for project by default

### DIFF
--- a/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
+++ b/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
@@ -98,6 +98,7 @@ export function resolveProjectList(
           ? []
           : globSync([...globProjects, ...projectFolderIgnoreList], {
               cwd: options.tsconfigRootDir,
+              dot: true,
             }),
       )
       .map(project =>


### PR DESCRIPTION
BREAKING CHANGE: Changes the default glob settings for projects.

## PR Checklist

- [x] Addresses an existing open issue:  fixes #6306
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Enables `dot: true`.

Not sure if this should be a breaking change 🤔 but just to be safe, sending at the `v8` branch.

💖