### PR TITLE
docs: mention non-semver guarantees in Shared Configs docs

### DIFF
--- a/docs/users/Shared_Configurations.mdx
+++ b/docs/users/Shared_Configurations.mdx
@@ -184,11 +184,11 @@ module.exports = {
 Some rules also enabled in `recommended` default to more strict settings in this configuration.
 See [`configs/strict.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/strict.ts) for the exact contents of this config.
 
-:::caution
+:::tip
 We recommend a TypeScript project extend from `plugin:@typescript-eslint/strict` only if a nontrivial percentage of its developers are highly proficient in TypeScript.
 :::
 
-:::note
+:::warning
 This configuration is not considered "stable" under Semantic Versioning (semver).
 Its enabled rules and/or their options may change outside of major version updates.
 :::
@@ -220,11 +220,11 @@ module.exports = {
 Some rules also enabled in `recommended-type-checked` default to more strict settings in this configuration.
 See [`configs/strict-type-checked.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/strict-type-checked.ts) for the exact contents of this config.
 
-:::caution
+:::tip
 We recommend a TypeScript project extend from `plugin:@typescript-eslint/strict-type-checked` only if a nontrivial percentage of its developers are highly proficient in TypeScript.
 :::
 
-:::note
+:::warning
 This configuration is not considered "stable" under Semantic Versioning (semver).
 Its enabled rules and/or their options may change outside of major version updates.
 :::
@@ -303,7 +303,7 @@ We do not recommend TypeScript projects extend from `plugin:@typescript-eslint/a
 Many rules conflict with each other and/or are intended to be configured per-project.
 :::
 
-:::note
+:::warning
 This configuration is not considered "stable" under Semantic Versioning (semver).
 Its enabled rules and/or their options may change outside of major version updates.
 :::
@@ -381,7 +381,7 @@ module.exports = {
 </TabItem>
 </Tabs>
 
-:::note
+:::warning
 This configuration is not considered "stable" under Semantic Versioning (semver).
 Its enabled rules and/or their options may change outside of major version updates.
 :::
@@ -447,7 +447,7 @@ module.exports = {
 
 See [`configs/strict-type-checked-only.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/strict-type-checked-only.ts) for the exact contents of this config.
 
-:::note
+:::warning
 This configuration is not considered "stable" under Semantic Versioning (semver).
 Its enabled rules and/or their options may change outside of major version updates.
 :::

--- a/docs/users/Shared_Configurations.mdx
+++ b/docs/users/Shared_Configurations.mdx
@@ -188,6 +188,11 @@ See [`configs/strict.ts`](https://github.com/typescript-eslint/typescript-eslint
 We recommend a TypeScript project extend from `plugin:@typescript-eslint/strict` only if a nontrivial percentage of its developers are highly proficient in TypeScript.
 :::
 
+:::note
+This configuration is not considered "stable" under Semantic Versioning (semver).
+Its enabled rules and/or their options may change outside of major version updates.
+:::
+
 ### `strict-type-checked`
 
 Contains all of `recommended`, `recommended-type-checked`, and `strict`, along with additional strict rules that require type information.
@@ -217,6 +222,11 @@ See [`configs/strict-type-checked.ts`](https://github.com/typescript-eslint/type
 
 :::caution
 We recommend a TypeScript project extend from `plugin:@typescript-eslint/strict-type-checked` only if a nontrivial percentage of its developers are highly proficient in TypeScript.
+:::
+
+:::note
+This configuration is not considered "stable" under Semantic Versioning (semver).
+Its enabled rules and/or their options may change outside of major version updates.
 :::
 
 ### `stylistic`
@@ -293,6 +303,11 @@ We do not recommend TypeScript projects extend from `plugin:@typescript-eslint/a
 Many rules conflict with each other and/or are intended to be configured per-project.
 :::
 
+:::note
+This configuration is not considered "stable" under Semantic Versioning (semver).
+Its enabled rules and/or their options may change outside of major version updates.
+:::
+
 ### `base`
 
 A minimal ruleset that sets only the required parser and plugin options needed to run typescript-eslint.
@@ -366,6 +381,11 @@ module.exports = {
 </TabItem>
 </Tabs>
 
+:::note
+This configuration is not considered "stable" under Semantic Versioning (semver).
+Its enabled rules and/or their options may change outside of major version updates.
+:::
+
 ### `eslint-recommended`
 
 This ruleset is meant to be used after extending `eslint:recommended`.
@@ -426,6 +446,11 @@ module.exports = {
 ```
 
 See [`configs/strict-type-checked-only.ts`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/strict-type-checked-only.ts) for the exact contents of this config.
+
+:::note
+This configuration is not considered "stable" under Semantic Versioning (semver).
+Its enabled rules and/or their options may change outside of major version updates.
+:::
 
 ### `stylistic-type-checked-only`
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9073
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a `:::note` very similar to @bachmacintosh's phrasing to each of the configs that may change in minor or patch versions.

💖 

Co-authored-by: @bachmacintosh