### PR TITLE
chore: update file patterns in package.json for dist files

### DIFF
--- a/packages/ast-spec/package.json
+++ b/packages/ast-spec/package.json
@@ -12,7 +12,8 @@
     "node": "^18.18.0 || >=20.0.0"
   },
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -3,7 +3,8 @@
   "version": "7.12.0",
   "description": "TypeScript plugin for ESLint",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "docs",
     "index.d.ts",
     "rules.d.ts",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -3,7 +3,8 @@
   "version": "7.12.0",
   "description": "An ESLint custom parser which leverages TypeScript ESTree",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "_ts4.3",
     "README.md",
     "LICENSE"

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -3,7 +3,8 @@
   "version": "7.12.0",
   "description": "Tooling to test ESLint rules",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "_ts4.2",
     "README.md",
     "LICENSE"

--- a/packages/scope-manager/package.json
+++ b/packages/scope-manager/package.json
@@ -3,7 +3,8 @@
   "version": "7.12.0",
   "description": "TypeScript scope analyser for ESLint",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -3,7 +3,8 @@
   "version": "7.12.0",
   "description": "Type utilities for working with TypeScript + ESLint together",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "_ts4.3",
     "package.json",
     "README.md",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,7 +3,8 @@
   "version": "7.12.0",
   "description": "Types for the TypeScript-ESTree AST spec",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "_ts4.3",
     "package.json",
     "README.md",

--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -3,7 +3,8 @@
   "version": "7.12.0",
   "description": "Tooling which enables you to use TypeScript with ESLint",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "_ts4.3",
     "README.md",
     "LICENSE"

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -3,7 +3,8 @@
   "version": "7.12.0",
   "description": "A parser that converts TypeScript source code into an ESTree compatible form",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "_ts4.3",
     "README.md",
     "LICENSE"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,7 +3,8 @@
   "version": "7.12.0",
   "description": "Utilities for working with TypeScript + ESLint together",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "_ts4.3",
     "package.json",
     "README.md",

--- a/packages/visitor-keys/package.json
+++ b/packages/visitor-keys/package.json
@@ -3,7 +3,8 @@
   "version": "7.12.0",
   "description": "Visitor keys used to help traverse the TypeScript-ESTree AST",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
     "_ts4.3",
     "package.json",
     "README.md",

--- a/packages/website-eslint/package.json
+++ b/packages/website-eslint/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "ESLint which works in browsers.",
   "files": [
-    "dist"
+    "dist/**/*.js",
+    "dist/**/*.d.ts"
   ],
   "type": "commonjs",
   "exports": {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Currently `.js.map` files is published to npm but does not come with source `.ts` files. This causes tools like [`source-map-support`](https://npmjs.com/package/source-map-support) to fail in converting source lines. This PR avoids related issues by excluding `.js.map` files.
