### PR TITLE
docs(eslint-plugin): [no-misused-promises] replace third-party EventEmitter example with native document

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-misused-promises.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misused-promises.mdx
@@ -127,18 +127,18 @@ Examples of code for this rule with `checksVoidReturn: true`:
 
 ```ts option='{ "checksVoidReturn": true }'
 [1, 2, 3].forEach(async value => {
-  await doSomething(value);
+  await fetch(`/${value}`);
 });
 
-new Promise(async (resolve, reject) => {
-  await doSomething();
+new Promise<void>(async (resolve, reject) => {
+  await fetch('/');
   resolve();
 });
 
 document.addEventListener('click', async () => {
-  synchronousCall();
-  await doSomething();
-  otherSynchronousCall();
+  console.log('synchronous call');
+  await fetch('/');
+  console.log('synchronous call');
 });
 ```
 
@@ -208,30 +208,30 @@ Examples of code for this rule with `checksSpreads: true`:
 <TabItem value="❌ Incorrect">
 
 ```ts option='{ "checksSpreads": true }'
-const getData = () => someAsyncOperation({ myArg: 'foo' });
+const getData = () => fetch('/');
 
-return { foo: 42, ...getData() };
+console.log({ foo: 42, ...getData() });
 
-const getData2 = async () => {
-  await someAsyncOperation({ myArg: 'foo' });
+const awaitData = async () => {
+  await fetch('/');
 };
 
-return { foo: 42, ...getData2() };
+console.log({ foo: 42, ...awaitData() });
 ```
 
 </TabItem>
 <TabItem value="✅ Correct">
 
 ```ts option='{ "checksSpreads": true }'
-const getData = () => someAsyncOperation({ myArg: 'foo' });
+const getData = () => fetch('/');
 
-return { foo: 42, ...(await getData()) };
+console.log({ foo: 42, ...(await getData()) });
 
-const getData2 = async () => {
-  await someAsyncOperation({ myArg: 'foo' });
+const awaitData = async () => {
+  await fetch('/');
 };
 
-return { foo: 42, ...(await getData2()) };
+console.log({ foo: 42, ...(await awaitData()) });
 ```
 
 </TabItem>

--- a/packages/eslint-plugin/docs/rules/no-misused-promises.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misused-promises.mdx
@@ -135,8 +135,7 @@ new Promise(async (resolve, reject) => {
   resolve();
 });
 
-const eventEmitter = new EventEmitter();
-eventEmitter.on('some-event', async () => {
+document.addEventListener('click', async () => {
   synchronousCall();
   await doSomething();
   otherSynchronousCall();
@@ -169,8 +168,7 @@ new Promise((resolve, reject) => {
 });
 
 // Name the async wrapper to call it later
-const eventEmitter = new EventEmitter();
-eventEmitter.on('some-event', () => {
+document.addEventListener('click', () => {
   const handler = async () => {
     await doSomething();
     otherSynchronousCall();

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misused-promises.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misused-promises.shot
@@ -60,8 +60,7 @@ new Promise(async (resolve, reject) => {
 });
 ~
 
-const eventEmitter = new EventEmitter();
-eventEmitter.on('some-event', async () => {
+document.addEventListener('click', async () => {
   synchronousCall();
   await doSomething();
   otherSynchronousCall();
@@ -95,8 +94,7 @@ new Promise((resolve, reject) => {
 });
 
 // Name the async wrapper to call it later
-const eventEmitter = new EventEmitter();
-eventEmitter.on('some-event', () => {
+document.addEventListener('click', () => {
   const handler = async () => {
     await doSomething();
     otherSynchronousCall();

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misused-promises.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-misused-promises.shot
@@ -46,24 +46,24 @@ Options: { "checksVoidReturn": true }
 
 [1, 2, 3].forEach(async value => {
                   ~~~~~~~~~~~~~~~~ Promise returned in function argument where a void return was expected.
-  await doSomething(value);
+  await fetch(\`/\${value}\`);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 });
 ~
 
-new Promise(async (resolve, reject) => {
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Promise returned in function argument where a void return was expected.
-  await doSomething();
-~~~~~~~~~~~~~~~~~~~~~~
+new Promise<void>(async (resolve, reject) => {
+                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Promise returned in function argument where a void return was expected.
+  await fetch('/');
+~~~~~~~~~~~~~~~~~~~
   resolve();
 ~~~~~~~~~~~~
 });
 ~
 
 document.addEventListener('click', async () => {
-  synchronousCall();
-  await doSomething();
-  otherSynchronousCall();
+  console.log('synchronous call');
+  await fetch('/');
+  console.log('synchronous call');
 });
 "
 `;
@@ -115,16 +115,17 @@ exports[`Validating rule docs no-misused-promises.mdx code examples ESLint outpu
 "Incorrect
 Options: { "checksSpreads": true }
 
-const getData = () => someAsyncOperation({ myArg: 'foo' });
+const getData = () => fetch('/');
 
-return { foo: 42, ...getData() };
+console.log({ foo: 42, ...getData() });
+                          ~~~~~~~~~ Expected a non-Promise value to be spreaded in an object.
 
-const getData2 = async () => {
-  await someAsyncOperation({ myArg: 'foo' });
+const awaitData = async () => {
+  await fetch('/');
 };
 
-return { foo: 42, ...getData2() };
-                     ~~~~~~~~~~ Expected a non-Promise value to be spreaded in an object.
+console.log({ foo: 42, ...awaitData() });
+                          ~~~~~~~~~~~ Expected a non-Promise value to be spreaded in an object.
 "
 `;
 
@@ -132,14 +133,14 @@ exports[`Validating rule docs no-misused-promises.mdx code examples ESLint outpu
 "Correct
 Options: { "checksSpreads": true }
 
-const getData = () => someAsyncOperation({ myArg: 'foo' });
+const getData = () => fetch('/');
 
-return { foo: 42, ...(await getData()) };
+console.log({ foo: 42, ...(await getData()) });
 
-const getData2 = async () => {
-  await someAsyncOperation({ myArg: 'foo' });
+const awaitData = async () => {
+  await fetch('/');
 };
 
-return { foo: 42, ...(await getData2()) };
+console.log({ foo: 42, ...(await awaitData()) });
 "
 `;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8053
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Even with ATA added (#8696), it's conceptually easier to avoid third-party packages altogether.

💖 