### PR TITLE
docs: add @typescript-eslint/no-unnecessary-type-parameters to strict-type-checked diff

### DIFF
--- a/packages/website/blog/2024-07-31-announcing-typescript-eslint-v8.md
+++ b/packages/website/blog/2024-07-31-announcing-typescript-eslint-v8.md
@@ -346,6 +346,7 @@ If your ESLint configuration contains many `rules` configurations, we suggest th
    '@typescript-eslint/no-unnecessary-type-arguments': '...',
    '@typescript-eslint/no-unnecessary-type-assertion': '...',
    '@typescript-eslint/no-unnecessary-type-constraint': '...',
++  '@typescript-eslint/no-unnecessary-type-parameters': '...',
    '@typescript-eslint/no-unsafe-argument': '...',
    '@typescript-eslint/no-unsafe-assignment': '...',
    '@typescript-eslint/no-unsafe-call': '...',


### PR DESCRIPTION
docs: add @typescript-eslint/no-unnecessary-type-parameters to strict-type-checked diff

## PR Checklist

- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
The `@typescript-eslint/no-unnecessary-type-parameters` was added to `strict-type-checked` in v8 (related pr 
https://github.com/typescript-eslint/typescript-eslint/pull/9662), but was not described in the release docs.

The description was added because without it, it would be difficult to find out the reason when the version is upgraded.