### PR TITLE
chore: replace globby with tinyglobby

### DIFF
--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -57,10 +57,10 @@
     "@typescript-eslint/types": "8.2.0",
     "@typescript-eslint/visitor-keys": "8.2.0",
     "debug": "^4.3.4",
-    "globby": "^11.1.0",
     "is-glob": "^4.0.3",
     "minimatch": "^9.0.4",
     "semver": "^7.6.0",
+    "tinyglobby": "^0.2.5",
     "ts-api-utils": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
+++ b/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
@@ -1,6 +1,6 @@
 import debug from 'debug';
-import { sync as globSync } from 'globby';
 import isGlob from 'is-glob';
+import { globSync } from 'tinyglobby';
 
 import type { CanonicalPath } from '../create-program/shared';
 import {

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -2,7 +2,7 @@ import { join, resolve } from 'node:path';
 
 import type { CacheDurationSeconds } from '@typescript-eslint/types';
 import debug from 'debug';
-import * as globbyModule from 'globby';
+import * as globbyModule from 'tinyglobby';
 import type * as typescriptModule from 'typescript';
 
 import * as parser from '../../src';
@@ -39,11 +39,11 @@ jest.mock('typescript', () => {
   };
 });
 
-jest.mock('globby', () => {
-  const globby = jest.requireActual<typeof globbyModule>('globby');
+jest.mock('tinyglobby', () => {
+  const globby = jest.requireActual<typeof globbyModule>('tinyglobby');
   return {
     ...globby,
-    sync: jest.fn(globby.sync),
+    globSync: jest.fn(globby.globSync),
   };
 });
 
@@ -52,7 +52,7 @@ const hrtimeSpy = jest.spyOn(process, 'hrtime');
 const createDefaultCompilerOptionsFromExtra = jest.mocked(
   sharedParserUtilsModule.createDefaultCompilerOptionsFromExtra,
 );
-const globbySyncMock = jest.mocked(globbyModule.sync);
+const globbySyncMock = jest.mocked(globbyModule.globSync);
 
 /**
  * Aligns paths between environments, node for windows uses `\`, for linux and mac uses `/`

--- a/yarn.lock
+++ b/yarn.lock
@@ -5916,13 +5916,13 @@ __metadata:
     "@typescript-eslint/visitor-keys": 8.2.0
     debug: ^4.3.4
     glob: "*"
-    globby: ^11.1.0
     is-glob: ^4.0.3
     jest: 29.7.0
     minimatch: ^9.0.4
     prettier: ^3.2.5
     rimraf: "*"
     semver: ^7.6.0
+    tinyglobby: ^0.2.5
     tmp: "*"
     ts-api-utils: ^1.3.0
     typescript: "*"
@@ -10455,6 +10455,18 @@ __metadata:
   dependencies:
     bser: 2.1.1
   checksum: b15a124cef28916fe07b400eb87cbc73ca082c142abf7ca8e8de6af43eca79ca7bd13eb4d4d48240b3bd3136eaac40d16e42d6edf87a8e5d1dd8070626860c78
+  languageName: node
+  linkType: hard
+
+"fdir@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "fdir@npm:6.2.0"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 49f23efa8e045f5096cd3384ae5f9cbe49d7e4aa73714d00ffc9301f2231b4fe1ceb23006ba76a75770c4758ae537d774bf26642921cd7872e0e330a7e3839c9
   languageName: node
   linkType: hard
 
@@ -16047,7 +16059,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.1":
+"picomatch@npm:^4.0.1, picomatch@npm:^4.0.2":
   version: 4.0.2
   resolution: "picomatch@npm:4.0.2"
   checksum: a7a5188c954f82c6585720e9143297ccd0e35ad8072231608086ca950bee672d51b0ef676254af0788205e59bd4e4deb4e7708769226bed725bf13370a7d1464
@@ -19092,6 +19104,16 @@ __metadata:
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "tinyglobby@npm:0.2.5"
+  dependencies:
+    fdir: ^6.2.0
+    picomatch: ^4.0.2
+  checksum: 04d01bb603c10a94d44045236bab6a5402c59ead6a02a7317f119647d31c250394189cee152fddbf13e80496697987b29d90d75786b12f76358a936cff307d35
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/9453
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Replaces `globby` with `tinyglobby` for a smaller more efficient implementation with fewer dependencies