### PR TITLE
test(type-utils): disable automatic single run inference for isSymbolFromDefaultLibrary tests

### DIFF
--- a/packages/type-utils/tests/isSymbolFromDefaultLibrary.test.ts
+++ b/packages/type-utils/tests/isSymbolFromDefaultLibrary.test.ts
@@ -14,6 +14,7 @@ describe('isSymbolFromDefaultLibrary', () => {
     symbol: ts.Symbol | undefined;
   } {
     const { services, ast } = parseForESLint(code, {
+      disallowAutomaticSingleRunInference: true,
       project: './tsconfig.json',
       filePath: path.join(rootDir, 'file.ts'),
       tsconfigRootDir: rootDir,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9519
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
