### PR TITLE
fix(eslint-plugin): [dot-notation] fix false positive when accessing private/protected property with optional chaining

### DIFF
--- a/packages/eslint-plugin/src/rules/dot-notation.ts
+++ b/packages/eslint-plugin/src/rules/dot-notation.ts
@@ -112,7 +112,6 @@ export default createRule<Options, MessageIds>({
           ) {
             return;
           }
-
           if (
             propertySymbol === undefined &&
             allowIndexSignaturePropertyAccess

--- a/packages/eslint-plugin/tests/rules/dot-notation.test.ts
+++ b/packages/eslint-plugin/tests/rules/dot-notation.test.ts
@@ -24,7 +24,7 @@ function q(str: string): string {
 
 ruleTester.run('dot-notation', rule, {
   valid: [
-    //     //  baseRule
+    //  baseRule
     'a.b;',
     'a.b.c;',
     "a['12'];",
@@ -127,7 +127,7 @@ class X {
 
 let x: X | undefined;
 console.log(x?.['priv_prop']);
-    `,
+      `,
       options: [{ allowPrivateClassPropertyAccess: true }],
     },
     {
@@ -138,7 +138,7 @@ class X {
 
 let x: X | undefined;
 console.log(x?.['priv_prop']);
-`,
+      `,
       options: [{ allowProtectedClassPropertyAccess: true }],
     },
   ],

--- a/packages/eslint-plugin/tests/rules/dot-notation.test.ts
+++ b/packages/eslint-plugin/tests/rules/dot-notation.test.ts
@@ -24,8 +24,7 @@ function q(str: string): string {
 
 ruleTester.run('dot-notation', rule, {
   valid: [
-    //  baseRule
-
+    //     //  baseRule
     'a.b;',
     'a.b.c;',
     "a['12'];",
@@ -119,6 +118,28 @@ dingus?.nested['hello'];
       `,
       options: [{ allowIndexSignaturePropertyAccess: true }],
       parserOptions: { ecmaVersion: 2020 },
+    },
+    {
+      code: `
+class X {
+  private priv_prop = 123;
+}
+
+let x: X | undefined;
+console.log(x?.['priv_prop']);
+    `,
+      options: [{ allowPrivateClassPropertyAccess: true }],
+    },
+    {
+      code: `
+class X {
+  protected priv_prop = 123;
+}
+
+let x: X | undefined;
+console.log(x?.['priv_prop']);
+`,
+      options: [{ allowProtectedClassPropertyAccess: true }],
     },
   ],
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8813
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
fix error when chaning operation is used in member acceess. thanks to #3711, i resolve this problem

additionally, the issue was not refer to protected option, but protected option also make false positive, so fix too. 
