### PR TITLE
docs: mention needing an isolated repro in bug-report-other.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
+++ b/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
@@ -20,7 +20,11 @@ body:
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
   - type: markdown
-    id: complexity-note
+    attributes:
+      value: |
+        **All typescript-eslint bug reports need an isolated reproduction** we can clone locally and get running without other projects or existing knowledge of your project.
+        If you can't provide one, your report will likely be closed without action.
+  - type: markdown
     attributes:
       value: |
         ### Note For Complex Issues


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8270
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a quick note as described in the issue.

Also removes the `id` field that my VS Code extension is telling me is disallowed.

💖