### PR TITLE
docs: fix broken link to `import/no-duplicates` on `no-duplicate-imports` page

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-duplicate-imports.mdx
+++ b/packages/eslint-plugin/docs/rules/no-duplicate-imports.mdx
@@ -1,6 +1,6 @@
 :::danger Deprecated
 
-This rule has been deprecated in favour of the [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-duplicates.mdx) rule.
+This rule has been deprecated in favour of the [`import/no-duplicates`](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-duplicates.md) rule.
 
 :::
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR fixes a broken link to `import/no-duplicates` on the `no-duplicate-imports` page.
