### PR TITLE
test(eslint-plugin): [consistent-type-assertions] add missing `output: null` causing lint failure on `main`

### DIFF
--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -815,6 +815,7 @@ ruleTester.run('consistent-type-assertions', rule, {
     }),
     {
       code: 'const foo = <Foo style={{ bar: 5 } as Bar} />;',
+      output: null,
       parserOptions: {
         ecmaFeatures: {
           jsx: true,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9135 
- [] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
Add missing `output: null` causing lint failure on `main`.