### PR TITLE
docs: correct allowDefaultProject references to not start with ./

### DIFF
--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -337,7 +337,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     projectService: {
-      allowDefaultProject: ['./*.js'],
+      allowDefaultProject: ['*.js'],
     },
   },
 };

--- a/packages/typescript-estree/tests/lib/validateDefaultProjectForFilesGlob.test.ts
+++ b/packages/typescript-estree/tests/lib/validateDefaultProjectForFilesGlob.test.ts
@@ -10,7 +10,7 @@ describe('validateDefaultProjectForFilesGlob', () => {
   it('does not throw when options.allowDefaultProject contains a non-** glob', () => {
     expect(() =>
       validateDefaultProjectForFilesGlob({
-        allowDefaultProject: ['./*.js'],
+        allowDefaultProject: ['*.js'],
       }),
     ).not.toThrow();
   });

--- a/packages/website/blog/2024-05-27-announcing-typescript-eslint-v8-beta.mdx
+++ b/packages/website/blog/2024-05-27-announcing-typescript-eslint-v8-beta.mdx
@@ -132,7 +132,7 @@ export default tseslint.config(
         project: ['packages/*/tsconfig.json', 'tsconfig.eslint.json'],
         // Added lines start
         projectService: {
-          allowDefaultProject: ['./*.js'],
+          allowDefaultProject: ['*.js'],
           defaultProject: './tsconfig.json',
         },
         // Added lines end

--- a/packages/website/blog/2024-07-31-announcing-typescript-eslint-v8.md
+++ b/packages/website/blog/2024-07-31-announcing-typescript-eslint-v8.md
@@ -120,7 +120,7 @@ export default tseslint.config(
         project: ['packages/*/tsconfig.json', 'tsconfig.eslint.json'],
         // Added lines start
         projectService: {
-          allowDefaultProject: ['./*.js'],
+          allowDefaultProject: ['*.js'],
           defaultProject: './tsconfig.json',
         },
         // Added lines end


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9715
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fixes up the docs - I'd missed this discrepancy in the initial launch.

💖 