### PR TITLE
chore: add v8 canary version publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v8
   pull_request:
     branches:
       - '**'
@@ -296,6 +297,39 @@ jobs:
       - name: Publish all packages to npm with the canary tag
         # NOTE: this needs to be npx, rather than yarn, to make sure the authenticated npm registry is used
         run: npx nx release publish --tag canary --verbose
+        env:
+          NX_CLOUD_DISTRIBUTED_EXECUTION: false
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+
+  publish_canary_version_v8:
+    name: Publish the latest v8 code as a canary version
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    needs: [integration_tests, lint_with_build, lint_without_build, unit_tests]
+    if: github.repository == 'typescript-eslint/typescript-eslint' && github.ref == 'refs/heads/v8'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # we need the tags to be available
+
+      - name: Install
+        uses: ./.github/actions/prepare-install
+        with:
+          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Build
+        uses: ./.github/actions/prepare-build
+
+      - name: Figure out and apply the next canary version
+        run: npx nx run repo-tools:apply-canary-version
+
+      - name: Publish all packages to npm with the canary tag
+        # NOTE: this needs to be npx, rather than yarn, to make sure the authenticated npm registry is used
+        run: npx lerna publish premajor --loglevel=verbose --canary --exact --force-publish --yes --dist-tag rc-v8
         env:
           NX_CLOUD_DISTRIBUTED_EXECUTION: false
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/maintenance/Releases.mdx
+++ b/docs/maintenance/Releases.mdx
@@ -23,9 +23,9 @@ Per [Users > Releases > Major Releases](../users/Releases.mdx#major-releases), w
    - `v${major}`
    - `v${major}-canary-auto-release`
 1. Raise a PR from `v${major}-canary-auto-release` to `main` modifying the [`ci.yml` workflow](https://github.com/typescript-eslint/typescript-eslint/blob/main/.github/workflows/ci.yml) [example: [chore: add auto-canary release for v6](https://github.com/typescript-eslint/typescript-eslint/pull/5883)]:
-   - Under `pushes:` at the beginning of the file, add an `- v${major}` list item.
+   - Under `push:` > `branches:` at the beginning of the file, add an `- v${major}` list item.
    - Add a `publish_canary_version_v${major}` step the same as `publish_canary_version` except:
-     - Add the condition: `if: github.ref == 'refs/heads/v${major}'`.
+     - Change the `if` condition's branch check to: `if: github.ref == 'refs/heads/v${major}'`.
      - Its publish command should be `npx lerna publish premajor --loglevel=verbose --canary --exact --force-publish --yes --dist-tag rc-v${major}`.
    - Merge this into `main` once reviewed and rebase the `v${major}` branch.
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8948
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Sets up the `publish_canary_version_v8` job per the guide. Also touches up a couple of small typos in the guide.