### PR TITLE
fix(eslint-plugin): [no-deprecated] don't report recursive types in destructuring assignment twice

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -52,19 +52,17 @@ export default createRule({
           return parent.key === node;
 
         case AST_NODE_TYPES.Property:
+          // foo in "const { foo } = bar" will be processed twice, as parent.key
+          // and parent.value. The second is treated as a declaration.
           return (
             (parent.shorthand && parent.value === node) ||
             parent.parent.type === AST_NODE_TYPES.ObjectExpression
           );
 
         case AST_NODE_TYPES.AssignmentPattern:
-          return (
-            parent.left === node &&
-            !(
-              parent.parent.type === AST_NODE_TYPES.Property &&
-              parent.parent.shorthand
-            )
-          );
+          // foo in "const { foo = "" } = bar" will be processed twice, as parent.parent.key
+          // and parent.left. The second is treated as a declaration.
+          return parent.left === node;
 
         case AST_NODE_TYPES.ArrowFunctionExpression:
         case AST_NODE_TYPES.FunctionDeclaration:

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -157,6 +157,30 @@ ruleTester.run('no-deprecated', rule, {
 
       export type D = A.C | A.D;
     `,
+    `
+      interface Props {
+        anchor: 'foo';
+      }
+      declare const x: Props;
+      const { anchor = '' } = x;
+    `,
+    `
+      interface Props {
+        anchor: 'foo';
+      }
+      declare const x: { bar: Props };
+      const {
+        bar: { anchor = '' },
+      } = x;
+    `,
+    `
+      interface Props {
+        anchor: 'foo';
+      }
+      declare const x: [item: Props];
+      const [{ anchor = 'bar' }] = x;
+    `,
+    'function fn(/** @deprecated */ foo = 4) {}',
   ],
   invalid: [
     {
@@ -1282,6 +1306,88 @@ ruleTester.run('no-deprecated', rule, {
           line: 9,
           endLine: 9,
           data: { name: 'B' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        interface Props {
+          /** @deprecated */
+          anchor: 'foo';
+        }
+        declare const x: Props;
+        const { anchor = '' } = x;
+      `,
+      errors: [
+        {
+          column: 17,
+          endColumn: 23,
+          line: 7,
+          endLine: 7,
+          data: { name: 'anchor' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        interface Props {
+          /** @deprecated */
+          anchor: 'foo';
+        }
+        declare const x: { bar: Props };
+        const {
+          bar: { anchor = '' },
+        } = x;
+      `,
+      errors: [
+        {
+          column: 18,
+          endColumn: 24,
+          line: 8,
+          endLine: 8,
+          data: { name: 'anchor' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        interface Props {
+          /** @deprecated */
+          anchor: 'foo';
+        }
+        declare const x: [item: Props];
+        const [{ anchor = 'bar' }] = x;
+      `,
+      errors: [
+        {
+          column: 18,
+          endColumn: 24,
+          line: 7,
+          endLine: 7,
+          data: { name: 'anchor' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+      interface Props {
+        /** @deprecated */
+        foo: Props
+      }
+      declare const x: Props;
+      const { foo = x } = x;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 18,
+          line: 7,
+          endLine: 7,
+          data: { name: 'foo' },
           messageId: 'deprecated',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -1374,12 +1374,12 @@ ruleTester.run('no-deprecated', rule, {
     },
     {
       code: `
-      interface Props {
-        /** @deprecated */
-        foo: Props
-      }
-      declare const x: Props;
-      const { foo = x } = x;
+        interface Props {
+          /** @deprecated */
+          foo: Props;
+        }
+        declare const x: Props;
+        const { foo = x } = x;
       `,
       errors: [
         {


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #9965
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

