### PR TITLE
fix(eslint-plugin): [prefer-nullish-coalescing] treat enums and literals as their underlying primitive types

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -325,13 +325,13 @@ export default createRule<Options, MessageIds>({
         /* eslint-disable @typescript-eslint/no-non-null-assertion */
         const ignorableFlags = [
           (ignorePrimitives === true || ignorePrimitives!.bigint) &&
-            ts.TypeFlags.BigInt,
+            ts.TypeFlags.BigIntLike,
           (ignorePrimitives === true || ignorePrimitives!.boolean) &&
-            ts.TypeFlags.BooleanLiteral,
+            ts.TypeFlags.BooleanLike,
           (ignorePrimitives === true || ignorePrimitives!.number) &&
-            ts.TypeFlags.Number,
+            ts.TypeFlags.NumberLike,
           (ignorePrimitives === true || ignorePrimitives!.string) &&
-            ts.TypeFlags.String,
+            ts.TypeFlags.StringLike,
         ]
           .filter((flag): flag is number => typeof flag === 'number')
           .reduce((previous, flag) => previous | flag, 0);

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -233,6 +233,102 @@ x || y;
       declare const y: number;
       x || y;
     `,
+    {
+      code: `
+declare const x: 0 | 1 | 0n | 1n | undefined;
+x || y;
+      `,
+      options: [
+        {
+          ignorePrimitives: {
+            string: true,
+            number: false,
+            boolean: true,
+            bigint: true,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: 0 | 1 | 0n | 1n | undefined;
+x || y;
+      `,
+      options: [
+        {
+          ignorePrimitives: {
+            string: true,
+            number: true,
+            boolean: true,
+            bigint: false,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: 0 | 'foo' | undefined;
+x || y;
+      `,
+      options: [
+        {
+          ignorePrimitives: {
+            number: true,
+            string: true,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: 0 | 'foo' | undefined;
+x || y;
+      `,
+      options: [
+        {
+          ignorePrimitives: {
+            number: true,
+            string: false,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+enum Enum {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+declare const x: Enum | undefined;
+x || y;
+      `,
+      options: [
+        {
+          ignorePrimitives: {
+            number: true,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+enum Enum {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+declare const x: Enum.A | Enum.B | undefined;
+x || y;
+      `,
+      options: [
+        {
+          ignorePrimitives: {
+            number: true,
+          },
+        },
+      ],
+    },
   ],
   invalid: [
     ...nullishTypeInvalidTest((nullish, type) => ({
@@ -1154,42 +1250,6 @@ x || y;
             string: true,
             number: false,
             boolean: true,
-            bigint: true,
-          },
-        },
-      ],
-      errors: [{ messageId: 'preferNullishOverOr' }],
-    },
-    {
-      code: `
-declare const x: 0 | 1 | 0n | 1n | undefined;
-x || y;
-      `,
-      output: null,
-      options: [
-        {
-          ignorePrimitives: {
-            string: true,
-            number: true,
-            boolean: true,
-            bigint: false,
-          },
-        },
-      ],
-      errors: [{ messageId: 'preferNullishOverOr' }],
-    },
-    {
-      code: `
-declare const x: 0 | 1 | 0n | 1n | undefined;
-x || y;
-      `,
-      output: null,
-      options: [
-        {
-          ignorePrimitives: {
-            string: true,
-            number: false,
-            boolean: true,
             bigint: false,
           },
         },
@@ -1213,46 +1273,6 @@ x || y;
         },
       ],
       errors: [{ messageId: 'preferNullishOverOr' }],
-    },
-    {
-      code: `
-declare const x: 0 | 'foo' | undefined;
-x || y;
-      `,
-      output: null,
-      options: [
-        {
-          ignorePrimitives: {
-            number: true,
-            string: true,
-          },
-        },
-      ],
-      errors: [
-        {
-          messageId: 'preferNullishOverOr',
-        },
-      ],
-    },
-    {
-      code: `
-declare const x: 0 | 'foo' | undefined;
-x || y;
-      `,
-      output: null,
-      options: [
-        {
-          ignorePrimitives: {
-            number: true,
-            string: false,
-          },
-        },
-      ],
-      errors: [
-        {
-          messageId: 'preferNullishOverOr',
-        },
-      ],
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -332,9 +332,9 @@ x || y;
     {
       code: `
 enum Enum {
-  A = "a",
-  B = "b",
-  C = "c",
+  A = 'a',
+  B = 'b',
+  C = 'c',
 }
 declare const x: Enum | undefined;
 x || y;
@@ -350,9 +350,9 @@ x || y;
     {
       code: `
 enum Enum {
-  A = "a",
-  B = "b",
-  C = "c",
+  A = 'a',
+  B = 'b',
+  C = 'c',
 }
 declare const x: Enum.A | Enum.B | undefined;
 x || y;
@@ -1393,9 +1393,9 @@ x || y;
     {
       code: `
 enum Enum {
-  A = "a",
-  B = "b",
-  C = "c",
+  A = 'a',
+  B = 'b',
+  C = 'c',
 }
 declare const x: Enum | undefined;
 x || y;
@@ -1410,9 +1410,9 @@ x || y;
     {
       code: `
 enum Enum {
-  A = "a",
-  B = "b",
-  C = "c",
+  A = 'a',
+  B = 'b',
+  C = 'c',
 }
 declare const x: Enum.A | Enum.B | undefined;
 x || y;

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -329,6 +329,42 @@ x || y;
         },
       ],
     },
+    {
+      code: `
+enum Enum {
+  A = "a",
+  B = "b",
+  C = "c",
+}
+declare const x: Enum | undefined;
+x || y;
+      `,
+      options: [
+        {
+          ignorePrimitives: {
+            string: true,
+          },
+        },
+      ],
+    },
+    {
+      code: `
+enum Enum {
+  A = "a",
+  B = "b",
+  C = "c",
+}
+declare const x: Enum.A | Enum.B | undefined;
+x || y;
+      `,
+      options: [
+        {
+          ignorePrimitives: {
+            string: true,
+          },
+        },
+      ],
+    },
   ],
   invalid: [
     ...nullishTypeInvalidTest((nullish, type) => ({
@@ -1312,6 +1348,74 @@ null || y;
     {
       code: `
 undefined || y;
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+        },
+      ],
+    },
+    {
+      code: `
+enum Enum {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+declare const x: Enum | undefined;
+x || y;
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+        },
+      ],
+    },
+    {
+      code: `
+enum Enum {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+declare const x: Enum.A | Enum.B | undefined;
+x || y;
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+        },
+      ],
+    },
+    {
+      code: `
+enum Enum {
+  A = "a",
+  B = "b",
+  C = "c",
+}
+declare const x: Enum | undefined;
+x || y;
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+        },
+      ],
+    },
+    {
+      code: `
+enum Enum {
+  A = "a",
+  B = "b",
+  C = "c",
+}
+declare const x: Enum.A | Enum.B | undefined;
+x || y;
       `,
       output: null,
       errors: [


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9375
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The `ignorePrimitives` flag did not treat literals or enums as their underlying primitive types; for enum heavy codebases like TS, setting `ignorePrimitives` still leads to hundreds of "please use `??`" errors even when applying that fix would change behavior.

This PR instead uses the `-Like` flags variants, which also match against literals and enum values.

I have yet to test this on TS's codebase; just trying to figure out how I can even do that locally... I'll probably just hack the published package, since this change is so small.