### PR TITLE
feat(eslint-plugin): [prefer-nullish-coalescing] change ignoreConditionalTests default to true

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
@@ -65,7 +65,7 @@ foo ?? 'a string';
 
 ### `ignoreConditionalTests`
 
-Setting this option to `true` will cause the rule to ignore any cases that are located within a conditional test. This is set to `false` by default.
+Setting this option to `false` will cause the rule to also check cases that are located within a conditional test. This is set to `true` by default.
 
 Generally expressions within conditional tests intentionally use the falsy fallthrough behavior of the logical or operator, meaning that fixing the operator to the nullish coalesce operator could cause bugs.
 

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -100,7 +100,7 @@ export default createRule<Options, MessageIds>({
   defaultOptions: [
     {
       allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
-      ignoreConditionalTests: false,
+      ignoreConditionalTests: true,
       ignoreTernaryTests: false,
       ignoreMixedLogicalExpressions: false,
       ignorePrimitives: {

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -147,35 +147,30 @@ x === null ? x : y;
 declare const x: ${type} | ${nullish};
 x || 'foo' ? null : null;
       `,
-      options: [{ ignoreConditionalTests: true }],
     })),
     ...nullishTypeValidTest((nullish, type) => ({
       code: `
 declare const x: ${type} | ${nullish};
 if (x || 'foo') {}
       `,
-      options: [{ ignoreConditionalTests: true }],
     })),
     ...nullishTypeValidTest((nullish, type) => ({
       code: `
 declare const x: ${type} | ${nullish};
 do {} while (x || 'foo')
       `,
-      options: [{ ignoreConditionalTests: true }],
     })),
     ...nullishTypeValidTest((nullish, type) => ({
       code: `
 declare const x: ${type} | ${nullish};
 for (;x || 'foo';) {}
       `,
-      options: [{ ignoreConditionalTests: true }],
     })),
     ...nullishTypeValidTest((nullish, type) => ({
       code: `
 declare const x: ${type} | ${nullish};
 while (x || 'foo') {}
       `,
-      options: [{ ignoreConditionalTests: true }],
     })),
 
     // ignoreMixedLogicalExpressions
@@ -706,7 +701,6 @@ declare const x: ${type} | ${nullish};
 if (() => x || 'foo') {}
       `,
       output: null,
-      options: [{ ignoreConditionalTests: true }],
       errors: [
         {
           messageId: 'preferNullishOverOr',
@@ -732,7 +726,6 @@ declare const x: ${type} | ${nullish};
 if (function werid() { return x || 'foo' }) {}
       `,
       output: null,
-      options: [{ ignoreConditionalTests: true }],
       errors: [
         {
           messageId: 'preferNullishOverOr',


### PR DESCRIPTION
BREAKING CHANGE:
Changes the default value of a rule's option.

## PR Checklist

- [x] Addresses an existing open issue: fixes #8243
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Straightforward change of the default value from `false` to `true`.

I'd considered renaming the option to `checkConditionalTests` so we could avoid having a truthy default... but figured that was a bit more user effort than folks are likely to want. I'd be happy to make that change if requested though.

💖 