### PR TITLE
docs: add docs for using rule tester with node:test

### DIFF
--- a/docs/packages/Rule_Tester.mdx
+++ b/docs/packages/Rule_Tester.mdx
@@ -233,6 +233,28 @@ RuleTester.itOnly = vitest.it.only;
 RuleTester.describe = vitest.describe;
 ```
 
+#### Node built-in test runner
+
+Consider setting up `RuleTester`'s static properties in a preloaded module using the [`--import`](https://nodejs.org/api/cli.html#--importmodule) or [`--require`](https://nodejs.org/api/cli.html#-r---require-module) flag:
+
+```ts
+// setup.js
+import * as test from 'node:test';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+RuleTester.afterAll = test.afterAll;
+
+RuleTester.it = test.it;
+RuleTester.itOnly = test.it.only;
+RuleTester.describe = test.describe;
+```
+
+Tests can then be [run from the command line](https://nodejs.org/api/test.html#running-tests-from-the-command-line) like so:
+
+```sh
+node --import setup.js --test
+```
+
 ## Options
 
 ### `RuleTester` constructor options

--- a/docs/packages/Rule_Tester.mdx
+++ b/docs/packages/Rule_Tester.mdx
@@ -243,10 +243,9 @@ import * as test from 'node:test';
 import { RuleTester } from '@typescript-eslint/rule-tester';
 
 RuleTester.afterAll = test.afterAll;
-
+RuleTester.describe = test.describe;
 RuleTester.it = test.it;
 RuleTester.itOnly = test.it.only;
-RuleTester.describe = test.describe;
 ```
 
 Tests can then be [run from the command line](https://nodejs.org/api/test.html#running-tests-from-the-command-line) like so:


### PR DESCRIPTION


<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8273
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Adds an example of RuleTester with the node:test runner, which uses Node's CLI flags to import the setup file (as there's no equivalent test runner specific flag). The test file will get imported for every test, but that should be fine since we just copy some variables.