### PR TITLE
feat(type-utils): support intersection types in TypeOrValueSpecifier

### DIFF
--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -369,6 +369,42 @@ describe('TypeOrValueSpecifier', () => {
       ],
     ])('matches a matching package specifier: %s', runTestPositive);
 
+    it.each<[string, TypeOrValueSpecifier]>([
+      [
+        `
+          type Other = { __otherBrand: true };
+          type SafePromise = Promise<number> & { __safeBrand: string };
+          type JoinedPromise = SafePromise & {};
+        `,
+        { from: 'file', name: ['Other'] },
+      ],
+      // The SafePromise alias acts as an actual alias ("cut-and-paste"). I.e.:
+      // type JoinedPromise = Promise<number> & { __safeBrand: string };
+      [
+        `
+          type SafePromise = Promise<number> & { __safeBrand: string };
+          type JoinedPromise = SafePromise & {};
+        `,
+        { from: 'file', name: ['SafePromise'] },
+      ],
+    ])(
+      "doesn't match a mismatched type specifier for an intersection type: %s",
+      runTestNegative,
+    );
+
+    it.each<[string, TypeOrValueSpecifier]>([
+      [
+        `
+          type SafePromise = Promise<number> & { __safeBrand: string };
+          type JoinedPromise = SafePromise & {};
+        `,
+        { from: 'file', name: ['JoinedPromise'] },
+      ],
+    ])(
+      'matches a matching type specifier for an intersection type: %s',
+      runTestPositive,
+    );
+
     it("does not match a `declare global` with the 'global' package name", () => {
       runTestNegative(
         `


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9303
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Changes `specifierNameMatches` to:

1. Always check alias names of the types, to support directly matching type aliases
2. For intersection types, also check `type.types.some(...)` recursively

Sending this to the `v8` branch because it's based on some `TypeOrValueSpecifier` changes in `v8`. But it doesn't block shipping v8 and isn't a part of the v8 milestone.

💖 