### PR TITLE
docs: fix link to renovate config

### DIFF
--- a/docs/maintenance/pull-requests/Dependency_Version_Upgrades.mdx
+++ b/docs/maintenance/pull-requests/Dependency_Version_Upgrades.mdx
@@ -5,7 +5,7 @@ title: Dependency Version Upgrades
 
 ## Renovate
 
-We rely on [renovate bot](https://github.com/renovatebot/renovate/) to automatically raise PRs to update our dependencies using [this configuration].
+We rely on [renovate bot](https://github.com/renovatebot/renovate/) to automatically raise PRs to update our dependencies using [this configuration](https://github.com/typescript-eslint/typescript-eslint/blob/main/.github/renovate.json5).
 
 ### Dependency Dashboard
 


### PR DESCRIPTION
*PR template intentionally not followed, because it is such a small documentation fix.*