### PR TITLE
fix(eslint-plugin): [no-redundant-type-constituents] differentiate a types-error any from a true any

### DIFF
--- a/packages/eslint-plugin/src/rules/no-redundant-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-type-constituents.ts
@@ -205,6 +205,7 @@ export default createRule({
       primitiveOverridden: `{{primitive}} is overridden by the {{literal}} in this intersection type.`,
       overridden: `'{{typeName}}' is overridden by other types in this {{container}} type.`,
       overrides: `'{{typeName}}' overrides all other types in this {{container}} type.`,
+      errorTypeOverrides: `'{{typeName}}' is an 'error' type that acts as 'any' and overrides all other types in this {{container}} type.`,
     },
     schema: [],
     type: 'suggestion',
@@ -423,7 +424,10 @@ export default createRule({
                   container: 'union',
                   typeName,
                 },
-                messageId: 'overrides',
+                messageId:
+                  typeFlags === ts.TypeFlags.Any && typeName !== 'any'
+                    ? 'errorTypeOverrides'
+                    : 'overrides',
                 node: typeNode,
               });
               return true;

--- a/packages/eslint-plugin/src/rules/no-redundant-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-type-constituents.ts
@@ -297,7 +297,10 @@ export default createRule({
                   container: 'intersection',
                   typeName,
                 },
-                messageId,
+                messageId:
+                  typeFlags === ts.TypeFlags.Any && typeName !== 'any'
+                    ? 'errorTypeOverrides'
+                    : messageId,
                 node: typeNode,
               });
               return true;

--- a/packages/eslint-plugin/src/rules/no-redundant-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/no-redundant-type-constituents.ts
@@ -102,6 +102,10 @@ function describeLiteralType(type: ts.Type): string {
     return type.value.toString();
   }
 
+  if (tsutils.isIntrinsicErrorType(type) && type.aliasSymbol) {
+    return type.aliasSymbol.escapedName.toString();
+  }
+
   if (isTypeAnyType(type)) {
     return 'any';
   }

--- a/packages/eslint-plugin/tests/rules/no-redundant-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-type-constituents.test.ts
@@ -319,7 +319,7 @@ ruleTester.run('no-redundant-type-constituents', rule, {
             container: 'union',
             typeName: 'NotKnown',
           },
-          messageId: 'overrides',
+          messageId: 'errorTypeOverrides',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-redundant-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-type-constituents.test.ts
@@ -675,7 +675,7 @@ ruleTester.run('no-redundant-type-constituents', rule, {
             container: 'intersection',
             typeName: 'NotKnown',
           },
-          messageId: 'overrides',
+          messageId: 'errorTypeOverrides',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-redundant-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-type-constituents.test.ts
@@ -311,6 +311,19 @@ ruleTester.run('no-redundant-type-constituents', rule, {
       ],
     },
     {
+      code: 'type ErrorTypes = NotKnown | 0;',
+      errors: [
+        {
+          column: 19,
+          data: {
+            container: 'union',
+            typeName: 'NotKnown',
+          },
+          messageId: 'overrides',
+        },
+      ],
+    },
+    {
       code: 'type T = number | 0;',
       errors: [
         {
@@ -648,6 +661,19 @@ ruleTester.run('no-redundant-type-constituents', rule, {
           data: {
             container: 'intersection',
             typeName: 'any',
+          },
+          messageId: 'overrides',
+        },
+      ],
+    },
+    {
+      code: 'type ErrorTypes = NotKnown & 0;',
+      errors: [
+        {
+          column: 19,
+          data: {
+            container: 'intersection',
+            typeName: 'NotKnown',
           },
           messageId: 'overrides',
         },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9214
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
