### PR TITLE
chore: enable `unicorn/prefer-array-some`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -329,6 +329,7 @@ export default tseslint.config(
       'unicorn/no-typeof-undefined': 'error',
       'unicorn/no-single-promise-in-promise-methods': 'error',
       'unicorn/no-useless-spread': 'error',
+      'unicorn/prefer-array-some': 'error',
       'unicorn/prefer-export-from': 'error',
       'unicorn/prefer-node-protocol': 'error',
       'unicorn/prefer-regexp-test': 'error',

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -575,9 +575,9 @@ export default createRule<Options, MessageId>({
         }
       }
       const typeName = getTypeName(checker, propertyType);
-      return !!checker
+      return checker
         .getIndexInfosOfType(objType)
-        .find(info => getTypeName(checker, info.keyType) === typeName);
+        .some(info => getTypeName(checker, info.keyType) === typeName);
     }
 
     // Checks whether a member expression is nullable or not regardless of it's previous node.

--- a/packages/website/tools/typedoc-plugin-no-inherit-fork.mjs
+++ b/packages/website/tools/typedoc-plugin-no-inherit-fork.mjs
@@ -115,12 +115,9 @@ class NoInheritPlugin {
    * @param search  The DeclarationReflection to search for in the list.
    */
   isNoInherit(search) {
-    if (
-      this.noInherit.find(no => no.id === search.id && no.name === search.name)
-    ) {
-      return true;
-    }
-    return false;
+    return this.noInherit.some(
+      no => no.id === search.id && no.name === search.name,
+    );
   }
 
   /**
@@ -128,14 +125,9 @@ class NoInheritPlugin {
    * @param search  The Reflection to search for in the list.
    */
   isInherited(search) {
-    if (
-      this.inheritedReflections.find(
-        inh => inh.id === search.id && inh.name === search.name,
-      )
-    ) {
-      return true;
-    }
-    return false;
+    return this.inheritedReflections.some(
+      inh => inh.id === search.id && inh.name === search.name,
+    );
   }
 
   /**


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes part of #9623 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Enable `unicorn/prefer-array-some` ([docs](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-some.md)).
This rule might have been added to `typescript-eslint`, but was recently closed in #8378 .
