### PR TITLE
chore(website): correct version to be v8, not latest merged v7

### DIFF
--- a/packages/website/docusaurus.config.mts
+++ b/packages/website/docusaurus.config.mts
@@ -91,8 +91,8 @@ const themeConfig: AlgoliaThemeConfig & ThemeCommonConfig = {
       },
       {
         position: 'right',
-        href: `https://github.com/typescript-eslint/typescript-eslint/releases/tag/v${version}`,
-        label: `v${version}`,
+        href: `https://github.com/blog/announcing-typescript-eslint-v8-beta`,
+        label: `v8`,
       },
       {
         to: 'play',

--- a/packages/website/docusaurus.config.mts
+++ b/packages/website/docusaurus.config.mts
@@ -8,7 +8,6 @@ import type { UserThemeConfig as ThemeCommonConfig } from '@docusaurus/theme-com
 import type { UserThemeConfig as AlgoliaThemeConfig } from '@docusaurus/theme-search-algolia';
 import type { Config } from '@docusaurus/types';
 
-import { version } from './package.json';
 import { blogFooter } from './plugins/blog-footer';
 import { generatedRuleDocs } from './plugins/generated-rule-docs';
 import { rulesMeta } from './rulesMeta';
@@ -91,7 +90,7 @@ const themeConfig: AlgoliaThemeConfig & ThemeCommonConfig = {
       },
       {
         position: 'right',
-        href: `https://github.com/blog/announcing-typescript-eslint-v8-beta`,
+        href: `/blog/announcing-typescript-eslint-v8-beta`,
         label: `v8`,
       },
       {

--- a/packages/website/docusaurus.config.mts
+++ b/packages/website/docusaurus.config.mts
@@ -91,6 +91,7 @@ const themeConfig: AlgoliaThemeConfig & ThemeCommonConfig = {
       {
         position: 'right',
         href: `/blog/announcing-typescript-eslint-v8-beta`,
+        // TODO: Move back to package.json's version shortly after v8 launches
         label: `v8`,
       },
       {

--- a/packages/website/src/components/OptionsSelector.tsx
+++ b/packages/website/src/components/OptionsSelector.tsx
@@ -74,7 +74,7 @@ function OptionsSelectorContent({
           />
         </InputLabel>
         <InputLabel name="Eslint">{process.env.ESLINT_VERSION}</InputLabel>
-        <InputLabel name="TSEslint">{process.env.TS_ESLINT_VERSION}</InputLabel>
+        <InputLabel name="TSESlint">{process.env.TS_ESLINT_VERSION}</InputLabel>
       </Expander>
       <Expander label="Options">
         <InputLabel name="File type">

--- a/packages/website/webpack.plugin.js
+++ b/packages/website/webpack.plugin.js
@@ -21,9 +21,7 @@ module.exports = function (/*context, options*/) {
             'process.env.ESLINT_VERSION': JSON.stringify(
               require('eslint/package.json').version,
             ),
-            'process.env.TS_ESLINT_VERSION': JSON.stringify(
-              require('@typescript-eslint/eslint-plugin/package.json').version,
-            ),
+            'process.env.TS_ESLINT_VERSION': JSON.stringify('v8'),
           }),
           new CopyPlugin({
             patterns: [

--- a/packages/website/webpack.plugin.js
+++ b/packages/website/webpack.plugin.js
@@ -21,6 +21,7 @@ module.exports = function (/*context, options*/) {
             'process.env.ESLINT_VERSION': JSON.stringify(
               require('eslint/package.json').version,
             ),
+            // TODO: Move back to package.json's version shortly after v8 launches
             'process.env.TS_ESLINT_VERSION': JSON.stringify('v8'),
           }),
           new CopyPlugin({


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9361
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Hardcodes the version to `'v8'`. The root issue is that our versioning infra doesn't touch the `package.json`s directly, so they still say the latest v7 version in them & get imported into components with that...

💖 