### PR TITLE
fix(eslint-plugin): include alpha pre-releases in parser peer dependency

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -102,7 +102,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
     "eslint": "^8.57.0 || ^9.0.0"
   },
   "peerDependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5526,7 +5526,7 @@ __metadata:
     typescript: "*"
     unist-util-visit: ^5.0.0
   peerDependencies:
-    "@typescript-eslint/parser": ^8.0.0
+    "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: Fixes #9087
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

A fix for #9087 was pushed in #9089 to bump the eslint-plugin's peerDependencdy on the parser to `^8.0.0`, but due to how NPM handles SemVer, it does not include pre-releases such as `8.0.0-alpha.11`, causing a "version not found" error if someone tried to install the pre-release plugin (eg on tag `rc-v8`). This PR adds another SemVer constraint to the `@typescript-eslint/parser` peerDependency to include alpha pre-releases as suggested in https://github.com/typescript-eslint/typescript-eslint/pull/9089#discussion_r1600804371