### PR TITLE
fix(typescript-eslint): allow `@types/eslint`'s config type in arguments of `configs()` helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "@jest/test-result": "^29",
     "@microsoft/api-extractor@^7.38.0": "patch:@microsoft/api-extractor@npm%3A7.38.0#./.yarn/patches/@microsoft-api-extractor-npm-7.38.0-955f1e0725.patch",
     "@types/eslint-scope": "link:./tools/dummypkg",
-    "@types/eslint": "link:./tools/dummypkg",
     "@types/estree": "link:./tools/dummypkg",
     "@types/node": "^20.0.0",
     "@types/react": "^18.2.14",

--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -52,6 +52,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@types/eslint": "^9.6.0",
     "@typescript-eslint/eslint-plugin": "8.0.1",
     "@typescript-eslint/parser": "8.0.1",
     "@typescript-eslint/utils": "8.0.1"

--- a/packages/typescript-eslint/src/config-helper.ts
+++ b/packages/typescript-eslint/src/config-helper.ts
@@ -17,6 +17,7 @@ https://github.com/typescript-eslint/typescript-eslint/pull/8460
 TODO - convert this to /utils/ts-eslint
 */
 import type { TSESLint } from '@typescript-eslint/utils';
+import type { Linter } from 'eslint';
 
 export interface ConfigWithExtends extends TSESLint.FlatConfig.Config {
   /**
@@ -83,9 +84,12 @@ export interface ConfigWithExtends extends TSESLint.FlatConfig.Config {
  * ```
  */
 export function config(
-  ...configs: ConfigWithExtends[]
+  ...configs: (ConfigWithExtends | Linter.Config)[]
 ): TSESLint.FlatConfig.ConfigArray {
   return configs.flatMap(configWithExtends => {
+    if (!('extends' in configWithExtends)) {
+      return configWithExtends;
+    }
     const { extends: extendsArr, ...config } = configWithExtends;
     if (extendsArr == null || extendsArr.length === 0) {
       return config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5111,6 +5111,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/eslint@npm:^9.6.0":
+  version: 9.6.0
+  resolution: "@types/eslint@npm:9.6.0"
+  dependencies:
+    "@types/estree": "*"
+    "@types/json-schema": "*"
+  checksum: 7be4b1d24f3df30b28e9cbaac6a5fa14ec1ceca7c173d9605c0ec6e0d1dcdba0452d326dd695dd980f5c14b42aa09fe41675c4f09ffc82db4f466588d3f837cb
+  languageName: node
+  linkType: hard
+
 "@types/estree-jsx@npm:^1.0.0":
   version: 1.0.5
   resolution: "@types/estree-jsx@npm:1.0.5"
@@ -5265,7 +5275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
@@ -19461,6 +19471,7 @@ __metadata:
   resolution: "typescript-eslint@workspace:packages/typescript-eslint"
   dependencies:
     "@jest/types": 29.6.3
+    "@types/eslint": ^9.6.0
     "@typescript-eslint/eslint-plugin": 8.0.1
     "@typescript-eslint/parser": 8.0.1
     "@typescript-eslint/utils": 8.0.1


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9724
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR fixes #9724 by allowing `Linter.Config` defined in `@types/eslint` in arguments of `typescript-eslint`'s `configs()` helper function. By this change, many eslint plugin packages which provide their type definitions can be type-checked in `eslint.config.mjs` with typescript-eslint.