### PR TITLE
feat(utils): swap LegacyESLint out for FlatESLint as ESLint export

### DIFF
--- a/packages/utils/src/ts-eslint/ESLint.ts
+++ b/packages/utils/src/ts-eslint/ESLint.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
 export {
-  // TODO - remove this in the next major
+  // TODO(v9) - remove this in the next major
   /**
-   * @deprecated - use FlatESLint or LegacyESLint instead
+   * @deprecated - use ESLint instead
    */
-  LegacyESLint as ESLint,
+  LegacyESLint,
 } from './eslint/LegacyESLint';
 export { FlatESLint } from './eslint/FlatESLint';
-export { LegacyESLint } from './eslint/LegacyESLint';
+export { FlatESLint as ESLint } from './eslint/FlatESLint';

--- a/packages/utils/src/ts-eslint/ESLint.ts
+++ b/packages/utils/src/ts-eslint/ESLint.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 
 export {
-  // TODO(v9) - remove this in the next major
+  // TODO(eslint@v10) - remove this in the next major
   /**
    * @deprecated - use ESLint instead
    */


### PR DESCRIPTION
BREAKING:
Changes the names of exports.

## PR Checklist

- [x] Addresses an existing open issue: fixes #8970
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Applies just a quick export name change so importing `ESLint` gives you `FlatESLint`, not `LegacyESLint`.

Also updates the _TODO_ comment to reflect keeping the legacy class around.

💖 