### PR TITLE
fix(typescript-estree): don't throw on missing tsconfig.json by default in project service

### DIFF
--- a/packages/typescript-estree/src/create-program/createProjectService.ts
+++ b/packages/typescript-estree/src/create-program/createProjectService.ts
@@ -42,9 +42,10 @@ export function createProjectService(
   jsDocParsingMode: ts.JSDocParsingMode | undefined,
   tsconfigRootDir: string | undefined,
 ): ProjectServiceSettings {
+  const optionsRawObject = typeof optionsRaw === 'object' ? optionsRaw : {};
   const options = {
     defaultProject: 'tsconfig.json',
-    ...(typeof optionsRaw === 'object' && optionsRaw),
+    ...optionsRawObject,
   };
   validateDefaultProjectForFilesGlob(options.allowDefaultProject);
 
@@ -126,7 +127,7 @@ export function createProjectService(
   });
 
   log('Enabling default project: %s', options.defaultProject);
-  let configFile: ts.ParsedCommandLine;
+  let configFile: ts.ParsedCommandLine | undefined;
 
   try {
     configFile = getParsedConfigFile(
@@ -135,18 +136,22 @@ export function createProjectService(
       tsconfigRootDir,
     );
   } catch (error) {
-    throw new Error(
-      `Could not read project service default project '${options.defaultProject}': ${(error as Error).message}`,
-    );
+    if (optionsRawObject.defaultProject) {
+      throw new Error(
+        `Could not read project service default project '${options.defaultProject}': ${(error as Error).message}`,
+      );
+    }
   }
 
-  service.setCompilerOptionsForInferredProjects(
-    // NOTE: The inferred projects API is not intended for source files when a tsconfig
-    // exists.  There is no API that generates an InferredProjectCompilerOptions suggesting
-    // it is meant for hard coded options passed in. Hard asserting as a work around.
-    // See https://github.com/microsoft/TypeScript/blob/27bcd4cb5a98bce46c9cdd749752703ead021a4b/src/server/protocol.ts#L1904
-    configFile.options as ts.server.protocol.InferredProjectCompilerOptions,
-  );
+  if (configFile) {
+    service.setCompilerOptionsForInferredProjects(
+      // NOTE: The inferred projects API is not intended for source files when a tsconfig
+      // exists.  There is no API that generates an InferredProjectCompilerOptions suggesting
+      // it is meant for hard coded options passed in. Hard asserting as a work around.
+      // See https://github.com/microsoft/TypeScript/blob/27bcd4cb5a98bce46c9cdd749752703ead021a4b/src/server/protocol.ts#L1904
+      configFile.options as ts.server.protocol.InferredProjectCompilerOptions,
+    );
+  }
 
   return {
     allowDefaultProject: options.allowDefaultProject,

--- a/packages/typescript-estree/tests/lib/createProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/createProjectService.test.ts
@@ -65,7 +65,7 @@ describe('createProjectService', () => {
     expect(settings.allowDefaultProject).toBeUndefined();
   });
 
-  it('throws an error with a local path when options.defaultProject is not provided and getParsedConfigFile throws a diagnostic error', () => {
+  it('does not throw an error when options.defaultProject is not provided and getParsedConfigFile throws a diagnostic error', () => {
     mockGetParsedConfigFile.mockImplementation(() => {
       throw new Error('tsconfig.json(1,1): error TS1234: Oh no!');
     });
@@ -78,9 +78,7 @@ describe('createProjectService', () => {
         undefined,
         undefined,
       ),
-    ).toThrow(
-      /Could not read project service default project 'tsconfig.json': .+ error TS1234: Oh no!/,
-    );
+    ).not.toThrow();
   });
 
   it('throws an error with a relative path when options.defaultProject is set to a relative path and getParsedConfigFile throws a diagnostic error', () => {
@@ -132,6 +130,7 @@ describe('createProjectService', () => {
       createProjectService(
         {
           allowDefaultProject: ['file.js'],
+          defaultProject: 'tsconfig.json',
         },
         undefined,
         undefined,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9985
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Changes error throwing to only occur if the user explicitly provides a `parserOptions.defaultProject`.

💖 