### PR TITLE
chore(rule-tester): remove unused dep on @eslint/eslintrc

### DIFF
--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -56,7 +56,6 @@
     "semver": "^7.6.0"
   },
   "peerDependencies": {
-    "@eslint/eslintrc": ">=2",
     "eslint": "^8.57.0 || ^9.0.0"
   },
   "devDependencies": {

--- a/packages/rule-tester/typings/eslint.d.ts
+++ b/packages/rule-tester/typings/eslint.d.ts
@@ -4,21 +4,6 @@ declare module 'eslint/use-at-your-own-risk' {
   export const builtinRules: ReadonlyMap<string, AnyRuleModule>;
 }
 
-declare module '@eslint/eslintrc' {
-  import type { Linter } from '@typescript-eslint/utils/ts-eslint';
-
-  export const Legacy: {
-    ConfigOps: {
-      normalizeConfigGlobal: (
-        configuredValue: boolean | string | null,
-      ) => Linter.GlobalVariableOptionBase;
-      // ...
-    };
-    environments: Map<string, Linter.Environment>;
-    // ...
-  };
-}
-
 declare module 'eslint' {
   export { SourceCode } from '@typescript-eslint/utils/ts-eslint';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5746,7 +5746,6 @@ __metadata:
     source-map-support: ^0.5.21
     typescript: "*"
   peerDependencies:
-    "@eslint/eslintrc": ">=2"
     eslint: ^8.57.0 || ^9.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9785
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This dep is unused in the package; removing it seems to have no effect. (Not that it much matters, `eslint` itself directly depends on it.)