### PR TITLE
feat(eslint-plugin): [strict-boolean-expressions] support double exclamation `!!` expression as well as `Boolean()`

### DIFF
--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -375,76 +375,75 @@ export default createRule<Options, MessageId>({
       // string
       if (is('string') || is('truthy string')) {
         if (!options.allowString) {
-          if (hasDoubleExclamationExpression(node.parent)) {
-            return;
-          }
-          if (isLogicalNegationExpression(node.parent)) {
-            // if (!string)
-            context.report({
-              node,
-              messageId: 'conditionErrorString',
-              suggest: [
-                {
-                  messageId: 'conditionFixCompareStringLength',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node: node.parent,
-                    innerNode: node,
-                    wrap: code => `${code}.length === 0`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixCompareEmptyString',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node: node.parent,
-                    innerNode: node,
-                    wrap: code => `${code} === ""`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixCastBoolean',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node: node.parent,
-                    innerNode: node,
-                    wrap: code => `!Boolean(${code})`,
-                  }),
-                },
-              ],
-            });
-          } else {
-            // if (string)
-            context.report({
-              node,
-              messageId: 'conditionErrorString',
-              suggest: [
-                {
-                  messageId: 'conditionFixCompareStringLength',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `${code}.length > 0`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixCompareEmptyString',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `${code} !== ""`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixCastBoolean',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `Boolean(${code})`,
-                  }),
-                },
-              ],
-            });
+          if (!hasDoubleExclamationExpression(node.parent)) {
+            if (isLogicalNegationExpression(node.parent)) {
+              // if (!string)
+              context.report({
+                node,
+                messageId: 'conditionErrorString',
+                suggest: [
+                  {
+                    messageId: 'conditionFixCompareStringLength',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node: node.parent,
+                      innerNode: node,
+                      wrap: code => `${code}.length === 0`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCompareEmptyString',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node: node.parent,
+                      innerNode: node,
+                      wrap: code => `${code} === ""`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCastBoolean',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node: node.parent,
+                      innerNode: node,
+                      wrap: code => `!Boolean(${code})`,
+                    }),
+                  },
+                ],
+              });
+            } else {
+              // if (string)
+              context.report({
+                node,
+                messageId: 'conditionErrorString',
+                suggest: [
+                  {
+                    messageId: 'conditionFixCompareStringLength',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `${code}.length > 0`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCompareEmptyString',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `${code} !== ""`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCastBoolean',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `Boolean(${code})`,
+                    }),
+                  },
+                ],
+              });
+            }
           }
         }
         return;
@@ -453,75 +452,74 @@ export default createRule<Options, MessageId>({
       // nullable string
       if (is('nullish', 'string')) {
         if (!options.allowNullableString) {
-          if (hasDoubleExclamationExpression(node.parent)) {
-            return;
-          }
-          if (isLogicalNegationExpression(node.parent)) {
-            // if (!nullableString)
-            context.report({
-              node,
-              messageId: 'conditionErrorNullableString',
-              suggest: [
-                {
-                  messageId: 'conditionFixCompareNullish',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node: node.parent,
-                    innerNode: node,
-                    wrap: code => `${code} == null`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixDefaultEmptyString',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `${code} ?? ""`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixCastBoolean',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node: node.parent,
-                    innerNode: node,
-                    wrap: code => `!Boolean(${code})`,
-                  }),
-                },
-              ],
-            });
-          } else {
-            // if (nullableString)
-            context.report({
-              node,
-              messageId: 'conditionErrorNullableString',
-              suggest: [
-                {
-                  messageId: 'conditionFixCompareNullish',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `${code} != null`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixDefaultEmptyString',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `${code} ?? ""`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixCastBoolean',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `Boolean(${code})`,
-                  }),
-                },
-              ],
-            });
+          if (!hasDoubleExclamationExpression(node.parent)) {
+            if (isLogicalNegationExpression(node.parent)) {
+              // if (!nullableString)
+              context.report({
+                node,
+                messageId: 'conditionErrorNullableString',
+                suggest: [
+                  {
+                    messageId: 'conditionFixCompareNullish',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node: node.parent,
+                      innerNode: node,
+                      wrap: code => `${code} == null`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixDefaultEmptyString',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `${code} ?? ""`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCastBoolean',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node: node.parent,
+                      innerNode: node,
+                      wrap: code => `!Boolean(${code})`,
+                    }),
+                  },
+                ],
+              });
+            } else {
+              // if (nullableString)
+              context.report({
+                node,
+                messageId: 'conditionErrorNullableString',
+                suggest: [
+                  {
+                    messageId: 'conditionFixCompareNullish',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `${code} != null`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixDefaultEmptyString',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `${code} ?? ""`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCastBoolean',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `Boolean(${code})`,
+                    }),
+                  },
+                ],
+              });
+            }
           }
         }
         return;
@@ -530,103 +528,102 @@ export default createRule<Options, MessageId>({
       // number
       if (is('number') || is('truthy number')) {
         if (!options.allowNumber) {
-          if (hasDoubleExclamationExpression(node.parent)) {
-            return;
-          }
-          if (isArrayLengthExpression(node, checker, services)) {
-            if (isLogicalNegationExpression(node.parent)) {
-              // if (!array.length)
-              context.report({
-                node,
-                messageId: 'conditionErrorNumber',
-                fix: getWrappingFixer({
-                  sourceCode: context.sourceCode,
-                  node: node.parent,
-                  innerNode: node,
-                  wrap: code => `${code} === 0`,
-                }),
-              });
-            } else {
-              // if (array.length)
-              context.report({
-                node,
-                messageId: 'conditionErrorNumber',
-                fix: getWrappingFixer({
-                  sourceCode: context.sourceCode,
+          if (!hasDoubleExclamationExpression(node.parent)) {
+            if (isArrayLengthExpression(node, checker, services)) {
+              if (isLogicalNegationExpression(node.parent)) {
+                // if (!array.length)
+                context.report({
                   node,
-                  wrap: code => `${code} > 0`,
-                }),
-              });
-            }
-          } else if (isLogicalNegationExpression(node.parent)) {
-            // if (!number)
-            context.report({
-              node,
-              messageId: 'conditionErrorNumber',
-              suggest: [
-                {
-                  messageId: 'conditionFixCompareZero',
+                  messageId: 'conditionErrorNumber',
                   fix: getWrappingFixer({
                     sourceCode: context.sourceCode,
                     node: node.parent,
                     innerNode: node,
-                    // TODO: we have to compare to 0n if the type is bigint
                     wrap: code => `${code} === 0`,
                   }),
-                },
-                {
-                  // TODO: don't suggest this for bigint because it can't be NaN
-                  messageId: 'conditionFixCompareNaN',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node: node.parent,
-                    innerNode: node,
-                    wrap: code => `Number.isNaN(${code})`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixCastBoolean',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node: node.parent,
-                    innerNode: node,
-                    wrap: code => `!Boolean(${code})`,
-                  }),
-                },
-              ],
-            });
-          } else {
-            // if (number)
-            context.report({
-              node,
-              messageId: 'conditionErrorNumber',
-              suggest: [
-                {
-                  messageId: 'conditionFixCompareZero',
+                });
+              } else {
+                // if (array.length)
+                context.report({
+                  node,
+                  messageId: 'conditionErrorNumber',
                   fix: getWrappingFixer({
                     sourceCode: context.sourceCode,
                     node,
-                    wrap: code => `${code} !== 0`,
+                    wrap: code => `${code} > 0`,
                   }),
-                },
-                {
-                  messageId: 'conditionFixCompareNaN',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `!Number.isNaN(${code})`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixCastBoolean',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `Boolean(${code})`,
-                  }),
-                },
-              ],
-            });
+                });
+              }
+            } else if (isLogicalNegationExpression(node.parent)) {
+              // if (!number)
+              context.report({
+                node,
+                messageId: 'conditionErrorNumber',
+                suggest: [
+                  {
+                    messageId: 'conditionFixCompareZero',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node: node.parent,
+                      innerNode: node,
+                      // TODO: we have to compare to 0n if the type is bigint
+                      wrap: code => `${code} === 0`,
+                    }),
+                  },
+                  {
+                    // TODO: don't suggest this for bigint because it can't be NaN
+                    messageId: 'conditionFixCompareNaN',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node: node.parent,
+                      innerNode: node,
+                      wrap: code => `Number.isNaN(${code})`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCastBoolean',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node: node.parent,
+                      innerNode: node,
+                      wrap: code => `!Boolean(${code})`,
+                    }),
+                  },
+                ],
+              });
+            } else {
+              // if (number)
+              context.report({
+                node,
+                messageId: 'conditionErrorNumber',
+                suggest: [
+                  {
+                    messageId: 'conditionFixCompareZero',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `${code} !== 0`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCompareNaN',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `!Number.isNaN(${code})`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCastBoolean',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `Boolean(${code})`,
+                    }),
+                  },
+                ],
+              });
+            }
           }
         }
         return;
@@ -635,75 +632,74 @@ export default createRule<Options, MessageId>({
       // nullable number
       if (is('nullish', 'number')) {
         if (!options.allowNullableNumber) {
-          if (hasDoubleExclamationExpression(node.parent)) {
-            return;
-          }
-          if (isLogicalNegationExpression(node.parent)) {
-            // if (!nullableNumber)
-            context.report({
-              node,
-              messageId: 'conditionErrorNullableNumber',
-              suggest: [
-                {
-                  messageId: 'conditionFixCompareNullish',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node: node.parent,
-                    innerNode: node,
-                    wrap: code => `${code} == null`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixDefaultZero',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `${code} ?? 0`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixCastBoolean',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node: node.parent,
-                    innerNode: node,
-                    wrap: code => `!Boolean(${code})`,
-                  }),
-                },
-              ],
-            });
-          } else {
-            // if (nullableNumber)
-            context.report({
-              node,
-              messageId: 'conditionErrorNullableNumber',
-              suggest: [
-                {
-                  messageId: 'conditionFixCompareNullish',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `${code} != null`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixDefaultZero',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `${code} ?? 0`,
-                  }),
-                },
-                {
-                  messageId: 'conditionFixCastBoolean',
-                  fix: getWrappingFixer({
-                    sourceCode: context.sourceCode,
-                    node,
-                    wrap: code => `Boolean(${code})`,
-                  }),
-                },
-              ],
-            });
+          if (!hasDoubleExclamationExpression(node.parent)) {
+            if (isLogicalNegationExpression(node.parent)) {
+              // if (!nullableNumber)
+              context.report({
+                node,
+                messageId: 'conditionErrorNullableNumber',
+                suggest: [
+                  {
+                    messageId: 'conditionFixCompareNullish',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node: node.parent,
+                      innerNode: node,
+                      wrap: code => `${code} == null`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixDefaultZero',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `${code} ?? 0`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCastBoolean',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node: node.parent,
+                      innerNode: node,
+                      wrap: code => `!Boolean(${code})`,
+                    }),
+                  },
+                ],
+              });
+            } else {
+              // if (nullableNumber)
+              context.report({
+                node,
+                messageId: 'conditionErrorNullableNumber',
+                suggest: [
+                  {
+                    messageId: 'conditionFixCompareNullish',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `${code} != null`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixDefaultZero',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `${code} ?? 0`,
+                    }),
+                  },
+                  {
+                    messageId: 'conditionFixCastBoolean',
+                    fix: getWrappingFixer({
+                      sourceCode: context.sourceCode,
+                      node,
+                      wrap: code => `Boolean(${code})`,
+                    }),
+                  },
+                ],
+              });
+            }
           }
         }
         return;
@@ -799,23 +795,22 @@ export default createRule<Options, MessageId>({
       // any
       if (is('any')) {
         if (!options.allowAny) {
-          if (hasDoubleExclamationExpression(node.parent)) {
-            return;
+          if (!hasDoubleExclamationExpression(node.parent)) {
+            context.report({
+              node,
+              messageId: 'conditionErrorAny',
+              suggest: [
+                {
+                  messageId: 'conditionFixCastBoolean',
+                  fix: getWrappingFixer({
+                    sourceCode: context.sourceCode,
+                    node,
+                    wrap: code => `Boolean(${code})`,
+                  }),
+                },
+              ],
+            });
           }
-          context.report({
-            node,
-            messageId: 'conditionErrorAny',
-            suggest: [
-              {
-                messageId: 'conditionFixCastBoolean',
-                fix: getWrappingFixer({
-                  sourceCode: context.sourceCode,
-                  node,
-                  wrap: code => `Boolean(${code})`,
-                }),
-              },
-            ],
-          });
         }
         return;
       }

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -375,7 +375,9 @@ export default createRule<Options, MessageId>({
       // string
       if (is('string') || is('truthy string')) {
         if (!options.allowString) {
-          if (hasDoubleExclamationExpression(node.parent)) return;
+          if (hasDoubleExclamationExpression(node.parent)) {
+            return;
+          }
           if (isLogicalNegationExpression(node.parent)) {
             // if (!string)
             context.report({
@@ -451,7 +453,9 @@ export default createRule<Options, MessageId>({
       // nullable string
       if (is('nullish', 'string')) {
         if (!options.allowNullableString) {
-          if (hasDoubleExclamationExpression(node.parent)) return;
+          if (hasDoubleExclamationExpression(node.parent)) {
+            return;
+          }
           if (isLogicalNegationExpression(node.parent)) {
             // if (!nullableString)
             context.report({
@@ -526,7 +530,9 @@ export default createRule<Options, MessageId>({
       // number
       if (is('number') || is('truthy number')) {
         if (!options.allowNumber) {
-          if (hasDoubleExclamationExpression(node.parent)) return;
+          if (hasDoubleExclamationExpression(node.parent)) {
+            return;
+          }
           if (isArrayLengthExpression(node, checker, services)) {
             if (isLogicalNegationExpression(node.parent)) {
               // if (!array.length)
@@ -629,7 +635,9 @@ export default createRule<Options, MessageId>({
       // nullable number
       if (is('nullish', 'number')) {
         if (!options.allowNullableNumber) {
-          if (hasDoubleExclamationExpression(node.parent)) return;
+          if (hasDoubleExclamationExpression(node.parent)) {
+            return;
+          }
           if (isLogicalNegationExpression(node.parent)) {
             // if (!nullableNumber)
             context.report({
@@ -791,7 +799,9 @@ export default createRule<Options, MessageId>({
       // any
       if (is('any')) {
         if (!options.allowAny) {
-          if (hasDoubleExclamationExpression(node.parent)) return;
+          if (hasDoubleExclamationExpression(node.parent)) {
+            return;
+          }
           context.report({
             node,
             messageId: 'conditionErrorAny',

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -375,6 +375,7 @@ export default createRule<Options, MessageId>({
       // string
       if (is('string') || is('truthy string')) {
         if (!options.allowString) {
+          if (hasDoubleExclamationExpression(node.parent)) return;
           if (isLogicalNegationExpression(node.parent)) {
             // if (!string)
             context.report({
@@ -450,6 +451,7 @@ export default createRule<Options, MessageId>({
       // nullable string
       if (is('nullish', 'string')) {
         if (!options.allowNullableString) {
+          if (hasDoubleExclamationExpression(node.parent)) return;
           if (isLogicalNegationExpression(node.parent)) {
             // if (!nullableString)
             context.report({
@@ -524,6 +526,7 @@ export default createRule<Options, MessageId>({
       // number
       if (is('number') || is('truthy number')) {
         if (!options.allowNumber) {
+          if (hasDoubleExclamationExpression(node.parent)) return;
           if (isArrayLengthExpression(node, checker, services)) {
             if (isLogicalNegationExpression(node.parent)) {
               // if (!array.length)
@@ -626,6 +629,7 @@ export default createRule<Options, MessageId>({
       // nullable number
       if (is('nullish', 'number')) {
         if (!options.allowNullableNumber) {
+          if (hasDoubleExclamationExpression(node.parent)) return;
           if (isLogicalNegationExpression(node.parent)) {
             // if (!nullableNumber)
             context.report({
@@ -787,6 +791,7 @@ export default createRule<Options, MessageId>({
       // any
       if (is('any')) {
         if (!options.allowAny) {
+          if (hasDoubleExclamationExpression(node.parent)) return;
           context.report({
             node,
             messageId: 'conditionErrorAny',
@@ -938,6 +943,15 @@ function isLogicalNegationExpression(
   node: TSESTree.Node,
 ): node is TSESTree.UnaryExpression {
   return node.type === AST_NODE_TYPES.UnaryExpression && node.operator === '!';
+}
+
+function hasDoubleExclamationExpression(
+  node: TSESTree.Node,
+): node is TSESTree.UnaryExpression {
+  return (
+    isLogicalNegationExpression(node) &&
+    isLogicalNegationExpression(node.parent)
+  );
 }
 
 function isArrayLengthExpression(

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -410,6 +410,43 @@ if (y) {
         },
       ],
     },
+    {
+      // double exclamation `!!x` expression should be considered as well as `Boolean(x)`
+      options: [{ allowString: false, allowNumber: false }],
+      // test strings listed below are taken from cases in this file.
+      code: noFormat`
+        if (true && !!(1 + 1)) {}
+        while (false || !!("a" + "b")) {}
+        if (((!!('')) && {}) || (0 && void 0)) { }
+        if (('' && {}) || ((!!(0)) && void 0)) { }
+        while (!!("")) {}
+        for (; !!("foo");) {}
+        declare const x: string; if (!!(x)) {}
+        (x: string) => (!!!(x));
+        (x: string) => (!!!!(x)); // additional case for multiple "!!"
+        (x: string) => (!!!!!(x)); // additional case for multiple "!!"
+        <T extends string>(x: T) => (!!(x)) ? 1 : 0;
+        while (!!(0n)) {}
+        for (; !!(123);) {}
+        declare const xx: number; if (!!(xx)) {}
+        (x: bigint) => !!!(x);
+        <T extends number>(x: T) => (!!(x)) ? 1 : 0;
+        !!!([]["length"]); // doesn't count as array.length when computed
+        declare const a: any[] & { notLength: number }; if (!!(a.notLength)) {}
+      `,
+    },
+    noFormat`declare const x: string | null; if (!!(x)) {}`,
+    noFormat`if (true && (!!((1 + 1)))) {}`,
+    noFormat`<T extends string | null | undefined>(x: T) => (!!(x)) ? 1 : 0;`,
+    noFormat`function foo(x: '' | 'bar' | null) { if (!!!(x)) {} }`,
+    noFormat`declare const x: number | null; if (!!(x)) {}`,
+    noFormat`(x?: number) => !!!(x);`,
+    noFormat`<T extends number | null | undefined>(x: T) => (!!(x)) ? 1 : 0;`,
+    noFormat`function foo(x: 0 | 1 | null) { if (!!!(x)) {} }`,
+    noFormat`if (!!(x)) {}`,
+    noFormat`x => !(!!(x));`,
+    noFormat`<T extends any>(x: T) => (!!(x)) ? 1 : 0;`,
+    noFormat`<T>(x: T) => (Boolean(x)) ? 1 : 0;`,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -410,7 +410,7 @@ if (y) {
         },
       ],
     },
-    ...batchedSingleLineTests<MessageId, Options>({
+    {
       // double exclamation `!!x` expression should be considered as well as `Boolean(x)`
       options: [{ allowString: false, allowNumber: false }],
       // test strings listed below are taken from cases already existing in this file.
@@ -435,7 +435,7 @@ if (y) {
         !!!([]["length"]); // doesn't count as array.length when computed
         declare const a: any[] & { notLength: number }; if (!!(a.notLength)) {}
       `,
-    }),
+    },
     noFormat`declare const x: string | null; if (!!(x)) {}`,
     noFormat`if (true && (!!((1 + 1)))) {}`,
     noFormat`<T extends string | null | undefined>(x: T) => (!!(x)) ? 1 : 0;`,
@@ -447,7 +447,6 @@ if (y) {
     noFormat`if (!!(x)) {}`,
     noFormat`x => !(!!(x));`,
     noFormat`<T extends any>(x: T) => (!!(x)) ? 1 : 0;`,
-    noFormat`<T>(x: T) => (Boolean(x)) ? 1 : 0;`,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -410,15 +410,16 @@ if (y) {
         },
       ],
     },
-    {
+    ...batchedSingleLineTests<MessageId, Options>({
       // double exclamation `!!x` expression should be considered as well as `Boolean(x)`
       options: [{ allowString: false, allowNumber: false }],
-      // test strings listed below are taken from cases in this file.
+      // test strings listed below are taken from cases already existing in this file.
       code: noFormat`
         if (true && !!(1 + 1)) {}
         while (false || !!("a" + "b")) {}
-        if (((!!('')) && {}) || (0 && void 0)) { }
-        if (('' && {}) || ((!!(0)) && void 0)) { }
+        // if (((!!('')) && {}) || (0 && void 0)) { }
+        // if (('' && {}) || ((!!(0)) && void 0)) { }
+        if (((!!(''))) || ((!!(0)))) { } // remove uncorrelated "&& {}" and "&& void 0"
         while (!!("")) {}
         for (; !!("foo");) {}
         declare const x: string; if (!!(x)) {}
@@ -434,7 +435,7 @@ if (y) {
         !!!([]["length"]); // doesn't count as array.length when computed
         declare const a: any[] & { notLength: number }; if (!!(a.notLength)) {}
       `,
-    },
+    }),
     noFormat`declare const x: string | null; if (!!(x)) {}`,
     noFormat`if (true && (!!((1 + 1)))) {}`,
     noFormat`<T extends string | null | undefined>(x: T) => (!!(x)) ? 1 : 0;`,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hi, I think the result of double exclamation `!!x` expression is consistent with that of `Boolean(x)`, so it should be supported. That's also my usual practice.

Any opinions are welcome.

References: https://stackoverflow.com/questions/13984309/whats-the-difference-between-double-exclamation-operator-and-boolean-in-javas


