### PR TITLE
docs: fix broken anchor links

### DIFF
--- a/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
@@ -172,7 +172,7 @@ function linkToConfigs(configs: string[]): mdast.Node[] {
         } as mdast.InlineCode,
       ],
       type: 'link',
-      url: `/users/configs#${config})`,
+      url: `/users/configs#${config}`,
     }),
   );
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9070 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR removes the unclosed paren linked [here](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts#L175) for links to strict, strict-type-checked anchors.

