### PR TITLE
fix(rule-tester): provide Linter a cwd in its constructor

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -167,13 +167,18 @@ function getUnsubstitutedMessagePlaceholders(
 export class RuleTester extends TestFramework {
   readonly #testerConfig: TesterConfigWithDefaults;
   readonly #rules: Record<string, AnyRuleCreateFunction | AnyRuleModule> = {};
-  readonly #linter: Linter = new Linter({ configType: 'flat' });
+  readonly #linter: Linter;
 
   /**
    * Creates a new instance of RuleTester.
    */
   constructor(testerConfig?: RuleTesterConfig) {
     super();
+
+    this.#linter = new Linter({
+      configType: 'flat',
+      cwd: testerConfig?.languageOptions?.parserOptions?.tsconfigRootDir,
+    });
 
     /**
      * The configuration to use for this tester. Combination of the tester
@@ -707,16 +712,7 @@ export class RuleTester extends TestFramework {
             },
           },
         });
-        messages = this.#linter.verify(
-          code,
-          // ESLint uses an internal FlatConfigArray that extends @humanwhocodes/config-array.
-          // Linter uses a typeof getConfig === "function" check.
-          // We mock out that check here to force it not to use Linter's cwd as basePath.
-          Object.assign([], {
-            getConfig: () => actualConfig,
-          }),
-          filename,
-        );
+        messages = this.#linter.verify(code, actualConfig, filename);
       } finally {
         SourceCode.prototype.applyInlineConfig = applyInlineConfig;
         SourceCode.prototype.applyLanguageOptions = applyLanguageOptions;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9676
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Per https://github.com/typescript-eslint/typescript-eslint/issues/9676#issuecomment-2258846758, uses the more friendly `Linter` `cwd` constructor param instead of working around ESLint's internals.

💖 