### PR TITLE
chore: ensure 'breaking change' label for PRs that touch stable configs

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,25 @@
+name: Pull Request Labels
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, unlabeled]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - id: changed-stable-configs
+        uses: tj-actions/changed-files@v44.5.2
+        with:
+          files: packages/{eslint-plugin,typescript-eslint}/src/configs/{recommended,stylistic}*
+      - if: steps.changed-stable-configs.outputs.any_changed == 'true'
+        uses: mheap/github-action-required-labels@v5.4.1
+        with:
+          add_comment: true
+          count: 1
+          labels: breaking change
+          message: "🤖 Beep boop! PRs that change our stable preset configs must be labeled with `breaking change`."
+          mode: minimum

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -21,5 +21,5 @@ jobs:
           add_comment: true
           count: 1
           labels: breaking change
-          message: "🤖 Beep boop! PRs that change our stable preset configs must be labeled with `breaking change`."
+          message: '🤖 Beep boop! PRs that change our stable preset configs must be labeled with `breaking change`.'
           mode: minimum


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6890
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Combines:

1. https://github.com/marketplace/actions/changed-files: to check whether the stable configs were changed
2. https://github.com/marketplace/actions/require-labels: to require the `breaking change` when any stable config was changed

For an example CI failure, see https://github.com/JoshuaKGoldberg/typescript-eslint/pull/322 -> https://github.com/JoshuaKGoldberg/typescript-eslint/pull/322#issuecomment-2146330650:

> 🤖 Beep boop! PRs that change our stable preset configs must be labeled with breaking change.

💖 