### PR TITLE
chore: enable eslint-plugin-perfectionist on visitor-keys package

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -578,7 +578,7 @@ export default tseslint.config(
   },
   {
     extends: [perfectionistPlugin.configs['recommended-alphabetical']],
-    files: ['packages/utils/src/**/*.ts'],
+    files: ['packages/utils/src/**/*.ts', 'packages/visitor-keys/src/**/*.ts'],
     rules: {
       'perfectionist/sort-classes': [
         'error',

--- a/packages/visitor-keys/src/get-keys.ts
+++ b/packages/visitor-keys/src/get-keys.ts
@@ -1,4 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/types';
+
 import { getKeys as getKeysOriginal } from 'eslint-visitor-keys';
 
 const getKeys: (node: TSESTree.Node) => readonly string[] = getKeysOriginal;

--- a/packages/visitor-keys/src/visitor-keys.ts
+++ b/packages/visitor-keys/src/visitor-keys.ts
@@ -1,4 +1,5 @@
 import type { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/types';
+
 import * as eslintVisitorKeys from 'eslint-visitor-keys';
 
 type VisitorKeys = Record<string, readonly string[] | undefined>;
@@ -140,10 +141,8 @@ const SharedVisitorKeys = (() => {
   ] as const;
 
   return {
+    AbstractPropertyDefinition: ['decorators', 'key', 'typeAnnotation'],
     AnonymousFunction,
-    Function: ['id', ...AnonymousFunction],
-    FunctionType,
-
     ClassDeclaration: [
       'decorators',
       'id',
@@ -153,8 +152,8 @@ const SharedVisitorKeys = (() => {
       'implements',
       'body',
     ],
-
-    AbstractPropertyDefinition: ['decorators', 'key', 'typeAnnotation'],
+    Function: ['id', ...AnonymousFunction],
+    FunctionType,
     PropertyDefinition: [...AbstractPropertyDefinition, 'value'],
     TypeAssertion: ['expression', 'typeAnnotation'],
   } as const;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: continues #8479
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Enables sorting on `packages/visitor-keys`.

💖