### PR TITLE
chore(website): align file names to RuleTester requirements

### DIFF
--- a/packages/website/src/components/editor/LoadedEditor.tsx
+++ b/packages/website/src/components/editor/LoadedEditor.tsx
@@ -13,7 +13,11 @@ import {
 } from '../lib/jsonSchema';
 import { parseTSConfig, tryParseEslintModule } from '../lib/parseConfig';
 import type { LintCodeAction } from '../linter/utils';
-import { parseLintResults, parseMarkers } from '../linter/utils';
+import {
+  createFileName,
+  parseLintResults,
+  parseMarkers,
+} from '../linter/utils';
 import type { TabType } from '../types';
 import { createProvideCodeActions } from './createProvideCodeActions';
 import type { CommonEditorProps } from './types';
@@ -89,7 +93,7 @@ export const LoadedEditor: React.FC<LoadedEditorProps> = ({
   }, [webLinter, sourceType]);
 
   useEffect(() => {
-    const newPath = `/input${fileType}`;
+    const newPath = createFileName(fileType);
     if (tabs.code.uri.path !== newPath) {
       const code = tabs.code.getValue();
       const newModel = monaco.editor.createModel(
@@ -240,7 +244,7 @@ export const LoadedEditor: React.FC<LoadedEditorProps> = ({
       system.watchFile('/.eslintrc', filename => {
         onChange({ eslintrc: system.readFile(filename) });
       }),
-      system.watchFile('/input.*', filename => {
+      system.watchFile('/{file,react}.*', filename => {
         onChange({ code: system.readFile(filename) });
       }),
     ];

--- a/packages/website/src/components/linter/bridge.ts
+++ b/packages/website/src/components/linter/bridge.ts
@@ -4,7 +4,7 @@ import type * as ts from 'typescript';
 import { debounce } from '../lib/debounce';
 import type { ConfigModel } from '../types';
 import type { PlaygroundSystem } from './types';
-import { getPathRegExp } from './utils';
+import { createFileName, getPathRegExp } from './utils';
 
 export function createFileSystem(
   config: Pick<ConfigModel, 'code' | 'eslintrc' | 'fileType' | 'tsconfig'>,
@@ -13,7 +13,7 @@ export function createFileSystem(
   const files = new Map<string, string>();
   files.set(`/.eslintrc`, config.eslintrc);
   files.set(`/tsconfig.json`, config.tsconfig);
-  files.set(`/input${config.fileType}`, config.code);
+  files.set(createFileName(config.fileType), config.code);
 
   const fileWatcherCallbacks = new Map<RegExp, Set<ts.FileWatcherCallback>>();
 

--- a/packages/website/src/components/linter/createLinter.ts
+++ b/packages/website/src/components/linter/createLinter.ts
@@ -164,10 +164,10 @@ export function createLinter(
   };
 
   const triggerLintAll = (): void => {
-    system.searchFiles('/input.*').forEach(triggerLint);
+    system.searchFiles('/{file,react}.*').forEach(triggerLint);
   };
 
-  system.watchFile('/input.*', triggerLint);
+  system.watchFile('/{file,react}.*', triggerLint);
   system.watchFile('/.eslintrc', filename => {
     applyEslintConfig(filename);
     triggerLintAll();

--- a/packages/website/src/components/linter/createParser.ts
+++ b/packages/website/src/components/linter/createParser.ts
@@ -10,6 +10,7 @@ import type {
   UpdateModel,
   WebLinterModule,
 } from './types';
+import { createFileName } from './utils';
 
 export function createParser(
   system: PlaygroundSystem,
@@ -43,7 +44,7 @@ export function createParser(
       text: string,
       options: ParserOptions = {},
     ): Parser.ParseResult => {
-      const filePath = options.filePath ?? '/input.ts';
+      const filePath = options.filePath ?? createFileName('.ts');
 
       // if text is empty use empty line to avoid error
       const code = text || '\n';

--- a/packages/website/src/components/linter/utils.ts
+++ b/packages/website/src/components/linter/utils.ts
@@ -48,6 +48,13 @@ export function createEditOperation(
   };
 }
 
+/**
+ * @see https://typescript-eslint.io/packages/rule-tester/#type-aware-testing
+ */
+export function createFileName(extension = '.ts'): string {
+  return `/${extension.endsWith('sx') ? 'react' : 'file'}.${extension}`;
+}
+
 function normalizeCode(code: Monaco.editor.IMarker['code']): {
   value: string;
   target?: string;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9269
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Creates and uses a helper in the website to always keep file names as `file.ts` or `react.tsx`.