### PR TITLE
fix(eslint-plugin): [no-invalid-this] support AccessorProperty

### DIFF
--- a/packages/eslint-plugin/src/rules/no-invalid-this.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-this.ts
@@ -51,7 +51,13 @@ export default createRule<Options, MessageIds>({
       PropertyDefinition(): void {
         thisIsValidStack.push(true);
       },
+      AccessorProperty(): void {
+        thisIsValidStack.push(true);
+      },
       'PropertyDefinition:exit'(): void {
+        thisIsValidStack.pop();
+      },
+      'AccessorProperty:exit'(): void {
         thisIsValidStack.pop();
       },
       FunctionDeclaration(node: TSESTree.FunctionDeclaration): void {

--- a/packages/eslint-plugin/src/rules/no-invalid-this.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-this.ts
@@ -51,11 +51,11 @@ export default createRule<Options, MessageIds>({
       PropertyDefinition(): void {
         thisIsValidStack.push(true);
       },
-      AccessorProperty(): void {
-        thisIsValidStack.push(true);
-      },
       'PropertyDefinition:exit'(): void {
         thisIsValidStack.pop();
+      },
+      AccessorProperty(): void {
+        thisIsValidStack.push(true);
       },
       'AccessorProperty:exit'(): void {
         thisIsValidStack.pop();

--- a/packages/eslint-plugin/tests/rules/no-invalid-this.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-invalid-this.test.ts
@@ -424,6 +424,11 @@ class A {
   }
 }
     `,
+    `
+class A {
+      accessor b = this.c;
+}
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-invalid-this.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-invalid-this.test.ts
@@ -426,7 +426,9 @@ class A {
     `,
     `
 class A {
-      accessor b = this.c;
+  a = 5;
+  b = this.a;
+  accessor c = this.a;
 }
     `,
   ],

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -417,6 +417,7 @@ export type RuleFunction<T extends TSESTree.NodeOrTokenData = never> = (
 ) => void;
 
 interface RuleListenerBaseSelectors {
+  AccessorProperty?: RuleFunction<TSESTree.AccessorProperty>;
   ArrayExpression?: RuleFunction<TSESTree.ArrayExpression>;
   ArrayPattern?: RuleFunction<TSESTree.ArrayPattern>;
   ArrowFunctionExpression?: RuleFunction<TSESTree.ArrowFunctionExpression>;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9410
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
Support auto-accessor syntax in `no-invalid-this` rule
