### PR TITLE
docs: expand rule deprecation docs to also include renames

### DIFF
--- a/docs/maintenance/issues/Rule_Deprecations_And_Deletions.mdx
+++ b/docs/maintenance/issues/Rule_Deprecations_And_Deletions.mdx
@@ -1,6 +1,6 @@
 ---
 id: rule-deprecations-and-deletions
-title: Rule Deprecations And Deletions
+title: Rule Deprecations, Renames, And Deletions
 ---
 
 Sometimes a rule that used to be 👍 does not age well and becomes 👎.

--- a/docs/maintenance/issues/Rule_Deprecations_And_Deletions.mdx
+++ b/docs/maintenance/issues/Rule_Deprecations_And_Deletions.mdx
@@ -1,6 +1,6 @@
 ---
-id: rule-deprecations
-title: Rule Deprecations
+id: rule-deprecations-and-deletions
+title: Rule Deprecations And Deletions
 ---
 
 Sometimes a rule that used to be 👍 does not age well and becomes 👎.
@@ -14,12 +14,12 @@ In these cases, we aim to remove the old rule with minimal user disruption.
 
 ## Filing the Issue
 
-Rule deprecations can be filed as a [new issue bypassing templates](https://github.com/typescript-eslint/typescript-eslint/issues/new).
+Rule deprecations and renames can be filed as a [new issue bypassing templates](https://github.com/typescript-eslint/typescript-eslint/issues/new).
 
 Provide it an `## Overview` containing:
 
 - The rule name & link to its documentation page
-- A clear explanation of why you believe it should be deprecated
+- A clear explanation of why you believe it should be deprecated and/or renamed
 - Whether it exists in popular configs such as `eslint-config-airbnb-typescript` and `eslint-config-standard-with-typescript`
 - Sourcegraph queries showing how often it appears in user configs
 
@@ -30,5 +30,8 @@ Provide it an `## Overview` containing:
 1. In any minor/patch version, add [rule `meta` properties](https://eslint.org/docs/latest/developer-guide/working-with-rules#rule-basics):
    - `deprecated: true`
    - `replacedBy`, if applicable
-2. In the next major version, you may delete the rule
-   - If the rule is relatively popular with users, consider leaving a documentation page as a tombstone pointing to the new relevant rule or docs (see [`camelcase`](/rules/camelcase/) as an example)
+2. Search through open issues and PRs, and update the name in them accordingly:
+   - Deletions: close them with a link to the issue and deprecation PR
+   - Renames: update their title and explicitly mention in a comment that the rule has been renamed
+3. In the next major version, you may delete the deprecated rule
+   - Leave a documentation page as a tombstone pointing to the new relevant rule or docs (see [`camelcase`](/rules/camelcase) as an example)

--- a/packages/website/docusaurus.config.mts
+++ b/packages/website/docusaurus.config.mts
@@ -287,6 +287,10 @@ const redirects: PluginRedirectOptions = {
       from: '/linting/typed-linting/monorepos',
       to: '/getting-started/typed-linting/monorepos',
     },
+    {
+      from: '/maintenance/issues/rule-deprecations',
+      to: '/maintenance/issues/rule-deprecations-and-deletions',
+    },
   ],
 };
 

--- a/packages/website/sidebars/sidebar.base.js
+++ b/packages/website/sidebars/sidebar.base.js
@@ -125,7 +125,7 @@ module.exports = {
         'maintenance/contributor-tiers',
         {
           collapsible: true,
-          items: ['maintenance/issues/rule-deprecations'],
+          items: ['maintenance/issues/rule-deprecations-and-deletions'],
           label: 'Issues',
           link: {
             id: 'maintenance/issues',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8548
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Since the processes for deprecations / deletions / renames are pretty overlapped, I just kept them in roughly the same page.

💖 