### PR TITLE
fix(eslint-plugin): [no-floating-promises] add `suggestions` to tests from #9263 `checkThenables`

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -3760,7 +3760,21 @@ void myTag\`abc\`;
 declare const createPromise: () => PromiseLike<number>;
 createPromise();
       `,
-      errors: [{ line: 3, messageId: 'floatingVoid' }],
+      errors: [
+        {
+          line: 3,
+          messageId: 'floatingVoid',
+          suggestions: [
+            {
+              messageId: 'floatingFixVoid',
+              output: `
+declare const createPromise: () => PromiseLike<number>;
+void createPromise();
+      `,
+            },
+          ],
+        },
+      ],
       options: [{ checkThenables: true }],
     },
     {
@@ -3773,7 +3787,26 @@ declare function createMyThenable(): MyThenable;
 
 createMyThenable();
       `,
-      errors: [{ line: 8, messageId: 'floatingVoid' }],
+      errors: [
+        {
+          line: 8,
+          messageId: 'floatingVoid',
+          suggestions: [
+            {
+              messageId: 'floatingFixVoid',
+              output: `
+interface MyThenable {
+  then(onFulfilled: () => void, onRejected: () => void): MyThenable;
+}
+
+declare function createMyThenable(): MyThenable;
+
+void createMyThenable();
+      `,
+            },
+          ],
+        },
+      ],
       options: [{ checkThenables: true }],
     },
     {
@@ -3781,7 +3814,21 @@ createMyThenable();
 declare const createPromise: () => Promise<number>;
 createPromise();
       `,
-      errors: [{ line: 3, messageId: 'floatingVoid' }],
+      errors: [
+        {
+          line: 3,
+          messageId: 'floatingVoid',
+          suggestions: [
+            {
+              messageId: 'floatingFixVoid',
+              output: `
+declare const createPromise: () => Promise<number>;
+void createPromise();
+      `,
+            },
+          ],
+        },
+      ],
       options: [{ checkThenables: false }],
     },
     {
@@ -3790,7 +3837,22 @@ class MyPromise<T> extends Promise<T> {}
 declare const createMyPromise: () => MyPromise<number>;
 createMyPromise();
       `,
-      errors: [{ line: 4, messageId: 'floatingVoid' }],
+      errors: [
+        {
+          line: 4,
+          messageId: 'floatingVoid',
+          suggestions: [
+            {
+              messageId: 'floatingFixVoid',
+              output: `
+class MyPromise<T> extends Promise<T> {}
+declare const createMyPromise: () => MyPromise<number>;
+void createMyPromise();
+      `,
+            },
+          ],
+        },
+      ],
       options: [{ checkThenables: false }],
     },
     {
@@ -3801,7 +3863,24 @@ class MyPromise<T> extends Promise<T> {
 declare const createMyPromise: () => MyPromise<number>;
 createMyPromise();
       `,
-      errors: [{ line: 6, messageId: 'floatingVoid' }],
+      errors: [
+        {
+          line: 6,
+          messageId: 'floatingVoid',
+          suggestions: [
+            {
+              messageId: 'floatingFixVoid',
+              output: `
+class MyPromise<T> extends Promise<T> {
+  additional: string;
+}
+declare const createMyPromise: () => MyPromise<number>;
+void createMyPromise();
+      `,
+            },
+          ],
+        },
+      ],
       options: [{ checkThenables: false }],
     },
   ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9516 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds `suggestions` property that was missing in tests from #9263 causing pipeline failures in `main`.