### PR TITLE
chore: [no-empty-object-type] remove unused option in-type-alias-with-name

### DIFF
--- a/packages/eslint-plugin/src/rules/no-empty-object-type.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-object-type.ts
@@ -60,7 +60,7 @@ export default createRule<Options, MessageIds>({
             type: 'string',
           },
           allowObjectTypes: {
-            enum: ['always', 'in-type-alias-with-name', 'never'],
+            enum: ['always', 'never'],
             type: 'string',
           },
           allowWithName: {

--- a/packages/eslint-plugin/tests/schema-snapshots/no-empty-object-type.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-empty-object-type.shot
@@ -13,7 +13,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "type": "string"
       },
       "allowObjectTypes": {
-        "enum": ["always", "in-type-alias-with-name", "never"],
+        "enum": ["always", "never"],
         "type": "string"
       },
       "allowWithName": {
@@ -30,7 +30,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 type Options = [
   {
     allowInterfaces?: 'always' | 'never' | 'with-single-extends';
-    allowObjectTypes?: 'always' | 'in-type-alias-with-name' | 'never';
+    allowObjectTypes?: 'always' | 'never';
     allowWithName?: string;
   },
 ];


### PR DESCRIPTION
I think it was just renamed at some point in #8977 (to `allowWithName`)  and didn't get cleaned up.

This is a followup to https://github.com/typescript-eslint/typescript-eslint/pull/8977/files/218d8e5fc8d63e0dd4653ac2e6aef408c22aa98a#r1597015684.

(see also https://v8--typescript-eslint.netlify.app/rules/no-empty-object-type#options)

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken - the mental gymnastics to consider this a docs issue are not too big
