### PR TITLE
chore(eslint-plugin): [no-unnecessary-parameter-property-assignment] remove `fixable` from `meta`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts
@@ -13,7 +13,6 @@ export default createRule({
       description:
         'Disallow unnecessary assignment of constructor property parameter',
     },
-    fixable: 'code',
     messages: {
       unnecessaryAssign:
         'This assignment is unnecessary since it is already assigned by a parameter property.',


### PR DESCRIPTION
No fixer is actually present.

Ref: https://github.com/typescript-eslint/typescript-eslint/pull/8903#discussion_r1669379472

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
