### PR TITLE
fix(eslint-plugin): [no-unsafe-enum-comparison] add logic to see through intersections

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
@@ -227,16 +227,6 @@ ruleTester.run('strict-enums-comparison', rule, {
         Beet = 'beet',
         Celery = 'celery',
       }
-      type WeirdString = string & { __someBrand: void };
-      declare const weirdString: WeirdString;
-      Vegetable.Asparagus === weirdString;
-    `,
-    `
-      enum Vegetable {
-        Asparagus = 'asparagus',
-        Beet = 'beet',
-        Celery = 'celery',
-      }
       const foo = {};
       const vegetable = Vegetable.Asparagus;
       vegetable in foo;

--- a/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
@@ -1213,5 +1213,38 @@ ruleTester.run('no-unsafe-enum-comparison', rule, {
       `,
       errors: [{ messageId: 'mismatchedCondition' }],
     },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+        declare const foo: number & { __someBrand: void };
+        if (foo === Fruit.Apple) {
+        }
+      `,
+      errors: [{ messageId: 'mismatchedCondition' }],
+    },
+    {
+      code: `
+        enum Vegetable {
+          Asparagus = 'asparagus',
+        }
+        declare const foo: string & {};
+        if (foo === Vegetable.Asparagus) {
+        }
+      `,
+      errors: [{ messageId: 'mismatchedCondition' }],
+    },
+    {
+      code: `
+        enum Vegetable {
+          Asparagus = 'asparagus',
+        }
+        declare const foo: string & { __someBrand: void };
+        if (foo === Vegetable.Asparagus) {
+        }
+      `,
+      errors: [{ messageId: 'mismatchedCondition' }],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
@@ -1212,5 +1212,16 @@ ruleTester.run('strict-enums-comparison', rule, {
         },
       ],
     },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+        declare const foo: number & {};
+        if (foo === Fruit.Apple) {
+        }
+      `,
+      errors: [{ messageId: 'mismatchedCondition' }],
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7114
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Added additional logic for the rule to "see through" intersections, allowing the rule to work properly in the case outlined in the linked issue.
