### PR TITLE
fix(utils): context.parserPath may be undefined

### DIFF
--- a/packages/utils/src/eslint-utils/getParserServices.ts
+++ b/packages/utils/src/eslint-utils/getParserServices.ts
@@ -3,7 +3,7 @@ import type {
   ParserServices,
   ParserServicesWithTypeInformation,
 } from '../ts-estree';
-import { parserSeemsToBeTSESLint as parserSeemsToBeTSESLint } from './parserSeemsToBeTSESLint';
+import { parserSeemsToBeTSESLint } from './parserSeemsToBeTSESLint';
 
 const ERROR_MESSAGE_REQUIRES_PARSER_SERVICES =
   'You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.';

--- a/packages/utils/src/eslint-utils/parserPathSeemsToBeTSESLint.ts
+++ b/packages/utils/src/eslint-utils/parserPathSeemsToBeTSESLint.ts
@@ -1,3 +1,0 @@
-export function parserPathSeemsToBeTSESLint(parserPath: string): boolean {
-  return /(?:typescript-eslint|\.\.)[\w/\\]*parser/.test(parserPath);
-}

--- a/packages/utils/src/eslint-utils/parserSeemsToBeTSESLint.ts
+++ b/packages/utils/src/eslint-utils/parserSeemsToBeTSESLint.ts
@@ -1,0 +1,3 @@
+export function parserSeemsToBeTSESLint(parser: string | undefined): boolean {
+  return !!parser && /(?:typescript-eslint|\.\.)[\w/\\]*parser/.test(parser);
+}

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -203,9 +203,9 @@ export interface RuleContext<
    */
   options: Options;
   /**
-   * The name of the parser from configuration.
+   * The name of the parser from configuration, if in eslintrc (legacy) config.
    */
-  parserPath: string;
+  parserPath: string | undefined;
   /**
    * The language options configured for this run
    */

--- a/packages/utils/tests/eslint-utils/getParserServices.test.ts
+++ b/packages/utils/tests/eslint-utils/getParserServices.test.ts
@@ -3,6 +3,7 @@ import type * as ts from 'typescript';
 
 import type { ParserServices, TSESLint, TSESTree } from '../../src';
 import { ESLintUtils } from '../../src';
+import type { FlatConfig } from '../../src/ts-eslint';
 
 type UnknownRuleContext = Readonly<TSESLint.RuleContext<string, unknown[]>>;
 
@@ -25,18 +26,20 @@ const createMockRuleContext = (
     ...overrides,
   }) as unknown as UnknownRuleContext;
 
-const requiresParserServicesMessageTemplate =
+const requiresParserServicesMessageTemplate = (parser = '\\S*'): string =>
   'You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.\n' +
-  'Parser: \\S*';
-const baseErrorRegex = new RegExp(requiresParserServicesMessageTemplate);
-const unknownParserErrorRegex = new RegExp(
-  requiresParserServicesMessageTemplate +
-    '\n' +
-    'Note: detected a parser other than @typescript-eslint/parser. Make sure the parser is configured to forward "parserOptions.project" to @typescript-eslint/parser.',
-);
+  `Parser: ${parser}`;
+const baseErrorRegex = (parser?: string): RegExp =>
+  new RegExp(requiresParserServicesMessageTemplate(parser));
+const unknownParserErrorRegex = (parser?: string): RegExp =>
+  new RegExp(
+    requiresParserServicesMessageTemplate(parser) +
+      '\n' +
+      'Note: detected a parser other than @typescript-eslint/parser. Make sure the parser is configured to forward "parserOptions.project" to @typescript-eslint/parser.',
+  );
 
 describe('getParserServices', () => {
-  it('throws a standard error when parserOptions.esTreeNodeToTSNodeMap is missing and the parser is known', () => {
+  it('throws a standard error with the parser when parserOptions.esTreeNodeToTSNodeMap is missing and the parser is typescript-eslint', () => {
     const context = createMockRuleContext({
       sourceCode: {
         ...defaults.sourceCode,
@@ -48,7 +51,69 @@ describe('getParserServices', () => {
     });
 
     expect(() => ESLintUtils.getParserServices(context)).toThrow(
-      baseErrorRegex,
+      baseErrorRegex('@typescript-eslint[\\/]parser[\\/]dist[\\/]index\\.js'),
+    );
+  });
+
+  it('throws a standard error with the parser when parserOptions.esTreeNodeToTSNodeMap is missing and the parser is custom', () => {
+    const context = createMockRuleContext({
+      languageOptions: {
+        parser: {
+          meta: {
+            name: 'custom-parser',
+          },
+        } as FlatConfig.Parser,
+      },
+      parserPath: undefined,
+      sourceCode: {
+        ...defaults.sourceCode,
+        parserServices: {
+          ...defaults.sourceCode.parserServices,
+          esTreeNodeToTSNodeMap: undefined as any,
+        },
+      },
+    });
+
+    expect(() => ESLintUtils.getParserServices(context)).toThrow(
+      baseErrorRegex('custom-parser'),
+    );
+  });
+
+  it('throws a standard error with an unknown parser when parserOptions.esTreeNodeToTSNodeMap is missing and the parser is missing', () => {
+    const context = createMockRuleContext({
+      languageOptions: {},
+      parserPath: undefined,
+      sourceCode: {
+        ...defaults.sourceCode,
+        parserServices: {
+          ...defaults.sourceCode.parserServices,
+          esTreeNodeToTSNodeMap: undefined as any,
+        },
+      },
+    });
+
+    expect(() => ESLintUtils.getParserServices(context)).toThrow(
+      baseErrorRegex('\\(unknown\\)'),
+    );
+  });
+
+  it('throws a standard error with an unknown parser when parserOptions.esTreeNodeToTSNodeMap is missing and the parser is unknown', () => {
+    const context = createMockRuleContext({
+      languageOptions: {
+        parser: {} as FlatConfig.Parser,
+      },
+      parserPath: undefined,
+      sourceCode: {
+        ...defaults.sourceCode,
+        parserServices: {
+          ...defaults.sourceCode.parserServices,
+          esTreeNodeToTSNodeMap: undefined as any,
+        },
+      },
+    });
+
+    expect(() => ESLintUtils.getParserServices(context)).toThrow(
+      baseErrorRegex('\\(unknown\\)'),
     );
   });
 
@@ -64,7 +129,7 @@ describe('getParserServices', () => {
       },
     });
     expect(() => ESLintUtils.getParserServices(context)).toThrow(
-      unknownParserErrorRegex,
+      unknownParserErrorRegex(),
     );
   });
 
@@ -80,7 +145,7 @@ describe('getParserServices', () => {
     });
 
     expect(() => ESLintUtils.getParserServices(context)).toThrow(
-      baseErrorRegex,
+      baseErrorRegex(),
     );
   });
 
@@ -96,7 +161,7 @@ describe('getParserServices', () => {
     });
 
     expect(() => ESLintUtils.getParserServices(context)).toThrow(
-      baseErrorRegex,
+      baseErrorRegex(),
     );
   });
 

--- a/packages/utils/tests/eslint-utils/parserSeemsToBeTSESLint.test.ts
+++ b/packages/utils/tests/eslint-utils/parserSeemsToBeTSESLint.test.ts
@@ -1,7 +1,9 @@
-import { parserPathSeemsToBeTSESLint } from '../../src/eslint-utils/parserPathSeemsToBeTSESLint';
+import { parserSeemsToBeTSESLint } from '../../src/eslint-utils/parserSeemsToBeTSESLint';
 
-describe('parserPathSeemsToBeTSESLint', () => {
+describe('parserSeemsToBeTSESLint', () => {
   test.each([
+    [undefined, false],
+    ['espree', false],
     ['local.js', false],
     ['../other.js', false],
     ['@babel/eslint-parser/lib/index.cjs', false],
@@ -19,6 +21,6 @@ describe('parserPathSeemsToBeTSESLint', () => {
     ['/path/to/@typescript-eslint/packages/parser/dist/index.js', true],
     ['/path/to/@typescript-eslint/packages/parser/index.js', true],
   ])('%s', (parserPath, expected) => {
-    expect(parserPathSeemsToBeTSESLint(parserPath)).toBe(expected);
+    expect(parserSeemsToBeTSESLint(parserPath)).toBe(expected);
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes ##8891; fixes #9475
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

First switches `parserPath` to `string | undefined`, then adds in handling to try to use `context.languageOptions.parser.meta.name` if it exists.

💖 