### PR TITLE
feat(eslint-plugin): [no-floating-promises] disable checkThenables by default for v8

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
@@ -129,10 +129,6 @@ await createMyThenable();
 </TabItem>
 </Tabs>
 
-:::info
-This option is enabled by default in v7 but will be turned off by default in v8.
-:::
-
 ### `ignoreVoid`
 
 This option, which is `true` by default, allows you to stop the rule reporting promises consumed with void operator.

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -104,7 +104,7 @@ export default createRule<Options, MessageId>({
     {
       allowForKnownSafeCalls: readonlynessOptionsDefaults.allow,
       allowForKnownSafePromises: readonlynessOptionsDefaults.allow,
-      checkThenables: true,
+      checkThenables: false,
       ignoreIIFE: false,
       ignoreVoid: true,
     },

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -770,15 +770,11 @@ createSafePromise();
         },
       ],
     },
-    {
-      code: `
-declare const createPromise: () => PromiseLike<number>;
-createPromise();
-      `,
-      options: [{ checkThenables: false }],
-    },
-    {
-      code: `
+    `
+declare const createPromiseLike: () => PromiseLike<number>;
+createPromiseLike();
+    `,
+    `
 interface MyThenable {
   then(onFulfilled: () => void, onRejected: () => void): MyThenable;
 }
@@ -786,9 +782,7 @@ interface MyThenable {
 declare function createMyThenable(): MyThenable;
 
 createMyThenable();
-      `,
-      options: [{ checkThenables: false }],
-    },
+    `,
   ],
 
   invalid: [
@@ -2104,6 +2098,7 @@ async function test() {
           ],
         },
       ],
+      options: [{ checkThenables: true }],
     },
     {
       code: `
@@ -3586,6 +3581,7 @@ promise;
       options: [
         {
           allowForKnownSafePromises: [{ from: 'file', name: 'SafeThenable' }],
+          checkThenables: true,
         },
       ],
       errors: [
@@ -3962,7 +3958,6 @@ void createPromise();
           ],
         },
       ],
-      options: [{ checkThenables: false }],
     },
     {
       code: `
@@ -3986,7 +3981,6 @@ void createMyPromise();
           ],
         },
       ],
-      options: [{ checkThenables: false }],
     },
     {
       code: `
@@ -4014,7 +4008,7 @@ void createMyPromise();
           ],
         },
       ],
-      options: [{ checkThenables: false }],
+      options: [{ checkThenables: true }],
     },
   ],
 });


### PR DESCRIPTION
BREAKING CHANGE:
Changes a rule's default option.

## PR Checklist

- [x] Addresses an existing open issue: fixes #9508
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Changes the option's default from `true` to `false` and updates docs + tests.

💖 