### PR TITLE
feat(typescript-estree): reload project service once when file config isn't found

### DIFF
--- a/packages/typescript-estree/src/create-program/createProjectService.ts
+++ b/packages/typescript-estree/src/create-program/createProjectService.ts
@@ -32,6 +32,7 @@ export type TypeScriptProjectService = ts.server.ProjectService;
 
 export interface ProjectServiceSettings {
   allowDefaultProject: string[] | undefined;
+  lastReloadTimestamp: number;
   maximumDefaultProjectFileMatchCount: number;
   service: TypeScriptProjectService;
 }
@@ -148,6 +149,7 @@ export function createProjectService(
 
   return {
     allowDefaultProject: options.allowDefaultProject,
+    lastReloadTimestamp: performance.now(),
     maximumDefaultProjectFileMatchCount:
       options.maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING ??
       DEFAULT_PROJECT_MATCHED_FILES_THRESHOLD,

--- a/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
@@ -33,6 +33,7 @@ const currentDirectory = '/repos/repo';
 function createMockProjectService() {
   const openClientFile = jest.fn();
   const setHostConfiguration = jest.fn();
+  const reloadProjects = jest.fn();
   const service = {
     getDefaultProjectForFile: () => ({
       getLanguageService: () => ({
@@ -44,12 +45,14 @@ function createMockProjectService() {
       getCurrentDirectory: () => currentDirectory,
     },
     openClientFile,
+    reloadProjects,
     setHostConfiguration,
   };
 
   return {
     service: service as typeof service & TypeScriptProjectService,
     openClientFile,
+    reloadProjects,
   };
 }
 
@@ -58,6 +61,7 @@ const mockFileName = 'camelCaseFile.ts';
 const mockParseSettings = {
   filePath: `path/PascalCaseDirectory/${mockFileName}`,
   extraFileExtensions: [] as readonly string[],
+  singleRun: false,
   tsconfigRootDir: currentDirectory,
 } as ParseSettings;
 
@@ -67,6 +71,7 @@ const createProjectServiceSettings = <
   settings: T,
 ) => ({
   maximumDefaultProjectFileMatchCount: 8,
+  lastReloadTimestamp: 0,
   ...settings,
 });
 
@@ -126,11 +131,11 @@ describe('useProgramFromProjectService', () => {
 
     expect(() =>
       useProgramFromProjectService(
-        {
+        createProjectServiceSettings({
           allowDefaultProject: [mockParseSettings.filePath],
           maximumDefaultProjectFileMatchCount: 8,
           service,
-        },
+        }),
         mockParseSettings,
         true,
         new Set(),
@@ -140,7 +145,7 @@ describe('useProgramFromProjectService', () => {
     );
   });
 
-  it('throws an error when hasFullTypeInformation is enabled and the file is neither in the project service nor allowDefaultProject', () => {
+  it('throws an error without reloading projects when hasFullTypeInformation is enabled, the file is neither in the project service nor allowDefaultProject, and the last reload was not a long time ago', () => {
     const { service } = createMockProjectService();
 
     service.openClientFile.mockReturnValueOnce({});
@@ -149,6 +154,7 @@ describe('useProgramFromProjectService', () => {
       useProgramFromProjectService(
         createProjectServiceSettings({
           allowDefaultProject: [],
+          lastReloadTimestamp: Infinity,
           service,
         }),
         mockParseSettings,
@@ -158,6 +164,55 @@ describe('useProgramFromProjectService', () => {
     ).toThrow(
       `${mockParseSettings.filePath} was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject.`,
     );
+    expect(service.reloadProjects).not.toHaveBeenCalled();
+  });
+
+  it('throws an error after reloading projects when hasFullTypeInformation is enabled, the file is neither in the project service nor allowDefaultProject, and the last reload was recent', () => {
+    const { service } = createMockProjectService();
+
+    service.openClientFile.mockReturnValueOnce({}).mockReturnValueOnce({});
+
+    expect(() =>
+      useProgramFromProjectService(
+        createProjectServiceSettings({
+          allowDefaultProject: [],
+          lastReloadTimestamp: 0,
+          service,
+        }),
+        mockParseSettings,
+        true,
+        new Set(),
+      ),
+    ).toThrow(
+      `${mockParseSettings.filePath} was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject.`,
+    );
+    expect(service.reloadProjects).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a created program after reloading projects when hasFullTypeInformation is enabled, the file is only in the project service after reload, and the last reload was recent', () => {
+    const { service } = createMockProjectService();
+    const program = { getSourceFile: jest.fn() };
+
+    service.openClientFile.mockReturnValueOnce({}).mockReturnValueOnce({
+      configFileName: 'tsconfig.json',
+    });
+    mockCreateProjectProgram.mockReturnValueOnce(program);
+
+    mockGetProgram.mockReturnValueOnce(program);
+
+    const actual = useProgramFromProjectService(
+      createProjectServiceSettings({
+        allowDefaultProject: [],
+        lastReloadTimestamp: 0,
+        service,
+      }),
+      mockParseSettings,
+      true,
+      new Set(),
+    );
+
+    expect(actual).toBe(program);
+    expect(service.reloadProjects).toHaveBeenCalledTimes(1);
   });
 
   it('throws an error when more than the maximum allowed file count is matched to the default project', () => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9772
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

If a file isn't found by `parserOptions.projectService`, then this will attempt to reload the project service. Doing so refreshes how it sees TSConfigs on disk. This should fix most -but not all- cases mentioned in #9731 -> https://github.com/microsoft/vscode-eslint/issues/1911 of a new file being created & ESLint not knowing to update parser information.

This includes several limits on it to avoid slowing down unrelated situations:

* It won't happen in single-run mode at all (i.e. CLI calls without `--fix`)
* It's throttled to 250ms so it shouldn't slow down editors if multiple files have this issue

💖 