### PR TITLE
feat(eslint-plugin): [no-unsafe-argument] differentiate error types

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-argument.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-argument.mdx
@@ -41,7 +41,7 @@ const tuple1 = ['a', anyTyped, 'b'] as const;
 foo(...tuple1);
 
 const tuple2 = [1] as const;
-foo('a', ...tuple, anyTyped);
+foo('a', ...tuple2, anyTyped);
 
 declare function bar(arg1: string, arg2: number, ...rest: string[]): void;
 const x = [1, 2] as [number, ...number[]];

--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -175,8 +175,7 @@ export default createRule<[], MessageIds>({
     function describeTypeForSpread(type: ts.Type): string {
       if (
         checker.isArrayType(type) &&
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        tsutils.isIntrinsicErrorType(type.typeArguments![0])
+        tsutils.isIntrinsicErrorType(checker.getTypeArguments(type)[0])
       ) {
         return 'error';
       }

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unsafe-argument.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unsafe-argument.shot
@@ -14,16 +14,15 @@ foo(anyTyped, 1, 'a');
 
 const anyArray: any[] = [];
 foo(...anyArray);
-    ~~~~~~~~~~~ Unsafe spread of an \`any\` array type.
+    ~~~~~~~~~~~ Unsafe spread of an \`any[]\` array type.
 
 const tuple1 = ['a', anyTyped, 'b'] as const;
 foo(...tuple1);
     ~~~~~~~~~ Unsafe spread of a tuple type. The argument is of type \`any\` and is assigned to a parameter of type \`number\`.
 
 const tuple2 = [1] as const;
-foo('a', ...tuple, anyTyped);
-         ~~~~~~~~ Unsafe spread of an \`any\` type.
-                   ~~~~~~~~ Unsafe argument of type \`any\` assigned to a parameter of type \`number\`.
+foo('a', ...tuple2, anyTyped);
+                    ~~~~~~~~ Unsafe argument of type \`any\` assigned to a parameter of type \`string\`.
 
 declare function bar(arg1: string, arg2: number, ...rest: string[]): void;
 const x = [1, 2] as [number, ...number[]];

--- a/packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts
@@ -132,8 +132,26 @@ foo(1 as any);
           column: 5,
           endColumn: 13,
           data: {
-            sender: 'any',
-            receiver: 'number',
+            sender: '`any`',
+            receiver: '`number`',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+declare function foo(arg: number): void;
+foo(error);
+      `,
+      errors: [
+        {
+          messageId: 'unsafeArgument',
+          line: 3,
+          column: 5,
+          endColumn: 10,
+          data: {
+            sender: 'error typed',
+            receiver: '`number`',
           },
         },
       ],
@@ -150,8 +168,8 @@ foo(1, 1 as any);
           column: 8,
           endColumn: 16,
           data: {
-            sender: 'any',
-            receiver: 'string',
+            sender: '`any`',
+            receiver: '`string`',
           },
         },
       ],
@@ -168,8 +186,8 @@ foo(1, 2, 3, 1 as any);
           column: 14,
           endColumn: 22,
           data: {
-            sender: 'any',
-            receiver: 'number',
+            sender: '`any`',
+            receiver: '`number`',
           },
         },
       ],
@@ -186,8 +204,8 @@ foo(1 as any, 1 as any);
           column: 5,
           endColumn: 13,
           data: {
-            sender: 'any',
-            receiver: 'string',
+            sender: '`any`',
+            receiver: '`string`',
           },
         },
         {
@@ -196,8 +214,8 @@ foo(1 as any, 1 as any);
           column: 15,
           endColumn: 23,
           data: {
-            sender: 'any',
-            receiver: 'number',
+            sender: '`any`',
+            receiver: '`number`',
           },
         },
       ],
@@ -225,10 +243,29 @@ foo(...(x as any[]));
       `,
       errors: [
         {
+          data: { sender: '`any[]`' },
           messageId: 'unsafeArraySpread',
           line: 4,
           column: 5,
           endColumn: 20,
+        },
+      ],
+    },
+    {
+      code: `
+declare function foo(arg1: string, arg2: number): void;
+
+declare const errors: error[];
+
+foo(...errors);
+      `,
+      errors: [
+        {
+          data: { sender: 'error' },
+          messageId: 'unsafeArraySpread',
+          line: 6,
+          column: 5,
+          endColumn: 14,
         },
       ],
     },
@@ -246,8 +283,28 @@ foo(...x);
           column: 5,
           endColumn: 9,
           data: {
-            sender: 'any',
-            receiver: 'number',
+            sender: 'of type `any`',
+            receiver: '`number`',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+declare function foo(arg1: string, arg2: number): void;
+
+const x = ['a', error] as const;
+foo(...x);
+      `,
+      errors: [
+        {
+          messageId: 'unsafeTupleSpread',
+          line: 5,
+          column: 5,
+          endColumn: 9,
+          data: {
+            sender: 'error typed',
+            receiver: '`number`',
           },
         },
       ],
@@ -259,6 +316,10 @@ foo(...(['foo', 1, 2] as [string, any, number]));
       `,
       errors: [
         {
+          data: {
+            sender: 'of type `any`',
+            receiver: '`number`',
+          },
           messageId: 'unsafeTupleSpread',
           line: 3,
           column: 5,
@@ -280,8 +341,8 @@ foo('a', ...x, 1 as any);
           column: 16,
           endColumn: 24,
           data: {
-            sender: 'any',
-            receiver: 'string',
+            sender: '`any`',
+            receiver: '`string`',
           },
         },
       ],
@@ -300,8 +361,8 @@ foo('a', ...x, 1 as any);
           column: 16,
           endColumn: 24,
           data: {
-            sender: 'any',
-            receiver: 'string',
+            sender: '`any`',
+            receiver: '`string`',
           },
         },
       ],
@@ -320,8 +381,8 @@ foo(new Set<any>(), ...x);
           column: 5,
           endColumn: 19,
           data: {
-            sender: 'Set<any>',
-            receiver: 'Set<string>',
+            sender: '`Set<any>`',
+            receiver: '`Set<string>`',
           },
         },
         {
@@ -330,8 +391,8 @@ foo(new Set<any>(), ...x);
           column: 21,
           endColumn: 25,
           data: {
-            sender: 'Map<any, string>',
-            receiver: 'Map<string, string>',
+            sender: 'of type `Map<any, string>`',
+            receiver: '`Map<string, string>`',
           },
         },
       ],
@@ -348,8 +409,8 @@ foo(1 as any, 'a' as any, 1 as any);
           column: 5,
           endColumn: 13,
           data: {
-            sender: 'any',
-            receiver: 'number',
+            sender: '`any`',
+            receiver: '`number`',
           },
         },
         {
@@ -358,8 +419,8 @@ foo(1 as any, 'a' as any, 1 as any);
           column: 15,
           endColumn: 25,
           data: {
-            sender: 'any',
-            receiver: 'string',
+            sender: '`any`',
+            receiver: '`string`',
           },
         },
       ],
@@ -376,8 +437,8 @@ foo('a', 1 as any, 'a' as any, 1 as any);
           column: 10,
           endColumn: 18,
           data: {
-            sender: 'any',
-            receiver: 'number',
+            sender: '`any`',
+            receiver: '`number`',
           },
         },
         {
@@ -386,8 +447,8 @@ foo('a', 1 as any, 'a' as any, 1 as any);
           column: 20,
           endColumn: 30,
           data: {
-            sender: 'any',
-            receiver: 'string',
+            sender: '`any`',
+            receiver: '`string`',
           },
         },
       ],
@@ -406,8 +467,8 @@ foo(t as any);
           column: 5,
           endColumn: 13,
           data: {
-            sender: 'any',
-            receiver: 'T',
+            sender: '`any`',
+            receiver: '`T`',
           },
         },
       ],
@@ -430,8 +491,8 @@ foo<number>\`\${arg}\${arg}\${arg}\`;
           column: 15,
           endColumn: 18,
           data: {
-            sender: 'any',
-            receiver: 'number',
+            sender: '`any`',
+            receiver: '`number`',
           },
         },
         {
@@ -440,8 +501,8 @@ foo<number>\`\${arg}\${arg}\${arg}\`;
           column: 27,
           endColumn: 30,
           data: {
-            sender: 'any',
-            receiver: 'string',
+            sender: '`any`',
+            receiver: '`string`',
           },
         },
       ],
@@ -459,8 +520,8 @@ foo\`\${arg}\`;
           column: 7,
           endColumn: 10,
           data: {
-            sender: 'any',
-            receiver: 'number',
+            sender: '`any`',
+            receiver: '`number`',
           },
         },
       ],
@@ -479,8 +540,8 @@ foo\`\${arg}\`;
           column: 7,
           endColumn: 10,
           data: {
-            sender: 'any',
-            receiver: 'T',
+            sender: '`any`',
+            receiver: '`T`',
           },
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9215
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Uses the same _"error typed"_ phrasing as other `no-unsafe-*` rules.

💖 