### PR TITLE
feat(eslint-plugin): [no-unused-vars] support `ignoreClassWithStaticInitBlock`

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-eslint.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-eslint.test.ts
@@ -1261,6 +1261,39 @@ console.log(a + c);
       ],
       parserOptions: { ecmaVersion: 6 },
     },
+
+    // ignore class with static initialization block https://github.com/eslint/eslint/issues/17772
+    {
+      code: `
+class Foo {
+  static {}
+}
+      `,
+      options: [{ ignoreClassWithStaticInitBlock: true }],
+      parserOptions: { ecmaVersion: 2022 },
+    },
+    {
+      code: `
+class Foo {
+  static {}
+}
+      `,
+      options: [
+        { ignoreClassWithStaticInitBlock: true, varsIgnorePattern: '^_' },
+      ],
+      parserOptions: { ecmaVersion: 2022 },
+    },
+    {
+      code: `
+class Foo {
+  static {}
+}
+      `,
+      options: [
+        { ignoreClassWithStaticInitBlock: false, varsIgnorePattern: '^Foo' },
+      ],
+      parserOptions: { ecmaVersion: 2022 },
+    },
   ],
   invalid: [
     {
@@ -2964,6 +2997,65 @@ try {
         },
       ],
       errors: [usedIgnoredError('_err', '. Used args must not match /^_/u')],
+    },
+
+    // ignore class with static initialization block https://github.com/eslint/eslint/issues/17772
+    {
+      code: `
+class Foo {
+  static {}
+}
+      `,
+      options: [{ ignoreClassWithStaticInitBlock: false }],
+      parserOptions: { ecmaVersion: 2022 },
+      errors: [{ ...definedError('Foo'), line: 2, column: 7 }],
+    },
+    {
+      code: `
+class Foo {
+  static {}
+}
+      `,
+      parserOptions: { ecmaVersion: 2022 },
+      errors: [{ ...definedError('Foo'), line: 2, column: 7 }],
+    },
+    {
+      code: `
+class Foo {
+  static {
+    var bar;
+  }
+}
+      `,
+      options: [{ ignoreClassWithStaticInitBlock: true }],
+      parserOptions: { ecmaVersion: 2022 },
+      errors: [{ ...definedError('bar'), line: 4, column: 9 }],
+    },
+    {
+      code: 'class Foo {}',
+      options: [{ ignoreClassWithStaticInitBlock: true }],
+      parserOptions: { ecmaVersion: 2022 },
+      errors: [{ ...definedError('Foo'), line: 1, column: 7 }],
+    },
+    {
+      code: `
+class Foo {
+  static bar;
+}
+      `,
+      options: [{ ignoreClassWithStaticInitBlock: true }],
+      parserOptions: { ecmaVersion: 2022 },
+      errors: [{ ...definedError('Foo'), line: 2, column: 7 }],
+    },
+    {
+      code: `
+class Foo {
+  static bar() {}
+}
+      `,
+      options: [{ ignoreClassWithStaticInitBlock: true }],
+      parserOptions: { ecmaVersion: 2022 },
+      errors: [{ ...definedError('Foo'), line: 2, column: 7 }],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unused-vars.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unused-vars.shot
@@ -31,6 +31,9 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
           "destructuredArrayIgnorePattern": {
             "type": "string"
           },
+          "ignoreClassWithStaticInitBlock": {
+            "type": "boolean"
+          },
           "ignoreRestSiblings": {
             "type": "boolean"
           },
@@ -63,6 +66,7 @@ type Options = [
       caughtErrors?: 'all' | 'none';
       caughtErrorsIgnorePattern?: string;
       destructuredArrayIgnorePattern?: string;
+      ignoreClassWithStaticInitBlock?: boolean;
       ignoreRestSiblings?: boolean;
       reportUsedIgnorePattern?: boolean;
       vars?: 'all' | 'local';


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9120
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This was added upstream in https://github.com/eslint/eslint/pull/18170.
This syncs the changes to our implementation.

NOTE: stacked on top of #9324 - retarget to `v8` before merging