### PR TITLE
docs: note the stylistic configs as sticking around past formatting rules

### DIFF
--- a/docs/troubleshooting/Formatting.mdx
+++ b/docs/troubleshooting/Formatting.mdx
@@ -114,6 +114,9 @@ Per [ESLint's 2020 Changes to Rule Policies blog post](https://eslint.org/blog/2
 We mirror the ESLint team's move away from _formatting_ and _stylistic_ rules.
 With the exception of bug fixes, no new formatting- or stylistic-related pull requests will be accepted into typescript-eslint.
 
+> Note that the [`stylistic` configurations](../users/Shared_Configurations.mdx#stylistic) are not deprecated or recommended-against.
+> We'll continue to include those configs and their rules to help enforce TypeScript-related stylistic consistency for the forseeable future.
+
 ## `eslint-stylistic`
 
 The downside of using a comprehensive formatter for formatting is that it will strictly apply opinions to code.

--- a/docs/troubleshooting/Formatting.mdx
+++ b/docs/troubleshooting/Formatting.mdx
@@ -114,8 +114,10 @@ Per [ESLint's 2020 Changes to Rule Policies blog post](https://eslint.org/blog/2
 We mirror the ESLint team's move away from _formatting_ and _stylistic_ rules.
 With the exception of bug fixes, no new formatting- or stylistic-related pull requests will be accepted into typescript-eslint.
 
-> Note that the [`stylistic` configurations](../users/Shared_Configurations.mdx#stylistic) are not deprecated or recommended-against.
-> We'll continue to include those configs and their rules to help enforce TypeScript-related stylistic consistency for the forseeable future.
+:::note
+The [`stylistic` configurations](../users/Shared_Configurations.mdx#stylistic) are not deprecated or recommended-against.
+We'll continue to include those configs and their rules to help enforce TypeScript-related stylistic consistency for the foreseeable future.
+:::
 
 ## `eslint-stylistic`
 

--- a/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
+++ b/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
@@ -32,6 +32,9 @@ Per semantic versioning, formatting-related rules will remain available for all 
 
 **Our next major version, v7, will remove all deprecated rules.**
 
+> Note that the [`stylistic` configurations](/users/configs#stylistic) are not deprecated or recommended-against.
+> We'll continue to include those configs and their rules to help enforce TypeScript-related stylistic consistency for the forseeable future.
+
 ## Upgrading to ESLint Stylistic
 
 Although you can continue to use formatting rules in typescript-eslint for now, we don't plan on adding any new features or fixes to the rules.

--- a/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
+++ b/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
@@ -32,8 +32,10 @@ Per semantic versioning, formatting-related rules will remain available for all 
 
 **Our next major version, v7, will remove all deprecated rules.**
 
-> Note that the [`stylistic` configurations](/users/configs#stylistic) are not deprecated or recommended-against.
-> We'll continue to include those configs and their rules to help enforce TypeScript-related stylistic consistency for the forseeable future.
+:::note
+The [`stylistic` configurations](/users/configs#stylistic) are not deprecated or recommended-against.
+We'll continue to include those configs and their rules to help enforce TypeScript-related stylistic consistency for the foreseeable future.
+:::
 
 ## Upgrading to ESLint Stylistic
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8275
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I don't think we need many more places than this. It's been a while since formatting rules were deprecated, and we added more mentions of using the stylistic configs in #8823 -> #8916.

💖 