### PR TITLE
feat(eslint-plugin): disable no-constant-condition in eslint-recommended

### DIFF
--- a/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
+++ b/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
@@ -23,6 +23,7 @@ export default (
     'constructor-super': 'off', // ts(2335) & ts(2377)
     'getter-return': 'off', // ts(2378)
     'no-const-assign': 'off', // ts(2588)
+    'no-constant-binary-condition': 'off', // ts(2872) + no-unnecessary-condition
     'no-dupe-args': 'off', // ts(2300)
     'no-dupe-class-members': 'off', // ts(2393) & ts(2300)
     'no-dupe-keys': 'off', // ts(1117)


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9973
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a disable of `no-constant-condition` to the `eslint-recommended` ruleset.

In theory, someone might be on TypeScript <5.6 and the latest version of typescript-eslint. This would reduce their linter surface area. But we already have [`@typescript-eslint/no-unnecessary-condition`](https://typescript-eslint.io/rules/no-unnecessary-condition).

💖 