### PR TITLE
docs: update link to ESLint legacy config

### DIFF
--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -14,7 +14,7 @@ This page is a quick-start for [ESLint's new "flat" config format](https://eslin
 
 :::note
 
-- For the same guide but for [ESLint's legacy format](https://eslint.org/docs/latest/use/configure/configuration-files) — see [Legacy ESLint Setup](./Legacy_ESLint_Setup.mdx).
+- For the same guide but for [ESLint's legacy format](https://eslint.org/docs/latest/use/configure/configuration-files-deprecated) — see [Legacy ESLint Setup](./Legacy_ESLint_Setup.mdx).
 - For quickstart information on linting with type information — see [Typed Linting](./Typed_Linting.mdx).
 
 :::


### PR DESCRIPTION
Fix a link to the legacy (<9.0.0) config on eslint.org.

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

eslint.org restructured their site so the legacy config documentation is now at `https://eslint.org/docs/latest/use/configure/configuration-files-deprecated`.
