### PR TITLE
docs: tseslint.config takes a spread argument, not an array

### DIFF
--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -248,18 +248,16 @@ We found that this is a pretty common operation when writing ESLint configs whic
 For example in codebases with type-aware linting a config object like this is a very common way to disable TS-specific linting setups on JS files:
 
 ```js
-export default tseslint.config([
-  {
-    files: ['**/*.js'],
-    extends: [tseslint.configs.disableTypeChecked],
-    rules: {
-      // turn off other type-aware rules
-      'deprecation/deprecation': 'off',
-      '@typescript-eslint/internal/no-poorly-typed-ts-props': 'off',
+export default tseslint.config({
+  files: ['**/*.js'],
+  extends: [tseslint.configs.disableTypeChecked],
+  rules: {
+    // turn off other type-aware rules
+    'deprecation/deprecation': 'off',
+    '@typescript-eslint/internal/no-poorly-typed-ts-props': 'off',
 
-      // turn off rules that don't apply to JS code
-      '@typescript-eslint/explicit-function-return-type': 'off',
-    },
+    // turn off rules that don't apply to JS code
+    '@typescript-eslint/explicit-function-return-type': 'off',
   },
-]);
+});
 ```


### PR DESCRIPTION
## PR Checklist

- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
  - [x] "One exception: extremely minor documentation typos"

## Overview

Pasting the last configuration at https://typescript-eslint.io/packages/typescript-eslint#flat-config-extends (under "For example in codebases with type-aware linting a config object like this is a very common way to disable TS-specific linting...") resulted in this warning:

![image](https://github.com/typescript-eslint/typescript-eslint/assets/33569/4ca3f0bb-17b9-4d70-ae23-2da455c8722a)

Removing the enclosing array brackets solved the issue.