### PR TITLE
fix(eslint-plugin): [no-unused-vars] ignore imports used only as types

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -579,16 +579,6 @@ export default createRule<Options, MessageIds>({
         for (const unusedVar of unusedVars) {
           // Report the first declaration.
           if (unusedVar.defs.length > 0) {
-            const writeReferences = unusedVar.references.filter(
-              ref =>
-                ref.isWrite() &&
-                ref.from.variableScope === unusedVar.scope.variableScope,
-            );
-
-            const id = writeReferences.length
-              ? writeReferences[writeReferences.length - 1].identifier
-              : unusedVar.identifiers[0];
-
             const usedOnlyAsType = unusedVar.references.some(ref =>
               referenceContainsTypeQuery(ref.identifier),
             );
@@ -601,6 +591,16 @@ export default createRule<Options, MessageIds>({
             if (isImportUsedOnlyAsType) {
               continue;
             }
+
+            const writeReferences = unusedVar.references.filter(
+              ref =>
+                ref.isWrite() &&
+                ref.from.variableScope === unusedVar.scope.variableScope,
+            );
+
+            const id = writeReferences.length
+              ? writeReferences[writeReferences.length - 1].identifier
+              : unusedVar.identifiers[0];
 
             const messageId = usedOnlyAsType ? 'usedOnlyAsType' : 'unusedVar';
 

--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -593,6 +593,15 @@ export default createRule<Options, MessageIds>({
               referenceContainsTypeQuery(ref.identifier),
             );
 
+            const isImportUsedOnlyAsType =
+              usedOnlyAsType &&
+              unusedVar.defs.some(
+                def => def.type === DefinitionType.ImportBinding,
+              );
+            if (isImportUsedOnlyAsType) {
+              continue;
+            }
+
             const messageId = usedOnlyAsType ? 'usedOnlyAsType' : 'unusedVar';
 
             const { start } = id.loc;

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -1173,6 +1173,16 @@ export type Foo = typeof foo;
 
 export const bar = (): Foo => foo;
     `,
+    `
+import { SomeType } from 'foo';
+
+export const value = 1234 as typeof SomeType;
+    `,
+    `
+import { foo } from 'foo';
+
+export type Bar = typeof foo;
+    `,
   ],
 
   invalid: [
@@ -2253,27 +2263,6 @@ export const x = _Foo;
           column: 15,
           endLine: 2,
           endColumn: 18,
-        },
-      ],
-    },
-    {
-      code: `
-        import { foo } from 'foo';
-
-        export type Bar = typeof foo;
-      `,
-      errors: [
-        {
-          messageId: 'usedOnlyAsType',
-          data: {
-            varName: 'foo',
-            action: 'defined',
-            additional: '',
-          },
-          line: 2,
-          column: 18,
-          endLine: 2,
-          endColumn: 21,
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9679
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

If `usedOnlyAsType`, then ignore the variable if it came from an import definition. This showed that there were existing tests which encoded the old behavior, which I updated.


The second commit moves some code slightly to avoid extra work now that this loop can `continue`.

Due to #9688, I had to commit with `--no-verify`, so hopefully this passes CI.