### PR TITLE
docs: fix incorrect tab item values in prefer-optional-chain

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-optional-chain.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-optional-chain.mdx
@@ -102,8 +102,7 @@ thing && thing.toString();
 ```
 
 </TabItem>
-<TabItem value="✅ Correct">
- for `checkAny: false`
+<TabItem value="✅ Correct for `checkAny: false`">
 
 ```ts option='{ "checkAny": false }'
 declare const thing: any;
@@ -129,8 +128,7 @@ thing && thing.toString();
 ```
 
 </TabItem>
-<TabItem value="✅ Correct">
- for `checkUnknown: false`
+<TabItem value="✅ Correct for `checkUnknown: false`">
 
 ```ts option='{ "checkUnknown": false }'
 declare const thing: unknown;
@@ -156,8 +154,7 @@ thing && thing.toString();
 ```
 
 </TabItem>
-<TabItem value="✅ Correct">
- for `checkString: false`
+<TabItem value="✅ Correct for `checkString: false`">
 
 ```ts option='{ "checkString": false }'
 declare const thing: string;
@@ -183,8 +180,7 @@ thing && thing.toString();
 ```
 
 </TabItem>
-<TabItem value="✅ Correct">
- for `checkNumber: false`
+<TabItem value="✅ Correct for `checkNumber: false`">
 
 ```ts option='{ "checkNumber": false }'
 declare const thing: number;
@@ -224,8 +220,7 @@ thing && thing.toString();
 ```
 
 </TabItem>
-<TabItem value="✅ Correct">
- for `checkBoolean: false`
+<TabItem value="✅ Correct for `checkBoolean: false`">
 
 ```ts option='{ "checkBoolean": false }'
 declare const thing: true;
@@ -251,8 +246,7 @@ thing && thing.toString();
 ```
 
 </TabItem>
-<TabItem value="✅ Correct">
- for `checkBigInt: false`
+<TabItem value="✅ Correct for `checkBigInt: false`">
 
 ```ts option='{ "checkBigInt": false }'
 declare const thing: bigint;
@@ -277,8 +271,7 @@ thing1 && thing1.toString();
 ```
 
 </TabItem>
-<TabItem value="✅ Correct">
- for `requireNullish: true`
+<TabItem value="✅ Correct for `requireNullish: true`">
 
 ```ts option='{ "requireNullish": true }'
 declare const thing1: string | null;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview


Some tab titles in prefer-optional-chain are displaying incorrectly.

as-is
<img width="400" alt="incorrect tab title screenshot" src="https://github.com/typescript-eslint/typescript-eslint/assets/41323220/3828bfb1-fe7d-4529-a897-dbf665e1948c">

to-be

<img width="400" alt="correct tab title screenshot" src="https://github.com/typescript-eslint/typescript-eslint/assets/41323220/bbf3ccc5-4413-42e2-8b39-76ab108c92a7">


<!-- Description of what is changed and how the code change does that. -->
