### PR TITLE
feat(type-utils): isNullableType add Void logic

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -644,10 +644,9 @@ export default createRule<Options, MessageId>({
             ? !isCallExpressionNullableOriginFromCallee(node)
             : true;
 
-      const possiblyVoid = isTypeFlagSet(type, ts.TypeFlags.Void);
       return (
         isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown) ||
-        (isOwnNullable && (isNullableType(type) || possiblyVoid))
+        (isOwnNullable && isNullableType(type))
       );
     }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -235,7 +235,7 @@ export default createRule<Options, MessageIds>({
 
         const type = getConstrainedTypeAtLocation(services, node.expression);
 
-        if (!isNullableType(type) && !isTypeFlagSet(type, ts.TypeFlags.Void)) {
+        if (!isNullableType(type)) {
           if (
             node.expression.type === AST_NODE_TYPES.Identifier &&
             isPossiblyUsedBeforeAssigned(node.expression)

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -868,6 +868,15 @@ type Foo = { [key: string]: () => number | undefined } | null;
 declare const foo: Foo;
 foo?.['bar']()?.toExponential();
     `,
+    `
+declare function foo(): void | { key: string}
+const bar = foo()?.key
+    `,
+    `
+type fn = () => void
+declare function foo(): void | fn
+const bar = foo()?.()
+    `,
     {
       languageOptions: { parserOptions: optionsWithExactOptionalPropertyTypes },
       code: `

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -869,13 +869,13 @@ declare const foo: Foo;
 foo?.['bar']()?.toExponential();
     `,
     `
-declare function foo(): void | { key: string}
-const bar = foo()?.key
+declare function foo(): void | { key: string };
+const bar = foo()?.key;
     `,
     `
-type fn = () => void
-declare function foo(): void | fn
-const bar = foo()?.()
+type fn = () => void;
+declare function foo(): void | fn;
+const bar = foo()?.();
     `,
     {
       languageOptions: { parserOptions: optionsWithExactOptionalPropertyTypes },

--- a/packages/type-utils/src/predicates.ts
+++ b/packages/type-utils/src/predicates.ts
@@ -15,7 +15,8 @@ export function isNullableType(type: ts.Type): boolean {
     ts.TypeFlags.Any |
       ts.TypeFlags.Unknown |
       ts.TypeFlags.Null |
-      ts.TypeFlags.Undefined,
+      ts.TypeFlags.Undefined |
+      ts.TypeFlags.Void,
   );
 }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8974
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Since there are two rules using this utility function, I removed the same logic from the rule and added test code.

And I tried to add a unit test for isNullableType, but I couldn't find the original unit test file. Is it true that unit tests are not originally written for this utility file? 
<!-- Description of what is changed and how the code change does that. -->
