### PR TITLE
fix(eslint-plugin): [restrict-template-expressions] don't report tuples if `allowArray` option is enabled

### DIFF
--- a/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
+++ b/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
@@ -30,7 +30,7 @@ const optionTesters = (
     [
       'Array',
       (type, checker, recursivelyCheckType): boolean =>
-        checker.isArrayType(type) &&
+        (checker.isArrayType(type) || checker.isTupleType(type)) &&
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         recursivelyCheckType(type.getNumberIndexType()!),
     ],

--- a/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
@@ -149,11 +149,39 @@ ruleTester.run('restrict-template-expressions', rule, {
     {
       options: [{ allowArray: true }],
       code: `
-        const arg = [];
         function test<T extends string[]>(arg: T) {
           return \`arg = \${arg}\`;
         }
       `,
+    },
+    {
+      options: [{ allowArray: true }],
+      code: `
+        declare const arg: [number, string];
+        const msg = \`arg = \${arg}\`;
+      `,
+    },
+    {
+      options: [{ allowArray: true }],
+      code: `
+        const arg = [1, 'a'] as const;
+        const msg = \`arg = \${arg || 'default'}\`;
+      `,
+    },
+    {
+      options: [{ allowArray: true }],
+      code: `
+        function test<T extends [string, string]>(arg: T) {
+          return \`arg = \${arg}\`;
+        }
+      `,
+    },
+    {
+      code: `
+        declare const arg: [number | undefined, string];
+        const msg = \`arg = \${arg}\`;
+      `,
+      options: [{ allowNullish: true, allowArray: true }],
     },
     // allowAny
     {
@@ -367,6 +395,20 @@ ruleTester.run('restrict-template-expressions', rule, {
     },
     {
       code: `
+        declare const arg: number[];
+        const msg = \`arg = \${arg}\`;
+      `,
+      errors: [
+        {
+          messageId: 'invalidType',
+          data: { type: 'number[]' },
+          line: 3,
+          column: 30,
+        },
+      ],
+    },
+    {
+      code: `
         const msg = \`arg = \${[, 2]}\`;
       `,
       errors: [
@@ -374,6 +416,21 @@ ruleTester.run('restrict-template-expressions', rule, {
           messageId: 'invalidType',
           data: { type: '(number | undefined)[]' },
           line: 2,
+          column: 30,
+        },
+      ],
+      options: [{ allowNullish: false, allowArray: true }],
+    },
+    {
+      code: `
+        declare const arg: [number | undefined, string];
+        const msg = \`arg = \${arg}\`;
+      `,
+      errors: [
+        {
+          messageId: 'invalidType',
+          data: { type: '[number | undefined, string]' },
+          line: 3,
           column: 30,
         },
       ],


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #9491
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
