### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] combine template literal check with `const` variable check

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -116,7 +116,7 @@ export default createRule<Options, MessageIds>({
       const maybeDeclarationNode = parent.parent!;
       const isTemplateLiteralWithExpressions =
         expression.type === AST_NODE_TYPES.TemplateLiteral &&
-        expression.expressions.length === 0;
+        expression.expressions.length !== 0;
       return (
         maybeDeclarationNode.type === AST_NODE_TYPES.VariableDeclaration &&
         maybeDeclarationNode.kind === 'const' &&

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -114,16 +114,17 @@ export default createRule<Options, MessageIds>({
     }: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion): boolean {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const maybeDeclarationNode = parent.parent!;
+      const isTemplateLiteralWithExpressions =
+        expression.type === AST_NODE_TYPES.TemplateLiteral &&
+        expression.expressions.length === 0;
       return (
         maybeDeclarationNode.type === AST_NODE_TYPES.VariableDeclaration &&
         maybeDeclarationNode.kind === 'const' &&
         /**
-         * If the type assertion is on a template literal WITH expressions we
-         * should keep the `const` casting
+         * Even on `const` variable declarations, type assertions on template literals with expressions are sometimes required.
          * @see https://github.com/typescript-eslint/typescript-eslint/issues/8737
          */
-        (expression.type !== AST_NODE_TYPES.TemplateLiteral ||
-          !expression.expressions.length)
+        !isTemplateLiteralWithExpressions
       );
     }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -108,7 +108,7 @@ export default createRule<Options, MessageIds>({
       );
     }
 
-    function isSafeConstVariableDeclaration({
+    function isImplicitlyNarrowedConstDeclaration({
       expression,
       parent,
     }: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion): boolean {
@@ -267,7 +267,7 @@ export default createRule<Options, MessageIds>({
         const typeIsUnchanged = isTypeUnchanged(uncastType, castType);
 
         const wouldSameTypeBeInferred = castType.isLiteral()
-          ? isSafeConstVariableDeclaration(node)
+          ? isImplicitlyNarrowedConstDeclaration(node)
           : !isConstAssertion(node.typeAnnotation);
 
         if (typeIsUnchanged && wouldSameTypeBeInferred) {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -108,7 +108,7 @@ export default createRule<Options, MessageIds>({
       );
     }
 
-    function isImplicitlyNarrowedConstDeclaration({
+    function isSafeConstVariableDeclaration({
       expression,
       parent,
     }: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion): boolean {
@@ -121,7 +121,7 @@ export default createRule<Options, MessageIds>({
         maybeDeclarationNode.type === AST_NODE_TYPES.VariableDeclaration &&
         maybeDeclarationNode.kind === 'const' &&
         /**
-         * Even on `const` variable declarations, type assertions on template literals with expressions are sometimes required.
+         * Even on `const` variable declarations, template literals with expressions can sometimes be widened without a type assertion.
          * @see https://github.com/typescript-eslint/typescript-eslint/issues/8737
          */
         !isTemplateLiteralWithExpressions
@@ -267,7 +267,7 @@ export default createRule<Options, MessageIds>({
         const typeIsUnchanged = isTypeUnchanged(uncastType, castType);
 
         const wouldSameTypeBeInferred = castType.isLiteral()
-          ? isImplicitlyNarrowedConstDeclaration(node)
+          ? isSafeConstVariableDeclaration(node)
           : !isConstAssertion(node.typeAnnotation);
 
         if (typeIsUnchanged && wouldSameTypeBeInferred) {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -284,12 +284,12 @@ function bar(items: string[]) {
     },
     // https://github.com/typescript-eslint/typescript-eslint/issues/8737
     `
-const myString = 'foo';
+let myString = 'foo';
 const templateLiteral = \`\${myString}-somethingElse\` as const;
     `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/8737
     `
-const myString = 'foo';
+let myString = 'foo';
 const templateLiteral = <const>\`\${myString}-somethingElse\`;
     `,
     'let a = `a` as const;',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -348,11 +348,6 @@ const bar = foo.a as string | undefined | bigint;
       errors: [{ messageId: 'unnecessaryAssertion', line: 1 }],
     },
     {
-      code: 'const a = `a${`b`}` as const;',
-      output: 'const a = `a${`b`}`;',
-      errors: [{ messageId: 'unnecessaryAssertion', line: 1 }],
-    },
-    {
       code: "const a = 'a' as const;",
       output: "const a = 'a';",
       errors: [{ messageId: 'unnecessaryAssertion', line: 1 }],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -292,6 +292,7 @@ const templateLiteral = \`\${myString}-somethingElse\` as const;
 const myString = 'foo';
 const templateLiteral = <const>\`\${myString}-somethingElse\`;
     `,
+    'let a = `a` as const;',
     {
       code: `
 declare const foo: {
@@ -344,6 +345,11 @@ const bar = foo.a as string | undefined | bigint;
     {
       code: 'const a = `a` as const;',
       output: 'const a = `a`;',
+      errors: [{ messageId: 'unnecessaryAssertion', line: 1 }],
+    },
+    {
+      code: 'const a = `a${`b`}` as const;',
+      output: 'const a = `a${`b`}`;',
       errors: [{ messageId: 'unnecessaryAssertion', line: 1 }],
     },
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8819, #8721
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
In #8740, new logic was added for template literals. This logic was wrongly added as a precondition, when it needs to be combined with the existing `const` variable declaration logic.

- Fix failing case from #8819 by re-arranging conditions
- The type assertions in the `valid` tests added in #8740 are actually unnecessary (but are too complex to be detected by the current logic). Changed `const` to `let`, so that the type assertions are truly necessary.
- Improved the name of `isLiteralVariableDeclarationChangingTypeWithConst` to `isImplicitlyNarrowedConstDeclaration`.