### PR TITLE
docs: add @types/eslint__js to Quickstart.mdx

### DIFF
--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -25,7 +25,7 @@ These steps will get you running ESLint with our recommended rules on your TypeS
 First, install the required packages for [ESLint](https://eslint.org), [TypeScript](https://typescriptlang.org), and [our tooling](../packages/TypeScript_ESLint.mdx):
 
 ```bash npm2yarn
-npm install --save-dev eslint @eslint/js typescript typescript-eslint
+npm install --save-dev eslint @eslint/js @types/eslint__js typescript typescript-eslint 
 ```
 
 ### Step 2: Configuration

--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -25,7 +25,7 @@ These steps will get you running ESLint with our recommended rules on your TypeS
 First, install the required packages for [ESLint](https://eslint.org), [TypeScript](https://typescriptlang.org), and [our tooling](../packages/TypeScript_ESLint.mdx):
 
 ```bash npm2yarn
-npm install --save-dev eslint @eslint/js @types/eslint__js typescript typescript-eslint 
+npm install --save-dev eslint @eslint/js @types/eslint__js typescript typescript-eslint
 ```
 
 ### Step 2: Configuration


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

Without this, I was getting an error `Could not find a declaration file for module '@eslint/js'`. In VS Code, in the following `eslint.config.js` from the Getting Started guide:

```
// @ts-check

import eslint from "@eslint/js";
import tseslint from "typescript-eslint";

export default tseslint.config(
  eslint.configs.recommended,
  ...tseslint.configs.recommended,
);
```

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
