### PR TITLE
chore: fix `prefer-node-protocol` lint failure on main

### DIFF
--- a/packages/type-utils/tests/containsAllTypesByName.test.ts
+++ b/packages/type-utils/tests/containsAllTypesByName.test.ts
@@ -1,6 +1,7 @@
+import path from 'node:path';
+
 import { parseForESLint } from '@typescript-eslint/parser';
 import type { TSESTree } from '@typescript-eslint/typescript-estree';
-import path from 'path';
 import type * as ts from 'typescript';
 
 import { containsAllTypesByName } from '../src';


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

#9711 added a lint failure on main because of my lint rule being enabled (`prefer-node-protocol`)
