### PR TITLE
fix(eslint-plugin): remove allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing option 

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -89,6 +89,26 @@ for (; true; ) {}
 do {} while (true);
 ```
 
+## When Not To Use It
+
+If your project is not accurately typed, such as if it's in the process of being converted to TypeScript or is susceptible to [trade-offs in control flow analysis](https://github.com/Microsoft/TypeScript/issues/9998), it may be difficult to enable this rule for particularly non-type-safe areas of code.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+
+This rule has a known edge case of triggering on conditions that were modified within function calls (as side effects).
+It is due to limitations of TypeScript's type narrowing.
+See [#9998](https://github.com/microsoft/TypeScript/issues/9998) for details.
+We recommend using a [type assertion](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions) in those cases.
+
+```ts
+let condition = false as boolean;
+
+const f = () => (condition = true);
+f();
+
+if (condition) {
+}
+```
+
 ## Related To
 
 - ESLint: [no-constant-condition](https://eslint.org/docs/rules/no-constant-condition) - `no-unnecessary-condition` is essentially a stronger version of `no-constant-condition`, but requires type information.

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -89,36 +89,6 @@ for (; true; ) {}
 do {} while (true);
 ```
 
-### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
-
-If this is set to `false`, then the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
-
-Without `strictNullChecks`, TypeScript essentially erases `undefined` and `null` from the types. This means when this rule inspects the types from a variable, **it will not be able to tell that the variable might be `null` or `undefined`**, which essentially makes this rule useless.
-
-You should be using `strictNullChecks` to ensure complete type-safety in your codebase.
-
-If for some reason you cannot turn on `strictNullChecks`, but still want to use this rule - you can use this option to allow it - but know that the behavior of this rule is _undefined_ with the compiler option turned off. We will not accept bug reports if you are using this option.
-
-## When Not To Use It
-
-If your project is not accurately typed, such as if it's in the process of being converted to TypeScript or is susceptible to [trade-offs in control flow analysis](https://github.com/Microsoft/TypeScript/issues/9998), it may be difficult to enable this rule for particularly non-type-safe areas of code.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
-
-This rule has a known edge case of triggering on conditions that were modified within function calls (as side effects).
-It is due to limitations of TypeScript's type narrowing.
-See [#9998](https://github.com/microsoft/TypeScript/issues/9998) for details.
-We recommend using a [type assertion](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions) in those cases.
-
-```ts
-let condition = false as boolean;
-
-const f = () => (condition = true);
-f();
-
-if (condition) {
-}
-```
-
 ## Related To
 
 - ESLint: [no-constant-condition](https://eslint.org/docs/rules/no-constant-condition) - `no-unnecessary-condition` is essentially a stronger version of `no-constant-condition`, but requires type information.

--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
@@ -172,16 +172,6 @@ foo ?? 'a string';
 
 Also, if you would like to ignore all primitives types, you can set `ignorePrimitives: true`. It is equivalent to `ignorePrimitives: { string: true, number: true, bigint: true, boolean: true }`.
 
-### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
-
-Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
-
-Without `strictNullChecks`, TypeScript essentially erases `undefined` and `null` from the types. This means when this rule inspects the types from a variable, **it will not be able to tell that the variable might be `null` or `undefined`**, which essentially makes this rule useless.
-
-You should be using `strictNullChecks` to ensure complete type-safety in your codebase.
-
-If for some reason you cannot turn on `strictNullChecks`, but still want to use this rule - you can use this option to allow it - but know that the behavior of this rule is _undefined_ with the compiler option turned off. We will not accept bug reports if you are using this option.
-
 ## When Not To Use It
 
 If you are not using TypeScript 3.7 (or greater), then you will not be able to use this rule, as the operator is not supported.

--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.mdx
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.mdx
@@ -142,16 +142,6 @@ Allows `any` in a boolean context.
 This is unsafe for obvious reasons.
 Set this to `true` at your own risk.
 
-### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
-
-If this is set to `false`, then the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
-
-Without `strictNullChecks`, TypeScript essentially erases `undefined` and `null` from the types. This means when this rule inspects the types from a variable, **it will not be able to tell that the variable might be `null` or `undefined`**, which essentially makes this rule a lot less useful.
-
-You should be using `strictNullChecks` to ensure complete type-safety in your codebase.
-
-If for some reason you cannot turn on `strictNullChecks`, but still want to use this rule - you can use this option to allow it - but know that the behavior of this rule is _undefined_ with the compiler option turned off. We will not accept bug reports if you are using this option.
-
 ## Fixes and Suggestions
 
 This rule provides following fixes and suggestions for particular types in boolean context:

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -69,7 +69,6 @@ const isLiteral = (type: ts.Type): boolean =>
 export type Options = [
   {
     allowConstantLoopConditions?: boolean;
-    allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
   },
 ];
 
@@ -105,11 +104,6 @@ export default createRule<Options, MessageId>({
               'Whether to ignore constant loop conditions, such as `while (true)`.',
             type: 'boolean',
           },
-          allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: {
-            description:
-              'Whether to not error when running with a tsconfig that has strictNullChecks turned.',
-            type: 'boolean',
-          },
         },
         additionalProperties: false,
       },
@@ -139,18 +133,9 @@ export default createRule<Options, MessageId>({
   defaultOptions: [
     {
       allowConstantLoopConditions: false,
-      allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
     },
   ],
-  create(
-    context,
-    [
-      {
-        allowConstantLoopConditions,
-        allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing,
-      },
-    ],
-  ) {
+  create(context, [{ allowConstantLoopConditions }]) {
     const services = getParserServices(context);
     const checker = services.program.getTypeChecker();
 
@@ -160,10 +145,7 @@ export default createRule<Options, MessageId>({
       'strictNullChecks',
     );
 
-    if (
-      !isStrictNullChecks &&
-      allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing !== true
-    ) {
+    if (!isStrictNullChecks) {
       context.report({
         loc: {
           start: { line: 0, column: 0 },

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -19,7 +19,6 @@ import {
 
 export type Options = [
   {
-    allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
     ignoreConditionalTests?: boolean;
     ignoreMixedLogicalExpressions?: boolean;
     ignorePrimitives?:
@@ -64,11 +63,6 @@ export default createRule<Options, MessageIds>({
       {
         type: 'object',
         properties: {
-          allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: {
-            description:
-              'Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.',
-            type: 'boolean',
-          },
           ignoreConditionalTests: {
             description:
               'Whether to ignore cases that are located within a conditional test.',
@@ -110,7 +104,6 @@ export default createRule<Options, MessageIds>({
   },
   defaultOptions: [
     {
-      allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
       ignoreConditionalTests: true,
       ignoreTernaryTests: false,
       ignoreMixedLogicalExpressions: false,
@@ -126,7 +119,6 @@ export default createRule<Options, MessageIds>({
     context,
     [
       {
-        allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing,
         ignoreConditionalTests,
         ignoreMixedLogicalExpressions,
         ignorePrimitives,
@@ -143,10 +135,7 @@ export default createRule<Options, MessageIds>({
       'strictNullChecks',
     );
 
-    if (
-      !isStrictNullChecks &&
-      allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing !== true
-    ) {
+    if (!isStrictNullChecks) {
       context.report({
         loc: {
           start: { line: 0, column: 0 },

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -24,7 +24,6 @@ export type Options = [
     allowNullableNumber?: boolean;
     allowNullableEnum?: boolean;
     allowAny?: boolean;
-    allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
   },
 ];
 
@@ -104,9 +103,6 @@ export default createRule<Options, MessageId>({
             description: 'Whether to allow `any` in a boolean context.',
             type: 'boolean',
           },
-          allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: {
-            type: 'boolean',
-          },
         },
         additionalProperties: false,
       },
@@ -182,7 +178,6 @@ export default createRule<Options, MessageId>({
       allowNullableNumber: false,
       allowNullableEnum: false,
       allowAny: false,
-      allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
     },
   ],
   create(context, [options]) {
@@ -195,10 +190,7 @@ export default createRule<Options, MessageId>({
       'strictNullChecks',
     );
 
-    if (
-      !isStrictNullChecks &&
-      options.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing !== true
-    ) {
+    if (!isStrictNullChecks) {
       context.report({
         loc: {
           start: { line: 0, column: 0 },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -721,24 +721,6 @@ declare const unknownTyped: unknown;
 if (!(booleanTyped || unknownTyped)) {
 }
     `,
-    {
-      code: `
-declare const x: string[] | null;
-// eslint-disable-next-line
-if (x) {
-}
-      `,
-      options: [
-        {
-          allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: true,
-        },
-      ],
-      languageOptions: {
-        parserOptions: {
-          tsconfigRootDir: path.join(rootPath, 'unstrict'),
-        },
-      },
-    },
     `
 interface Foo {
   [key: string]: [string] | undefined;

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -330,26 +330,6 @@ if (x) {
       `,
       options: [{ allowNullableEnum: true }],
     },
-
-    {
-      code: `
-declare const x: string[] | null;
-// eslint-disable-next-line
-if (x) {
-}
-      `,
-      options: [
-        {
-          allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: true,
-        },
-      ],
-      languageOptions: {
-        parserOptions: {
-          tsconfigRootDir: path.join(rootPath, 'unstrict'),
-        },
-      },
-    },
-
     `
 function f(arg: 'a' | null) {
   if (arg) console.log(arg);

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
@@ -11,10 +11,6 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
       "allowConstantLoopConditions": {
         "description": "Whether to ignore constant loop conditions, such as \`while (true)\`.",
         "type": "boolean"
-      },
-      "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
-        "description": "Whether to not error when running with a tsconfig that has strictNullChecks turned.",
-        "type": "boolean"
       }
     },
     "type": "object"
@@ -28,8 +24,6 @@ type Options = [
   {
     /** Whether to ignore constant loop conditions, such as \`while (true)\`. */
     allowConstantLoopConditions?: boolean;
-    /** Whether to not error when running with a tsconfig that has strictNullChecks turned. */
-    allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
   },
 ];
 "

--- a/packages/eslint-plugin/tests/schema-snapshots/prefer-nullish-coalescing.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/prefer-nullish-coalescing.shot
@@ -8,10 +8,6 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
   {
     "additionalProperties": false,
     "properties": {
-      "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
-        "description": "Unless this is set to \`true\`, the rule will error on every file whose \`tsconfig.json\` does _not_ have the \`strictNullChecks\` compiler option (or \`strict\`) set to \`true\`.",
-        "type": "boolean"
-      },
       "ignoreConditionalTests": {
         "description": "Whether to ignore cases that are located within a conditional test.",
         "type": "boolean"
@@ -60,8 +56,6 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
-    /** Unless this is set to \`true\`, the rule will error on every file whose \`tsconfig.json\` does _not_ have the \`strictNullChecks\` compiler option (or \`strict\`) set to \`true\`. */
-    allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
     /** Whether to ignore cases that are located within a conditional test. */
     ignoreConditionalTests?: boolean;
     /** Whether to ignore any logical or expressions that are part of a mixed logical expression (with \`&&\`). */

--- a/packages/eslint-plugin/tests/schema-snapshots/strict-boolean-expressions.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/strict-boolean-expressions.shot
@@ -36,9 +36,6 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "description": "Whether to allow \`number\` in a boolean context.",
         "type": "boolean"
       },
-      "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
-        "type": "boolean"
-      },
       "allowString": {
         "description": "Whether to allow \`string\` in a boolean context.",
         "type": "boolean"
@@ -67,7 +64,6 @@ type Options = [
     allowNullableString?: boolean;
     /** Whether to allow \`number\` in a boolean context. */
     allowNumber?: boolean;
-    allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
     /** Whether to allow \`string\` in a boolean context. */
     allowString?: boolean;
   },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9891 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

remove rule's option, test case using option, docs option description
- [no-unnecessary-condition](https://typescript-eslint.io/rules/no-unnecessary-condition/#allowruletorunwithoutstrictnullchecksiknowwhatiamdoing)
- [prefer-nullish-coalescing](https://typescript-eslint.io/rules/prefer-nullish-coalescing/#allowruletorunwithoutstrictnullchecksiknowwhatiamdoing)
- [strict-boolean-expressions](https://typescript-eslint.io/rules/strict-boolean-expressions/#allowruletorunwithoutstrictnullchecksiknowwhatiamdoing)