### PR TITLE
chore(typescript-estree): do not pin `minimatch`

### DIFF
--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -59,7 +59,7 @@
     "debug": "^4.3.4",
     "globby": "^11.1.0",
     "is-glob": "^4.0.3",
-    "minimatch": "9.0.3",
+    "minimatch": "^9.0.3",
     "semver": "^7.5.4",
     "ts-api-utils": "^1.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5828,7 +5828,7 @@ __metadata:
     jest: 29.7.0
     jest-specific-snapshot: ^8.0.0
     make-dir: "*"
-    minimatch: 9.0.3
+    minimatch: ^9.0.3
     prettier: ^3.0.3
     rimraf: "*"
     semver: ^7.5.4
@@ -14771,7 +14771,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:9.0.3, minimatch@npm:^9.0.1, minimatch@npm:~9.0.3":
+"minimatch@npm:^9.0.3, minimatch@npm:^9.0.1, minimatch@npm:~9.0.3":
   version: 9.0.3
   resolution: "minimatch@npm:9.0.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -14771,7 +14771,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.3, minimatch@npm:^9.0.1, minimatch@npm:~9.0.3":
+"minimatch@npm:9.0.3, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3, minimatch@npm:~9.0.3":
   version: 9.0.3
   resolution: "minimatch@npm:9.0.3"
   dependencies:


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
#7752 installed `minimatch` on the estree package but pinned it with no explanation. This results in duplicated dependencies in some projects now that minimatch 9.0.4 is out. This PR fixes it by using `^` in its version, just like every other package.

Note that #7752 was merged in December, and 9.0.3 was the latest minimatch version back then until 9.0.4 was released 6 days ago, so the PR author probably couldn't have found an incompatibility between different patch `minimatch` versions
<!-- Description of what is changed and how the code change does that. -->
