### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-parameters] skip checking function bodies for AST references

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -447,6 +447,46 @@ ruleTester.run('no-unnecessary-type-parameters', rule, {
     },
     {
       code: `
+        function foo<T>(_: T) {
+          const x: T = null!;
+          const y: T = null!;
+        }
+      `,
+      errors: [{ messageId: 'sole', data: { name: 'T' } }],
+    },
+    {
+      code: `
+        function foo<T>(_: T): void {
+          const x: T = null!;
+          const y: T = null!;
+        }
+      `,
+      errors: [{ messageId: 'sole', data: { name: 'T' } }],
+    },
+    {
+      code: `
+        function foo<T>(_: T): <T>(input: T) => T {
+          const x: T = null!;
+          const y: T = null!;
+        }
+      `,
+      errors: [{ messageId: 'sole', data: { name: 'T' } }],
+    },
+    {
+      code: `
+        function foo<T>(_: T) {
+          function withX(): T {
+            return null!;
+          }
+          function withY(): T {
+            return null!;
+          }
+        }
+      `,
+      errors: [{ messageId: 'sole', data: { name: 'T' } }],
+    },
+    {
+      code: `
         function parseYAML<T>(input: string): T {
           return input as any as T;
         }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9735
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Prevents checking of references inside a function body, or if one doesn't exist, generally after the return type.

This might give a little speed boost for not checking function bodies... but:
* Since that's just AST iteration, it probably won't be noticeable for any real world cases
* Inferred return types will now have to go to the type checker, which might slow things down anyway

💖 