### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] false positive on optional private field

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -211,8 +211,17 @@ export default createRule<Options, MessageId>({
       }
       const property = node.property;
 
-      if (property.type === AST_NODE_TYPES.Identifier) {
-        const propertyType = objectType.getProperty(property.name);
+      if (
+        property.type === AST_NODE_TYPES.Identifier ||
+        property.type === AST_NODE_TYPES.PrivateIdentifier
+      ) {
+        // Get the actual property name, to account for private properties (this.#prop).
+        const propName = context.sourceCode.getText(property);
+
+        const propertyType = objectType
+          .getProperties()
+          .find(prop => prop.name === propName);
+
         if (
           propertyType &&
           tsutils.isSymbolFlagSet(propertyType, ts.SymbolFlags.Optional)

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -211,24 +211,20 @@ export default createRule<Options, MessageId>({
       }
       const property = node.property;
 
+      // Get the actual property name, to account for private properties (this.#prop).
+      const propertyName = context.sourceCode.getText(property);
+
+      const propertyType = objectType
+        .getProperties()
+        .find(prop => prop.name === propertyName);
+
       if (
-        property.type === AST_NODE_TYPES.Identifier ||
-        property.type === AST_NODE_TYPES.PrivateIdentifier
+        propertyType &&
+        tsutils.isSymbolFlagSet(propertyType, ts.SymbolFlags.Optional)
       ) {
-        // Get the actual property name, to account for private properties (this.#prop).
-        const propName = context.sourceCode.getText(property);
-
-        const propertyType = objectType
-          .getProperties()
-          .find(prop => prop.name === propName);
-
-        if (
-          propertyType &&
-          tsutils.isSymbolFlagSet(propertyType, ts.SymbolFlags.Optional)
-        ) {
-          return true;
-        }
+        return true;
       }
+
       return false;
     }
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -852,7 +852,6 @@ type Foo = { [key: string]: () => number | undefined } | null;
 declare const foo: Foo;
 foo?.['bar']()?.toExponential();
     `,
-
     {
       parserOptions: optionsWithExactOptionalPropertyTypes,
       code: `
@@ -864,7 +863,7 @@ class ConsistentRand {
     return this.#rand;
   }
 }
-    `,
+      `,
     },
   ],
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -852,6 +852,20 @@ type Foo = { [key: string]: () => number | undefined } | null;
 declare const foo: Foo;
 foo?.['bar']()?.toExponential();
     `,
+
+    {
+      parserOptions: optionsWithExactOptionalPropertyTypes,
+      code: `
+class ConsistentRand {
+  #rand?: number;
+
+  getCachedRand() {
+    this.#rand ??= Math.random();
+    return this.#rand;
+  }
+}
+    `,
+    },
   ],
   invalid: [
     // Ensure that it's checking in all the right places


### PR DESCRIPTION
## PR Checklist

- [X] Addresses an existing open issue: fixes #9564
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR accounts for private identifiers when checking if a member expression is nullable

Not sure if/which additional test cases I should add here, so I'm open for suggestions 😄 