### PR TITLE
fix(typescript-estree): specific error for parserOptions.project not including a file

### DIFF
--- a/packages/typescript-estree/src/create-program/useProvidedPrograms.ts
+++ b/packages/typescript-estree/src/create-program/useProvidedPrograms.ts
@@ -3,9 +3,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
+import type { ParseSettings } from '../parseSettings';
 import type { ASTAndDefiniteProgram } from './shared';
 import { CORE_COMPILER_OPTIONS, getAstFromProgram } from './shared';
-import { ParseSettings } from '../parseSettings';
 
 const log = debug('typescript-eslint:typescript-estree:useProvidedProgram');
 

--- a/packages/typescript-estree/src/create-program/useProvidedPrograms.ts
+++ b/packages/typescript-estree/src/create-program/useProvidedPrograms.ts
@@ -5,45 +5,49 @@ import * as ts from 'typescript';
 
 import type { ASTAndDefiniteProgram } from './shared';
 import { CORE_COMPILER_OPTIONS, getAstFromProgram } from './shared';
+import { ParseSettings } from '../parseSettings';
 
 const log = debug('typescript-eslint:typescript-estree:useProvidedProgram');
 
-export interface ProvidedProgramsSettings {
-  filePath: string;
-  tsconfigRootDir: string;
-}
-
 function useProvidedPrograms(
   programInstances: Iterable<ts.Program>,
-  { filePath, tsconfigRootDir }: ProvidedProgramsSettings,
+  parseSettings: ParseSettings,
 ): ASTAndDefiniteProgram | undefined {
-  log('Retrieving ast for %s from provided program instance(s)', filePath);
+  log(
+    'Retrieving ast for %s from provided program instance(s)',
+    parseSettings.filePath,
+  );
 
   let astAndProgram: ASTAndDefiniteProgram | undefined;
   for (const programInstance of programInstances) {
-    astAndProgram = getAstFromProgram(programInstance, filePath);
+    astAndProgram = getAstFromProgram(programInstance, parseSettings.filePath);
     // Stop at the first applicable program instance
     if (astAndProgram) {
       break;
     }
   }
 
-  if (!astAndProgram) {
-    const relativeFilePath = path.relative(
-      tsconfigRootDir || process.cwd(),
-      filePath,
-    );
-    const errorLines = [
-      '"parserOptions.programs" has been provided for @typescript-eslint/parser.',
-      `The file was not found in any of the provided program instance(s): ${relativeFilePath}`,
-    ];
-
-    throw new Error(errorLines.join('\n'));
+  if (astAndProgram) {
+    astAndProgram.program.getTypeChecker(); // ensure parent pointers are set in source files
+    return astAndProgram;
   }
 
-  astAndProgram.program.getTypeChecker(); // ensure parent pointers are set in source files
+  const relativeFilePath = path.relative(
+    parseSettings.tsconfigRootDir,
+    parseSettings.filePath,
+  );
 
-  return astAndProgram;
+  const [typeSource, typeSources] =
+    parseSettings.projects.size > 0
+      ? ['project', 'project(s)']
+      : ['programs', 'program instance(s)'];
+
+  const errorLines = [
+    `"parserOptions.${typeSource}" has been provided for @typescript-eslint/parser.`,
+    `The file was not found in any of the provided ${typeSources}: ${relativeFilePath}`,
+  ];
+
+  throw new Error(errorLines.join('\n'));
 }
 
 /**

--- a/packages/website/src/hooks/useClipboard.ts
+++ b/packages/website/src/hooks/useClipboard.ts
@@ -9,7 +9,7 @@ export function useClipboard(code: () => string): useClipboardResult {
 
   const copy = useCallback(
     () =>
-      void navigator.clipboard.writeText(code()).then(() => {
+      navigator.clipboard.writeText(code()).then(() => {
         setCopied(true);
       }),
     [setCopied, code],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9096
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

When `parseSettings.projects` is populated, `useProvidedPrograms` nows refer to `parserOptions.project` and `project(s)` instead of `parserOptions.programs` and `program(s)`.

Also applies a mild refactor to reduce nesting in the function.

I think after this I'd like to holistically revamp the error messages around invalid 

💖 