### PR TITLE
docs: make absolute links relative

### DIFF
--- a/docs/Contributing.mdx
+++ b/docs/Contributing.mdx
@@ -16,6 +16,6 @@ If you're new to open source, you may also find the [How to Contribute to Open S
 
 ## Next Steps
 
-1. [Finding or opening an issue](https://typescript-eslint.io/contributing/issues): In the issue tab, find the pr currently tagged with `accepting prs` or create a new issue.
-2. [Setting up a local environment](https://typescript-eslint.io/contributing/local-development): Let's learn how to set up the local environment to start development.
-3. [Making a PR](https://typescript-eslint.io/contributing/pull-requests): you've got changes locally that address an issue, take a look at that topic.
+1. [Finding or opening an issue](./contributing/Issues.mdx): In the issue tab, find the pr currently tagged with `accepting prs` or create a new issue.
+2. [Setting up a local environment](./contributing/Local_Development.mdx): Let's learn how to set up the local environment to start development.
+3. [Making a PR](./contributing/Pull_Requests.mdx): you've got changes locally that address an issue, take a look at that topic.


### PR DESCRIPTION
## PR Checklist

- [ ] ~Addresses an existing open issue~
- [ ] ~That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Absolute links open in a new tab. Since these are links to other docs pages, these should be relative links instead which open in the same tab.

I've checked that these are the only absolute links to `typescript-eslint.io`.