### PR TITLE
feat(ast-spec): add parent property to AccessorProperty node types

### DIFF
--- a/packages/ast-spec/src/element/AccessorProperty/spec.ts
+++ b/packages/ast-spec/src/element/AccessorProperty/spec.ts
@@ -3,18 +3,15 @@ import type {
   PropertyDefinitionComputedNameBase,
   PropertyDefinitionNonComputedNameBase,
 } from '../../base/PropertyDefinitionBase';
-import type { ClassBody } from '../../special/ClassBody/spec';
 
 export interface AccessorPropertyComputedName
   extends PropertyDefinitionComputedNameBase {
   type: AST_NODE_TYPES.AccessorProperty;
-  parent: ClassBody;
 }
 
 export interface AccessorPropertyNonComputedName
   extends PropertyDefinitionNonComputedNameBase {
   type: AST_NODE_TYPES.AccessorProperty;
-  parent: ClassBody;
 }
 
 export type AccessorProperty =

--- a/packages/ast-spec/src/element/AccessorProperty/spec.ts
+++ b/packages/ast-spec/src/element/AccessorProperty/spec.ts
@@ -3,15 +3,18 @@ import type {
   PropertyDefinitionComputedNameBase,
   PropertyDefinitionNonComputedNameBase,
 } from '../../base/PropertyDefinitionBase';
+import type { ClassBody } from '../../special/ClassBody/spec';
 
 export interface AccessorPropertyComputedName
   extends PropertyDefinitionComputedNameBase {
   type: AST_NODE_TYPES.AccessorProperty;
+  parent: ClassBody;
 }
 
 export interface AccessorPropertyNonComputedName
   extends PropertyDefinitionNonComputedNameBase {
   type: AST_NODE_TYPES.AccessorProperty;
+  parent: ClassBody;
 }
 
 export type AccessorProperty =

--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -12,6 +12,14 @@ declare module './generated/ast-spec' {
      */
     parent?: never;
   }
+
+  interface AccessorPropertyComputedName {
+    parent: TSESTree.ClassBody;
+  }
+
+  export interface AccessorPropertyNonComputedName {
+    parent: TSESTree.ClassBody;
+  }
 }
 
 export * as TSESTree from './generated/ast-spec';

--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -17,7 +17,7 @@ declare module './generated/ast-spec' {
     parent: TSESTree.ClassBody;
   }
 
-  export interface AccessorPropertyNonComputedName {
+  interface AccessorPropertyNonComputedName {
     parent: TSESTree.ClassBody;
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: starts on #6225
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds `parent: ClassBody` to the `AccessorPropertyComputedName` interfaces to start on #6225.