### PR TITLE
fix(eslint-plugin): [no-unsafe-member-access] differentiate a types-error any from a true any

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-member-access.ts
@@ -26,7 +26,7 @@ export default createRule({
     },
     messages: {
       unsafeMemberExpression:
-        'Unsafe member access {{property}} on an `any` value.',
+        'Unsafe member access {{property}} on an {{type}} value.',
       unsafeThisMemberExpression: [
         'Unsafe member access {{property}} on an `any` value. `this` is typed as `any`.',
         'You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.',
@@ -86,12 +86,14 @@ export default createRule({
             messageId = 'unsafeThisMemberExpression';
           }
         }
+        const isErrorType = tsutils.isIntrinsicErrorType(type);
 
         context.report({
           node: node.property,
           messageId,
           data: {
             property: node.computed ? `[${propertyName}]` : `.${propertyName}`,
+            type: isErrorType ? '`error`' : '`any`',
           },
         });
       }

--- a/packages/eslint-plugin/tests/rules/no-unsafe-member-access.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-member-access.test.ts
@@ -75,6 +75,7 @@ function foo(x: any) {
           column: 5,
           endColumn: 6,
           data: {
+            type: '`any`',
             property: '.a',
           },
         },
@@ -93,6 +94,7 @@ function foo(x: any) {
           column: 5,
           endColumn: 6,
           data: {
+            type: '`any`',
             property: '.a',
           },
         },
@@ -111,6 +113,7 @@ function foo(x: { a: any }) {
           column: 7,
           endColumn: 8,
           data: {
+            type: '`any`',
             property: '.b',
           },
         },
@@ -129,6 +132,7 @@ function foo(x: any) {
           column: 5,
           endColumn: 8,
           data: {
+            type: '`any`',
             property: "['a']",
           },
         },
@@ -147,7 +151,27 @@ function foo(x: any) {
           column: 5,
           endColumn: 8,
           data: {
+            type: '`any`',
             property: "['a']",
+          },
+        },
+      ],
+    },
+    {
+      code: `
+let value: NotKnown;
+
+value.property;
+      `,
+      errors: [
+        {
+          messageId: 'unsafeMemberExpression',
+          line: 4,
+          column: 7,
+          endColumn: 15,
+          data: {
+            type: '`error`',
+            property: '.property',
           },
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #9217
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
