### PR TITLE
chore: enable no-useless-computed-key

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -206,6 +206,7 @@ export default tseslint.config(
         'error',
         { commentPattern: '.*intentional fallthrough.*' },
       ],
+      'no-useless-computed-key': 'error',
       'one-var': ['error', 'never'],
       'prefer-arrow-callback': 'error',
 

--- a/packages/eslint-plugin/src/rules/prefer-find.ts
+++ b/packages/eslint-plugin/src/rules/prefer-find.ts
@@ -282,7 +282,7 @@ export default createRule({
       //
       // Note: we're always looking for array member access to be "computed",
       // i.e. `filteredResults[0]`, since `filteredResults.0` isn't a thing.
-      ['MemberExpression[computed=true]'](
+      'MemberExpression[computed=true]'(
         node: TSESTree.MemberExpressionComputedName,
       ): void {
         if (isMemberAccessOfZero(node)) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes part of #9523
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Enable `no-useless-computed-key` ([docs](https://eslint.org/docs/latest/rules/no-useless-computed-key)).
