### PR TITLE
fix(eslint-plugin): [prefer-nullish-coalescing] ensure ternary fix does not remove parens

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -7,6 +7,7 @@ import {
   getOperatorPrecedence,
   getOperatorPrecedenceForNode,
   getParserServices,
+  getTextWithParentheses,
   isClosingParenToken,
   isOpeningParenToken,
   isParenthesized,
@@ -104,28 +105,6 @@ export default createRule<Options, MessageIds>({
         node.typeName.type === AST_NODE_TYPES.Identifier &&
         node.typeName.name === 'const'
       );
-    }
-
-    function getTextWithParentheses(node: TSESTree.Node): string {
-      // Capture parentheses before and after the node
-      let beforeCount = 0;
-      let afterCount = 0;
-
-      if (isParenthesized(node, context.sourceCode)) {
-        const bodyOpeningParen = nullThrows(
-          context.sourceCode.getTokenBefore(node, isOpeningParenToken),
-          NullThrowsReasons.MissingToken('(', 'node'),
-        );
-        const bodyClosingParen = nullThrows(
-          context.sourceCode.getTokenAfter(node, isClosingParenToken),
-          NullThrowsReasons.MissingToken(')', 'node'),
-        );
-
-        beforeCount = node.range[0] - bodyOpeningParen.range[0];
-        afterCount = bodyClosingParen.range[1] - node.range[1];
-      }
-
-      return context.sourceCode.getText(node, beforeCount, afterCount);
     }
 
     function reportIncorrectAssertionType(
@@ -253,7 +232,10 @@ export default createRule<Options, MessageIds>({
                 parent.id,
                 `: ${context.sourceCode.getText(node.typeAnnotation)}`,
               ),
-              fixer.replaceText(node, getTextWithParentheses(node.expression)),
+              fixer.replaceText(
+                node,
+                getTextWithParentheses(context.sourceCode, node.expression),
+              ),
             ],
           });
         }
@@ -261,7 +243,10 @@ export default createRule<Options, MessageIds>({
           messageId: 'replaceObjectTypeAssertionWithSatisfies',
           data: { cast: context.sourceCode.getText(node.typeAnnotation) },
           fix: fixer => [
-            fixer.replaceText(node, getTextWithParentheses(node.expression)),
+            fixer.replaceText(
+              node,
+              getTextWithParentheses(context.sourceCode, node.expression),
+            ),
             fixer.insertTextAfter(
               node,
               ` satisfies ${context.sourceCode.getText(node.typeAnnotation)}`,

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -6,6 +6,7 @@ import * as ts from 'typescript';
 import {
   createRule,
   getParserServices,
+  getTextWithParentheses,
   getTypeFlags,
   isLogicalOrOperator,
   isNodeEqual,
@@ -288,12 +289,9 @@ export default createRule<Options, MessageIds>({
                       : [node.consequent, node.alternate];
                   return fixer.replaceText(
                     node,
-                    `${context.sourceCode.text.slice(
-                      left.range[0],
-                      left.range[1],
-                    )} ?? ${context.sourceCode.text.slice(
-                      right.range[0],
-                      right.range[1],
+                    `${getTextWithParentheses(context.sourceCode, left)} ?? ${getTextWithParentheses(
+                      context.sourceCode,
+                      right,
                     )}`,
                   );
                 },

--- a/packages/eslint-plugin/src/util/getTextWithParentheses.ts
+++ b/packages/eslint-plugin/src/util/getTextWithParentheses.ts
@@ -1,0 +1,34 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import type { SourceCode } from '@typescript-eslint/utils/ts-eslint';
+import {
+  isClosingParenToken,
+  isOpeningParenToken,
+  isParenthesized,
+  nullThrows,
+  NullThrowsReasons,
+} from '.';
+
+export function getTextWithParentheses(
+  sourceCode: Readonly<SourceCode>,
+  node: TSESTree.Node,
+): string {
+  // Capture parentheses before and after the node
+  let beforeCount = 0;
+  let afterCount = 0;
+
+  if (isParenthesized(node, sourceCode)) {
+    const bodyOpeningParen = nullThrows(
+      sourceCode.getTokenBefore(node, isOpeningParenToken),
+      NullThrowsReasons.MissingToken('(', 'node'),
+    );
+    const bodyClosingParen = nullThrows(
+      sourceCode.getTokenAfter(node, isClosingParenToken),
+      NullThrowsReasons.MissingToken(')', 'node'),
+    );
+
+    beforeCount = node.range[0] - bodyOpeningParen.range[0];
+    afterCount = bodyClosingParen.range[1] - node.range[1];
+  }
+
+  return sourceCode.getText(node, beforeCount, afterCount);
+}

--- a/packages/eslint-plugin/src/util/index.ts
+++ b/packages/eslint-plugin/src/util/index.ts
@@ -7,6 +7,7 @@ export * from './getFunctionHeadLoc';
 export * from './getOperatorPrecedence';
 export * from './getStaticStringValue';
 export * from './getStringLength';
+export * from './getTextWithParentheses';
 export * from './getThisExpression';
 export * from './getWrappingFixer';
 export * from './isNodeEqual';

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -333,6 +333,26 @@ x ?? 'foo';
           },
         ],
       },
+      {
+        code: code.replace(/y/g, '(z = y)'),
+        output: null,
+        options: [{ ignoreTernaryTests: false }] as const,
+        errors: [
+          {
+            messageId: 'preferNullishOverTernary' as const,
+            line: 1,
+            column: 1,
+            endLine: 1,
+            endColumn: code.replace(/y/g, '(z = y)').length,
+            suggestions: [
+              {
+                messageId: 'suggestNullish' as const,
+                output: 'x ?? (z = y);',
+              },
+            ],
+          },
+        ],
+      },
     ]),
 
     {


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9379
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Parens aren't in the AST, and this fixer's text manipulation did not handle that.

I took the time to move a helper out of another lint rule into a common place. This pattern is seemingly very common, too, so a lot of other lint rules have a bespoke version of this. I can happily go refactor those cases to as they should all become quite a bit simpler.