### PR TITLE
feat(eslint-plugin): [return-await] add return-await to strict-type-checked preset

### DIFF
--- a/packages/eslint-plugin/src/configs/strict-type-checked-only.ts
+++ b/packages/eslint-plugin/src/configs/strict-type-checked-only.ts
@@ -64,6 +64,11 @@ export = {
         allowNever: false,
       },
     ],
+    'no-return-await': 'off',
+    '@typescript-eslint/return-await': [
+      'error',
+      'error-handling-correctness-only',
+    ],
     '@typescript-eslint/unbound-method': 'error',
     '@typescript-eslint/use-unknown-in-catch-callback-variable': 'error',
   },

--- a/packages/eslint-plugin/src/configs/strict-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/strict-type-checked.ts
@@ -97,6 +97,11 @@ export = {
         allowNever: false,
       },
     ],
+    'no-return-await': 'off',
+    '@typescript-eslint/return-await': [
+      'error',
+      'error-handling-correctness-only',
+    ],
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/unbound-method': 'error',
     '@typescript-eslint/unified-signatures': 'error',

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -37,6 +37,9 @@ export default createRule({
       description: 'Enforce consistent awaiting of returned promises',
       requiresTypeChecking: true,
       extendsBaseRule: 'no-return-await',
+      recommended: {
+        strict: ['error-handling-correctness-only'],
+      },
     },
     fixable: 'code',
     hasSuggestions: true,

--- a/packages/typescript-eslint/src/configs/strict-type-checked-only.ts
+++ b/packages/typescript-eslint/src/configs/strict-type-checked-only.ts
@@ -73,6 +73,11 @@ export default (
           allowNever: false,
         },
       ],
+      'no-return-await': 'off',
+      '@typescript-eslint/return-await': [
+        'error',
+        'error-handling-correctness-only',
+      ],
       '@typescript-eslint/unbound-method': 'error',
       '@typescript-eslint/use-unknown-in-catch-callback-variable': 'error',
     },

--- a/packages/typescript-eslint/src/configs/strict-type-checked.ts
+++ b/packages/typescript-eslint/src/configs/strict-type-checked.ts
@@ -106,6 +106,11 @@ export default (
           allowNever: false,
         },
       ],
+      'no-return-await': 'off',
+      '@typescript-eslint/return-await': [
+        'error',
+        'error-handling-correctness-only',
+      ],
       '@typescript-eslint/triple-slash-reference': 'error',
       '@typescript-eslint/unbound-method': 'error',
       '@typescript-eslint/unified-signatures': 'error',

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -11,7 +11,7 @@ export type RuleRecommendation = 'recommended' | 'strict' | 'stylistic';
 export interface RuleRecommendationAcrossConfigs<
   Options extends readonly unknown[],
 > {
-  recommended: true;
+  recommended?: true;
   strict: Partial<Options>;
 }
 


### PR DESCRIPTION
~BREAKING CHANGE~ Technically _not_ a breaking change, since it's only going to the strict config, but targeting v8 anyway to batch it in with the rest of our config changes.

## PR Checklist

- [x] Addresses an existing open issue: fixes #8667 
- [x] That issue was marked as <s>[accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)</s> "team assigned"
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Nothin but a config change

Note, also, followup to #9595, thanks @JoshuaKGoldberg for the tip on the config generation infra

***

Co-authored-by: @JoshuaKGoldberg 