### PR TITLE
docs(website): enable automatic types acqusition (ATA) in the playground

### DIFF
--- a/packages/website/src/components/editor/useSandboxServices.ts
+++ b/packages/website/src/components/editor/useSandboxServices.ts
@@ -62,7 +62,7 @@ export const useSandboxServices = (
               wrappingIndent: 'same',
               hover: { above: false },
             },
-            acquireTypes: false,
+            acquireTypes: true,
             compilerOptions:
               compilerOptions as Monaco.languages.typescript.CompilerOptions,
             domID: editorEmbedId,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8696
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Enables the `acquireTypes` option as @armano2 suggested in https://github.com/typescript-eslint/typescript-eslint/issues/8696#issuecomment-2054126062. It doesn't enable preview work or better font family for the side view - that seems like ... a lot more work, which IMO would be fine as a followup.

![Screenshot of importing the lodash package in the playground, with Monaco auto-completing its properties](https://github.com/typescript-eslint/typescript-eslint/assets/3335181/6f4aa687-e824-43af-ab73-c5c8c0d85aee)


💖 