### PR TITLE
fix(utils): add missing entries to the RuleListener selectors list

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -65,6 +65,9 @@ export default {
       entry: ['src/use-at-your-own-risk.ts'],
       ignore: ['tests/fixtures/**'],
     },
+    'packages/utils': {
+      ignore: ['tests/**/*.type-test.ts'],
+    },
     'packages/website': {
       entry: [
         'docusaurus.config.mts',

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -423,7 +423,6 @@ interface RuleListenerBaseSelectors {
   AssignmentExpression?: RuleFunction<TSESTree.AssignmentExpression>;
   AssignmentPattern?: RuleFunction<TSESTree.AssignmentPattern>;
   AwaitExpression?: RuleFunction<TSESTree.AwaitExpression>;
-  BigIntLiteral?: RuleFunction<TSESTree.BigIntLiteral>;
   BinaryExpression?: RuleFunction<TSESTree.BinaryExpression>;
   BlockStatement?: RuleFunction<TSESTree.BlockStatement>;
   BreakStatement?: RuleFunction<TSESTree.BreakStatement>;
@@ -451,6 +450,7 @@ interface RuleListenerBaseSelectors {
   FunctionExpression?: RuleFunction<TSESTree.FunctionExpression>;
   Identifier?: RuleFunction<TSESTree.Identifier>;
   IfStatement?: RuleFunction<TSESTree.IfStatement>;
+  ImportAttribute?: RuleFunction<TSESTree.ImportAttribute>;
   ImportDeclaration?: RuleFunction<TSESTree.ImportDeclaration>;
   ImportDefaultSpecifier?: RuleFunction<TSESTree.ImportDefaultSpecifier>;
   ImportExpression?: RuleFunction<TSESTree.ImportExpression>;
@@ -465,6 +465,7 @@ interface RuleListenerBaseSelectors {
   JSXFragment?: RuleFunction<TSESTree.JSXFragment>;
   JSXIdentifier?: RuleFunction<TSESTree.JSXIdentifier>;
   JSXMemberExpression?: RuleFunction<TSESTree.JSXMemberExpression>;
+  JSXNamespacedName?: RuleFunction<TSESTree.JSXNamespacedName>;
   JSXOpeningElement?: RuleFunction<TSESTree.JSXOpeningElement>;
   JSXOpeningFragment?: RuleFunction<TSESTree.JSXOpeningFragment>;
   JSXSpreadAttribute?: RuleFunction<TSESTree.JSXSpreadAttribute>;
@@ -479,6 +480,7 @@ interface RuleListenerBaseSelectors {
   NewExpression?: RuleFunction<TSESTree.NewExpression>;
   ObjectExpression?: RuleFunction<TSESTree.ObjectExpression>;
   ObjectPattern?: RuleFunction<TSESTree.ObjectPattern>;
+  PrivateIdentifier?: RuleFunction<TSESTree.PrivateIdentifier>;
   Program?: RuleFunction<TSESTree.Program>;
   Property?: RuleFunction<TSESTree.Property>;
   PropertyDefinition?: RuleFunction<TSESTree.PropertyDefinition>;
@@ -486,6 +488,7 @@ interface RuleListenerBaseSelectors {
   ReturnStatement?: RuleFunction<TSESTree.ReturnStatement>;
   SequenceExpression?: RuleFunction<TSESTree.SequenceExpression>;
   SpreadElement?: RuleFunction<TSESTree.SpreadElement>;
+  StaticBlock?: RuleFunction<TSESTree.StaticBlock>;
   Super?: RuleFunction<TSESTree.Super>;
   SwitchCase?: RuleFunction<TSESTree.SwitchCase>;
   SwitchStatement?: RuleFunction<TSESTree.SwitchStatement>;
@@ -495,6 +498,7 @@ interface RuleListenerBaseSelectors {
   ThisExpression?: RuleFunction<TSESTree.ThisExpression>;
   ThrowStatement?: RuleFunction<TSESTree.ThrowStatement>;
   TryStatement?: RuleFunction<TSESTree.TryStatement>;
+  TSAbstractAccessorProperty?: RuleFunction<TSESTree.TSAbstractAccessorProperty>;
   TSAbstractKeyword?: RuleFunction<TSESTree.TSAbstractKeyword>;
   TSAbstractMethodDefinition?: RuleFunction<TSESTree.TSAbstractMethodDefinition>;
   TSAbstractPropertyDefinition?: RuleFunction<TSESTree.TSAbstractPropertyDefinition>;
@@ -512,6 +516,7 @@ interface RuleListenerBaseSelectors {
   TSDeclareFunction?: RuleFunction<TSESTree.TSDeclareFunction>;
   TSDeclareKeyword?: RuleFunction<TSESTree.TSDeclareKeyword>;
   TSEmptyBodyFunctionExpression?: RuleFunction<TSESTree.TSEmptyBodyFunctionExpression>;
+  TSEnumBody?: RuleFunction<TSESTree.TSEnumBody>;
   TSEnumDeclaration?: RuleFunction<TSESTree.TSEnumDeclaration>;
   TSEnumMember?: RuleFunction<TSESTree.TSEnumMember>;
   TSExportAssignment?: RuleFunction<TSESTree.TSExportAssignment>;
@@ -523,15 +528,18 @@ interface RuleListenerBaseSelectors {
   TSIndexedAccessType?: RuleFunction<TSESTree.TSIndexedAccessType>;
   TSIndexSignature?: RuleFunction<TSESTree.TSIndexSignature>;
   TSInferType?: RuleFunction<TSESTree.TSInferType>;
+  TSInstantiationExpression?: RuleFunction<TSESTree.TSInstantiationExpression>;
   TSInterfaceBody?: RuleFunction<TSESTree.TSInterfaceBody>;
   TSInterfaceDeclaration?: RuleFunction<TSESTree.TSInterfaceDeclaration>;
   TSInterfaceHeritage?: RuleFunction<TSESTree.TSInterfaceHeritage>;
   TSIntersectionType?: RuleFunction<TSESTree.TSIntersectionType>;
+  TSIntrinsicKeyword?: RuleFunction<TSESTree.TSIntrinsicKeyword>;
   TSLiteralType?: RuleFunction<TSESTree.TSLiteralType>;
   TSMappedType?: RuleFunction<TSESTree.TSMappedType>;
   TSMethodSignature?: RuleFunction<TSESTree.TSMethodSignature>;
   TSModuleBlock?: RuleFunction<TSESTree.TSModuleBlock>;
   TSModuleDeclaration?: RuleFunction<TSESTree.TSModuleDeclaration>;
+  TSNamedTupleMember?: RuleFunction<TSESTree.TSNamedTupleMember>;
   TSNamespaceExportDeclaration?: RuleFunction<TSESTree.TSNamespaceExportDeclaration>;
   TSNeverKeyword?: RuleFunction<TSESTree.TSNeverKeyword>;
   TSNonNullExpression?: RuleFunction<TSESTree.TSNonNullExpression>;
@@ -551,6 +559,7 @@ interface RuleListenerBaseSelectors {
   TSStaticKeyword?: RuleFunction<TSESTree.TSStaticKeyword>;
   TSStringKeyword?: RuleFunction<TSESTree.TSStringKeyword>;
   TSSymbolKeyword?: RuleFunction<TSESTree.TSSymbolKeyword>;
+  TSTemplateLiteralType?: RuleFunction<TSESTree.TSTemplateLiteralType>;
   TSThisType?: RuleFunction<TSESTree.TSThisType>;
   TSTupleType?: RuleFunction<TSESTree.TSTupleType>;
   TSTypeAliasDeclaration?: RuleFunction<TSESTree.TSTypeAliasDeclaration>;

--- a/packages/utils/tests/ts-eslint/Rule.type-test.ts
+++ b/packages/utils/tests/ts-eslint/Rule.type-test.ts
@@ -1,0 +1,37 @@
+import type { TSESTree } from '@typescript-eslint/types';
+
+import type { RuleListener } from '../../src/ts-eslint';
+
+type RuleListenerKeysWithoutIndexSignature = {
+  [K in keyof RuleListener as string extends K ? never : K]: K;
+};
+
+type RuleListenerSelectors = NonNullable<
+  RuleListenerKeysWithoutIndexSignature[keyof RuleListenerKeysWithoutIndexSignature]
+>;
+
+type AllSelectors =
+  | `${TSESTree.AST_NODE_TYPES}`
+  | `${TSESTree.AST_NODE_TYPES}:exit`;
+
+type ExpectNever<T extends never> = T;
+
+type SelectorsWithWrongNodeType = {
+  [K in TSESTree.AST_NODE_TYPES]: Parameters<
+    NonNullable<RuleListener[K]>
+  >[0]['type'] extends K
+    ? K extends Parameters<NonNullable<RuleListener[K]>>[0]['type']
+      ? never
+      : K
+    : K;
+}[TSESTree.AST_NODE_TYPES];
+type _test_rule_listener_selectors_have_correct_node_types =
+  ExpectNever<SelectorsWithWrongNodeType>;
+
+type ExtraSelectors = Exclude<RuleListenerSelectors, AllSelectors>;
+type _test_rule_listener_does_not_define_extra_selectors =
+  ExpectNever<ExtraSelectors>;
+
+type MissingSelectors = Exclude<AllSelectors, RuleListenerSelectors>;
+type _test_rule_listener_has_selectors_for_all_node_types =
+  ExpectNever<MissingSelectors>;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9988
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I added some tests, and it turns out there were 10 selectors missing!