### PR TITLE
fix(typescript-estree): factor tsconfigRootDir into allowDefaultProject

### DIFF
--- a/packages/typescript-estree/src/useProgramFromProjectService.ts
+++ b/packages/typescript-estree/src/useProgramFromProjectService.ts
@@ -202,8 +202,12 @@ export function useProgramFromProjectService(
     filePathAbsolute,
   );
 
+  const filePathRelative = path.relative(
+    parseSettings.tsconfigRootDir,
+    filePathAbsolute,
+  );
   const isDefaultProjectAllowed = filePathMatchedBy(
-    parseSettings.filePath,
+    filePathRelative,
     serviceSettings.allowDefaultProject,
   );
 

--- a/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
@@ -57,6 +57,7 @@ const mockFileName = 'camelCaseFile.ts';
 const mockParseSettings = {
   filePath: `path/PascalCaseDirectory/${mockFileName}`,
   extraFileExtensions: [] as readonly string[],
+  tsconfigRootDir: currentDirectory,
 } as ParseSettings;
 
 const createProjectServiceSettings = <
@@ -106,10 +107,12 @@ describe('useProgramFromProjectService', () => {
     );
 
     expect(service.openClientFile).toHaveBeenCalledWith(
-      path.normalize('/repos/repo/path/PascalCaseDirectory/camelCaseFile.ts'),
+      path.normalize(
+        `${currentDirectory}/path/PascalCaseDirectory/camelCaseFile.ts`,
+      ),
       undefined,
       undefined,
-      undefined,
+      currentDirectory,
     );
   });
 
@@ -184,7 +187,7 @@ See https://typescript-eslint.io/troubleshooting/typed-linting#allowdefaultproje
 Matching files:
 - a
 - b
-- ${path.normalize('/repos/repo/path/PascalCaseDirectory/camelCaseFile.ts')}
+- ${path.normalize(`${currentDirectory}/path/PascalCaseDirectory/camelCaseFile.ts`)}
 
 If you absolutely need more files included, set parserOptions.projectService.maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING to a larger value.
 `);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9674
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The _"does this file's path match the allowed list of files"_ needed to be relative to `tsconfigRootDir`, not the absolute path.

💖  