### PR TITLE
chore: new grapheme library

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -67,11 +67,11 @@
     "@typescript-eslint/utils": "7.7.0",
     "@typescript-eslint/visitor-keys": "7.7.0",
     "debug": "^4.3.4",
-    "graphemer": "^1.4.0",
     "ignore": "^5.3.1",
     "natural-compare": "^1.4.0",
     "semver": "^7.6.0",
-    "ts-api-utils": "^1.3.0"
+    "ts-api-utils": "^1.3.0",
+    "unicode-segmenter": "^0.3.2"
   },
   "devDependencies": {
     "@types/debug": "*",
@@ -85,7 +85,6 @@
     "cross-env": "^7.0.3",
     "cross-fetch": "*",
     "eslint": "*",
-    "grapheme-splitter": "^1.0.4",
     "jest": "29.7.0",
     "jest-specific-snapshot": "^8.0.0",
     "json-schema": "*",

--- a/packages/eslint-plugin/src/util/getStringLength.ts
+++ b/packages/eslint-plugin/src/util/getStringLength.ts
@@ -1,6 +1,4 @@
-import Graphemer from 'graphemer';
-
-let splitter: Graphemer | undefined;
+import { countGrapheme } from 'unicode-segmenter/grapheme';
 
 function isASCII(value: string): boolean {
   return /^[\u0020-\u007f]*$/u.test(value);
@@ -11,7 +9,5 @@ export function getStringLength(value: string): number {
     return value.length;
   }
 
-  splitter ??= new Graphemer();
-
-  return splitter.countGraphemes(value);
+  return countGrapheme(value);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5569,8 +5569,6 @@ __metadata:
     cross-fetch: "*"
     debug: ^4.3.4
     eslint: "*"
-    grapheme-splitter: ^1.0.4
-    graphemer: ^1.4.0
     ignore: ^5.3.1
     jest: 29.7.0
     jest-specific-snapshot: ^8.0.0
@@ -5588,6 +5586,7 @@ __metadata:
     ts-api-utils: ^1.3.0
     tsx: "*"
     typescript: "*"
+    unicode-segmenter: ^0.3.2
     unist-util-visit: ^5.0.0
   peerDependencies:
     "@typescript-eslint/parser": ^7.0.0
@@ -11105,13 +11104,6 @@ __metadata:
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: ac85f94da92d8eb6b7f5a8b20ce65e43d66761c55ce85ac96df6865308390da45a8d3f0296dd3a663de65d30ba497bd46c696cc1e248c72b13d6d567138a4fc7
-  languageName: node
-  linkType: hard
-
-"grapheme-splitter@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "grapheme-splitter@npm:1.0.4"
-  checksum: 0c22ec54dee1b05cd480f78cf14f732cb5b108edc073572c4ec205df4cd63f30f8db8025afc5debc8835a8ddeacf648a1c7992fe3dcd6ad38f9a476d84906620
   languageName: node
   linkType: hard
 
@@ -19382,6 +19374,13 @@ __metadata:
   version: 2.0.0
   resolution: "unicode-property-aliases-ecmascript@npm:2.0.0"
   checksum: dda4d39128cbbede2ac60fbb85493d979ec65913b8a486bf7cb7a375a2346fa48cbf9dc6f1ae23376e7e8e684c2b411434891e151e865a661b40a85407db51d0
+  languageName: node
+  linkType: hard
+
+"unicode-segmenter@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "unicode-segmenter@npm:0.3.2"
+  checksum: 0b0104711ca7947058acbf382b1fa623b1ae08fee4eae0d73e8df66f9b01288e8a144202dd4a3be45d26b9c4639069482c526efbd4a37a9b600825f86e51d7c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Replace [graphemer] library to [unicode-segmenter] library which is ligher and faster. See [benchmark](https://github.com/cometkim/unicode-segmenter#grapheme-clusters)

The Unicode grapheme splitter library, [graphemer] that the TypeScript-ESLint core currently relies on was last updated two years ago and does not include the Unicode 15.1.0 specification.

I created an alternative, the [unicode-segmeneter] library, has a lighter bundle and better performance.

unicode-segmeneter is based on the latest(v15.1.0) Unicode data, is smaller than graphemer, and has over 6x faster count performance.

Specification compliance is tested through fast-check property assertion with V8's built-in [Intl.Segmenter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) which is based on ICU.

See also https://github.com/eslint/eslint/pull/18359

<!-- Description of what is changed and how the code change does that. -->

[graphemer]: https://github.com/flmnt/graphemer
[unicode-segmenter]: https://github.com/cometkim/unicode-segmenter