### PR TITLE
chore: disable eslint-plugin-perfectionist on enums

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -591,14 +591,7 @@ export default tseslint.config(
           type: 'natural',
         },
       ],
-      'perfectionist/sort-enums': [
-        'error',
-        {
-          order: 'asc',
-          partitionByComment: true,
-          type: 'natural',
-        },
-      ],
+      'perfectionist/sort-enums': 'off',
       'perfectionist/sort-objects': [
         'error',
         {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: addresses https://github.com/typescript-eslint/typescript-eslint/issues/8479#issuecomment-2308652962

## Overview

As per the comment, completely disables sorting on enums. We tend to use them in ways where our own ordering makes more sense than alphabetical/natural.

💖 