### PR TITLE
fix(types): update variable options

### DIFF
--- a/packages/utils/src/ts-eslint/Config.ts
+++ b/packages/utils/src/ts-eslint/Config.ts
@@ -16,7 +16,13 @@ export namespace SharedConfig {
   export type RuleEntry = RuleLevel | RuleLevelAndOptions;
   export type RulesRecord = Partial<Record<string, RuleEntry>>;
 
-  export type GlobalVariableOptionBase = 'off' | 'readonly' | 'writable';
+  export type GlobalVariableOptionBase =
+    | boolean
+    | 'off'
+    | 'readable'
+    | 'readonly'
+    | 'writable'
+    | 'writeable';
   export type GlobalVariableOption = GlobalVariableOptionBase | boolean;
 
   export interface GlobalsConfig {


### PR DESCRIPTION
Aligns types with https://github.com/DefinitelyTyped/DefinitelyTyped/blob/375da3bcb7512239e65f6e1955f982a20bcc20a9/types/eslint/index.d.ts#L1283

This is the second conflict I'm finding with `@types/eslint@9`. Maybe I'm on the wrong track, or maybe there's a bigger approach that could solve more. I leave this up to more experienced people :smiley: 

Relates to #9634

> Issue template skipped, due to minor and clear change.