### PR TITLE
docs(eslint-plugin): [prefer-readonly-parameter-types] mention limitations

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.mdx
@@ -402,3 +402,8 @@ function foo(arg: MyType) {}
 ## When Not To Use It
 
 If your project does not attempt to enforce strong immutability guarantees of parameters, you can avoid this rule.
+
+This rule is very strict on what it considers mutable.
+Many types that describe themselves as readonly are considered mutable because they have mutable properties such as arrays or tuples.
+To work around these limitations, you might need to use the rule's options.
+In particular, the [`allow` option](#allow) can explicitly mark a type as readable.

--- a/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.mdx
@@ -406,4 +406,4 @@ If your project does not attempt to enforce strong immutability guarantees of pa
 This rule is very strict on what it considers mutable.
 Many types that describe themselves as readonly are considered mutable because they have mutable properties such as arrays or tuples.
 To work around these limitations, you might need to use the rule's options.
-In particular, the [`allow` option](#allow) can explicitly mark a type as readable.
+In particular, the [`allow` option](#allow) can explicitly mark a type as readonly.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7179
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Per #8932, a lot of third-party types actually do trigger the rule. So I opted to not mention them.

💖 