### PR TITLE
docs(typescript-eslint): add missing ellipsis in ConfigWithExtends

### DIFF
--- a/packages/typescript-eslint/src/config-helper.ts
+++ b/packages/typescript-eslint/src/config-helper.ts
@@ -30,7 +30,7 @@ export interface ConfigWithExtends extends TSESLint.FlatConfig.Config {
    *   files: ['** /*.ts'],
    *   extends: [
    *     eslint.configs.recommended,
-   *     tseslint.configs.recommended,
+   *     ...tseslint.configs.recommended,
    *   ],
    *   rules: {
    *     '@typescript-eslint/array-type': 'error',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
The interface docs were missing the ellipsis.

```ts
tseslint.config({ extends: [tseslint.configs.recommended] })
-> [
  {
    '0': {
      name: 'typescript-eslint/base',
      languageOptions: [Object],
      plugins: [Object]
    },
    '1': {
      files: [Array],
      rules: [Object],
      name: 'typescript-eslint/eslint-recommended'
    },
    '2': { name: 'typescript-eslint/recommended', rules: [Object] }
  },
  {}
]
```
