### PR TITLE
fix(eslint-plugin): [consistent-type-assertions] prevent syntax errors on arrow functions

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -5,6 +5,7 @@ import * as ts from 'typescript';
 import {
   createRule,
   getOperatorPrecedence,
+  getOperatorPrecedenceForNode,
   getParserServices,
   isClosingParenToken,
   isOpeningParenToken,
@@ -150,10 +151,6 @@ export default createRule<Options, MessageIds>({
                   node as TSESTree.TSTypeAssertion,
                 );
 
-                /**
-                 * AsExpression has lower precedence than TypeAssertionExpression,
-                 * so we don't need to wrap expression and typeAnnotation in parens.
-                 */
                 const expressionCode = context.sourceCode.getText(
                   node.expression,
                 );
@@ -176,7 +173,17 @@ export default createRule<Options, MessageIds>({
                     : undefined,
                 );
 
-                const text = `${expressionCode} as ${typeAnnotationCode}`;
+                const expressionPrecedence = getOperatorPrecedenceForNode(
+                  node.expression,
+                );
+
+                const expressionCodeWrapped = getWrappedCode(
+                  expressionCode,
+                  expressionPrecedence,
+                  asPrecedence,
+                );
+
+                const text = `${expressionCodeWrapped} as ${typeAnnotationCode}`;
                 return fixer.replaceText(
                   node,
                   isParenthesized(node, context.sourceCode)

--- a/packages/eslint-plugin/src/util/getOperatorPrecedence.ts
+++ b/packages/eslint-plugin/src/util/getOperatorPrecedence.ts
@@ -206,6 +206,7 @@ export function getOperatorPrecedenceForNode(
       return OperatorPrecedence.Spread;
 
     case AST_NODE_TYPES.YieldExpression:
+    case AST_NODE_TYPES.ArrowFunctionExpression:
       return OperatorPrecedence.Yield;
 
     case AST_NODE_TYPES.ConditionalExpression:
@@ -280,7 +281,6 @@ export function getOperatorPrecedenceForNode(
     case AST_NODE_TYPES.ArrayExpression:
     case AST_NODE_TYPES.ObjectExpression:
     case AST_NODE_TYPES.FunctionExpression:
-    case AST_NODE_TYPES.ArrowFunctionExpression:
     case AST_NODE_TYPES.ClassExpression:
     case AST_NODE_TYPES.TemplateLiteral:
     case AST_NODE_TYPES.JSXElement:

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable deprecation/deprecation -- TODO - migrate this test away from `batchedSingleLineTests` */
 
-import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
 
 import type {
   MessageIds,
@@ -41,8 +41,8 @@ const x = !'string' as A;
 const x = (a as A) + b;
 const x = (a as A) + (b);
 const x = new Generic<string>() as Foo;
-const x = new (Generic<string> as Foo)();
-const x = new (Generic<string> as Foo)('string');
+const x = new ((Generic<string>) as Foo)();
+const x = new ((Generic<string>) as Foo)('string');
 const x = () => ({ bar: 5 } as Foo);
 const x = () => ({ bar: 5 } as Foo);
 const x = () => (bar as Foo);`;
@@ -786,6 +786,127 @@ ruleTester.run('consistent-type-assertions', rule, {
       errors: [
         {
           messageId: 'never',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'const a = <any>(b, c);',
+      output: `const a = (b, c) as any;`,
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'as',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'const f = <any>(() => {});',
+      output: 'const f = (() => {}) as any;',
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'as',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'const f = <any>function () {};',
+      output: 'const f = function () {} as any;',
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'as',
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'const f = <any>(async () => {});',
+      output: 'const f = (async () => {}) as any;',
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'as',
+          line: 1,
+        },
+      ],
+    },
+    {
+      // prettier wants to remove the parens around the yield expression,
+      // but they're required.
+      code: noFormat`
+function* g() {
+  const y = <any>(yield a);
+}
+      `,
+      output: `
+function* g() {
+  const y = (yield a) as any;
+}
+      `,
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'as',
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: `
+declare let x: number, y: number;
+const bs = <any>(x <<= y);
+      `,
+      output: `
+declare let x: number, y: number;
+const bs = (x <<= y) as any;
+      `,
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'as',
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: 'const ternary = <any>(true ? x : y);',
+      output: 'const ternary = (true ? x : y) as any;',
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+      errors: [
+        {
+          messageId: 'as',
           line: 1,
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8824 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Upon looking into this bug, I learned that there are a whole host of circumstances where the `<T>(expr)` => `(expr) as T` fix failed to put necessary parens around expr (since it was coded to _never_ put any parens around expr). A generic fix has been added, and test cases from lots of precedence categories.

Also, had to change the precedence pertaining to the `=>` operator to address the specific issue in the bug, bringing the `=>` precedence into agreement with its ranking on MDN. Feels suspicious, but didn't seem to break any test cases.