### PR TITLE
fix(eslint-plugin): [prefer-literal-enum-member] allow using member it self on allowBitwiseExpressions

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
+++ b/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
@@ -33,10 +33,7 @@ export default createRule({
     },
   ],
   create(context, [{ allowBitwiseExpressions }]) {
-    function isIdentifierWithName(
-      node: TSESTree.Node,
-      name: string,
-    ): node is TSESTree.Identifier {
+    function isIdentifierWithName(node: TSESTree.Node, name: string): boolean {
       return node.type === AST_NODE_TYPES.Identifier && node.name === name;
     }
 

--- a/packages/eslint-plugin/tests/rules/prefer-literal-enum-member.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-literal-enum-member.test.ts
@@ -77,6 +77,45 @@ enum Foo {
       `,
       options: [{ allowBitwiseExpressions: true }],
     },
+    {
+      code: `
+enum Foo {
+  A = 1 << 0,
+  B = 1 >> 0,
+  C = A | B,
+}
+      `,
+      options: [{ allowBitwiseExpressions: true }],
+    },
+    {
+      code: `
+enum Foo {
+  A = 1 << 0,
+  B = 1 >> 0,
+  C = Foo.A | Foo.B,
+}
+      `,
+      options: [{ allowBitwiseExpressions: true }],
+    },
+    {
+      code: `
+enum Foo {
+  A = 1 << 0,
+  B = 1 >> 0,
+  C = Foo['A'] | B,
+}
+      `,
+      options: [{ allowBitwiseExpressions: true }],
+    },
+    {
+      code: `
+enum Foo {
+  ['A-1'] = 1 << 0,
+  C = ~Foo['A-1'],
+}
+      `,
+      options: [{ allowBitwiseExpressions: true }],
+    },
   ],
   invalid: [
     {
@@ -369,6 +408,29 @@ enum Foo {
         {
           messageId: 'notLiteral',
           line: 10,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+const x = 1;
+enum Foo {
+  A = 1 << 0,
+  B = x >> Foo.A,
+  C = x >> A,
+}
+      `,
+      options: [{ allowBitwiseExpressions: true }],
+      errors: [
+        {
+          messageId: 'notLiteral',
+          line: 5,
+          column: 3,
+        },
+        {
+          messageId: 'notLiteral',
+          line: 6,
           column: 3,
         },
       ],


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7763
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
