### PR TITLE
feat(typescript-estree): disable plugin loading by default in project service

### DIFF
--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -369,6 +369,24 @@ It takes in a string path that will be resolved relative to the [`tsconfigRootDi
 
 `projectService.defaultProject` only impacts the "out-of-project" files included by [`allowDefaultProject`](#allowdefaultproject).
 
+##### `loadTypeScriptPlugins`
+
+> Default `false`
+
+Whether the project service should be allowed to load [TypeScript plugins](https://www.typescriptlang.org/tsconfig/plugins.html).
+This is `false` by default to prevent plugins from registering persistent file watchers or other operations that might prevent ESLint processes from exiting when run on the command-line.
+
+If your project is configured with custom rules that interact with TypeScript plugins, it may be useful to turn this on in your editor.
+For example, only enabling this option when running within VS Code:
+
+```js
+parserOptions: {
+  projectService: {
+    loadTypeScriptPlugins: !!process.env.VSCODE_PID,
+  }
+}
+```
+
 ##### `maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING`
 
 > Default: `8`.

--- a/docs/packages/TypeScript_ESTree.mdx
+++ b/docs/packages/TypeScript_ESTree.mdx
@@ -280,6 +280,11 @@ interface ProjectServiceOptions {
   defaultProject?: string;
 
   /**
+   * Whether to load TypeScript plugins as configured in the TSConfig.
+   */
+  loadTypeScriptPlugins?: boolean;
+
+  /**
    * The maximum number of files {@link allowDefaultProject} may match.
    * Each file match slows down linting, so if you do need to use this, please
    * file an informative issue on typescript-eslint explaining why - so we can

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -55,6 +55,11 @@ interface ProjectServiceOptions {
   defaultProject?: string;
 
   /**
+   * Whether to allow TypeScript plugins as configured in the TSConfig.
+   */
+  loadTypeScriptPlugins?: boolean;
+
+  /**
    * The maximum number of files {@link allowDefaultProject} may match.
    * Each file match slows down linting, so if you do need to use this, please
    * file an informative issue on typescript-eslint explaining why - so we can

--- a/packages/typescript-estree/src/create-program/createProjectService.ts
+++ b/packages/typescript-estree/src/create-program/createProjectService.ts
@@ -65,6 +65,18 @@ export function createProjectService(
     setTimeout,
     watchDirectory: createStubFileWatcher,
     watchFile: createStubFileWatcher,
+
+    // We stop loading any TypeScript plugins by default, to prevent them from attaching disk watchers
+    // See https://github.com/typescript-eslint/typescript-eslint/issues/9905
+    ...(!options.loadTypeScriptPlugins && {
+      require: () => ({
+        module: undefined,
+        error: {
+          message:
+            'TypeScript plugins are not required when using parserOptions.projectService.',
+        },
+      }),
+    }),
   };
 
   const logger: ts.server.Logger = {

--- a/packages/typescript-estree/tests/lib/createProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/createProjectService.test.ts
@@ -327,7 +327,7 @@ describe('createProjectService', () => {
     });
   });
 
-  it('does not provide a require to the host system when loadTypeScriptPlugins is falsy', () => {
+  it('does not provide a require to the host system when loadTypeScriptPlugins is truthy', () => {
     const { service } = createProjectService(
       {
         loadTypeScriptPlugins: true,

--- a/packages/typescript-estree/tests/lib/createProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/createProjectService.test.ts
@@ -14,13 +14,15 @@ jest.mock('typescript/lib/tsserverlibrary', () => ({
   server: {
     ...jest.requireActual('typescript/lib/tsserverlibrary').server,
     ProjectService: class {
-      logger: ts.server.Logger;
       eventHandler: ts.server.ProjectServiceEventHandler | undefined;
+      host: ts.server.ServerHost;
+      logger: ts.server.Logger;
       constructor(
         ...args: ConstructorParameters<typeof ts.server.ProjectService>
       ) {
-        this.logger = args[0].logger;
         this.eventHandler = args[0].eventHandler;
+        this.host = args[0].host;
+        this.logger = args[0].logger;
         if (this.eventHandler) {
           this.eventHandler({
             eventName: 'projectLoadingStart',
@@ -309,6 +311,34 @@ describe('createProjectService', () => {
     createProjectService(undefined, undefined, undefined);
 
     expect(process.stderr.write).toHaveBeenCalledTimes(0);
+  });
+
+  it('provides a stub require to the host system when loadTypeScriptPlugins is falsy', () => {
+    const { service } = createProjectService({}, undefined, undefined);
+
+    const required = service.host.require();
+
+    expect(required).toEqual({
+      module: undefined,
+      error: {
+        message:
+          'TypeScript plugins are not required when using parserOptions.projectService.',
+      },
+    });
+  });
+
+  it('does not provide a require to the host system when loadTypeScriptPlugins is falsy', () => {
+    const { service } = createProjectService(
+      {
+        loadTypeScriptPlugins: true,
+      },
+      undefined,
+      undefined,
+    );
+
+    expect(service.host.require).toBe(
+      jest.requireActual('typescript/lib/tsserverlibrary').sys.require,
+    );
   });
 
   it('sets a host configuration', () => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9905
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds an off-by-default `projectService.loadTypeScriptPlugins` option to configure whether plugins are loaded. This is a bugfix in that plugins were previously always loaded. It's a feature in that it's held behind an option.

💖 