### PR TITLE
fix(eslint-plugin): properly coerce all types to string in `getStaticMemberAccessValue`

### DIFF
--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -4,7 +4,6 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import {
   createRule,
   getStaticMemberAccessValue,
-  getStaticStringValue,
   isAssignee,
   isFunction,
   isStaticMemberAccessOfValue,

--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -25,7 +25,7 @@ interface NodeWithModifiers {
 
 interface PropertiesInfo {
   properties: TSESTree.PropertyDefinition[];
-  excludeSet: Set<string>;
+  excludeSet: Set<string | symbol>;
 }
 
 const printNodeModifiers = (
@@ -132,9 +132,7 @@ export default createRule<Options, MessageIds>({
         const { excludeSet } =
           propertiesInfoStack[propertiesInfoStack.length - 1];
 
-        const name =
-          getStaticStringValue(node.property) ??
-          context.sourceCode.getText(node.property);
+        const name = getStaticMemberAccessValue(node, context);
 
         if (name) {
           excludeSet.add(name);

--- a/packages/eslint-plugin/src/rules/class-methods-use-this.ts
+++ b/packages/eslint-plugin/src/rules/class-methods-use-this.ts
@@ -184,7 +184,9 @@ export default createRule<Options, MessageIds>({
         node.key.type === AST_NODE_TYPES.PrivateIdentifier ? '#' : '';
       const name = getStaticMemberAccessValue(node, context);
 
-      return !exceptMethods.has(hashIfNeeded + (name ?? ''));
+      return (
+        typeof name !== 'string' || !exceptMethods.has(hashIfNeeded + name)
+      );
     }
 
     /**

--- a/packages/eslint-plugin/src/util/isArrayMethodCallWithPredicate.ts
+++ b/packages/eslint-plugin/src/util/isArrayMethodCallWithPredicate.ts
@@ -30,7 +30,10 @@ export function isArrayMethodCallWithPredicate(
 
   const staticAccessValue = getStaticMemberAccessValue(node.callee, context);
 
-  if (!staticAccessValue || !ARRAY_PREDICATE_FUNCTIONS.has(staticAccessValue)) {
+  if (
+    typeof staticAccessValue !== 'string' ||
+    !ARRAY_PREDICATE_FUNCTIONS.has(staticAccessValue)
+  ) {
     return false;
   }
 

--- a/packages/eslint-plugin/src/util/isArrayMethodCallWithPredicate.ts
+++ b/packages/eslint-plugin/src/util/isArrayMethodCallWithPredicate.ts
@@ -9,7 +9,7 @@ import * as tsutils from 'ts-api-utils';
 
 import { getStaticMemberAccessValue } from './misc';
 
-const ARRAY_PREDICATE_FUNCTIONS = new Set([
+const ARRAY_PREDICATE_FUNCTIONS = new Set<unknown>([
   'filter',
   'find',
   'findIndex',
@@ -30,10 +30,7 @@ export function isArrayMethodCallWithPredicate(
 
   const staticAccessValue = getStaticMemberAccessValue(node.callee, context);
 
-  if (
-    typeof staticAccessValue !== 'string' ||
-    !ARRAY_PREDICATE_FUNCTIONS.has(staticAccessValue)
-  ) {
+  if (!ARRAY_PREDICATE_FUNCTIONS.has(staticAccessValue)) {
     return false;
   }
 

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -292,9 +292,6 @@ function getStaticMemberAccessValue(
   const key =
     node.type === AST_NODE_TYPES.MemberExpression ? node.property : node.key;
   const { type } = key;
-  if (type === AST_NODE_TYPES.Literal) {
-    return String(key.value);
-  }
   if (
     !node.computed &&
     (type === AST_NODE_TYPES.Identifier ||

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -253,20 +253,15 @@ function getStaticMemberAccessValue(
     node.type === AST_NODE_TYPES.MemberExpression ? node.property : node.key;
   if (!node.computed) {
     return key.type === AST_NODE_TYPES.Literal
-      ? `${key.value}`
+      ? String(key.value)
       : (key as TSESTree.Identifier | TSESTree.PrivateIdentifier).name;
   }
   const result = getStaticValue(key, sourceCode.getScope(node));
   if (!result) {
-    return;
+    return undefined;
   }
   const { value } = result;
-  return typeof value === 'symbol'
-    ? value
-    : /* intentional interpolation of an `unknown` value, because any non-Symbol value is coerced to a string by
-         JavaScript when in a `MemberAccess`. */
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `${value}`;
+  return typeof value === 'symbol' ? value : String(value);
 }
 
 /**

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -2,8 +2,7 @@
  * @fileoverview Really small utility functions that didn't deserve their own files
  */
 import { requiresQuoting } from '@typescript-eslint/type-utils';
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
 import * as ts from 'typescript';
 
@@ -251,10 +250,15 @@ function getStaticMemberAccessValue(
 ): string | symbol | undefined {
   const key =
     node.type === AST_NODE_TYPES.MemberExpression ? node.property : node.key;
-  if (!node.computed) {
-    return key.type === AST_NODE_TYPES.Literal
-      ? String(key.value)
-      : (key as TSESTree.Identifier | TSESTree.PrivateIdentifier).name;
+  const { type } = key;
+  if (type === AST_NODE_TYPES.Literal) {
+    return String(key.value);
+  }
+  if (
+    type === AST_NODE_TYPES.Identifier ||
+    type === AST_NODE_TYPES.PrivateIdentifier
+  ) {
+    return key.name;
   }
   const result = getStaticValue(key, sourceCode.getScope(node));
   if (!result) {

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -242,7 +242,7 @@ type NodeWithKey =
 function getStaticMemberAccessValue(
   node: NodeWithKey,
   { sourceCode }: RuleContext<string, unknown[]>,
-): string | undefined {
+): string | null {
   const key =
     node.type === AST_NODE_TYPES.MemberExpression ? node.property : node.key;
   if (!node.computed) {
@@ -250,12 +250,9 @@ function getStaticMemberAccessValue(
       ? `${key.value}`
       : (key as TSESTree.Identifier | TSESTree.PrivateIdentifier).name;
   }
-  const value = getStaticValue(key, sourceCode.getScope(node))?.value as
-    | string
-    | number
-    | null
-    | undefined;
-  return value == null ? undefined : `${value}`;
+  const result = getStaticValue(key, sourceCode.getScope(node));
+  // we must use `String(...)` rather than template literal interpolation, because interpolation throws a runtime error if `value` is a `symbol`
+  return result && String(result.value);
 }
 
 /**
@@ -268,7 +265,7 @@ const isStaticMemberAccessOfValue = (
   context: RuleContext<string, unknown[]>,
   ...values: string[]
 ): boolean =>
-  (values as (string | undefined)[]).includes(
+  (values as (string | null)[]).includes(
     getStaticMemberAccessValue(memberExpression, context),
   );
 

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -251,7 +251,8 @@ function getStaticMemberAccessValue(
       : (key as TSESTree.Identifier | TSESTree.PrivateIdentifier).name;
   }
   const result = getStaticValue(key, sourceCode.getScope(node));
-  // we must use `String(...)` rather than template literal interpolation, because interpolation throws a runtime error if `value` is a `symbol`
+  /* we must use `String(...)` rather than template literal interpolation, because interpolation throws a runtime error
+     if `value` is a `symbol` */
   return result && String(result.value);
 }
 

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -251,8 +251,9 @@ function getStaticMemberAccessValue(
       : (key as TSESTree.Identifier | TSESTree.PrivateIdentifier).name;
   }
   const result = getStaticValue(key, sourceCode.getScope(node));
-  /* we must use `String(...)` rather than template literal interpolation, because interpolation throws a runtime error
-     if `value` is a `symbol` */
+  /* If a value is returned, coerce it to a string, because that's what JavaScript does with any data type in a
+     `MemberAccess`. We must use `String(...)` rather than template literal interpolation, because interpolation throws
+     a runtime error if `result.value` is a `symbol` */
   return result && String(result.value);
 }
 

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -2,7 +2,8 @@
  * @fileoverview Really small utility functions that didn't deserve their own files
  */
 import { requiresQuoting } from '@typescript-eslint/type-utils';
-import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint';
 import * as ts from 'typescript';
 

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -239,6 +239,12 @@ type NodeWithKey =
   | TSESTree.PropertyDefinition
   | TSESTree.TSAbstractMethodDefinition
   | TSESTree.TSAbstractPropertyDefinition;
+
+/**
+ * Gets the key being accessed or declared, such as `value` in
+ * `x.value`, `x['value']`,
+ * or even `const v = 'value'; x[v]` (or optional variants thereof).
+ */
 function getStaticMemberAccessValue(
   node: NodeWithKey,
   { sourceCode }: RuleContext<string, unknown[]>,
@@ -265,8 +271,8 @@ function getStaticMemberAccessValue(
 
 /**
  * Answers whether the member expression looks like
- * `x.memberName`, `x['memberName']`,
- * or even `const mn = 'memberName'; x[mn]` (or optional variants thereof).
+ * `x.value`, `x['value']`,
+ * or even `const v = 'value'; x[v]` (or optional variants thereof).
  */
 const isStaticMemberAccessOfValue = (
   memberExpression: NodeWithKey,

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -407,6 +407,7 @@ export class Test {
   'method'() {}
   ['prop']() {}
   [\`prop\`]() {}
+  [null]() {}
   [\`\${v}\`](): void {}
 
   foo = () => {
@@ -416,7 +417,7 @@ export class Test {
       `,
       options: [
         {
-          allowedNames: ['prop', 'method', 'foo'],
+          allowedNames: ['prop', 'method', 'null', 'foo'],
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/prefer-promise-reject-errors.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-promise-reject-errors.test.ts
@@ -266,6 +266,7 @@ ruleTester.run('prefer-promise-reject-errors', rule, {
       declare const foo: PromiseConstructor;
       foo.reject(new Error());
     `,
+    'console[Symbol.iterator]();',
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/prefer-promise-reject-errors.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-promise-reject-errors.test.ts
@@ -267,6 +267,14 @@ ruleTester.run('prefer-promise-reject-errors', rule, {
       foo.reject(new Error());
     `,
     'console[Symbol.iterator]();',
+    `
+      class A {
+        a = [];
+        [Symbol.iterator]() {
+          return this.a[Symbol.iterator]();
+        }
+      }
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9999 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

#9836 had some bugs with how various data types are coerced to strings when used in a computed `MemberAccess`; this PR fixes those bugs.
