### PR TITLE
docs: mark allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing options as deprecated

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -91,6 +91,10 @@ do {} while (true);
 
 ### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
 
+:::danger Deprecated
+This option will be removed in the next major version of typescript-eslint.
+:::
+
 If this is set to `false`, then the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
 
 Without `strictNullChecks`, TypeScript essentially erases `undefined` and `null` from the types. This means when this rule inspects the types from a variable, **it will not be able to tell that the variable might be `null` or `undefined`**, which essentially makes this rule useless.

--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
@@ -174,7 +174,11 @@ Also, if you would like to ignore all primitives types, you can set `ignorePrimi
 
 ### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
 
-Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
+:::danger Deprecated
+
+> This option will be removed in the next major version of typescript-eslint.
+> :::
+> Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
 
 Without `strictNullChecks`, TypeScript essentially erases `undefined` and `null` from the types. This means when this rule inspects the types from a variable, **it will not be able to tell that the variable might be `null` or `undefined`**, which essentially makes this rule useless.
 

--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.mdx
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.mdx
@@ -144,7 +144,11 @@ Set this to `true` at your own risk.
 
 ### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
 
-If this is set to `false`, then the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
+:::danger Deprecated
+
+> This option will be removed in the next major version of typescript-eslint.
+> :::
+> If this is set to `false`, then the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
 
 Without `strictNullChecks`, TypeScript essentially erases `undefined` and `null` from the types. This means when this rule inspects the types from a variable, **it will not be able to tell that the variable might be `null` or `undefined`**, which essentially makes this rule a lot less useful.
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9913
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a `:::danger` admonition to each docs page.

💖 