### PR TITLE
docs: fix link in Legacy ESLint Setup page

### DIFF
--- a/docs/getting-started/Legacy_ESLint_Setup.mdx
+++ b/docs/getting-started/Legacy_ESLint_Setup.mdx
@@ -116,7 +116,7 @@ You can read more about these in our [shared configurations docs](../users/Share
 ### Typed Linting
 
 We also provide a plethora of powerful rules that utilize the power of TypeScript's type information.
-[Visit the next page for a typed rules setup guide](../troubleshooting/typed-linting/index.mdx).
+[Visit the next page for a typed rules setup guide](./Typed_Linting.mdx).
 
 ### Documentation Resources
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

In the [Legacy ESLint Setup](https://typescript-eslint.io/getting-started/legacy-eslint-setup) page, the following link...

> We also provide a plethora of powerful rules that utilize the power of TypeScript's type information. [Visit the next page for a typed rules setup guide](https://typescript-eslint.io/troubleshooting/typed-linting).

...points to the [Typed Linting page under Troubleshooting](https://typescript-eslint.io/troubleshooting/typed-linting). However, it seems that the intent was to link to the [Linting with Type Information](https://typescript-eslint.io/getting-started/typed-linting) page, which describes how to set up typed linting.

Compare the corresponding passage in the [Quickstart](https://typescript-eslint.io/getting-started/) which correctly links to "Linting with Type Information":

> We also provide a plethora of powerful rules that utilize the power of TypeScript's type information. [Visit the next page for a typed rules setup guide](https://typescript-eslint.io/getting-started/typed-linting).