### PR TITLE
feat(typescript-estree): require `import = require()` argument to be a string literal

### DIFF
--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-2/fixture.ts
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-2/fixture.ts
@@ -1,0 +1,1 @@
+import F = require(1 + 1);

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-2/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-2/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ external-module-ref-non-string-2 TSESTree - Error 1`] = `
+"TSError
+> 1 | import F = require(1 + 1);
+    |                    ^^^^^ String literal expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-2/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-2/snapshots/2-Babel-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ external-module-ref-non-string-2 Babel - Error 1`] = `[SyntaxError: Unexpected token (1:19)]`;

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-2/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-2/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ external-module-ref-non-string-2 Error Alignment 1`] = `"Both errored"`;

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-3/fixture.ts
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-3/fixture.ts
@@ -1,0 +1,1 @@
+import F = require(`1`);

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-3/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-3/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ external-module-ref-non-string-3 TSESTree - Error 1`] = `
+"TSError
+> 1 | import F = require(\`1\`);
+    |                    ^^^ String literal expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-3/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-3/snapshots/2-Babel-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ external-module-ref-non-string-3 Babel - Error 1`] = `[SyntaxError: Unexpected token (1:19)]`;

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-3/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string-3/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ external-module-ref-non-string-3 Error Alignment 1`] = `"Both errored"`;

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string/snapshots/1-TSESTree-Error.shot
@@ -1,3 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ external-module-ref-non-string TSESTree - Error 1`] = `"NO ERROR"`;
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ external-module-ref-non-string TSESTree - Error 1`] = `
+"TSError
+> 1 | import F = require(1);
+    |                    ^ String literal expected.
+  2 |"
+`;

--- a/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string/snapshots/3-Alignment-Error.shot
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ external-module-ref-non-string Error Alignment 1`] = `"Babel errored but TSESTree didn't"`;
+exports[`AST Fixtures declaration TSImportEqualsDeclaration _error_ external-module-ref-non-string Error Alignment 1`] = `"Both errored"`;

--- a/packages/ast-spec/src/special/TSExternalModuleReference/spec.ts
+++ b/packages/ast-spec/src/special/TSExternalModuleReference/spec.ts
@@ -1,9 +1,8 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
-import type { Expression } from '../../unions/Expression';
+import type { StringLiteral } from '../../expression/literal/StringLiteral/spec';
 
 export interface TSExternalModuleReference extends BaseNode {
   type: AST_NODE_TYPES.TSExternalModuleReference;
-  // TODO(#1852) - this must be a string
-  expression: Expression;
+  expression: StringLiteral;
 }

--- a/packages/ast-spec/tests/fixtures-with-differences-errors.shot
+++ b/packages/ast-spec/tests/fixtures-with-differences-errors.shot
@@ -11,7 +11,6 @@ exports[`AST Fixtures List fixtures with Error differences 1`] = `
     "declaration/TSDeclareFunction/fixtures/_error_/async/fixture.ts",
     "declaration/TSDeclareFunction/fixtures/_error_/declare-with-body/fixture.ts",
     "declaration/TSDeclareFunction/fixtures/_error_/missing-type-param/fixture.ts",
-    "declaration/TSImportEqualsDeclaration/fixtures/_error_/external-module-ref-non-string/fixture.ts",
     "declaration/TSImportEqualsDeclaration/fixtures/_error_/import-kind/fixture.ts",
     "declaration/TSInterfaceDeclaration/fixtures/_error_/missing-extends/fixture.ts",
     "declaration/TSInterfaceDeclaration/fixtures/_error_/missing-type-param/fixture.ts",

--- a/packages/eslint-plugin-internal/src/rules/no-typescript-default-import.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-typescript-default-import.ts
@@ -1,5 +1,4 @@
 import type { TSESTree } from '@typescript-eslint/utils';
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import { createRule } from '../util';
 

--- a/packages/eslint-plugin-internal/src/rules/no-typescript-default-import.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-typescript-default-import.ts
@@ -62,10 +62,7 @@ export default createRule({
         node: TSESTree.TSExternalModuleReference,
       ): void {
         const parent = node.parent as TSESTree.TSImportEqualsDeclaration;
-        if (
-          node.expression.type === AST_NODE_TYPES.Literal &&
-          node.expression.value === 'typescript'
-        ) {
+        if (node.expression.value === 'typescript') {
           context.report({
             node,
             messageId: 'noTSDefaultImport',

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -312,10 +312,7 @@ export default createRule<Options, MessageIds>({
         node: TSESTree.TSImportEqualsDeclaration,
       ): void {
         if (
-          node.moduleReference.type ===
-            AST_NODE_TYPES.TSExternalModuleReference &&
-          node.moduleReference.expression.type === AST_NODE_TYPES.Literal &&
-          typeof node.moduleReference.expression.value === 'string'
+          node.moduleReference.type === AST_NODE_TYPES.TSExternalModuleReference
         ) {
           const synthesizedImport = {
             ...node,

--- a/packages/eslint-plugin/tests/rules/no-require-imports.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-require-imports.test.ts
@@ -51,10 +51,6 @@ require('remark-preset-prettier');
       code: "import pkg = require('some-package');",
       options: [{ allow: ['^some-package$'] }],
     },
-    {
-      code: 'import pkg = require(`some-package`);',
-      options: [{ allow: ['^some-package$'] }],
-    },
   ],
   invalid: [
     {
@@ -198,17 +194,6 @@ var lib5 = require?.('lib5'),
     },
     {
       code: "import pkg = require('./package.json');",
-      options: [{ allow: ['^some-package$'] }],
-      errors: [
-        {
-          line: 1,
-          column: 14,
-          messageId: 'noRequireImports',
-        },
-      ],
-    },
-    {
-      code: 'import pkg = require(`./package.json`);',
       options: [{ allow: ['^some-package$'] }],
       errors: [
         {

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -3107,6 +3107,9 @@ export class Converter {
         );
       }
       case SyntaxKind.ExternalModuleReference: {
+        if (node.expression.kind !== SyntaxKind.StringLiteral) {
+          this.#throwError(node.expression, 'String literal expected.');
+        }
         return this.createNode<TSESTree.TSExternalModuleReference>(node, {
           type: AST_NODE_TYPES.TSExternalModuleReference,
           expression: this.convertChild(node.expression),


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9220
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
