### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] conflict with TS for variables used before assignment

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -96,7 +96,10 @@ export default createRule<Options, MessageIds>({
         if (
           ts.isVariableDeclarationList(declaration.parent) &&
           // var
-          declaration.parent.flags === ts.NodeFlags.None
+          declaration.parent.flags === ts.NodeFlags.None &&
+          // If they are not in the same file it will not exist.
+          // This situation must not occur using before defined.
+          services.tsNodeToESTreeNodeMap.has(declaration)
         ) {
           const declaratorNode: TSESTree.VariableDeclaration =
             services.tsNodeToESTreeNodeMap.get(declaration);

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -83,12 +83,22 @@ export default createRule<Options, MessageIds>({
         // also ignore function arguments as they can't be used before defined
         ts.isVariableDeclaration(declaration)
       ) {
+        // For var declarations, we need to check whether the node
+        // is actually in a descendant of its declaration or not. If not,
+        // it may be used before defined.
+
+        // eg
+        // if (Math.random() < 0.5) {
+        //     var x: number  = 2;
+        // } else {
+        //     x!.toFixed();
+        // }
         if (
           ts.isVariableDeclarationList(declaration.parent) &&
           // var
           declaration.parent.flags === ts.NodeFlags.None
         ) {
-          const declaratorNode: TSESTree.VariableDeclarator =
+          const declaratorNode: TSESTree.VariableDeclaration =
             services.tsNodeToESTreeNodeMap.get(declaration);
           const scope = context.sourceCode.getScope(node);
           const declaratorScope = context.sourceCode.getScope(declaratorNode);

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -1,3 +1,4 @@
+import type { Scope } from '@typescript-eslint/scope-manager';
 import type { TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
@@ -80,33 +81,53 @@ export default createRule<Options, MessageIds>({
         ) &&
         // ignore class properties as they are compile time guarded
         // also ignore function arguments as they can't be used before defined
-        ts.isVariableDeclaration(declaration) &&
-        // is it `const x!: number`
-        declaration.initializer === undefined &&
-        declaration.exclamationToken === undefined &&
-        declaration.type !== undefined
+        ts.isVariableDeclaration(declaration)
       ) {
-        // check if the defined variable type has changed since assignment
-        const declarationType = checker.getTypeFromTypeNode(declaration.type);
-        const type = getConstrainedTypeAtLocation(services, node);
         if (
-          declarationType === type &&
-          // `declare`s are never narrowed, so never skip them
-          !(
-            ts.isVariableDeclarationList(declaration.parent) &&
-            ts.isVariableStatement(declaration.parent.parent) &&
-            tsutils.includesModifier(
-              getModifiers(declaration.parent.parent),
-              ts.SyntaxKind.DeclareKeyword,
-            )
-          )
+          ts.isVariableDeclarationList(declaration.parent) &&
+          // var
+          declaration.parent.flags === ts.NodeFlags.None
         ) {
-          // possibly used before assigned, so just skip it
-          // better to false negative and skip it, than false positive and fix to compile erroring code
-          //
-          // no better way to figure this out right now
-          // https://github.com/Microsoft/TypeScript/issues/31124
-          return true;
+          const declaratorNode: TSESTree.VariableDeclarator =
+            services.tsNodeToESTreeNodeMap.get(declaration);
+          const scope = context.sourceCode.getScope(node);
+          const declaratorScope = context.sourceCode.getScope(declaratorNode);
+          let parentScope: Scope | null = declaratorScope;
+          while ((parentScope = parentScope.upper)) {
+            if (parentScope === scope) {
+              return true;
+            }
+          }
+        }
+
+        if (
+          // is it `const x!: number`
+          declaration.initializer === undefined &&
+          declaration.exclamationToken === undefined &&
+          declaration.type !== undefined
+        ) {
+          // check if the defined variable type has changed since assignment
+          const declarationType = checker.getTypeFromTypeNode(declaration.type);
+          const type = getConstrainedTypeAtLocation(services, node);
+          if (
+            declarationType === type &&
+            // `declare`s are never narrowed, so never skip them
+            !(
+              ts.isVariableDeclarationList(declaration.parent) &&
+              ts.isVariableStatement(declaration.parent.parent) &&
+              tsutils.includesModifier(
+                getModifiers(declaration.parent.parent),
+                ts.SyntaxKind.DeclareKeyword,
+              )
+            )
+          ) {
+            // possibly used before assigned, so just skip it
+            // better to false negative and skip it, than false positive and fix to compile erroring code
+            //
+            // no better way to figure this out right now
+            // https://github.com/Microsoft/TypeScript/issues/31124
+            return true;
+          }
         }
       }
       return false;

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.json
@@ -12,6 +12,7 @@
     "file.ts",
     "consistent-type-exports.ts",
     "mixed-enums-decl.ts",
-    "react.tsx"
+    "react.tsx",
+    "var-declaration.ts"
   ]
 }

--- a/packages/eslint-plugin/tests/fixtures/var-declaration.ts
+++ b/packages/eslint-plugin/tests/fixtures/var-declaration.ts
@@ -1,0 +1,1 @@
+var varDeclarationFromFixture = 1;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -1102,5 +1102,25 @@ x;
         },
       ],
     },
+    {
+      code: `
+var x = 1;
+{
+  x!;
+}
+      `,
+      output: `
+var x = 1;
+{
+  x;
+}
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 4,
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -348,6 +348,16 @@ const bar = foo.a as string | undefined | bigint;
       `,
       languageOptions: { parserOptions: optionsWithExactOptionalPropertyTypes },
     },
+    {
+      code: `
+if (Math.random()) {
+  {
+    var x = 1;
+  }
+}
+x!;
+      `,
+    },
   ],
 
   invalid: [
@@ -1075,6 +1085,22 @@ const bar = foo.a;
         },
       ],
       languageOptions: { parserOptions: optionsWithExactOptionalPropertyTypes },
+    },
+    {
+      code: `
+var x = 1;
+x!;
+      `,
+      output: `
+var x = 1;
+x;
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 3,
+        },
+      ],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -1088,6 +1088,20 @@ const bar = foo.a;
     },
     {
       code: `
+varDeclarationFromFixture!;
+      `,
+      output: `
+varDeclarationFromFixture;
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: `
 var x = 1;
 x!;
       `,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9206
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR makes the rule ignore var declared in child scopes.