### PR TITLE
chore: update eslint peer dependency to "^8.56.0 || ^9.0.0"

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -103,7 +103,7 @@
   },
   "peerDependencies": {
     "@typescript-eslint/parser": "^7.0.0",
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -49,7 +49,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "dependencies": {
     "@typescript-eslint/scope-manager": "7.7.1",

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "@eslint/eslintrc": ">=2",
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "devDependencies": {
     "@types/lodash.merge": "4.6.9",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -61,7 +61,7 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -52,7 +52,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "7.7.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -76,7 +76,7 @@
     "semver": "^7.6.0"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "7.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5591,7 +5591,7 @@ __metadata:
     unist-util-visit: ^5.0.0
   peerDependencies:
     "@typescript-eslint/parser": ^7.0.0
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
@@ -5626,7 +5626,7 @@ __metadata:
     rimraf: "*"
     typescript: "*"
   peerDependencies:
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
@@ -5677,7 +5677,7 @@ __metadata:
     typescript: "*"
   peerDependencies:
     "@eslint/eslintrc": ">=2"
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -5733,7 +5733,7 @@ __metadata:
     ts-api-utils: ^1.3.0
     typescript: "*"
   peerDependencies:
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
@@ -5923,7 +5923,7 @@ __metadata:
     semver: ^7.6.0
     typescript: "*"
   peerDependencies:
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -19285,7 +19285,7 @@ __metadata:
     rimraf: "*"
     typescript: "*"
   peerDependencies:
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: https://github.com/typescript-eslint/typescript-eslint/issues/8211
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Since eslint v9 is a major version, I added it to peerDependencies to avoid a warning message when installing `eslint` and `typescript-eslint`.

**yarn classic**:
```bash
$ yarn add -D typescript-eslint
yarn add v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > @typescript-eslint/eslint-plugin@7.7.1" has incorrect peer dependency "eslint@^8.56.0".
warning "@typescript-eslint/eslint-plugin > @typescript-eslint/type-utils@7.7.1" has incorrect peer dependency "eslint@^
8.56.0".
warning "@typescript-eslint/eslint-plugin > @typescript-eslint/utils@7.7.1" has incorrect peer dependency "eslint@^8.56.
0".
warning " > @typescript-eslint/parser@7.7.1" has incorrect peer dependency "eslint@^8.56.0".
[4/4] Building fresh packages...
```

**yarn berry**:
```bash
$ yarn add -D typescript-eslint
➤ YN0000: · Yarn 4.1.1
➤ YN0000: ┌ Resolution step
➤ YN0085: │ + typescript-eslint@npm:7.7.1, @types/json-schema@npm:7.0.15, @types/semver@npm:7.5.8, and 24 more.
➤ YN0000: └ Completed in 4s 119ms
➤ YN0000: ┌ Post-resolution validation
➤ YN0060: │ eslint is listed by your project with version 9.1.1, which doesn't satisfy what typescript-eslint (p47665) a
nd other dependencies request (^8.56.0).
➤ YN0086: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <ha
sh> is the six-letter p-prefixed code.
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0013: │ 27 packages were added to the project (+ 6.78 MiB).
➤ YN0000: └ Completed in 0s 916ms
➤ YN0000: ┌ Link step
➤ YN0000: │ ESM support for PnP uses the experimental loader API and is therefore experimental
➤ YN0000: └ Completed in 0s 272ms
➤ YN0000: · Done with warnings in 5s 356ms
```


<!-- Description of what is changed and how the code change does that. -->
