### PR TITLE
fix: keep warnAbountTSVersion in sync with package.json

### DIFF
--- a/packages/typescript-estree/src/parseSettings/warnAboutTSVersion.ts
+++ b/packages/typescript-estree/src/parseSettings/warnAboutTSVersion.ts
@@ -6,7 +6,7 @@ import type { ParseSettings } from './index';
 /**
  * This needs to be kept in sync with package.json in the typescript-eslint monorepo
  */
-const SUPPORTED_TYPESCRIPT_VERSIONS = '>=4.7.4 <5.5.0';
+const SUPPORTED_TYPESCRIPT_VERSIONS = '>=4.7.4 <5.6.0';
 
 /*
  * The semver package will ignore prerelease ranges, and we don't want to explicitly document every one


### PR DESCRIPTION


<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9399
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

const SUPPORTED_TYPESCRIPT_VERSIONS needs to be kept in sync with package.json in the typescript-eslint monorepo. However, this was not changed in #9397.
