### PR TITLE
docs: formalized '1 approval' and 'team assigned' labels

### DIFF
--- a/.github/workflows/pr-review-requested.yml
+++ b/.github/workflows/pr-review-requested.yml
@@ -4,7 +4,9 @@ jobs:
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1
         with:
-          labels: 'awaiting response'
+          labels: |
+            1 approval
+            awaiting response
       - if: failure()
         run: |
           echo "Don't worry if the previous step failed."

--- a/docs/maintenance/Issues.mdx
+++ b/docs/maintenance/Issues.mdx
@@ -60,7 +60,9 @@ Most issues go through the following review flow when created or updated:
      - Close the issue as _not planned_
    - If the issue requires further discussion or community engagement evaluation:
      - Add the `evaluating community engagement` label and remove the `triage` label
-2. If the report is valid, add the `accepting prs` label and remove the `triage` label
+2. If the report is valid:
+   - Remove the `triage` label
+   - Add the `team assigned` label if you think only a member of the team should tackle it, or `accepting prs` if anybody could
 3. If you know the rough steps for a fix, consider writing a comment with links to codebase to help someone put together a fix
 4. If you think that the fix is relatively straightforward, consider also adding the `good first issue` label
 
@@ -97,7 +99,7 @@ However, there are cases when maintainers can't confidently choose the most reas
 
 3-6 months after the issue is labeled `evaluating community engagement`, the engagement of community is evaluated:
 
-- If the community was active and common ground was found, the issue is labeled as `accepting prs`
+- If the community was active and common ground was found, the issue is labeled as `accepting prs` or `team assigned`
 - Otherwise, the issue is closed as _not planned_ with the `wontfix` label
 
 For requests that can be implemented outside of typescript-eslint, be sure to mention any relevant APIs such as [Custom Rules](../developers/Custom_Rules.mdx) that can be used.

--- a/docs/maintenance/Pull_Requests.mdx
+++ b/docs/maintenance/Pull_Requests.mdx
@@ -121,11 +121,6 @@ Then:
 
 We try to wait a week on PRs to give reviewers who aren't active every day a chance to get to it.
 
-:::tip
-If a PR has had `1 approval` and no change requests for a week, go ahead and merge it.
-We try to do a final pass over [`label:"1 approval" -review:changes-requested` PRs](https://github.com/typescript-eslint/typescript-eslint/pulls?q=is%3Apr+is%3Aopen+label%3A%221+approval%22+-review%3Achanges-requested) the 1-2 days before each [weekly Monday release](../users/Releases.mdx#latest).
-:::
-
 ### Other States
 
 #### External Blockers

--- a/docs/maintenance/Pull_Requests.mdx
+++ b/docs/maintenance/Pull_Requests.mdx
@@ -110,7 +110,9 @@ Don't apologize if the missed information was only made clear because of request
 
 ### Approvals
 
-Upon completing your review, if the build is passing and you have no blockers, approve it on GitHub.
+If the PR addresses a time critical task, such as a security fix or `main` branch build break, go ahead and squash merge it.
+
+Otherwise, upon completing your review, if the build is passing and you have no blockers, approve it on GitHub.
 Then:
 
 - If there isn't a `1 approval` label or existing approval, add the `1 approval` label

--- a/docs/maintenance/Pull_Requests.mdx
+++ b/docs/maintenance/Pull_Requests.mdx
@@ -117,7 +117,7 @@ Then:
 
 - If there isn't a `1 approval` label or existing approval, add the `1 approval` label
 - If there's already `1 approval` and/or it's been a week since the last request for changes, go ahead and squash merge
-  - For straightforward PRs that don't impact users, you can wait 3 business days instead
+  - For straightforward PRs that don't impact users, you can wait 3 days instead
 
 We try to wait a week on PRs to give reviewers who aren't active every day a chance to get to it.
 

--- a/docs/maintenance/Pull_Requests.mdx
+++ b/docs/maintenance/Pull_Requests.mdx
@@ -117,7 +117,7 @@ Then:
 - If there's already `1 approval` and/or it's been a week since the last request for changes, go ahead and squash merge
   - For straightforward PRs that don't impact users, you can wait 3 business days instead
 
-We try to wait a week on PRs to give part-time reviewers a chance to get to it.
+We try to wait a week on PRs to give reviewers who aren't active every day a chance to get to it.
 
 :::tip
 If a PR has had `1 approval` and no change requests for a week, go ahead and merge it.

--- a/docs/maintenance/Pull_Requests.mdx
+++ b/docs/maintenance/Pull_Requests.mdx
@@ -37,7 +37,7 @@ Open pull requests ideally switch between two states:
 - Ready for review: either newly created or after [review is re-requested](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review)
 - Waiting for author activity: either by virtue of [being a draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests) or having the [`awaiting response` label](https://github.com/typescript-eslint/typescript-eslint/pulls?q=is%3Apr+is%3Aopen+label%3A%22awaiting+response%22)
 
-Add the `awaiting response` label to a PR whenever you post a review.
+Add the `awaiting response` label to a PR and remove `1 approval` if it exists whenever you post a request for changes.
 It will be automatically removed if the author re-requests review.
 
 ### Be Kind
@@ -65,9 +65,6 @@ If there's no backing issue:
 
 - If the PR is a straightforward docs or tooling fix that doesn't impact users, it's ok to review it as-is
 - Otherwise, add the `please fill out the template` label and post a comment like the _Needs Issue_ template
-
-Upon completing your review, if the build is passing and you feel comfortable merging it in, go ahead and squash merge.
-Otherwise, add the `1 approval` label.
 
 #### Common Things to Look For
 
@@ -110,6 +107,22 @@ For preliminary reviews, be clear with what scale you're reviewing at: _"Reviewi
 
 For repeat reviews, be clear when it's something you missed earlier and/or there's new information.
 Don't apologize if the missed information was only made clear because of requested changes - this is part of the review process!
+
+### Approvals
+
+Upon completing your review, if the build is passing and you have no blockers, approve it on GitHub.
+Then:
+
+- If there isn't a `1 approval` label or existing approval, add the `1 approval` label
+- If there's already `1 approval` and/or it's been a week since the last request for changes, go ahead and squash merge
+  - For straightforward PRs that don't impact users, you can wait 3 business days instead
+
+We try to wait a week on PRs to give part-time reviewers a chance to get to it.
+
+:::tip
+If a PR has had `1 approval` and no change requests for a week, go ahead and merge it.
+We try to do a final pass over [`label:"1 approval" -review:changes-requested` PRs](https://github.com/typescript-eslint/typescript-eslint/pulls?q=is%3Apr+is%3Aopen+label%3A%221+approval%22+-review%3Achanges-requested) the 1-2 days before each [weekly Monday release](../users/Releases.mdx#latest).
+:::
 
 ### Other States
 

--- a/docs/maintenance/Pull_Requests.mdx
+++ b/docs/maintenance/Pull_Requests.mdx
@@ -119,7 +119,9 @@ Then:
 - If there's already `1 approval` and/or it's been a week since the last request for changes, go ahead and squash merge
   - For straightforward PRs that don't impact users, you can wait 3 days instead
 
-We try to wait a week on PRs to give reviewers who aren't active every day a chance to get to it.
+There's no need to reset waiting periods for minor fixups from code reviews of otherwise approved code.
+
+We try to leave PRs open for at least a week to give reviewers who aren't active every day a chance to get to it.
 
 ### Other States
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9423
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Summarizing scattered conversations I've had over the last few months. This PR is very much a proposal, I'm expecting some discussions in it. 😄 

💖 