### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] properly reflect multiple negations in message

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -233,21 +233,22 @@ export default createRule<Options, MessageId>({
      * if the type of the node is always true or always false, it's not necessary.
      */
     function checkNode(
-      node: TSESTree.Expression,
+      expression: TSESTree.Expression,
       isUnaryNotArgument = false,
+      node = expression,
     ): void {
       // Check if the node is Unary Negation expression and handle it
       if (
-        node.type === AST_NODE_TYPES.UnaryExpression &&
-        node.operator === '!'
+        expression.type === AST_NODE_TYPES.UnaryExpression &&
+        expression.operator === '!'
       ) {
-        return checkNode(node.argument, !isUnaryNotArgument);
+        return checkNode(expression.argument, !isUnaryNotArgument, node);
       }
 
       // Since typescript array index signature types don't represent the
       //  possibility of out-of-bounds access, if we're indexing into an array
       //  just skip the check, to avoid false positives
-      if (isArrayIndexExpression(node)) {
+      if (isArrayIndexExpression(expression)) {
         return;
       }
 
@@ -258,13 +259,13 @@ export default createRule<Options, MessageId>({
       //  boolean checks if we inspect the right here, it'll usually be a constant condition on purpose.
       // In this case it's better to inspect the type of the expression as a whole.
       if (
-        node.type === AST_NODE_TYPES.LogicalExpression &&
-        node.operator !== '??'
+        expression.type === AST_NODE_TYPES.LogicalExpression &&
+        expression.operator !== '??'
       ) {
-        return checkNode(node.right);
+        return checkNode(expression.right);
       }
 
-      const type = getConstrainedTypeAtLocation(services, node);
+      const type = getConstrainedTypeAtLocation(services, expression);
 
       // Conditional is always necessary if it involves:
       //    `any` or `unknown` or a naked type variable

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -241,7 +241,7 @@ export default createRule<Options, MessageId>({
         node.type === AST_NODE_TYPES.UnaryExpression &&
         node.operator === '!'
       ) {
-        return checkNode(node.argument, true);
+        return checkNode(node.argument, !isUnaryNotArgument);
       }
 
       // Since typescript array index signature types don't represent the

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -2277,6 +2277,14 @@ foo?.['bar']?.().toExponential();
         },
       ],
     },
+    {
+      code: `
+        const a = true;
+        if (!!a) {
+        }
+      `,
+      errors: [ruleError(3, 15, 'alwaysTruthy')],
+    },
 
     // "branded" types
     unnecessaryConditionTest('"" & {}', 'alwaysFalsy'),

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1909,7 +1909,7 @@ if (!a) {
 }
       `,
       output: null,
-      errors: [ruleError(3, 6, 'alwaysTruthy')],
+      errors: [ruleError(3, 5, 'alwaysTruthy')],
     },
     {
       code: `
@@ -1918,7 +1918,7 @@ if (!a) {
 }
       `,
       output: null,
-      errors: [ruleError(3, 6, 'alwaysFalsy')],
+      errors: [ruleError(3, 5, 'alwaysFalsy')],
     },
     {
       code: `
@@ -1931,7 +1931,7 @@ if (!speech) {
 }
       `,
       output: null,
-      errors: [ruleError(7, 6, 'never')],
+      errors: [ruleError(7, 5, 'never')],
     },
     {
       code: `
@@ -2283,7 +2283,7 @@ foo?.['bar']?.().toExponential();
         if (!!a) {
         }
       `,
-      errors: [ruleError(3, 15, 'alwaysTruthy')],
+      errors: [ruleError(3, 13, 'alwaysTruthy')],
     },
 
     // "branded" types


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9939 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Properly reflect the truthiness or falsiness of a value after multiple negations, and expand the reporting range to include the negation operator(s).