### PR TITLE
fix(types): allow ProjectServiceOptions for projectService

### DIFF
--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -36,6 +36,31 @@ type SourceType = SourceTypeClassic | 'commonjs';
 
 type JSDocParsingMode = 'all' | 'none' | 'type-info';
 
+/**
+ * Granular options to configure the project service.
+ */
+interface ProjectServiceOptions {
+  /**
+   * Globs of files to allow running with the default project compiler options
+   * despite not being matched by the project service.
+   */
+  allowDefaultProject?: string[];
+
+  /**
+   * Path to a TSConfig to use instead of TypeScript's default project configuration.
+   */
+  defaultProject?: string;
+
+  /**
+   * The maximum number of files {@link allowDefaultProject} may match.
+   * Each file match slows down linting, so if you do need to use this, please
+   * file an informative issue on typescript-eslint explaining why - so we can
+   * help you avoid using it!
+   * @default 8
+   */
+  maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING?: number;
+}
+
 // If you add publicly visible options here, make sure they're also documented in `docs/packages/Parser.mdx`
 interface ParserOptions {
   ecmaFeatures?:
@@ -67,7 +92,7 @@ interface ParserOptions {
   programs?: Program[] | null;
   project?: string[] | string | boolean | null;
   projectFolderIgnoreList?: string[];
-  projectService?: boolean;
+  projectService?: boolean | ProjectServiceOptions;
   range?: boolean;
   sourceType?: SourceType | undefined;
   tokens?: boolean;
@@ -86,5 +111,6 @@ export {
   EcmaVersion,
   JSDocParsingMode,
   ParserOptions,
+  ProjectServiceOptions,
   SourceType,
 };

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -2,10 +2,13 @@ import type {
   CacheDurationSeconds,
   DebugLevel,
   JSDocParsingMode,
+  ProjectServiceOptions,
 } from '@typescript-eslint/types';
 import type * as ts from 'typescript';
 
 import type { TSESTree, TSESTreeToTSNode, TSNode, TSToken } from './ts-estree';
+
+export { ProjectServiceOptions } from '@typescript-eslint/types';
 
 //////////////////////////////////////////////////////////
 // MAKE SURE THIS IS KEPT IN SYNC WITH THE WEBSITE DOCS //
@@ -99,31 +102,6 @@ interface ParseOptions {
    * Whether deprecated AST properties should skip calling console.warn on accesses.
    */
   suppressDeprecatedPropertyWarnings?: boolean;
-}
-
-/**
- * Granular options to configure the project service.
- */
-export interface ProjectServiceOptions {
-  /**
-   * Globs of files to allow running with the default project compiler options
-   * despite not being matched by the project service.
-   */
-  allowDefaultProject?: string[];
-
-  /**
-   * Path to a TSConfig to use instead of TypeScript's default project configuration.
-   */
-  defaultProject?: string;
-
-  /**
-   * The maximum number of files {@link allowDefaultProject} may match.
-   * Each file match slows down linting, so if you do need to use this, please
-   * file an informative issue on typescript-eslint explaining why - so we can
-   * help you avoid using it!
-   * @default 8
-   */
-  maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING?: number;
 }
 
 interface ParseAndGenerateServicesOptions extends ParseOptions {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9313
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds in the missing `| ProjectServiceOptions` to the `types` package's `ParserOptions`. That necessitates taking in the `ProjectServiceOptions` into the `types` package. 

💖 