### PR TITLE
docs: [strict-boolean-expressions] fix nullable number/string example

### DIFF
--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.mdx
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.mdx
@@ -30,13 +30,13 @@ The following nodes are considered boolean expressions and their type is checked
 
 ```ts
 // nullable numbers are considered unsafe by default
-let num: number | undefined = 0;
+declare const num: number | undefined;
 if (num) {
   console.log('num is defined');
 }
 
 // nullable strings are considered unsafe by default
-let str: string | null = null;
+declare const str: string | null;
 if (!str) {
   console.log('str is empty');
 }

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/strict-boolean-expressions.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/strict-boolean-expressions.shot
@@ -4,15 +4,16 @@ exports[`Validating rule docs strict-boolean-expressions.mdx code examples ESLin
 "Incorrect
 
 // nullable numbers are considered unsafe by default
-let num: number | undefined = 0;
+declare const num: number | undefined;
 if (num) {
+    ~~~ Unexpected nullable number value in conditional. Please handle the nullish/zero/NaN cases explicitly.
   console.log('num is defined');
 }
 
 // nullable strings are considered unsafe by default
-let str: string | null = null;
+declare const str: string | null;
 if (!str) {
-     ~~~ Unexpected nullish value in conditional. The condition is always false.
+     ~~~ Unexpected nullable string value in conditional. Please handle the nullish/empty cases explicitly.
   console.log('str is empty');
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9699
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

https://typescript-eslint.io/rules/strict-boolean-expressions/#examples

fixes incorrect example for nullable numbers not actually raising lint error due to [typescript type narrowing](https://github.com/typescript-eslint/typescript-eslint/issues/9699#issuecomment-2264352992)