### PR TITLE
chore: patch nx changelog to fix releases

### DIFF
--- a/.yarn/patches/nx-npm-18.3.5-58c0bedf91.patch
+++ b/.yarn/patches/nx-npm-18.3.5-58c0bedf91.patch
@@ -1,0 +1,30 @@
+diff --git a/src/command-line/release/changelog.js b/src/command-line/release/changelog.js
+index f997f4c45e841bcdce86c9ffc6e776c08ccdbb60..ed9cbdcfa0913b1a4662eb35bd98526e1e863869 100644
+--- a/src/command-line/release/changelog.js
++++ b/src/command-line/release/changelog.js
+@@ -364,15 +364,20 @@ function resolveChangelogRenderer(changelogRendererPath) {
+     const interpolatedChangelogRendererPath = (0, utils_1.interpolate)(changelogRendererPath, {
+         workspaceRoot: workspace_root_1.workspaceRoot,
+     });
++    const path = require("node:path");
++    const joinedChangelogRendererPath = path.join(
++      workspace_root_1.workspaceRoot,
++      interpolatedChangelogRendererPath
++    );
+     // Try and load the provided (or default) changelog renderer
+     let changelogRenderer;
+     let cleanupTranspiler = () => { };
+     try {
+-        const rootTsconfigPath = (0, typescript_1.getRootTsConfigPath)();
+-        if (rootTsconfigPath) {
+-            cleanupTranspiler = (0, register_1.registerTsProject)(rootTsconfigPath);
+-        }
+-        const r = require(interpolatedChangelogRendererPath);
++        // const rootTsconfigPath = (0, typescript_1.getRootTsConfigPath)();
++        // if (rootTsconfigPath) {
++        //     cleanupTranspiler = (0, register_1.registerTsProject)(rootTsconfigPath);
++        // }
++        const r = require(joinedChangelogRendererPath);
+         changelogRenderer = r.default || r;
+     }
+     catch {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
     "tmp": "0.2.1",
     "tsx": "^4.7.2",
     "typescript": "5.4.5",
-    "@nx/eslint@17.3.1": "patch:@nx/eslint@npm%3A17.3.1#./.yarn/patches/@nx-eslint-npm-17.3.1-a2f85d8c50.patch"
+    "@nx/eslint@17.3.1": "patch:@nx/eslint@npm%3A17.3.1#./.yarn/patches/@nx-eslint-npm-17.3.1-a2f85d8c50.patch",
+    "nx@18.3.5": "patch:nx@npm%3A18.3.5#./.yarn/patches/nx-npm-18.3.5-58c0bedf91.patch"
   },
   "packageManager": "yarn@3.8.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15602,6 +15602,90 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nx@patch:nx@npm%3A18.3.5#./.yarn/patches/nx-npm-18.3.5-58c0bedf91.patch::locator=%40typescript-eslint%2Ftypescript-eslint%40workspace%3A.":
+  version: 18.3.5
+  resolution: "nx@patch:nx@npm%3A18.3.5#./.yarn/patches/nx-npm-18.3.5-58c0bedf91.patch::version=18.3.5&hash=6b29d0&locator=%40typescript-eslint%2Ftypescript-eslint%40workspace%3A."
+  dependencies:
+    "@nrwl/tao": 18.3.5
+    "@nx/nx-darwin-arm64": 18.3.5
+    "@nx/nx-darwin-x64": 18.3.5
+    "@nx/nx-freebsd-x64": 18.3.5
+    "@nx/nx-linux-arm-gnueabihf": 18.3.5
+    "@nx/nx-linux-arm64-gnu": 18.3.5
+    "@nx/nx-linux-arm64-musl": 18.3.5
+    "@nx/nx-linux-x64-gnu": 18.3.5
+    "@nx/nx-linux-x64-musl": 18.3.5
+    "@nx/nx-win32-arm64-msvc": 18.3.5
+    "@nx/nx-win32-x64-msvc": 18.3.5
+    "@yarnpkg/lockfile": ^1.1.0
+    "@yarnpkg/parsers": 3.0.0-rc.46
+    "@zkochan/js-yaml": 0.0.6
+    axios: ^1.6.0
+    chalk: ^4.1.0
+    cli-cursor: 3.1.0
+    cli-spinners: 2.6.1
+    cliui: ^8.0.1
+    dotenv: ~16.3.1
+    dotenv-expand: ~10.0.0
+    enquirer: ~2.3.6
+    figures: 3.2.0
+    flat: ^5.0.2
+    fs-extra: ^11.1.0
+    ignore: ^5.0.4
+    jest-diff: ^29.4.1
+    js-yaml: 4.1.0
+    jsonc-parser: 3.2.0
+    lines-and-columns: ~2.0.3
+    minimatch: 9.0.3
+    node-machine-id: 1.1.12
+    npm-run-path: ^4.0.1
+    open: ^8.4.0
+    ora: 5.3.0
+    semver: ^7.5.3
+    string-width: ^4.2.3
+    strong-log-transformer: ^2.1.0
+    tar-stream: ~2.2.0
+    tmp: ~0.2.1
+    tsconfig-paths: ^4.1.2
+    tslib: ^2.3.0
+    yargs: ^17.6.2
+    yargs-parser: 21.1.1
+  peerDependencies:
+    "@swc-node/register": ^1.8.0
+    "@swc/core": ^1.3.85
+  dependenciesMeta:
+    "@nx/nx-darwin-arm64":
+      optional: true
+    "@nx/nx-darwin-x64":
+      optional: true
+    "@nx/nx-freebsd-x64":
+      optional: true
+    "@nx/nx-linux-arm-gnueabihf":
+      optional: true
+    "@nx/nx-linux-arm64-gnu":
+      optional: true
+    "@nx/nx-linux-arm64-musl":
+      optional: true
+    "@nx/nx-linux-x64-gnu":
+      optional: true
+    "@nx/nx-linux-x64-musl":
+      optional: true
+    "@nx/nx-win32-arm64-msvc":
+      optional: true
+    "@nx/nx-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc-node/register":
+      optional: true
+    "@swc/core":
+      optional: true
+  bin:
+    nx: bin/nx.js
+    nx-cloud: bin/nx-cloud.js
+  checksum: 6b367fec17181559d323cadd3978652b36455054fc6c3c6b7560320c7ceb2b6250220635554563efa88e8bf6b4d0c51a39b09bf182e64ffc4ea26c10067b4d5c
+  languageName: node
+  linkType: hard
+
 "object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9158
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Thanks to a tip from @JamesHenry, this:

1. Removes the TypeScript registration, as that's what's crashing
2. Fixes the changelog renderer path to work as a direct `require()`