### PR TITLE
chore(plugin): [prefer-readonly-parameter-types] remove null from comparison when null does not exist

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
@@ -117,7 +117,7 @@ export default createRule<Options, MessageIds>({
               ? param.parameter
               : param;
 
-          if (ignoreInferredTypes && actualParam.typeAnnotation == null) {
+          if (ignoreInferredTypes && actualParam.typeAnnotation === undefined) {
             continue;
           }
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This line is written in a confusing way because the type of `actualParam.typeAnnotation` is `TSESTree.TSTypeAnnotation | undefined`, and thus does not contain `null` at all.

I think an audit of all such confusing cases in the monorepo should be done in the future. The root of the issue is the usage of the "==" operator, which in my opinion should just be banned, but maybe that is too controversial.