### PR TITLE
chore: add breaking change pr check ci

### DIFF
--- a/.github/actions/breaking-pr-check/action.yml
+++ b/.github/actions/breaking-pr-check/action.yml
@@ -1,0 +1,6 @@
+name: Validate Breaking Change PR
+description: Validate breaking change PR title and description
+
+runs:
+  using: node20
+  main: index.js

--- a/.github/actions/breaking-pr-check/index.js
+++ b/.github/actions/breaking-pr-check/index.js
@@ -28,8 +28,10 @@ async function getPullRequest() {
 }
 
 function checkTitle(title) {
-  if (/!/.test(title)) {
-    raiseError(`Do not use exclamation mark ('!') in your PR Title.`);
+  if (/^[a-z]+(\([a-z]+\))?!: /.test(title)) {
+    raiseError(
+      `Do not use exclamation mark ('!') to indicate breaking change in the PR Title.`,
+    );
   }
 }
 
@@ -40,10 +42,14 @@ function checkDescription(body, labels) {
   const [firstLine, secondLine] = body.split(/\r?\n/);
 
   if (!firstLine || !/^BREAKING CHANGE:/.test(firstLine)) {
-    raiseError(`Breaking change PR body should start with "BREAKING CHANGE:"`);
+    raiseError(
+      `Breaking change PR body should start with "BREAKING CHANGE:". See https://typescript-eslint.io/maintenance/releases#2-merging-breaking-changes.`,
+    );
   }
   if (!secondLine) {
-    raiseError(`The description of breaking change is missing.`);
+    raiseError(
+      `The description of breaking change is missing. See https://typescript-eslint.io/maintenance/releases#2-merging-breaking-changes.`,
+    );
   }
 }
 

--- a/.github/actions/breaking-pr-check/index.js
+++ b/.github/actions/breaking-pr-check/index.js
@@ -1,0 +1,60 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+
+function raiseError(message) {
+  throw new Error(message);
+}
+
+async function getPullRequest() {
+  const client = github.getOctokit(process.env.GITHUB_TOKEN);
+
+  const pr = github.context.payload.pull_request;
+  if (!pr) {
+    throw new Error(
+      "This action can only be invoked in `pull_request_target` or `pull_request` events. Otherwise the pull request can't be inferred.",
+    );
+  }
+
+  const owner = pr.base.user.login;
+  const repo = pr.base.repo.name;
+
+  const { data } = await client.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pr.number,
+  });
+
+  return data;
+}
+
+function checkTitle(title) {
+  if (/!/.test(title)) {
+    raiseError(`Do not use exclamation mark ('!') in your PR Title.`);
+  }
+}
+
+function checkDescription(body, labels) {
+  if (!labels.some(label => label.name === 'breaking change')) {
+    return;
+  }
+  const [firstLine, secondLine] = body.split(/\r?\n/);
+
+  if (!firstLine || !/^BREAKING CHANGE:/.test(firstLine)) {
+    raiseError(`Breaking change PR body should start with "BREAKING CHANGE:"`);
+  }
+  if (!secondLine) {
+    raiseError(`The description of breaking change is missing.`);
+  }
+}
+
+async function run() {
+  const pullRequest = await getPullRequest();
+  try {
+    checkTitle(pullRequest.title);
+    checkDescription(pullRequest.body, pullRequest.labels);
+  } catch (e) {
+    core.setFailed(e.message);
+  }
+}
+
+run();

--- a/.github/actions/breaking-pr-check/index.js
+++ b/.github/actions/breaking-pr-check/index.js
@@ -28,7 +28,7 @@ async function getPullRequest() {
 }
 
 function checkTitle(title) {
-  if (/^[a-z]+(\([a-z]+\))?!: /.test(title)) {
+  if (/^[a-z]+(\([a-z-]+\))?!: /.test(title)) {
     raiseError(
       `Do not use exclamation mark ('!') to indicate breaking change in the PR Title.`,
     );

--- a/.github/workflows/semantic-breaking-change-pr.yml
+++ b/.github/workflows/semantic-breaking-change-pr.yml
@@ -1,0 +1,21 @@
+name: Semantic Breaking Change PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  main:
+    name: Validate Breaking Change PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare-install
+      - uses: ./.github/actions/breaking-pr-check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9027, fixes #5884
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
Add CI that checks breaking change pr title and body.
- Disallows the use of exclamation mark(`!`) in PR title.
- Enforces to write “BREAKING CHANGE:” at the beginning of the PR body if the pr has breaking change label.
<!-- Description of what is changed and how the code change does that. -->
