### PR TITLE
feat(eslint-plugin): [return-await] check for-await loop iteree

### DIFF
--- a/packages/eslint-plugin/docs/rules/await-thenable.mdx
+++ b/packages/eslint-plugin/docs/rules/await-thenable.mdx
@@ -50,8 +50,9 @@ While it is valid JavaScript to use `for await...of` with synchronous iterables 
 Synchronous iteration over thenables and asynchronous iteration are fundamentally different things, and the `for await...of` has several behaviors that are specifically designed for operating on async-iterables, that do not apply to sync-iterables.
 
 For one, the `for await...of` loop accesses its fulfilled values sequentially, which is an appropriate behavior for async-iterables, but is not always desirable for sync-iterables of Thenables.
+For instance, sync-iterables may need to manipulate their Thenable entries directly, without accessing their fulfillment values at all (that is to say, without awaiting them).
 
-Because of this, the error-handling of the `for await...of` loop works properly for async-iterables, but subtly permits unclosed generators and unhandled promise rejections when operating on sync-iterables of Thenables. For detailed examples of this, see the [MDN documentation on using `for await...of` with sync-iterables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of#iterating_over_sync_iterables_and_generators).
+Because of this, the error-handling protocol of the `for await...of` loop works properly for async-iterables, but subtly permits unclosed generators and unhandled promise rejections when operating on sync-iterables of Thenables. For detailed examples of this, see the [MDN documentation on using `for await...of` with sync-iterables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of#iterating_over_sync_iterables_and_generators).
 
 Instead of using the `for await...of` loop with sync-iterables of Thenables, or using `await` on promises within the body of a `for...of` (which also permits floating promise rejections), consider instead using one of the [promise concurrency methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#promise_concurrency) for robust behavior.
 

--- a/packages/eslint-plugin/docs/rules/await-thenable.mdx
+++ b/packages/eslint-plugin/docs/rules/await-thenable.mdx
@@ -10,9 +10,9 @@ import TabItem from '@theme/TabItem';
 > See **https://typescript-eslint.io/rules/await-thenable** for documentation.
 
 A "Thenable" value is an object which has a `then` method, such as a Promise.
-The `await` keyword is generally used to retrieve the result of calling a Thenable's `then` method.
+The [`await` keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) is generally used to retrieve the result of calling a Thenable's `then` method.
 
-If the `await` keyword is used on a value that is not a Thenable, the value is directly resolved immediately.
+If the `await` keyword is used on a value that is not a Thenable, the value is directly resolved, but will still pause execution until the next microtask.
 While doing so is valid JavaScript, it is often a programmer error, such as forgetting to add parenthesis to call a function that returns a Promise.
 
 ## Examples
@@ -35,6 +35,76 @@ await Promise.resolve('value');
 
 const createValue = async () => 'value';
 await createValue();
+```
+
+</TabItem>
+</Tabs>
+
+## Async Iteration (`for await...of` Loops)
+
+This rule also inspects [`for await...of` statements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of), which are designed for iterating over async-iterable objects.
+If the value being iterated over is not async-iterable, an ordinary `for...of` statement is preferable, even if the value is an iterable of Thenables.
+
+### Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+async function syncIterable() {
+  const arrayOfValues = [1, 2, 3];
+  for await (const value of arrayOfValues) {
+    console.log(value);
+  }
+}
+
+async function syncIterableOfPromises() {
+  const arrayOfPromises = [
+    Promise.resolve(1),
+    Promise.resolve(2),
+    Promise.resolve(3),
+  ];
+  for await (const promisedValue of arrayOfPromises) {
+    console.log(promisedValue);
+  }
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+async function syncIterable() {
+  const arrayOfValues = [1, 2, 3];
+  for (const value of arrayOfValues) {
+    console.log(value);
+  }
+}
+
+async function syncIterableOfPromises() {
+  const arrayOfPromises = [
+    Promise.resolve(1),
+    Promise.resolve(2),
+    Promise.resolve(3),
+  ];
+  for (const promise of arrayOfPromises) {
+    // Note that the promise must be explicitly awaited if the promised value is needed.
+    const promisedValue = await promise;
+    console.log(promisedValue);
+  }
+}
+
+async function validUseOfForAwaitOnAsyncIterable() {
+  async function* yieldThingsAsynchronously() {
+    yield 1;
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    yield 2;
+  }
+
+  for await (const promisedValue of yieldThingsAsynchronously()) {
+    console.log(promisedValue);
+  }
+}
 ```
 
 </TabItem>

--- a/packages/eslint-plugin/docs/rules/await-thenable.mdx
+++ b/packages/eslint-plugin/docs/rules/await-thenable.mdx
@@ -46,15 +46,14 @@ This rule also inspects [`for await...of` statements](https://developer.mozilla.
 
 :::info[Why does the rule report on `for await...of` loops used on an array of Promises?]
 
-While it is valid JavaScript to use `for await...of` with synchronous iterables (it falls back to synchronous iteration), it is inadvisable to do so.
-Synchronous iteration over thenables and asynchronous iteration are fundamentally different things, and the `for await...of` has several behaviors that are specifically designed for operating on async-iterables, that do not apply to sync-iterables.
+While `for await...of` can be used with synchronous iterables, and it will await each promise produced by the iterable, it is inadvisable to do so.
+There are some tiny nuances that you may want to consider.
 
-For one, the `for await...of` loop accesses its fulfilled values sequentially, which is an appropriate behavior for async-iterables, but is not always desirable for sync-iterables of Thenables.
-For instance, sync-iterables may need to manipulate their Thenable entries directly, without accessing their fulfillment values at all (that is to say, without awaiting them).
+The biggest difference between using `for await...of` and using `for...of` (plus awaiting each result yourself) is error handling.
+When an error occurs within the loop body, `for await...of` does _not_ close the original sync iterable, while `for...of` does.
+For detailed examples of this, see the [MDN documentation on using `for await...of` with sync-iterables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of#iterating_over_sync_iterables_and_generators).
 
-Because of this, the error-handling protocol of the `for await...of` loop works properly for async-iterables, but subtly permits unclosed generators and unhandled promise rejections when operating on sync-iterables of Thenables. For detailed examples of this, see the [MDN documentation on using `for await...of` with sync-iterables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of#iterating_over_sync_iterables_and_generators).
-
-Instead of using the `for await...of` loop with sync-iterables of Thenables, or using `await` on promises within the body of a `for...of` (which also permits floating promise rejections), consider instead using one of the [promise concurrency methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#promise_concurrency) for robust behavior.
+Also consider whether you need sequential awaiting at all. Using `for await...of` may obscure potential opportunities for concurrent processing, such as those reported by [`no-await-in-loop`](https://eslint.org/docs/latest/rules/no-await-in-loop). Consider instead using one of the [promise concurrency methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#promise_concurrency) for better performance.
 
 :::
 

--- a/packages/eslint-plugin/docs/rules/await-thenable.mdx
+++ b/packages/eslint-plugin/docs/rules/await-thenable.mdx
@@ -42,8 +42,20 @@ await createValue();
 
 ## Async Iteration (`for await...of` Loops)
 
-This rule also inspects [`for await...of` statements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of), which are designed for iterating over async-iterable objects.
-If the value being iterated over is not async-iterable, an ordinary `for...of` statement is preferable, even if the value is an iterable of Thenables.
+This rule also inspects [`for await...of` statements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of), and reports if the value being iterated over is not async-iterable.
+
+:::info[Why does the rule report on `for await...of` loops used on an array of Promises?]
+
+While it is valid JavaScript to use `for await...of` with synchronous iterables (it falls back to synchronous iteration), it is inadvisable to do so.
+Synchronous iteration over thenables and asynchronous iteration are fundamentally different things, and the `for await...of` has several behaviors that are specifically designed for operating on async-iterables, that do not apply to sync-iterables.
+
+For one, the `for await...of` loop accesses its fulfilled values sequentially, which is an appropriate behavior for async-iterables, but is not always desirable for sync-iterables of Thenables.
+
+Because of this, the error-handling of the `for await...of` loop works properly for async-iterables, but subtly permits unclosed generators and unhandled promise rejections when operating on sync-iterables of Thenables. For detailed examples of this, see the [MDN documentation on using `for await...of` with sync-iterables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of#iterating_over_sync_iterables_and_generators).
+
+Instead of using the `for await...of` loop with sync-iterables of Thenables, or using `await` on promises within the body of a `for...of` (which also permits floating promise rejections), consider instead using one of the [promise concurrency methods](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#promise_concurrency) for robust behavior.
+
+:::
 
 ### Examples
 
@@ -87,9 +99,7 @@ async function syncIterableOfPromises() {
     Promise.resolve(2),
     Promise.resolve(3),
   ];
-  for (const promise of arrayOfPromises) {
-    // Note that the promise must be explicitly awaited if the promised value is needed.
-    const promisedValue = await promise;
+  for (const promisedValue of await Promise.all(arrayOfPromises)) {
     console.log(promisedValue);
   }
 }

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -73,7 +73,7 @@ export default createRule<[], MessageId>({
         }
       },
 
-      ForOfStatement(node): void {
+      'ForOfStatement[await=true]'(node): void {
         if (!node.await) {
           return;
         }

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -30,7 +30,7 @@ export default createRule<[], MessageId>({
     messages: {
       await: 'Unexpected `await` of a non-Promise (non-"Thenable") value.',
       forAwaitOfNonThenable:
-        'Unexpected `for await...of` of a value that is not AsyncIterable.',
+        'Unexpected `for await...of` of a value that is not async iterable.',
       removeAwait: 'Remove unnecessary `await`.',
       convertToOrdinaryFor: 'Convert to an ordinary `for...of` loop.',
     },
@@ -89,24 +89,13 @@ export default createRule<[], MessageId>({
           checker,
         );
 
-        // if there is an async iterator symbol, but it doesn't have the correct
-        // shape, TS will report a type error, so we only need to check if the
-        // symbol exists.
         if (asyncIteratorSymbol == null) {
           context.report({
             loc: getForStatementHeadLoc(context.sourceCode, node),
             messageId: 'forAwaitOfNonThenable',
             suggest: [
-              // This suggestion causes broken code for sync iterables of promises, since
-              // the loop variable will not be awaited.
-              //
-              // Ideally, if the iterable yields promises, we would offer a suggestion to
-              // fix the for loop to `for (const value of await Promise.all(iterable))`.
-              // However, I don't think we can do that with the TS API for now, since we
-              // don't have access to `getIterationTypesOfType` or similar.
-              //
-              // If that becomes available to us, we should provide an alternate suggestion
-              // to fix the code to `for (const value of await Promise.all(iterable))`
+              // Note that this suggestion causes broken code for sync iterables
+              // of promises, since the loop variable is not awaited.
               {
                 messageId: 'convertToOrdinaryFor',
                 fix(fixer): TSESLint.RuleFix {

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -97,6 +97,16 @@ export default createRule<[], MessageId>({
             loc: getForStatementHeadLoc(context.sourceCode, node),
             messageId: 'forAwaitOfNonThenable',
             suggest: [
+              // This suggestion causes broken code for sync iterables of promises, since
+              // the loop variable will not be awaited.
+              //
+              // Ideally, if the iterable yields promises, we would offer a suggestion to
+              // fix the for loop to `for (const value of await Promise.all(iterable))`.
+              // However, I don't think we can do that with the TS API for now, since we
+              // don't have access to `getIterationTypesOfType` or similar.
+              //
+              // If that becomes available to us, we should provide an alternate suggestion
+              // to fix the code to `for (const value of await Promise.all(iterable))`
               {
                 messageId: 'convertToOrdinaryFor',
                 fix(fixer): TSESLint.RuleFix {

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -75,7 +75,7 @@ export default createRule<[], MessageId>({
 
       'ForOfStatement[await=true]'(node: TSESTree.ForOfStatement): void {
         const type = services.getTypeAtLocation(node.right);
-        if (isTypeAnyType(type) || isTypeUnknownType(type)) {
+        if (isTypeAnyType(type)) {
           return;
         }
 

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -1,4 +1,4 @@
-import type { TSESLint } from '@typescript-eslint/utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 
 import {
@@ -73,11 +73,7 @@ export default createRule<[], MessageId>({
         }
       },
 
-      'ForOfStatement[await=true]'(node): void {
-        if (!node.await) {
-          return;
-        }
-
+      'ForOfStatement[await=true]'(node: TSESTree.ForOfStatement): void {
         const type = services.getTypeAtLocation(node.right);
         if (isTypeAnyType(type) || isTypeUnknownType(type)) {
           return;

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/await-thenable.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/await-thenable.shot
@@ -28,7 +28,7 @@ exports[`Validating rule docs await-thenable.mdx code examples ESLint output 3`]
 async function syncIterable() {
   const arrayOfValues = [1, 2, 3];
   for await (const value of arrayOfValues) {
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Unexpected \`for await...of\` of a value that is not AsyncIterable.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Unexpected \`for await...of\` of a value that is not async iterable.
     console.log(value);
   }
 }
@@ -40,7 +40,7 @@ async function syncIterableOfPromises() {
     Promise.resolve(3),
   ];
   for await (const promisedValue of arrayOfPromises) {
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Unexpected \`for await...of\` of a value that is not AsyncIterable.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Unexpected \`for await...of\` of a value that is not async iterable.
     console.log(promisedValue);
   }
 }
@@ -63,9 +63,7 @@ async function syncIterableOfPromises() {
     Promise.resolve(2),
     Promise.resolve(3),
   ];
-  for (const promise of arrayOfPromises) {
-    // Note that the promise must be explicitly awaited if the promised value is needed.
-    const promisedValue = await promise;
+  for (const promisedValue of await Promise.all(arrayOfPromises)) {
     console.log(promisedValue);
   }
 }

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/await-thenable.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/await-thenable.shot
@@ -21,3 +21,65 @@ const createValue = async () => 'value';
 await createValue();
 "
 `;
+
+exports[`Validating rule docs await-thenable.mdx code examples ESLint output 3`] = `
+"Incorrect
+
+async function syncIterable() {
+  const arrayOfValues = [1, 2, 3];
+  for await (const value of arrayOfValues) {
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Unexpected \`for await...of\` of a value that is not AsyncIterable.
+    console.log(value);
+  }
+}
+
+async function syncIterableOfPromises() {
+  const arrayOfPromises = [
+    Promise.resolve(1),
+    Promise.resolve(2),
+    Promise.resolve(3),
+  ];
+  for await (const promisedValue of arrayOfPromises) {
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Unexpected \`for await...of\` of a value that is not AsyncIterable.
+    console.log(promisedValue);
+  }
+}
+"
+`;
+
+exports[`Validating rule docs await-thenable.mdx code examples ESLint output 4`] = `
+"Correct
+
+async function syncIterable() {
+  const arrayOfValues = [1, 2, 3];
+  for (const value of arrayOfValues) {
+    console.log(value);
+  }
+}
+
+async function syncIterableOfPromises() {
+  const arrayOfPromises = [
+    Promise.resolve(1),
+    Promise.resolve(2),
+    Promise.resolve(3),
+  ];
+  for (const promise of arrayOfPromises) {
+    // Note that the promise must be explicitly awaited if the promised value is needed.
+    const promisedValue = await promise;
+    console.log(promisedValue);
+  }
+}
+
+async function validUseOfForAwaitOnAsyncIterable() {
+  async function* yieldThingsAsynchronously() {
+    yield 1;
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    yield 2;
+  }
+
+  for await (const promisedValue of yieldThingsAsynchronously()) {
+    console.log(promisedValue);
+  }
+}
+"
+`;

--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -210,6 +210,16 @@ for await (const value of asyncYieldNumbers()) {
 }
       `,
     },
+    {
+      code: `
+declare const anee: any;
+async function forAwait() {
+  for await (const value of anee) {
+    console.log(value);
+  }
+}
+      `,
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -198,6 +198,23 @@ const doSomething = async (
   await callback?.();
 };
     `,
+    {
+      code: `
+Promise.race(...[1, 'a', 3]);
+      `,
+    },
+    {
+      code: `
+async function* yieldNumbers() {
+  yield 1;
+  yield 2;
+  yield 3;
+}
+for await (const value of yieldNumbers()) {
+  console.log(value);
+}
+      `,
+    },
   ],
 
   invalid: [
@@ -372,6 +389,74 @@ await obj?.a.b.c?.();
               output: `
 declare const obj: { a: { b: { c?: () => void } } } | undefined;
  obj?.a.b.c?.();
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function* yieldNumbers() {
+  yield 1;
+  yield 2;
+  yield 3;
+}
+for await (const value of yieldNumbers()) {
+  console.log(value);
+}
+      `,
+      errors: [
+        {
+          messageId: 'forAwaitOfNonThenable',
+          line: 7,
+          endLine: 7,
+          column: 1,
+          endColumn: 42,
+          suggestions: [
+            {
+              messageId: 'convertToOrdinaryFor',
+              output: `
+function* yieldNumbers() {
+  yield 1;
+  yield 2;
+  yield 3;
+}
+for  (const value of yieldNumbers()) {
+  console.log(value);
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+function* yieldNumberPromises() {
+  yield Promise.resolve(1);
+  yield Promise.resolve(2);
+  yield Promise.resolve(3);
+}
+for await (const value of yieldNumberPromises()) {
+  console.log(value);
+}
+      `,
+      errors: [
+        {
+          messageId: 'forAwaitOfNonThenable',
+          suggestions: [
+            {
+              messageId: 'convertToOrdinaryFor',
+              output: `
+function* yieldNumberPromises() {
+  yield Promise.resolve(1);
+  yield Promise.resolve(2);
+  yield Promise.resolve(3);
+}
+for  (const value of yieldNumberPromises()) {
+  console.log(value);
+}
       `,
             },
           ],

--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -200,17 +200,12 @@ const doSomething = async (
     `,
     {
       code: `
-Promise.race(...[1, 'a', 3]);
-      `,
-    },
-    {
-      code: `
-async function* yieldNumbers() {
+async function* asyncYieldNumbers() {
   yield 1;
   yield 2;
   yield 3;
 }
-for await (const value of yieldNumbers()) {
+for await (const value of asyncYieldNumbers()) {
   console.log(value);
 }
       `,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8858 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Just ask the type checker if a `Symbol.asyncIterator` is present, ezpz. Add tests and docs (less ezpz).