### PR TITLE
fix(typescript-estree): truncate number of files printed by the maximum file error

### DIFF
--- a/packages/typescript-estree/src/useProgramFromProjectService.ts
+++ b/packages/typescript-estree/src/useProgramFromProjectService.ts
@@ -87,13 +87,19 @@ export function useProgramFromProjectService(
     defaultProjectMatchedFiles.add(filePathAbsolute);
   }
   if (defaultProjectMatchedFiles.size > maximumDefaultProjectFileMatchCount) {
+    const filePrintLimit = 20;
+    const filesToPrint = Array.from(defaultProjectMatchedFiles).slice(
+      0,
+      filePrintLimit,
+    );
+    const truncatedFileCount =
+      defaultProjectMatchedFiles.size - filesToPrint.length;
+
     throw new Error(
       `Too many files (>${maximumDefaultProjectFileMatchCount}) have matched the default project.${DEFAULT_PROJECT_FILES_ERROR_EXPLANATION}
 Matching files:
-${Array.from(defaultProjectMatchedFiles)
-  .map(file => `- ${file}`)
-  .join('\n')}
-
+${filesToPrint.map(file => `- ${file}`).join('\n')}
+${truncatedFileCount ? `...and ${truncatedFileCount} more files\n` : ''}
 If you absolutely need more files included, set parserOptions.EXPERIMENTAL_useProjectService.maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING to a larger value.
 `,
     );

--- a/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
@@ -153,6 +153,58 @@ If you absolutely need more files included, set parserOptions.EXPERIMENTAL_usePr
 `);
   });
 
+  it('truncates the files printed by the maximum allowed files error when they exceed the print limit', () => {
+    const { service } = createMockProjectService();
+    const program = { getSourceFile: jest.fn() };
+
+    mockGetProgram.mockReturnValueOnce(program);
+
+    service.openClientFile.mockReturnValueOnce({});
+
+    expect(() =>
+      useProgramFromProjectService(
+        createProjectServiceSettings({
+          allowDefaultProjectForFiles: [mockParseSettings.filePath],
+          maximumDefaultProjectFileMatchCount: 2,
+          service,
+        }),
+        mockParseSettings,
+        true,
+        new Set(Array.from({ length: 100 }, (_, i) => String(i))),
+      ),
+    ).toThrow(`Too many files (>2) have matched the default project.
+
+Having many files run with the default project is known to cause performance issues and slow down linting.
+
+See https://typescript-eslint.io/troubleshooting/#allowdefaultprojectforfiles-glob-too-wide
+
+Matching files:
+- 0
+- 1
+- 2
+- 3
+- 4
+- 5
+- 6
+- 7
+- 8
+- 9
+- 10
+- 11
+- 12
+- 13
+- 14
+- 15
+- 16
+- 17
+- 18
+- 19
+...and 81 more files
+
+If you absolutely need more files included, set parserOptions.EXPERIMENTAL_useProjectService.maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING to a larger value.
+`);
+  });
+
   it('returns undefined when hasFullTypeInformation is disabled, the file is both in the project service and allowDefaultProjectForFiles, and the service does not have a matching program', () => {
     const { service } = createMockProjectService();
 


### PR DESCRIPTION
* fix(typescript-estree): truncate number of files printed

Address issue with size of error string produced causing serialization failure https://github.com/typescript-eslint/typescript-eslint/issues/9124.

* test(typescript-estree): add additional unit test for project service

Additional test for truncated error message.

## PR Checklist

- [x] Addresses an existing open issue: fixes #9124 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
  - (I couldn't reproduce following the steps outlined by https://github.com/typescript-eslint/typescript-eslint/issues/9124#issuecomment-2122986459) 

## Overview
