### PR TITLE
chore: enable @typescript-eslint/no-unused-expressions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -135,6 +135,7 @@ export default tseslint.config(
         { allowConstantLoopConditions: true },
       ],
       '@typescript-eslint/no-unnecessary-type-parameters': 'error',
+      '@typescript-eslint/no-unused-expressions': 'error',
       '@typescript-eslint/no-var-requires': 'off',
       '@typescript-eslint/prefer-literal-enum-member': [
         'error',

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -848,9 +848,9 @@ export default createRule<Options, MessageId>({
       // If incoming type is boolean, there will be two type objects with
       // intrinsicName set "true" and "false" each because of ts-api-utils.unionTypeParts()
       if (booleans.length === 1) {
-        tsutils.isTrueLiteralType(booleans[0])
-          ? variantTypes.add('truthy boolean')
-          : variantTypes.add('boolean');
+        variantTypes.add(
+          tsutils.isTrueLiteralType(booleans[0]) ? 'truthy boolean' : 'boolean',
+        );
       } else if (booleans.length === 2) {
         variantTypes.add('boolean');
       }

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -499,7 +499,9 @@ export default createRule<Options, MessageIds>({
       parent: ScopeNode,
       typeParameters?: TSESTree.TSTypeParameterDeclaration,
     ): void {
-      currentScope && scopes.push(currentScope);
+      if (currentScope) {
+        scopes.push(currentScope);
+      }
       currentScope = {
         overloads: new Map<string, OverloadNode[]>(),
         parent,

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -305,7 +305,7 @@ describe('convert', () => {
         suppressDeprecatedPropertyWarnings: false,
       });
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line deprecation/deprecation,@typescript-eslint/no-unused-expressions
       esCallExpression.typeParameters;
 
       expect(emitWarning).toHaveBeenCalledWith(
@@ -322,10 +322,10 @@ describe('convert', () => {
         suppressDeprecatedPropertyWarnings: false,
       });
 
-      /* eslint-disable deprecation/deprecation */
+      /* eslint-disable deprecation/deprecation,@typescript-eslint/no-unused-expressions */
       esCallExpression.typeParameters;
       esCallExpression.typeParameters;
-      /* eslint-enable deprecation/deprecation */
+      /* eslint-enable deprecation/deprecation,@typescript-eslint/no-unused-expressions */
 
       expect(emitWarning).toHaveBeenCalledTimes(1);
     });
@@ -338,7 +338,7 @@ describe('convert', () => {
         suppressDeprecatedPropertyWarnings: true,
       });
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line deprecation/deprecation,@typescript-eslint/no-unused-expressions
       esCallExpression.typeParameters;
 
       expect(emitWarning).not.toHaveBeenCalled();

--- a/packages/typescript-estree/tests/lib/persistentParse.test.ts
+++ b/packages/typescript-estree/tests/lib/persistentParse.test.ts
@@ -65,7 +65,9 @@ function setup(tsconfig: Record<string, unknown>, writeBar = true): string {
   fs.mkdirSync(path.join(tmpDir.name, 'src'));
   fs.mkdirSync(path.join(tmpDir.name, 'src', 'baz'));
   writeFile(tmpDir.name, 'foo');
-  writeBar && writeFile(tmpDir.name, 'bar');
+  if (writeBar) {
+    writeFile(tmpDir.name, 'bar');
+  }
 
   return tmpDir.name;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes part of #9523 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Enable `@typescript-eslint/no-unused-expressions` ([docs](https://typescript-eslint.io/rules/no-unused-expressions/)). This allows for more dogfooding, as well.
