### PR TITLE
docs: add missing sort-type-union-intersection-members.mdx tombstone page

### DIFF
--- a/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.mdx
+++ b/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.mdx
@@ -1,0 +1,12 @@
+:::danger Deprecated
+
+This rule has been rename to [`sort-type-constituents`](https://typescript-eslint.io/rules/sort-type-constituents).
+
+:::
+
+<!--
+This doc file has been left on purpose to help direct people to the replacement rule.
+
+Note that there is no actual way to get to this page in the normal navigation,
+so end-users will only be able to get to this page from the search bar.
+-->

--- a/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.mdx
+++ b/packages/eslint-plugin/docs/rules/sort-type-union-intersection-members.mdx
@@ -1,6 +1,6 @@
 :::danger Deprecated
 
-This rule has been rename to [`sort-type-constituents`](https://typescript-eslint.io/rules/sort-type-constituents).
+This rule has been renamed to [`sort-type-constituents`](https://typescript-eslint.io/rules/sort-type-constituents).
 
 :::
 

--- a/packages/eslint-plugin/tests/docs.test.ts
+++ b/packages/eslint-plugin/tests/docs.test.ts
@@ -133,6 +133,7 @@ describe('Validating rule docs', () => {
     'camelcase.md',
     'no-duplicate-imports.mdx',
     'no-parameter-properties.mdx',
+    'sort-type-union-intersection-members.mdx',
   ]);
 
   const rulesWithComplexOptions = new Set(['array-type', 'member-ordering']);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8105
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

No other rules were nominated, and I didn't see any more deletions in the file history of the `all` configs that needed to be addressed.

💖 