### PR TITLE
docs: add shields.io badges to package pages

### DIFF
--- a/docs/packages/ESLint_Plugin.mdx
+++ b/docs/packages/ESLint_Plugin.mdx
@@ -5,6 +5,8 @@ sidebar_label: eslint-plugin
 
 # `@typescript-eslint/eslint-plugin`
 
+<PackageLink packageName="eslint-plugin" scope="@typescript-eslint" />
+
 > The TypeScript plugin for ESLint. ✨
 
 :::info

--- a/docs/packages/ESLint_Plugin_TSLint.mdx
+++ b/docs/packages/ESLint_Plugin_TSLint.mdx
@@ -5,6 +5,8 @@ sidebar_label: eslint-plugin-tslint
 
 # `@typescript-eslint/eslint-plugin-tslint`
 
+<PackageLink packageName="eslint-plugin-tslint" scope="@typescript-eslint" />
+
 > ESLint plugin that allows running TSLint rules within ESLint to help you migrate from TSLint to ESLint. ✨
 
 :::caution

--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -5,6 +5,8 @@ sidebar_label: parser
 
 # `@typescript-eslint/parser`
 
+<PackageLink packageName="parser" scope="@typescript-eslint" />
+
 > An [ESLint parser](https://eslint.org/docs/user-guide/configuring/plugins#specifying-parser) used to parse TypeScript code into ESLint-compatible nodes, as well as provide backing TypeScript programs. ✨
 
 This is necessary because TypeScript produces a different, incompatible AST format to the one that ESLint requires to work.

--- a/docs/packages/Rule_Tester.mdx
+++ b/docs/packages/Rule_Tester.mdx
@@ -7,6 +7,8 @@ import CodeBlock from '@theme/CodeBlock';
 
 # `@typescript-eslint/rule-tester`
 
+<PackageLink packageName="rule-tester" scope="@typescript-eslint" />
+
 > A utility for testing ESLint rules
 
 This is a fork of ESLint's built-in `RuleTester` to provide some better types and additional features for testing TypeScript rules.

--- a/docs/packages/Scope_Manager.mdx
+++ b/docs/packages/Scope_Manager.mdx
@@ -5,6 +5,8 @@ sidebar_label: scope-manager
 
 # `@typescript-eslint/scope-manager`
 
+<PackageLink packageName="scope-manager" scope="@typescript-eslint" />
+
 > A fork of [`eslint-scope`](https://github.com/eslint/eslint-scope), enhanced to support TypeScript functionality. ✨
 
 A "scope analyser" traverses an AST and builds a model of how variables (and in our case, types) are defined and consumed by the source code.

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -8,6 +8,8 @@ import TabItem from '@theme/TabItem';
 
 # `typescript-eslint`
 
+<PackageLink packageName="typescript-eslint" />
+
 > Tooling which enables you to use TypeScript with ESLint
 
 This package is the main entrypoint that you can use to consume our tooling with ESLint.

--- a/docs/packages/TypeScript_ESTree.mdx
+++ b/docs/packages/TypeScript_ESTree.mdx
@@ -5,6 +5,8 @@ sidebar_label: typescript-estree
 
 # `@typescript-eslint/typescript-estree`
 
+<PackageLink packageName="typescript-estree" scope="@typescript-eslint" />
+
 > The underlying code used by [`@typescript-eslint/parser`](./Parser.mdx) that converts TypeScript source code into an <a href="https://github.com/estree/estree">ESTree</a>-compatible form. ✨
 
 This parser is designed to be generic and robust.

--- a/docs/packages/Utils.mdx
+++ b/docs/packages/Utils.mdx
@@ -5,6 +5,8 @@ sidebar_label: utils
 
 # `@typescript-eslint/utils`
 
+<PackageLink packageName="utils" scope="@typescript-eslint" />
+
 > Utilities for working with TypeScript + ESLint together. ✨
 
 This package contains public utilities for writing custom rules and plugins in TypeScript.

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -25,6 +25,7 @@
     "@docusaurus/theme-common": "^3.2.1",
     "@typescript-eslint/parser": "7.12.0",
     "@typescript-eslint/website-eslint": "7.12.0",
+    "@uiw/react-shields": "2.0.1",
     "clsx": "^2.1.0",
     "eslint": "*",
     "json5": "^2.2.3",

--- a/packages/website/src/theme/MDXComponents/PackageLink.module.css
+++ b/packages/website/src/theme/MDXComponents/PackageLink.module.css
@@ -1,0 +1,3 @@
+.packageLink {
+  margin-bottom: 0.5rem;
+}

--- a/packages/website/src/theme/MDXComponents/PackageLink.tsx
+++ b/packages/website/src/theme/MDXComponents/PackageLink.tsx
@@ -1,0 +1,29 @@
+import Npm from '@uiw/react-shields/npm';
+import React from 'react';
+
+import packageData from '../../../package.json';
+import styles from './PackageLink.module.css';
+
+export interface PackageLinkProps {
+  scope?: string;
+  packageName: string;
+}
+
+export function PackageLink({
+  packageName,
+  scope,
+}: PackageLinkProps): React.JSX.Element {
+  const fullPackageName = [scope, packageName].filter(Boolean).join('/');
+  const { version } = packageData;
+
+  return (
+    <Npm.Version
+      alt={`npm: ${fullPackageName} v${version}`}
+      anchor={{ target: '_blank' }}
+      className={styles.packageLink}
+      href={`https://npmjs.com/${fullPackageName}`}
+      packageName={packageName}
+      scope={scope}
+    />
+  );
+}

--- a/packages/website/src/theme/MDXComponents/index.tsx
+++ b/packages/website/src/theme/MDXComponents/index.tsx
@@ -3,6 +3,7 @@ import MDXComponents from '@theme-original/MDXComponents';
 
 import { BaseRuleReference } from './BaseRuleReference';
 import { HiddenHeading } from './HiddenHeading';
+import { PackageLink } from './PackageLink';
 import { RuleAttributes } from './RuleAttributes';
 import { TryInPlayground } from './TryInPlayground';
 
@@ -11,6 +12,7 @@ export default {
   Admonition,
   BaseRuleReference,
   HiddenHeading,
+  PackageLink,
   RuleAttributes,
   TryInPlayground,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6046,6 +6046,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@uiw/react-shields@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@uiw/react-shields@npm:2.0.1"
+  dependencies:
+    "@babel/runtime": ^7.22.6
+  peerDependencies:
+    "@babel/runtime": ">=7.0.0"
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 7103c5c6e135b15fc68fcae9818ddd71ecb40aef253abf45dec9fb068383f2219c08bd5a22957daebbe8395c941632e0e0447ade3e64cda84b79967512b16c19
+  languageName: node
+  linkType: hard
+
 "@ungap/structured-clone@npm:^1.0.0, @ungap/structured-clone@npm:^1.2.0":
   version: 1.2.0
   resolution: "@ungap/structured-clone@npm:1.2.0"
@@ -20424,6 +20437,7 @@ __metadata:
     "@typescript-eslint/typescript-estree": 7.12.0
     "@typescript-eslint/utils": 7.12.0
     "@typescript-eslint/website-eslint": 7.12.0
+    "@uiw/react-shields": 2.0.1
     clsx: ^2.1.0
     copy-webpack-plugin: ^12.0.0
     cross-fetch: "*"


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a `PackageLink` component that's then used on all the package docs pages, such as `/packages/utils`. Uses https://uiwjs.github.io/react-shields for the shields themselves.

I'd wanted to use a "self-hosted" version but couldn't find one that worked well. The closest was https://www.npmjs.com/package/badge-maker but it has a runtime dependency on `fs`. Ah well - fodder for a followup.

💖 