### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] fix TSNonNullExpression fixer

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -1,6 +1,7 @@
 import type { Scope } from '@typescript-eslint/scope-manager';
 import type { TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
+import type { ReportFixFunction } from '@typescript-eslint/utils/ts-eslint';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -208,6 +209,18 @@ export default createRule<Options, MessageIds>({
 
     return {
       TSNonNullExpression(node): void {
+        const removeExclamationFix: ReportFixFunction = fixer => {
+          const exclamationToken = nullThrows(
+            context.sourceCode.getLastToken(node, token => token.value === '!'),
+            NullThrowsReasons.MissingToken(
+              'exclamation mark',
+              'non-null assertion',
+            ),
+          );
+
+          return fixer.removeRange(exclamationToken.range);
+        };
+
         if (
           node.parent.type === AST_NODE_TYPES.AssignmentExpression &&
           node.parent.operator === '='
@@ -216,12 +229,7 @@ export default createRule<Options, MessageIds>({
             context.report({
               node,
               messageId: 'contextuallyUnnecessary',
-              fix(fixer) {
-                return fixer.removeRange([
-                  node.expression.range[1],
-                  node.range[1],
-                ]);
-              },
+              fix: removeExclamationFix,
             });
           }
           // for all other = assignments we ignore non-null checks
@@ -246,9 +254,7 @@ export default createRule<Options, MessageIds>({
           context.report({
             node,
             messageId: 'unnecessaryAssertion',
-            fix(fixer) {
-              return fixer.removeRange([node.range[1] - 1, node.range[1]]);
-            },
+            fix: removeExclamationFix,
           });
         } else {
           // we know it's a nullable type
@@ -294,12 +300,7 @@ export default createRule<Options, MessageIds>({
               context.report({
                 node,
                 messageId: 'contextuallyUnnecessary',
-                fix(fixer) {
-                  return fixer.removeRange([
-                    node.expression.range[1],
-                    node.range[1],
-                  ]);
-                },
+                fix: removeExclamationFix,
               });
             }
           }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -1137,5 +1137,20 @@ var x = 1;
         },
       ],
     },
+    {
+      code: `
+const a = '';
+const b: string | undefined = (a ? undefined : a)!;
+      `,
+      output: `
+const a = '';
+const b: string | undefined = (a ? undefined : a);
+      `,
+      errors: [
+        {
+          messageId: 'contextuallyUnnecessary',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9897  
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Updates the fixer to remove the range of the `!` token. 