### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-parameters] consider type parameter used as rest parameter type to be used multiple times

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -5,7 +5,12 @@ import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
 import type { MakeRequired } from '../util';
-import { createRule, getParserServices, nullThrows } from '../util';
+import {
+  createRule,
+  getParserServices,
+  isRestParameterDeclaration,
+  nullThrows,
+} from '../util';
 
 type NodeWithTypeParameters = MakeRequired<
   ts.SignatureDeclaration | ts.ClassLikeDeclaration,
@@ -373,7 +378,10 @@ function collectTypeParameterUsageCounts(
     }
 
     for (const parameter of signature.parameters) {
-      visitType(checker.getTypeOfSymbol(parameter), false);
+      const isRestParameter = (parameter.getDeclarations() ?? []).every(
+        declaration => isRestParameterDeclaration(declaration),
+      );
+      visitType(checker.getTypeOfSymbol(parameter), isRestParameter);
     }
 
     for (const typeParameter of signature.getTypeParameters() ?? []) {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -167,6 +167,9 @@ ruleTester.run('no-unnecessary-type-parameters', rule, {
         };
       }
     `,
+    'function fn<T extends unknown[]>(...args: T) {}',
+    'function fn<T extends unknown[]>(cb: (...args: T) => void) {}',
+    'function fn<U, T extends U[]>(firstArg: U, ...restArgs: T) {}',
     `
       function lengthyIdentity<T extends { length: number }>(x: T) {
         return x;

--- a/packages/website/src/globals.d.ts
+++ b/packages/website/src/globals.d.ts
@@ -3,9 +3,6 @@ import type * as ts from 'typescript';
 
 declare global {
   interface WindowRequire {
-    // We know it's an unsafe assertion. It's for window.require usage, so we
-    // don't have to use verbose type assertions on every call.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
     <T extends unknown[]>(
       files: string[],
       success?: (...arg: T) => void,


### PR DESCRIPTION


## PR Checklist

- [x] Addresses an existing open issue: fixes #9890
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
