### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] prevent runtime error when asserting a variable declared in default TS lib

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -8,6 +8,7 @@ import {
   getConstrainedTypeAtLocation,
   getContextualType,
   getDeclaration,
+  getModifiers,
   getParserServices,
   isNullableType,
   isTypeFlagSet,
@@ -95,7 +96,7 @@ export default createRule<Options, MessageIds>({
             ts.isVariableDeclarationList(declaration.parent) &&
             ts.isVariableStatement(declaration.parent.parent) &&
             tsutils.includesModifier(
-              ts.getModifiers(declaration.parent.parent),
+              getModifiers(declaration.parent.parent),
               ts.SyntaxKind.DeclareKeyword,
             )
           )

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -92,9 +92,13 @@ export default createRule<Options, MessageIds>({
           declarationType === type &&
           // `declare`s are never narrowed, so never skip them
           !(
-            services.tsNodeToESTreeNodeMap.get(declaration)
-              .parent as TSESTree.VariableDeclaration
-          ).declare
+            ts.isVariableDeclarationList(declaration.parent) &&
+            ts.isVariableStatement(declaration.parent.parent) &&
+            tsutils.includesModifier(
+              ts.getModifiers(declaration.parent.parent),
+              ts.SyntaxKind.DeclareKeyword,
+            )
+          )
         ) {
           // possibly used before assigned, so just skip it
           // better to false negative and skip it, than false positive and fix to compile erroring code

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -542,6 +542,11 @@ bar + 1;
       errors: [{ messageId: 'unnecessaryAssertion' }],
     },
     {
+      code: 'Proxy!;',
+      output: 'Proxy;',
+      errors: [{ messageId: 'unnecessaryAssertion' }],
+    },
+    {
       code: `
 function foo<T extends string>(bar: T) {
   return bar!;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9268
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

As Kirk mentioned in https://github.com/typescript-eslint/typescript-eslint/issues/9268#issuecomment-2148437137, we can't rely on ESTree because the variable can be declared in the TS default lib, so we don't even have a corresponding ESTree AST.
