### PR TITLE
enhancement(eslint-plugin): [return-await] add option to report in error-handling scenarios only

### DIFF
--- a/packages/eslint-plugin/docs/rules/return-await.mdx
+++ b/packages/eslint-plugin/docs/rules/return-await.mdx
@@ -203,6 +203,35 @@ async function validAlways3() {
 </TabItem>
 </Tabs>
 
+### `error-handling-correctness-only`
+
+Same as `in-try-catch`, except _only_ enforces Promises be awaited within the
+error handling contexts explained under that option. Outside of error-handling
+contexts, returned Promises are ignored, whether awaited or not.
+
+:::warning
+We recommend you configure either `in-try-catch` or `always` instead of this option.
+While the choice or awaiting or not awaiting promises outside of error-handling contexts is mostly stylistic, it is best to be consistent.
+:::
+
+Examples of additional correct code with `error-handling-correctness-only`:
+
+<Tabs>
+<TabItem value="✅ Correct">
+
+```ts option='"error-handling-correctness-only"'
+async function asyncFunction(): Promise<void> {
+  if (Math.random() < 0.5) {
+    return await Promise.resolve();
+  } else {
+    return Promise.resolve();
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
 ### `never`
 
 Disallows all `await`ing any returned promises.

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -2,6 +2,7 @@ import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
 
 import rule from '../../src/rules/return-await';
 import { getFixturesRootDir } from '../RuleTester';
+import { InvalidTestCase } from '@typescript-eslint/utils/ts-eslint';
 
 const rootDir = getFixturesRootDir();
 
@@ -56,6 +57,25 @@ ruleTester.run('return-await', rule, {
         }
       }
     `,
+    {
+      code: `
+        async function test() {
+          if (Math.random() < 0.33) {
+            return await Promise.resolve(1);
+          } else if (Math.random () < 0.5) {
+            return Promise.resolve(2);
+          }
+
+          try {
+          } catch (e) {
+            return await Promise.resolve(3);
+          } finally {
+            console.log('cleanup');
+          }
+        }
+      `,
+      options: ['error-handling-correctness-only'],
+    },
     `
       async function test() {
         try {
@@ -435,8 +455,11 @@ async function test() {
         },
       ],
     },
-    {
-      code: `
+
+    ...['error-handling-correctness-only', 'always', 'in-try-catch'].map(
+      option =>
+        ({
+          code: `
         async function test() {
           try {
             return Promise.resolve(1);
@@ -447,15 +470,15 @@ async function test() {
           }
         }
       `,
-      output: null,
-      errors: [
-        {
-          line: 4,
-          messageId: 'requiredPromiseAwait',
-          suggestions: [
+          output: null,
+          errors: [
             {
-              messageId: 'requiredPromiseAwaitSuggestion',
-              output: `
+              line: 4,
+              messageId: 'requiredPromiseAwait',
+              suggestions: [
+                {
+                  messageId: 'requiredPromiseAwaitSuggestion',
+                  output: `
         async function test() {
           try {
             return await Promise.resolve(1);
@@ -466,16 +489,16 @@ async function test() {
           }
         }
       `,
+                },
+              ],
             },
-          ],
-        },
-        {
-          line: 6,
-          messageId: 'requiredPromiseAwait',
-          suggestions: [
             {
-              messageId: 'requiredPromiseAwaitSuggestion',
-              output: `
+              line: 6,
+              messageId: 'requiredPromiseAwait',
+              suggestions: [
+                {
+                  messageId: 'requiredPromiseAwaitSuggestion',
+                  output: `
         async function test() {
           try {
             return Promise.resolve(1);
@@ -486,11 +509,17 @@ async function test() {
           }
         }
       `,
+                },
+              ],
             },
           ],
-        },
-      ],
-    },
+          options: [option],
+        }) satisfies InvalidTestCase<
+          'requiredPromiseAwait' | 'requiredPromiseAwaitSuggestion',
+          [string]
+        >,
+    ),
+
     {
       code: `
         async function test() {
@@ -554,63 +583,6 @@ async function test() {
       options: ['in-try-catch'],
       code: `
         async function test() {
-          try {
-            return Promise.resolve(1);
-          } catch (e) {
-            return Promise.resolve(2);
-          } finally {
-            console.log('cleanup');
-          }
-        }
-      `,
-      output: null,
-      errors: [
-        {
-          line: 4,
-          messageId: 'requiredPromiseAwait',
-          suggestions: [
-            {
-              messageId: 'requiredPromiseAwaitSuggestion',
-              output: `
-        async function test() {
-          try {
-            return await Promise.resolve(1);
-          } catch (e) {
-            return Promise.resolve(2);
-          } finally {
-            console.log('cleanup');
-          }
-        }
-      `,
-            },
-          ],
-        },
-        {
-          line: 6,
-          messageId: 'requiredPromiseAwait',
-          suggestions: [
-            {
-              messageId: 'requiredPromiseAwaitSuggestion',
-              output: `
-        async function test() {
-          try {
-            return Promise.resolve(1);
-          } catch (e) {
-            return await Promise.resolve(2);
-          } finally {
-            console.log('cleanup');
-          }
-        }
-      `,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      options: ['in-try-catch'],
-      code: `
-        async function test() {
           return await Promise.resolve(1);
         }
       `,
@@ -737,63 +709,6 @@ async function test() {
         {
           line: 3,
           messageId: 'nonPromiseAwait',
-        },
-      ],
-    },
-    {
-      options: ['always'],
-      code: `
-        async function test() {
-          try {
-            return Promise.resolve(1);
-          } catch (e) {
-            return Promise.resolve(2);
-          } finally {
-            console.log('cleanup');
-          }
-        }
-      `,
-      output: null,
-      errors: [
-        {
-          line: 4,
-          messageId: 'requiredPromiseAwait',
-          suggestions: [
-            {
-              messageId: 'requiredPromiseAwaitSuggestion',
-              output: `
-        async function test() {
-          try {
-            return await Promise.resolve(1);
-          } catch (e) {
-            return Promise.resolve(2);
-          } finally {
-            console.log('cleanup');
-          }
-        }
-      `,
-            },
-          ],
-        },
-        {
-          line: 6,
-          messageId: 'requiredPromiseAwait',
-          suggestions: [
-            {
-              messageId: 'requiredPromiseAwaitSuggestion',
-              output: `
-        async function test() {
-          try {
-            return Promise.resolve(1);
-          } catch (e) {
-            return await Promise.resolve(2);
-          } finally {
-            console.log('cleanup');
-          }
-        }
-      `,
-            },
-          ],
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9030 
- [x] That issue was marked as ~~[accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~~ "team assigned"
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Just adds an option to ignore return-await concerns outside of scenarios relevant for error-handling