### PR TITLE
fix(typescript-estree): don't add in-project files to defaultProjectMatchedFiles

### DIFF
--- a/packages/typescript-estree/src/useProgramFromProjectService.ts
+++ b/packages/typescript-estree/src/useProgramFromProjectService.ts
@@ -83,7 +83,9 @@ export function useProgramFromProjectService(
     return undefined;
   }
 
-  defaultProjectMatchedFiles.add(filePathAbsolute);
+  if (!opened.configFileName) {
+    defaultProjectMatchedFiles.add(filePathAbsolute);
+  }
   if (defaultProjectMatchedFiles.size > maximumDefaultProjectFileMatchCount) {
     throw new Error(
       `Too many files (>${maximumDefaultProjectFileMatchCount}) have matched the default project.${DEFAULT_PROJECT_FILES_ERROR_EXPLANATION}

--- a/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
@@ -220,4 +220,29 @@ If you absolutely need more files included, set parserOptions.EXPERIMENTAL_usePr
 
     expect(actual).toBe(program);
   });
+
+  it('returns a created program when hasFullTypeInformation is disabled, the file is in the project service, the service has a matching program, and no out-of-project files are allowed', () => {
+    const { service } = createMockProjectService();
+    const program = { getSourceFile: jest.fn() };
+
+    mockGetProgram.mockReturnValueOnce(program);
+
+    service.openClientFile.mockReturnValueOnce({
+      configFileName: 'tsconfig.json',
+    });
+    mockCreateProjectProgram.mockReturnValueOnce(program);
+
+    const actual = useProgramFromProjectService(
+      createProjectServiceSettings({
+        allowDefaultProjectForFiles: [],
+        maximumDefaultProjectFileMatchCount: 0,
+        service,
+      }),
+      mockParseSettings,
+      false,
+      new Set(),
+    );
+
+    expect(actual).toBe(program);
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9032
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Only add path to `defaultProjectMatchedFiles` if `opened.configFileName` is falsy.

The fix itself is pretty trivial and existing tests still pass, but I might need some help with adding a new testcase. I tried adapting the existing testcase at https://github.com/typescript-eslint/typescript-eslint/blob/77fc366aa03f3cee1ebcf91a10dc0be8b669520e/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts#L122 but only succeeded in making *other* tests fail (maybe I mocked a result and then didn't call the function, I'm not sure).
