### PR TITLE
fix(eslint-plugin): [no-deprecated] report on deprecated properties with function-like types

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -180,8 +180,16 @@ export default createRule({
         if (signatureDeprecation !== undefined) {
           return signatureDeprecation;
         }
-        const symbolDeclarationKind = symbol?.declarations?.[0].kind;
 
+        // Properties with function-like types have "deprecated" jsdoc
+        // on their symbols, not their signatures:
+        //
+        // interface Props {
+        //   /** @deprecated */
+        //   property: () => 'foo'
+        //   ^symbol^  ^signature^
+        // }
+        const symbolDeclarationKind = symbol?.declarations?.[0].kind;
         if (
           symbolDeclarationKind !== ts.SyntaxKind.MethodDeclaration &&
           symbolDeclarationKind !== ts.SyntaxKind.FunctionDeclaration &&

--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -174,15 +174,24 @@ export default createRule({
       const signature = checker.getResolvedSignature(
         tsNode as ts.CallLikeExpression,
       );
+      const symbol = services.getSymbolAtLocation(node);
       if (signature) {
         const signatureDeprecation = getJsDocDeprecation(signature);
         if (signatureDeprecation !== undefined) {
           return signatureDeprecation;
         }
+        const symbolDeclarationKind = symbol?.declarations?.[0].kind;
+
+        if (
+          symbolDeclarationKind !== ts.SyntaxKind.MethodDeclaration &&
+          symbolDeclarationKind !== ts.SyntaxKind.FunctionDeclaration &&
+          symbolDeclarationKind !== ts.SyntaxKind.MethodSignature
+        ) {
+          return getJsDocDeprecation(symbol);
+        }
       }
 
       // Or it could be a ClassDeclaration or a variable set to a ClassExpression.
-      const symbol = services.getSymbolAtLocation(node);
       const symbolAtLocation =
         symbol && checker.getTypeOfSymbolAtLocation(symbol, tsNode).getSymbol();
 

--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -182,7 +182,7 @@ export default createRule({
         }
 
         // Properties with function-like types have "deprecated" jsdoc
-        // on their symbols, not their signatures:
+        // on their symbols, not on their signatures:
         //
         // interface Props {
         //   /** @deprecated */

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -813,8 +813,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           column: 11,
           endColumn: 12,
-          line: 9,
-          endLine: 9,
+          line: 11,
+          endLine: 11,
           data: { name: 'b' },
           messageId: 'deprecated',
         },

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -101,6 +101,32 @@ ruleTester.run('no-deprecated', rule, {
       a('b');
     `,
     `
+      class A {
+        a(value: 'b'): void;
+        /** @deprecated */
+        a(value: 'c'): void;
+      }
+      declare const foo: A;
+      foo.a('b');
+    `,
+    `
+      type A = {
+        (value: 'b'): void;
+        /** @deprecated */
+        (value: 'c'): void;
+      }
+      declare const foo: A;
+      foo('b');
+    `,
+    `
+      declare const a: {
+        new (value: 'b'): void;
+        /** @deprecated */
+        new (value: 'c'): void;
+      }
+      new a('b');
+    `,
+    `
       namespace assert {
         export function fail(message?: string | Error): never;
         /** @deprecated since v10.0.0 - use fail([message]) or other assert functions instead. */
@@ -597,6 +623,26 @@ ruleTester.run('no-deprecated', rule, {
     },
     {
       code: `
+        declare const A: {
+          /** @deprecated */
+          new (): string
+        };
+
+        new A();
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 14,
+          line: 7,
+          endLine: 7,
+          data: { name: 'A' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
         /** @deprecated */
         declare class A {
           constructor();
@@ -670,6 +716,97 @@ ruleTester.run('no-deprecated', rule, {
 
         a.b();
       `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 12,
+          line: 9,
+          endLine: 9,
+          data: { name: 'b' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        declare class A {
+          /** @deprecated */
+          b: () => string;
+        }
+
+        declare const a: A;
+
+        a.b;
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 12,
+          line: 9,
+          endLine: 9,
+          data: { name: 'b' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        declare class A {
+          /** @deprecated */
+          b: () => string;
+        }
+
+        declare const a: A;
+
+        a.b();
+      `,
+      only: false,
+      errors: [
+        {
+          column: 11,
+          endColumn: 12,
+          line: 9,
+          endLine: 9,
+          data: { name: 'b' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        interface A {
+          /** @deprecated */
+          b: () => string;
+        }
+
+        declare const a: A;
+
+        a.b();
+      `,
+      only: false,
+      errors: [
+        {
+          column: 11,
+          endColumn: 12,
+          line: 9,
+          endLine: 9,
+          data: { name: 'b' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        class A {
+          /** @deprecated */
+          b(): string { return ''; }
+        }
+
+        declare const a: A;
+
+        a.b();
+      `,
+      only: false,
       errors: [
         {
           column: 11,
@@ -1095,6 +1232,27 @@ ruleTester.run('no-deprecated', rule, {
           line: 7,
           endLine: 7,
           data: { name: 'a' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        type A = {
+          (value: 'b'): void;
+          /** @deprecated */
+          (value: 'c'): void;
+        }
+        declare const foo: A;
+        foo('c');
+      `,
+      errors: [
+        {
+          column: 9,
+          endColumn: 12,
+          line: 8,
+          endLine: 8,
+          data: { name: 'foo' },
           messageId: 'deprecated',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -114,7 +114,7 @@ ruleTester.run('no-deprecated', rule, {
         (value: 'b'): void;
         /** @deprecated */
         (value: 'c'): void;
-      }
+      };
       declare const foo: A;
       foo('b');
     `,
@@ -123,7 +123,7 @@ ruleTester.run('no-deprecated', rule, {
         new (value: 'b'): void;
         /** @deprecated */
         new (value: 'c'): void;
-      }
+      };
       new a('b');
     `,
     `
@@ -625,9 +625,9 @@ ruleTester.run('no-deprecated', rule, {
       code: `
         declare const A: {
           /** @deprecated */
-          new (): string
+          new (): string;
         };
-
+        
         new A();
       `,
       errors: [
@@ -799,11 +799,13 @@ ruleTester.run('no-deprecated', rule, {
       code: `
         class A {
           /** @deprecated */
-          b(): string { return ''; }
+          b(): string {
+            return '';
+          }
         }
-
+        
         declare const a: A;
-
+        
         a.b();
       `,
       only: false,
@@ -1242,7 +1244,7 @@ ruleTester.run('no-deprecated', rule, {
           (value: 'b'): void;
           /** @deprecated */
           (value: 'c'): void;
-        }
+        };
         declare const foo: A;
         foo('c');
       `,

--- a/packages/utils/tests/ts-eslint/ESLint.test.ts
+++ b/packages/utils/tests/ts-eslint/ESLint.test.ts
@@ -13,6 +13,7 @@ describe('ESLint', () => {
       expect(eslint).toBeInstanceOf(FlatESLint);
     });
     it('legacy', () => {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       const eslint = new ESLint.LegacyESLint({
         // accepts legacy configs
         baseConfig: {


### PR DESCRIPTION


## PR Checklist

- [x] Addresses an existing open issue: fixes #9970
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

```ts
declare interface SomeInterface {
  /** @deprecated */
  property: () => void;

  /** @deprecated */
  method(): void;
}

declare const someInterface: SomeInterface;
someInterface.property(); // ❌ missing error
someInterface.method(); // ✅ errors
```

Both `property` and `method` identifiers have call signatures, but:
- `method` has `"deprecated"` jsdoc tag on its **signature**
- `property` has `"deprecated"` jsdoc tag on its **symbol**