### PR TITLE
feat(utils): allow specifying additional rule meta.docs in RuleCreator

### DIFF
--- a/docs/developers/Custom_Rules.mdx
+++ b/docs/developers/Custom_Rules.mdx
@@ -99,6 +99,32 @@ export const rule = createRule<Options, MessageIds>({
 });
 ```
 
+#### Extra Rule Docs Types
+
+By default, rule `meta.docs` is allowed to contain only `description` and `url` as described in [ESLint's Custom Rules > Rule Structure docs](https://eslint.org/docs/latest/extend/custom-rules#rule-structure).
+Additional docs properties may be added as a type argument to `ESLintUtils.RuleCreator`:
+
+```ts
+interface MyPluginDocs {
+  recommended: boolean;
+}
+
+const createRule = ESLintUtils.RuleCreator<MyPluginDocs>(
+  name => `https://example.com/rule/${name}`,
+);
+
+createRule({
+  // ...
+  meta: {
+    docs: {
+      description: '...',
+      recommended: true,
+    },
+    // ...
+  },
+});
+```
+
 ### Undocumented Rules
 
 Although it is generally not recommended to create custom rules without documentation, if you are sure you want to do this you can use the `ESLintUtils.RuleCreator.withoutDocs` function to directly create a rule.

--- a/packages/eslint-plugin-internal/src/rules/no-poorly-typed-ts-props.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-poorly-typed-ts-props.ts
@@ -31,7 +31,6 @@ export default createRule({
     docs: {
       description:
         "Enforce that rules don't use TS API properties with known bad type definitions",
-      recommended: 'recommended',
       requiresTypeChecking: true,
     },
     fixable: 'code',

--- a/packages/eslint-plugin-internal/src/rules/no-relative-paths-to-internal-packages.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-relative-paths-to-internal-packages.ts
@@ -10,7 +10,6 @@ export default createRule({
   meta: {
     type: 'problem',
     docs: {
-      recommended: 'recommended',
       description: 'Disallow relative paths to internal packages',
     },
     messages: {

--- a/packages/eslint-plugin-internal/src/rules/no-typescript-default-import.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-typescript-default-import.ts
@@ -21,7 +21,6 @@ export default createRule({
     docs: {
       description:
         "Enforce that packages rules don't do `import ts from 'typescript';`",
-      recommended: 'recommended',
     },
     fixable: 'code',
     schema: [],

--- a/packages/eslint-plugin-internal/src/rules/no-typescript-estree-import.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-typescript-estree-import.ts
@@ -16,7 +16,6 @@ export default createRule({
     type: 'problem',
     docs: {
       description: `Enforce that eslint-plugin rules don't require anything from ${TSESTREE_NAME} or ${TYPES_NAME}`,
-      recommended: 'recommended',
     },
     fixable: 'code',
     schema: [],

--- a/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
+++ b/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
@@ -109,7 +109,6 @@ export default createRule<Options, MessageIds>({
     type: 'problem',
     docs: {
       description: `Enforce that eslint-plugin test snippets are correctly formatted`,
-      recommended: 'recommended',
       requiresTypeChecking: true,
     },
     fixable: 'code',

--- a/packages/eslint-plugin-internal/src/rules/prefer-ast-types-enum.ts
+++ b/packages/eslint-plugin-internal/src/rules/prefer-ast-types-enum.ts
@@ -13,7 +13,6 @@ export default createRule({
   meta: {
     type: 'problem',
     docs: {
-      recommended: 'recommended',
       description:
         'Enforce consistent usage of `AST_NODE_TYPES`, `AST_TOKEN_TYPES` and `DefinitionType` enums',
     },

--- a/packages/eslint-plugin-internal/src/util/createRule.ts
+++ b/packages/eslint-plugin-internal/src/util/createRule.ts
@@ -4,7 +4,11 @@ import { ESLintUtils } from '@typescript-eslint/utils';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const { version }: { version: string } = require('../../package.json');
 
-const createRule = ESLintUtils.RuleCreator(
+export interface ESLintPluginInternalDocs {
+  requiresTypeChecking?: true;
+}
+
+const createRule = ESLintUtils.RuleCreator<ESLintPluginInternalDocs>(
   name =>
     `https://github.com/typescript-eslint/typescript-eslint/blob/v${version}/packages/eslint-plugin-internal/src/rules/${name}.ts`,
 );

--- a/packages/eslint-plugin/rules.d.ts
+++ b/packages/eslint-plugin/rules.d.ts
@@ -35,11 +35,15 @@ This is likely not portable. A type annotation is necessary. ts(2742)
 ```
 */
 
-import type { RuleModule } from '@typescript-eslint/utils/ts-eslint';
+import type { RuleModuleWithMetaDocs } from '@typescript-eslint/utils/ts-eslint';
+
+import type { ESLintPluginDocs, ESLintPluginRuleModule } from './src/util';
+
+export { ESLintPluginDocs, ESLintPluginRuleModule };
 
 export type TypeScriptESLintRules = Record<
   string,
-  RuleModule<string, unknown[]>
+  RuleModuleWithMetaDocs<string, unknown[], ESLintPluginDocs>
 >;
 declare const rules: TypeScriptESLintRules;
 // eslint-disable-next-line import/no-default-export

--- a/packages/eslint-plugin/src/util/createRule.ts
+++ b/packages/eslint-plugin/src/util/createRule.ts
@@ -1,5 +1,37 @@
 import { ESLintUtils } from '@typescript-eslint/utils';
+import type {
+  RuleModuleWithMetaDocs,
+  RuleRecommendation,
+  RuleRecommendationAcrossConfigs,
+} from '@typescript-eslint/utils/ts-eslint';
 
-export const createRule = ESLintUtils.RuleCreator(
+export interface ESLintPluginDocs {
+  /**
+   * Does the rule extend (or is it based off of) an ESLint code rule?
+   * Alternately accepts the name of the base rule, in case the rule has been renamed.
+   * This is only used for documentation purposes.
+   */
+  extendsBaseRule?: boolean | string;
+
+  /**
+   * If a string config name, which starting config this rule is enabled in.
+   * If an object, which settings it has enabled in each of those configs.
+   */
+  recommended?: RuleRecommendation | RuleRecommendationAcrossConfigs<unknown[]>;
+
+  /**
+   * Does the rule require us to create a full TypeScript Program in order for it
+   * to type-check code. This is only used for documentation purposes.
+   */
+  requiresTypeChecking?: boolean;
+}
+
+export const createRule = ESLintUtils.RuleCreator<ESLintPluginDocs>(
   name => `https://typescript-eslint.io/rules/${name}`,
 );
+
+export type ESLintPluginRuleModule = RuleModuleWithMetaDocs<
+  string,
+  readonly unknown[],
+  ESLintPluginDocs
+>;

--- a/packages/eslint-plugin/src/util/getFunctionHeadLoc.ts
+++ b/packages/eslint-plugin/src/util/getFunctionHeadLoc.ts
@@ -153,8 +153,8 @@ export function getFunctionHeadLoc(
   sourceCode: TSESLint.SourceCode,
 ): TSESTree.SourceLocation {
   const parent = node.parent;
-  let start = null;
-  let end = null;
+  let start: TSESTree.Position | null = null;
+  let end: TSESTree.Position | null = null;
 
   if (
     parent.type === AST_NODE_TYPES.MethodDefinition ||

--- a/packages/eslint-plugin/tools/generate-breaking-changes.mts
+++ b/packages/eslint-plugin/tools/generate-breaking-changes.mts
@@ -1,12 +1,10 @@
-import type { TypeScriptESLintRules } from '@typescript-eslint/eslint-plugin/use-at-your-own-risk/rules';
-import type { RuleModule } from '@typescript-eslint/utils/ts-eslint';
+import type {
+  ESLintPluginRuleModule,
+  TypeScriptESLintRules,
+} from '@typescript-eslint/eslint-plugin/use-at-your-own-risk/rules';
 import { fetch } from 'cross-fetch';
 // markdown-table is ESM, hence this file needs to be `.mts`
 import { markdownTable } from 'markdown-table';
-
-type RuleModuleWithDocs = RuleModule<string, unknown[]> & {
-  meta: { docs: object };
-};
 
 async function main(): Promise<void> {
   const rulesImport = await import('../src/rules/index.js');
@@ -18,7 +16,7 @@ async function main(): Promise<void> {
   */
   const rules = rulesImport.default as unknown as Record<
     string,
-    RuleModuleWithDocs
+    ESLintPluginRuleModule
   >;
 
   // Annotate which rules are new since the last version

--- a/packages/eslint-plugin/typings/eslint-rules.d.ts
+++ b/packages/eslint-plugin/typings/eslint-rules.d.ts
@@ -50,6 +50,7 @@ declare module 'eslint/lib/rules/arrow-parens' {
         requireForBlockBody?: boolean;
       }?,
     ],
+    unknown,
     {
       ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression): void;
     }
@@ -67,6 +68,7 @@ declare module 'eslint/lib/rules/consistent-return' {
         treatUndefinedAsUnspecified?: boolean;
       }?,
     ],
+    unknown,
     {
       ReturnStatement(node: TSESTree.ReturnStatement): void;
       'FunctionDeclaration:exit'(node: TSESTree.FunctionDeclaration): void;
@@ -92,6 +94,7 @@ declare module 'eslint/lib/rules/camelcase' {
         genericType?: 'always' | 'never';
       },
     ],
+    unknown,
     {
       Identifier(node: TSESTree.Identifier): void;
     }
@@ -107,6 +110,7 @@ declare module 'eslint/lib/rules/max-params' {
       | { max: number; countVoidThis?: boolean }
       | { maximum: number; countVoidThis?: boolean }
     )[],
+    unknown,
     {
       FunctionDeclaration(node: TSESTree.FunctionDeclaration): void;
       FunctionExpression(node: TSESTree.FunctionExpression): void;
@@ -122,6 +126,7 @@ declare module 'eslint/lib/rules/no-dupe-class-members' {
   const rule: TSESLint.RuleModule<
     'unexpected',
     [],
+    unknown,
     {
       Program(): void;
       ClassBody(): void;
@@ -140,6 +145,7 @@ declare module 'eslint/lib/rules/no-dupe-args' {
   const rule: TSESLint.RuleModule<
     'unexpected',
     [],
+    unknown,
     {
       FunctionDeclaration(node: TSESTree.FunctionDeclaration): void;
       FunctionExpression(node: TSESTree.FunctionExpression): void;
@@ -158,6 +164,7 @@ declare module 'eslint/lib/rules/no-empty-function' {
         allow?: string[];
       },
     ],
+    unknown,
     {
       FunctionDeclaration(node: TSESTree.FunctionDeclaration): void;
       FunctionExpression(node: TSESTree.FunctionExpression): void;
@@ -176,6 +183,7 @@ declare module 'eslint/lib/rules/no-implicit-globals' {
     | 'globalVariableLeak'
     | 'redeclarationOfReadonlyGlobal',
     [],
+    unknown,
     {
       Program(node: TSESTree.Program): void;
     }
@@ -189,6 +197,7 @@ declare module 'eslint/lib/rules/no-loop-func' {
   const rule: TSESLint.RuleModule<
     'unsafeRefs',
     [],
+    unknown,
     {
       ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression): void;
       FunctionExpression(node: TSESTree.FunctionExpression): void;
@@ -215,6 +224,7 @@ declare module 'eslint/lib/rules/no-magic-numbers' {
         ignoreTypeIndexes?: boolean;
       },
     ],
+    unknown,
     {
       Literal(node: TSESTree.Literal): void;
     }
@@ -232,6 +242,7 @@ declare module 'eslint/lib/rules/no-redeclare' {
         builtinGlobals?: boolean;
       }?,
     ],
+    unknown,
     {
       ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression): void;
     }
@@ -251,6 +262,7 @@ declare module 'eslint/lib/rules/no-restricted-globals' {
           message?: string;
         }
     )[],
+    unknown,
     {
       ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression): void;
     }
@@ -271,6 +283,7 @@ declare module 'eslint/lib/rules/no-shadow' {
         ignoreOnInitialization?: boolean;
       },
     ],
+    unknown,
     {
       ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression): void;
     }
@@ -288,6 +301,7 @@ declare module 'eslint/lib/rules/no-undef' {
         typeof?: boolean;
       },
     ],
+    unknown,
     {
       ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression): void;
     }
@@ -314,6 +328,7 @@ declare module 'eslint/lib/rules/no-unused-vars' {
           destructuredArrayIgnorePattern?: string;
         },
     ],
+    unknown,
     {
       ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression): void;
     }
@@ -333,6 +348,7 @@ declare module 'eslint/lib/rules/no-unused-expressions' {
         allowTaggedTemplates?: boolean;
       },
     ],
+    unknown,
     {
       ExpressionStatement(node: TSESTree.ExpressionStatement): void;
     }
@@ -353,6 +369,7 @@ declare module 'eslint/lib/rules/no-use-before-define' {
           variables?: boolean;
         }
     )[],
+    unknown,
     {
       ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression): void;
     }
@@ -375,6 +392,7 @@ declare module 'eslint/lib/rules/strict' {
     | 'unnecessaryInClasses'
     | 'wrap',
     ['function' | 'global' | 'never' | 'safe'],
+    unknown,
     {
       ArrowFunctionExpression(node: TSESTree.ArrowFunctionExpression): void;
     }
@@ -388,6 +406,7 @@ declare module 'eslint/lib/rules/no-useless-constructor' {
   const rule: TSESLint.RuleModule<
     'noUselessConstructor',
     [],
+    unknown,
     {
       MethodDefinition(node: TSESTree.MethodDefinition): void;
     }
@@ -406,6 +425,7 @@ declare module 'eslint/lib/rules/init-declarations' {
         ignoreForLoopInit?: boolean;
       }?,
     ],
+    unknown,
     {
       'VariableDeclaration:exit'(node: TSESTree.VariableDeclaration): void;
     }
@@ -423,6 +443,7 @@ declare module 'eslint/lib/rules/no-invalid-this' {
         capIsConstructor?: boolean;
       }?,
     ],
+    unknown,
     {
       // Common
       ThisExpression(node: TSESTree.ThisExpression): void;
@@ -444,6 +465,7 @@ declare module 'eslint/lib/rules/dot-notation' {
         allowIndexSignaturePropertyAccess?: boolean;
       },
     ],
+    unknown,
     {
       MemberExpression(node: TSESTree.MemberExpression): void;
     }
@@ -457,6 +479,7 @@ declare module 'eslint/lib/rules/no-loss-of-precision' {
   const rule: TSESLint.RuleModule<
     'noLossOfPrecision',
     [],
+    unknown,
     {
       Literal(node: TSESTree.Literal): void;
     }
@@ -475,6 +498,7 @@ declare module 'eslint/lib/rules/prefer-const' {
         ignoreReadBeforeAssign?: boolean;
       },
     ],
+    unknown,
     {
       'Program:exit'(node: TSESTree.Program): void;
       VariableDeclaration(node: TSESTree.VariableDeclaration): void;
@@ -502,6 +526,7 @@ declare module 'eslint/lib/rules/prefer-destructuring' {
   const rule: TSESLint.RuleModule<
     'preferDestructuring',
     [Option0, Option1?],
+    unknown,
     {
       VariableDeclarator(node: TSESTree.VariableDeclarator): void;
       AssignmentExpression(node: TSESTree.AssignmentExpression): void;
@@ -556,6 +581,7 @@ declare module 'eslint/lib/rules/no-restricted-imports' {
     | 'patterns'
     | 'patternWithCustomMessage',
     rule.ArrayOfStringOrObject | [ObjectOfPathsAndPatterns],
+    unknown,
     rule.RuleListener
   >;
   export = rule;

--- a/packages/repo-tools/src/generate-configs.mts
+++ b/packages/repo-tools/src/generate-configs.mts
@@ -2,11 +2,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import eslintPlugin from '@typescript-eslint/eslint-plugin';
+import type { ESLintPluginRuleModule } from '@typescript-eslint/eslint-plugin/use-at-your-own-risk/rules';
 import type {
   ClassicConfig,
   FlatConfig,
   Linter,
-  RuleModule,
   RuleRecommendation,
 } from '@typescript-eslint/utils/ts-eslint';
 import prettier from 'prettier';
@@ -78,26 +78,26 @@ async function main(): Promise<void> {
   );
   const BASE_RULES_TO_BE_OVERRIDDEN = new Map(
     Object.entries(eslintPlugin.rules)
-      .filter(([, rule]) => rule.meta.docs?.extendsBaseRule)
+      .filter(([, rule]) => rule.meta.docs.extendsBaseRule)
       .map(
         ([ruleName, rule]) =>
           [
             ruleName,
-            typeof rule.meta.docs?.extendsBaseRule === 'string'
+            typeof rule.meta.docs.extendsBaseRule === 'string'
               ? rule.meta.docs.extendsBaseRule
               : ruleName,
           ] as const,
       ),
   );
 
-  type RuleEntry = [string, RuleModule<string, readonly unknown[]>];
+  type RuleEntry = [string, ESLintPluginRuleModule];
 
   const allRuleEntries: RuleEntry[] = Object.entries(eslintPlugin.rules).sort(
     (a, b) => a[0].localeCompare(b[0]),
   );
 
   type GetRuleOptions = (
-    rule: RuleModule<string, readonly unknown[]>,
+    rule: ESLintPluginRuleModule,
   ) => true | readonly unknown[] | undefined;
 
   interface ConfigRuleSettings {
@@ -123,14 +123,14 @@ async function main(): Promise<void> {
     // Explicitly exclude rules requiring type-checking
     if (
       settings.typeChecked === 'exclude' &&
-      value.meta.docs?.requiresTypeChecking === true
+      value.meta.docs.requiresTypeChecking === true
     ) {
       return config;
     }
 
     if (
       settings.typeChecked === 'include-only' &&
-      value.meta.docs?.requiresTypeChecking !== true
+      value.meta.docs.requiresTypeChecking !== true
     ) {
       return config;
     }
@@ -288,11 +288,11 @@ async function main(): Promise<void> {
     ...recommendations: (RuleRecommendation | undefined)[]
   ): RuleEntry[] {
     return allRuleEntries.filter(([, rule]) =>
-      typeof rule.meta.docs?.recommended === 'object'
+      typeof rule.meta.docs.recommended === 'object'
         ? Object.keys(rule.meta.docs.recommended).some(level =>
             recommendations.includes(level as RuleRecommendation),
           )
-        : recommendations.includes(rule.meta.docs?.recommended),
+        : recommendations.includes(rule.meta.docs.recommended),
     );
   }
 
@@ -300,7 +300,7 @@ async function main(): Promise<void> {
     level: 'recommended' | 'strict',
   ): GetRuleOptions {
     return rule =>
-      typeof rule.meta.docs?.recommended === 'object'
+      typeof rule.meta.docs.recommended === 'object'
         ? rule.meta.docs.recommended[level]
         : undefined;
   }

--- a/packages/typescript-eslint/tests/configs.test.ts
+++ b/packages/typescript-eslint/tests/configs.test.ts
@@ -55,14 +55,14 @@ function filterAndMapRuleConfigs({
   if (typeChecked) {
     result = result.filter(([, rule]) =>
       typeChecked === 'exclude'
-        ? !rule.meta.docs?.requiresTypeChecking
-        : rule.meta.docs?.requiresTypeChecking,
+        ? !rule.meta.docs.requiresTypeChecking
+        : rule.meta.docs.requiresTypeChecking,
     );
   }
 
   if (recommendations) {
     result = result.filter(([, rule]) => {
-      switch (typeof rule.meta.docs?.recommended) {
+      switch (typeof rule.meta.docs.recommended) {
         case 'undefined':
           return false;
         case 'object':
@@ -80,7 +80,7 @@ function filterAndMapRuleConfigs({
   return result.map(([name, rule]) => {
     const customRecommendation =
       highestRecommendation &&
-      typeof rule.meta.docs?.recommended === 'object' &&
+      typeof rule.meta.docs.recommended === 'object' &&
       rule.meta.docs.recommended[
         highestRecommendation as 'recommended' | 'strict'
       ];
@@ -135,7 +135,7 @@ describe('disable-type-checked.ts', () => {
     const configRules = filterRules(unfilteredConfigRules);
 
     const ruleConfigs: [string, string][] = Object.entries(rules)
-      .filter(([, rule]) => rule.meta.docs?.requiresTypeChecking)
+      .filter(([, rule]) => rule.meta.docs.requiresTypeChecking)
       .map(([name]) => [`${RULE_NAME_PREFIX}${name}`, 'off']);
 
     expect(entriesToObject(ruleConfigs)).toEqual(entriesToObject(configRules));

--- a/packages/typescript-eslint/tests/configs.test.ts
+++ b/packages/typescript-eslint/tests/configs.test.ts
@@ -8,12 +8,12 @@ import plugin from '../src/index';
 
 const RULE_NAME_PREFIX = '@typescript-eslint/';
 const EXTENSION_RULES = Object.entries(rules)
-  .filter(([, rule]) => rule.meta.docs?.extendsBaseRule)
+  .filter(([, rule]) => rule.meta.docs.extendsBaseRule)
   .map(
     ([ruleName, rule]) =>
       [
         `${RULE_NAME_PREFIX}${ruleName}`,
-        typeof rule.meta.docs?.extendsBaseRule === 'string'
+        typeof rule.meta.docs.extendsBaseRule === 'string'
           ? rule.meta.docs.extendsBaseRule
           : ruleName,
       ] as const,

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -15,46 +15,27 @@ export interface RuleRecommendationAcrossConfigs<
   strict: Partial<Options>;
 }
 
-export interface RuleMetaDataDocs<Options extends readonly unknown[]> {
+export interface RuleMetaDataDocs {
   /**
-   * Concise description of the rule
+   * Concise description of the rule.
    */
   description: string;
+
   /**
-   * The recommendation level for the rule.
-   * Used by the build tools to generate the recommended and strict configs.
-   * Exclude to not include it as a recommendation.
-   */
-  recommended?: RuleRecommendation | RuleRecommendationAcrossConfigs<Options>;
-  /**
-   * The URL of the rule's docs
+   * The URL of the rule's docs.
    */
   url?: string;
-  /**
-   * Does the rule require us to create a full TypeScript Program in order for it
-   * to type-check code. This is only used for documentation purposes.
-   */
-  requiresTypeChecking?: boolean;
-  /**
-   * Does the rule extend (or is it based off of) an ESLint code rule?
-   * Alternately accepts the name of the base rule, in case the rule has been renamed.
-   * This is only used for documentation purposes.
-   */
-  extendsBaseRule?: boolean | string;
 }
 
-export interface RuleMetaData<
-  MessageIds extends string,
-  Options extends readonly unknown[],
-> {
+export interface RuleMetaData<MessageIds extends string, PluginDocs = unknown> {
   /**
    * True if the rule is deprecated, false otherwise
    */
   deprecated?: boolean;
   /**
-   * Documentation for the rule, unnecessary for custom rules/plugins
+   * Documentation for the rule
    */
-  docs?: RuleMetaDataDocs<Options>;
+  docs?: PluginDocs & RuleMetaDataDocs;
   /**
    * The fixer category. Omit if there is no fixer
    */
@@ -73,8 +54,9 @@ export interface RuleMetaData<
    * The type of rule.
    * - `"problem"` means the rule is identifying code that either will cause an error or may cause a confusing behavior. Developers should consider this a high priority to resolve.
    * - `"suggestion"` means the rule is identifying something that could be done in a better way but no errors will occur if the code isn’t changed.
+   * - `"layout"` means the rule cares primarily about whitespace, semicolons, commas, and parentheses, all the parts of the program that determine how the code looks rather than how it executes. These rules work on parts of the code that aren’t specified in the AST.
    */
-  type: 'problem' | 'suggestion';
+  type: 'problem' | 'suggestion' | 'layout';
   /**
    * The name of the rule this rule was replaced by, if it was deprecated.
    */
@@ -83,6 +65,16 @@ export interface RuleMetaData<
    * The options schema. Supply an empty array if there are no options.
    */
   schema: JSONSchema4 | readonly JSONSchema4[];
+}
+
+export interface RuleMetaDataWithDocs<
+  MessageIds extends string,
+  PluginDocs = unknown,
+> extends RuleMetaData<MessageIds, PluginDocs> {
+  /**
+   * Documentation for the rule
+   */
+  docs: PluginDocs & RuleMetaDataDocs;
 }
 
 export interface RuleFix {
@@ -628,6 +620,7 @@ export type RuleListener = RuleListenerBaseSelectors &
 export interface RuleModule<
   MessageIds extends string,
   Options extends readonly unknown[] = [],
+  Docs = unknown,
   // for extending base rules
   ExtendedRuleListener extends RuleListener = RuleListener,
 > {
@@ -639,7 +632,7 @@ export interface RuleModule<
   /**
    * Metadata about the rule
    */
-  meta: RuleMetaData<MessageIds, Options>;
+  meta: RuleMetaData<MessageIds, Docs>;
 
   /**
    * Function which returns an object with methods that ESLint calls to “visit”
@@ -649,7 +642,26 @@ export interface RuleModule<
     context: Readonly<RuleContext<MessageIds, Options>>,
   ): ExtendedRuleListener;
 }
+
 export type AnyRuleModule = RuleModule<string, readonly unknown[]>;
+
+export interface RuleModuleWithMetaDocs<
+  MessageIds extends string,
+  Options extends readonly unknown[] = [],
+  Docs = unknown,
+  // for extending base rules
+  ExtendedRuleListener extends RuleListener = RuleListener,
+> extends RuleModule<MessageIds, Options, Docs, ExtendedRuleListener> {
+  /**
+   * Metadata about the rule
+   */
+  meta: RuleMetaDataWithDocs<MessageIds, Docs>;
+}
+
+export type AnyRuleModuleWithMetaDocs = RuleModuleWithMetaDocs<
+  string,
+  unknown[]
+>;
 
 /**
  * A loose definition of the RuleModule type for use with configs. This type is

--- a/packages/utils/src/ts-eslint/eslint/ESLintShared.ts
+++ b/packages/utils/src/ts-eslint/eslint/ESLintShared.ts
@@ -27,7 +27,7 @@ export declare class ESLintBase<
 
   getRulesMetaForResults(
     results: LintResult[],
-  ): Record<string, RuleMetaData<string, readonly unknown[]>>;
+  ): Record<string, RuleMetaData<string, Record<string, unknown>>>;
 
   /**
    * This method checks if a given file is ignored by your configuration.

--- a/packages/utils/tests/eslint-utils/RuleCreator.test.ts
+++ b/packages/utils/tests/eslint-utils/RuleCreator.test.ts
@@ -1,7 +1,11 @@
 import { ESLintUtils } from '../../src';
 
 describe('RuleCreator', () => {
-  const createRule = ESLintUtils.RuleCreator(name => `test/${name}`);
+  interface TestDocs {
+    recommended?: 'yes';
+  }
+
+  const createRule = ESLintUtils.RuleCreator<TestDocs>(name => `test/${name}`);
 
   it('createRule should be a function', () => {
     expect(typeof createRule).toBe('function');
@@ -13,8 +17,7 @@ describe('RuleCreator', () => {
       meta: {
         docs: {
           description: 'some description',
-          recommended: 'recommended',
-          requiresTypeChecking: true,
+          recommended: 'yes',
         },
         messages: {
           foo: 'some message',

--- a/packages/utils/tests/eslint-utils/RuleCreator.test.ts
+++ b/packages/utils/tests/eslint-utils/RuleCreator.test.ts
@@ -34,8 +34,7 @@ describe('RuleCreator', () => {
       docs: {
         description: 'some description',
         url: 'test/test',
-        recommended: 'recommended',
-        requiresTypeChecking: true,
+        recommended: 'yes',
       },
       messages: {
         foo: 'some message',

--- a/packages/website/plugins/generated-rule-docs/RuleDocsPage.ts
+++ b/packages/website/plugins/generated-rule-docs/RuleDocsPage.ts
@@ -1,6 +1,7 @@
+import type { ESLintPluginRuleModule } from '@typescript-eslint/eslint-plugin/use-at-your-own-risk/rules';
 import type * as unist from 'unist';
 
-import type { RuleModuleWithMetaDocs, VFileWithStem } from './utils';
+import type { VFileWithStem } from './utils';
 import { findH2Index } from './utils';
 
 export interface RequiredHeadingIndices {
@@ -24,7 +25,7 @@ export class RuleDocsPage {
   #children: unist.Node[];
   #file: Readonly<VFileWithStem>;
   #headingIndices: RequiredHeadingIndices;
-  #rule: Readonly<RuleModuleWithMetaDocs>;
+  #rule: Readonly<ESLintPluginRuleModule>;
 
   get children(): Readonly<unist.Node[]> {
     return this.#children;
@@ -38,14 +39,14 @@ export class RuleDocsPage {
     return this.#headingIndices;
   }
 
-  get rule(): Readonly<RuleModuleWithMetaDocs> {
+  get rule(): Readonly<ESLintPluginRuleModule> {
     return this.#rule;
   }
 
   constructor(
     children: unist.Node[],
     file: Readonly<VFileWithStem>,
-    rule: Readonly<RuleModuleWithMetaDocs>,
+    rule: Readonly<ESLintPluginRuleModule>,
   ) {
     this.#children = children;
     this.#file = file;

--- a/packages/website/plugins/generated-rule-docs/createRuleDocsPage.ts
+++ b/packages/website/plugins/generated-rule-docs/createRuleDocsPage.ts
@@ -1,15 +1,16 @@
+import type { ESLintPluginRuleModule } from '@typescript-eslint/eslint-plugin/use-at-your-own-risk/rules';
 import type * as mdast from 'mdast';
 import type * as unist from 'unist';
 
 import type { HeadingName } from './RuleDocsPage';
 import { requiredHeadingNames, RuleDocsPage } from './RuleDocsPage';
-import type { RuleModuleWithMetaDocs, VFileWithStem } from './utils';
+import type { VFileWithStem } from './utils';
 import { findH2Index } from './utils';
 
 export function createRuleDocsPage(
   children: unist.Node[],
   file: Readonly<VFileWithStem>,
-  rule: Readonly<RuleModuleWithMetaDocs>,
+  rule: Readonly<ESLintPluginRuleModule>,
 ): RuleDocsPage {
   const headingIndices = requiredHeadingNames.map(headingName =>
     findH2Index(children, headingName),

--- a/packages/website/plugins/generated-rule-docs/index.ts
+++ b/packages/website/plugins/generated-rule-docs/index.ts
@@ -12,7 +12,7 @@ import { insertSpecialCaseOptions } from './insertions/insertSpecialCaseOptions'
 import { insertWhenNotToUseIt } from './insertions/insertWhenNotToUseIt';
 import { removeSourceCodeNotice } from './removeSourceCodeNotice';
 import {
-  isRuleModuleWithMetaDocs,
+  isAnyRuleModuleWithMetaDocs,
   isVFileWithStem,
   nodeIsParent,
 } from './utils';
@@ -24,7 +24,7 @@ export const generatedRuleDocs: Plugin = () => {
     }
 
     const rule = pluginRules[file.stem];
-    if (!isRuleModuleWithMetaDocs(rule)) {
+    if (!isAnyRuleModuleWithMetaDocs(rule)) {
       return;
     }
 

--- a/packages/website/plugins/generated-rule-docs/utils.ts
+++ b/packages/website/plugins/generated-rule-docs/utils.ts
@@ -1,6 +1,5 @@
 import type {
-  RuleMetaData,
-  RuleMetaDataDocs,
+  AnyRuleModuleWithMetaDocs,
   RuleModule,
 } from '@typescript-eslint/utils/ts-eslint';
 import * as fs from 'fs';
@@ -55,17 +54,9 @@ export function getUrlForRuleTest(ruleName: string): string {
   throw new Error(`Could not find test file for ${ruleName}.`);
 }
 
-export type RuleMetaDataWithDocs = RuleMetaData<string, readonly unknown[]> & {
-  docs: RuleMetaDataDocs<readonly unknown[]>;
-};
-
-export type RuleModuleWithMetaDocs = RuleModule<string, unknown[]> & {
-  meta: RuleMetaDataWithDocs;
-};
-
-export function isRuleModuleWithMetaDocs(
+export function isAnyRuleModuleWithMetaDocs(
   rule: RuleModule<string, unknown[]> | undefined,
-): rule is RuleModuleWithMetaDocs {
+): rule is AnyRuleModuleWithMetaDocs {
   return !!rule?.meta.docs;
 }
 

--- a/packages/website/src/components/RulesTable/index.tsx
+++ b/packages/website/src/components/RulesTable/index.tsx
@@ -34,7 +34,7 @@ function interpolateCode(
 function getActualRecommended({
   docs,
 }: RulesMeta[number]): RuleRecommendation | undefined {
-  const recommended = docs?.recommended;
+  const recommended = docs.recommended;
   return typeof recommended === 'object' ? 'recommended' : recommended;
 }
 
@@ -43,7 +43,7 @@ function RuleRow({
 }: {
   rule: RulesMeta[number];
 }): React.JSX.Element | null {
-  if (!rule.docs?.url) {
+  if (!rule.docs.url) {
     return null;
   }
   const { fixable, hasSuggestions, deprecated } = rule;
@@ -181,8 +181,8 @@ export default function RulesTable(): React.JSX.Element {
           match(filters.stylistic, actualRecommended === 'stylistic'),
           match(filters.fixable, !!r.fixable),
           match(filters.suggestions, !!r.hasSuggestions),
-          match(filters.typeInformation, !!r.docs?.requiresTypeChecking),
-          match(filters.extension, !!r.docs?.extendsBaseRule),
+          match(filters.typeInformation, !!r.docs.requiresTypeChecking),
+          match(filters.extension, !!r.docs.extendsBaseRule),
           match(filters.deprecated, !!r.deprecated),
         ].filter((o): o is boolean => o !== undefined);
         return opinions.every(o => o);

--- a/packages/website/src/theme/MDXComponents/RuleAttributes.tsx
+++ b/packages/website/src/theme/MDXComponents/RuleAttributes.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import Link from '@docusaurus/Link';
-import type { RuleMetaDataDocs } from '@site/../utils/dist/ts-eslint/Rule';
 import { useRulesMeta } from '@site/src/hooks/useRulesMeta';
+import type { ESLintPluginDocs } from '@typescript-eslint/eslint-plugin/use-at-your-own-risk/rules';
 import React from 'react';
 
 import {
@@ -25,16 +25,16 @@ type MakeRequired<Base, Key extends keyof Base> = Omit<Base, Key> & {
   [K in Key]-?: NonNullable<Base[Key]>;
 };
 
-type RecommendedRuleMetaDataDocs<Options extends readonly unknown[]> =
-  MakeRequired<RuleMetaDataDocs<Options>, 'recommended'>;
+type RecommendedRuleMetaDataDocs = MakeRequired<
+  ESLintPluginDocs,
+  'recommended'
+>;
 
 const isRecommendedDocs = (
-  docs: RuleMetaDataDocs<unknown[]>,
-): docs is RecommendedRuleMetaDataDocs<unknown[]> => !!docs.recommended;
+  docs: ESLintPluginDocs,
+): docs is RecommendedRuleMetaDataDocs => !!docs.recommended;
 
-const getRecommendation = (
-  docs: RecommendedRuleMetaDataDocs<unknown[]>,
-): string[] => {
+const getRecommendation = (docs: RecommendedRuleMetaDataDocs): string[] => {
   const recommended = docs.recommended;
   const recommendation =
     recommendations[


### PR DESCRIPTION
BREAKING CHANGE:

Changes the default allowed types on custom rule docs.

## PR Checklist

- [x] Addresses an existing open issue: fixes #8695
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds an optional `PluginDocs` type parameter to `RuleCreator` that allows adding additional properties to `meta.docs`. That allows us to move `extendsBaseRule`, `recommended`, and `requiresTypeChecking` into our own `ESLintPluginDocs` interface so that they're no longer exposed to consumers.

Adds new `RuleModuleWithMetaDocs` and `AnyRuleModuleWithMetaDocs` interfaces so that we can finally get rid of the `?.` after `meta.docs` in some of our internal tooling. And `RuleMetaDataDocs` no longer has an `Options` parameter, which simplifies some other types too.

Adds back in `"layout"` to `meta.type` as it actually is specified in https://eslint.org/docs/latest/extend/custom-rules.

💖 