### PR TITLE
chore: use recommended config for Node.js 18 in TSConfig

### DIFF
--- a/packages/eslint-plugin-internal/tsconfig.json
+++ b/packages/eslint-plugin-internal/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "composite": false,
-    "target": "ES2022",
     "rootDir": "."
   },
   "include": ["src", "typings", "tests", "index.d.ts"],

--- a/packages/scope-manager/tsconfig.spec.json
+++ b/packages/scope-manager/tsconfig.spec.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "module": "Node16",
     "types": ["jest", "node"]
   },
   "exclude": ["tests/fixtures"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
-    "lib": ["ES2021"],
+    "lib": ["ES2023"],
     "module": "Node16",
     "moduleResolution": "Node16",
     "noImplicitReturns": true,
@@ -16,6 +16,6 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2021"
+    "target": "ES2022"
   }
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/9028
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Changed TSConfig to target Node.js 18 since this is the minimal version we support. According to https://node.green/, Node.js 18 fully supports ES2022 and ES2023:

![Table that shows Node.js 18 supports ES2022 and ES2023 fully](https://github.com/typescript-eslint/typescript-eslint/assets/10157660/6f04444a-6c8d-4bf2-a9ed-d24136945e08)

There is a recommended TSConfig for Node.js 18 - https://github.com/tsconfig/bases/blob/main/bases/node18.json and I followed it as a reference.

In another PR, I'm planning to enable ESLint https://eslint.org/docs/latest/rules/prefer-object-has-own rule and fix all related errors.
