### PR TITLE
feat(typescript-estree): make withoutProjectParserOptions generic

### DIFF
--- a/packages/typescript-estree/src/withoutProjectParserOptions.ts
+++ b/packages/typescript-estree/src/withoutProjectParserOptions.ts
@@ -1,5 +1,3 @@
-import type { TSESTreeOptions } from './parser-options';
-
 /**
  * Removes options that prompt the parser to parse the project with type
  * information. In other words, you can use this if you are invoking the parser

--- a/packages/typescript-estree/src/withoutProjectParserOptions.ts
+++ b/packages/typescript-estree/src/withoutProjectParserOptions.ts
@@ -8,12 +8,15 @@ import type { TSESTreeOptions } from './parser-options';
  *
  * @see https://github.com/typescript-eslint/typescript-eslint/issues/8428
  */
-export function withoutProjectParserOptions(
-  opts: TSESTreeOptions,
-): TSESTreeOptions {
+export function withoutProjectParserOptions<Options extends TSESTreeOptions>(
+  opts: Options,
+): Omit<
+  Options,
+  'EXPERIMENTAL_useProjectService' | 'project' | 'projectService'
+> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- The variables are meant to be omitted
   const { EXPERIMENTAL_useProjectService, project, projectService, ...rest } =
     opts as Record<string, unknown>;
 
-  return rest;
+  return rest as unknown as Options;
 }

--- a/packages/typescript-estree/src/withoutProjectParserOptions.ts
+++ b/packages/typescript-estree/src/withoutProjectParserOptions.ts
@@ -8,7 +8,7 @@ import type { TSESTreeOptions } from './parser-options';
  *
  * @see https://github.com/typescript-eslint/typescript-eslint/issues/8428
  */
-export function withoutProjectParserOptions<Options extends TSESTreeOptions>(
+export function withoutProjectParserOptions<Options extends object>(
   opts: Options,
 ): Omit<
   Options,

--- a/packages/typescript-estree/tests/lib/withoutProjectParserOptions.test.ts
+++ b/packages/typescript-estree/tests/lib/withoutProjectParserOptions.test.ts
@@ -3,14 +3,31 @@ import { withoutProjectParserOptions } from '../../src';
 
 describe('withoutProjectParserOptions', () => {
   it('removes only project parser options', () => {
-    const without = withoutProjectParserOptions({
+    const options = {
       comment: true,
       EXPERIMENTAL_useProjectService: true,
       project: true,
       projectService: true,
-    } as TSESTreeOptions);
+    } as TSESTreeOptions;
+
+    const without = withoutProjectParserOptions(options);
+
     expect(without).toEqual({
       comment: true,
+    });
+  });
+
+  it('allows an alternate type extending from TSESTreeOptions', () => {
+    const without = withoutProjectParserOptions({
+      comment: true,
+      project: true,
+      projectService: true,
+      other: true,
+    });
+
+    expect(without).toEqual({
+      comment: true,
+      other: true,
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9827
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds an `<Options extends TSESTreeOptions>` to `withoutProjectParserOptions` so it can use types that happen to match it.

💖 