### PR TITLE
chore(eslint-plugin): replaced map/reduce with flatMap in normalizedOptions in parse

### DIFF
--- a/packages/eslint-plugin/src/rules/naming-convention-utils/parse-options.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/parse-options.ts
@@ -80,9 +80,7 @@ function normalizeOption(option: Selector): NormalizedSelector[] {
 }
 
 function parseOptions(context: Context): ParsedOptions {
-  const normalizedOptions = context.options
-    .map(opt => normalizeOption(opt))
-    .reduce((acc, val) => acc.concat(val), []);
+  const normalizedOptions = context.options.flatMap(normalizeOption);
 
   const result = getEnumNames(Selectors).reduce((acc, k) => {
     acc[k] = createValidator(k, context, normalizedOptions);


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

I replaced `map` + `reduce with concat` with single `flatMap`.

## PR Checklist

- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
