### PR TITLE
chore(website): remove incorrect `twitterHandle` from type

### DIFF
--- a/packages/repo-tools/src/generate-sponsors.mts
+++ b/packages/repo-tools/src/generate-sponsors.mts
@@ -90,7 +90,6 @@ interface MemberAccount {
   id: string;
   imageUrl: string;
   name: string;
-  twitterHandle: string;
   website: string;
 }
 
@@ -154,7 +153,6 @@ async function main(): Promise<void> {
         image: fromAccount.imageUrl,
         name: fromAccount.name,
         totalDonations,
-        twitterHandle: fromAccount.twitterHandle,
         website,
       };
     })


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`twitterHandle` was added to the TypeScript type when `generate-sponsors` was initially built, but it was never used and also never added to the GraphQL query, so it never existed.

[9bb88e55](https://github.com/typescript-eslint/typescript-eslint/pull/4105/commits/9bb88e557a1758a66201f77176f2bfdc231eb1f3)
