### PR TITLE
fix(typescript-estree): pass extraFileExtensions to projectService

### DIFF
--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -124,6 +124,11 @@ export interface ProjectServiceOptions {
    * @default 8
    */
   maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING?: number;
+
+  /**
+   * Additional file extensions which should be considered in the TypeScript Program compilation.
+   */
+  extraFileExtensions?: string[];
 }
 
 interface ParseAndGenerateServicesOptions extends ParseOptions {

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -124,11 +124,6 @@ export interface ProjectServiceOptions {
    * @default 8
    */
   maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING?: number;
-
-  /**
-   * Additional file extensions which should be considered in the TypeScript Program compilation.
-   */
-  extraFileExtensions?: string[];
 }
 
 interface ParseAndGenerateServicesOptions extends ParseOptions {

--- a/packages/typescript-estree/src/useProgramFromProjectService.ts
+++ b/packages/typescript-estree/src/useProgramFromProjectService.ts
@@ -1,6 +1,7 @@
 import debug from 'debug';
 import { minimatch } from 'minimatch';
 import path from 'path';
+import { ScriptKind } from 'typescript';
 
 import { createProjectProgram } from './create-program/createProjectProgram';
 import type { ProjectServiceSettings } from './create-program/createProjectService';
@@ -30,6 +31,16 @@ export function useProgramFromProjectService(
     parseSettings.filePath,
     filePathAbsolute,
   );
+
+  if (parseSettings.extraFileExtensions.length) {
+    service.setHostConfiguration({
+      extraFileExtensions: parseSettings.extraFileExtensions.map(extension => ({
+        extension,
+        isMixedContent: false,
+        scriptKind: ScriptKind.Deferred,
+      })),
+    });
+  }
 
   const opened = service.openClientFile(
     filePathAbsolute,

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -352,7 +352,6 @@ describe('parseAndGenerateServices', () => {
         range: true,
         loc: true,
         tsconfigRootDir: PROJECT_DIR,
-        project: './tsconfig.json',
       };
       const testParse =
         (filePath: string, extraFileExtensions: string[] = ['.vue']) =>
@@ -362,12 +361,13 @@ describe('parseAndGenerateServices', () => {
               ...config,
               extraFileExtensions,
               filePath: join(PROJECT_DIR, filePath),
+              project: './tsconfig.json',
             });
           } catch (error) {
             alignErrorPath(error as Error);
           }
         };
-      const testParseExperimentalProjectService =
+      const testExtraFileExtensions =
         (filePath: string, extraFileExtensions: string[] = ['.vue']) =>
         (): void => {
           const result = parser.parseAndGenerateServices(code, {
@@ -499,14 +499,12 @@ describe('parseAndGenerateServices', () => {
       describe('"parserOptions.extraFileExtensions" is non-empty and EXPERIMENTAL_useProjectService is true', () => {
         describe('the extension matches', () => {
           it('the file is included', () => {
-            expect(
-              testParseExperimentalProjectService('other/included.vue'),
-            ).not.toThrow();
+            expect(testExtraFileExtensions('other/included.vue')).not.toThrow();
           });
 
           it("the file isn't included", () => {
             expect(
-              testParseExperimentalProjectService('other/notIncluded.vue'),
+              testExtraFileExtensions('other/notIncluded.vue'),
             ).toThrowErrorMatchingInlineSnapshot(
               `"No config file found, using inferred project"`,
             );
@@ -514,7 +512,7 @@ describe('parseAndGenerateServices', () => {
 
           it('duplicate extension', () => {
             expect(
-              testParseExperimentalProjectService('ts/notIncluded.ts', ['.ts']),
+              testExtraFileExtensions('ts/notIncluded.ts', ['.ts']),
             ).toThrowErrorMatchingInlineSnapshot(
               `"No config file found, using inferred project"`,
             );
@@ -523,10 +521,9 @@ describe('parseAndGenerateServices', () => {
 
         it('invalid extension', () => {
           expect(
-            testParseExperimentalProjectService(
-              'other/unknownFileType.unknown',
-              ['unknown'],
-            ),
+            testExtraFileExtensions('other/unknownFileType.unknown', [
+              'unknown',
+            ]),
           ).toThrowErrorMatchingInlineSnapshot(
             `"No config file found, using inferred project"`,
           );
@@ -534,9 +531,7 @@ describe('parseAndGenerateServices', () => {
 
         it('the extension does not match', () => {
           expect(
-            testParseExperimentalProjectService(
-              'other/unknownFileType.unknown',
-            ),
+            testExtraFileExtensions('other/unknownFileType.unknown'),
           ).toThrowErrorMatchingInlineSnapshot(
             `"No config file found, using inferred project"`,
           );
@@ -571,7 +566,7 @@ describe('parseAndGenerateServices', () => {
 
           expect(testParse('ts/notIncluded0j1.ts'))
             .toThrowErrorMatchingInlineSnapshot(`
-            "ESLint was configured to run on \`<tsconfigRootDir>/ts/notIncluded0j1.ts\` using \`parserOptions.project\`: 
+            "ESLint was configured to run on \`<tsconfigRootDir>/ts/notIncluded0j1.ts\` using \`parserOptions.project\`:
             - <tsconfigRootDir>/tsconfig.json
             - <tsconfigRootDir>/tsconfig.extra.json
             However, none of those TSConfigs include this file. Either:

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -374,8 +374,7 @@ describe('parseAndGenerateServices', () => {
             ...config,
             extraFileExtensions,
             filePath: join(PROJECT_DIR, filePath),
-            project: true,
-            EXPERIMENTAL_useProjectService: true,
+            projectService: true,
           });
           const compilerOptions = result.services.program?.getCompilerOptions();
 

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -495,7 +495,7 @@ describe('parseAndGenerateServices', () => {
         });
       });
 
-      describe('"parserOptions.extraFileExtensions" is non-empty and EXPERIMENTAL_useProjectService is true', () => {
+      describe('"parserOptions.extraFileExtensions" is non-empty and projectService is true', () => {
         describe('the extension matches', () => {
           it('the file is included', () => {
             expect(testExtraFileExtensions('other/included.vue')).not.toThrow();

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -368,7 +368,7 @@ describe('parseAndGenerateServices', () => {
           }
         };
       const testExtraFileExtensions =
-        (filePath: string, extraFileExtensions: string[] = ['.vue']) =>
+        (filePath: string, extraFileExtensions: string[]) =>
         (): void => {
           const result = parser.parseAndGenerateServices(code, {
             ...config,

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -368,8 +368,7 @@ describe('parseAndGenerateServices', () => {
           }
         };
       const testExtraFileExtensions =
-        (filePath: string, extraFileExtensions: string[]) =>
-        (): void => {
+        (filePath: string, extraFileExtensions: string[]) => (): void => {
           const result = parser.parseAndGenerateServices(code, {
             ...config,
             extraFileExtensions,
@@ -498,12 +497,14 @@ describe('parseAndGenerateServices', () => {
       describe('"parserOptions.extraFileExtensions" is non-empty and projectService is true', () => {
         describe('the extension matches', () => {
           it('the file is included', () => {
-            expect(testExtraFileExtensions('other/included.vue')).not.toThrow();
+            expect(
+              testExtraFileExtensions('other/included.vue', ['.vue']),
+            ).not.toThrow();
           });
 
           it("the file isn't included", () => {
             expect(
-              testExtraFileExtensions('other/notIncluded.vue'),
+              testExtraFileExtensions('other/notIncluded.vue', ['.vue']),
             ).toThrowErrorMatchingInlineSnapshot(
               `"No config file found, using inferred project"`,
             );
@@ -530,7 +531,7 @@ describe('parseAndGenerateServices', () => {
 
         it('the extension does not match', () => {
           expect(
-            testExtraFileExtensions('other/unknownFileType.unknown'),
+            testExtraFileExtensions('other/unknownFileType.unknown', ['.vue']),
           ).toThrowErrorMatchingInlineSnapshot(
             `"No config file found, using inferred project"`,
           );
@@ -565,7 +566,7 @@ describe('parseAndGenerateServices', () => {
 
           expect(testParse('ts/notIncluded0j1.ts'))
             .toThrowErrorMatchingInlineSnapshot(`
-            "ESLint was configured to run on \`<tsconfigRootDir>/ts/notIncluded0j1.ts\` using \`parserOptions.project\`: 
+            "ESLint was configured to run on \`<tsconfigRootDir>/ts/notIncluded0j1.ts\` using \`parserOptions.project\`:
             - <tsconfigRootDir>/tsconfig.json
             - <tsconfigRootDir>/tsconfig.extra.json
             However, none of those TSConfigs include this file. Either:

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -566,7 +566,7 @@ describe('parseAndGenerateServices', () => {
 
           expect(testParse('ts/notIncluded0j1.ts'))
             .toThrowErrorMatchingInlineSnapshot(`
-            "ESLint was configured to run on \`<tsconfigRootDir>/ts/notIncluded0j1.ts\` using \`parserOptions.project\`:
+            "ESLint was configured to run on \`<tsconfigRootDir>/ts/notIncluded0j1.ts\` using \`parserOptions.project\`: 
             - <tsconfigRootDir>/tsconfig.json
             - <tsconfigRootDir>/tsconfig.extra.json
             However, none of those TSConfigs include this file. Either:

--- a/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
@@ -43,6 +43,7 @@ function createMockProjectService() {
 
 const mockParseSettings = {
   filePath: 'path/PascalCaseDirectory/camelCaseFile.ts',
+  extraFileExtensions: [] as readonly string[],
 } as ParseSettings;
 
 const createProjectServiceSettings = <

--- a/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
@@ -307,7 +307,7 @@ If you absolutely need more files included, set parserOptions.projectService.max
 
     useProgramFromProjectService(
       createProjectServiceSettings({
-        allowDefaultProjectForFiles: [mockParseSettings.filePath],
+        allowDefaultProject: [mockParseSettings.filePath],
         service,
       }),
       mockParseSettings,
@@ -323,7 +323,7 @@ If you absolutely need more files included, set parserOptions.projectService.max
 
     useProgramFromProjectService(
       createProjectServiceSettings({
-        allowDefaultProjectForFiles: [mockParseSettings.filePath],
+        allowDefaultProject: [mockParseSettings.filePath],
         service,
       }),
       {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8899 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Uses `setHostConfiguration` to pass `extraFileExtensions` to project service, when using `EXPERIMENTAL_useProjectService`. This fixes an issue where project service would not detect the appropriate tsconfig file when using non-default file extensions.

The tests are checking that the configFilePath is set in the compiler options. If it's not, it's an indication that the default inferred project is used. I duplicated the test cases used for the non-experimental projects option.