### PR TITLE
fix(typescript-estree): don't infer single-run when --fix is in proces.argv

### DIFF
--- a/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
+++ b/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
@@ -47,7 +47,7 @@ export function inferSingleRun(options: TSESTreeOptions | undefined): boolean {
         process.argv[1].endsWith(normalize(path)),
       )
     ) {
-      return true;
+      return !process.argv.includes('--fix');
     }
   }
 

--- a/packages/typescript-estree/tests/lib/inferSingleRun.test.ts
+++ b/packages/typescript-estree/tests/lib/inferSingleRun.test.ts
@@ -36,9 +36,22 @@ describe('inferSingleRun', () => {
     expect(actual).toBe(expected);
   });
 
-  it.each(['node_modules/.bin/eslint', 'node_modules/eslint/bin/eslint.js'])(
-    'returns true when singleRun is inferred from process.argv',
-    pathName => {
+  describe.each([
+    'node_modules/.bin/eslint',
+    'node_modules/eslint/bin/eslint.js',
+  ])('%s', pathName => {
+    it('returns false when singleRun is inferred from process.argv with --fix', () => {
+      process.argv = ['', path.normalize(pathName), '', '--fix'];
+
+      const actual = inferSingleRun({
+        programs: null,
+        project: './tsconfig.json',
+      });
+
+      expect(actual).toBe(false);
+    });
+
+    it('returns true when singleRun is inferred from process.argv without --fix', () => {
       process.argv = ['', path.normalize(pathName), ''];
 
       const actual = inferSingleRun({
@@ -48,8 +61,8 @@ describe('inferSingleRun', () => {
       });
 
       expect(actual).toBe(true);
-    },
-  );
+    });
+  });
 
   it('returns true when singleRun is inferred from CI=true', () => {
     process.env.CI = 'true';


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: works around #9344
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Does a straightforward check for `'--fix'` in `process.argv`.

I'd have loved to use something more ... not-hacky, i.e. some explicit indication from ESLint itself. But our old friend https://github.com/eslint/rfcs/pull/102 was rejected.

💖 