### PR TITLE
feat(eslint-plugin): replace `no-new-symbol` with `no-new-native-nonconstructor`

### DIFF
--- a/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
+++ b/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
@@ -28,7 +28,7 @@ export default (
     'no-dupe-keys': 'off', // ts(1117)
     'no-func-assign': 'off', // ts(2630)
     'no-import-assign': 'off', // ts(2632) & ts(2540)
-    'no-new-symbol': 'off', // ts(7009)
+    'no-new-native-nonconstructor': 'off', // ts(7009)
     'no-obj-calls': 'off', // ts(2349)
     'no-redeclare': 'off', // ts(2451)
     'no-setter-return': 'off', // ts(2408)

--- a/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
+++ b/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
@@ -28,6 +28,8 @@ export default (
     'no-dupe-keys': 'off', // ts(1117)
     'no-func-assign': 'off', // ts(2630)
     'no-import-assign': 'off', // ts(2632) & ts(2540)
+    // TODO - remove this once we no longer support ESLint v8
+    'no-new-symbol': 'off', // ts(7009)
     'no-new-native-nonconstructor': 'off', // ts(7009)
     'no-obj-calls': 'off', // ts(2349)
     'no-redeclare': 'off', // ts(2451)


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: #8211
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

See: 
* https://github.com/typescript-eslint/typescript-eslint/issues/8211#issuecomment-2044654506
* https://github.com/eslint/eslint/issues/17446

ESLint's `no-new-symbol` rule was deprecated and replaced with `no-new-native-nonconstructor`. This PR disables `no-new-native-nonconstructor` instead of disabling `no-new-symbol`.


