### PR TITLE
docs: fill in most remaining rule option descriptions

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-ts-comment.mdx
+++ b/packages/eslint-plugin/docs/rules/ban-ts-comment.mdx
@@ -153,7 +153,7 @@ if (false) {
 
 ## When Not To Use It
 
-If your project or its dependencies were not architected with strong type safety in mind, it can be difficult to always adhere to proper TypeScript semantics.
+If your project or its dependencies were not architected with strong type safety in mind, it can be difficult to always adhere to proper TypeScript semantics.
 You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading

--- a/packages/eslint-plugin/docs/rules/consistent-type-assertions.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-type-assertions.mdx
@@ -30,7 +30,7 @@ Examples of them include `let x = "hello" as const;` and `let x = <const>"hello"
 
 ### `assertionStyle`
 
-This option defines the expected assertion style. Valid values for `assertionStyle` are:
+The expected assertion style to enforce. Valid values for `assertionStyle` are:
 
 - `as` will enforce that you always use `... as foo`.
 - `angle-bracket` will enforce that you always use `<foo>...`
@@ -42,7 +42,10 @@ Some codebases like to go for an extra level of type safety, and ban assertions 
 
 ### `objectLiteralTypeAssertions`
 
-Always prefer `const x: T = { ... };` to `const x = { ... } as T;` (or similar with angle brackets). The type assertion in the latter case is either unnecessary or will probably hide an error.
+Whether to always prefer type declarations for object literals used as variable initializers, rather than type assertions.
+
+For example, this would prefer `const x: T = { ... };` to `const x = { ... } as T;` (or similar with angle brackets).
+The type assertion in the latter case is either unnecessary or will probably hide an error.
 
 The compiler will warn for excess properties with this syntax, but not missing _required_ fields. For example: `const x: { foo: number } = {};` will fail to compile, but `const x = {} as { foo: number }` will succeed.
 

--- a/packages/eslint-plugin/docs/rules/consistent-type-exports.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-type-exports.mdx
@@ -54,7 +54,7 @@ export type { ButtonProps };
 
 ### `fixMixedExportsWithInlineTypeSpecifier`
 
-When this is set to true, the rule will autofix "mixed" export cases using TS 4.5's "inline type specifier".
+Whether the rule will autofix "mixed" export cases using TS inline type specifiers.
 If you are using a TypeScript version less than 4.5, then you will not be able to use this option.
 
 For example the following code:

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx
@@ -18,7 +18,7 @@ This allows transpilers to drop imports without knowing the types of the depende
 
 ### `prefer`
 
-This option defines the expected import kind for type-only imports. Valid values for `prefer` are:
+The expected import kind for type-only imports. Valid values for `prefer` are:
 
 - `type-imports` will enforce that you always use `import type Foo from '...'` except referenced by metadata of decorators. It is the default.
 - `no-type-imports` will enforce that you always use `import Foo from '...'`.
@@ -43,7 +43,7 @@ const x: Bar = 1;
 
 ### `fixStyle`
 
-This option defines the expected type modifier to be added when an import is detected as used only in the type position. Valid values for `fixStyle` are:
+The expected type modifier to be added when an import is detected as used only in the type position. Valid values for `fixStyle` are:
 
 - `separate-type-imports` will add the type keyword after the import keyword `import type { A } from '...'`. It is the default.
 - `inline-type-imports` will inline the type keyword `import { type A } from '...'` and is only available in TypeScript 4.5 and onwards. See [documentation here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names 'TypeScript 4.5 documentation on type modifiers and import names').
@@ -83,7 +83,7 @@ const x: Bar = 1;
 
 ### `disallowTypeAnnotations`
 
-If `true`, type imports in type annotations (`import()`) are not allowed.
+Whether to disallow type imports in type annotations (`import()`).
 Default is `true`.
 
 Examples of **incorrect** code with `{disallowTypeAnnotations: true}`:

--- a/packages/eslint-plugin/docs/rules/dot-notation.mdx
+++ b/packages/eslint-plugin/docs/rules/dot-notation.mdx
@@ -38,6 +38,9 @@ If the TypeScript compiler option `noPropertyAccessFromIndexSignature` is set to
 
 ### `allowPrivateClassPropertyAccess`
 
+Whether to allow accessing class members marked as `private` with array notation.
+This can be useful because TypeScript will report a type error on dot notation but not array notation.
+
 Example of a correct code when `allowPrivateClassPropertyAccess` is set to `true`:
 
 ```ts option='{ "allowPrivateClassPropertyAccess": true }' showPlaygroundButton
@@ -51,6 +54,9 @@ x['priv_prop'] = 123;
 
 ### `allowProtectedClassPropertyAccess`
 
+Whether to allow accessing class members marked as `protected` with array notation.
+This can be useful because TypeScript will report a type error on dot notation but not array notation.
+
 Example of a correct code when `allowProtectedClassPropertyAccess` is set to `true`:
 
 ```ts option='{ "allowProtectedClassPropertyAccess": true }' showPlaygroundButton
@@ -63,6 +69,8 @@ x['protected_prop'] = 123;
 ```
 
 ### `allowIndexSignaturePropertyAccess`
+
+Whether to allow accessing properties matching an index signature with array notation.
 
 Example of correct code when `allowIndexSignaturePropertyAccess` is set to `true`:
 

--- a/packages/eslint-plugin/docs/rules/explicit-member-accessibility.mdx
+++ b/packages/eslint-plugin/docs/rules/explicit-member-accessibility.mdx
@@ -317,7 +317,8 @@ class Animal {
 
 ### `ignoredMethodNames`
 
-If you want to ignore some specific methods, you can do it by specifying method names. Note that this option does not care for the context, and will ignore every method with these names, which could lead to it missing some cases. You should use this sparingly.
+Specific method names that may be ignored.
+Note that this option does not care for the context, and will ignore every method with these names, which could lead to it missing some cases. You should use this sparingly.
 e.g. `[ { ignoredMethodNames: ['specificMethod', 'whateverMethod'] } ]`
 
 ```ts option='{ "ignoredMethodNames": ["specificMethod", "whateverMethod"] }' showPlaygroundButton

--- a/packages/eslint-plugin/docs/rules/max-params.mdx
+++ b/packages/eslint-plugin/docs/rules/max-params.mdx
@@ -11,3 +11,45 @@ import TabItem from '@theme/TabItem';
 
 This rule extends the base [`eslint/max-params`](https://eslint.org/docs/rules/max-params) rule.
 This version adds support for TypeScript `this` parameters so they won't be counted as a parameter.
+
+## Options
+
+This rule adds the following options:
+
+```ts
+interface Options extends BaseMaxParamsOptions {
+  countVoidThis?: boolean;
+}
+
+const defaultOptions: Options = {
+  ...baseMaxParamsOptions,
+  countVoidThis: false,
+};
+```
+
+### `countVoidThis`
+
+Whether to count a `this` declaration when the type is `void`.
+
+Example of a code when `countVoidThis` is set to `false` and `max` is `1`:
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts option='{ "countVoidThis": false, "max": 1 }'
+function hasNoThis(this: void, first: string, second: string) {
+  // ...
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts option='{ "countVoidThis": false, "max": 1 }'
+function hasNoThis(this: void, first: string) {
+  // ...
+}
+```
+
+</TabItem>
+</Tabs>

--- a/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
+++ b/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
@@ -66,7 +66,8 @@ const literalWithToString = {
 
 ### `ignoredTypeNames`
 
-A string array of type names to ignore, this is useful for types missing `toString()` (but actually has `toString()`).
+Stringified regular expressions of type names to ignore.
+This is useful for types missing `toString()` (but actually has `toString()`).
 There are some types missing `toString()` in old version TypeScript, like `RegExp`, `URL`, `URLSearchParams` etc.
 
 The following patterns are considered correct with the default options `{ ignoredTypeNames: ["RegExp"] }`:

--- a/packages/eslint-plugin/docs/rules/no-confusing-void-expression.mdx
+++ b/packages/eslint-plugin/docs/rules/no-confusing-void-expression.mdx
@@ -77,8 +77,10 @@ cond ? console.log('true') : console.error('false');
 
 ### `ignoreArrowShorthand`
 
-It might be undesirable to wrap every arrow function shorthand expression with braces.
-Especially when using Prettier formatter, which spreads such code across 3 lines instead of 1.
+Whether to ignore "shorthand" `() =>` arrow functions: those without `{ ... }` braces.
+
+It might be undesirable to wrap every arrow function shorthand expression.
+Especially when using the Prettier formatter, which spreads such code across 3 lines instead of 1.
 
 Examples of additional **correct** code with this option enabled:
 
@@ -87,6 +89,8 @@ promise.then(value => window.postMessage(value));
 ```
 
 ### `ignoreVoidOperator`
+
+Whether to ignore returns that start with the `void` operator.
 
 It might be preferable to only use some distinct syntax
 to explicitly mark the confusing but valid usage of void expressions.

--- a/packages/eslint-plugin/docs/rules/no-inferrable-types.mdx
+++ b/packages/eslint-plugin/docs/rules/no-inferrable-types.mdx
@@ -80,6 +80,8 @@ function fn(a = 5, b = true) {}
 
 ### `ignoreParameters`
 
+Whether to ignore function parameters.
+
 When set to true, the following pattern is considered valid:
 
 ```ts option='{ "ignoreParameters": true }' showPlaygroundButton
@@ -89,6 +91,8 @@ function foo(a: number = 5, b: boolean = true) {
 ```
 
 ### `ignoreProperties`
+
+Whether to ignore class properties.
 
 When set to true, the following pattern is considered valid:
 

--- a/packages/eslint-plugin/docs/rules/no-invalid-void-type.mdx
+++ b/packages/eslint-plugin/docs/rules/no-invalid-void-type.mdx
@@ -62,7 +62,7 @@ type stillVoid = void | never;
 
 ### `allowInGenericTypeArguments`
 
-This option lets you control if `void` can be used as a valid value for generic type parameters.
+Whether `void` can be used as a valid value for generic type parameters.
 
 Alternatively, you can provide an array of strings which whitelist which types may accept `void` as a generic type parameter.
 
@@ -98,7 +98,7 @@ type AllowedVoidUnion = void | Ex.Mx.Tx<void>;
 
 ### `allowAsThisParameter`
 
-This option allows specifying a `this` parameter of a function to be `void` when set to `true`.
+Whether a `this` parameter of a function may be `void`.
 This pattern can be useful to explicitly label function types that do not use a `this` argument. [See the TypeScript docs for more information](https://www.typescriptlang.org/docs/handbook/functions.html#this-parameters-in-callbacks).
 
 This option is `false` by default.

--- a/packages/eslint-plugin/docs/rules/no-magic-numbers.mdx
+++ b/packages/eslint-plugin/docs/rules/no-magic-numbers.mdx
@@ -39,7 +39,7 @@ const defaultOptions: Options = {
 
 ### `ignoreEnums`
 
-A boolean to specify if enums used in TypeScript are considered okay. `false` by default.
+Whether enums used in TypeScript are considered okay. `false` by default.
 
 Examples of **incorrect** code for the `{ "ignoreEnums": false }` option:
 
@@ -59,7 +59,7 @@ enum foo {
 
 ### `ignoreNumericLiteralTypes`
 
-A boolean to specify if numbers used in TypeScript numeric literal types are considered okay. `false` by default.
+Whether numbers used in TypeScript numeric literal types are considered okay. `false` by default.
 
 Examples of **incorrect** code for the `{ "ignoreNumericLiteralTypes": false }` option:
 
@@ -74,6 +74,8 @@ type SmallPrimes = 2 | 3 | 5 | 7 | 11;
 ```
 
 ### `ignoreReadonlyClassProperties`
+
+Whether `readonly` class properties are considered okay.
 
 Examples of **incorrect** code for the `{ "ignoreReadonlyClassProperties": false }` option:
 
@@ -99,7 +101,7 @@ class Foo {
 
 ### `ignoreTypeIndexes`
 
-A boolean to specify if numbers used to index types are okay. `false` by default.
+Whether numbers used to index types are okay. `false` by default.
 
 Examples of **incorrect** code for the `{ "ignoreTypeIndexes": false }` option:
 

--- a/packages/eslint-plugin/docs/rules/no-meaningless-void-operator.mdx
+++ b/packages/eslint-plugin/docs/rules/no-meaningless-void-operator.mdx
@@ -54,7 +54,7 @@ void bar(1); // discarding a number
 
 ### `checkNever`
 
-`checkNever: true` will suggest removing `void` when the argument has type `never`.
+Whether to suggest removing `void` when the argument has type `never`.
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/docs/rules/no-misused-promises.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misused-promises.mdx
@@ -101,6 +101,8 @@ Disables checking an asynchronous function used as a variable whose return type 
 
 ### `checksSpreads`
 
+Whether to warn when `...` spreading a `Promise`.
+
 If you don't want to check object spreads, you can add this configuration:
 
 ```json

--- a/packages/eslint-plugin/docs/rules/no-redeclare.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redeclare.mdx
@@ -33,7 +33,7 @@ const defaultOptions: Options = {
 
 ### `ignoreDeclarationMerge`
 
-When set to `true`, the rule will ignore declaration merges between the following sets:
+Whether to ignore declaration merges between the following sets:
 
 - interface + interface
 - namespace + namespace

--- a/packages/eslint-plugin/docs/rules/no-restricted-imports.mdx
+++ b/packages/eslint-plugin/docs/rules/no-restricted-imports.mdx
@@ -45,7 +45,7 @@ You can specify this option for a specific path or pattern as follows:
 }
 ```
 
-When set to `true`, the rule will allow [Type-Only Imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export).
+Whether to allow [Type-Only Imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export).
 
 Examples of code with the above config:
 

--- a/packages/eslint-plugin/docs/rules/no-shadow.mdx
+++ b/packages/eslint-plugin/docs/rules/no-shadow.mdx
@@ -31,7 +31,7 @@ const defaultOptions: Options = {
 
 ### `ignoreTypeValueShadow`
 
-When set to `true`, the rule will ignore the case when you name a type the same as a variable. This is generally safe because you cannot use variables in type locations without a `typeof` operator, so there's little risk of confusion.
+Whether to ignore types named the same as a variable. This is generally safe because you cannot use variables in type locations without a `typeof` operator, so there's little risk of confusion.
 
 Examples of **correct** code with `{ ignoreTypeValueShadow: true }`:
 
@@ -55,7 +55,7 @@ _Shadowing_ specifically refers to two identical identifiers that are in differe
 
 ### `ignoreFunctionTypeParameterNameValueShadow`
 
-When set to `true`, the rule will ignore the case when you name a parameter in a function type the same as a variable.
+Whether to ignore function parameters named the same as a variable.
 
 Each of a function type's arguments creates a value variable within the scope of the function type. This is done so that you can reference the type later using the `typeof` operator:
 

--- a/packages/eslint-plugin/docs/rules/no-use-before-define.mdx
+++ b/packages/eslint-plugin/docs/rules/no-use-before-define.mdx
@@ -33,6 +33,8 @@ const defaultOptions: Options = {
 
 ### `enums`
 
+Whether to check references to enums before the enum declaration.
+
 If this is `true`, this rule warns every reference to a enum before the enum declaration.
 If this is `false`, this rule will ignore references to enums, when the reference is in a child scope.
 
@@ -67,6 +69,8 @@ enum Foo {
 
 ### `typedefs`
 
+Whether to check references to types before the type declaration.
+
 If this is `true`, this rule warns every reference to a type before the type declaration.
 If this is `false`, this rule will ignore references to types.
 
@@ -79,7 +83,9 @@ type StringOrNumber = string | number;
 
 ### `ignoreTypeReferences`
 
-If this is `true`, this rule ignores all type references, such as in type annotations and assertions.
+Whether to ignore type references, such as in type annotations and assertions.
+
+If this is `true`, this rule ignores all type references.
 If this is `false`, this will check all type references.
 
 Examples of **correct** code for the `{ "ignoreTypeReferences": true }` option:

--- a/packages/eslint-plugin/docs/rules/prefer-literal-enum-member.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-literal-enum-member.mdx
@@ -67,7 +67,7 @@ enum Valid {
 
 ### `allowBitwiseExpressions`
 
-When set to `true` will allow you to use bitwise expressions in enum initializer (default: `false`).
+Whether to allow using bitwise expressions in enum initializers (default: `false`).
 
 Examples of code for the `{ "allowBitwiseExpressions": true }` option:
 

--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
@@ -25,7 +25,7 @@ This rule will not work as expected if [`strictNullChecks`](https://www.typescri
 
 ### `ignoreTernaryTests`
 
-Setting this option to `true` will cause the rule to ignore any ternary expressions that could be simplified by using the nullish coalescing operator. This is set to `false` by default.
+Whether to ignore any ternary expressions that could be simplified by using the nullish coalescing operator. This is set to `false` by default.
 
 Incorrect code for `ignoreTernaryTests: false`, and correct code for `ignoreTernaryTests: true`:
 
@@ -65,7 +65,7 @@ foo ?? 'a string';
 
 ### `ignoreConditionalTests`
 
-Setting this option to `false` will cause the rule to also check cases that are located within a conditional test. This is set to `true` by default.
+Whether to ignore cases that are located within a conditional test. This is set to `true` by default.
 
 Generally expressions within conditional tests intentionally use the falsy fallthrough behavior of the logical or operator, meaning that fixing the operator to the nullish coalesce operator could cause bugs.
 
@@ -107,7 +107,7 @@ a ?? b ? true : false;
 
 ### `ignoreMixedLogicalExpressions`
 
-Setting this option to `true` will cause the rule to ignore any logical or expressions that are part of a mixed logical expression (with `&&`). This is set to `false` by default.
+Whether to ignore any logical or expressions that are part of a mixed logical expression (with `&&`). This is set to `false` by default.
 
 Generally expressions within mixed logical expressions intentionally use the falsy fallthrough behavior of the logical or operator, meaning that fixing the operator to the nullish coalesce operator could cause bugs.
 
@@ -147,6 +147,8 @@ a ?? (b && c && d);
 
 ### `ignorePrimitives`
 
+Whether to ignore all (`true`) or some (an object with properties) primitive types.
+
 If you would like to ignore expressions containing operands of certain primitive types that can be falsy then you may pass an object containing a boolean value for each primitive:
 
 - `string: true`, ignores `null` or `undefined` unions with `string` (default: false).
@@ -172,7 +174,7 @@ Also, if you would like to ignore all primitives types, you can set `ignorePrimi
 
 ### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
 
-If this is set to `false`, then the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
+Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
 
 Without `strictNullChecks`, TypeScript essentially erases `undefined` and `null` from the types. This means when this rule inspects the types from a variable, **it will not be able to tell that the variable might be `null` or `undefined`**, which essentially makes this rule useless.
 

--- a/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-readonly-parameter-types.mdx
@@ -140,9 +140,9 @@ interface Foo {
 
 ### `allow`
 
+An array of type specifiers to ignore.
 Some complex types cannot easily be made readonly, for example the `HTMLElement` type or the `JQueryStatic` type from `@types/jquery`. This option allows you to globally disable reporting of such types.
 
-This option takes an array of type specifiers to ignore.
 Each item in the array must have one of the following forms:
 
 - A type defined in a file (`{ from: "file", name: "Foo", path: "src/foo-file.ts" }` with `path` being an optional path relative to the project root directory)
@@ -258,7 +258,7 @@ function fn(arg: Foo) {}
 
 ### `checkParameterProperties`
 
-This option allows you to enable or disable the checking of parameter properties.
+Whether to check class parameter properties.
 Because parameter properties create properties on the class, it may be undesirable to force them to be readonly.
 
 Examples of code for this rule with `{checkParameterProperties: true}`:
@@ -297,7 +297,8 @@ class Foo {
 
 ### `ignoreInferredTypes`
 
-This option allows you to ignore parameters which don't explicitly specify a type. This may be desirable in cases where an external dependency specifies a callback with mutable parameters, and manually annotating the callback's parameters is undesirable.
+Whether to ignore parameters which don't explicitly specify a type.
+This may be desirable in cases where an external dependency specifies a callback with mutable parameters, and manually annotating the callback's parameters is undesirable.
 
 Examples of code for this rule with `{ignoreInferredTypes: true}`:
 
@@ -354,7 +355,8 @@ export const acceptsCallback: AcceptsCallback;
 
 ### `treatMethodsAsReadonly`
 
-This option allows you to treat all mutable methods as though they were readonly. This may be desirable when you are never reassigning methods.
+Whether to treat all mutable methods as though they are readonly.
+This may be desirable when you are never reassigning methods.
 
 Examples of code for this rule with `{treatMethodsAsReadonly: false}`:
 

--- a/packages/eslint-plugin/docs/rules/promise-function-async.mdx
+++ b/packages/eslint-plugin/docs/rules/promise-function-async.mdx
@@ -68,7 +68,7 @@ async function functionReturnsUnionWithPromiseImplicitly(p: boolean) {
 
 ### `allowAny`
 
-Whether to ignore functions that return `any` and `unknown`.
+Whether to ignore functions that return `any` or `unknown`.
 If you want additional safety, consider turning this option off, as it makes the rule less able to catch incorrect Promise behaviors.
 
 Examples of code with `{ "allowAny": false }`:
@@ -135,7 +135,7 @@ Whether to check inline function expressions.
 
 ### `checkMethodDeclarations`
 
-Whether to check methods on classes and object literals
+Whether to check methods on classes and object literals.
 `true` by default, but can be set to `false` to ignore them.
 
 ## When Not To Use It

--- a/packages/eslint-plugin/docs/rules/typedef.mdx
+++ b/packages/eslint-plugin/docs/rules/typedef.mdx
@@ -306,7 +306,7 @@ let delayedText: string;
 
 ### `variableDeclarationIgnoreFunction`
 
-Ignore variable declarations for non-arrow and arrow functions.
+Whether to ignore variable declarations for non-arrow and arrow functions.
 
 Examples of code with `{ "variableDeclaration": true, "variableDeclarationIgnoreFunction": true }`:
 

--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -84,6 +84,8 @@ export default createRule<[Options], MessageIds>({
           'ts-nocheck': { $ref: '#/items/0/$defs/directiveConfigSchema' },
           'ts-check': { $ref: '#/items/0/$defs/directiveConfigSchema' },
           minimumDescriptionLength: {
+            description:
+              'A minimum character length for descriptions when `allow-with-description` is enabled.',
             type: 'number',
             default: defaultMinimumDescriptionLength,
           },

--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -57,6 +57,7 @@ export default createRule<Options, MessageIds>({
             type: 'object',
             properties: {
               assertionStyle: {
+                description: 'The expected assertion style to enforce.',
                 type: 'string',
                 enum: ['never'],
               },
@@ -68,10 +69,13 @@ export default createRule<Options, MessageIds>({
             type: 'object',
             properties: {
               assertionStyle: {
+                description: 'The expected assertion style to enforce.',
                 type: 'string',
                 enum: ['as', 'angle-bracket'],
               },
               objectLiteralTypeAssertions: {
+                description:
+                  'Whether to always prefer type declarations for object literals used as variable initializers, rather than type assertions.',
                 type: 'string',
                 enum: ['allow', 'allow-as-parameter', 'never'],
               },

--- a/packages/eslint-plugin/src/rules/consistent-type-exports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-exports.ts
@@ -48,7 +48,6 @@ export default createRule<Options, MessageIds>({
     messages: {
       typeOverValue:
         'All exports in the declaration are only used as types. Use `export type`.',
-
       singleExportIsType:
         'Type export {{exportNames}} is not a value and should be exported using `export type`.',
       multipleExportsAreTypes:
@@ -59,6 +58,8 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           fixMixedExportsWithInlineTypeSpecifier: {
+            description:
+              'Whether the rule will autofix "mixed" export cases using TS inline type specifiers.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -60,7 +60,6 @@ export default createRule<Options, MessageIds>({
       typeOverValue:
         'All imports in the declaration are only used as types. Use `import type`.',
       someImportsAreOnlyTypes: 'Imports {{typeImports}} are only used as type.',
-
       avoidImportType: 'Use an `import` instead of an `import type`.',
       noImportTypeAnnotations: '`import()` type annotations are forbidden.',
     },
@@ -69,13 +68,18 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           disallowTypeAnnotations: {
+            description:
+              'Whether to disallow type imports in type annotations (`import()`).',
             type: 'boolean',
           },
           fixStyle: {
+            description:
+              'The expected type modifier to be added when an import is detected as used only in the type position.',
             type: 'string',
             enum: ['separate-type-imports', 'inline-type-imports'],
           },
           prefer: {
+            description: 'The expected import kind for type-only imports.',
             type: 'string',
             enum: ['type-imports', 'no-type-imports'],
           },

--- a/packages/eslint-plugin/src/rules/dot-notation.ts
+++ b/packages/eslint-plugin/src/rules/dot-notation.ts
@@ -30,22 +30,30 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           allowKeywords: {
+            description: 'Whether to allow keywords such as ["class"]`.',
             type: 'boolean',
             default: true,
           },
           allowPattern: {
+            description: 'Regular expression of names to allow.',
             type: 'string',
             default: '',
           },
           allowPrivateClassPropertyAccess: {
+            description:
+              'Whether to allow accessing class members marked as `private` with array notation.',
             type: 'boolean',
             default: false,
           },
           allowProtectedClassPropertyAccess: {
+            description:
+              'Whether to allow accessing class members marked as `protected` with array notation.',
             type: 'boolean',
             default: false,
           },
           allowIndexSignaturePropertyAccess: {
+            description:
+              'Whether to allow accessing properties matching an index signature with array notation.',
             type: 'boolean',
             default: false,
           },

--- a/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
+++ b/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
@@ -91,10 +91,10 @@ export default createRule<Options, MessageIds>({
                 $ref: '#/items/0/$defs/accessibilityLevel',
               },
             },
-
             additionalProperties: false,
           },
           ignoredMethodNames: {
+            description: 'Specific method names that may be ignored.',
             type: 'array',
             items: {
               type: 'string',

--- a/packages/eslint-plugin/src/rules/max-params.ts
+++ b/packages/eslint-plugin/src/rules/max-params.ts
@@ -33,15 +33,21 @@ export default createRule<Options, MessageIds>({
       {
         type: 'object',
         properties: {
-          maximum: {
+          max: {
+            description:
+              'A maximum number of parameters in function definitions.',
             type: 'integer',
             minimum: 0,
           },
-          max: {
+          maximum: {
+            description:
+              '(deprecated) A maximum number of parameters in function definitions.',
             type: 'integer',
             minimum: 0,
           },
           countVoidThis: {
+            description:
+              'Whether to count a `this` declaration when the type is `void`.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -35,6 +35,8 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           ignoredTypeNames: {
+            description:
+              'Stringified regular expressions of type names to ignore.',
             type: 'array',
             items: {
               type: 'string',

--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -70,8 +70,16 @@ export default createRule<Options, MessageId>({
       {
         type: 'object',
         properties: {
-          ignoreArrowShorthand: { type: 'boolean' },
-          ignoreVoidOperator: { type: 'boolean' },
+          ignoreArrowShorthand: {
+            description:
+              'Whether to ignore "shorthand" `() =>` arrow functions: those without `{ ... }` braces.',
+            type: 'boolean',
+          },
+          ignoreVoidOperator: {
+            description:
+              'Whether to ignore returns that start with the `void` operator.',
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
       },

--- a/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
@@ -86,9 +86,11 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           ignoreIntersections: {
+            description: 'Whether to ignore `&` intersections.',
             type: 'boolean',
           },
           ignoreUnions: {
+            description: 'Whether to ignore `|` unions.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-empty-function.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-function.ts
@@ -22,6 +22,8 @@ const schema = deepMerge(
   {
     properties: {
       allow: {
+        description:
+          'Locations and kinds of functions that are allowed to be empty.',
         items: {
           type: 'string',
           enum: [

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -33,6 +33,8 @@ export default createRule<Options, MessageIds>({
         additionalProperties: false,
         properties: {
           allowSingleExtends: {
+            description:
+              'Whether to allow empty interfaces that extend a single other interface.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-empty-object-type.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-object-type.ts
@@ -56,14 +56,18 @@ export default createRule<Options, MessageIds>({
         additionalProperties: false,
         properties: {
           allowInterfaces: {
+            description: 'Whether to allow empty interfaces.',
             enum: ['always', 'never', 'with-single-extends'],
             type: 'string',
           },
           allowObjectTypes: {
+            description: 'Whether to allow empty object type literals.',
             enum: ['always', 'never'],
             type: 'string',
           },
           allowWithName: {
+            description:
+              'A stringified regular expression to allow interfaces and object type aliases with the configured name.',
             type: 'string',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -76,8 +76,15 @@ export default createRule<Options, MessageId>({
       {
         type: 'object',
         properties: {
-          allowForKnownSafePromises: readonlynessOptionsSchema.properties.allow,
-          allowForKnownSafeCalls: readonlynessOptionsSchema.properties.allow,
+          allowForKnownSafePromises: {
+            ...readonlynessOptionsSchema.properties.allow,
+            description: 'Type specifiers that are known to be safe to float.',
+          },
+          allowForKnownSafeCalls: {
+            ...readonlynessOptionsSchema.properties.allow,
+            description:
+              'Type specifiers of functions whose calls are safe to float.',
+          },
           checkThenables: {
             description:
               'Whether to check all "Thenable"s, not just the built-in Promise type.',

--- a/packages/eslint-plugin/src/rules/no-inferrable-types.ts
+++ b/packages/eslint-plugin/src/rules/no-inferrable-types.ts
@@ -31,9 +31,11 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           ignoreParameters: {
+            description: 'Whether to ignore function parameters.',
             type: 'boolean',
           },
           ignoreProperties: {
+            description: 'Whether to ignore class properties.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
@@ -42,6 +42,8 @@ export default createRule<[Options], MessageIds>({
         type: 'object',
         properties: {
           allowInGenericTypeArguments: {
+            description:
+              'Whether `void` can be used as a valid value for generic type parameters.',
             oneOf: [
               { type: 'boolean' },
               {
@@ -52,6 +54,8 @@ export default createRule<[Options], MessageIds>({
             ],
           },
           allowAsThisParameter: {
+            description:
+              'Whether a `this` parameter of a function may be `void`.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-magic-numbers.ts
+++ b/packages/eslint-plugin/src/rules/no-magic-numbers.ts
@@ -23,15 +23,20 @@ const schema = deepMerge(
   {
     properties: {
       ignoreNumericLiteralTypes: {
+        description:
+          'Whether numbers used in TypeScript numeric literal types are considered okay.',
         type: 'boolean',
       },
       ignoreEnums: {
+        description: 'Whether enums used in TypeScript are considered okay.',
         type: 'boolean',
       },
       ignoreReadonlyClassProperties: {
+        description: 'Whether `readonly` class properties are considered okay.',
         type: 'boolean',
       },
       ignoreTypeIndexes: {
+        description: 'Whether numbers used to index types are okay.',
         type: 'boolean',
       },
     },

--- a/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
+++ b/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
@@ -33,6 +33,8 @@ export default createRule<Options, 'meaninglessVoidOperator' | 'removeVoid'>({
         type: 'object',
         properties: {
           checkNever: {
+            description:
+              'Whether to suggest removing `void` when the argument has type `never`.',
             type: 'boolean',
             default: false,
           },

--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -107,18 +107,43 @@ export default createRule<Options, MessageId>({
               {
                 additionalProperties: false,
                 properties: {
-                  arguments: { type: 'boolean' },
-                  attributes: { type: 'boolean' },
-                  inheritedMethods: { type: 'boolean' },
-                  properties: { type: 'boolean' },
-                  returns: { type: 'boolean' },
-                  variables: { type: 'boolean' },
+                  arguments: {
+                    description:
+                      'Disables checking an asynchronous function passed as argument where the parameter type expects a function that returns `void`.',
+                    type: 'boolean',
+                  },
+                  attributes: {
+                    description:
+                      'Disables checking an asynchronous function passed as a JSX attribute expected to be a function that returns `void`.',
+                    type: 'boolean',
+                  },
+                  inheritedMethods: {
+                    description:
+                      'Disables checking an asynchronous method in a type that extends or implements another type expecting that method to return `void`.',
+                    type: 'boolean',
+                  },
+                  properties: {
+                    description:
+                      'Disables checking an asynchronous function passed as an object property expected to be a function that returns `void`.',
+                    type: 'boolean',
+                  },
+                  returns: {
+                    description:
+                      'Disables checking an asynchronous function returned in a function whose return type is a function that returns `void`.',
+                    type: 'boolean',
+                  },
+                  variables: {
+                    description:
+                      'Disables checking an asynchronous function used as a variable whose return type is a function that returns `void`.',
+                    type: 'boolean',
+                  },
                 },
                 type: 'object',
               },
             ],
           },
           checksSpreads: {
+            description: 'Whether to warn when `...` spreading a `Promise`.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-redeclare.ts
+++ b/packages/eslint-plugin/src/rules/no-redeclare.ts
@@ -25,9 +25,13 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           builtinGlobals: {
+            description:
+              'Whether to report shadowing of built-in global variables.',
             type: 'boolean',
           },
           ignoreDeclarationMerge: {
+            description:
+              'Whether to ignore declaration merges between certain TypeScript declaration types.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -37,25 +37,36 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           builtinGlobals: {
+            description:
+              'Whether to report shadowing of built-in global variables.',
             type: 'boolean',
           },
           hoist: {
+            description:
+              'Whether to report shadowing before outer functions or variables are defined.',
             type: 'string',
             enum: ['all', 'functions', 'never'],
           },
           allow: {
+            description: 'Identifier names for which shadowing is allowed.',
             type: 'array',
             items: {
               type: 'string',
             },
           },
           ignoreOnInitialization: {
+            description:
+              'Whether to ignore the variable initializers when the shadowed variable is presumably still unitialized.',
             type: 'boolean',
           },
           ignoreTypeValueShadow: {
+            description:
+              'Whether to ignore types named the same as a variable.',
             type: 'boolean',
           },
           ignoreFunctionTypeParameterNameValueShadow: {
+            description:
+              'Whether to ignore function parameters named the same as a variable.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -77,36 +77,54 @@ export default createRule<Options, MessageIds>({
             type: 'object',
             properties: {
               vars: {
+                description:
+                  'Whether to check all variables or only locally-declared variables.',
                 type: 'string',
                 enum: ['all', 'local'],
               },
               varsIgnorePattern: {
+                description:
+                  'Regular expressions of variable names to not check for usage.',
                 type: 'string',
               },
               args: {
+                description: 'Whether to check all, some, or no arguments.',
                 type: 'string',
                 enum: ['all', 'after-used', 'none'],
               },
-              ignoreRestSiblings: {
-                type: 'boolean',
-              },
               argsIgnorePattern: {
+                description:
+                  'Regular expressions of argument names to not check for usage.',
                 type: 'string',
               },
               caughtErrors: {
+                description: 'Whether to check catch block arguments.',
                 type: 'string',
                 enum: ['all', 'none'],
               },
               caughtErrorsIgnorePattern: {
+                description:
+                  'Regular expressions of catch block argument names to not check for usage.',
                 type: 'string',
               },
               destructuredArrayIgnorePattern: {
+                description:
+                  'Regular expressions of destructured array variable names to not check for usage.',
                 type: 'string',
               },
               ignoreClassWithStaticInitBlock: {
+                description:
+                  'Whether to ignore classes with at least one static initialization block.',
+                type: 'boolean',
+              },
+              ignoreRestSiblings: {
+                description:
+                  'Whether to ignore sibling properties in `...` destructurings.',
                 type: 'boolean',
               },
               reportUsedIgnorePattern: {
+                description:
+                  'Whether to report variables that match any of the valid ignore pattern options if they have been used.',
                 type: 'boolean',
               },
             },

--- a/packages/eslint-plugin/src/rules/no-use-before-define.ts
+++ b/packages/eslint-plugin/src/rules/no-use-before-define.ts
@@ -235,12 +235,33 @@ export default createRule<Options, MessageIds>({
           {
             type: 'object',
             properties: {
-              functions: { type: 'boolean' },
-              classes: { type: 'boolean' },
-              enums: { type: 'boolean' },
-              variables: { type: 'boolean' },
-              typedefs: { type: 'boolean' },
-              ignoreTypeReferences: { type: 'boolean' },
+              functions: {
+                description:
+                  'Whether to ignore references to function declarations.',
+                type: 'boolean',
+              },
+              classes: {
+                description:
+                  'Whether to ignore references to class declarations.',
+                type: 'boolean',
+              },
+              enums: {
+                description: 'Whether to check references to enums.',
+                type: 'boolean',
+              },
+              variables: {
+                description: 'Whether to ignore references to variables.',
+                type: 'boolean',
+              },
+              typedefs: {
+                description: 'Whether to check references to types.',
+                type: 'boolean',
+              },
+              ignoreTypeReferences: {
+                description:
+                  'Whether to ignore type references, such as in type annotations and assertions.',
+                type: 'boolean',
+              },
               allowNamedExports: { type: 'boolean' },
             },
             additionalProperties: false,

--- a/packages/eslint-plugin/src/rules/only-throw-error.ts
+++ b/packages/eslint-plugin/src/rules/only-throw-error.ts
@@ -34,9 +34,13 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           allowThrowingAny: {
+            description:
+              'Whether to always allow throwing values typed as `any`.',
             type: 'boolean',
           },
           allowThrowingUnknown: {
+            description:
+              'Whether to always allow throwing values typed as `unknown`.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/parameter-properties.ts
+++ b/packages/eslint-plugin/src/rules/parameter-properties.ts
@@ -56,12 +56,16 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           allow: {
+            description:
+              'Whether to allow certain kinds of properties to be ignored.',
             type: 'array',
             items: {
               $ref: '#/items/0/$defs/modifier',
             },
           },
           prefer: {
+            description:
+              'Whether to prefer class properties or parameter properties.',
             type: 'string',
             enum: ['class-property', 'parameter-property'],
           },

--- a/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
+++ b/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
@@ -20,6 +20,8 @@ export default createRule({
         type: 'object',
         properties: {
           allowBitwiseExpressions: {
+            description:
+              'Whether to allow using bitwise expressions in enum initializers.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -65,15 +65,23 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: {
+            description:
+              'Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.',
             type: 'boolean',
           },
           ignoreConditionalTests: {
+            description:
+              'Whether to ignore cases that are located within a conditional test.',
             type: 'boolean',
           },
           ignoreMixedLogicalExpressions: {
+            description:
+              'Whether to ignore any logical or expressions that are part of a mixed logical expression (with `&&`).',
             type: 'boolean',
           },
           ignorePrimitives: {
+            description:
+              'Whether to ignore all (`true`) or some (an object with properties) primitive types.',
             oneOf: [
               {
                 type: 'object',
@@ -91,6 +99,8 @@ export default createRule<Options, MessageIds>({
             ],
           },
           ignoreTernaryTests: {
+            description:
+              'Whether to ignore any ternary expressions that could be simplified by using the nullish coalescing operator.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/prefer-promise-reject-errors.ts
+++ b/packages/eslint-plugin/src/rules/prefer-promise-reject-errors.ts
@@ -35,6 +35,8 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           allowEmptyReject: {
+            description:
+              'Whether to allow calls to `Promise.reject()` with no arguments.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
@@ -34,15 +34,24 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         additionalProperties: false,
         properties: {
-          allow: readonlynessOptionsSchema.properties.allow,
+          allow: {
+            ...readonlynessOptionsSchema.properties.allow,
+            description: 'An array of type specifiers to ignore.',
+          },
           checkParameterProperties: {
+            description: 'Whether to check class parameter properties.',
             type: 'boolean',
           },
           ignoreInferredTypes: {
+            description:
+              "Whether to ignore parameters which don't explicitly specify a type.",
             type: 'boolean',
           },
-          treatMethodsAsReadonly:
-            readonlynessOptionsSchema.properties.treatMethodsAsReadonly,
+          treatMethodsAsReadonly: {
+            ...readonlynessOptionsSchema.properties.treatMethodsAsReadonly,
+            description:
+              'Whether to treat all mutable methods as though they are readonly.',
+          },
         },
       },
     ],

--- a/packages/eslint-plugin/src/rules/prefer-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly.ts
@@ -46,6 +46,8 @@ export default createRule<Options, MessageIds>({
         additionalProperties: false,
         properties: {
           onlyInlineLambdas: {
+            description:
+              'Whether to restrict checking only to members immediately assigned a lambda value.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -55,15 +55,20 @@ export default createRule<Options, MessageIds>({
             },
           },
           checkArrowFunctions: {
+            description: 'Whether to check arrow functions.',
             type: 'boolean',
           },
           checkFunctionDeclarations: {
+            description: 'Whether to check standalone function declarations.',
             type: 'boolean',
           },
           checkFunctionExpressions: {
+            description: 'Whether to check inline function expressions',
             type: 'boolean',
           },
           checkMethodDeclarations: {
+            description:
+              'Whether to check methods on classes and object literals.',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -59,12 +59,30 @@ export default createRule({
     schema: [
       {
         type: 'string',
-        enum: [
-          'in-try-catch',
-          'always',
-          'never',
-          'error-handling-correctness-only',
-        ] satisfies Option[],
+        oneOf: [
+          {
+            type: 'string',
+            enum: ['always'],
+            description: 'Requires that all returned promises be awaited.',
+          },
+          {
+            type: 'string',
+            enum: ['error-handling-correctness-only'],
+            description:
+              'In error-handling contexts, the rule enforces that returned promises must be awaited. In ordinary contexts, the rule does not enforce any particular behavior around whether returned promises are awaited.',
+          },
+          {
+            type: 'string',
+            enum: ['in-try-catch'],
+            description:
+              'In error-handling contexts, the rule enforces that returned promises must be awaited. In ordinary contexts, the rule enforces that returned promises _must not_ be awaited.',
+          },
+          {
+            type: 'string',
+            enum: ['never'],
+            description: 'Disallows awaiting any returned promises.',
+          },
+        ],
       },
     ],
   },

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -67,14 +67,43 @@ export default createRule<Options, MessageId>({
       {
         type: 'object',
         properties: {
-          allowString: { type: 'boolean' },
-          allowNumber: { type: 'boolean' },
-          allowNullableObject: { type: 'boolean' },
-          allowNullableBoolean: { type: 'boolean' },
-          allowNullableString: { type: 'boolean' },
-          allowNullableNumber: { type: 'boolean' },
-          allowNullableEnum: { type: 'boolean' },
-          allowAny: { type: 'boolean' },
+          allowString: {
+            description: 'Whether to allow `string` in a boolean context.',
+            type: 'boolean',
+          },
+          allowNumber: {
+            description: 'Whether to allow `number` in a boolean context.',
+            type: 'boolean',
+          },
+          allowNullableObject: {
+            description:
+              'Whether to allow nullable `object`s in a boolean context.',
+            type: 'boolean',
+          },
+          allowNullableBoolean: {
+            description:
+              'Whether to allow nullable `boolean`s in a boolean context.',
+            type: 'boolean',
+          },
+          allowNullableString: {
+            description:
+              'Whether to allow nullable `string`s in a boolean context.',
+            type: 'boolean',
+          },
+          allowNullableNumber: {
+            description:
+              'Whether to allow nullable `number`s in a boolean context.',
+            type: 'boolean',
+          },
+          allowNullableEnum: {
+            description:
+              'Whether to allow nullable `enum`s in a boolean context.',
+            type: 'boolean',
+          },
+          allowAny: {
+            description: 'Whether to allow `any` in a boolean context.',
+            type: 'boolean',
+          },
           allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: {
             type: 'boolean',
           },

--- a/packages/eslint-plugin/src/rules/triple-slash-reference.ts
+++ b/packages/eslint-plugin/src/rules/triple-slash-reference.ts
@@ -30,14 +30,20 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         properties: {
           lib: {
+            description:
+              'What to enforce for `/// <reference lib="..." />` references.',
             type: 'string',
             enum: ['always', 'never'],
           },
           path: {
+            description:
+              'What to enforce for `/// <reference path="..." />` references.',
             type: 'string',
             enum: ['always', 'never'],
           },
           types: {
+            description:
+              'What to enforce for `/// <reference types="..." />` references.',
             type: 'string',
             enum: ['always', 'never', 'prefer-import'],
           },

--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -33,14 +33,46 @@ export default createRule<[Options], MessageIds>({
         type: 'object',
         additionalProperties: false,
         properties: {
-          [OptionKeys.ArrayDestructuring]: { type: 'boolean' },
-          [OptionKeys.ArrowParameter]: { type: 'boolean' },
-          [OptionKeys.MemberVariableDeclaration]: { type: 'boolean' },
-          [OptionKeys.ObjectDestructuring]: { type: 'boolean' },
-          [OptionKeys.Parameter]: { type: 'boolean' },
-          [OptionKeys.PropertyDeclaration]: { type: 'boolean' },
-          [OptionKeys.VariableDeclaration]: { type: 'boolean' },
-          [OptionKeys.VariableDeclarationIgnoreFunction]: { type: 'boolean' },
+          [OptionKeys.ArrayDestructuring]: {
+            description:
+              'Whether to enforce type annotations on variables declared using array destructuring.',
+            type: 'boolean',
+          },
+          [OptionKeys.ArrowParameter]: {
+            description:
+              'Whether to enforce type annotations for parameters of arrow functions.',
+            type: 'boolean',
+          },
+          [OptionKeys.MemberVariableDeclaration]: {
+            description:
+              'Whether to enforce type annotations on member variables of classes.',
+            type: 'boolean',
+          },
+          [OptionKeys.ObjectDestructuring]: {
+            description:
+              'Whether to enforce type annotations on variables declared using object destructuring.',
+            type: 'boolean',
+          },
+          [OptionKeys.Parameter]: {
+            description:
+              'Whether to enforce type annotations for parameters of functions and methods.',
+            type: 'boolean',
+          },
+          [OptionKeys.PropertyDeclaration]: {
+            description:
+              'Whether to enforce type annotations for properties of interfaces and types.',
+            type: 'boolean',
+          },
+          [OptionKeys.VariableDeclaration]: {
+            description:
+              'Whether to enforce type annotations for variable declarations, excluding array and object destructuring.',
+            type: 'boolean',
+          },
+          [OptionKeys.VariableDeclarationIgnoreFunction]: {
+            description:
+              'Whether to ignore variable declarations for non-arrow and arrow functions.',
+            type: 'boolean',
+          },
         },
       },
     ],

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/max-params.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/max-params.shot
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Validating rule docs max-params.mdx code examples ESLint output 1`] = `
+"Incorrect
+Options: { "countVoidThis": false, "max": 1 }
+
+function hasNoThis(this: void, first: string, second: string) {
+~~~~~~~~~~~~~~~~~~ Function 'hasNoThis' has too many parameters (2). Maximum allowed is 1.
+  // ...
+}
+"
+`;
+
+exports[`Validating rule docs max-params.mdx code examples ESLint output 2`] = `
+"Correct
+Options: { "countVoidThis": false, "max": 1 }
+
+function hasNoThis(this: void, first: string) {
+  // ...
+}
+"
+`;

--- a/packages/eslint-plugin/tests/schema-snapshots/ban-ts-comment.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/ban-ts-comment.shot
@@ -33,6 +33,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "properties": {
       "minimumDescriptionLength": {
         "default": 3,
+        "description": "A minimum character length for descriptions when \`allow-with-description\` is enabled.",
         "type": "number"
       },
       "ts-check": {
@@ -68,6 +69,7 @@ type Options = [
     'ts-expect-error'?: DirectiveConfigSchema;
     'ts-ignore'?: DirectiveConfigSchema;
     'ts-nocheck'?: DirectiveConfigSchema;
+    /** A minimum character length for descriptions when \`allow-with-description\` is enabled. */
     minimumDescriptionLength?: number;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/consistent-type-assertions.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/consistent-type-assertions.shot
@@ -11,6 +11,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "additionalProperties": false,
         "properties": {
           "assertionStyle": {
+            "description": "The expected assertion style to enforce.",
             "enum": ["never"],
             "type": "string"
           }
@@ -22,10 +23,12 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "additionalProperties": false,
         "properties": {
           "assertionStyle": {
+            "description": "The expected assertion style to enforce.",
             "enum": ["angle-bracket", "as"],
             "type": "string"
           },
           "objectLiteralTypeAssertions": {
+            "description": "Whether to always prefer type declarations for object literals used as variable initializers, rather than type assertions.",
             "enum": ["allow", "allow-as-parameter", "never"],
             "type": "string"
           }
@@ -42,11 +45,22 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   | {
-      assertionStyle: 'angle-bracket' | 'as';
-      objectLiteralTypeAssertions?: 'allow' | 'allow-as-parameter' | 'never';
+      /** The expected assertion style to enforce. */
+      assertionStyle:
+        | 'as'
+        /** The expected assertion style to enforce. */
+        | 'angle-bracket';
+      /** Whether to always prefer type declarations for object literals used as variable initializers, rather than type assertions. */
+      objectLiteralTypeAssertions?:
+        | 'allow-as-parameter'
+        | 'never'
+        /** Whether to always prefer type declarations for object literals used as variable initializers, rather than type assertions. */
+        | 'allow';
     }
   | {
-      assertionStyle: 'never';
+      /** The expected assertion style to enforce. */
+      assertionStyle: /** The expected assertion style to enforce. */
+      'never';
     },
 ];
 "

--- a/packages/eslint-plugin/tests/schema-snapshots/consistent-type-exports.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/consistent-type-exports.shot
@@ -9,6 +9,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "fixMixedExportsWithInlineTypeSpecifier": {
+        "description": "Whether the rule will autofix \\"mixed\\" export cases using TS inline type specifiers.",
         "type": "boolean"
       }
     },
@@ -21,6 +22,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether the rule will autofix "mixed" export cases using TS inline type specifiers. */
     fixMixedExportsWithInlineTypeSpecifier?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/consistent-type-imports.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/consistent-type-imports.shot
@@ -9,13 +9,16 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "disallowTypeAnnotations": {
+        "description": "Whether to disallow type imports in type annotations (\`import()\`).",
         "type": "boolean"
       },
       "fixStyle": {
+        "description": "The expected type modifier to be added when an import is detected as used only in the type position.",
         "enum": ["inline-type-imports", "separate-type-imports"],
         "type": "string"
       },
       "prefer": {
+        "description": "The expected import kind for type-only imports.",
         "enum": ["no-type-imports", "type-imports"],
         "type": "string"
       }
@@ -29,9 +32,18 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to disallow type imports in type annotations (\`import()\`). */
     disallowTypeAnnotations?: boolean;
-    fixStyle?: 'inline-type-imports' | 'separate-type-imports';
-    prefer?: 'no-type-imports' | 'type-imports';
+    /** The expected type modifier to be added when an import is detected as used only in the type position. */
+    fixStyle?:
+      | 'separate-type-imports'
+      /** The expected type modifier to be added when an import is detected as used only in the type position. */
+      | 'inline-type-imports';
+    /** The expected import kind for type-only imports. */
+    prefer?:
+      | 'type-imports'
+      /** The expected import kind for type-only imports. */
+      | 'no-type-imports';
   },
 ];
 "

--- a/packages/eslint-plugin/tests/schema-snapshots/dot-notation.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/dot-notation.shot
@@ -10,22 +10,27 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "properties": {
       "allowIndexSignaturePropertyAccess": {
         "default": false,
+        "description": "Whether to allow accessing properties matching an index signature with array notation.",
         "type": "boolean"
       },
       "allowKeywords": {
         "default": true,
+        "description": "Whether to allow keywords such as [\\"class\\"]\`.",
         "type": "boolean"
       },
       "allowPattern": {
         "default": "",
+        "description": "Regular expression of names to allow.",
         "type": "string"
       },
       "allowPrivateClassPropertyAccess": {
         "default": false,
+        "description": "Whether to allow accessing class members marked as \`private\` with array notation.",
         "type": "boolean"
       },
       "allowProtectedClassPropertyAccess": {
         "default": false,
+        "description": "Whether to allow accessing class members marked as \`protected\` with array notation.",
         "type": "boolean"
       }
     },
@@ -38,10 +43,15 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to allow accessing properties matching an index signature with array notation. */
     allowIndexSignaturePropertyAccess?: boolean;
+    /** Whether to allow keywords such as ["class"]\`. */
     allowKeywords?: boolean;
+    /** Regular expression of names to allow. */
     allowPattern?: string;
+    /** Whether to allow accessing class members marked as \`private\` with array notation. */
     allowPrivateClassPropertyAccess?: boolean;
+    /** Whether to allow accessing class members marked as \`protected\` with array notation. */
     allowProtectedClassPropertyAccess?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/explicit-member-accessibility.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/explicit-member-accessibility.shot
@@ -33,6 +33,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "$ref": "#/items/0/$defs/accessibilityLevel"
       },
       "ignoredMethodNames": {
+        "description": "Specific method names that may be ignored.",
         "items": {
           "type": "string"
         },
@@ -78,6 +79,7 @@ type AccessibilityLevel =
 type Options = [
   {
     accessibility?: AccessibilityLevel;
+    /** Specific method names that may be ignored. */
     ignoredMethodNames?: string[];
     overrides?: {
       accessors?: AccessibilityLevel;

--- a/packages/eslint-plugin/tests/schema-snapshots/max-params.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/max-params.shot
@@ -9,13 +9,16 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "countVoidThis": {
+        "description": "Whether to count a \`this\` declaration when the type is \`void\`.",
         "type": "boolean"
       },
       "max": {
+        "description": "A maximum number of parameters in function definitions.",
         "minimum": 0,
         "type": "integer"
       },
       "maximum": {
+        "description": "(deprecated) A maximum number of parameters in function definitions.",
         "minimum": 0,
         "type": "integer"
       }
@@ -29,8 +32,11 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to count a \`this\` declaration when the type is \`void\`. */
     countVoidThis?: boolean;
+    /** A maximum number of parameters in function definitions. */
     max?: number;
+    /** (deprecated) A maximum number of parameters in function definitions. */
     maximum?: number;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-base-to-string.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-base-to-string.shot
@@ -9,6 +9,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "ignoredTypeNames": {
+        "description": "Stringified regular expressions of type names to ignore.",
         "items": {
           "type": "string"
         },
@@ -24,6 +25,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Stringified regular expressions of type names to ignore. */
     ignoredTypeNames?: string[];
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-confusing-void-expression.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-confusing-void-expression.shot
@@ -9,9 +9,11 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "ignoreArrowShorthand": {
+        "description": "Whether to ignore \\"shorthand\\" \`() =>\` arrow functions: those without \`{ ... }\` braces.",
         "type": "boolean"
       },
       "ignoreVoidOperator": {
+        "description": "Whether to ignore returns that start with the \`void\` operator.",
         "type": "boolean"
       }
     },
@@ -24,7 +26,9 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to ignore "shorthand" \`() =>\` arrow functions: those without \`{ ... }\` braces. */
     ignoreArrowShorthand?: boolean;
+    /** Whether to ignore returns that start with the \`void\` operator. */
     ignoreVoidOperator?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-duplicate-type-constituents.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-duplicate-type-constituents.shot
@@ -9,9 +9,11 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "ignoreIntersections": {
+        "description": "Whether to ignore \`&\` intersections.",
         "type": "boolean"
       },
       "ignoreUnions": {
+        "description": "Whether to ignore \`|\` unions.",
         "type": "boolean"
       }
     },
@@ -24,7 +26,9 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to ignore \`&\` intersections. */
     ignoreIntersections?: boolean;
+    /** Whether to ignore \`|\` unions. */
     ignoreUnions?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-empty-function.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-empty-function.shot
@@ -9,6 +9,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allow": {
+        "description": "Locations and kinds of functions that are allowed to be empty.",
         "items": {
           "enum": [
             "arrowFunctions",
@@ -41,6 +42,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Locations and kinds of functions that are allowed to be empty. */
     allow?: (
       | 'arrowFunctions'
       | 'asyncFunctions'

--- a/packages/eslint-plugin/tests/schema-snapshots/no-empty-interface.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-empty-interface.shot
@@ -9,6 +9,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowSingleExtends": {
+        "description": "Whether to allow empty interfaces that extend a single other interface.",
         "type": "boolean"
       }
     },
@@ -21,6 +22,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to allow empty interfaces that extend a single other interface. */
     allowSingleExtends?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-empty-object-type.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-empty-object-type.shot
@@ -9,14 +9,17 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowInterfaces": {
+        "description": "Whether to allow empty interfaces.",
         "enum": ["always", "never", "with-single-extends"],
         "type": "string"
       },
       "allowObjectTypes": {
+        "description": "Whether to allow empty object type literals.",
         "enum": ["always", "never"],
         "type": "string"
       },
       "allowWithName": {
+        "description": "A stringified regular expression to allow interfaces and object type aliases with the configured name.",
         "type": "string"
       }
     },
@@ -29,8 +32,18 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
-    allowInterfaces?: 'always' | 'never' | 'with-single-extends';
-    allowObjectTypes?: 'always' | 'never';
+    /** Whether to allow empty interfaces. */
+    allowInterfaces?:
+      | 'never'
+      | 'with-single-extends'
+      /** Whether to allow empty interfaces. */
+      | 'always';
+    /** Whether to allow empty object type literals. */
+    allowObjectTypes?:
+      | 'never'
+      /** Whether to allow empty object type literals. */
+      | 'always';
+    /** A stringified regular expression to allow interfaces and object type aliases with the configured name. */
     allowWithName?: string;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-floating-promises.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-floating-promises.shot
@@ -9,6 +9,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowForKnownSafeCalls": {
+        "description": "Type specifiers of functions whose calls are safe to float.",
         "items": {
           "oneOf": [
             {
@@ -103,6 +104,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "type": "array"
       },
       "allowForKnownSafePromises": {
+        "description": "Type specifiers that are known to be safe to float.",
         "items": {
           "oneOf": [
             {
@@ -218,6 +220,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Type specifiers of functions whose calls are safe to float. */
     allowForKnownSafeCalls?: (
       | {
           from: 'file';
@@ -235,6 +238,7 @@ type Options = [
         }
       | string
     )[];
+    /** Type specifiers that are known to be safe to float. */
     allowForKnownSafePromises?: (
       | {
           from: 'file';

--- a/packages/eslint-plugin/tests/schema-snapshots/no-inferrable-types.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-inferrable-types.shot
@@ -9,9 +9,11 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "ignoreParameters": {
+        "description": "Whether to ignore function parameters.",
         "type": "boolean"
       },
       "ignoreProperties": {
+        "description": "Whether to ignore class properties.",
         "type": "boolean"
       }
     },
@@ -24,7 +26,9 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to ignore function parameters. */
     ignoreParameters?: boolean;
+    /** Whether to ignore class properties. */
     ignoreProperties?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-invalid-void-type.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-invalid-void-type.shot
@@ -9,9 +9,11 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowAsThisParameter": {
+        "description": "Whether a \`this\` parameter of a function may be \`void\`.",
         "type": "boolean"
       },
       "allowInGenericTypeArguments": {
+        "description": "Whether \`void\` can be used as a valid value for generic type parameters.",
         "oneOf": [
           {
             "type": "boolean"
@@ -35,8 +37,13 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether a \`this\` parameter of a function may be \`void\`. */
     allowAsThisParameter?: boolean;
-    allowInGenericTypeArguments?: [string, ...string[]] | boolean;
+    /** Whether \`void\` can be used as a valid value for generic type parameters. */
+    allowInGenericTypeArguments?:
+      | [string, ...string[]]
+      /** Whether \`void\` can be used as a valid value for generic type parameters. */
+      | boolean;
   },
 ];
 "

--- a/packages/eslint-plugin/tests/schema-snapshots/no-magic-numbers.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-magic-numbers.shot
@@ -44,15 +44,19 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "type": "boolean"
       },
       "ignoreEnums": {
+        "description": "Whether enums used in TypeScript are considered okay.",
         "type": "boolean"
       },
       "ignoreNumericLiteralTypes": {
+        "description": "Whether numbers used in TypeScript numeric literal types are considered okay.",
         "type": "boolean"
       },
       "ignoreReadonlyClassProperties": {
+        "description": "Whether \`readonly\` class properties are considered okay.",
         "type": "boolean"
       },
       "ignoreTypeIndexes": {
+        "description": "Whether numbers used to index types are okay.",
         "type": "boolean"
       }
     },
@@ -71,9 +75,13 @@ type Options = [
     ignoreArrayIndexes?: boolean;
     ignoreClassFieldInitialValues?: boolean;
     ignoreDefaultValues?: boolean;
+    /** Whether enums used in TypeScript are considered okay. */
     ignoreEnums?: boolean;
+    /** Whether numbers used in TypeScript numeric literal types are considered okay. */
     ignoreNumericLiteralTypes?: boolean;
+    /** Whether \`readonly\` class properties are considered okay. */
     ignoreReadonlyClassProperties?: boolean;
+    /** Whether numbers used to index types are okay. */
     ignoreTypeIndexes?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-meaningless-void-operator.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-meaningless-void-operator.shot
@@ -10,6 +10,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "properties": {
       "checkNever": {
         "default": false,
+        "description": "Whether to suggest removing \`void\` when the argument has type \`never\`.",
         "type": "boolean"
       }
     },
@@ -22,6 +23,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to suggest removing \`void\` when the argument has type \`never\`. */
     checkNever?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-misused-promises.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-misused-promises.shot
@@ -12,6 +12,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "type": "boolean"
       },
       "checksSpreads": {
+        "description": "Whether to warn when \`...\` spreading a \`Promise\`.",
         "type": "boolean"
       },
       "checksVoidReturn": {
@@ -23,21 +24,27 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
             "additionalProperties": false,
             "properties": {
               "arguments": {
+                "description": "Disables checking an asynchronous function passed as argument where the parameter type expects a function that returns \`void\`.",
                 "type": "boolean"
               },
               "attributes": {
+                "description": "Disables checking an asynchronous function passed as a JSX attribute expected to be a function that returns \`void\`.",
                 "type": "boolean"
               },
               "inheritedMethods": {
+                "description": "Disables checking an asynchronous method in a type that extends or implements another type expecting that method to return \`void\`.",
                 "type": "boolean"
               },
               "properties": {
+                "description": "Disables checking an asynchronous function passed as an object property expected to be a function that returns \`void\`.",
                 "type": "boolean"
               },
               "returns": {
+                "description": "Disables checking an asynchronous function returned in a function whose return type is a function that returns \`void\`.",
                 "type": "boolean"
               },
               "variables": {
+                "description": "Disables checking an asynchronous function used as a variable whose return type is a function that returns \`void\`.",
                 "type": "boolean"
               }
             },
@@ -56,14 +63,21 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 type Options = [
   {
     checksConditionals?: boolean;
+    /** Whether to warn when \`...\` spreading a \`Promise\`. */
     checksSpreads?: boolean;
     checksVoidReturn?:
       | {
+          /** Disables checking an asynchronous function passed as argument where the parameter type expects a function that returns \`void\`. */
           arguments?: boolean;
+          /** Disables checking an asynchronous function passed as a JSX attribute expected to be a function that returns \`void\`. */
           attributes?: boolean;
+          /** Disables checking an asynchronous method in a type that extends or implements another type expecting that method to return \`void\`. */
           inheritedMethods?: boolean;
+          /** Disables checking an asynchronous function passed as an object property expected to be a function that returns \`void\`. */
           properties?: boolean;
+          /** Disables checking an asynchronous function returned in a function whose return type is a function that returns \`void\`. */
           returns?: boolean;
+          /** Disables checking an asynchronous function used as a variable whose return type is a function that returns \`void\`. */
           variables?: boolean;
         }
       | boolean;

--- a/packages/eslint-plugin/tests/schema-snapshots/no-redeclare.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-redeclare.shot
@@ -9,9 +9,11 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "builtinGlobals": {
+        "description": "Whether to report shadowing of built-in global variables.",
         "type": "boolean"
       },
       "ignoreDeclarationMerge": {
+        "description": "Whether to ignore declaration merges between certain TypeScript declaration types.",
         "type": "boolean"
       }
     },
@@ -24,7 +26,9 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to report shadowing of built-in global variables. */
     builtinGlobals?: boolean;
+    /** Whether to ignore declaration merges between certain TypeScript declaration types. */
     ignoreDeclarationMerge?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-shadow.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-shadow.shot
@@ -9,25 +9,31 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allow": {
+        "description": "Identifier names for which shadowing is allowed.",
         "items": {
           "type": "string"
         },
         "type": "array"
       },
       "builtinGlobals": {
+        "description": "Whether to report shadowing of built-in global variables.",
         "type": "boolean"
       },
       "hoist": {
+        "description": "Whether to report shadowing before outer functions or variables are defined.",
         "enum": ["all", "functions", "never"],
         "type": "string"
       },
       "ignoreFunctionTypeParameterNameValueShadow": {
+        "description": "Whether to ignore function parameters named the same as a variable.",
         "type": "boolean"
       },
       "ignoreOnInitialization": {
+        "description": "Whether to ignore the variable initializers when the shadowed variable is presumably still unitialized.",
         "type": "boolean"
       },
       "ignoreTypeValueShadow": {
+        "description": "Whether to ignore types named the same as a variable.",
         "type": "boolean"
       }
     },
@@ -40,11 +46,21 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Identifier names for which shadowing is allowed. */
     allow?: string[];
+    /** Whether to report shadowing of built-in global variables. */
     builtinGlobals?: boolean;
-    hoist?: 'all' | 'functions' | 'never';
+    /** Whether to report shadowing before outer functions or variables are defined. */
+    hoist?:
+      | 'functions'
+      | 'never'
+      /** Whether to report shadowing before outer functions or variables are defined. */
+      | 'all';
+    /** Whether to ignore function parameters named the same as a variable. */
     ignoreFunctionTypeParameterNameValueShadow?: boolean;
+    /** Whether to ignore the variable initializers when the shadowed variable is presumably still unitialized. */
     ignoreOnInitialization?: boolean;
+    /** Whether to ignore types named the same as a variable. */
     ignoreTypeValueShadow?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unused-vars.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unused-vars.shot
@@ -15,36 +15,46 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "additionalProperties": false,
         "properties": {
           "args": {
+            "description": "Whether to check all, some, or no arguments.",
             "enum": ["after-used", "all", "none"],
             "type": "string"
           },
           "argsIgnorePattern": {
+            "description": "Regular expressions of argument names to not check for usage.",
             "type": "string"
           },
           "caughtErrors": {
+            "description": "Whether to check catch block arguments.",
             "enum": ["all", "none"],
             "type": "string"
           },
           "caughtErrorsIgnorePattern": {
+            "description": "Regular expressions of catch block argument names to not check for usage.",
             "type": "string"
           },
           "destructuredArrayIgnorePattern": {
+            "description": "Regular expressions of destructured array variable names to not check for usage.",
             "type": "string"
           },
           "ignoreClassWithStaticInitBlock": {
+            "description": "Whether to ignore classes with at least one static initialization block.",
             "type": "boolean"
           },
           "ignoreRestSiblings": {
+            "description": "Whether to ignore sibling properties in \`...\` destructurings.",
             "type": "boolean"
           },
           "reportUsedIgnorePattern": {
+            "description": "Whether to report variables that match any of the valid ignore pattern options if they have been used.",
             "type": "boolean"
           },
           "vars": {
+            "description": "Whether to check all variables or only locally-declared variables.",
             "enum": ["all", "local"],
             "type": "string"
           },
           "varsIgnorePattern": {
+            "description": "Regular expressions of variable names to not check for usage.",
             "type": "string"
           }
         },
@@ -61,15 +71,35 @@ type Options = [
   | 'all'
   | 'local'
   | {
-      args?: 'after-used' | 'all' | 'none';
+      /** Whether to check all, some, or no arguments. */
+      args?:
+        | 'all'
+        | 'none'
+        /** Whether to check all, some, or no arguments. */
+        | 'after-used';
+      /** Regular expressions of argument names to not check for usage. */
       argsIgnorePattern?: string;
-      caughtErrors?: 'all' | 'none';
+      /** Whether to check catch block arguments. */
+      caughtErrors?:
+        | 'none'
+        /** Whether to check catch block arguments. */
+        | 'all';
+      /** Regular expressions of catch block argument names to not check for usage. */
       caughtErrorsIgnorePattern?: string;
+      /** Regular expressions of destructured array variable names to not check for usage. */
       destructuredArrayIgnorePattern?: string;
+      /** Whether to ignore classes with at least one static initialization block. */
       ignoreClassWithStaticInitBlock?: boolean;
+      /** Whether to ignore sibling properties in \`...\` destructurings. */
       ignoreRestSiblings?: boolean;
+      /** Whether to report variables that match any of the valid ignore pattern options if they have been used. */
       reportUsedIgnorePattern?: boolean;
-      vars?: 'all' | 'local';
+      /** Whether to check all variables or only locally-declared variables. */
+      vars?:
+        | 'local'
+        /** Whether to check all variables or only locally-declared variables. */
+        | 'all';
+      /** Regular expressions of variable names to not check for usage. */
       varsIgnorePattern?: string;
     },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-use-before-define.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-use-before-define.shot
@@ -18,21 +18,27 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
             "type": "boolean"
           },
           "classes": {
+            "description": "Whether to ignore references to class declarations.",
             "type": "boolean"
           },
           "enums": {
+            "description": "Whether to check references to enums.",
             "type": "boolean"
           },
           "functions": {
+            "description": "Whether to ignore references to function declarations.",
             "type": "boolean"
           },
           "ignoreTypeReferences": {
+            "description": "Whether to ignore type references, such as in type annotations and assertions.",
             "type": "boolean"
           },
           "typedefs": {
+            "description": "Whether to check references to types.",
             "type": "boolean"
           },
           "variables": {
+            "description": "Whether to ignore references to variables.",
             "type": "boolean"
           }
         },
@@ -49,11 +55,17 @@ type Options = [
   | 'nofunc'
   | {
       allowNamedExports?: boolean;
+      /** Whether to ignore references to class declarations. */
       classes?: boolean;
+      /** Whether to check references to enums. */
       enums?: boolean;
+      /** Whether to ignore references to function declarations. */
       functions?: boolean;
+      /** Whether to ignore type references, such as in type annotations and assertions. */
       ignoreTypeReferences?: boolean;
+      /** Whether to check references to types. */
       typedefs?: boolean;
+      /** Whether to ignore references to variables. */
       variables?: boolean;
     },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/only-throw-error.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/only-throw-error.shot
@@ -9,9 +9,11 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowThrowingAny": {
+        "description": "Whether to always allow throwing values typed as \`any\`.",
         "type": "boolean"
       },
       "allowThrowingUnknown": {
+        "description": "Whether to always allow throwing values typed as \`unknown\`.",
         "type": "boolean"
       }
     },
@@ -24,7 +26,9 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to always allow throwing values typed as \`any\`. */
     allowThrowingAny?: boolean;
+    /** Whether to always allow throwing values typed as \`unknown\`. */
     allowThrowingUnknown?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/parameter-properties.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/parameter-properties.shot
@@ -23,12 +23,14 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allow": {
+        "description": "Whether to allow certain kinds of properties to be ignored.",
         "items": {
           "$ref": "#/items/0/$defs/modifier"
         },
         "type": "array"
       },
       "prefer": {
+        "description": "Whether to prefer class properties or parameter properties.",
         "enum": ["class-property", "parameter-property"],
         "type": "string"
       }
@@ -51,8 +53,13 @@ type Modifier =
 
 type Options = [
   {
+    /** Whether to allow certain kinds of properties to be ignored. */
     allow?: Modifier[];
-    prefer?: 'class-property' | 'parameter-property';
+    /** Whether to prefer class properties or parameter properties. */
+    prefer?:
+      | 'parameter-property'
+      /** Whether to prefer class properties or parameter properties. */
+      | 'class-property';
   },
 ];
 "

--- a/packages/eslint-plugin/tests/schema-snapshots/prefer-literal-enum-member.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/prefer-literal-enum-member.shot
@@ -9,6 +9,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowBitwiseExpressions": {
+        "description": "Whether to allow using bitwise expressions in enum initializers.",
         "type": "boolean"
       }
     },
@@ -21,6 +22,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to allow using bitwise expressions in enum initializers. */
     allowBitwiseExpressions?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/prefer-nullish-coalescing.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/prefer-nullish-coalescing.shot
@@ -9,15 +9,19 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
+        "description": "Unless this is set to \`true\`, the rule will error on every file whose \`tsconfig.json\` does _not_ have the \`strictNullChecks\` compiler option (or \`strict\`) set to \`true\`.",
         "type": "boolean"
       },
       "ignoreConditionalTests": {
+        "description": "Whether to ignore cases that are located within a conditional test.",
         "type": "boolean"
       },
       "ignoreMixedLogicalExpressions": {
+        "description": "Whether to ignore any logical or expressions that are part of a mixed logical expression (with \`&&\`).",
         "type": "boolean"
       },
       "ignorePrimitives": {
+        "description": "Whether to ignore all (\`true\`) or some (an object with properties) primitive types.",
         "oneOf": [
           {
             "properties": {
@@ -43,6 +47,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         ]
       },
       "ignoreTernaryTests": {
+        "description": "Whether to ignore any ternary expressions that could be simplified by using the nullish coalescing operator.",
         "type": "boolean"
       }
     },
@@ -55,18 +60,24 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Unless this is set to \`true\`, the rule will error on every file whose \`tsconfig.json\` does _not_ have the \`strictNullChecks\` compiler option (or \`strict\`) set to \`true\`. */
     allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
+    /** Whether to ignore cases that are located within a conditional test. */
     ignoreConditionalTests?: boolean;
+    /** Whether to ignore any logical or expressions that are part of a mixed logical expression (with \`&&\`). */
     ignoreMixedLogicalExpressions?: boolean;
+    /** Whether to ignore all (\`true\`) or some (an object with properties) primitive types. */
     ignorePrimitives?:
+      | true
+      /** Whether to ignore all (\`true\`) or some (an object with properties) primitive types. */
       | {
           bigint?: boolean;
           boolean?: boolean;
           number?: boolean;
           string?: boolean;
           [k: string]: unknown;
-        }
-      | true;
+        };
+    /** Whether to ignore any ternary expressions that could be simplified by using the nullish coalescing operator. */
     ignoreTernaryTests?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/prefer-promise-reject-errors.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/prefer-promise-reject-errors.shot
@@ -9,6 +9,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowEmptyReject": {
+        "description": "Whether to allow calls to \`Promise.reject()\` with no arguments.",
         "type": "boolean"
       }
     },
@@ -21,6 +22,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to allow calls to \`Promise.reject()\` with no arguments. */
     allowEmptyReject?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/prefer-readonly-parameter-types.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/prefer-readonly-parameter-types.shot
@@ -9,6 +9,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allow": {
+        "description": "An array of type specifiers to ignore.",
         "items": {
           "oneOf": [
             {
@@ -103,12 +104,15 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "type": "array"
       },
       "checkParameterProperties": {
+        "description": "Whether to check class parameter properties.",
         "type": "boolean"
       },
       "ignoreInferredTypes": {
+        "description": "Whether to ignore parameters which don't explicitly specify a type.",
         "type": "boolean"
       },
       "treatMethodsAsReadonly": {
+        "description": "Whether to treat all mutable methods as though they are readonly.",
         "type": "boolean"
       }
     },
@@ -121,6 +125,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** An array of type specifiers to ignore. */
     allow?: (
       | {
           from: 'file';
@@ -138,8 +143,11 @@ type Options = [
         }
       | string
     )[];
+    /** Whether to check class parameter properties. */
     checkParameterProperties?: boolean;
+    /** Whether to ignore parameters which don't explicitly specify a type. */
     ignoreInferredTypes?: boolean;
+    /** Whether to treat all mutable methods as though they are readonly. */
     treatMethodsAsReadonly?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/prefer-readonly.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/prefer-readonly.shot
@@ -9,6 +9,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "onlyInlineLambdas": {
+        "description": "Whether to restrict checking only to members immediately assigned a lambda value.",
         "type": "boolean"
       }
     },
@@ -21,6 +22,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to restrict checking only to members immediately assigned a lambda value. */
     onlyInlineLambdas?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/promise-function-async.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/promise-function-async.shot
@@ -20,15 +20,19 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "type": "array"
       },
       "checkArrowFunctions": {
+        "description": "Whether to check arrow functions.",
         "type": "boolean"
       },
       "checkFunctionDeclarations": {
+        "description": "Whether to check standalone function declarations.",
         "type": "boolean"
       },
       "checkFunctionExpressions": {
+        "description": "Whether to check inline function expressions",
         "type": "boolean"
       },
       "checkMethodDeclarations": {
+        "description": "Whether to check methods on classes and object literals.",
         "type": "boolean"
       }
     },
@@ -45,9 +49,13 @@ type Options = [
     allowAny?: boolean;
     /** Any extra names of classes or interfaces to be considered Promises. */
     allowedPromiseNames?: string[];
+    /** Whether to check arrow functions. */
     checkArrowFunctions?: boolean;
+    /** Whether to check standalone function declarations. */
     checkFunctionDeclarations?: boolean;
+    /** Whether to check inline function expressions */
     checkFunctionExpressions?: boolean;
+    /** Whether to check methods on classes and object literals. */
     checkMethodDeclarations?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/return-await.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/return-await.shot
@@ -6,11 +6,27 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 [
   {
-    "enum": [
-      "always",
-      "error-handling-correctness-only",
-      "in-try-catch",
-      "never"
+    "oneOf": [
+      {
+        "description": "Requires that all returned promises be awaited.",
+        "enum": ["always"],
+        "type": "string"
+      },
+      {
+        "description": "In error-handling contexts, the rule enforces that returned promises must be awaited. In ordinary contexts, the rule does not enforce any particular behavior around whether returned promises are awaited.",
+        "enum": ["error-handling-correctness-only"],
+        "type": "string"
+      },
+      {
+        "description": "In error-handling contexts, the rule enforces that returned promises must be awaited. In ordinary contexts, the rule enforces that returned promises _must not_ be awaited.",
+        "enum": ["in-try-catch"],
+        "type": "string"
+      },
+      {
+        "description": "Disallows awaiting any returned promises.",
+        "enum": ["never"],
+        "type": "string"
+      }
     ],
     "type": "string"
   }
@@ -20,7 +36,14 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 # TYPES:
 
 type Options = [
-  'always' | 'error-handling-correctness-only' | 'in-try-catch' | 'never',
+  /** Disallows awaiting any returned promises. */
+  | 'never'
+  /** In error-handling contexts, the rule enforces that returned promises must be awaited. In ordinary contexts, the rule does not enforce any particular behavior around whether returned promises are awaited. */
+  | 'error-handling-correctness-only'
+  /** In error-handling contexts, the rule enforces that returned promises must be awaited. In ordinary contexts, the rule enforces that returned promises _must not_ be awaited. */
+  | 'in-try-catch'
+  /** Requires that all returned promises be awaited. */
+  | 'always',
 ];
 "
 `;

--- a/packages/eslint-plugin/tests/schema-snapshots/strict-boolean-expressions.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/strict-boolean-expressions.shot
@@ -9,30 +9,38 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowAny": {
+        "description": "Whether to allow \`any\` in a boolean context.",
         "type": "boolean"
       },
       "allowNullableBoolean": {
+        "description": "Whether to allow nullable \`boolean\`s in a boolean context.",
         "type": "boolean"
       },
       "allowNullableEnum": {
+        "description": "Whether to allow nullable \`enum\`s in a boolean context.",
         "type": "boolean"
       },
       "allowNullableNumber": {
+        "description": "Whether to allow nullable \`number\`s in a boolean context.",
         "type": "boolean"
       },
       "allowNullableObject": {
+        "description": "Whether to allow nullable \`object\`s in a boolean context.",
         "type": "boolean"
       },
       "allowNullableString": {
+        "description": "Whether to allow nullable \`string\`s in a boolean context.",
         "type": "boolean"
       },
       "allowNumber": {
+        "description": "Whether to allow \`number\` in a boolean context.",
         "type": "boolean"
       },
       "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
         "type": "boolean"
       },
       "allowString": {
+        "description": "Whether to allow \`string\` in a boolean context.",
         "type": "boolean"
       }
     },
@@ -45,14 +53,22 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to allow \`any\` in a boolean context. */
     allowAny?: boolean;
+    /** Whether to allow nullable \`boolean\`s in a boolean context. */
     allowNullableBoolean?: boolean;
+    /** Whether to allow nullable \`enum\`s in a boolean context. */
     allowNullableEnum?: boolean;
+    /** Whether to allow nullable \`number\`s in a boolean context. */
     allowNullableNumber?: boolean;
+    /** Whether to allow nullable \`object\`s in a boolean context. */
     allowNullableObject?: boolean;
+    /** Whether to allow nullable \`string\`s in a boolean context. */
     allowNullableString?: boolean;
+    /** Whether to allow \`number\` in a boolean context. */
     allowNumber?: boolean;
     allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
+    /** Whether to allow \`string\` in a boolean context. */
     allowString?: boolean;
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/triple-slash-reference.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/triple-slash-reference.shot
@@ -9,14 +9,17 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "lib": {
+        "description": "What to enforce for \`/// <reference lib=\\"...\\" />\` references.",
         "enum": ["always", "never"],
         "type": "string"
       },
       "path": {
+        "description": "What to enforce for \`/// <reference path=\\"...\\" />\` references.",
         "enum": ["always", "never"],
         "type": "string"
       },
       "types": {
+        "description": "What to enforce for \`/// <reference types=\\"...\\" />\` references.",
         "enum": ["always", "never", "prefer-import"],
         "type": "string"
       }
@@ -30,9 +33,22 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
-    lib?: 'always' | 'never';
-    path?: 'always' | 'never';
-    types?: 'always' | 'never' | 'prefer-import';
+    /** What to enforce for \`/// <reference lib="..." />\` references. */
+    lib?:
+      | 'never'
+      /** What to enforce for \`/// <reference lib="..." />\` references. */
+      | 'always';
+    /** What to enforce for \`/// <reference path="..." />\` references. */
+    path?:
+      | 'never'
+      /** What to enforce for \`/// <reference path="..." />\` references. */
+      | 'always';
+    /** What to enforce for \`/// <reference types="..." />\` references. */
+    types?:
+      | 'never'
+      | 'prefer-import'
+      /** What to enforce for \`/// <reference types="..." />\` references. */
+      | 'always';
   },
 ];
 "

--- a/packages/eslint-plugin/tests/schema-snapshots/typedef.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/typedef.shot
@@ -9,27 +9,35 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "arrayDestructuring": {
+        "description": "Whether to enforce type annotations on variables declared using array destructuring.",
         "type": "boolean"
       },
       "arrowParameter": {
+        "description": "Whether to enforce type annotations for parameters of arrow functions.",
         "type": "boolean"
       },
       "memberVariableDeclaration": {
+        "description": "Whether to enforce type annotations on member variables of classes.",
         "type": "boolean"
       },
       "objectDestructuring": {
+        "description": "Whether to enforce type annotations on variables declared using object destructuring.",
         "type": "boolean"
       },
       "parameter": {
+        "description": "Whether to enforce type annotations for parameters of functions and methods.",
         "type": "boolean"
       },
       "propertyDeclaration": {
+        "description": "Whether to enforce type annotations for properties of interfaces and types.",
         "type": "boolean"
       },
       "variableDeclaration": {
+        "description": "Whether to enforce type annotations for variable declarations, excluding array and object destructuring.",
         "type": "boolean"
       },
       "variableDeclarationIgnoreFunction": {
+        "description": "Whether to ignore variable declarations for non-arrow and arrow functions.",
         "type": "boolean"
       }
     },
@@ -42,13 +50,21 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to enforce type annotations on variables declared using array destructuring. */
     arrayDestructuring?: boolean;
+    /** Whether to enforce type annotations for parameters of arrow functions. */
     arrowParameter?: boolean;
+    /** Whether to enforce type annotations on member variables of classes. */
     memberVariableDeclaration?: boolean;
+    /** Whether to enforce type annotations on variables declared using object destructuring. */
     objectDestructuring?: boolean;
+    /** Whether to enforce type annotations for parameters of functions and methods. */
     parameter?: boolean;
+    /** Whether to enforce type annotations for properties of interfaces and types. */
     propertyDeclaration?: boolean;
+    /** Whether to enforce type annotations for variable declarations, excluding array and object destructuring. */
     variableDeclaration?: boolean;
+    /** Whether to ignore variable declarations for non-arrow and arrow functions. */
     variableDeclarationIgnoreFunction?: boolean;
   },
 ];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5392
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds `description` properties to most rule options that didn't have them. This should be all remaining rules that aren't feature-frozen or using only an enum/string array (instead of object) for their options.

There are probably some rules missing that could be improved. I ran out of energy before converting most string literal union types into enums... If #9866 lands, we'll be forced to fill them in anyway.

Also standardizes the phrasing of some options to sound more like each other. Mostly, that's starting boolean options with _"Whether ..."_ instead of some of the many more wordy ways we've used.

Another good next step after this would be #9867 IMO: using these descriptions in rule docs pages. The phrasing standardization helps with that.

💖 