### PR TITLE
feat(typescript-estree): also remove projectService in withoutProjectParserOptions

### DIFF
--- a/packages/typescript-estree/src/withoutProjectParserOptions.ts
+++ b/packages/typescript-estree/src/withoutProjectParserOptions.ts
@@ -12,10 +12,8 @@ export function withoutProjectParserOptions(
   opts: TSESTreeOptions,
 ): TSESTreeOptions {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- The variables are meant to be omitted
-  const { EXPERIMENTAL_useProjectService, project, ...rest } = opts as Record<
-    string,
-    unknown
-  >;
+  const { EXPERIMENTAL_useProjectService, project, projectService, ...rest } =
+    opts as Record<string, unknown>;
 
   return rest;
 }

--- a/packages/typescript-estree/tests/lib/withoutProjectParserOptions.test.ts
+++ b/packages/typescript-estree/tests/lib/withoutProjectParserOptions.test.ts
@@ -7,6 +7,7 @@ describe('withoutProjectParserOptions', () => {
       comment: true,
       EXPERIMENTAL_useProjectService: true,
       project: true,
+      projectService: true,
     } as TSESTreeOptions);
     expect(without).toEqual({
       comment: true,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9286
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds the new `projectService` key to the list of removed keys.

💖 