### PR TITLE
chore: remove lib: esnext

### DIFF
--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -6,7 +6,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "jsx": "react",
-    "lib": ["DOM", "ESNext"],
+    "lib": ["DOM", "ES2023"],
     "noEmit": true,
     "noImplicitAny": false,
     "resolveJsonModule": true,

--- a/tools/scripts/generate-sponsors.mts
+++ b/tools/scripts/generate-sponsors.mts
@@ -64,11 +64,13 @@ const { members } = (
   ).json()) as { data: { collective: { members: { nodes: MemberNodes } } } }
 ).data.collective;
 
-const sponsors = (
-  Object.entries(
-    Object.groupBy(members.nodes, ({ account }) => account.name || account.id),
-    // When using `Object.entries` to iterate the result of `Object.groupBy`, we do not get any `undefined`s
-  ) as [string, MemberNodes][]
+const sponsors = Object.entries(
+  // TODO: use Object.groupBy in Node 22
+  members.nodes.reduce<Record<string, MemberNodes>>((membersById, member) => {
+    const { account } = member;
+    (membersById[account.name || account.id] ??= []).push(member);
+    return membersById;
+  }, {}),
 )
   .map(([id, members]) => {
     const [{ account }] = members;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
     "types": ["@types/node"],
     "noEmit": true,
     "allowJs": true,
-    "allowImportingTsExtensions": true,
-    "lib": ["ESNext"]
+    "allowImportingTsExtensions": true
   },
   "extends": "./tsconfig.base.json",
   "include": [


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/pull/9757#discussion_r1723222246
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Remove `lib: ES2023` from `tsconfig`s
