### PR TITLE
docs: add note about typescript-eslint as peer dependency

### DIFF
--- a/docs/developers/ESLint_Plugins.mdx
+++ b/docs/developers/ESLint_Plugins.mdx
@@ -42,6 +42,10 @@ Include the following to enforce the version range allowed without making users'
 
 Those are all packages consumers are expected to be using already.
 
+The parser for TypeScript files generally requires `typescript-eslint`.
+However, you do not need to add the parser, and therefore `typescript-eslint`, as a peer dependency.
+Our setup guide ensures that the parser is automatically registered when configuring ESLint.
+
 ## `RuleCreator` Usage
 
 We recommend including at least the following three properties in your plugin's [`RuleCreator` extra rule docs types](./Custom_Rules.mdx#extra-rule-docs-types):

--- a/docs/developers/ESLint_Plugins.mdx
+++ b/docs/developers/ESLint_Plugins.mdx
@@ -42,8 +42,7 @@ Include the following to enforce the version range allowed without making users'
 
 Those are all packages consumers are expected to be using already.
 
-The parser for TypeScript files generally requires `typescript-eslint`.
-However, you do not need to add the parser, and therefore `typescript-eslint`, as a peer dependency.
+You don't need to declare any dependencies on `typescript-eslint` or `@typescript-eslint/eslint-plugin`.
 Our setup guide ensures that the parser is automatically registered when configuring ESLint.
 
 ## `RuleCreator` Usage


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9814
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Explain, that there is not need to define the parser and therefore include `typescript-eslint` as peer dependency.