### PR TITLE
chore: enable `prefer-object-has-own` ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -195,6 +195,7 @@ export default tseslint.config(
         { commentPattern: '.*intentional fallthrough.*' },
       ],
       'one-var': ['error', 'never'],
+      'prefer-object-has-own': 'error',
 
       //
       // eslint-plugin-eslint-comment

--- a/packages/eslint-plugin-internal/src/rules/prefer-ast-types-enum.ts
+++ b/packages/eslint-plugin-internal/src/rules/prefer-ast-types-enum.ts
@@ -53,15 +53,15 @@ export default createRule({
 
         const value = node.value;
 
-        if (Object.prototype.hasOwnProperty.call(AST_NODE_TYPES, value)) {
+        if (Object.hasOwn(AST_NODE_TYPES, value)) {
           report('AST_NODE_TYPES', node);
         }
 
-        if (Object.prototype.hasOwnProperty.call(AST_TOKEN_TYPES, value)) {
+        if (Object.hasOwn(AST_TOKEN_TYPES, value)) {
           report('AST_TOKEN_TYPES', node);
         }
 
-        if (Object.prototype.hasOwnProperty.call(DefinitionType, value)) {
+        if (Object.hasOwn(DefinitionType, value)) {
           report('DefinitionType', node);
         }
       },

--- a/packages/eslint-plugin-internal/tsconfig.json
+++ b/packages/eslint-plugin-internal/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "composite": false,
-    "target": "ES2022",
     "rootDir": "."
   },
   "include": ["src", "typings", "tests", "index.d.ts"],

--- a/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
@@ -44,8 +44,7 @@ const isSameAstNode = (actualNode: unknown, expectedNode: unknown): boolean => {
     }
     if (
       actualNodeKeys.some(
-        actualNodeKey =>
-          !Object.prototype.hasOwnProperty.call(expectedNode, actualNodeKey),
+        actualNodeKey => !Object.hasOwn(expectedNode, actualNodeKey),
       )
     ) {
       return false;

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -172,13 +172,13 @@ const schema: JSONSchema4AnyOfSchema = {
 function isObjectOfPaths(
   obj: unknown,
 ): obj is { paths: ArrayOfStringOrObject } {
-  return Object.prototype.hasOwnProperty.call(obj, 'paths');
+  return !!obj && Object.hasOwn(obj, 'paths');
 }
 
 function isObjectOfPatterns(
   obj: unknown,
 ): obj is { patterns: ArrayOfStringOrObjectPatterns } {
-  return Object.prototype.hasOwnProperty.call(obj, 'patterns');
+  return !!obj && Object.hasOwn(obj, 'patterns');
 }
 
 function isOptionsArrayOfStringOrObject(

--- a/packages/rule-tester/src/utils/cloneDeeplyExcludesParent.ts
+++ b/packages/rule-tester/src/utils/cloneDeeplyExcludesParent.ts
@@ -11,7 +11,7 @@ export function cloneDeeplyExcludesParent<T>(x: T): T {
     const retv = {} as typeof x;
 
     for (const key in x) {
-      if (key !== 'parent' && Object.prototype.hasOwnProperty.call(x, key)) {
+      if (key !== 'parent' && Object.hasOwn(x, key)) {
         retv[key] = cloneDeeplyExcludesParent(x[key]);
       }
     }

--- a/packages/rule-tester/src/utils/freezeDeeply.ts
+++ b/packages/rule-tester/src/utils/freezeDeeply.ts
@@ -7,7 +7,7 @@ export function freezeDeeply(x: unknown): void {
       x.forEach(freezeDeeply);
     } else {
       for (const key in x) {
-        if (key !== 'parent' && Object.prototype.hasOwnProperty.call(x, key)) {
+        if (key !== 'parent' && Object.hasOwn(x, key)) {
           freezeDeeply((x as Record<string, unknown>)[key]);
         }
       }

--- a/packages/rule-tester/src/utils/hasOwnProperty.ts
+++ b/packages/rule-tester/src/utils/hasOwnProperty.ts
@@ -1,5 +1,5 @@
 // typed so that TS can remove optionality
-export const hasOwnProperty = Function.call.bind(Object.hasOwnProperty) as <
+export const hasOwnProperty = Object.hasOwn as <
   Obj extends object,
   K extends keyof Obj,
 >(

--- a/packages/scope-manager/tsconfig.spec.json
+++ b/packages/scope-manager/tsconfig.spec.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "module": "Node16",
     "types": ["jest", "node"]
   },
   "exclude": ["tests/fixtures"],

--- a/packages/type-utils/src/isTypeReadonly.ts
+++ b/packages/type-utils/src/isTypeReadonly.ts
@@ -44,7 +44,7 @@ export const readonlynessOptionsDefaults: ReadonlynessOptions = {
 };
 
 function hasSymbol(node: ts.Node): node is ts.Node & { symbol: ts.Symbol } {
-  return Object.prototype.hasOwnProperty.call(node, 'symbol');
+  return Object.hasOwn(node, 'symbol');
 }
 
 function isTypeReadonlyArrayOrTuple(

--- a/packages/typescript-estree/tests/test-utils/test-utils.ts
+++ b/packages/typescript-estree/tests/test-utils/test-utils.ts
@@ -124,7 +124,7 @@ export function omitDeep<T = UnknownObject>(
     const node = { ...oNode };
 
     for (const prop in node) {
-      if (Object.prototype.hasOwnProperty.call(node, prop)) {
+      if (Object.hasOwn(node, prop)) {
         if (shouldOmit(prop, node[prop]) || node[prop] === undefined) {
           // Filter out omitted and undefined props from the node
           // eslint-disable-next-line @typescript-eslint/no-dynamic-delete

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
-    "lib": ["ES2021"],
+    "lib": ["ES2023"],
     "module": "Node16",
     "moduleResolution": "Node16",
     "noImplicitReturns": true,
@@ -16,6 +16,6 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2021"
+    "target": "ES2022"
   }
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/9028
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

> This PR depends on https://github.com/typescript-eslint/typescript-eslint/pull/9113. See fbeede974a2dd4b0e7b123fc89f934aace7bb8cf...cf9c7ae9a39fbb1e0975719a382c1e7e0423841b for changes.

Enables [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) ESLint rule and fixes all rule errors.
