### PR TITLE
fix(website): expose ATA types to eslint instance

### DIFF
--- a/packages/website/src/components/editor/useSandboxServices.ts
+++ b/packages/website/src/components/editor/useSandboxServices.ts
@@ -81,6 +81,24 @@ export const useSandboxServices = (
 
         const system = createFileSystem(props, sandboxInstance.tsvfs);
 
+        // Write files in vfs when a model is created in the editor (this is used only for ATA types)
+        sandboxInstance.monaco.editor.onDidCreateModel(model => {
+          if (!model.uri.path.includes('node_modules')) {
+            return;
+          }
+          const path = model.uri.path.replace('/file:///', '/');
+          system.writeFile(path, model.getValue());
+        });
+        // Delete files in vfs when a model is disposed in the editor (this is used only for ATA types)
+        sandboxInstance.monaco.editor.onWillDisposeModel(model => {
+          if (!model.uri.path.includes('node_modules')) {
+            return;
+          }
+          const path = model.uri.path.replace('/file:///', '/');
+          system.deleteFile(path);
+        });
+
+        // Load the lib files from typescript to vfs (eg. es2020.d.ts)
         const worker = await sandboxInstance.getWorkerProcess();
         if (worker.getLibFiles) {
           const libs = await worker.getLibFiles();

--- a/packages/website/src/vendor/sandbox.d.ts
+++ b/packages/website/src/vendor/sandbox.d.ts
@@ -60,23 +60,23 @@ export declare function defaultPlaygroundSettings(): {
   /** The default source code for the playground */
   text: string;
   /** @deprecated */
-  useJavaScript?: boolean | undefined;
+  useJavaScript?: boolean;
   /** The default file for the playground  */
   filetype: 'js' | 'ts' | 'd.ts';
   /** Compiler options which are automatically just forwarded on */
-  compilerOptions: MonacoEditor.languages.typescript.CompilerOptions;
+  compilerOptions: CompilerOptions;
   /** Optional monaco settings overrides */
-  monacoSettings?: MonacoEditor.editor.IEditorOptions | undefined;
+  monacoSettings?: MonacoEditor.editor.IEditorOptions;
   /** Acquire types via type acquisition */
   acquireTypes: boolean;
   /** Support twoslash compiler options */
   supportTwoslashCompilerOptions: boolean;
   /** Get the text via query params and local storage, useful when the editor is the main experience */
-  suppressAutomaticallyGettingDefaultText?: true | undefined;
+  suppressAutomaticallyGettingDefaultText?: true;
   /** Suppress setting compiler options from the compiler flags from query params */
-  suppressAutomaticallyGettingCompilerFlags?: true | undefined;
+  suppressAutomaticallyGettingCompilerFlags?: true;
   /** Optional path to TypeScript worker wrapper class script, see https://github.com/microsoft/monaco-typescript/pull/65  */
-  customTypeScriptWorkerPath?: string | undefined;
+  customTypeScriptWorkerPath?: string;
   /** Logging system */
   logger: {
     log: (...args: any[]) => void;
@@ -94,29 +94,52 @@ export declare const createTypeScriptSandbox: (
   ts: typeof ts,
 ) => {
   /** The same config you passed in */
-  config: {
-    text: string;
-    useJavaScript?: boolean | undefined;
-    filetype: 'js' | 'ts' | 'd.ts';
-    compilerOptions: CompilerOptions;
-    monacoSettings?: MonacoEditor.editor.IEditorOptions | undefined;
-    acquireTypes: boolean;
-    supportTwoslashCompilerOptions: boolean;
-    suppressAutomaticallyGettingDefaultText?: true | undefined;
-    suppressAutomaticallyGettingCompilerFlags?: true | undefined;
-    customTypeScriptWorkerPath?: string | undefined;
-    logger: {
-      log: (...args: any[]) => void;
-      error: (...args: any[]) => void;
-      groupCollapsed: (...args: any[]) => void;
-      groupEnd: (...args: any[]) => void;
-    };
-    domID: string;
-  };
+  config:
+    | {
+        text: string;
+        useJavaScript?: boolean;
+        filetype: 'js' | 'ts' | 'd.ts';
+        compilerOptions: CompilerOptions;
+        monacoSettings?: MonacoEditor.editor.IEditorOptions;
+        acquireTypes: boolean;
+        supportTwoslashCompilerOptions: boolean;
+        suppressAutomaticallyGettingDefaultText?: true;
+        suppressAutomaticallyGettingCompilerFlags?: true;
+        customTypeScriptWorkerPath?: string;
+        logger: {
+          log: (...args: any[]) => void;
+          error: (...args: any[]) => void;
+          groupCollapsed: (...args: any[]) => void;
+          groupEnd: (...args: any[]) => void;
+        };
+        domID: string;
+      }
+    | {
+        text: string;
+        useJavaScript?: boolean;
+        filetype: 'js' | 'ts' | 'd.ts';
+        compilerOptions: CompilerOptions;
+        monacoSettings?: MonacoEditor.editor.IEditorOptions;
+        acquireTypes: boolean;
+        supportTwoslashCompilerOptions: boolean;
+        suppressAutomaticallyGettingDefaultText?: true;
+        suppressAutomaticallyGettingCompilerFlags?: true;
+        customTypeScriptWorkerPath?: string;
+        logger: {
+          log: (...args: any[]) => void;
+          error: (...args: any[]) => void;
+          groupCollapsed: (...args: any[]) => void;
+          groupEnd: (...args: any[]) => void;
+        };
+        elementToAppend?: HTMLElement | undefined;
+        domID: string;
+      };
   /** A list of TypeScript versions you can use with the TypeScript sandbox */
   supportedVersions: readonly [
-    '5.2.1-rc',
-    '5.2.0-beta',
+    '5.5.3',
+    '5.4.5',
+    '5.3.3',
+    '5.2.2',
     '5.1.6',
     '5.0.4',
     '4.9.5',
@@ -152,7 +175,10 @@ export declare const createTypeScriptSandbox: (
   /** A copy of require("@typescript/vfs") this can be used to quickly set up an in-memory compiler runs for ASTs, or to get complex language server results (anything above has to be serialized when passed)*/
   tsvfs: typeof tsvfs;
   /** Get all the different emitted files after TypeScript is run */
-  getEmitResult: () => Promise<ts.EmitOutput>;
+  getEmitResult: (
+    emitOnlyDtsFiles?: boolean,
+    forceDtsEmit?: boolean,
+  ) => Promise<ts.EmitOutput>;
   /** Gets just the JavaScript for your sandbox, will transpile if in TS only */
   getRunnableJS: () => Promise<string>;
   /** Gets the DTS output of the main code in the editor */
@@ -188,6 +214,7 @@ export declare const createTypeScriptSandbox: (
     host: {
       compilerHost: ts.CompilerHost;
       updateFile: (sourceFile: ts.SourceFile) => boolean;
+      deleteFile: (sourceFile: ts.SourceFile) => boolean;
     };
     fsMap: Map<string, string>;
   }>;
@@ -196,87 +223,85 @@ export declare const createTypeScriptSandbox: (
   /** The Sandbox's default compiler options  */
   compilerDefaults: {
     [x: string]: MonacoEditor.languages.typescript.CompilerOptionsValue;
-    allowJs?: boolean | undefined;
-    allowSyntheticDefaultImports?: boolean | undefined;
-    allowUmdGlobalAccess?: boolean | undefined;
-    allowUnreachableCode?: boolean | undefined;
-    allowUnusedLabels?: boolean | undefined;
-    alwaysStrict?: boolean | undefined;
-    baseUrl?: string | undefined;
-    charset?: string | undefined;
-    checkJs?: boolean | undefined;
-    declaration?: boolean | undefined;
-    declarationMap?: boolean | undefined;
-    emitDeclarationOnly?: boolean | undefined;
-    declarationDir?: string | undefined;
-    disableSizeLimit?: boolean | undefined;
-    disableSourceOfProjectReferenceRedirect?: boolean | undefined;
-    downlevelIteration?: boolean | undefined;
-    emitBOM?: boolean | undefined;
-    emitDecoratorMetadata?: boolean | undefined;
-    experimentalDecorators?: boolean | undefined;
-    forceConsistentCasingInFileNames?: boolean | undefined;
-    importHelpers?: boolean | undefined;
-    inlineSourceMap?: boolean | undefined;
-    inlineSources?: boolean | undefined;
-    isolatedModules?: boolean | undefined;
-    jsx?: MonacoEditor.languages.typescript.JsxEmit | undefined;
-    keyofStringsOnly?: boolean | undefined;
-    lib?: string[] | undefined;
-    locale?: string | undefined;
-    mapRoot?: string | undefined;
-    maxNodeModuleJsDepth?: number | undefined;
-    module?: MonacoEditor.languages.typescript.ModuleKind | undefined;
-    moduleResolution?:
-      | MonacoEditor.languages.typescript.ModuleResolutionKind
-      | undefined;
-    newLine?: MonacoEditor.languages.typescript.NewLineKind | undefined;
-    noEmit?: boolean | undefined;
-    noEmitHelpers?: boolean | undefined;
-    noEmitOnError?: boolean | undefined;
-    noErrorTruncation?: boolean | undefined;
-    noFallthroughCasesInSwitch?: boolean | undefined;
-    noImplicitAny?: boolean | undefined;
-    noImplicitReturns?: boolean | undefined;
-    noImplicitThis?: boolean | undefined;
-    noStrictGenericChecks?: boolean | undefined;
-    noUnusedLocals?: boolean | undefined;
-    noUnusedParameters?: boolean | undefined;
-    noImplicitUseStrict?: boolean | undefined;
-    noLib?: boolean | undefined;
-    noResolve?: boolean | undefined;
-    out?: string | undefined;
-    outDir?: string | undefined;
-    outFile?: string | undefined;
-    paths?: MonacoEditor.languages.typescript.MapLike<string[]> | undefined;
-    preserveConstEnums?: boolean | undefined;
-    preserveSymlinks?: boolean | undefined;
-    project?: string | undefined;
-    reactNamespace?: string | undefined;
-    jsxFactory?: string | undefined;
-    composite?: boolean | undefined;
-    removeComments?: boolean | undefined;
-    rootDir?: string | undefined;
-    rootDirs?: string[] | undefined;
-    skipLibCheck?: boolean | undefined;
-    skipDefaultLibCheck?: boolean | undefined;
-    sourceMap?: boolean | undefined;
-    sourceRoot?: string | undefined;
-    strict?: boolean | undefined;
-    strictFunctionTypes?: boolean | undefined;
-    strictBindCallApply?: boolean | undefined;
-    strictNullChecks?: boolean | undefined;
-    strictPropertyInitialization?: boolean | undefined;
-    stripInternal?: boolean | undefined;
-    suppressExcessPropertyErrors?: boolean | undefined;
-    suppressImplicitAnyIndexErrors?: boolean | undefined;
-    target?: MonacoEditor.languages.typescript.ScriptTarget | undefined;
-    traceResolution?: boolean | undefined;
-    resolveJsonModule?: boolean | undefined;
-    types?: string[] | undefined;
-    typeRoots?: string[] | undefined;
-    esModuleInterop?: boolean | undefined;
-    useDefineForClassFields?: boolean | undefined;
+    allowJs?: boolean;
+    allowSyntheticDefaultImports?: boolean;
+    allowUmdGlobalAccess?: boolean;
+    allowUnreachableCode?: boolean;
+    allowUnusedLabels?: boolean;
+    alwaysStrict?: boolean;
+    baseUrl?: string;
+    charset?: string;
+    checkJs?: boolean;
+    declaration?: boolean;
+    declarationMap?: boolean;
+    emitDeclarationOnly?: boolean;
+    declarationDir?: string;
+    disableSizeLimit?: boolean;
+    disableSourceOfProjectReferenceRedirect?: boolean;
+    downlevelIteration?: boolean;
+    emitBOM?: boolean;
+    emitDecoratorMetadata?: boolean;
+    experimentalDecorators?: boolean;
+    forceConsistentCasingInFileNames?: boolean;
+    importHelpers?: boolean;
+    inlineSourceMap?: boolean;
+    inlineSources?: boolean;
+    isolatedModules?: boolean;
+    jsx?: MonacoEditor.languages.typescript.JsxEmit;
+    keyofStringsOnly?: boolean;
+    lib?: string[];
+    locale?: string;
+    mapRoot?: string;
+    maxNodeModuleJsDepth?: number;
+    module?: MonacoEditor.languages.typescript.ModuleKind;
+    moduleResolution?: MonacoEditor.languages.typescript.ModuleResolutionKind;
+    newLine?: MonacoEditor.languages.typescript.NewLineKind;
+    noEmit?: boolean;
+    noEmitHelpers?: boolean;
+    noEmitOnError?: boolean;
+    noErrorTruncation?: boolean;
+    noFallthroughCasesInSwitch?: boolean;
+    noImplicitAny?: boolean;
+    noImplicitReturns?: boolean;
+    noImplicitThis?: boolean;
+    noStrictGenericChecks?: boolean;
+    noUnusedLocals?: boolean;
+    noUnusedParameters?: boolean;
+    noImplicitUseStrict?: boolean;
+    noLib?: boolean;
+    noResolve?: boolean;
+    out?: string;
+    outDir?: string;
+    outFile?: string;
+    paths?: MonacoEditor.languages.typescript.MapLike<string[]>;
+    preserveConstEnums?: boolean;
+    preserveSymlinks?: boolean;
+    project?: string;
+    reactNamespace?: string;
+    jsxFactory?: string;
+    composite?: boolean;
+    removeComments?: boolean;
+    rootDir?: string;
+    rootDirs?: string[];
+    skipLibCheck?: boolean;
+    skipDefaultLibCheck?: boolean;
+    sourceMap?: boolean;
+    sourceRoot?: string;
+    strict?: boolean;
+    strictFunctionTypes?: boolean;
+    strictBindCallApply?: boolean;
+    strictNullChecks?: boolean;
+    strictPropertyInitialization?: boolean;
+    stripInternal?: boolean;
+    suppressExcessPropertyErrors?: boolean;
+    suppressImplicitAnyIndexErrors?: boolean;
+    target?: MonacoEditor.languages.typescript.ScriptTarget;
+    traceResolution?: boolean;
+    resolveJsonModule?: boolean;
+    types?: string[];
+    typeRoots?: string[];
+    esModuleInterop?: boolean;
+    useDefineForClassFields?: boolean;
   };
   /** The Sandbox's current compiler options */
   getCompilerOptions: () => MonacoEditor.languages.typescript.CompilerOptions;

--- a/packages/website/src/vendor/typescript-vfs.d.ts
+++ b/packages/website/src/vendor/typescript-vfs.d.ts
@@ -16,6 +16,15 @@ type LanguageServiceHost = ts.LanguageServiceHost;
 type CompilerHost = ts.CompilerHost;
 type SourceFile = ts.SourceFile;
 type TS = typeof ts;
+type FetchLike = (url: string) => Promise<{
+  json(): Promise<any>;
+  text(): Promise<string>;
+}>;
+interface LocalStorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
 export interface VirtualTypeScriptEnvironment {
   sys: System;
   languageService: ts.LanguageService;
@@ -26,6 +35,7 @@ export interface VirtualTypeScriptEnvironment {
     content: string,
     replaceTextSpan?: ts.TextSpan,
   ) => void;
+  deleteFile: (fileName: string) => void;
 }
 /**
  * Makes a virtual copy of the TypeScript environment. This is the main API you want to be using with
@@ -79,6 +89,10 @@ export declare const addAllFilesFromFolder: (
 export declare const addFilesForTypesIntoFolder: (
   map: Map<string, string>,
 ) => void;
+export interface LZString {
+  compressToUTF16(input: string): string;
+  decompressFromUTF16(compressed: string): string;
+}
 /**
  * Create a virtual FS Map with the lib files from a particular TypeScript
  * version based on the target, Always includes dom ATM.
@@ -96,9 +110,9 @@ export declare const createDefaultMapFromCDN: (
   version: string,
   cache: boolean,
   ts: TS,
-  lzstring?: typeof import('lz-string'),
-  fetcher?: typeof fetch,
-  storer?: typeof localStorage,
+  lzstring?: LZString,
+  fetcher?: FetchLike,
+  storer?: LocalStorageLike,
 ) => Promise<Map<string, string>>;
 /**
  * Creates an in-memory System object which can be used in a TypeScript program, this
@@ -128,6 +142,7 @@ export declare function createVirtualCompilerHost(
 ): {
   compilerHost: CompilerHost;
   updateFile: (sourceFile: SourceFile) => boolean;
+  deleteFile: (sourceFile: SourceFile) => boolean;
 };
 /**
  * Creates an object which can host a language service against the virtual file-system
@@ -141,5 +156,6 @@ export declare function createVirtualLanguageServiceHost(
 ): {
   languageServiceHost: LanguageServiceHost;
   updateFile: (sourceFile: ts.SourceFile) => void;
+  deleteFile: (sourceFile: ts.SourceFile) => void;
 };
 export {};


### PR DESCRIPTION
this solves most of issues with ATA types not beeing visible to eslint, but sadly `node:*` is still not fully supported


ref: https://github.com/typescript-eslint/typescript-eslint/issues/9594