### PR TITLE
feat(typescript-estree): default projectService.defaultProject to 'tsconfig.json'

### DIFF
--- a/docs/developers/Custom_Rules.mdx
+++ b/docs/developers/Custom_Rules.mdx
@@ -400,7 +400,6 @@ const ruleTester = new RuleTester({
     parserOptions: {
       projectService: {
         allowDefaultProjectForFiles: ['*.ts*'],
-        defaultProject: 'tsconfig.json',
       },
       tsconfigRootDir: __dirname,
     },

--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -335,17 +335,21 @@ The behavior of `parserOptions.projectService` can be customized by setting it t
   parserOptions: {
     projectService: {
       allowDefaultProject: ['*.js'],
-      defaultProject: 'tsconfig.json',
     },
   },
 };
 ```
 
+:::tip
+See [Troubleshooting & FAQs > Typed Linting > Project Service Issues](../troubleshooting/typed-linting/index.mdx#project-service-issues) for help using these options.
+:::
+
 ##### `allowDefaultProject`
+
+> Default `[]` _(none)_
 
 Globs of files to allow running with the default project compiler options despite not being matched by the project service.
 It takes in an array of string paths that will be resolved relative to the [`tsconfigRootDir`](#tsconfigrootdir).
-When set, [`projectService.defaultProject`](#defaultproject) must be set as well.
 
 This is intended to produce type information for config files such as `eslint.config.js` that aren't included in their sibling `tsconfig.json`.
 Every file with type information retrieved from the default project incurs a non-trivial performance overhead to linting.
@@ -358,10 +362,12 @@ There are several restrictions on this option to prevent it from being overused:
 
 ##### `defaultProject`
 
+> Default `'tsconfig.json'`
+
 Path to a TSConfig to use instead of TypeScript's default project configuration.
 It takes in a string path that will be resolved relative to the [`tsconfigRootDir`](#tsconfigrootdir).
 
-This is required to specify which TSConfig file on disk will be used for [`projectService.allowDefaultProject`](#allowdefaultproject).
+`projectService.defaultProject` only impacts the "out-of-project" files included by [`allowDefaultProject`](#allowdefaultproject).
 
 ##### `maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING`
 

--- a/docs/packages/Rule_Tester.mdx
+++ b/docs/packages/Rule_Tester.mdx
@@ -123,10 +123,7 @@ ruleTester.run('my-rule', rule, {
 ### Type-Aware Testing
 
 Type-aware rules can be tested in almost exactly the same way as regular code, using `parserOptions.projectService`.
-Most rule tests can use settings like:
-
-- `allowDefaultProjectForFiles: ["*.ts*"]`: to include files in your tests
-- `defaultProject: "tsconfig.json"`: to use the same TSConfig as other files
+Most rule tests specify `parserOptions.allowDefaultProjectForFiles: ["*.ts*"]` to enable type checking on all test files.
 
 You can then test your rule by providing the type-aware config:
 
@@ -135,9 +132,8 @@ const ruleTester = new RuleTester({
   // Added lines start
   languageOptions: {
     parserOptions: {
-      projectServices: {
+      projectService: {
         allowDefaultProject: ['*.ts*'],
-        defaultProject: 'tsconfig.json',
       },
       tsconfigRootDir: './path/to/your/folder/fixture',
     },

--- a/docs/packages/TypeScript_ESTree.mdx
+++ b/docs/packages/TypeScript_ESTree.mdx
@@ -275,6 +275,7 @@ interface ProjectServiceOptions {
 
   /**
    * Path to a TSConfig to use instead of TypeScript's default project configuration.
+   * @default 'tsconfig.json'
    */
   defaultProject?: string;
 

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -50,6 +50,7 @@ interface ProjectServiceOptions {
 
   /**
    * Path to a TSConfig to use instead of TypeScript's default project configuration.
+   * @default 'tsconfig.json'
    */
   defaultProject?: string;
 

--- a/packages/typescript-estree/jest.config.js
+++ b/packages/typescript-estree/jest.config.js
@@ -1,8 +1,14 @@
 'use strict';
 // @ts-check
 
+console.log('with', process.env.TYPESCRIPT_ESLINT_PROJECT_SERVICE);
+
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
   ...require('../../jest.config.base.js'),
   testRegex: ['./tests/lib/.*\\.test\\.ts$'],
+  testPathIgnorePatterns: process.env.TYPESCRIPT_ESLINT_PROJECT_SERVICE && [
+    '/node_modules/',
+    'project-true',
+  ],
 };

--- a/packages/typescript-estree/jest.config.js
+++ b/packages/typescript-estree/jest.config.js
@@ -1,8 +1,6 @@
 'use strict';
 // @ts-check
 
-console.log('with', process.env.TYPESCRIPT_ESLINT_PROJECT_SERVICE);
-
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
   ...require('../../jest.config.base.js'),

--- a/packages/typescript-estree/jest.config.js
+++ b/packages/typescript-estree/jest.config.js
@@ -7,8 +7,7 @@ console.log('with', process.env.TYPESCRIPT_ESLINT_PROJECT_SERVICE);
 module.exports = {
   ...require('../../jest.config.base.js'),
   testRegex: ['./tests/lib/.*\\.test\\.ts$'],
-  testPathIgnorePatterns: process.env.TYPESCRIPT_ESLINT_PROJECT_SERVICE && [
-    '/node_modules/',
-    'project-true',
-  ],
+  testPathIgnorePatterns: process.env.TYPESCRIPT_ESLINT_PROJECT_SERVICE
+    ? ['/node_modules/', 'project-true']
+    : [],
 };

--- a/packages/typescript-estree/src/create-program/getParsedConfigFile.ts
+++ b/packages/typescript-estree/src/create-program/getParsedConfigFile.ts
@@ -33,7 +33,11 @@ function getParsedConfigFile(
       fileExists: fs.existsSync,
       getCurrentDirectory,
       readDirectory: tsserver.sys.readDirectory,
-      readFile: file => fs.readFileSync(file, 'utf-8'),
+      readFile: file =>
+        fs.readFileSync(
+          path.isAbsolute(file) ? file : path.join(getCurrentDirectory(), file),
+          'utf-8',
+        ),
       useCaseSensitiveFileNames: tsserver.sys.useCaseSensitiveFileNames,
     },
   );

--- a/packages/typescript-estree/src/create-program/validateDefaultProjectForFilesGlob.ts
+++ b/packages/typescript-estree/src/create-program/validateDefaultProjectForFilesGlob.ts
@@ -1,5 +1,3 @@
-import type { ProjectServiceOptions } from '../parser-options';
-
 export const DEFAULT_PROJECT_FILES_ERROR_EXPLANATION = `
 
 Having many files run with the default project is known to cause performance issues and slow down linting.

--- a/packages/typescript-estree/src/create-program/validateDefaultProjectForFilesGlob.ts
+++ b/packages/typescript-estree/src/create-program/validateDefaultProjectForFilesGlob.ts
@@ -8,13 +8,13 @@ See https://typescript-eslint.io/troubleshooting/typed-linting#allowdefaultproje
 `;
 
 export function validateDefaultProjectForFilesGlob(
-  options: ProjectServiceOptions,
+  allowDefaultProject: string[] | undefined,
 ): void {
-  if (!options.allowDefaultProject?.length) {
+  if (!allowDefaultProject?.length) {
     return;
   }
 
-  for (const glob of options.allowDefaultProject) {
+  for (const glob of allowDefaultProject) {
     if (glob === '*') {
       throw new Error(
         `allowDefaultProject contains the overly wide '*'.${DEFAULT_PROJECT_FILES_ERROR_EXPLANATION}`,

--- a/packages/typescript-estree/tests/lib/createProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/createProjectService.test.ts
@@ -40,6 +40,10 @@ const {
 } = require('../../src/create-program/createProjectService');
 
 describe('createProjectService', () => {
+  beforeEach(() => {
+    mockGetParsedConfigFile.mockReturnValue({ options: {} });
+  });
+
   afterEach(() => {
     jest.resetAllMocks();
   });
@@ -61,41 +65,59 @@ describe('createProjectService', () => {
     expect(settings.allowDefaultProject).toBeUndefined();
   });
 
-  it('throws an error with a relative path when options.defaultProject is set to a relative path and getParsedConfigFile throws a diagnostic error', () => {
+  it('throws an error with a local path when options.defaultProject is not provided and getParsedConfigFile throws a diagnostic error', () => {
     mockGetParsedConfigFile.mockImplementation(() => {
-      throw new Error('./tsconfig.json(1,1): error TS1234: Oh no!');
+      throw new Error('tsconfig.json(1,1): error TS1234: Oh no!');
     });
 
     expect(() =>
       createProjectService(
         {
           allowDefaultProject: ['file.js'],
-          defaultProject: './tsconfig.json',
         },
         undefined,
         undefined,
       ),
     ).toThrow(
-      /Could not read default project '\.\/tsconfig.json': .+ error TS1234: Oh no!/,
+      /Could not read project service default project 'tsconfig.json': .+ error TS1234: Oh no!/,
+    );
+  });
+
+  it('throws an error with a relative path when options.defaultProject is set to a relative path and getParsedConfigFile throws a diagnostic error', () => {
+    mockGetParsedConfigFile.mockImplementation(() => {
+      throw new Error('./tsconfig.eslint.json(1,1): error TS1234: Oh no!');
+    });
+
+    expect(() =>
+      createProjectService(
+        {
+          allowDefaultProject: ['file.js'],
+          defaultProject: './tsconfig.eslint.json',
+        },
+        undefined,
+        undefined,
+      ),
+    ).toThrow(
+      /Could not read project service default project '\.\/tsconfig.eslint.json': .+ error TS1234: Oh no!/,
     );
   });
 
   it('throws an error with a local path when options.defaultProject is set to a local path and getParsedConfigFile throws a diagnostic error', () => {
     mockGetParsedConfigFile.mockImplementation(() => {
-      throw new Error('./tsconfig.json(1,1): error TS1234: Oh no!');
+      throw new Error('./tsconfig.eslint.json(1,1): error TS1234: Oh no!');
     });
 
     expect(() =>
       createProjectService(
         {
           allowDefaultProject: ['file.js'],
-          defaultProject: 'tsconfig.json',
+          defaultProject: 'tsconfig.eslint.json',
         },
         undefined,
         undefined,
       ),
     ).toThrow(
-      /Could not read default project 'tsconfig.json': .+ error TS1234: Oh no!/,
+      /Could not read project service default project 'tsconfig.eslint.json': .+ error TS1234: Oh no!/,
     );
   });
 
@@ -110,24 +132,24 @@ describe('createProjectService', () => {
       createProjectService(
         {
           allowDefaultProject: ['file.js'],
-          defaultProject: 'tsconfig.json',
         },
         undefined,
         undefined,
       ),
     ).toThrow(
-      "Could not read default project 'tsconfig.json': `getParsedConfigFile` is only supported in a Node-like environment.",
+      "Could not read project service default project 'tsconfig.json': `getParsedConfigFile` is only supported in a Node-like environment.",
     );
   });
 
-  it('uses the default projects compiler options when options.defaultProject is set and getParsedConfigFile succeeds', () => {
+  it('uses the default project compiler options when options.defaultProject is set and getParsedConfigFile succeeds', () => {
     const compilerOptions = { strict: true };
     mockGetParsedConfigFile.mockReturnValue({ options: compilerOptions });
+    const defaultProject = 'tsconfig.eslint.json';
 
     const { service } = createProjectService(
       {
         allowDefaultProject: ['file.js'],
-        defaultProject: 'tsconfig.json',
+        defaultProject: defaultProject,
       },
       undefined,
       undefined,
@@ -135,6 +157,12 @@ describe('createProjectService', () => {
 
     expect(service.setCompilerOptionsForInferredProjects).toHaveBeenCalledWith(
       compilerOptions,
+    );
+    expect(mockGetParsedConfigFile).toHaveBeenCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('typescript/lib/tsserverlibrary'),
+      defaultProject,
+      undefined,
     );
   });
 
@@ -146,7 +174,6 @@ describe('createProjectService', () => {
     const { service } = createProjectService(
       {
         allowDefaultProject: ['file.js'],
-        defaultProject: 'tsconfig.json',
       },
       undefined,
       tsconfigRootDir,
@@ -165,6 +192,7 @@ describe('createProjectService', () => {
 
   it('uses the default projects error debugger for error messages when enabled', () => {
     jest.spyOn(process.stderr, 'write').mockImplementation();
+
     const { service } = createProjectService(undefined, undefined, undefined);
     debug.enable('typescript-eslint:typescript-estree:tsserver:err');
     const enabled = service.logger.loggingEnabled();
@@ -181,6 +209,7 @@ describe('createProjectService', () => {
 
   it('does not use the default projects error debugger for error messages when disabled', () => {
     jest.spyOn(process.stderr, 'write').mockImplementation();
+
     const { service } = createProjectService(undefined, undefined, undefined);
     const enabled = service.logger.loggingEnabled();
     service.logger.msg('foo', ts.server.Msg.Err);
@@ -191,6 +220,7 @@ describe('createProjectService', () => {
 
   it('uses the default projects info debugger for info messages when enabled', () => {
     jest.spyOn(process.stderr, 'write').mockImplementation();
+
     const { service } = createProjectService(undefined, undefined, undefined);
     debug.enable('typescript-eslint:typescript-estree:tsserver:info');
     const enabled = service.logger.loggingEnabled();
@@ -207,6 +237,7 @@ describe('createProjectService', () => {
 
   it('does not use the default projects info debugger for info messages when disabled', () => {
     jest.spyOn(process.stderr, 'write').mockImplementation();
+
     const { service } = createProjectService(undefined, undefined, undefined);
     const enabled = service.logger.loggingEnabled();
     service.logger.info('foo');
@@ -217,6 +248,7 @@ describe('createProjectService', () => {
 
   it('uses the default projects perf debugger for perf messages when enabled', () => {
     jest.spyOn(process.stderr, 'write').mockImplementation();
+
     const { service } = createProjectService(undefined, undefined, undefined);
     debug.enable('typescript-eslint:typescript-estree:tsserver:perf');
     const enabled = service.logger.loggingEnabled();
@@ -233,6 +265,7 @@ describe('createProjectService', () => {
 
   it('does not use the default projects perf debugger for perf messages when disabled', () => {
     jest.spyOn(process.stderr, 'write').mockImplementation();
+
     const { service } = createProjectService(undefined, undefined, undefined);
     const enabled = service.logger.loggingEnabled();
     service.logger.perftrc('foo');

--- a/packages/typescript-estree/tests/lib/createProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/createProjectService.test.ts
@@ -149,7 +149,7 @@ describe('createProjectService', () => {
     const { service } = createProjectService(
       {
         allowDefaultProject: ['file.js'],
-        defaultProject: defaultProject,
+        defaultProject,
       },
       undefined,
       undefined,

--- a/packages/typescript-estree/tests/lib/parse.project-true.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.project-true.test.ts
@@ -35,17 +35,15 @@ describe('parseAndGenerateServices', () => {
       });
     });
 
-    if (process.env.TYPESCRIPT_ESLINT_PROJECT_SERVICE !== 'true') {
-      it('throws an error when a parent project does not exist', () => {
-        expect(() =>
-          parser.parseAndGenerateServices('const a = true', {
-            ...config,
-            filePath: join(PROJECT_DIR, 'notIncluded.ts'),
-          }),
-        ).toThrow(
-          /project was set to `true` but couldn't find any tsconfig.json relative to '.+[/\\]tests[/\\]fixtures[/\\]projectTrue[/\\]notIncluded.ts' within '.+[/\\]tests[/\\]fixtures[/\\]projectTrue'./,
-        );
-      });
-    }
+    it('throws an error when a parent project does not exist', () => {
+      expect(() =>
+        parser.parseAndGenerateServices('const a = true', {
+          ...config,
+          filePath: join(PROJECT_DIR, 'notIncluded.ts'),
+        }),
+      ).toThrow(
+        /project was set to `true` but couldn't find any tsconfig.json relative to '.+[/\\]tests[/\\]fixtures[/\\]projectTrue[/\\]notIncluded.ts' within '.+[/\\]tests[/\\]fixtures[/\\]projectTrue'./,
+      );
+    });
   });
 });

--- a/packages/typescript-estree/tests/lib/validateDefaultProjectForFilesGlob.test.ts
+++ b/packages/typescript-estree/tests/lib/validateDefaultProjectForFilesGlob.test.ts
@@ -2,33 +2,21 @@ import { validateDefaultProjectForFilesGlob } from '../../src/create-program/val
 
 describe('validateDefaultProjectForFilesGlob', () => {
   it('does not throw when options.allowDefaultProject is an empty array', () => {
-    expect(() =>
-      validateDefaultProjectForFilesGlob({ allowDefaultProject: [] }),
-    ).not.toThrow();
+    expect(() => validateDefaultProjectForFilesGlob([])).not.toThrow();
   });
 
   it('does not throw when options.allowDefaultProject contains a non-** glob', () => {
-    expect(() =>
-      validateDefaultProjectForFilesGlob({
-        allowDefaultProject: ['*.js'],
-      }),
-    ).not.toThrow();
+    expect(() => validateDefaultProjectForFilesGlob(['*.js'])).not.toThrow();
   });
 
   it('throws when options.allowDefaultProject contains a * glob', () => {
-    expect(() =>
-      validateDefaultProjectForFilesGlob({
-        allowDefaultProject: ['*'],
-      }),
-    ).toThrow(/allowDefaultProject contains the overly wide '\*'\./);
+    expect(() => validateDefaultProjectForFilesGlob(['*'])).toThrow(
+      /allowDefaultProject contains the overly wide '\*'\./,
+    );
   });
 
   it('throws when options.allowDefaultProject contains a ** glob', () => {
-    expect(() =>
-      validateDefaultProjectForFilesGlob({
-        allowDefaultProject: ['**/*.js'],
-      }),
-    ).toThrow(
+    expect(() => validateDefaultProjectForFilesGlob(['**/*.js'])).toThrow(
       /allowDefaultProject glob '\*\*\/\*\.js' contains a disallowed '\*\*'\./,
     );
   });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9807
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Now, `getParsedConfigFile` will always be called, even if the user hasn't explicitly provided `projectService.defaultProject` manually. This is actually good, I think: it'll make sure the project's `tsconfig.json` is valid.

💖 