### PR TITLE
feat(eslint-plugin): [return-await] promote to recommended: strict

### DIFF
--- a/packages/eslint-plugin/src/configs/strict-type-checked-only.ts
+++ b/packages/eslint-plugin/src/configs/strict-type-checked-only.ts
@@ -64,6 +64,8 @@ export = {
         allowNever: false,
       },
     ],
+    'no-return-await': 'off',
+    '@typescript-eslint/return-await': 'error',
     '@typescript-eslint/unbound-method': 'error',
     '@typescript-eslint/use-unknown-in-catch-callback-variable': 'error',
   },

--- a/packages/eslint-plugin/src/configs/strict-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/strict-type-checked.ts
@@ -97,6 +97,8 @@ export = {
         allowNever: false,
       },
     ],
+    'no-return-await': 'off',
+    '@typescript-eslint/return-await': 'error',
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/unbound-method': 'error',
     '@typescript-eslint/unified-signatures': 'error',

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -29,6 +29,7 @@ export default createRule({
   meta: {
     docs: {
       description: 'Enforce consistent awaiting of returned promises',
+      recommended: 'strict',
       requiresTypeChecking: true,
       extendsBaseRule: 'no-return-await',
     },

--- a/packages/typescript-eslint/src/configs/strict-type-checked-only.ts
+++ b/packages/typescript-eslint/src/configs/strict-type-checked-only.ts
@@ -73,6 +73,8 @@ export default (
           allowNever: false,
         },
       ],
+      'no-return-await': 'off',
+      '@typescript-eslint/return-await': 'error',
       '@typescript-eslint/unbound-method': 'error',
       '@typescript-eslint/use-unknown-in-catch-callback-variable': 'error',
     },

--- a/packages/typescript-eslint/src/configs/strict-type-checked.ts
+++ b/packages/typescript-eslint/src/configs/strict-type-checked.ts
@@ -106,6 +106,8 @@ export default (
           allowNever: false,
         },
       ],
+      'no-return-await': 'off',
+      '@typescript-eslint/return-await': 'error',
       '@typescript-eslint/triple-slash-reference': 'error',
       '@typescript-eslint/unbound-method': 'error',
       '@typescript-eslint/unified-signatures': 'error',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8667
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds `return-await` to the `strict-type-checked` preset shared config.

This is not a breaking change, as `strict` configs are explicitly allowed to be modified in minor versions. But targeting to `v8` to be friendly.

💖 