### PR TITLE
docs: fix bad glob in Shared_Configurations.mdx doc

### DIFF
--- a/docs/users/Shared_Configurations.mdx
+++ b/docs/users/Shared_Configurations.mdx
@@ -321,7 +321,7 @@ export default tseslint.config(
   },
   // Added lines start
   {
-    files: ['*.js'],
+    files: ['**/*.js'],
     ...tseslint.configs.disableTypeChecked,
   },
   // Added lines end
@@ -346,7 +346,7 @@ module.exports = {
   // Added lines start
   overrides: [
     {
-      files: ['*.js'],
+      files: ['**/*.js'],
       extends: ['plugin:@typescript-eslint/disable-type-checked'],
     },
   ],


### PR DESCRIPTION
Hey, so, I noticed that docs mention a wrong glob in Shared Configs - `*.js` would only match files in root directory, it should instead be `**/*.js` if we want to match all JS files
