### PR TITLE
feat(eslint-plugin): [no-unused-vars] align catch behavior to ESLint 9

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -104,7 +104,7 @@ export default createRule<Options, MessageIds>({
         vars: 'all',
         args: 'after-used',
         ignoreRestSiblings: false,
-        caughtErrors: 'none',
+        caughtErrors: 'all',
       };
 
       if (typeof firstOption === 'string') {
@@ -245,9 +245,7 @@ export default createRule<Options, MessageIds>({
           ) {
             continue;
           }
-        }
-
-        if (def.type === TSESLint.Scope.DefinitionType.Parameter) {
+        } else if (def.type === TSESLint.Scope.DefinitionType.Parameter) {
           // if "args" option is "none", skip any parameter
           if (options.args === 'none') {
             continue;

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-eslint.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-eslint.test.ts
@@ -232,10 +232,13 @@ foo();
   doSomething();
 })();
     `,
-    `
+    {
+      code: `
 try {
 } catch (e) {}
-    `,
+      `,
+      options: [{ caughtErrors: 'none' }],
+    },
     '/*global a */ a;',
     {
       code: `
@@ -925,7 +928,7 @@ try {
 try {
 } catch (err) {}
       `,
-      options: [{ vars: 'all', args: 'all' }],
+      options: [{ vars: 'all', args: 'all', caughtErrors: 'none' }],
     },
 
     // Using object rest for variable omission
@@ -2234,6 +2237,22 @@ try {
       errors: [
         definedError('err', '. Allowed unused args must match /^ignore/u'),
       ],
+    },
+    {
+      code: `
+try {
+} catch (err) {}
+      `,
+      options: [{ caughtErrors: 'all', varsIgnorePattern: '^err' }],
+      errors: [definedError('err', '. Allowed unused vars must match /^err/u')],
+    },
+    {
+      code: `
+try {
+} catch (err) {}
+      `,
+      options: [{ caughtErrors: 'all', varsIgnorePattern: '^.' }],
+      errors: [definedError('err', '. Allowed unused vars must match /^./u')],
     },
 
     // multiple try catch with one success


### PR DESCRIPTION
BREAKING CHANGE:
Changes the default behavior of a rule.

## PR Checklist

- [x] Addresses an existing open issue: fixes #8967
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Roughly applies the same changes from https://github.com/eslint/eslint/pull/17932 and https://github.com/eslint/eslint/pull/18043.

💖 