### PR TITLE
chore: enable unicorn/no-for-loop

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -318,6 +318,7 @@ export default tseslint.config(
       //
 
       'jsdoc/informative-docs': 'error',
+      'unicorn/no-for-loop': 'error',
       'unicorn/no-typeof-undefined': 'error',
     },
   },

--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -56,8 +56,7 @@ class FunctionSignature {
     let restType: RestType | null = null;
 
     const parameters = signature.getParameters();
-    for (let i = 0; i < parameters.length; i += 1) {
-      const param = parameters[i];
+    for (const [i, param] of parameters.entries()) {
       const type = checker.getTypeOfSymbolAtLocation(param, tsNode);
 
       const decl = param.getDeclarations()?.[0];

--- a/packages/eslint-plugin/src/rules/prefer-includes.ts
+++ b/packages/eslint-plugin/src/rules/prefer-includes.ts
@@ -79,8 +79,7 @@ export default createRule({
         return false;
       }
 
-      for (let i = 0; i < paramsA.length; ++i) {
-        const paramA = paramsA[i];
+      for (const [i, paramA] of paramsA.entries()) {
         const paramB = paramsB[i];
 
         // Check name, type, and question token once.

--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -136,8 +136,7 @@ export default createRule<Options, MessageIds>({
         return false;
       }
 
-      for (let i = 0; i < tokens1.length; ++i) {
-        const token1 = tokens1[i];
+      for (const [i, token1] of tokens1.entries()) {
         const token2 = tokens2[i];
 
         if (token1.type !== token2.type || token1.value !== token2.value) {

--- a/packages/eslint-plugin/tests/docs.test.ts
+++ b/packages/eslint-plugin/tests/docs.test.ts
@@ -63,8 +63,7 @@ function renderLintResults(code: string, errors: Linter.LintMessage[]): string {
   const output: string[] = [];
   const lines = code.split(/\r?\n/);
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  for (const [i, line] of lines.entries()) {
     output.push(line);
 
     for (const error of errors) {

--- a/packages/rule-schema-to-typescript-types/src/index.ts
+++ b/packages/rule-schema-to-typescript-types/src/index.ts
@@ -30,8 +30,8 @@ export async function compile(
 
   const refTypes: string[] = [];
   const types: AST[] = [];
-  for (let i = 0; i < schema.length; i += 1) {
-    const result = compileSchema(schema[i], i);
+  for (const [i, element] of schema.entries()) {
+    const result = compileSchema(element, i);
     refTypes.push(...result.refTypes);
     types.push(result.type);
   }

--- a/packages/scope-manager/tests/eslint-scope/es6-destructuring-assignments.test.ts
+++ b/packages/scope-manager/tests/eslint-scope/es6-destructuring-assignments.test.ts
@@ -533,16 +533,22 @@ describe('ES6 destructuring assignments', () => {
     expect(variables).toHaveLength(6);
     const expectedVariableNames = ['arguments', 'a', 'b', 'c', 'd', 'rest'];
 
-    for (let index = 0; index < expectedVariableNames.length; index++) {
-      expect(variables[index].name).toBe(expectedVariableNames[index]);
+    for (const [
+      index,
+      expectedVariableName,
+    ] of expectedVariableNames.entries()) {
+      expect(variables[index].name).toBe(expectedVariableName);
     }
 
     expect(scope.references).toHaveLength(6);
     const expectedReferenceNames = ['a', 'b', 'c', 'd', 'rest'];
 
-    for (let index = 0; index < expectedReferenceNames.length; index++) {
+    for (const [
+      index,
+      expectedReferenceName,
+    ] of expectedReferenceNames.entries()) {
       expect(scope.references[index].identifier.name).toBe(
-        expectedReferenceNames[index],
+        expectedReferenceName,
       );
       expect(scope.references[index].isWrite()).toBeTruthy();
     }
@@ -639,8 +645,11 @@ describe('ES6 destructuring assignments', () => {
       'world',
     ];
 
-    for (let index = 0; index < expectedVariableNames.length; index++) {
-      expect(variables[index].name).toBe(expectedVariableNames[index]);
+    for (const [
+      index,
+      expectedVariableName,
+    ] of expectedVariableNames.entries()) {
+      expect(variables[index].name).toBe(expectedVariableName);
     }
     expect(scope.references).toHaveLength(8);
     const expectedReferenceNames = [
@@ -653,9 +662,12 @@ describe('ES6 destructuring assignments', () => {
       'world',
     ];
 
-    for (let index = 0; index < expectedReferenceNames.length; index++) {
+    for (const [
+      index,
+      expectedReferenceName,
+    ] of expectedReferenceNames.entries()) {
       expect(scope.references[index].identifier.name).toBe(
-        expectedReferenceNames[index],
+        expectedReferenceName,
       );
       expect(scope.references[index].isWrite()).toBeTruthy();
     }
@@ -811,9 +823,12 @@ describe('ES6 destructuring assignments', () => {
     expect(scope.references).toHaveLength(6);
     const expectedReferenceNames = ['a', 'b', 'c', 'd', 'rest'];
 
-    for (let index = 0; index < expectedReferenceNames.length; index++) {
+    for (const [
+      index,
+      expectedReferenceName,
+    ] of expectedReferenceNames.entries()) {
       expect(scope.references[index].identifier.name).toBe(
-        expectedReferenceNames[index],
+        expectedReferenceName,
       );
       expect(scope.references[index].isWrite()).toBeTruthy();
       expect(scope.references[index].resolved).toBeNull();
@@ -947,9 +962,12 @@ describe('ES6 destructuring assignments', () => {
       'world',
     ];
 
-    for (let index = 0; index < expectedReferenceNames.length; index++) {
+    for (const [
+      index,
+      expectedReferenceName,
+    ] of expectedReferenceNames.entries()) {
       expect(scope.references[index].identifier.name).toBe(
-        expectedReferenceNames[index],
+        expectedReferenceName,
       );
       expect(scope.references[index].isWrite()).toBeTruthy();
     }
@@ -1096,8 +1114,11 @@ describe('ES6 destructuring assignments', () => {
       'world',
     ];
 
-    for (let index = 0; index < expectedVariableNames.length; index++) {
-      expect(variables[index].name).toBe(expectedVariableNames[index]);
+    for (const [
+      index,
+      expectedVariableName,
+    ] of expectedVariableNames.entries()) {
+      expect(variables[index].name).toBe(expectedVariableName);
     }
     expect(scope.references).toHaveLength(0);
   });
@@ -1124,8 +1145,11 @@ describe('ES6 destructuring assignments', () => {
     expect(variables).toHaveLength(5);
     const expectedVariableNames = ['arguments', 'a', 'b', 'c', 'd'];
 
-    for (let index = 0; index < expectedVariableNames.length; index++) {
-      expect(variables[index].name).toBe(expectedVariableNames[index]);
+    for (const [
+      index,
+      expectedVariableName,
+    ] of expectedVariableNames.entries()) {
+      expect(variables[index].name).toBe(expectedVariableName);
     }
     expect(scope.references).toHaveLength(6);
     const expectedReferenceNames = [
@@ -1137,9 +1161,12 @@ describe('ES6 destructuring assignments', () => {
       'array',
     ];
 
-    for (let index = 0; index < expectedReferenceNames.length; index++) {
+    for (const [
+      index,
+      expectedReferenceName,
+    ] of expectedReferenceNames.entries()) {
       expect(scope.references[index].identifier.name).toBe(
-        expectedReferenceNames[index],
+        expectedReferenceName,
       );
     }
   });
@@ -1166,8 +1193,11 @@ describe('ES6 destructuring assignments', () => {
     expect(variables).toHaveLength(5);
     const expectedVariableNames = ['arguments', 'a', 'b', 'c', 'd'];
 
-    for (let index = 0; index < expectedVariableNames.length; index++) {
-      expect(variables[index].name).toBe(expectedVariableNames[index]);
+    for (const [
+      index,
+      expectedVariableName,
+    ] of expectedVariableNames.entries()) {
+      expect(variables[index].name).toBe(expectedVariableName);
     }
     expect(scope.references).toHaveLength(7);
     const expectedReferenceNames = [
@@ -1180,9 +1210,12 @@ describe('ES6 destructuring assignments', () => {
       'array',
     ];
 
-    for (let index = 0; index < expectedReferenceNames.length; index++) {
+    for (const [
+      index,
+      expectedReferenceName,
+    ] of expectedReferenceNames.entries()) {
       expect(scope.references[index].identifier.name).toBe(
-        expectedReferenceNames[index],
+        expectedReferenceName,
       );
     }
   });
@@ -1209,8 +1242,11 @@ describe('ES6 destructuring assignments', () => {
     expect(variables).toHaveLength(5);
     const expectedVariableNames = ['arguments', 'a', 'b', 'c', 'd'];
 
-    for (let index = 0; index < expectedVariableNames.length; index++) {
-      expect(variables[index].name).toBe(expectedVariableNames[index]);
+    for (const [
+      index,
+      expectedVariableName,
+    ] of expectedVariableNames.entries()) {
+      expect(variables[index].name).toBe(expectedVariableName);
     }
     expect(scope.references).toHaveLength(10);
     const expectedReferenceNames = [
@@ -1226,9 +1262,12 @@ describe('ES6 destructuring assignments', () => {
       'array',
     ];
 
-    for (let index = 0; index < expectedReferenceNames.length; index++) {
+    for (const [
+      index,
+      expectedReferenceName,
+    ] of expectedReferenceNames.entries()) {
       expect(scope.references[index].identifier.name).toBe(
-        expectedReferenceNames[index],
+        expectedReferenceName,
       );
     }
   });

--- a/packages/type-utils/src/isUnsafeAssignment.ts
+++ b/packages/type-utils/src/isUnsafeAssignment.ts
@@ -95,8 +95,7 @@ function isUnsafeAssignmentWorker(
     const typeArguments = type.typeArguments ?? [];
     const receiverTypeArguments = receiver.typeArguments ?? [];
 
-    for (let i = 0; i < typeArguments.length; i += 1) {
-      const arg = typeArguments[i];
+    for (const [i, arg] of typeArguments.entries()) {
       const receiverArg = receiverTypeArguments[i];
 
       const unsafe = isUnsafeAssignmentWorker(

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -777,8 +777,8 @@ export function firstDefined<T, U>(
     return undefined;
   }
 
-  for (let i = 0; i < array.length; i++) {
-    const result = callback(array[i], i);
+  for (const [i, element] of array.entries()) {
+    const result = callback(element, i);
     if (result !== undefined) {
       return result;
     }

--- a/packages/website/src/components/ast/selectedRange.ts
+++ b/packages/website/src/components/ast/selectedRange.ts
@@ -50,10 +50,8 @@ function findInObject(
         };
       }
     } else if (Array.isArray(child)) {
-      for (let index = 0; index < child.length; ++index) {
-        const arrayChild: unknown = child[index];
-        // typescript array like elements have other iterable items
-        if (typeof index === 'number' && isRecord(arrayChild)) {
+      for (const [index, arrayChild] of child.entries()) {
+        if (isRecord(arrayChild)) {
           if (isInRange(cursorPosition, arrayChild)) {
             return {
               key: [name, String(index)],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes part of #9623
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Enable `unicorn/no-for-loop` ([docs](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-for-loop.md)). All of these are autofixable, and none are flagged by `@typescript-eslint/prefer-for-of` because the typescript-eslint rule does not flag instances where the index is used.