### PR TITLE
chore: add blog/authors.yml for Docusaurus

### DIFF
--- a/packages/website/blog/2022-09-18-automated-rule-docs-with-docusaurus-and-remark.md
+++ b/packages/website/blog/2022-09-18-automated-rule-docs-with-docusaurus-and-remark.md
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/joshuakgoldberg.jpg
-    name: Josh Goldberg
-    title: typescript-eslint Maintainer
-    url: https://github.com/JoshuaKGoldberg
+authors: joshuakgoldberg
 description: How typescript-eslint generates much of the docs pages for each of its lint rules.
 slug: automated-rule-docs-with-docusaurus-and-remark
 tags: [documentation, docusaurus, remark]

--- a/packages/website/blog/2022-12-05-asts-and-typescript-eslint.md
+++ b/packages/website/blog/2022-12-05-asts-and-typescript-eslint.md
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/joshuakgoldberg.jpg
-    name: Josh Goldberg
-    title: typescript-eslint Maintainer
-    url: https://github.com/JoshuaKGoldberg
+authors: joshuakgoldberg
 description: Describing what an AST (Abstract Syntax Tree) is and why it's useful for ESLint and TypeScript tooling.
 slug: asts-and-typescript-eslint
 tags: [ast, abstract syntax tree, parser, parsing, prettier]

--- a/packages/website/blog/2023-02-24-consistent-type-exports-and-imports-why-and-how.md
+++ b/packages/website/blog/2023-02-24-consistent-type-exports-and-imports-why-and-how.md
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/joshuakgoldberg.jpg
-    name: Josh Goldberg
-    title: typescript-eslint Maintainer
-    url: https://github.com/JoshuaKGoldberg
+authors: joshuakgoldberg
 description: Why enforcing TypeScript imports use the `type` modifier when possible benefits some project setups.
 slug: consistent-type-imports-and-exports-why-and-how
 tags: [typescript, imports, exports, types, transpiling]

--- a/packages/website/blog/2023-03-13-announcing-typescript-eslint-v6-beta.md
+++ b/packages/website/blog/2023-03-13-announcing-typescript-eslint-v6-beta.md
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/joshuakgoldberg.jpg
-    name: Josh Goldberg
-    title: typescript-eslint Maintainer
-    url: https://github.com/JoshuaKGoldberg
+authors: joshuakgoldberg
 description: Announcing the release of typescript-eslint's v6 beta, including its changes and timeline.
 slug: announcing-typescript-eslint-v6-beta
 tags: [breaking changes, typescript-eslint, v5, v6]

--- a/packages/website/blog/2023-07-09-announcing-typescript-eslint-v6.md
+++ b/packages/website/blog/2023-07-09-announcing-typescript-eslint-v6.md
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/joshuakgoldberg.jpg
-    name: Josh Goldberg
-    title: typescript-eslint Maintainer
-    url: https://github.com/JoshuaKGoldberg
+authors: joshuakgoldberg
 description: Announcing the release of typescript-eslint's stable v6 release, including its changes and timeline.
 slug: announcing-typescript-eslint-v6
 tags: [breaking changes, typescript-eslint, v5, v6]

--- a/packages/website/blog/2023-09-18-parser-options-project-true.md
+++ b/packages/website/blog/2023-09-18-parser-options-project-true.md
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/joshuakgoldberg.jpg
-    name: Josh Goldberg
-    title: typescript-eslint Maintainer
-    url: https://github.com/JoshuaKGoldberg
+authors: joshuakgoldberg
 description: Simplifying how many projects resolve their
 slug: parser-options-project-true
 tags: [parser, parser options, project, tsconfig]

--- a/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
+++ b/packages/website/blog/2023-12-25-deprecating-formatting-rules.md
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/joshuakgoldberg.jpg
-    name: Josh Goldberg
-    title: typescript-eslint Maintainer
-    url: https://github.com/JoshuaKGoldberg
+authors: joshuakgoldberg
 description: We're following ESLint's lead in moving our formatting lint rules to the ESLint Stylistic project.
 slug: deprecating-formatting-rules
 tags: [formatter, formatting, prettier, style, stylistic]

--- a/packages/website/blog/2024-02-12-announcing-typescript-eslint-v7.md
+++ b/packages/website/blog/2024-02-12-announcing-typescript-eslint-v7.md
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/bradzacher.jpg
-    name: Brad Zacher
-    title: typescript-eslint Maintainer
-    url: https://github.com/bradzacher
+authors: bradzacher
 description: Announcing the release of typescript-eslint's stable v7 release
 slug: announcing-typescript-eslint-v7
 tags: [breaking changes, typescript-eslint, v6, v7, flat configs]

--- a/packages/website/blog/2024-03-25-changes-to-consistent-type-imports-with-decorators.md
+++ b/packages/website/blog/2024-03-25-changes-to-consistent-type-imports-with-decorators.md
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/bradzacher.jpg
-    name: Brad Zacher
-    title: typescript-eslint Maintainer
-    url: https://github.com/bradzacher
+authors: bradzacher
 description: Changes to consistent-type-imports when used with decorators, experimentalDecorators, and emitDecoratorMetadata
 slug: changes-to-consistent-type-imports-with-decorators
 tags:

--- a/packages/website/blog/2024-05-27-announcing-typescript-eslint-v8-beta.mdx
+++ b/packages/website/blog/2024-05-27-announcing-typescript-eslint-v8-beta.mdx
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/joshuakgoldberg.jpg
-    name: Josh Goldberg
-    title: typescript-eslint Maintainer
-    url: https://github.com/JoshuaKGoldberg
+authors: joshuakgoldberg
 description: Announcing the release of typescript-eslint's v8 beta, including its changes and timeline.
 slug: announcing-typescript-eslint-v8-beta
 tags: [breaking changes, typescript-eslint, v7, v8]

--- a/packages/website/blog/2024-07-31-announcing-typescript-eslint-v8.md
+++ b/packages/website/blog/2024-07-31-announcing-typescript-eslint-v8.md
@@ -1,9 +1,5 @@
 ---
-authors:
-  - image_url: /img/team/joshuakgoldberg.jpg
-    name: Josh Goldberg
-    title: typescript-eslint Maintainer
-    url: https://github.com/JoshuaKGoldberg
+authors: joshuakgoldberg
 description: Announcing the stable release of typescript-eslint's v8.
 slug: announcing-typescript-eslint-v8
 tags: [breaking changes, typescript-eslint, v7, v8]

--- a/packages/website/blog/authors.yml
+++ b/packages/website/blog/authors.yml
@@ -1,0 +1,11 @@
+bradzacher:
+  image_url: /img/team/bradzacher.jpg
+  name: Brad Zacher
+  title: typescript-eslint Maintainer
+  url: https://github.com/bradzacher
+
+joshuakgoldberg:
+  image_url: /img/team/joshuakgoldberg.jpg
+  name: Josh Goldberg
+  title: typescript-eslint Maintainer
+  url: https://github.com/JoshuaKGoldberg


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9926
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Per https://docusaurus.io/docs/blog#global-authors. I like this feature, it's a nice bit of deduplication!

💖 