### PR TITLE
feat(eslint-plugin): deprecate prefer-ts-expect-error in favor of ban-ts-comment

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.mdx
@@ -9,6 +9,16 @@ import TabItem from '@theme/TabItem';
 >
 > See **https://typescript-eslint.io/rules/prefer-ts-expect-error** for documentation.
 
+:::danger Deprecated
+
+This rule has been deprecated in favor of [`@typescript-eslint/ban-ts-comment`](./ban-ts-comment.mdx).
+This rule (`@typescript-eslint/prefer-ts-expect-error`) will be removed in a future major version of typescript-eslint.
+
+When it was first created, `@typescript-eslint/ban-ts-comment` rule was only responsible for suggesting to remove `@ts-ignore` directive.
+It was later updated to suggest replacing `@ts-ignore` with `@ts-expect-error` directive, so that it replaces `@typescript-eslint/prefer-ts-expect-error` entirely.
+
+:::
+
 TypeScript allows you to suppress all errors on a line by placing a comment starting with `@ts-ignore` or `@ts-expect-error` immediately before the erroring line.
 The two directives work the same, except `@ts-expect-error` causes a type error if placed before a line that's not erroring in the first place.
 

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -139,7 +139,6 @@ export = {
     '@typescript-eslint/prefer-regexp-exec': 'error',
     '@typescript-eslint/prefer-return-this-type': 'error',
     '@typescript-eslint/prefer-string-starts-ends-with': 'error',
-    '@typescript-eslint/prefer-ts-expect-error': 'error',
     '@typescript-eslint/promise-function-async': 'error',
     '@typescript-eslint/require-array-sort-compare': 'error',
     'require-await': 'off',

--- a/packages/eslint-plugin/src/configs/strict-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/strict-type-checked.ts
@@ -71,7 +71,6 @@ export = {
     '@typescript-eslint/prefer-promise-reject-errors': 'error',
     '@typescript-eslint/prefer-reduce-type-parameter': 'error',
     '@typescript-eslint/prefer-return-this-type': 'error',
-    '@typescript-eslint/prefer-ts-expect-error': 'error',
     'require-await': 'off',
     '@typescript-eslint/require-await': 'error',
     '@typescript-eslint/restrict-plus-operands': [

--- a/packages/eslint-plugin/src/configs/strict.ts
+++ b/packages/eslint-plugin/src/configs/strict.ts
@@ -40,7 +40,6 @@ export = {
     '@typescript-eslint/no-var-requires': 'error',
     '@typescript-eslint/prefer-as-const': 'error',
     '@typescript-eslint/prefer-literal-enum-member': 'error',
-    '@typescript-eslint/prefer-ts-expect-error': 'error',
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/unified-signatures': 'error',
   },

--- a/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
+++ b/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
@@ -10,9 +10,10 @@ export default createRule<[], MessageIds>({
   name: 'prefer-ts-expect-error',
   meta: {
     type: 'problem',
+    deprecated: true,
+    replacedBy: ['@typescript-eslint/ban-ts-comment'],
     docs: {
       description: 'Enforce using `@ts-expect-error` over `@ts-ignore`',
-      recommended: 'strict',
     },
     fixable: 'code',
     messages: {

--- a/packages/typescript-eslint/src/configs/all.ts
+++ b/packages/typescript-eslint/src/configs/all.ts
@@ -148,7 +148,6 @@ export default (
       '@typescript-eslint/prefer-regexp-exec': 'error',
       '@typescript-eslint/prefer-return-this-type': 'error',
       '@typescript-eslint/prefer-string-starts-ends-with': 'error',
-      '@typescript-eslint/prefer-ts-expect-error': 'error',
       '@typescript-eslint/promise-function-async': 'error',
       '@typescript-eslint/require-array-sort-compare': 'error',
       'require-await': 'off',

--- a/packages/typescript-eslint/src/configs/strict-type-checked.ts
+++ b/packages/typescript-eslint/src/configs/strict-type-checked.ts
@@ -80,7 +80,6 @@ export default (
       '@typescript-eslint/prefer-promise-reject-errors': 'error',
       '@typescript-eslint/prefer-reduce-type-parameter': 'error',
       '@typescript-eslint/prefer-return-this-type': 'error',
-      '@typescript-eslint/prefer-ts-expect-error': 'error',
       'require-await': 'off',
       '@typescript-eslint/require-await': 'error',
       '@typescript-eslint/restrict-plus-operands': [

--- a/packages/typescript-eslint/src/configs/strict.ts
+++ b/packages/typescript-eslint/src/configs/strict.ts
@@ -49,7 +49,6 @@ export default (
       '@typescript-eslint/no-var-requires': 'error',
       '@typescript-eslint/prefer-as-const': 'error',
       '@typescript-eslint/prefer-literal-enum-member': 'error',
-      '@typescript-eslint/prefer-ts-expect-error': 'error',
       '@typescript-eslint/triple-slash-reference': 'error',
       '@typescript-eslint/unified-signatures': 'error',
     },


### PR DESCRIPTION
# PR Checklist

- [x] Addresses an existing open issue: fixes #8333
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`prefer-ts-expect-error` is just a subset of `ban-ts-comment` because `ban-ts-comment` also suggests replacing @ts-ignore with @ts-expect-error