### PR TITLE
docs: fix no-unnecessary-boolean-literal-compare example

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.mdx
@@ -101,11 +101,11 @@ Examples of code for this rule with `{ allowComparingNullableBooleansToFalse: fa
 
 ```ts option='{ "allowComparingNullableBooleansToFalse": false }'
 declare const someUndefinedCondition: boolean | undefined;
-if (!(someUndefinedCondition === false)) {
+if (someUndefinedCondition === false) {
 }
 
 declare const someNullCondition: boolean | null;
-if (!(someNullCondition !== false)) {
+if (someNullCondition !== false) {
 }
 ```
 
@@ -114,11 +114,11 @@ if (!(someNullCondition !== false)) {
 
 ```ts option='{ "allowComparingNullableBooleansToFalse": false }'
 declare const someUndefinedCondition: boolean | undefined;
-if (someUndefinedCondition ?? true) {
+if (!(someUndefinedCondition ?? true)) {
 }
 
 declare const someNullCondition: boolean | null;
-if (!(someNullCondition ?? true)) {
+if (someNullCondition ?? true) {
 }
 ```
 
@@ -127,16 +127,16 @@ if (!(someNullCondition ?? true)) {
 
 ## Fixer
 
-|            Comparison             | Fixer Output                    | Notes                                                                               |
-| :-------------------------------: | ------------------------------- | ----------------------------------------------------------------------------------- |
-|       `booleanVar === true`       | `booleanVar`                    |                                                                                     |
-|       `booleanVar !== true`       | `!booleanVar`                   |                                                                                     |
-|      `booleanVar === false`       | `!booleanVar`                   |                                                                                     |
-|      `booleanVar !== false`       | `booleanVar`                    |                                                                                     |
-|   `nullableBooleanVar === true`   | `nullableBooleanVar`            | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
-|   `nullableBooleanVar !== true`   | `!nullableBooleanVar`           | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
-| `!(nullableBooleanVar === false)` | `nullableBooleanVar ?? true`    | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
-| `!(nullableBooleanVar !== false)` | `!(nullableBooleanVar ?? true)` | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
+|           Comparison           | Fixer Output                    | Notes                                                                               |
+| :----------------------------: | ------------------------------- | ----------------------------------------------------------------------------------- |
+|     `booleanVar === true`      | `booleanVar`                    |                                                                                     |
+|     `booleanVar !== true`      | `!booleanVar`                   |                                                                                     |
+|     `booleanVar === false`     | `!booleanVar`                   |                                                                                     |
+|     `booleanVar !== false`     | `booleanVar`                    |                                                                                     |
+| `nullableBooleanVar === true`  | `nullableBooleanVar`            | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
+| `nullableBooleanVar !== true`  | `!nullableBooleanVar`           | Only checked/fixed if the `allowComparingNullableBooleansToTrue` option is `false`  |
+| `nullableBooleanVar === false` | `!(nullableBooleanVar ?? true)` | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
+| `nullableBooleanVar !== false` | `nullableBooleanVar ?? true`    | Only checked/fixed if the `allowComparingNullableBooleansToFalse` option is `false` |
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.mdx
@@ -101,11 +101,11 @@ Examples of code for this rule with `{ allowComparingNullableBooleansToFalse: fa
 
 ```ts option='{ "allowComparingNullableBooleansToFalse": false }'
 declare const someUndefinedCondition: boolean | undefined;
-if (someUndefinedCondition === false) {
+if (!(someUndefinedCondition === false)) {
 }
 
 declare const someNullCondition: boolean | null;
-if (someNullCondition !== false) {
+if (!(someNullCondition !== false)) {
 }
 ```
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-boolean-literal-compare.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-boolean-literal-compare.shot
@@ -78,11 +78,11 @@ exports[`Validating rule docs no-unnecessary-boolean-literal-compare.mdx code ex
 Options: { "allowComparingNullableBooleansToFalse": false }
 
 declare const someUndefinedCondition: boolean | undefined;
-if (someUndefinedCondition ?? true) {
+if (!(someUndefinedCondition ?? true)) {
 }
 
 declare const someNullCondition: boolean | null;
-if (!(someNullCondition ?? true)) {
+if (someNullCondition ?? true) {
 }
 "
 `;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8980
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22) _(intentionally skipped because it's a small documentation fix for something that was [already proved to be wrong](https://github.com/typescript-eslint/typescript-eslint/issues/6897))_
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Add missing `!( ... )` around comparison cases in example for the [`allowComparingNullableBooleansToFalse` option](https://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare#allowcomparingnullablebooleanstofalse) of the [no-unnecessary-boolean-literal-compare docs](https://typescript-eslint.io/rules/no-unnecessary-boolean-literal-compare).
