### PR TITLE
fix(eslint-plugin): [no-for-in-array] refine report location

### DIFF
--- a/packages/eslint-plugin/src/rules/no-for-in-array.ts
+++ b/packages/eslint-plugin/src/rules/no-for-in-array.ts
@@ -1,4 +1,3 @@
-import type { TSESTree } from '@typescript-eslint/utils';
 import * as ts from 'typescript';
 
 import {
@@ -6,8 +5,8 @@ import {
   getConstrainedTypeAtLocation,
   getParserServices,
   isTypeArrayTypeOrUnionOfArrayTypes,
-  nullThrows,
 } from '../util';
+import { getForStatementHeadLoc } from '../util/getForStatementHeadLoc';
 
 export default createRule({
   name: 'no-for-in-array',
@@ -26,22 +25,6 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    function getReportLoc(
-      forInNode: TSESTree.ForInStatement,
-    ): TSESTree.SourceLocation {
-      const closingParens = nullThrows(
-        context.sourceCode.getTokenBefore(
-          forInNode.body,
-          token => token.value === ')',
-        ),
-        'for-in must have a closing parenthesis.',
-      );
-      return {
-        start: structuredClone(forInNode.loc.start),
-        end: structuredClone(closingParens.loc.end),
-      };
-    }
-
     return {
       ForInStatement(node): void {
         const services = getParserServices(context);
@@ -54,7 +37,7 @@ export default createRule({
           (type.flags & ts.TypeFlags.StringLike) !== 0
         ) {
           context.report({
-            loc: getReportLoc(node),
+            loc: getForStatementHeadLoc(context.sourceCode, node),
             messageId: 'forInViolation',
           });
         }

--- a/packages/eslint-plugin/src/util/getForStatementHeadLoc.ts
+++ b/packages/eslint-plugin/src/util/getForStatementHeadLoc.ts
@@ -1,0 +1,34 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { nullThrows } from '@typescript-eslint/utils/eslint-utils';
+
+/**
+ * Gets the location of the head of the given for statement variant for reporting.
+ *
+ * - `for (const foo in bar) expressionOrBlock`
+ *    ^^^^^^^^^^^^^^^^^^^^^^
+ *
+ * - `for (const foo of bar) expressionOrBlock`
+ *    ^^^^^^^^^^^^^^^^^^^^^^
+ *
+ * - `for await (const foo of bar) expressionOrBlock`
+ *    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ *
+ * - `for (let i = 0; i < 10; i++) expressionOrBlock`
+ *    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ */
+export function getForStatementHeadLoc(
+  sourceCode: TSESLint.SourceCode,
+  node:
+    | TSESTree.ForInStatement
+    | TSESTree.ForOfStatement
+    | TSESTree.ForStatement,
+): TSESTree.SourceLocation {
+  const closingParens = nullThrows(
+    sourceCode.getTokenBefore(node.body, token => token.value === ')'),
+    'for statement must have a closing parenthesis.',
+  );
+  return {
+    start: structuredClone(node.loc.start),
+    end: structuredClone(closingParens.loc.end),
+  };
+}

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-for-in-array.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-for-in-array.shot
@@ -6,18 +6,14 @@ exports[`Validating rule docs no-for-in-array.mdx code examples ESLint output 1`
 declare const array: string[];
 
 for (const i in array) {
-~~~~~~~~~~~~~~~~~~~~~~~~ For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties. Use a more robust iteration method such as for-of or array.forEach instead.
+~~~~~~~~~~~~~~~~~~~~~~ For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties. Use a more robust iteration method such as for-of or array.forEach instead.
   console.log(array[i]);
-~~~~~~~~~~~~~~~~~~~~~~~~
 }
-~
 
 for (const i in array) {
-~~~~~~~~~~~~~~~~~~~~~~~~ For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties. Use a more robust iteration method such as for-of or array.forEach instead.
+~~~~~~~~~~~~~~~~~~~~~~ For-in loops over arrays skips holes, returns indices as strings, and may visit the prototype chain or other enumerable properties. Use a more robust iteration method such as for-of or array.forEach instead.
   console.log(i, array[i]);
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
 }
-~
 "
 `;
 

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -1,5 +1,4 @@
 import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import rule from '../../src/rules/no-for-in-array';
 import { getFixturesRootDir } from '../RuleTester';

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -1,4 +1,4 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import rule from '../../src/rules/no-for-in-array';
@@ -38,7 +38,10 @@ for (const x in [3, 4, 5]) {
       errors: [
         {
           messageId: 'forInViolation',
-          type: AST_NODE_TYPES.ForInStatement,
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 27,
         },
       ],
     },
@@ -52,7 +55,10 @@ for (const x in z) {
       errors: [
         {
           messageId: 'forInViolation',
-          type: AST_NODE_TYPES.ForInStatement,
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 19,
         },
       ],
     },
@@ -67,7 +73,10 @@ const fn = (arr: number[]) => {
       errors: [
         {
           messageId: 'forInViolation',
-          type: AST_NODE_TYPES.ForInStatement,
+          line: 3,
+          column: 3,
+          endLine: 3,
+          endColumn: 23,
         },
       ],
     },
@@ -82,7 +91,10 @@ const fn = (arr: number[] | string[]) => {
       errors: [
         {
           messageId: 'forInViolation',
-          type: AST_NODE_TYPES.ForInStatement,
+          line: 3,
+          column: 3,
+          endLine: 3,
+          endColumn: 23,
         },
       ],
     },
@@ -97,7 +109,72 @@ const fn = <T extends any[]>(arr: T) => {
       errors: [
         {
           messageId: 'forInViolation',
-          type: AST_NODE_TYPES.ForInStatement,
+          line: 3,
+          column: 3,
+          endLine: 3,
+          endColumn: 23,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+for (const x
+  in
+    (
+      (
+        (
+          [3, 4, 5]
+        )
+      )
+    )
+  )
+  // weird
+  /* spot for a */
+  // comment
+  /* ) */
+  /* ( */
+  {
+  console.log(x);
+}
+      `,
+      errors: [
+        {
+          messageId: 'forInViolation',
+          line: 2,
+          column: 1,
+          endLine: 11,
+          endColumn: 4,
+        },
+      ],
+    },
+    {
+      code: noFormat`
+for (const x
+  in
+    (
+      (
+        (
+          [3, 4, 5]
+        )
+      )
+    )
+  )
+  // weird
+  /* spot for a */
+  // comment
+  /* ) */
+  /* ( */
+
+  ((((console.log('body without braces ')))));
+
+      `,
+      errors: [
+        {
+          messageId: 'forInViolation',
+          line: 2,
+          column: 1,
+          endLine: 11,
+          endColumn: 4,
         },
       ],
     },


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes (partially) #8543 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

just reduces the amount of squigglies

```ts
// before
for (const i in array) { console.log(array[i]); }
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
// after
for (const i in array) { console.log(array[i]); }
^^^^^^^^^^^^^^^^^^^^^^
```