### PR TITLE
chore: revert "test(type-utils): skip mysteriously failing type unit tests (#9427)"

### DIFF
--- a/packages/type-utils/tests/getTypeName.test.ts
+++ b/packages/type-utils/tests/getTypeName.test.ts
@@ -1,6 +1,7 @@
 import { parseForESLint } from '@typescript-eslint/parser';
 import type { TSESTree } from '@typescript-eslint/typescript-estree';
 import path from 'path';
+import util from 'util';
 import type * as ts from 'typescript';
 
 import { getTypeName } from '../src';
@@ -15,6 +16,7 @@ describe('getTypeName', () => {
       filePath: path.join(rootDir, 'file.ts'),
       tsconfigRootDir: rootDir,
     });
+    console.log(util.inspect(ast, { depth: 25 }));
     expectToHaveParserServices(services);
     const checker = services.program.getTypeChecker();
     const declaration = ast.body[0] as TSESTree.TSTypeAliasDeclaration;

--- a/packages/type-utils/tests/getTypeName.test.ts
+++ b/packages/type-utils/tests/getTypeName.test.ts
@@ -1,7 +1,6 @@
 import { parseForESLint } from '@typescript-eslint/parser';
 import type { TSESTree } from '@typescript-eslint/typescript-estree';
 import path from 'path';
-import util from 'util';
 import type * as ts from 'typescript';
 
 import { getTypeName } from '../src';
@@ -16,7 +15,6 @@ describe('getTypeName', () => {
       filePath: path.join(rootDir, 'file.ts'),
       tsconfigRootDir: rootDir,
     });
-    console.log(util.inspect(ast, { depth: 25 }));
     expectToHaveParserServices(services);
     const checker = services.program.getTypeChecker();
     const declaration = ast.body[0] as TSESTree.TSTypeAliasDeclaration;
@@ -32,8 +30,8 @@ describe('getTypeName', () => {
 
   describe('returns primitive type', () => {
     it.each([
-      ['type Test = "text";', 'string'],
       ['type Test = string;', 'string'],
+      ['type Test = "text";', 'string'],
       ['type Test = string | "text";', 'string'],
       ['type Test = "string" | "text";', 'string'],
       ['type Test = string & { foo: number };', 'string'],

--- a/packages/type-utils/tests/getTypeName.test.ts
+++ b/packages/type-utils/tests/getTypeName.test.ts
@@ -6,9 +6,7 @@ import type * as ts from 'typescript';
 import { getTypeName } from '../src';
 import { expectToHaveParserServices } from './test-utils/expectToHaveParserServices';
 
-// TODO(#9426): re-enable this
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('getTypeName', () => {
+describe('getTypeName', () => {
   function getTypes(code: string): { checker: ts.TypeChecker; type: ts.Type } {
     const rootDir = path.join(__dirname, 'fixtures');
 

--- a/packages/type-utils/tests/getTypeName.test.ts
+++ b/packages/type-utils/tests/getTypeName.test.ts
@@ -32,8 +32,8 @@ describe('getTypeName', () => {
 
   describe('returns primitive type', () => {
     it.each([
-      ['type Test = string;', 'string'],
       ['type Test = "text";', 'string'],
+      ['type Test = string;', 'string'],
       ['type Test = string | "text";', 'string'],
       ['type Test = "string" | "text";', 'string'],
       ['type Test = string & { foo: number };', 'string'],

--- a/packages/type-utils/tests/getTypeName.test.ts
+++ b/packages/type-utils/tests/getTypeName.test.ts
@@ -11,6 +11,7 @@ describe('getTypeName', () => {
     const rootDir = path.join(__dirname, 'fixtures');
 
     const { ast, services } = parseForESLint(code, {
+      disallowAutomaticSingleRunInference: true,
       project: './tsconfig.json',
       filePath: path.join(rootDir, 'file.ts'),
       tsconfigRootDir: rootDir,

--- a/packages/type-utils/tests/typeFlagUtils.test.ts
+++ b/packages/type-utils/tests/typeFlagUtils.test.ts
@@ -6,9 +6,7 @@ import * as ts from 'typescript';
 import { getTypeFlags, isTypeFlagSet } from '../src';
 import { expectToHaveParserServices } from './test-utils/expectToHaveParserServices';
 
-// TODO(#9426): re-enable this
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('typeFlagUtils', () => {
+describe('typeFlagUtils', () => {
   const rootDir = path.join(__dirname, 'fixtures');
 
   function getType(code: string): ts.Type {

--- a/packages/type-utils/tests/typeFlagUtils.test.ts
+++ b/packages/type-utils/tests/typeFlagUtils.test.ts
@@ -11,6 +11,7 @@ describe('typeFlagUtils', () => {
 
   function getType(code: string): ts.Type {
     const { ast, services } = parseForESLint(code, {
+      disallowAutomaticSingleRunInference: true,
       project: './tsconfig.json',
       filePath: path.join(rootDir, 'file.ts'),
       tsconfigRootDir: rootDir,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9430
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This reverts commit 2cdf240f13af938c651e5cb5970d60fa788895d3.

Okay, I finally found the cause of the issue: 

- https://github.com/typescript-eslint/typescript-eslint/pull/8922
^ after this PR, it's required to add `disallowAutomaticSingleRunInference` to tests that work with manual parsing 

---

Fun fact: it required exporting `CI=true` to reproduce the failures in the tests.