### PR TITLE
chore: add GitHub workflow to close issues resolved in `v8` branch

### DIFF
--- a/.github/workflows/close-v8-issues.yml
+++ b/.github/workflows/close-v8-issues.yml
@@ -1,0 +1,16 @@
+name: Close issues related to a merged pull request based on v8 branch.
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - v8
+
+jobs:
+  close_v8_issue_on_pr_merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Closes issues related to a merged pull request.
+        uses: ldez/gha-mjolnir@v1.4.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9458
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I tested it in my own repo. It works pretty well. See:

https://github.com/auvred/test-gha-mjolnir/issues/1 -> https://github.com/auvred/test-gha-mjolnir/pull/2
