### PR TITLE
docs: clarify `promise-function-async` docs

### DIFF
--- a/packages/eslint-plugin/docs/rules/promise-function-async.mdx
+++ b/packages/eslint-plugin/docs/rules/promise-function-async.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Ensures that functions returning promises can only return rejected promises when an error is encountered and cannot throw. This simplifies the API for callers by making it so that they only need to handle errors in a single manner.
 
-> When functions return unions of `Promise` and non-`Promise` types implicitly, it is usually a mistake—this rule flags those cases. If it is intentional, explicitly specify the return type to allow the rule to pass.
+> When functions return unions of `Promise` and non-`Promise` types implicitly, it is usually a mistake — this rule flags those cases. If it is intentional, explicitly specify the return type to allow the rule to pass.
 
 ## Examples
 

--- a/packages/eslint-plugin/docs/rules/promise-function-async.mdx
+++ b/packages/eslint-plugin/docs/rules/promise-function-async.mdx
@@ -9,16 +9,9 @@ import TabItem from '@theme/TabItem';
 >
 > See **https://typescript-eslint.io/rules/promise-function-async** for documentation.
 
-Ensures that each function is only capable of:
+Ensures that functions returning promises can only return rejected promises when an error is encountered and cannot throw. This simplifies the API for callers by making it so that they only need to handle errors in a single manner.
 
-- returning a rejected promise, or
-- throwing an Error object.
-
-In contrast, non-`async`, `Promise`-returning functions are technically capable of either.
-Code that handles the results of those functions will often need to handle both cases, which can get complex.
-This rule's practice removes a requirement for creating code to handle both cases.
-
-> When functions return unions of `Promise` and non-`Promise` types implicitly, it is usually a mistake—this rule flags those cases. If it is intentional, make the return type explicitly to allow the rule to pass.
+> When functions return unions of `Promise` and non-`Promise` types implicitly, it is usually a mistake—this rule flags those cases. If it is intentional, explicitly specify the return type to allow the rule to pass.
 
 ## Examples
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue - no issue, but a maintainer also suggested these docs could be updated in https://github.com/typescript-eslint/typescript-eslint/issues/9284#issuecomment-2150757249
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken - N/A

## Overview

Reword the description much more simply

Fix an ungrammatical phrase in the callout that was hard to parse - "make the return type explicitly to allow the rule to pass"