### PR TITLE
fix(utils): add missing `TSSatisfiesExpression` in `RuleListenerBaseSelectors`

### DIFF
--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -539,6 +539,7 @@ interface RuleListenerBaseSelectors {
   TSQualifiedName?: RuleFunction<TSESTree.TSQualifiedName>;
   TSReadonlyKeyword?: RuleFunction<TSESTree.TSReadonlyKeyword>;
   TSRestType?: RuleFunction<TSESTree.TSRestType>;
+  TSSatisfiesExpression?: RuleFunction<TSESTree.TSSatisfiesExpression>;
   TSStaticKeyword?: RuleFunction<TSESTree.TSStaticKeyword>;
   TSStringKeyword?: RuleFunction<TSESTree.TSStringKeyword>;
   TSSymbolKeyword?: RuleFunction<TSESTree.TSSymbolKeyword>;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9824 
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
