### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-parameters] fix AST quick path scope analysis

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -5,7 +5,7 @@ import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
 import type { MakeRequired } from '../util';
-import { createRule, getParserServices } from '../util';
+import { createRule, getParserServices, nullThrows } from '../util';
 
 type NodeWithTypeParameters = MakeRequired<
   ts.SignatureDeclaration | ts.ClassLikeDeclaration,
@@ -38,19 +38,31 @@ export default createRule({
       const checker = parserServices.program.getTypeChecker();
       let counts: Map<ts.Identifier, number> | undefined;
 
+      // Get the scope in which the type parameters are declared.
+      const scope = context.sourceCode.getScope(node);
+
       for (const typeParameter of tsNode.typeParameters) {
         const esTypeParameter =
           parserServices.tsNodeToESTreeNodeMap.get<TSESTree.TSTypeParameter>(
             typeParameter,
           );
-        const scope = context.sourceCode.getScope(esTypeParameter);
+
+        const smTypeParameterVariable = nullThrows(
+          scope.variables.find(
+            variable =>
+              // type identifiers can only be declared once, unlike var.
+              variable.identifiers.length === 1 &&
+              variable.identifiers[0] === esTypeParameter.name,
+          ),
+          "Type parameter should be present in scope's variables.",
+        );
 
         // Quick path: if the type parameter is used multiple times in the AST,
         // we don't need to dip into types to know it's repeated.
         if (
           isTypeParameterRepeatedInAST(
             esTypeParameter,
-            scope.references,
+            smTypeParameterVariable.references,
             node.body?.range[0] ?? node.returnType?.range[1],
           )
         ) {
@@ -147,7 +159,7 @@ function isTypeParameterRepeatedInAST(
 
     total += 1;
 
-    if (total > 2) {
+    if (total >= 2) {
       return true;
     }
   }

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -48,12 +48,14 @@ export default createRule({
           );
 
         const smTypeParameterVariable = nullThrows(
-          scope.variables.find(
-            variable =>
-              // type identifiers can only be declared once, unlike var.
-              variable.identifiers.length === 1 &&
-              variable.identifiers[0] === esTypeParameter.name,
-          ),
+          (() => {
+            const variable = scope.set.get(esTypeParameter.name.name);
+            return variable != null &&
+              variable.isTypeVariable &&
+              !variable.isValueVariable
+              ? variable
+              : undefined;
+          })(),
           "Type parameter should be present in scope's variables.",
         );
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -393,6 +393,33 @@ ruleTester.run('no-unnecessary-type-parameters', rule, {
         return [{ value: () => mappedReturnType(x) }];
       }
     `,
+    `
+type Identity<T> = T;
+
+type Mapped<T, Value> = Identity<{ [P in keyof T]: Value }>;
+
+declare function sillyFoo<Data, Value>(
+  c: Value,
+): (data: Data) => Mapped<Data, Value>;
+    `,
+    `
+type Silly<T> = { [P in keyof T]: T[P] };
+
+type SillyFoo<T, Value> = Silly<{ [P in keyof T]: Value }>;
+
+type Foo<T, Value> = { [P in keyof T]: Value };
+
+declare function foo<T, Constant>(data: T, c: Constant): Foo<T, Constant>;
+declare function foo<T, Constant>(c: Constant): (data: T) => Foo<T, Constant>;
+
+declare function sillyFoo<T, Constant>(
+  data: T,
+  c: Constant,
+): SillyFoo<T, Constant>;
+declare function sillyFoo<T, Constant>(
+  c: Constant,
+): (data: T) => SillyFoo<T, Constant>;
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9889 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The existing code was inspecting the `references` on the `Scope` itself, but we want to be inspecting the `references` on the corresponding `Variable`.

 * [docs for `references` property on `Scope`](https://eslint.org/docs/latest/extend/scope-manager-interface#references)
 * [docs for `references` property on `Variable`](https://eslint.org/docs/latest/extend/scope-manager-interface#references-1)

Coauthor credit to Josh for the breadcrumbs in https://github.com/typescript-eslint/typescript-eslint/issues/9889#issuecomment-2313374807

Co-authored-by: @JoshuaKGoldberg 