### PR TITLE
fix(rule-tester): set configType to eslintrc in Linter options

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -115,7 +115,9 @@ function getUnsubstitutedMessagePlaceholders(
 export class RuleTester extends TestFramework {
   readonly #testerConfig: TesterConfigWithDefaults;
   readonly #rules: Record<string, AnyRuleCreateFunction | AnyRuleModule> = {};
-  readonly #linter: Linter = new Linter();
+  // `configType` is hardcoded to eslintrc until switch to flat config is complete
+  // We should look to support both eslintrc and flat config for consumers of RuleTester.
+  readonly #linter: Linter = new Linter({ configType: 'eslintrc' });
 
   /**
    * Creates a new instance of RuleTester.


### PR DESCRIPTION
This was a regression on v8 caused by a merge from main