### PR TITLE
fix(eslint-plugin): remove duplicate import `RuleModuleWithMetaDocs`

### DIFF
--- a/packages/eslint-plugin/rules.d.ts
+++ b/packages/eslint-plugin/rules.d.ts
@@ -37,7 +37,6 @@ This is likely not portable. A type annotation is necessary. ts(2742)
 
 import type {
   RuleModuleWithMetaDocs,
-  RuleModuleWithMetaDocs,
   RuleRecommendation,
   RuleRecommendationAcrossConfigs,
 } from '@typescript-eslint/utils/ts-eslint';


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
In #9339, @JoshuaKGoldberg introduced a regression causing a duplicate import identifier. In a project that consumes `@typescript-eslint/eslint-plugin@8.0.0-alpha.38`, this causes two TypeScript errors in that file (if `skipLibCheck` is `false`), complaining about the duplicate import.

I'm not sure, by the way, why this is not a TS error in the repo itself, but causes a TS error when in the `node_modules` of another package.
Should we consider turning on `skipLibCheck` in this repo?
Also, I did a cursory search and was unable to find any rule in `eslint`, `typescript-eslint` or `eslint-plugin-import` that would allow us to catch issues like these 🙁
