### PR TITLE
Update peer dependency for eslint to include v9+

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -69,7 +69,7 @@
     "@typescript-eslint/typescript-estree": "7.15.0"
   },
   "peerDependencies": {
-    "eslint": "^8.56.0"
+    "eslint": ">8.56.0"
   },
   "devDependencies": {
     "downlevel-dts": "*",


### PR DESCRIPTION
Update peer dependency for ESLint to use simple semver range instead of carets, allowing ESlint v9 and above to be accepted as peers,


## PR Checklist

- [ x] Addresses an existing open issue: fixes #9488 
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fixes Peer Dependency version range
