### PR TITLE
feat(eslint-plugin): [no-dynamic-delete] allow all string literals as index

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-dynamic-delete.mdx
+++ b/packages/eslint-plugin/docs/rules/no-dynamic-delete.mdx
@@ -25,10 +25,6 @@ Dynamically adding and removing keys from objects can cause occasional edge case
 <TabItem value="❌ Incorrect">
 
 ```ts
-// Can be replaced with the constant equivalents, such as container.aaa
-delete container['aaa'];
-delete container['Infinity'];
-
 // Dynamic, difficult-to-reason-about lookups
 const name = 'name';
 delete container[name];
@@ -48,7 +44,12 @@ delete container.aaa;
 
 // Constants that must be accessed by []
 delete container[7];
-delete container['-Infinity'];
+delete container[-1];
+
+// All strings are allowed, to be compatible with the noPropertyAccessFromIndexSignature
+// TS compiler option
+delete container['aaa'];
+delete container['Infinity'];
 ```
 
 </TabItem>

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-dynamic-delete.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-dynamic-delete.shot
@@ -3,12 +3,6 @@
 exports[`Validating rule docs no-dynamic-delete.mdx code examples ESLint output 1`] = `
 "Incorrect
 
-// Can be replaced with the constant equivalents, such as container.aaa
-delete container['aaa'];
-                 ~~~~~ Do not delete dynamically computed property keys.
-delete container['Infinity'];
-                 ~~~~~~~~~~ Do not delete dynamically computed property keys.
-
 // Dynamic, difficult-to-reason-about lookups
 const name = 'name';
 delete container[name];
@@ -30,6 +24,11 @@ delete container.aaa;
 
 // Constants that must be accessed by []
 delete container[7];
-delete container['-Infinity'];
+delete container[-1];
+
+// All strings are allowed, to be compatible with the noPropertyAccessFromIndexSignature
+// TS compiler option
+delete container['aaa'];
+delete container['Infinity'];
 "
 `;

--- a/packages/eslint-plugin/tests/rules/no-dynamic-delete.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-dynamic-delete.test.ts
@@ -51,19 +51,20 @@ delete value;
 const value = 1;
 delete -value;
     `,
-  ],
-  invalid: [
-    {
-      code: `
+    `
 const container: { [i: string]: 0 } = {};
 delete container['aaa'];
-      `,
-      errors: [{ messageId: 'dynamicDelete' }],
-      output: `
+    `,
+    `
 const container: { [i: string]: 0 } = {};
-delete container.aaa;
-      `,
-    },
+delete container['delete'];
+    `,
+    `
+const container: { [i: string]: 0 } = {};
+delete container['NaN'];
+    `,
+  ],
+  invalid: [
     {
       code: `
 const container: { [i: string]: 0 } = {};
@@ -71,17 +72,6 @@ delete container['aa' + 'b'];
       `,
       errors: [{ messageId: 'dynamicDelete' }],
       output: null,
-    },
-    {
-      code: `
-const container: { [i: string]: 0 } = {};
-delete container['delete'];
-      `,
-      errors: [{ messageId: 'dynamicDelete' }],
-      output: `
-const container: { [i: string]: 0 } = {};
-delete container.delete;
-      `,
     },
     {
       code: `
@@ -110,17 +100,6 @@ delete container[NaN];
     {
       code: `
 const container: { [i: string]: 0 } = {};
-delete container['NaN'];
-      `,
-      errors: [{ messageId: 'dynamicDelete' }],
-      output: `
-const container: { [i: string]: 0 } = {};
-delete container.NaN;
-      `,
-    },
-    {
-      code: `
-const container: { [i: string]: 0 } = {};
 const name = 'name';
 delete container[name];
       `,
@@ -141,6 +120,22 @@ delete container[getName()];
 const container: { [i: string]: 0 } = {};
 const name = { foo: { bar: 'bar' } };
 delete container[name.foo.bar];
+      `,
+      output: null,
+      errors: [{ messageId: 'dynamicDelete' }],
+    },
+    {
+      code: `
+const container: { [i: string]: 0 } = {};
+delete container[+"Infinity"];
+      `,
+      output: null,
+      errors: [{ messageId: 'dynamicDelete' }],
+    },
+    {
+      code: `
+const container: { [i: string]: 0 } = {};
+delete container[typeof 1];
       `,
       output: null,
       errors: [{ messageId: 'dynamicDelete' }],

--- a/packages/eslint-plugin/tests/rules/no-dynamic-delete.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-dynamic-delete.test.ts
@@ -33,10 +33,6 @@ delete container[-7];
     `,
     `
 const container: { [i: string]: 0 } = {};
-delete container[+7];
-    `,
-    `
-const container: { [i: string]: 0 } = {};
 delete container['-Infinity'];
     `,
     `
@@ -69,6 +65,14 @@ delete container['NaN'];
       code: `
 const container: { [i: string]: 0 } = {};
 delete container['aa' + 'b'];
+      `,
+      errors: [{ messageId: 'dynamicDelete' }],
+      output: null,
+    },
+    {
+      code: `
+const container: { [i: string]: 0 } = {};
+delete container[+7];
       `,
       errors: [{ messageId: 'dynamicDelete' }],
       output: null,

--- a/packages/eslint-plugin/tests/rules/no-dynamic-delete.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-dynamic-delete.test.ts
@@ -131,7 +131,7 @@ delete container[name.foo.bar];
     {
       code: `
 const container: { [i: string]: 0 } = {};
-delete container[+"Infinity"];
+delete container[+'Infinity'];
       `,
       output: null,
       errors: [{ messageId: 'dynamicDelete' }],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #3504
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Also tightened the condition for unary expressions, which I consider a bug (it allows `typeof 1`)
