### PR TITLE
fix: allow `eslint@^9.x` as a peer dependency

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -98,7 +98,7 @@
   },
   "peerDependencies": {
     "@typescript-eslint/parser": "^7.0.0",
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -49,7 +49,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "dependencies": {
     "@typescript-eslint/scope-manager": "7.13.1",

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "@eslint/eslintrc": ">=2",
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "devDependencies": {
     "@jest/types": "29.6.3",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -62,7 +62,7 @@
     "typescript": "*"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -52,7 +52,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "7.13.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -73,7 +73,7 @@
     "@typescript-eslint/typescript-estree": "7.13.1"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0"
+    "eslint": "^8.56.0 || ^9.0.0"
   },
   "devDependencies": {
     "downlevel-dts": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5627,7 +5627,7 @@ __metadata:
     unist-util-visit: ^5.0.0
   peerDependencies:
     "@typescript-eslint/parser": ^7.0.0
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
@@ -5664,7 +5664,7 @@ __metadata:
     rimraf: "*"
     typescript: "*"
   peerDependencies:
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
@@ -5727,7 +5727,7 @@ __metadata:
     typescript: "*"
   peerDependencies:
     "@eslint/eslintrc": ">=2"
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -5785,7 +5785,7 @@ __metadata:
     ts-api-utils: ^1.3.0
     typescript: "*"
   peerDependencies:
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
@@ -5967,7 +5967,7 @@ __metadata:
     rimraf: "*"
     typescript: "*"
   peerDependencies:
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   languageName: unknown
   linkType: soft
 
@@ -19657,7 +19657,7 @@ __metadata:
     rimraf: "*"
     typescript: "*"
   peerDependencies:
-    eslint: ^8.56.0
+    eslint: ^8.56.0 || ^9.0.0
   peerDependenciesMeta:
     typescript:
       optional: true


### PR DESCRIPTION
Every time I `pnpm i` (not sure about other package managers), i get a warning about the peer dependency `eslint` v9. 

![pnpm i output in the terminal with warnings, some of them relates to `@typescript-eslint/*`](https://github.com/typescript-eslint/typescript-eslint/assets/82659015/7610b88d-6736-4721-8199-ec2d044bf916)

According to [semver.npmjs.com](https://semver.npmjs.com/):
- `^8.56.0` matches only `8.56.0` and `8.57.0`.
- `^8.56.0 || ^9.0.0` matches them and `9.x.x`


| `^8.56.0` | `^8.56.0 \|\| ^9.0.0` |
| --- | --- |
| ![server.npmjs.com report about 8.56](https://github.com/typescript-eslint/typescript-eslint/assets/82659015/1ebb2e89-05ff-4ab6-910d-a5438d96f0b5) | ![server.npmjs.com report about 8.56 \|\| 9.0.0](https://github.com/typescript-eslint/typescript-eslint/assets/82659015/f279d832-5b15-41c3-8def-eabdbef915f2) |

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR updates the peer dependency to `^8.56.0 || ^9.0.0`