### PR TITLE
fix(eslint-plugin): [no-extraneous-class] handle abstract members

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-extraneous-class.mdx
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-class.mdx
@@ -44,6 +44,10 @@ class HelloWorldLogger {
 }
 ```
 
+```ts
+abstract class Foo {}
+```
+
 </TabItem>
 <TabItem value="✅ Correct">
 
@@ -56,6 +60,12 @@ export function isProduction() {
 
 function logHelloWorld() {
   console.log('Hello, world!');
+}
+```
+
+```ts
+abstract class Foo {
+  abstract prop: string;
 }
 ```
 

--- a/packages/eslint-plugin/docs/rules/no-extraneous-class.mdx
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-class.mdx
@@ -42,9 +42,7 @@ class HelloWorldLogger {
     console.log('Hello, world!');
   }
 }
-```
 
-```ts
 abstract class Foo {}
 ```
 
@@ -61,9 +59,7 @@ export function isProduction() {
 function logHelloWorld() {
   console.log('Hello, world!');
 }
-```
 
-```ts
 abstract class Foo {
   abstract prop: string;
 }

--- a/packages/eslint-plugin/src/rules/no-extraneous-class.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-class.ts
@@ -127,7 +127,7 @@ export default createRule<Options, MessageIds>({
                 prop.type === AST_NODE_TYPES.MethodDefinition) &&
                 !prop.static) ||
               prop.type === AST_NODE_TYPES.TSAbstractPropertyDefinition ||
-              prop.type === AST_NODE_TYPES.TSAbstractMethodDefinition
+              prop.type === AST_NODE_TYPES.TSAbstractMethodDefinition // `static abstract` methods and properties are currently not supported. See: https://github.com/microsoft/TypeScript/issues/34516
             ) {
               onlyStatic = false;
             }

--- a/packages/eslint-plugin/src/rules/no-extraneous-class.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-class.ts
@@ -123,9 +123,11 @@ export default createRule<Options, MessageIds>({
           } else {
             onlyConstructor = false;
             if (
-              (prop.type === AST_NODE_TYPES.PropertyDefinition ||
+              ((prop.type === AST_NODE_TYPES.PropertyDefinition ||
                 prop.type === AST_NODE_TYPES.MethodDefinition) &&
-              !prop.static
+                !prop.static) ||
+              prop.type === AST_NODE_TYPES.TSAbstractPropertyDefinition ||
+              prop.type === AST_NODE_TYPES.TSAbstractMethodDefinition
             ) {
               onlyStatic = false;
             }

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-extraneous-class.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-extraneous-class.shot
@@ -22,6 +22,14 @@ class HelloWorldLogger {
 `;
 
 exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 2`] = `
+"Incorrect
+
+abstract class Foo {}
+               ~~~ Unexpected empty class.
+"
+`;
+
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 3`] = `
 "Correct
 
 export const version = 42;
@@ -36,7 +44,16 @@ function logHelloWorld() {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 3`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 4`] = `
+"Correct
+
+abstract class Foo {
+  abstract prop: string;
+}
+"
+`;
+
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 5`] = `
 "Incorrect
 
 export class Utilities {
@@ -56,7 +73,7 @@ export class Utilities {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 4`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 6`] = `
 "Correct
 
 export function util1() {
@@ -73,7 +90,7 @@ export function util3() {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 5`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 7`] = `
 "Incorrect
 
 // utilities.ts
@@ -91,7 +108,7 @@ Utilities.sayHello();
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 6`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 8`] = `
 "
 
 // utilities.ts
@@ -106,7 +123,7 @@ utilities.sayHello();
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 7`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 9`] = `
 "
 
 // utilities.ts
@@ -121,7 +138,7 @@ sayHello();
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 8`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 10`] = `
 "Incorrect
 
 export class Utilities {
@@ -135,7 +152,7 @@ export class Utilities {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 9`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 11`] = `
 "Correct
 
 let mutableCount = 1;
@@ -150,7 +167,7 @@ export function incrementCount() {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 10`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 12`] = `
 "Incorrect
 Options: { "allowConstructorOnly": true }
 
@@ -159,7 +176,7 @@ class NoFields {}
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 11`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 13`] = `
 "Correct
 Options: { "allowConstructorOnly": true }
 
@@ -171,7 +188,7 @@ class NoFields {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 12`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 14`] = `
 "Incorrect
 Options: { "allowEmpty": true }
 
@@ -184,7 +201,7 @@ class NoFields {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 13`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 15`] = `
 "Correct
 Options: { "allowEmpty": true }
 
@@ -192,7 +209,7 @@ class NoFields {}
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 14`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 16`] = `
 "Incorrect
 Options: { "allowStaticOnly": true }
 
@@ -201,7 +218,7 @@ class EmptyClass {}
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 15`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 17`] = `
 "Correct
 Options: { "allowStaticOnly": true }
 
@@ -211,7 +228,7 @@ class NotEmptyClass {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 16`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 18`] = `
 "Incorrect
 Options: { "allowWithDecorator": true }
 
@@ -222,7 +239,7 @@ class Constants {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 17`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 19`] = `
 "Correct
 Options: { "allowWithDecorator": true }
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-extraneous-class.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-extraneous-class.shot
@@ -18,18 +18,13 @@ class HelloWorldLogger {
     console.log('Hello, world!');
   }
 }
-"
-`;
-
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 2`] = `
-"Incorrect
 
 abstract class Foo {}
                ~~~ Unexpected empty class.
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 3`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 2`] = `
 "Correct
 
 export const version = 42;
@@ -41,11 +36,6 @@ export function isProduction() {
 function logHelloWorld() {
   console.log('Hello, world!');
 }
-"
-`;
-
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 4`] = `
-"Correct
 
 abstract class Foo {
   abstract prop: string;
@@ -53,7 +43,7 @@ abstract class Foo {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 5`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 3`] = `
 "Incorrect
 
 export class Utilities {
@@ -73,7 +63,7 @@ export class Utilities {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 6`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 4`] = `
 "Correct
 
 export function util1() {
@@ -90,7 +80,7 @@ export function util3() {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 7`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 5`] = `
 "Incorrect
 
 // utilities.ts
@@ -108,7 +98,7 @@ Utilities.sayHello();
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 8`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 6`] = `
 "
 
 // utilities.ts
@@ -123,7 +113,7 @@ utilities.sayHello();
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 9`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 7`] = `
 "
 
 // utilities.ts
@@ -138,7 +128,7 @@ sayHello();
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 10`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 8`] = `
 "Incorrect
 
 export class Utilities {
@@ -152,7 +142,7 @@ export class Utilities {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 11`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 9`] = `
 "Correct
 
 let mutableCount = 1;
@@ -167,7 +157,7 @@ export function incrementCount() {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 12`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 10`] = `
 "Incorrect
 Options: { "allowConstructorOnly": true }
 
@@ -176,7 +166,7 @@ class NoFields {}
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 13`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 11`] = `
 "Correct
 Options: { "allowConstructorOnly": true }
 
@@ -188,7 +178,7 @@ class NoFields {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 14`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 12`] = `
 "Incorrect
 Options: { "allowEmpty": true }
 
@@ -201,7 +191,7 @@ class NoFields {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 15`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 13`] = `
 "Correct
 Options: { "allowEmpty": true }
 
@@ -209,7 +199,7 @@ class NoFields {}
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 16`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 14`] = `
 "Incorrect
 Options: { "allowStaticOnly": true }
 
@@ -218,7 +208,7 @@ class EmptyClass {}
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 17`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 15`] = `
 "Correct
 Options: { "allowStaticOnly": true }
 
@@ -228,7 +218,7 @@ class NotEmptyClass {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 18`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 16`] = `
 "Incorrect
 Options: { "allowWithDecorator": true }
 
@@ -239,7 +229,7 @@ class Constants {
 "
 `;
 
-exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 19`] = `
+exports[`Validating rule docs no-extraneous-class.mdx code examples ESLint output 17`] = `
 "Correct
 Options: { "allowWithDecorator": true }
 

--- a/packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts
@@ -90,6 +90,12 @@ class Foo {
       `,
       options: [{ allowWithDecorator: true }],
     },
+    `
+abstract class Foo {
+  public abstract prop: string;
+  public abstract hello(): void;
+}
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts
@@ -92,8 +92,12 @@ class Foo {
     },
     `
 abstract class Foo {
-  public abstract prop: string;
-  public abstract hello(): void;
+  abstract property: string;
+}
+    `,
+    `
+abstract class Foo {
+  abstract method(): string;
 }
     `,
   ],
@@ -187,6 +191,28 @@ class Foo {
           messageId: 'onlyConstructor',
         },
       ],
+    },
+    {
+      code: `
+abstract class Foo {}
+      `,
+      errors: [empty],
+    },
+    {
+      code: `
+abstract class Foo {
+  static property: string;
+}
+      `,
+      errors: [onlyStatic],
+    },
+    {
+      code: `
+abstract class Foo {
+  constructor() {}
+}
+      `,
+      errors: [onlyConstructor],
     },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9359
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
**Description**
This PR addresses an issue with the @typescript-eslint/no-extraneous-class rule where abstract fields and methods were not being counted as instance properties. The rule implementation was missing the handling of abstract members, which have different AST nodes compared to their concrete counterparts. This fix ensures that abstract fields and methods are correctly recognized as instance properties.

**Changes**
- Updated the no-extraneous-class rule to account for `TSAbstractMethodDefinition` and `TSAbstractPropertyDefinition` nodes.
- Added tests to cover scenarios with abstract classes containing abstract members.