### PR TITLE
feat(eslint-plugin): [no-floating-promises] add checkThenables option

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
@@ -89,7 +89,7 @@ await Promise.all([1, 2, 3].map(async x => x + 1));
 A ["Thenable"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) value is an object which has a `then` method, such as a `Promise`.
 Other Thenables include TypeScript's built-in `PromiseLike` interface and any custom object that happens to have a `.then()`.
 
-The `checkAllThenable` option triggers `no-floating-promises` to also consider all values that happen to be Thenable, not just Promises.
+The `checkAllThenable` option triggers `no-floating-promises` to also consider all values that happen to be Thenables with `.then()` two parameters, not just Promises.
 This can be useful if your code works with older `Promise` polyfills instead of the native `Promise` class.
 
 <Tabs>

--- a/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
@@ -84,6 +84,53 @@ await Promise.all([1, 2, 3].map(async x => x + 1));
 
 ## Options
 
+### `checkThenables`
+
+A ["Thenable"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) value is an object which has a `then` method, such as a `Promise`.
+Other Thenables include TypeScript's built-in `PromiseLike` interface and any custom object that happens to have a `.then()`.
+
+The `checkAllThenable` option triggers `no-floating-promises` to also consider all values that happen to be Thenable, not just Promises.
+This can be useful if your code works with older `Promise` polyfills instead of the native `Promise` class.
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts option='{"checkThenables": true}'
+declare function createPromiseLike(): PromiseLike<string>;
+
+createPromiseLike();
+
+interface MyThenable {
+  then(onFulfilled: () => void, onRejected: () => void): MyThenable;
+}
+
+declare function createMyThenable(): MyThenable;
+
+createMyThenable();
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts option='{"checkThenables": true}'
+declare function createPromiseLike(): PromiseLike<string>;
+
+await createPromiseLike();
+
+interface MyThenable {
+  then(onFulfilled: () => void, onRejected: () => void): MyThenable;
+}
+
+declare function createMyThenable(): MyThenable;
+
+await createMyThenable();
+```
+
+</TabItem>
+</Tabs>
+
+> This option is enabled by default in v7 but will be turned off by default in v8.
+
 ### `ignoreVoid`
 
 This option, which is `true` by default, allows you to stop the rule reporting promises consumed with void operator.

--- a/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
@@ -89,7 +89,7 @@ await Promise.all([1, 2, 3].map(async x => x + 1));
 A ["Thenable"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#thenables) value is an object which has a `then` method, such as a `Promise`.
 Other Thenables include TypeScript's built-in `PromiseLike` interface and any custom object that happens to have a `.then()`.
 
-The `checkAllThenable` option triggers `no-floating-promises` to also consider all values that happen to be Thenables with `.then()` two parameters, not just Promises.
+The `checkThenables` option triggers `no-floating-promises` to also consider all values that satisfy the Thenable shape (a `.then()` method that takes two callback parameters), not just Promises.
 This can be useful if your code works with older `Promise` polyfills instead of the native `Promise` class.
 
 <Tabs>
@@ -129,7 +129,9 @@ await createMyThenable();
 </TabItem>
 </Tabs>
 
-> This option is enabled by default in v7 but will be turned off by default in v8.
+:::info
+This option is enabled by default in v7 but will be turned off by default in v8.
+:::
 
 ### `ignoreVoid`
 

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -8,6 +8,7 @@ import {
   createRule,
   getOperatorPrecedence,
   getParserServices,
+  isSymbolFromDefaultLibrary,
   OperatorPrecedence,
   readonlynessOptionsDefaults,
   readonlynessOptionsSchema,
@@ -16,9 +17,10 @@ import {
 
 type Options = [
   {
-    ignoreVoid?: boolean;
-    ignoreIIFE?: boolean;
     allowForKnownSafePromises?: TypeOrValueSpecifier[];
+    checkThenables?: boolean;
+    ignoreIIFE?: boolean;
+    ignoreVoid?: boolean;
   },
 ];
 
@@ -75,6 +77,12 @@ export default createRule<Options, MessageId>({
       {
         type: 'object',
         properties: {
+          allowForKnownSafePromises: readonlynessOptionsSchema.properties.allow,
+          checkThenables: {
+            description:
+              'Whether to check all "Thenable"s, not just the built-in Promise type.',
+            type: 'boolean',
+          },
           ignoreVoid: {
             description: 'Whether to ignore `void` expressions.',
             type: 'boolean',
@@ -84,7 +92,6 @@ export default createRule<Options, MessageId>({
               'Whether to ignore async IIFEs (Immediately Invoked Function Expressions).',
             type: 'boolean',
           },
-          allowForKnownSafePromises: readonlynessOptionsSchema.properties.allow,
         },
         additionalProperties: false,
       },
@@ -93,15 +100,18 @@ export default createRule<Options, MessageId>({
   },
   defaultOptions: [
     {
+      allowForKnownSafePromises: readonlynessOptionsDefaults.allow,
+      checkThenables: true,
       ignoreVoid: true,
       ignoreIIFE: false,
-      allowForKnownSafePromises: readonlynessOptionsDefaults.allow,
     },
   ],
 
   create(context, [options]) {
     const services = getParserServices(context);
     const checker = services.program.getTypeChecker();
+    const { checkThenables } = options;
+
     // TODO: #5439
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const allowForKnownSafePromises = options.allowForKnownSafePromises!;
@@ -356,14 +366,10 @@ export default createRule<Options, MessageId>({
       return false;
     }
 
-    // Modified from tsutils.isThenable() to only consider thenables which can be
-    // rejected/caught via a second parameter. Original source (MIT licensed):
-    //
-    //   https://github.com/ajafff/tsutils/blob/49d0d31050b44b81e918eae4fbaf1dfe7b7286af/util/type.ts#L95-L125
     function isPromiseLike(node: ts.Node, type?: ts.Type): boolean {
       type ??= checker.getTypeAtLocation(node);
 
-      // Ignore anything specified by `allowForKnownSafePromises` option.
+      // The highest priority it so allow anything allowlisted
       if (
         allowForKnownSafePromises.some(allowedType =>
           typeMatchesSpecifier(type, allowedType, services.program),
@@ -372,6 +378,24 @@ export default createRule<Options, MessageId>({
         return false;
       }
 
+      // Otherwise, we always consider the built-in Promise to be Promise-like...
+      const symbol = type.getSymbol();
+      if (
+        symbol?.name === 'Promise' &&
+        isSymbolFromDefaultLibrary(services.program, symbol)
+      ) {
+        return true;
+      }
+
+      // ...and only check all Thenables if explicitly told to
+      if (!checkThenables) {
+        return false;
+      }
+
+      // Modified from tsutils.isThenable() to only consider thenables which can be
+      // rejected/caught via a second parameter. Original source (MIT licensed):
+      //
+      //   https://github.com/ajafff/tsutils/blob/49d0d31050b44b81e918eae4fbaf1dfe7b7286af/util/type.ts#L95-L125
       for (const ty of tsutils.unionTypeParts(checker.getApparentType(type))) {
         const then = ty.getProperty('then');
         if (then === undefined) {

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -369,7 +369,7 @@ export default createRule<Options, MessageId>({
     function isPromiseLike(node: ts.Node, type?: ts.Type): boolean {
       type ??= checker.getTypeAtLocation(node);
 
-      // The highest priority it so allow anything allowlisted
+      // The highest priority is to allow anything allowlisted
       if (
         allowForKnownSafePromises.some(allowedType =>
           typeMatchesSpecifier(type, allowedType, services.program),

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-floating-promises.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-floating-promises.shot
@@ -50,6 +50,44 @@ await Promise.all([1, 2, 3].map(async x => x + 1));
 `;
 
 exports[`Validating rule docs no-floating-promises.mdx code examples ESLint output 3`] = `
+"Incorrect
+Options: {"checkThenables": true}
+
+declare function createPromiseLike(): PromiseLike<string>;
+
+createPromiseLike();
+~~~~~~~~~~~~~~~~~~~~ Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the \`void\` operator.
+
+interface MyThenable {
+  then(onFulfilled: () => void, onRejected: () => void): MyThenable;
+}
+
+declare function createMyThenable(): MyThenable;
+
+createMyThenable();
+~~~~~~~~~~~~~~~~~~~ Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the \`void\` operator.
+"
+`;
+
+exports[`Validating rule docs no-floating-promises.mdx code examples ESLint output 4`] = `
+"Correct
+Options: {"checkThenables": true}
+
+declare function createPromiseLike(): PromiseLike<string>;
+
+await createPromiseLike();
+
+interface MyThenable {
+  then(onFulfilled: () => void, onRejected: () => void): MyThenable;
+}
+
+declare function createMyThenable(): MyThenable;
+
+await createMyThenable();
+"
+`;
+
+exports[`Validating rule docs no-floating-promises.mdx code examples ESLint output 5`] = `
 "Options: { "ignoreVoid": true }
 
 async function returnsPromise() {
@@ -61,7 +99,7 @@ void Promise.reject('value');
 "
 `;
 
-exports[`Validating rule docs no-floating-promises.mdx code examples ESLint output 4`] = `
+exports[`Validating rule docs no-floating-promises.mdx code examples ESLint output 6`] = `
 "Options: { "ignoreIIFE": true }
 
 await (async function () {
@@ -74,7 +112,7 @@ await (async function () {
 "
 `;
 
-exports[`Validating rule docs no-floating-promises.mdx code examples ESLint output 5`] = `
+exports[`Validating rule docs no-floating-promises.mdx code examples ESLint output 7`] = `
 "Incorrect
 Options: {"allowForKnownSafePromises":[{"from":"file","name":"SafePromise"},{"from":"lib","name":"PromiseLike"},{"from":"package","name":"Bar","package":"bar-lib"}]}
 
@@ -91,7 +129,7 @@ returnsPromise();
 "
 `;
 
-exports[`Validating rule docs no-floating-promises.mdx code examples ESLint output 6`] = `
+exports[`Validating rule docs no-floating-promises.mdx code examples ESLint output 8`] = `
 "Correct
 Options: {"allowForKnownSafePromises":[{"from":"file","name":"SafePromise"},{"from":"lib","name":"PromiseLike"},{"from":"package","name":"Bar","package":"bar-lib"}]}
 

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -2237,5 +2237,13 @@ createMyThenable();
       errors: [{ line: 8, messageId: 'floatingVoid' }],
       options: [{ checkThenables: true }],
     },
+    {
+      code: `
+declare const createPromise: () => Promise<number>;
+createPromise();
+      `,
+      errors: [{ line: 3, messageId: 'floatingVoid' }],
+      options: [{ checkThenables: false }],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -733,6 +733,41 @@ promise().then(() => {});
         },
       ],
     },
+    {
+      code: `
+interface SafePromise<T> extends Promise<T> {
+  brand: 'safe';
+}
+
+declare const createSafePromise: () => SafePromise<string>;
+createSafePromise();
+      `,
+      options: [
+        {
+          allowForKnownSafePromises: [{ from: 'file', name: 'SafePromise' }],
+          checkThenables: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const createPromise: () => PromiseLike<number>;
+createPromise();
+      `,
+      options: [{ checkThenables: false }],
+    },
+    {
+      code: `
+interface MyThenable {
+  then(onFulfilled: () => void, onRejected: () => void): MyThenable;
+}
+
+declare function createMyThenable(): MyThenable;
+
+createMyThenable();
+      `,
+      options: [{ checkThenables: false }],
+    },
   ],
 
   invalid: [
@@ -2180,6 +2215,27 @@ myTag\`abc\`;
       `,
       options: [{ allowForKnownSafePromises: [{ from: 'file', name: 'Foo' }] }],
       errors: [{ line: 4, messageId: 'floatingVoid' }],
+    },
+    {
+      code: `
+declare const createPromise: () => PromiseLike<number>;
+createPromise();
+      `,
+      errors: [{ line: 3, messageId: 'floatingVoid' }],
+      options: [{ checkThenables: true }],
+    },
+    {
+      code: `
+interface MyThenable {
+  then(onFulfilled: () => void, onRejected: () => void): MyThenable;
+}
+
+declare function createMyThenable(): MyThenable;
+
+createMyThenable();
+      `,
+      errors: [{ line: 8, messageId: 'floatingVoid' }],
+      options: [{ checkThenables: true }],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -2245,5 +2245,25 @@ createPromise();
       errors: [{ line: 3, messageId: 'floatingVoid' }],
       options: [{ checkThenables: false }],
     },
+    {
+      code: `
+class MyPromise<T> extends Promise<T> {}
+declare const createMyPromise: () => MyPromise<number>;
+createMyPromise();
+      `,
+      errors: [{ line: 4, messageId: 'floatingVoid' }],
+      options: [{ checkThenables: false }],
+    },
+    {
+      code: `
+class MyPromise<T> extends Promise<T> {
+  additional: string;
+}
+declare const createMyPromise: () => MyPromise<number>;
+createMyPromise();
+      `,
+      errors: [{ line: 6, messageId: 'floatingVoid' }],
+      options: [{ checkThenables: false }],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/schema-snapshots/no-floating-promises.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-floating-promises.shot
@@ -102,6 +102,10 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         },
         "type": "array"
       },
+      "checkThenables": {
+        "description": "Whether to check all \\"Thenable\\"s, not just the built-in Promise type.",
+        "type": "boolean"
+      },
       "ignoreIIFE": {
         "description": "Whether to ignore async IIFEs (Immediately Invoked Function Expressions).",
         "type": "boolean"
@@ -137,6 +141,8 @@ type Options = [
         }
       | string
     )[];
+    /** Whether to check all "Thenable"s, not just the built-in Promise type. */
+    checkThenables?: boolean;
     /** Whether to ignore async IIFEs (Immediately Invoked Function Expressions). */
     ignoreIIFE?: boolean;
     /** Whether to ignore \`void\` expressions. */


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8433
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a new `checkThenables` `boolean` option to the rule that enables checking all shapes for matching the `.then()` interface. It essentially gates the existing _"does this have a `.then()` with two parameters?"_ logic behind the option.

`checkThenables` is `true` by default in this PR so as to not cause a breaking change. If this PR goes in roughly as-is, I'd like to file a followup issue for v8 to turn it to `false` by default. 

#8433 also mentioned adding in an option for adding additional types to what's flagged by default. I haven't heard anybody mention this as a strong need, so for now I'm holding off on adding that.

💖 