### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-parameters] descend into all parts of mapped types in no-unnecessary-type-parameters

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -271,12 +271,17 @@ function collectTypeParameterUsageCounts(
     // `isTypeReference` to avoid descending into all the properties of a
     // generic interface/class, e.g. `Map<K, V>`.
     else if (tsutils.isObjectType(type)) {
-      visitSymbolsListOnce(type.getProperties(), false);
+      const properties = type.getProperties();
+      visitSymbolsListOnce(properties, false);
 
       if (isMappedType(type)) {
         visitType(type.typeParameter, false);
-        visitType(type.templateType, false);
-        visitType(type.constraintType, false);
+        if (properties.length === 0) {
+          // TS treats mapped types like `{[k in "a"]: T}` like `{a: T}`.
+          // They have properties, so we need to avoid double-counting.
+          visitType(type.templateType, false);
+          visitType(type.constraintType, false);
+        }
       }
 
       for (const typeArgument of type.aliasTypeArguments ?? []) {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -275,6 +275,8 @@ function collectTypeParameterUsageCounts(
 
       if (isMappedType(type)) {
         visitType(type.typeParameter, false);
+        visitType(type.templateType, false);
+        visitType(type.constraintType, false);
       }
 
       for (const typeArgument of type.aliasTypeArguments ?? []) {
@@ -372,6 +374,8 @@ function collectTypeParameterUsageCounts(
 
 interface MappedType extends ts.ObjectType {
   typeParameter?: ts.Type;
+  constraintType?: ts.Type;
+  templateType?: ts.Type;
 }
 
 function isMappedType(type: ts.Type): type is MappedType {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -280,7 +280,6 @@ function collectTypeParameterUsageCounts(
           // TS treats mapped types like `{[k in "a"]: T}` like `{a: T}`.
           // They have properties, so we need to avoid double-counting.
           visitType(type.templateType, false);
-          visitType(type.constraintType, false);
         }
       }
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -342,6 +342,12 @@ ruleTester.run('no-unnecessary-type-parameters', rule, {
         (token): token is Exclude<TSESTree.Token, Conditions & ExtractedToken> =>
           tokenType in conditions;
     `,
+    `
+      declare function mapObj<K extends string, V>(
+        obj: { [key in K]?: V },
+        fn: (key: K, val: V) => number,
+      ): number[];
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -617,15 +617,6 @@ ruleTester.run('no-unnecessary-type-parameters', rule, {
     {
       code: `
         declare function mapObj<K extends string, V>(
-          obj: { [key in K]?: null },
-          fn: (key: K) => number,
-        ): number[];
-      `,
-      errors: [{ messageId: 'sole', data: { name: 'V' } }],
-    },
-    {
-      code: `
-        declare function mapObj<K extends string, V>(
           obj: { [key in K]?: V },
           fn: (key: K) => number,
         ): number[];

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -605,7 +605,6 @@ ruleTester.run('no-unnecessary-type-parameters', rule, {
     {
       code: "type Fn = <T>() => { [K in 'a']: T };",
       errors: [{ messageId: 'sole', data: { name: 'T' } }],
-      // only: true,
     },
     {
       code: 'type Fn = <T>(value: unknown) => value is T;',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -614,5 +614,23 @@ ruleTester.run('no-unnecessary-type-parameters', rule, {
       code: 'type Fn = <T extends string>() => `a${T}b`;',
       errors: [{ messageId: 'sole', data: { name: 'T' } }],
     },
+    {
+      code: `
+        declare function mapObj<K extends string, V>(
+          obj: { [key in K]?: null },
+          fn: (key: K) => number,
+        ): number[];
+      `,
+      errors: [{ messageId: 'sole', data: { name: 'V' } }],
+    },
+    {
+      code: `
+        declare function mapObj<K extends string, V>(
+          obj: { [key in K]?: V },
+          fn: (key: K) => number,
+        ): number[];
+      `,
+      errors: [{ messageId: 'sole', data: { name: 'V' } }],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -605,6 +605,7 @@ ruleTester.run('no-unnecessary-type-parameters', rule, {
     {
       code: "type Fn = <T>() => { [K in 'a']: T };",
       errors: [{ messageId: 'sole', data: { name: 'T' } }],
+      // only: true,
     },
     {
       code: 'type Fn = <T>(value: unknown) => value is T;',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9524 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Mapped types have three parts: the type parameter, the template type and the constraint type:

```
> type.checker.typeToString(type)
'{ [key in K]?: V | undefined; }'
> type.checker.typeToString(type.typeParameter)
'key'
> type.checker.typeToString(type.templateType)
'V | undefined'
> type.checker.typeToString(type.constraintType)
'K'
```

The rule previously descended into the typeParameter. It doesn't need to descend into the constraintType because we get that through another code path. It does need to descend into the templateType, though.

One wrinkle is that if the mapped type is something like `{[k in 'a']: T}`, then TypeScript will treat it like `{a: T}` and we'll process it as an object type. In this case, we need to avoid _also_ processing it as a mapped type, even though `isMappedType` returns true.