### PR TITLE
fix(typescript-estree): disable single-run inference with extraFileExtensions

### DIFF
--- a/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
+++ b/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
@@ -15,6 +15,13 @@ import type { TSESTreeOptions } from '../parser-options';
  * @returns Whether this is part of a single run, rather than a long-running process.
  */
 export function inferSingleRun(options: TSESTreeOptions | undefined): boolean {
+  // https://github.com/typescript-eslint/typescript-eslint/issues/9504
+  // There's no support (yet?) for extraFileExtensions in single-run hosts.
+  // Only watch program hosts and project service can support that.
+  if (options?.extraFileExtensions?.length) {
+    return false;
+  }
+
   if (
     // single-run implies type-aware linting - no projects means we can't be in single-run mode
     options?.project == null ||

--- a/packages/typescript-estree/tests/lib/inferSingleRun.test.ts
+++ b/packages/typescript-estree/tests/lib/inferSingleRun.test.ts
@@ -63,6 +63,30 @@ describe('inferSingleRun', () => {
     expect(actual).toBe(true);
   });
 
+  it('returns true when singleRun can be inferred and options.extraFileExtensions is an empty array', () => {
+    process.env.CI = 'true';
+
+    const actual = inferSingleRun({
+      allowAutomaticSingleRunInference: true,
+      extraFileExtensions: [],
+      project: './tsconfig.json',
+    });
+
+    expect(actual).toBe(true);
+  });
+
+  it('returns false when singleRun can be inferred options.extraFileExtensions contains entries', () => {
+    process.env.CI = 'true';
+
+    const actual = inferSingleRun({
+      allowAutomaticSingleRunInference: true,
+      extraFileExtensions: ['.vue'],
+      project: './tsconfig.json',
+    });
+
+    expect(actual).toBe(false);
+  });
+
   it('returns false when there is no way to infer singleRun', () => {
     const actual = inferSingleRun({
       programs: null,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: works around #9504
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

There's no way to set extra file extensions on the classic standalone `ts.Host`. So we don't do that here.

Folks using `.svelte`, `.vue`, etc. can still use the project _service_.

💖 