### PR TITLE
feat(eslint-plugin): [no-circular-imports] add new rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-circular-import.mdx
+++ b/packages/eslint-plugin/docs/rules/no-circular-import.mdx
@@ -1,0 +1,47 @@
+---
+description: 'Disallow the use of import module that result in circular imports.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-circular-import** for documentation.
+
+This rule disallows the use of import module that result in circular imports except for the type-only imports.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts skipValidation
+// foo.ts
+import { bar } from './bar';
+export const foo = 1;
+
+// bar.ts
+import { foo } from './foo';
+export const bar = 1;
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+// foo.ts
+import type { bar } from './bar';
+export type baz = number;
+
+// bar.ts
+import { type baz } from './baz';
+export type bar = number;
+```
+
+</TabItem>
+</Tabs>
+
+## When Not To Use It
+
+## Related To

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -47,6 +47,7 @@ export = {
     '@typescript-eslint/no-base-to-string': 'error',
     '@typescript-eslint/no-confusing-non-null-assertion': 'error',
     '@typescript-eslint/no-confusing-void-expression': 'error',
+    '@typescript-eslint/no-circular-import': 'error',
     'no-dupe-class-members': 'off',
     '@typescript-eslint/no-dupe-class-members': 'error',
     '@typescript-eslint/no-duplicate-enum-values': 'error',

--- a/packages/eslint-plugin/src/configs/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/disable-type-checked.ts
@@ -17,6 +17,7 @@ export = {
     '@typescript-eslint/naming-convention': 'off',
     '@typescript-eslint/no-array-delete': 'off',
     '@typescript-eslint/no-base-to-string': 'off',
+    '@typescript-eslint/no-circular-import': 'off',
     '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/no-duplicate-type-constituents': 'off',
     '@typescript-eslint/no-floating-promises': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -39,6 +39,7 @@ import namingConvention from './naming-convention';
 import noArrayConstructor from './no-array-constructor';
 import noArrayDelete from './no-array-delete';
 import noBaseToString from './no-base-to-string';
+import noCircularImport from './no-circular-import';
 import confusingNonNullAssertionLikeNotEqual from './no-confusing-non-null-assertion';
 import noConfusingVoidExpression from './no-confusing-void-expression';
 import noDupeClassMembers from './no-dupe-class-members';
@@ -184,6 +185,7 @@ export default {
   'no-array-constructor': noArrayConstructor,
   'no-array-delete': noArrayDelete,
   'no-base-to-string': noBaseToString,
+  'no-circular-import': noCircularImport,
   'no-confusing-non-null-assertion': confusingNonNullAssertionLikeNotEqual,
   'no-confusing-void-expression': noConfusingVoidExpression,
   'no-dupe-class-members': noDupeClassMembers,

--- a/packages/eslint-plugin/src/rules/no-circular-import.ts
+++ b/packages/eslint-plugin/src/rules/no-circular-import.ts
@@ -1,0 +1,181 @@
+import * as ts from 'typescript';
+
+import { createRule, getParserServices } from '../util';
+
+type Options = [];
+type MessageIds = 'noCircularImport';
+
+interface Edge {
+  filename: string;
+  specifier: string;
+}
+
+class Graph {
+  private graph = new Map<
+    string,
+    {
+      filename: string;
+      specifier: string;
+    }[]
+  >();
+
+  addEdge(start: string, edge: Edge): void {
+    if (this.graph.has(start)) {
+      this.graph.get(start)?.push(edge);
+    } else {
+      this.graph.set(start, [edge]);
+    }
+  }
+
+  hasEdge(name: string): boolean {
+    return this.graph.has(name);
+  }
+
+  getEdges(name: string): Edge[] {
+    return this.graph.get(name) ?? [];
+  }
+}
+//  imports “a.ts” and is imported from “b.ts”, resulting in a circular reference.
+export default createRule<Options, MessageIds>({
+  name: 'no-circular-import',
+  meta: {
+    docs: {
+      description:
+        'Disallow the use of import module that result in circular imports',
+      requiresTypeChecking: true,
+    },
+    messages: {
+      noCircularImport: 'Circular import dcetected via {{paths}}.',
+    },
+    schema: [],
+    type: 'suggestion',
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = getParserServices(context);
+    const graph = new Graph();
+
+    function resolveSpecifier(
+      containingFile: string,
+      specifier: string,
+    ): ts.ResolvedModuleWithFailedLookupLocations {
+      return ts.resolveModuleName(
+        specifier,
+        containingFile,
+        services.program.getCompilerOptions(),
+        ts.sys,
+      );
+    }
+
+    function isTypeOnlyImport(node: ts.ImportDeclaration): boolean {
+      return (
+        node.importClause?.isTypeOnly ||
+        (!!node.importClause?.namedBindings &&
+          ts.isNamedImports(node.importClause.namedBindings) &&
+          node.importClause.namedBindings.elements.every(
+            elem => elem.isTypeOnly,
+          ))
+      );
+    }
+
+    function addEdgesRecursively(
+      graph: Graph,
+      containingFile: string,
+      importDeclaration: ts.ImportDeclaration,
+    ): void {
+      if (graph.hasEdge(containingFile)) {
+        return;
+      }
+
+      if (isTypeOnlyImport(importDeclaration)) {
+        return;
+      }
+
+      if (!ts.isStringLiteral(importDeclaration.moduleSpecifier)) {
+        return;
+      }
+
+      const specifier = importDeclaration.moduleSpecifier.text;
+
+      const resolved = resolveSpecifier(containingFile, specifier);
+
+      if (
+        !resolved.resolvedModule ||
+        resolved.resolvedModule.isExternalLibraryImport
+      ) {
+        return;
+      }
+
+      const resolvedFile = resolved.resolvedModule.resolvedFileName;
+
+      graph.addEdge(containingFile, {
+        filename: resolvedFile,
+        specifier,
+      });
+
+      const sourceCode = services.program.getSourceFile(resolvedFile);
+      sourceCode?.statements.forEach(statement => {
+        if (ts.isImportDeclaration(statement)) {
+          addEdgesRecursively(graph, resolvedFile, statement);
+        }
+      });
+    }
+
+    function detectCycleWorker(
+      start: string,
+      graph: Graph,
+      filename: string,
+      visited: Set<string>,
+      paths: string[],
+    ): string[] {
+      visited.add(filename);
+
+      for (const edge of graph.getEdges(filename)) {
+        if (visited.has(edge.filename)) {
+          if (edge.filename === start) {
+            return paths.concat(edge.specifier);
+          }
+          return [];
+        }
+        const detected = detectCycleWorker(
+          start,
+          graph,
+          edge.filename,
+          visited,
+          paths.concat(edge.specifier),
+        );
+        if (detected.length) {
+          return detected;
+        }
+      }
+      return [];
+    }
+
+    function detectCycle(graph: Graph, filename: string): string[] {
+      const visited = new Set<string>();
+      return detectCycleWorker(filename, graph, filename, visited, []);
+    }
+
+    return {
+      ImportDeclaration(node): void {
+        const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+        const containingFile = tsNode.parent.getSourceFile().fileName;
+        addEdgesRecursively(graph, containingFile, tsNode);
+
+        const cycle = detectCycle(graph, containingFile);
+        if (cycle.length > 1) {
+          context.report({
+            messageId: 'noCircularImport',
+            node,
+            data: {
+              paths:
+                cycle.length === 2
+                  ? cycle[0]
+                  : `${cycle[0]} ... ${cycle[cycle.length - 2]}`,
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-circular-import.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-circular-import.shot
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Validating rule docs no-circular-import.mdx code examples ESLint output 1`] = `
+"Incorrect
+
+// foo.ts
+import './bar';
+
+// bar.ts
+import './foo';
+"
+`;
+
+exports[`Validating rule docs no-circular-import.mdx code examples ESLint output 2`] = `
+"Correct
+
+// foo.ts
+import './bar';
+
+// bar.ts
+import './baz';
+"
+`;

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-circular-import.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-circular-import.shot
@@ -4,10 +4,12 @@ exports[`Validating rule docs no-circular-import.mdx code examples ESLint output
 "Incorrect
 
 // foo.ts
-import './bar';
+import { bar } from './bar';
+export const foo = 1;
 
 // bar.ts
-import './foo';
+import { foo } from './foo';
+export const bar = 1;
 "
 `;
 
@@ -15,9 +17,11 @@ exports[`Validating rule docs no-circular-import.mdx code examples ESLint output
 "Correct
 
 // foo.ts
-import './bar';
+import type { bar } from './bar';
+export type baz = number;
 
 // bar.ts
-import './baz';
+import { type baz } from './baz';
+export type bar = number;
 "
 `;

--- a/packages/eslint-plugin/tests/fixtures/no-circular-import/depth-one.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-circular-import/depth-one.ts
@@ -1,0 +1,2 @@
+import { entry } from './entry';
+export const one = entry;

--- a/packages/eslint-plugin/tests/fixtures/no-circular-import/depth-three.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-circular-import/depth-three.ts
@@ -1,0 +1,2 @@
+import { two } from './depth-two';
+export const three = two;

--- a/packages/eslint-plugin/tests/fixtures/no-circular-import/depth-two.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-circular-import/depth-two.ts
@@ -1,0 +1,2 @@
+import { one } from './depth-one';
+export const two = one;

--- a/packages/eslint-plugin/tests/fixtures/no-circular-import/entry.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-circular-import/entry.ts
@@ -1,0 +1,1 @@
+export const entry = 1;

--- a/packages/eslint-plugin/tests/fixtures/no-circular-import/isolated-circular-a.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-circular-import/isolated-circular-a.ts
@@ -1,0 +1,2 @@
+import { b } from './isolated-circular-b';
+export const a = 1;

--- a/packages/eslint-plugin/tests/fixtures/no-circular-import/isolated-circular-b.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-circular-import/isolated-circular-b.ts
@@ -1,0 +1,2 @@
+import { a } from './isolated-circular-a';
+export const b = 1;

--- a/packages/eslint-plugin/tests/fixtures/no-circular-import/no-circular.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-circular-import/no-circular.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/eslint-plugin/tests/fixtures/no-circular-import/type-only.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-circular-import/type-only.ts
@@ -1,0 +1,3 @@
+import type { entry } from './entry';
+import { type entry as EntryType } from './entry';
+export type TypeOnly = typeof entry | typeof EntryType;

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.json
@@ -12,6 +12,7 @@
     "file.ts",
     "consistent-type-exports.ts",
     "mixed-enums-decl.ts",
-    "react.tsx"
+    "react.tsx",
+    "no-circular-import"
   ]
 }

--- a/packages/eslint-plugin/tests/rules/no-circular-import.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-circular-import.test.ts
@@ -1,0 +1,102 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import rule from '../../src/rules/no-circular-import';
+import { getFixturesRootDir } from '../RuleTester';
+
+const ruleTester = new RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json',
+    tsconfigRootDir: getFixturesRootDir(),
+  },
+});
+
+const filename = './no-circular-import/entry.ts';
+
+ruleTester.run('no-circular-import', rule, {
+  valid: [
+    {
+      code: "import './isolated-circular-a';",
+      filename,
+    },
+    {
+      code: "import * as ts from 'typescript';",
+      filename,
+    },
+    {
+      code: "import foo from './no-circular';",
+      filename,
+    },
+    {
+      code: `
+import { TypeOnly } from './type-only';
+export const entry = 1;
+      `,
+      filename,
+    },
+    {
+      code: `
+import type { one } from './depth-one';
+export const entry = 1;
+      `,
+      filename,
+    },
+    {
+      code: `
+import { type one } from './depth-one';
+export const entry = 1;
+      `,
+      filename,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+import { one } from './depth-one';
+export const entry = 1;
+      `,
+      filename,
+      errors: [
+        {
+          messageId: 'noCircularImport',
+          line: 2,
+          data: {
+            paths: './depth-one',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+import { two } from './depth-two';
+export const entry = 1;
+      `,
+      filename,
+      errors: [
+        {
+          messageId: 'noCircularImport',
+          line: 2,
+          data: {
+            paths: './depth-two ... ./depth-one',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+import { three } from './depth-three';
+export const entry = 1;
+      `,
+      filename,
+      errors: [
+        {
+          messageId: 'noCircularImport',
+          line: 2,
+          data: {
+            paths: './depth-three ... ./depth-one',
+          },
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/schema-snapshots/no-circular-import.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-circular-import.shot
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rule schemas should be convertible to TS types for documentation purposes no-circular-import 1`] = `
+"
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];"
+`;

--- a/packages/typescript-eslint/src/configs/all.ts
+++ b/packages/typescript-eslint/src/configs/all.ts
@@ -56,6 +56,7 @@ export default (
       '@typescript-eslint/no-base-to-string': 'error',
       '@typescript-eslint/no-confusing-non-null-assertion': 'error',
       '@typescript-eslint/no-confusing-void-expression': 'error',
+      '@typescript-eslint/no-circular-import': 'error',
       'no-dupe-class-members': 'off',
       '@typescript-eslint/no-dupe-class-members': 'error',
       '@typescript-eslint/no-duplicate-enum-values': 'error',

--- a/packages/typescript-eslint/src/configs/disable-type-checked.ts
+++ b/packages/typescript-eslint/src/configs/disable-type-checked.ts
@@ -20,6 +20,7 @@ export default (
     '@typescript-eslint/naming-convention': 'off',
     '@typescript-eslint/no-array-delete': 'off',
     '@typescript-eslint/no-base-to-string': 'off',
+    '@typescript-eslint/no-circular-import': 'off',
     '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/no-duplicate-type-constituents': 'off',
     '@typescript-eslint/no-floating-promises': 'off',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #224
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

In this pr, I implemented `no-circular-import` which checks `circular-import` using the information that `TS` has. see https://github.com/typescript-eslint/typescript-eslint/issues/224#issuecomment-1116455239.

The current implementation lacks some handling compared to [eslint-plugin-import/no-cycle](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md). (dynamic-import, require..).

Before go any further, I have a question about the case with `dynamic-import`. 

With this implementation way,  it would be difficult to checks for modules that reference each other via dynamic import. Actually there is a way to traverse the ASTs in the TS to check for dynamic imports, but performance may be poor.

```ts
// foo.ts
const foo = () => import("./bar.ts");

// bar.ts
const bar = () => import("./foo.ts");
```

Should this be left as an edge case? 

---
I've already left an inquiry on discord about this. I'd be interested to hear what other members think.

- https://discord.com/channels/1026804805894672454/1088474511759917106/1231620012306075798
> I'm not sure if dynamic imports should be warned at all because (a) there are many ways they are not statically analyzable (b) one of their use cases is to avoid circular imports (by deferring them) - Josh-Cena
- https://discord.com/channels/1026804805894672454/1088474511759917106/1231507199348703313

<!-- Description of what is changed and how the code change does that. -->
