### PR TITLE
chore: enable unicorn/no-lonely-if

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -322,6 +322,7 @@ export default tseslint.config(
       //
 
       'jsdoc/informative-docs': 'error',
+      'unicorn/no-lonely-if': 'error',
       'unicorn/no-typeof-undefined': 'error',
       'unicorn/no-useless-spread': 'error',
       'unicorn/prefer-node-protocol': 'error',

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -221,14 +221,16 @@ export default createRule<Options, MessageIds>({
                * export = Type;
                */
               if (
-                ref.identifier.parent.type === AST_NODE_TYPES.ExportSpecifier ||
-                ref.identifier.parent.type ===
-                  AST_NODE_TYPES.ExportDefaultDeclaration ||
-                ref.identifier.parent.type === AST_NODE_TYPES.TSExportAssignment
+                (ref.identifier.parent.type ===
+                  AST_NODE_TYPES.ExportSpecifier ||
+                  ref.identifier.parent.type ===
+                    AST_NODE_TYPES.ExportDefaultDeclaration ||
+                  ref.identifier.parent.type ===
+                    AST_NODE_TYPES.TSExportAssignment) &&
+                ref.isValueReference &&
+                ref.isTypeReference
               ) {
-                if (ref.isValueReference && ref.isTypeReference) {
-                  return node.importKind === 'type';
-                }
+                return node.importKind === 'type';
               }
               if (ref.isValueReference) {
                 let parent = ref.identifier.parent as TSESTree.Node | undefined;
@@ -556,10 +558,8 @@ export default createRule<Options, MessageIds>({
         NullThrowsReasons.MissingToken('token', 'last specifier'),
       );
       textRange[1] = after.range[0];
-      if (isFirst || isLast) {
-        if (isCommaToken(after)) {
-          removeRange[1] = after.range[1];
-        }
+      if ((isFirst || isLast) && isCommaToken(after)) {
+        removeRange[1] = after.range[1];
       }
 
       return {

--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -257,10 +257,11 @@ export default createRule<Options, MessageId>({
      */
     function findInvalidAncestor(node: TSESTree.Node): InvalidAncestor | null {
       const parent = nullThrows(node.parent, NullThrowsReasons.MissingParent);
-      if (parent.type === AST_NODE_TYPES.SequenceExpression) {
-        if (node !== parent.expressions[parent.expressions.length - 1]) {
-          return null;
-        }
+      if (
+        parent.type === AST_NODE_TYPES.SequenceExpression &&
+        node !== parent.expressions[parent.expressions.length - 1]
+      ) {
+        return null;
       }
 
       if (parent.type === AST_NODE_TYPES.ExpressionStatement) {
@@ -269,38 +270,41 @@ export default createRule<Options, MessageId>({
         return null;
       }
 
-      if (parent.type === AST_NODE_TYPES.LogicalExpression) {
-        if (parent.right === node) {
-          // e.g. `x && console.log(x)`
-          // this is valid only if the next ancestor is valid
-          return findInvalidAncestor(parent);
-        }
+      if (
+        parent.type === AST_NODE_TYPES.LogicalExpression &&
+        parent.right === node
+      ) {
+        // e.g. `x && console.log(x)`
+        // this is valid only if the next ancestor is valid
+        return findInvalidAncestor(parent);
       }
 
-      if (parent.type === AST_NODE_TYPES.ConditionalExpression) {
-        if (parent.consequent === node || parent.alternate === node) {
-          // e.g. `cond ? console.log(true) : console.log(false)`
-          // this is valid only if the next ancestor is valid
-          return findInvalidAncestor(parent);
-        }
+      if (
+        parent.type === AST_NODE_TYPES.ConditionalExpression &&
+        (parent.consequent === node || parent.alternate === node)
+      ) {
+        // e.g. `cond ? console.log(true) : console.log(false)`
+        // this is valid only if the next ancestor is valid
+        return findInvalidAncestor(parent);
       }
 
-      if (parent.type === AST_NODE_TYPES.ArrowFunctionExpression) {
+      if (
+        parent.type === AST_NODE_TYPES.ArrowFunctionExpression &&
         // e.g. `() => console.log("foo")`
         // this is valid with an appropriate option
-        if (options.ignoreArrowShorthand) {
-          return null;
-        }
+        options.ignoreArrowShorthand
+      ) {
+        return null;
       }
 
-      if (parent.type === AST_NODE_TYPES.UnaryExpression) {
-        if (parent.operator === 'void') {
-          // e.g. `void console.log("foo")`
-          // this is valid with an appropriate option
-          if (options.ignoreVoidOperator) {
-            return null;
-          }
-        }
+      if (
+        parent.type === AST_NODE_TYPES.UnaryExpression &&
+        parent.operator === 'void' &&
+        // e.g. `void console.log("foo")`
+        // this is valid with an appropriate option
+        options.ignoreVoidOperator
+      ) {
+        return null;
       }
 
       if (parent.type === AST_NODE_TYPES.ChainExpression) {

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -58,56 +58,57 @@ export default createRule<Options, MessageIds>({
             node: node.id,
             messageId: 'noEmpty',
           });
-        } else if (extend.length === 1) {
+        } else if (
+          extend.length === 1 &&
           // interface extends exactly 1 interface --> Report depending on rule setting
-          if (!allowSingleExtends) {
-            const fix = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix => {
-              let typeParam = '';
-              if (node.typeParameters) {
-                typeParam = context.sourceCode.getText(node.typeParameters);
-              }
-              return fixer.replaceText(
-                node,
-                `type ${context.sourceCode.getText(
-                  node.id,
-                )}${typeParam} = ${context.sourceCode.getText(extend[0])}`,
-              );
-            };
-            const scope = context.sourceCode.getScope(node);
+          !allowSingleExtends
+        ) {
+          const fix = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix => {
+            let typeParam = '';
+            if (node.typeParameters) {
+              typeParam = context.sourceCode.getText(node.typeParameters);
+            }
+            return fixer.replaceText(
+              node,
+              `type ${context.sourceCode.getText(
+                node.id,
+              )}${typeParam} = ${context.sourceCode.getText(extend[0])}`,
+            );
+          };
+          const scope = context.sourceCode.getScope(node);
 
-            const mergedWithClassDeclaration = scope.set
-              .get(node.id.name)
-              ?.defs.some(
-                def => def.node.type === AST_NODE_TYPES.ClassDeclaration,
-              );
-
-            const isInAmbientDeclaration = !!(
-              isDefinitionFile(context.filename) &&
-              scope.type === ScopeType.tsModule &&
-              scope.block.declare
+          const mergedWithClassDeclaration = scope.set
+            .get(node.id.name)
+            ?.defs.some(
+              def => def.node.type === AST_NODE_TYPES.ClassDeclaration,
             );
 
-            const useAutoFix = !(
-              isInAmbientDeclaration || mergedWithClassDeclaration
-            );
+          const isInAmbientDeclaration = !!(
+            isDefinitionFile(context.filename) &&
+            scope.type === ScopeType.tsModule &&
+            scope.block.declare
+          );
 
-            context.report({
-              node: node.id,
-              messageId: 'noEmptyWithSuper',
-              ...(useAutoFix
-                ? { fix }
-                : !mergedWithClassDeclaration
-                  ? {
-                      suggest: [
-                        {
-                          messageId: 'noEmptyWithSuper',
-                          fix,
-                        },
-                      ],
-                    }
-                  : null),
-            });
-          }
+          const useAutoFix = !(
+            isInAmbientDeclaration || mergedWithClassDeclaration
+          );
+
+          context.report({
+            node: node.id,
+            messageId: 'noEmptyWithSuper',
+            ...(useAutoFix
+              ? { fix }
+              : !mergedWithClassDeclaration
+                ? {
+                    suggest: [
+                      {
+                        messageId: 'noEmptyWithSuper',
+                        fix,
+                      },
+                    ],
+                  }
+                : null),
+          });
         }
       },
     };

--- a/packages/eslint-plugin/src/rules/no-magic-numbers.ts
+++ b/packages/eslint-plugin/src/rules/no-magic-numbers.ts
@@ -162,11 +162,10 @@ function normalizeLiteralValue(
 ): bigint | number {
   if (
     node.parent.type === AST_NODE_TYPES.UnaryExpression &&
-    ['-', '+'].includes(node.parent.operator)
+    ['-', '+'].includes(node.parent.operator) &&
+    node.parent.operator === '-'
   ) {
-    if (node.parent.operator === '-') {
-      return -value;
-    }
+    return -value;
   }
 
   return value;

--- a/packages/eslint-plugin/src/rules/no-misused-new.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-new.ts
@@ -98,13 +98,14 @@ export default createRule({
       "ClassBody > MethodDefinition[key.name='new']"(
         node: TSESTree.MethodDefinition,
       ): void {
-        if (node.value.type === AST_NODE_TYPES.TSEmptyBodyFunctionExpression) {
-          if (isMatchingParentType(node.parent.parent, node.value.returnType)) {
-            context.report({
-              node,
-              messageId: 'errorMessageClass',
-            });
-          }
+        if (
+          node.value.type === AST_NODE_TYPES.TSEmptyBodyFunctionExpression &&
+          isMatchingParentType(node.parent.parent, node.value.returnType)
+        ) {
+          context.report({
+            node,
+            messageId: 'errorMessageClass',
+          });
         }
       },
     };

--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -681,12 +681,13 @@ function checkThenableOrVoidArgument(
 ): void {
   if (isThenableReturningFunctionType(checker, node.expression, type)) {
     thenableReturnIndices.add(index);
-  } else if (isVoidReturningFunctionType(checker, node.expression, type)) {
+  } else if (
+    isVoidReturningFunctionType(checker, node.expression, type) &&
     // If a certain argument accepts both thenable and void returns,
     // a promise-returning function is valid
-    if (!thenableReturnIndices.has(index)) {
-      voidReturnIndices.add(index);
-    }
+    !thenableReturnIndices.has(index)
+  ) {
+    voidReturnIndices.add(index);
   }
 }
 

--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -214,14 +214,13 @@ export default createRule<Options, MessageIds>({
       if (type.node.type === AST_NODE_TYPES.TSTupleType) {
         return true;
       }
-      if (type.node.type === AST_NODE_TYPES.TSTypeOperator) {
-        if (
-          ['keyof', 'readonly'].includes(type.node.operator) &&
-          type.node.typeAnnotation &&
-          type.node.typeAnnotation.type === AST_NODE_TYPES.TSTupleType
-        ) {
-          return true;
-        }
+      if (
+        type.node.type === AST_NODE_TYPES.TSTypeOperator &&
+        ['keyof', 'readonly'].includes(type.node.operator) &&
+        type.node.typeAnnotation &&
+        type.node.typeAnnotation.type === AST_NODE_TYPES.TSTupleType
+      ) {
+        return true;
       }
       return false;
     };

--- a/packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts
@@ -164,15 +164,14 @@ export default createRule({
         }
 
         const functionNode = findParentFunction(node);
-        if (functionNode) {
-          if (
-            !(
-              isArrowIIFE(functionNode) &&
-              findParentPropertyDefinition(node)?.value === functionNode.parent
-            )
-          ) {
-            return;
-          }
+        if (
+          functionNode &&
+          !(
+            isArrowIIFE(functionNode) &&
+            findParentPropertyDefinition(node)?.value === functionNode.parent
+          )
+        ) {
+          return;
         }
 
         const { assignedBeforeConstructor } = nullThrows(

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
@@ -68,7 +68,8 @@ function isValidFalseBooleanCheckType(
   const type = parserServices.getTypeAtLocation(node);
   const types = unionTypeParts(type);
 
-  if (disallowFalseyLiteral) {
+  if (
+    disallowFalseyLiteral &&
     /*
     ```
     declare const x: false | {a: string};
@@ -79,15 +80,14 @@ function isValidFalseBooleanCheckType(
     We don't want to consider these two cases because the boolean expression
     narrows out the non-nullish falsy cases - so converting the chain to `x?.a`
     would introduce a build error
-    */
-    if (
-      types.some(t => isBooleanLiteralType(t) && t.intrinsicName === 'false') ||
+    */ (types.some(
+      t => isBooleanLiteralType(t) && t.intrinsicName === 'false',
+    ) ||
       types.some(t => isStringLiteralType(t) && t.value === '') ||
       types.some(t => isNumberLiteralType(t) && t.value === 0) ||
-      types.some(t => isBigIntLiteralType(t) && t.value.base10Value === '0')
-    ) {
-      return false;
-    }
+      types.some(t => isBigIntLiteralType(t) && t.value.base10Value === '0'))
+  ) {
+    return false;
   }
 
   let allowedFlags = NULLISH_FLAGS | ts.TypeFlags.Object;

--- a/packages/eslint-plugin/src/util/collectUnusedVariables.ts
+++ b/packages/eslint-plugin/src/util/collectUnusedVariables.ts
@@ -309,12 +309,12 @@ class UnusedVarsVisitor extends Visitor {
     const scope = this.getScope(node);
     if (
       scope.type === TSESLint.Scope.ScopeType.function &&
-      node.name === 'this'
-    ) {
+      node.name === 'this' &&
       // this parameters should always be considered used as they're pseudo-parameters
-      if ('params' in scope.block && scope.block.params.includes(node)) {
-        this.markVariableAsUsed(node);
-      }
+      'params' in scope.block &&
+      scope.block.params.includes(node)
+    ) {
+      this.markVariableAsUsed(node);
     }
   }
 

--- a/packages/eslint-plugin/src/util/getWrappingFixer.ts
+++ b/packages/eslint-plugin/src/util/getWrappingFixer.ts
@@ -58,12 +58,13 @@ export function getWrappingFixer(
     let code = wrap(...innerCodes);
 
     // check the outer expression's precedence
-    if (isWeakPrecedenceParent(node)) {
+    if (
+      isWeakPrecedenceParent(node) &&
       // we wrapped the node in some expression which very likely has a different precedence than original wrapped node
       // let's wrap the whole expression in parens just in case
-      if (!ASTUtils.isParenthesized(node, sourceCode)) {
-        code = `(${code})`;
-      }
+      !ASTUtils.isParenthesized(node, sourceCode)
+    ) {
+      code = `(${code})`;
     }
 
     // check if we need to insert semicolon

--- a/packages/rule-tester/src/utils/serialization.ts
+++ b/packages/rule-tester/src/utils/serialization.ts
@@ -29,10 +29,11 @@ export function isSerializable(val: unknown): boolean {
         if (!isSerializablePrimitiveOrPlainObject(valAsObj[property])) {
           return false;
         }
-        if (typeof valAsObj[property] === 'object') {
-          if (!isSerializable(valAsObj[property])) {
-            return false;
-          }
+        if (
+          typeof valAsObj[property] === 'object' &&
+          !isSerializable(valAsObj[property])
+        ) {
+          return false;
         }
       }
     }

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -228,10 +228,12 @@ export class Converter {
     node: ts.Node,
     result: TSESTree.Node | null,
   ): void {
-    if (result && this.options.shouldPreserveNodeMaps) {
-      if (!this.tsNodeToESTreeNodeMap.has(node)) {
-        this.tsNodeToESTreeNodeMap.set(node, result);
-      }
+    if (
+      result &&
+      this.options.shouldPreserveNodeMaps &&
+      !this.tsNodeToESTreeNodeMap.has(node)
+    ) {
+      this.tsNodeToESTreeNodeMap.set(node, result);
     }
   }
 

--- a/packages/website/src/components/ast/selectedRange.ts
+++ b/packages/website/src/components/ast/selectedRange.ts
@@ -53,13 +53,15 @@ function findInObject(
       for (let index = 0; index < child.length; ++index) {
         const arrayChild: unknown = child[index];
         // typescript array like elements have other iterable items
-        if (typeof index === 'number' && isRecord(arrayChild)) {
-          if (isInRange(cursorPosition, arrayChild)) {
-            return {
-              key: [name, String(index)],
-              value: arrayChild,
-            };
-          }
+        if (
+          typeof index === 'number' &&
+          isRecord(arrayChild) &&
+          isInRange(cursorPosition, arrayChild)
+        ) {
+          return {
+            key: [name, String(index)],
+            value: arrayChild,
+          };
         }
       }
     }

--- a/packages/website/src/components/ast/tsUtils.ts
+++ b/packages/website/src/components/ast/tsUtils.ts
@@ -23,10 +23,8 @@ export function extractEnum(
   const result: Record<number, string> = {};
   const keys = Object.entries(obj);
   for (const [name, value] of keys) {
-    if (typeof value === 'number') {
-      if (!(value in result)) {
-        result[value] = name;
-      }
+    if (typeof value === 'number' && !(value in result)) {
+      result[value] = name;
     }
   }
   return result;

--- a/packages/website/tools/typedoc-plugin-no-inherit-fork.mjs
+++ b/packages/website/tools/typedoc-plugin-no-inherit-fork.mjs
@@ -175,10 +175,8 @@ class NoInheritPlugin {
       return false;
     };
 
-    if (parent.extendedTypes) {
-      if (parent.extendedTypes.some(checkExtended)) {
-        return true;
-      }
+    if (parent.extendedTypes?.some(checkExtended)) {
+      return true;
     }
 
     return false;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes part of #9623 
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Since we already enable `no-lonely-if` in #9547 (which handles `else { if (a) }` => `else if (a) {}`, this is the next logic step to enable `unicorn/no-lonely-if` ([docs](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-lonely-if.md)), which handles `if (a) { if (b) {} }` => `if (a && b) {}`.

Tests failed due to CI flake.
