### PR TITLE
docs: fix setup example for node:test in RuleTester

### DIFF
--- a/docs/packages/Rule_Tester.mdx
+++ b/docs/packages/Rule_Tester.mdx
@@ -250,7 +250,7 @@ Consider setting up `RuleTester`'s static properties in a preloaded module using
 import * as test from 'node:test';
 import { RuleTester } from '@typescript-eslint/rule-tester';
 
-RuleTester.afterAll = test.afterAll;
+RuleTester.afterAll = test.after;
 RuleTester.describe = test.describe;
 RuleTester.it = test.it;
 RuleTester.itOnly = test.it.only;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9822 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

node test-runner doesn’t have `afterAll` function, so fixed to `after`. ([Node.js Test runner doc](https://nodejs.org/api/test.html#afterfn-options))