### PR TITLE
docs(eslint-plugin): [no-floating-promises] make void a more prominent suggestion

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
@@ -17,6 +17,7 @@ Valid ways of handling a Promise-valued statement include:
 
 - `await`ing it
 - `return`ing it
+- `void`ing it
 - Calling its `.then()` with two arguments
 - Calling its `.catch()` with one argument
 
@@ -63,6 +64,9 @@ await promise;
 async function returnsPromise() {
   return 'value';
 }
+
+void returnsPromise();
+
 returnsPromise().then(
   () => {},
   () => {},
@@ -82,7 +86,7 @@ await Promise.all([1, 2, 3].map(async x => x + 1));
 
 ### `ignoreVoid`
 
-This allows you to stop the rule reporting promises consumed with void operator.
+This option, which is `true` by default, allows you to stop the rule reporting promises consumed with void operator.
 This can be a good way to explicitly mark a promise as intentionally not awaited.
 
 Examples of **correct** code for this rule with `{ ignoreVoid: true }`:

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-floating-promises.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-floating-promises.shot
@@ -33,6 +33,9 @@ await promise;
 async function returnsPromise() {
   return 'value';
 }
+
+void returnsPromise();
+
 returnsPromise().then(
   () => {},
   () => {},


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

In my experience it is rather common to have legitimate cases to `void` a promise. The current state of the docs led me to believe that this is a "lesser preferred" option and I don't think that should be the case.

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
