### PR TITLE
fix(ast-spec): add `EmptyStatement` to `Statement`

### DIFF
--- a/packages/ast-spec/src/unions/Statement.ts
+++ b/packages/ast-spec/src/unions/Statement.ts
@@ -12,6 +12,7 @@ import type { TSModuleDeclaration } from '../declaration/TSModuleDeclaration/spe
 import type { TSNamespaceExportDeclaration } from '../declaration/TSNamespaceExportDeclaration/spec';
 import type { TSTypeAliasDeclaration } from '../declaration/TSTypeAliasDeclaration/spec';
 import type { VariableDeclaration } from '../declaration/VariableDeclaration/spec';
+import type { EmptyStatement } from '../special/EmptyStatement/spec';
 import type { BlockStatement } from '../statement/BlockStatement/spec';
 import type { BreakStatement } from '../statement/BreakStatement/spec';
 import type { ContinueStatement } from '../statement/ContinueStatement/spec';
@@ -38,6 +39,7 @@ export type Statement =
   | ContinueStatement
   | DebuggerStatement
   | DoWhileStatement
+  | EmptyStatement
   | ExportAllDeclaration
   | ExportDefaultDeclaration
   | ExportNamedDeclaration


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8888
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
`EmptyStatement` is part of `Statement` according to ECMAScript - https://262.ecma-international.org/14.0/#prod-Statement
