### PR TITLE
chore: set `reportUnusedDisableDirectives` level to `error`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -93,6 +93,7 @@ export default tseslint.config(
         warnOnUnsupportedTypeScriptVersion: false,
       },
     },
+    linterOptions: { reportUnusedDisableDirectives: 'error' },
     rules: {
       // make sure we're not leveraging any deprecated APIs
       'deprecation/deprecation': 'error',

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -71,7 +71,6 @@ const configs = {
 export type Config = TSESLint.FlatConfig.ConfigFile;
 export type { ConfigWithExtends };
 /*
-eslint-disable-next-line import/no-default-export --
 we do both a default and named exports to allow people to use this package from
 both CJS and ESM in very natural ways.
 

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -29,7 +29,6 @@ describe('convert', () => {
       function fakeUnknownKind(node: ts.Node): void {
         ts.forEachChild(node, fakeUnknownKind);
         // @ts-expect-error -- intentionally writing to a readonly field
-        // eslint-disable-next-line deprecation/deprecation, @typescript-eslint/no-unused-expressions
         node.kind = ts.SyntaxKind.UnparsedPrologue;
       }
 
@@ -373,10 +372,10 @@ describe('convert', () => {
     it('allows writing to the deprecated aliased property as a new enumerable value', () => {
       const esTsEnumDeclaration = getEsTsEnumDeclaration();
 
-      // eslint-disable-next-line deprecation/deprecation, @typescript-eslint/no-unused-expressions
+      // eslint-disable-next-line deprecation/deprecation
       esTsEnumDeclaration.members = [];
 
-      // eslint-disable-next-line deprecation/deprecation, @typescript-eslint/no-unused-expressions
+      // eslint-disable-next-line deprecation/deprecation
       expect(esTsEnumDeclaration.members).toEqual([]);
       expect(Object.keys(esTsEnumDeclaration)).toContain('members');
     });
@@ -437,10 +436,10 @@ describe('convert', () => {
     it('allows writing to the deprecated getter property as a new enumerable value', () => {
       const tsMappedType = getEsTsMappedType();
 
-      // eslint-disable-next-line deprecation/deprecation, @typescript-eslint/no-unused-expressions
+      // eslint-disable-next-line deprecation/deprecation
       tsMappedType.typeParameter = undefined!;
 
-      // eslint-disable-next-line deprecation/deprecation, @typescript-eslint/no-unused-expressions
+      // eslint-disable-next-line deprecation/deprecation
       expect(tsMappedType.typeParameter).toBeUndefined();
       expect(Object.keys(tsMappedType)).toContain('typeParameter');
     });

--- a/packages/utils/src/ts-eslint/ESLint.ts
+++ b/packages/utils/src/ts-eslint/ESLint.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-namespace */
-
 export {
   // TODO(eslint@v10) - remove this in the next major
   /**


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/pull/9119#discussion_r1661294146
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Now, unused disable directives will block the pipeline. I cannot think of any reason not to have this, and per the linked comment, @auvred and @JoshuaKGoldberg support it 👍 
