### PR TITLE
chore: base Renovate config on config:recommended, without patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,12 +29,6 @@
 
   packageRules: [
     {
-      automerge: true,
-      automergeStrategy: 'squash',
-      description: 'Automerge everything but major updates.',
-      matchUpdateTypes: ['minor', 'pin', 'digest'],
-    },
-    {
       addLabels: ['javascript'],
       description: 'Label JS ecosystem PRs appropriately.',
       matchManagers: ['npm'],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,94 +1,68 @@
 {
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: ['config:recommended', ':approveMajorUpdates'],
+
+  dependencyDashboardLabels: ['dependencies', 'repo maintenance'],
   enabledManagers: ['github-actions', 'npm'],
+
   ignoreDeps: [
-    // AJV is out-of-date, but it's intentionally synced with ESLint - https://github.com/eslint/eslint/blob/ad9dd6a933fd098a0d99c6a9aa059850535c23ee/package.json#L70
+    // AJV is intentionally synced with ESLint.
+    // https://github.com/eslint/eslint/blob/13dbecdea749abf51951ce61662eec2621a4b9af/package.json#L77
     'ajv',
-    // globby is ESM so we can't go any higher right now
+    // ESM only so we can't go higher until we natively run ESM internally.
     'globby',
-    // this dep is now ESM only
+    // Blocked until we enable ESLint v9 locally in our own PR (#9119).
+    'eslint',
+    // ESM only so we can't go higher until we natively run ESM internally.
     'execa',
-    // the nx packages get updated using the nx migrate CLI
-    '@nrwl/cli',
-    '@nx/cli',
-    '@nrwl/devkit',
-    '@nx/devkit',
-    '@nx/jest',
-    '@nx/jest',
-    '@nrwl/nx-cloud',
-    'nx-cloud',
-    '@nrwl/tao',
   ],
   ignorePaths: [
-    // integration test package.json's should never be updated as they're purposely fixed tests
+    // Integration test package.json's should never be updated as they're purposely fixed tests.
     'tests/integration/fixtures',
   ],
-  internalChecksFilter: 'strict',
+
   labels: ['dependencies'],
-  dependencyDashboard: true,
-  dependencyDashboardLabels: ['dependencies', 'repo maintenance'],
-  major: {
-    // most majors will require some manual effort to upgrade to, so we don't want to create
-    // PRs automatically or else we'll just spam ourselves.
-    dependencyDashboardApproval: true,
-  },
-  // by default renovate will auto-rebase whenever the dep pranch falls behind main.
-  // this is annoying as it spams notifications and creates unnecessary action runs.
-  // instead only auto-rebase when conflicted, and we can trigger a manual rebase if required.
-  rebaseWhen: 'conflicted',
+
+  // Wait well over npm's three day window for any new package as a precaution against malicious publishes.
+  // https://docs.npmjs.com/policies/unpublish/#packages-published-less-than-72-hours-ago
+  minimumReleaseAge: '7 days',
+
   packageRules: [
-    // automerge everything but major updates
     {
-      matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
       automerge: true,
       automergeStrategy: 'squash',
+      description: 'Automerge everything but major updates.',
+      matchUpdateTypes: ['minor', 'pin', 'digest'],
     },
-
-    // label PRs appropriately
     {
-      matchManagers: ['npm'],
       addLabels: ['javascript'],
+      description: 'Label JS ecosystem PRs appropriately.',
+      matchManagers: ['npm'],
     },
     {
-      matchManagers: ['github-actions'],
       addLabels: ['github-actions'],
-    },
-
-    // batch package sets together
-    {
-      extends: ['packages:react'],
-      groupName: 'react',
+      description: 'Label GHA ecosystem PRs appropriately.',
+      matchManagers: ['github-actions'],
     },
     {
-      extends: ['monorepo:docusaurus'],
-      groupName: 'docusaurus',
-    },
-    {
-      extends: ['monorepo:nrwl'],
-      groupName: 'nx',
-    },
-    {
-      matchPackagePrefixes: ['@babel', 'babel-'],
-      groupName: 'babel',
-    },
-    {
-      matchPackageNames: ['ts-jest', 'pretty-format'],
-      matchPackagePrefixes: ['@types/jest', 'jest', '@jest'],
-      groupName: 'jest',
-    },
-    {
-      matchPackageNames: ['eslint'],
-      matchPackagePrefixes: ['@eslint'],
-      groupName: 'eslint',
-    },
-    {
-      matchPackageNames: ['stylelint'],
-      matchPackagePrefixes: ['@stylelint'],
-      groupName: 'stylelint',
+      description: 'Ignore Nrwl/Nx packages updated using the nx migrate CLI.',
+      enabled: false,
+      packagePatterns: ['^@nrwl/', '^@nx/', 'nx-cloud'],
     },
   ],
+
+  // We've found enabling patch updates on all dependencies is a lot of noise.
+  patch: {
+    enabled: false,
+  },
+
   postUpdateOptions: [
-    // run yarn dedupe to cleanup the lockfile after updates
+    // Run yarn dedupe to cleanup the lockfile after updates.
     'yarnDedupeHighest',
   ],
-  stabilityDays: 3,
+
+  // By default renovate will auto-rebase whenever the dep pranch falls behind main.
+  // This is annoying as it spams notifications and creates unnecessary action runs.
+  // Instead only auto-rebase when conflicted, and we can trigger a manual rebase if required.
+  rebaseWhen: 'conflicted',
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9372
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Applies three touchups to the Renovate config:
* Polishes up formatting and style
* Bases it off of [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended) to bring in the large set of groups, replacements, and workarounds
* Disables patch updates for the reasons in #9372