### PR TITLE
chore: pin eslint version in `@types/eslint@v8` integration test

### DIFF
--- a/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v8/package.json
+++ b/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v8/package.json
@@ -6,8 +6,8 @@
     "@types/eslint__js": "latest",
     "@eslint/js": "latest",
     "@types/eslint": "^8",
-    "eslint": "latest",
-    "@stylistic/eslint-plugin": "latest",
+    "eslint": "9.9.1",
+    "@stylistic/eslint-plugin": "2.3.0",
     "eslint-plugin-deprecation": "latest",
     "eslint-plugin-jest": "latest"
   }

--- a/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v8/package.json
+++ b/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v8/package.json
@@ -7,7 +7,7 @@
     "@eslint/js": "latest",
     "@types/eslint": "^8",
     "eslint": "latest",
-    "@stylistic/eslint-plugin": "2.3.0",
+    "@stylistic/eslint-plugin": "latest",
     "eslint-plugin-deprecation": "latest",
     "eslint-plugin-jest": "latest"
   }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9957
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The v9 integration test also uses latest. I believe any issues on eslint.stylistic around v8 / flat config types should be fixed now?

💖 