### PR TITLE
Add type-aware rules to disable-type-checked.ts

### DIFF
--- a/packages/eslint-plugin/src/configs/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/disable-type-checked.ts
@@ -12,7 +12,9 @@ export = {
   rules: {
     '@typescript-eslint/await-thenable': 'off',
     '@typescript-eslint/consistent-return': 'off',
+    '@typescript-eslint/consistent-type-assertions': 'off',
     '@typescript-eslint/consistent-type-exports': 'off',
+    '@typescript-eslint/consistent-type-imports': 'off',
     '@typescript-eslint/dot-notation': 'off',
     '@typescript-eslint/naming-convention': 'off',
     '@typescript-eslint/no-array-delete': 'off',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

In the scope of #7669 and #8335, the (respective) rules `consistent-type-assertions` and `consistent-type-imports` were updated in such a way they now use the `getParserServices` util and thus are type-aware. This means when combining them with other file types to lint (in my personal case `.graphql` files), an error is raised `Error: Error while loading rule '@typescript-eslint/consistent-type-assertions': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.`.

This even persists after using the [docs suggestion](https://typescript-eslint.io/troubleshooting/#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file) to use the "disable-type-checked" ruleset, given that these rules are not part of that.

To ensure the docs suggestion works, this PR adds them to this ruleset.

### Implementation notes
 
- Additionally, it would be probably be right to move these from "stylistic" to "stylistic-typechecked", but I'm not sure if such a change is warranted/wanted or not, and if so at what point (e.g. immediate or as some breaking change on a major release).
- I've not checked for further rules that may be incorrectly missing from the "disable-type-checked" configuration; maybe there should be some adequate way to test for this?