### PR TITLE
fix(eslint-plugin): [no-deprecated] report on imported deprecated variables

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -3,12 +3,7 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
-import {
-  createRule,
-  getParserServices,
-  nullThrows,
-  NullThrowsReasons,
-} from '../util';
+import { createRule, getParserServices, nullThrows } from '../util';
 
 type IdentifierLike = TSESTree.Identifier | TSESTree.JSXIdentifier;
 

--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -264,6 +264,9 @@ export default createRule({
           // all symbol declarations combined into one array. And AFAIK there is
           // no publicly exported TS function that can tell us if a particular
           // declaration is deprecated or not.
+          //
+          // So, in case of function and method declarations, we don't check original
+          // aliased symbol, but rely on the getJsDocDeprecation(signature) call below.
           false,
         ) ?? getJsDocDeprecation(signature)
       );

--- a/packages/eslint-plugin/tests/fixtures/class.ts
+++ b/packages/eslint-plugin/tests/fixtures/class.ts
@@ -11,14 +11,3 @@ export class Reducable {
 
 // used by no-implied-eval test function imports
 export class Function {}
-
-// used by no-deprecated to test importing deprecated things
-/** @deprecated */
-export class DeprecatedClass {
-  /** @deprecated */
-  foo: string = '';
-}
-/** @deprecated */
-export const deprecatedVariable = 1;
-/** @deprecated */
-export function deprecatedFunction() {}

--- a/packages/eslint-plugin/tests/fixtures/class.ts
+++ b/packages/eslint-plugin/tests/fixtures/class.ts
@@ -11,3 +11,14 @@ export class Reducable {
 
 // used by no-implied-eval test function imports
 export class Function {}
+
+// used by no-deprecated to test importing deprecated things
+/** @deprecated */
+export class DeprecatedClass {
+  /** @deprecated */
+  foo: string = '';
+}
+/** @deprecated */
+export const deprecatedVariable = 1;
+/** @deprecated */
+export function deprecatedFunction() {}

--- a/packages/eslint-plugin/tests/fixtures/deprecated.ts
+++ b/packages/eslint-plugin/tests/fixtures/deprecated.ts
@@ -1,0 +1,42 @@
+/** @deprecated */
+export class DeprecatedClass {
+  /** @deprecated */
+  foo: string = '';
+}
+/** @deprecated */
+export const deprecatedVariable = 1;
+/** @deprecated */
+export function deprecatedFunction(): void {}
+class NormalClass {}
+const normalVariable = 1;
+function normalFunction(): void;
+function normalFunction(arg: string): void;
+function normalFunction(arg?: string): void {}
+function deprecatedFunctionWithOverloads(): void;
+/** @deprecated */
+function deprecatedFunctionWithOverloads(arg: string): void;
+function deprecatedFunctionWithOverloads(arg?: string): void {}
+export class ClassWithDeprecatedConstructor {
+  constructor();
+  /** @deprecated */
+  constructor(arg: string);
+  constructor(arg?: string) {}
+}
+export {
+  /** @deprecated */
+  NormalClass,
+  /** @deprecated */
+  normalVariable,
+  /** @deprecated */
+  normalFunction,
+  deprecatedFunctionWithOverloads,
+  /** @deprecated Reason */
+  deprecatedFunctionWithOverloads as reexportedDeprecatedFunctionWithOverloads,
+  /** @deprecated Reason */
+  ClassWithDeprecatedConstructor as ReexportedClassWithDeprecatedConstructor,
+};
+
+/** @deprecated */
+export default {
+  foo: 1,
+};

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.json
@@ -11,6 +11,7 @@
   "include": [
     "file.ts",
     "consistent-type-exports.ts",
+    "deprecated.ts",
     "mixed-enums-decl.ts",
     "react.tsx",
     "var-declaration.ts"

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.moduleResolution-node16.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.moduleResolution-node16.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "node16",
+    "moduleResolution": "node16"
+  }
+}

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -251,7 +251,7 @@ ruleTester.run('no-deprecated', rule, {
         },
       },
     },
-    'call()',
+    'call();',
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -816,7 +816,6 @@ ruleTester.run('no-deprecated', rule, {
 
         a.b();
       `,
-      only: false,
       errors: [
         {
           column: 11,
@@ -839,7 +838,6 @@ ruleTester.run('no-deprecated', rule, {
 
         a.b();
       `,
-      only: false,
       errors: [
         {
           column: 11,
@@ -864,7 +862,6 @@ ruleTester.run('no-deprecated', rule, {
         
         a.b();
       `,
-      only: false,
       errors: [
         {
           column: 11,
@@ -1580,6 +1577,103 @@ ruleTester.run('no-deprecated', rule, {
           line: 7,
           endLine: 7,
           data: { name: 'foo' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        import { DeprecatedClass } from './class';
+        
+        const foo = new DeprecatedClass();
+      `,
+      errors: [
+        {
+          column: 25,
+          endColumn: 40,
+          line: 4,
+          endLine: 4,
+          data: { name: 'DeprecatedClass' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        import { DeprecatedClass } from './class';
+        
+        declare function inject(something: new () => unknown): void;
+        
+        inject(DeprecatedClass);
+      `,
+      errors: [
+        {
+          column: 16,
+          endColumn: 31,
+          line: 6,
+          endLine: 6,
+          data: { name: 'DeprecatedClass' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        import { deprecatedVariable } from './class';
+        
+        const foo = deprecatedVariable;
+      `,
+      errors: [
+        {
+          column: 21,
+          endColumn: 39,
+          line: 4,
+          endLine: 4,
+          data: { name: 'deprecatedVariable' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        import { DeprecatedClass } from './class';
+        
+        declare const x: DeprecatedClass;
+        
+        const { foo } = x;
+      `,
+      errors: [
+        {
+          column: 26,
+          endColumn: 41,
+          line: 4,
+          endLine: 4,
+          data: { name: 'DeprecatedClass' },
+          messageId: 'deprecated',
+        },
+        {
+          column: 17,
+          endColumn: 20,
+          line: 6,
+          endLine: 6,
+          data: { name: 'foo' },
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        import { deprecatedFunction } from './class';
+        
+        deprecatedFunction();
+      `,
+      errors: [
+        {
+          column: 9,
+          endColumn: 27,
+          line: 4,
+          endLine: 4,
+          data: { name: 'deprecatedFunction' },
           messageId: 'deprecated',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -247,7 +247,8 @@ ruleTester.run('no-deprecated', rule, {
       languageOptions: {
         parserOptions: {
           tsconfigRootDir: rootDir,
-          project: 'tsconfig.moduleResolution-node16.json',
+          projectService: false,
+          project: './tsconfig.moduleResolution-node16.json',
         },
       },
     },
@@ -2300,7 +2301,7 @@ ruleTester.run('no-deprecated', rule, {
     {
       code: `
         import imported from './deprecated';
-        
+
         imported;
       `,
       errors: [
@@ -2324,7 +2325,8 @@ ruleTester.run('no-deprecated', rule, {
       languageOptions: {
         parserOptions: {
           tsconfigRootDir: rootDir,
-          project: 'tsconfig.moduleResolution-node16.json',
+          projectService: false,
+          project: './tsconfig.moduleResolution-node16.json',
         },
       },
       errors: [


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9946
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

JSDoc tags are attached to the original symbols, not to symbol aliases. But symbols of imported variables are aliases, so we need to resolve those aliases, that's it!
