### PR TITLE
fix: correct eslint-plugin's peerDependency on parser@8

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -102,7 +102,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^7.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^8.57.0 || ^9.0.0"
   },
   "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5526,7 +5526,7 @@ __metadata:
     typescript: "*"
     unist-util-visit: ^5.0.0
   peerDependencies:
-    "@typescript-eslint/parser": ^7.0.0
+    "@typescript-eslint/parser": ^8.0.0
     eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9087
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Corrects the last `^7.0.0` peer dependency that we'd missed.

💖 