### PR TITLE
fix(rule-tester): support ESLint >=9.5.0's new language internal

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -696,8 +696,9 @@ export class RuleTester extends TestFramework {
           );
         });
 
+        const language = getLanguageIfAvailable();
         const actualConfig = merge(configWithoutCustomKeys, {
-          linterOptions: { reportUnusedDisableDirectives: 1 },
+          ...(language && { language }),
           languageOptions: {
             ...configWithoutCustomKeys.languageOptions,
             parserOptions: {
@@ -706,6 +707,7 @@ export class RuleTester extends TestFramework {
               ...configWithoutCustomKeys.languageOptions?.parserOptions,
             },
           },
+          linterOptions: { reportUnusedDisableDirectives: 1 },
         });
         messages = this.#linter.verify(
           code,
@@ -1331,5 +1333,21 @@ function assertMessageMatches(actual: string, expected: RegExp | string): void {
     );
   } else {
     assert.strictEqual(actual, expected);
+  }
+}
+
+/** @see {@link https://github.com/typescript-eslint/typescript-eslint/issues/9676} */
+function getLanguageIfAvailable(): object | undefined {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require(
+      path.join(
+        // Generally: "node_modules/eslint/lib/api.js"
+        path.dirname(require.resolve('eslint')),
+        'languages/js/index.js',
+      ),
+    ) as object;
+  } catch {
+    return undefined;
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9676
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

In theory, we could add in the full types from `@eslint/core` describing `(Flat)ESLint.Language`. But given that language support is so new in ESLint, and this PR needs to land before we release v8 as stable, I'd rather defer that to a followup.

💖 