### PR TITLE
docs: add a couple of starting issue queries

### DIFF
--- a/docs/Contributing.mdx
+++ b/docs/Contributing.mdx
@@ -16,6 +16,6 @@ If you're new to open source, you may also find the [How to Contribute to Open S
 
 ## Next Steps
 
-1. [Finding or opening an issue](./contributing/Issues.mdx): In the issue tab, find the pr currently tagged with `accepting prs` or create a new issue.
-2. [Setting up a local environment](./contributing/Local_Development.mdx): Let's learn how to set up the local environment to start development.
-3. [Making a PR](./contributing/Pull_Requests.mdx): you've got changes locally that address an issue, take a look at that topic.
+1. [Finding or opening an issue](./contributing/Issues.mdx): In the issue tab, finding or creating an issue to work on.
+2. [Setting up a local environment](./contributing/Local_Development.mdx): Learning how to set up the local environment to start development.
+3. [Making a PR](./contributing/Pull_Requests.mdx): Sending in your changes to resolve an accepted issue.

--- a/docs/contributing/Issues.mdx
+++ b/docs/contributing/Issues.mdx
@@ -34,6 +34,13 @@ We've found in the past that they result in accidental ["licked cookie"](https:/
 If an issue has been marked as `accepting prs` and an open PR does not exist, feel free to send a PR.
 You don't need to ask for permission.
 
+## Finding Issues
+
+Consider searching through:
+
+1. [Unassigned user-facing marked as `accepting prs` and `good first issue`](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+label%3A%22accepting+prs%22+-label%3A%22repo+maintenance%22+no%3Aassignee): to find issues marked as good for a first-timer
+2. [Unassigned user-facing marked as `accepting prs` without `good first issue`](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22+-label%3A%22good+first+issue%22+-label%3A%22repo+maintenance%22+no%3Aassignee): once you've finished a few issues, to find more intermediate-level issues
+
 ## Questions and Support Requests
 
 The issue tracker is not an appropriate place for questions or support requests.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6731
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Tightens up the phrasing in the root _Contributing_ page too, now that _Issues_ has more info on the `accepting prs` et al.

💖