### PR TITLE
fix(typescript-estree): disable includePackageJsonAutoImports in ProjectService

### DIFF
--- a/packages/typescript-estree/src/create-program/createProjectService.ts
+++ b/packages/typescript-estree/src/create-program/createProjectService.ts
@@ -67,6 +67,12 @@ export function createProjectService(
     jsDocParsingMode,
   });
 
+  service.setHostConfiguration({
+    preferences: {
+      includePackageJsonAutoImports: 'off',
+    },
+  });
+
   if (options.defaultProject) {
     let configRead;
 
@@ -93,12 +99,6 @@ export function createProjectService(
         )}`,
       );
     }
-
-    service.setHostConfiguration({
-      preferences: {
-        includePackageJsonAutoImports: 'off',
-      },
-    });
 
     service.setCompilerOptionsForInferredProjects(
       (

--- a/packages/typescript-estree/src/create-program/createProjectService.ts
+++ b/packages/typescript-estree/src/create-program/createProjectService.ts
@@ -67,12 +67,6 @@ export function createProjectService(
     jsDocParsingMode,
   });
 
-  service.setHostConfiguration({
-    preferences: {
-      includePackageJsonAutoImports: 'off',
-    },
-  });
-
   if (options.defaultProject) {
     let configRead;
 
@@ -99,6 +93,12 @@ export function createProjectService(
         )}`,
       );
     }
+
+    service.setHostConfiguration({
+      preferences: {
+        includePackageJsonAutoImports: 'off',
+      },
+    });
 
     service.setCompilerOptionsForInferredProjects(
       (

--- a/packages/typescript-estree/src/create-program/createProjectService.ts
+++ b/packages/typescript-estree/src/create-program/createProjectService.ts
@@ -67,6 +67,12 @@ export function createProjectService(
     jsDocParsingMode,
   });
 
+  service.setHostConfiguration({
+    preferences: {
+      includePackageJsonAutoImports: 'off',
+    },
+  });
+
   if (options.defaultProject) {
     let configRead;
 

--- a/packages/typescript-estree/tests/lib/createProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/createProjectService.test.ts
@@ -4,6 +4,7 @@ import { createProjectService } from '../../src/create-program/createProjectServ
 
 const mockReadConfigFile = jest.fn();
 const mockSetCompilerOptionsForInferredProjects = jest.fn();
+const mockSetHostConfiguration = jest.fn();
 
 jest.mock('typescript/lib/tsserverlibrary', () => ({
   ...jest.requireActual('typescript/lib/tsserverlibrary'),
@@ -12,6 +13,7 @@ jest.mock('typescript/lib/tsserverlibrary', () => ({
     ProjectService: class {
       setCompilerOptionsForInferredProjects =
         mockSetCompilerOptionsForInferredProjects;
+      setHostConfiguration = mockSetHostConfiguration;
     },
   },
 }));
@@ -93,5 +95,21 @@ describe('createProjectService', () => {
     expect(service.setCompilerOptionsForInferredProjects).toHaveBeenCalledWith(
       compilerOptions,
     );
+  });
+
+  it('sets a host configuration', () => {
+    const { service } = createProjectService(
+      {
+        allowDefaultProjectForFiles: ['file.js'],
+        defaultProject: './tsconfig.json',
+      },
+      undefined,
+    );
+
+    expect(service.setHostConfiguration).toHaveBeenCalledWith({
+      preferences: {
+        includePackageJsonAutoImports: 'off',
+      },
+    });
   });
 });

--- a/packages/typescript-estree/tests/lib/createProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/createProjectService.test.ts
@@ -101,7 +101,6 @@ describe('createProjectService', () => {
     const { service } = createProjectService(
       {
         allowDefaultProjectForFiles: ['file.js'],
-        defaultProject: './tsconfig.json',
       },
       undefined,
     );


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: for #9571
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Per https://github.com/microsoft/TypeScript/issues/59338#issuecomment-2236857239, disable this so that the auto import projects are not used.