### PR TITLE
fix(typescript-estree): pass in tsconfigRootDir as cwd to getParsedConfigFile

### DIFF
--- a/packages/typescript-estree/src/create-program/createProjectService.ts
+++ b/packages/typescript-estree/src/create-program/createProjectService.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function -- for TypeScript APIs*/
-import path from 'node:path';
-
 import debug from 'debug';
 import type * as ts from 'typescript/lib/tsserverlibrary';
 
@@ -41,6 +39,7 @@ export interface ProjectServiceSettings {
 export function createProjectService(
   optionsRaw: boolean | ProjectServiceOptions | undefined,
   jsDocParsingMode: ts.JSDocParsingMode | undefined,
+  tsconfigRootDir: string | undefined,
 ): ProjectServiceSettings {
   const options = typeof optionsRaw === 'object' ? optionsRaw : {};
   validateDefaultProjectForFilesGlob(options);
@@ -130,7 +129,7 @@ export function createProjectService(
       configFile = getParsedConfigFile(
         tsserver,
         options.defaultProject,
-        path.dirname(options.defaultProject),
+        tsconfigRootDir,
       );
     } catch (error) {
       throw new Error(

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -110,6 +110,7 @@ export function createParseSettings(
         ? (TSSERVER_PROJECT_SERVICE ??= createProjectService(
             tsestreeOptions.projectService,
             jsDocParsingMode,
+            tsconfigRootDir,
           ))
         : undefined,
     range: tsestreeOptions.range === true,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9801
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Not sure what a good test would be for this; I'm also not sure if adding this param is a break? I can make it optional.