### PR TITLE
fix(ast-spec): function-call-like callee should be Expression not LeftHandSideExpression

### DIFF
--- a/packages/ast-spec/src/base/UnaryExpressionBase.ts
+++ b/packages/ast-spec/src/base/UnaryExpressionBase.ts
@@ -1,10 +1,8 @@
-import type { UnaryExpression } from '../expression/UnaryExpression/spec';
-import type { LeftHandSideExpression } from '../unions/LeftHandSideExpression';
-import type { Literal } from '../unions/Literal';
+import type { Expression } from '../unions/Expression';
 import type { BaseNode } from './BaseNode';
 
 export interface UnaryExpressionBase extends BaseNode {
   operator: string;
   prefix: boolean;
-  argument: LeftHandSideExpression | Literal | UnaryExpression;
+  argument: Expression;
 }

--- a/packages/ast-spec/src/expression/CallExpression/spec.ts
+++ b/packages/ast-spec/src/expression/CallExpression/spec.ts
@@ -2,11 +2,11 @@ import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
 import type { TSTypeParameterInstantiation } from '../../special/TSTypeParameterInstantiation/spec';
 import type { CallExpressionArgument } from '../../unions/CallExpressionArgument';
-import type { LeftHandSideExpression } from '../../unions/LeftHandSideExpression';
+import type { Expression } from '../../unions/Expression';
 
 export interface CallExpression extends BaseNode {
   type: AST_NODE_TYPES.CallExpression;
-  callee: LeftHandSideExpression;
+  callee: Expression;
   arguments: CallExpressionArgument[];
   typeArguments: TSTypeParameterInstantiation | undefined;
 

--- a/packages/ast-spec/src/expression/ClassExpression/spec.ts
+++ b/packages/ast-spec/src/expression/ClassExpression/spec.ts
@@ -5,5 +5,4 @@ export interface ClassExpression extends ClassBase {
   type: AST_NODE_TYPES.ClassExpression;
   abstract: false;
   declare: false;
-  decorators: [];
 }

--- a/packages/ast-spec/src/expression/NewExpression/spec.ts
+++ b/packages/ast-spec/src/expression/NewExpression/spec.ts
@@ -2,11 +2,11 @@ import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
 import type { TSTypeParameterInstantiation } from '../../special/TSTypeParameterInstantiation/spec';
 import type { CallExpressionArgument } from '../../unions/CallExpressionArgument';
-import type { LeftHandSideExpression } from '../../unions/LeftHandSideExpression';
+import type { Expression } from '../../unions/Expression';
 
 export interface NewExpression extends BaseNode {
   type: AST_NODE_TYPES.NewExpression;
-  callee: LeftHandSideExpression;
+  callee: Expression;
   arguments: CallExpressionArgument[];
   typeArguments: TSTypeParameterInstantiation | undefined;
 

--- a/packages/ast-spec/src/expression/TaggedTemplateExpression/spec.ts
+++ b/packages/ast-spec/src/expression/TaggedTemplateExpression/spec.ts
@@ -1,7 +1,7 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
 import type { TSTypeParameterInstantiation } from '../../special/TSTypeParameterInstantiation/spec';
-import type { LeftHandSideExpression } from '../../unions/LeftHandSideExpression';
+import type { Expression } from '../../unions/Expression';
 import type { TemplateLiteral } from '../TemplateLiteral/spec';
 
 export interface TaggedTemplateExpression extends BaseNode {
@@ -11,6 +11,6 @@ export interface TaggedTemplateExpression extends BaseNode {
   /** @deprecated Use {@link `typeArguments`} instead. */
   typeParameters: TSTypeParameterInstantiation | undefined;
 
-  tag: LeftHandSideExpression;
+  tag: Expression;
   quasi: TemplateLiteral;
 }

--- a/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
+++ b/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
@@ -426,9 +426,7 @@ export default createRule<Options, MessageIds>({
       }
     }
 
-    function isNoFormatTemplateTag(
-      tag: TSESTree.LeftHandSideExpression,
-    ): boolean {
+    function isNoFormatTemplateTag(tag: TSESTree.Expression): boolean {
       return tag.type === AST_NODE_TYPES.Identifier && tag.name === 'noFormat';
     }
 

--- a/packages/eslint-plugin/src/rules/no-implied-eval.ts
+++ b/packages/eslint-plugin/src/rules/no-implied-eval.ts
@@ -36,9 +36,7 @@ export default createRule({
     const services = getParserServices(context);
     const checker = services.program.getTypeChecker();
 
-    function getCalleeName(
-      node: TSESTree.LeftHandSideExpression,
-    ): string | null {
+    function getCalleeName(node: TSESTree.Expression): string | null {
       if (node.type === AST_NODE_TYPES.Identifier) {
         return node.name;
       }

--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -165,7 +165,7 @@ export default createRule<[], MessageIds>({
 
     function checkUnsafeArguments(
       args: TSESTree.Expression[] | TSESTree.CallExpressionArgument[],
-      callee: TSESTree.LeftHandSideExpression,
+      callee: TSESTree.Expression,
       node:
         | TSESTree.CallExpression
         | TSESTree.NewExpression


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9229
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Also fixed two other types that are similarly too strict