### PR TITLE
docs: mention Quickstart and typescript-eslint in Shared Configs

### DIFF
--- a/docs/users/Shared_Configurations.mdx
+++ b/docs/users/Shared_Configurations.mdx
@@ -14,6 +14,9 @@ import TabItem from '@theme/TabItem';
 
 ## Getting Started
 
+See [Getting Started > Quickstart](../getting-started/Quickstart.mdx) first to set up your ESLint configuration file.
+[Packages > typescript-eslint](../packages/TypeScript_ESLint.mdx) includes more documentation on the `tseslint` helper.
+
 ### Projects Without Type Checking
 
 If your project does not enable [typed linting](../getting-started/Typed_Linting.mdx), we suggest enabling the [`recommended`](#recommended) and [`stylistic`](#stylistic) configurations to start:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8959
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Mentions the _Quickstart_ and _typescript-eslint_ pages in the _Shared Configs_ page. They have all the docs & links-to-docs folks would need to understand the concepts and identifiers used in the config docs.

This doesn't add `import` statements to the config docs, as that would make the page a few dozen lines taller.