### PR TITLE
chore: add 'locked due to age' label to lock.yml workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,8 +14,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@v5.0.1
         with:
+          add-issue-labels: 'locked due to age'
           github-token: ${{ github.token }}
           issue-inactive-days: '7'
           issue-lock-reason: 'resolved'


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8070
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Uses a new [`locked due to age`](https://github.com/typescript-eslint/typescript-eslint/labels/locked%20due%20to%20age) label I made just now per https://github.com/typescript-eslint/typescript-eslint/issues/8070#issuecomment-1858692983. It links to https://typescript-eslint.io/contributing.
