### PR TITLE
feat(eslint-plugin): [no-unnecessary-condition] add checkTypePredicates

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -129,7 +129,7 @@ export default tseslint.config(
       'no-constant-condition': 'off',
       '@typescript-eslint/no-unnecessary-condition': [
         'error',
-        { allowConstantLoopConditions: true },
+        { allowConstantLoopConditions: true, checkTruthinessAssertions: true },
       ],
       '@typescript-eslint/no-unnecessary-type-parameters': 'error',
       '@typescript-eslint/no-unused-expressions': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -129,7 +129,7 @@ export default tseslint.config(
       'no-constant-condition': 'off',
       '@typescript-eslint/no-unnecessary-condition': [
         'error',
-        { allowConstantLoopConditions: true, checkTruthinessAssertions: true },
+        { allowConstantLoopConditions: true, checkTypePredicates: true },
       ],
       '@typescript-eslint/no-unnecessary-type-parameters': 'error',
       '@typescript-eslint/no-unused-expressions': 'error',

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -105,10 +105,28 @@ assert(false); // Unnecessary; condition is always falsy.
 
 const neverNull = {};
 assert(neverNull); // Unnecessary; condition is always truthy.
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+declare const s: string;
+
+// Unnecessary; s is always a string.
+if (isString(s)) {
+}
+
+function assertIsString(value: unknown): asserts value is string {
+  if (!isString(value)) {
+    throw new Error('Value is not a string');
+  }
+}
+
+assertIsString(s); // Unnecessary; s is always a string.
 ```
 
 Whether this option makes sense for your project may vary.
-Some projects may intentionally use assertion functions to ensure that runtime values do indeed match the types according to TypeScript, especially in test code.
+Some projects may intentionally use type predicates to ensure that runtime values do indeed match the types according to TypeScript, especially in test code.
 Often, it makes sense to use eslint-disable comments in these cases, with a comment indicating why the condition should be checked at runtime, despite appearing unnecessary.
 However, in some contexts, it may be more appropriate to keep this option disabled entirely.
 

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -90,11 +90,11 @@ for (; true; ) {}
 do {} while (true);
 ```
 
-### `checkTruthinessAssertions`
+### `checkTypePredicates`
 
-Example of additional incorrect code with `{ checkTruthinessAssertions: true }`:
+Example of additional incorrect code with `{ checkTypePredicates: true }`:
 
-```ts option='{ "checkTruthinessAssertions": true }' showPlaygroundButton
+```ts option='{ "checkTypePredicates": true }' showPlaygroundButton
 function assert(condition: unknown): asserts condition {
   if (!condition) {
     throw new Error('Condition is falsy');

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -90,6 +90,28 @@ for (; true; ) {}
 do {} while (true);
 ```
 
+### `checkTruthinessAssertions`
+
+Example of additional incorrect code with `{ checkTruthinessAssertions: true }`:
+
+```ts option='{ "checkTruthinessAssertions": true }' showPlaygroundButton
+function assert(condition: unknown): asserts condition {
+  if (!condition) {
+    throw new Error('Condition is falsy');
+  }
+}
+
+assert(false); // Unnecessary; condition is always falsy.
+
+const neverNull = {};
+assert(neverNull); // Unnecessary; condition is always truthy.
+```
+
+Whether this option makes sense for your project may vary.
+Some projects may intentionally use assertion functions to ensure that runtime values do indeed match the types according to TypeScript, especially in test code.
+Often, it makes sense to use eslint-disable comments in these cases, with a comment indicating why the condition should be checked at runtime, despite appearing unnecessary.
+However, in some contexts, it may be more appropriate to keep this option disabled entirely.
+
 ### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
 
 :::danger Deprecated

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -1,6 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
-import type { ReportFixFunction } from '@typescript-eslint/utils/ts-eslint';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -98,7 +97,6 @@ export type MessageId =
 export default createRule<Options, MessageId>({
   name: 'no-unnecessary-condition',
   meta: {
-    hasSuggestions: true,
     type: 'suggestion',
     docs: {
       description:
@@ -151,7 +149,7 @@ export default createRule<Options, MessageId>({
       noStrictNullCheck:
         'This rule requires the `strictNullChecks` compiler option to be turned on to function correctly.',
       typeGuardAlreadyIsType:
-        'Unnecessary conditional, expression already has the type being checked.',
+        'Unnecessary conditional, expression already has the type being checked by the {{typeGuardOrAssertionFunction}}.',
     },
   },
   defaultOptions: [
@@ -502,8 +500,13 @@ export default createRule<Options, MessageId>({
           );
           if (typeOfArgument === typeGuardAssertedArgument.type) {
             context.report({
-              messageId: 'typeGuardAlreadyIsType',
               node: typeGuardAssertedArgument.argument,
+              messageId: 'typeGuardAlreadyIsType',
+              data: {
+                typeGuardOrAssertionFunction: typeGuardAssertedArgument.asserts
+                  ? 'assertion function'
+                  : 'type guard',
+              },
             });
           }
         }

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -76,7 +76,7 @@ export type Options = [
   {
     allowConstantLoopConditions?: boolean;
     allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
-    checkTruthinessAssertions?: boolean;
+    checkTypePredicates?: boolean;
   },
 ];
 
@@ -120,7 +120,7 @@ export default createRule<Options, MessageId>({
               'Whether to not error when running with a tsconfig that has strictNullChecks turned.',
             type: 'boolean',
           },
-          checkTruthinessAssertions: {
+          checkTypePredicates: {
             description:
               'Whether to check the asserted argument of a truthiness assertion function as a conditional context',
             type: 'boolean',
@@ -158,7 +158,7 @@ export default createRule<Options, MessageId>({
     {
       allowConstantLoopConditions: false,
       allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
-      checkTruthinessAssertions: false,
+      checkTypePredicates: false,
     },
   ],
   create(
@@ -167,7 +167,7 @@ export default createRule<Options, MessageId>({
       {
         allowConstantLoopConditions,
         allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing,
-        checkTruthinessAssertions,
+        checkTypePredicates,
       },
     ],
   ) {
@@ -482,7 +482,7 @@ export default createRule<Options, MessageId>({
     }
 
     function checkCallExpression(node: TSESTree.CallExpression): void {
-      if (checkTruthinessAssertions) {
+      if (checkTypePredicates) {
         const truthinessAssertedArgument = findTruthinessAssertedArgument(
           services,
           node,
@@ -490,29 +490,22 @@ export default createRule<Options, MessageId>({
         if (truthinessAssertedArgument != null) {
           checkNode(truthinessAssertedArgument);
         }
-      }
 
-      const typeGuardAssertedArgument = findTypeGuardAssertedArgument(
-        services,
-        node,
-      );
-      if (typeGuardAssertedArgument != null) {
-        const typeOfArgument = getConstrainedTypeAtLocation(
+        const typeGuardAssertedArgument = findTypeGuardAssertedArgument(
           services,
-          typeGuardAssertedArgument.argument,
+          node,
         );
-        if (typeOfArgument === typeGuardAssertedArgument.type) {
-          context.report({
-            messageId: 'typeGuardAlreadyIsType',
-            node: typeGuardAssertedArgument.argument,
-            suggest: [
-              {
-                messageId: 'replaceWithTrue',
-                fix: (fixer): ReturnType<ReportFixFunction> =>
-                  fixer.replaceText(node, '(true)'),
-              },
-            ],
-          });
+        if (typeGuardAssertedArgument != null) {
+          const typeOfArgument = getConstrainedTypeAtLocation(
+            services,
+            typeGuardAssertedArgument.argument,
+          );
+          if (typeOfArgument === typeGuardAssertedArgument.type) {
+            context.report({
+              messageId: 'typeGuardAlreadyIsType',
+              node: typeGuardAssertedArgument.argument,
+            });
+          }
         }
       }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -115,7 +115,7 @@ export default createRule<Options, MessageId>({
           },
           checkTruthinessAssertions: {
             description:
-              'Whether to check the assertedof a truthiness assertion function as a conditional context',
+              'Whether to check the asserted argument of a truthiness assertion function as a conditional context',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -120,7 +120,7 @@ export default createRule<Options, MessageId>({
           },
           checkTypePredicates: {
             description:
-              'Whether to check the asserted argument of a truthiness assertion function as a conditional context',
+              'Whether to check the asserted argument of a type predicate function for unnecessary conditions',
             type: 'boolean',
           },
         },

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -1,7 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import type { RuleFix } from '@typescript-eslint/utils/ts-eslint';
-import * as ts from 'typescript';
 
 import {
   createRule,

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -130,14 +130,10 @@ export default createRule<
 
         function isLeftSideLowerPrecedence(): boolean {
           const logicalTsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
-
           const leftTsNode = parserServices.esTreeNodeToTSNodeMap.get(leftNode);
-          const operator = ts.isBinaryExpression(logicalTsNode)
-            ? logicalTsNode.operatorToken.kind
-            : ts.SyntaxKind.Unknown;
           const leftPrecedence = getOperatorPrecedence(
             leftTsNode.kind,
-            operator,
+            logicalTsNode.operatorToken.kind,
           );
 
           return leftPrecedence < OperatorPrecedence.LeftHandSide;

--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -535,11 +535,7 @@ export default createRule<Options, MessageIds>({
         const callNode = getParent(node) as TSESTree.CallExpression;
         const parentNode = getParent(callNode) as TSESTree.BinaryExpression;
 
-        if (
-          !isEqualityComparison(parentNode) ||
-          !isNull(parentNode.right) ||
-          !isStringType(node.object)
-        ) {
+        if (!isNull(parentNode.right) || !isStringType(node.object)) {
           return;
         }
 

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -13,7 +13,7 @@ import {
   getWrappingFixer,
   isTypeArrayTypeOrUnionOfArrayTypes,
 } from '../util';
-import { findAssertedArgument } from '../util/assertionFunctionUtils';
+import { findTruthinessAssertedArgument } from '../util/assertionFunctionUtils';
 
 export type Options = [
   {
@@ -268,7 +268,7 @@ export default createRule<Options, MessageId>({
     }
 
     function traverseCallExpression(node: TSESTree.CallExpression): void {
-      const assertedArgument = findAssertedArgument(services, node);
+      const assertedArgument = findTruthinessAssertedArgument(services, node);
       if (assertedArgument != null) {
         traverseNode(assertedArgument, true);
       }

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -13,6 +13,7 @@ import {
   getWrappingFixer,
   isTypeArrayTypeOrUnionOfArrayTypes,
 } from '../util';
+import { findAssertedArgument } from '../util/assertionFunctionUtils';
 
 export type Options = [
   {
@@ -267,132 +268,10 @@ export default createRule<Options, MessageId>({
     }
 
     function traverseCallExpression(node: TSESTree.CallExpression): void {
-      const assertedArgument = findAssertedArgument(node);
+      const assertedArgument = findAssertedArgument(services, node);
       if (assertedArgument != null) {
         traverseNode(assertedArgument, true);
       }
-    }
-
-    /**
-     * Inspect a call expression to see if it's a call to an assertion function.
-     * If it is, return the node of the argument that is asserted.
-     */
-    function findAssertedArgument(
-      node: TSESTree.CallExpression,
-    ): TSESTree.Expression | undefined {
-      // If the call looks like `assert(expr1, expr2, ...c, d, e, f)`, then we can
-      // only care if `expr1` or `expr2` is asserted, since anything that happens
-      // within or after a spread argument is out of scope to reason about.
-      const checkableArguments: TSESTree.Expression[] = [];
-      for (const argument of node.arguments) {
-        if (argument.type === AST_NODE_TYPES.SpreadElement) {
-          break;
-        }
-
-        checkableArguments.push(argument);
-      }
-
-      // nothing to do
-      if (checkableArguments.length === 0) {
-        return undefined;
-      }
-
-      // Game plan: we're going to check the type of the callee. If it has call
-      // signatures and they _ALL_ agree that they assert on a parameter at the
-      // _SAME_ position, we'll consider the argument in that position to be an
-      // asserted argument.
-      const calleeType = getConstrainedTypeAtLocation(services, node.callee);
-      const callSignatures = tsutils.getCallSignaturesOfType(calleeType);
-
-      let assertedParameterIndex: number | undefined = undefined;
-      for (const signature of callSignatures) {
-        const declaration = signature.getDeclaration();
-        const returnTypeAnnotation = declaration.type;
-
-        // Be sure we're dealing with a truthiness assertion function.
-        if (
-          !(
-            returnTypeAnnotation != null &&
-            ts.isTypePredicateNode(returnTypeAnnotation) &&
-            // This eliminates things like `x is string` and `asserts x is T`
-            // leaving us with just the `asserts x` cases.
-            returnTypeAnnotation.type == null &&
-            // I think this is redundant but, still, it needs to be true
-            returnTypeAnnotation.assertsModifier != null
-          )
-        ) {
-          return undefined;
-        }
-
-        const assertionTarget = returnTypeAnnotation.parameterName;
-        if (assertionTarget.kind !== ts.SyntaxKind.Identifier) {
-          // This can happen when asserting on `this`. Ignore!
-          return undefined;
-        }
-
-        // If the first parameter is `this`, skip it, so that our index matches
-        // the index of the argument at the call site.
-        const firstParameter = declaration.parameters.at(0);
-        const nonThisParameters =
-          firstParameter?.name.kind === ts.SyntaxKind.Identifier &&
-          firstParameter.name.text === 'this'
-            ? declaration.parameters.slice(1)
-            : declaration.parameters;
-
-        // Don't bother inspecting parameters past the number of
-        // arguments we have at the call site.
-        const checkableNonThisParameters = nonThisParameters.slice(
-          0,
-          checkableArguments.length,
-        );
-
-        let assertedParameterIndexForThisSignature: number | undefined;
-        for (const [index, parameter] of checkableNonThisParameters.entries()) {
-          if (parameter.dotDotDotToken != null) {
-            // Cannot assert a rest parameter, and can't have a rest parameter
-            // before the asserted parameter. It's not only a TS error, it's
-            // not something we can logically make sense of, so give up here.
-            return undefined;
-          }
-
-          if (parameter.name.kind !== ts.SyntaxKind.Identifier) {
-            // Only identifiers are valid for assertion targets, so skip over
-            // anything like `{ destructuring: parameter }: T`
-            continue;
-          }
-
-          // we've found a match between the "target"s in
-          // `function asserts(target: T): asserts target;`
-          if (parameter.name.text === assertionTarget.text) {
-            assertedParameterIndexForThisSignature = index;
-            break;
-          }
-        }
-
-        if (assertedParameterIndexForThisSignature == null) {
-          // Didn't find an assertion target in this signature that could match
-          // the call site.
-          return undefined;
-        }
-
-        if (
-          assertedParameterIndex != null &&
-          assertedParameterIndex !== assertedParameterIndexForThisSignature
-        ) {
-          // The asserted parameter we found for this signature didn't match
-          // previous signatures.
-          return undefined;
-        }
-
-        assertedParameterIndex = assertedParameterIndexForThisSignature;
-      }
-
-      // Didn't find a unique assertion index.
-      if (assertedParameterIndex == null) {
-        return undefined;
-      }
-
-      return checkableArguments[assertedParameterIndex];
     }
 
     /**

--- a/packages/eslint-plugin/src/util/assertionFunctionUtils.ts
+++ b/packages/eslint-plugin/src/util/assertionFunctionUtils.ts
@@ -1,0 +1,132 @@
+import type {
+  ParserServicesWithTypeInformation,
+  TSESTree,
+} from '@typescript-eslint/utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import { getConstrainedTypeAtLocation } from './index';
+
+/**
+ * Inspect a call expression to see if it's a call to an assertion function.
+ * If it is, return the node of the argument that is asserted.
+ */
+export function findAssertedArgument(
+  services: ParserServicesWithTypeInformation,
+  node: TSESTree.CallExpression,
+): TSESTree.Expression | undefined {
+  // If the call looks like `assert(expr1, expr2, ...c, d, e, f)`, then we can
+  // only care if `expr1` or `expr2` is asserted, since anything that happens
+  // within or after a spread argument is out of scope to reason about.
+  const checkableArguments: TSESTree.Expression[] = [];
+  for (const argument of node.arguments) {
+    if (argument.type === AST_NODE_TYPES.SpreadElement) {
+      break;
+    }
+
+    checkableArguments.push(argument);
+  }
+
+  // nothing to do
+  if (checkableArguments.length === 0) {
+    return undefined;
+  }
+
+  // Game plan: we're going to check the type of the callee. If it has call
+  // signatures and they _ALL_ agree that they assert on a parameter at the
+  // _SAME_ position, we'll consider the argument in that position to be an
+  // asserted argument.
+  const calleeType = getConstrainedTypeAtLocation(services, node.callee);
+  const callSignatures = tsutils.getCallSignaturesOfType(calleeType);
+
+  let assertedParameterIndex: number | undefined = undefined;
+  for (const signature of callSignatures) {
+    const declaration = signature.getDeclaration();
+    const returnTypeAnnotation = declaration.type;
+
+    // Be sure we're dealing with a truthiness assertion function.
+    if (
+      !(
+        returnTypeAnnotation != null &&
+        ts.isTypePredicateNode(returnTypeAnnotation) &&
+        // This eliminates things like `x is string` and `asserts x is T`
+        // leaving us with just the `asserts x` cases.
+        returnTypeAnnotation.type == null &&
+        // I think this is redundant but, still, it needs to be true
+        returnTypeAnnotation.assertsModifier != null
+      )
+    ) {
+      return undefined;
+    }
+
+    const assertionTarget = returnTypeAnnotation.parameterName;
+    if (assertionTarget.kind !== ts.SyntaxKind.Identifier) {
+      // This can happen when asserting on `this`. Ignore!
+      return undefined;
+    }
+
+    // If the first parameter is `this`, skip it, so that our index matches
+    // the index of the argument at the call site.
+    const firstParameter = declaration.parameters.at(0);
+    const nonThisParameters =
+      firstParameter?.name.kind === ts.SyntaxKind.Identifier &&
+      firstParameter.name.text === 'this'
+        ? declaration.parameters.slice(1)
+        : declaration.parameters;
+
+    // Don't bother inspecting parameters past the number of
+    // arguments we have at the call site.
+    const checkableNonThisParameters = nonThisParameters.slice(
+      0,
+      checkableArguments.length,
+    );
+
+    let assertedParameterIndexForThisSignature: number | undefined;
+    for (const [index, parameter] of checkableNonThisParameters.entries()) {
+      if (parameter.dotDotDotToken != null) {
+        // Cannot assert a rest parameter, and can't have a rest parameter
+        // before the asserted parameter. It's not only a TS error, it's
+        // not something we can logically make sense of, so give up here.
+        return undefined;
+      }
+
+      if (parameter.name.kind !== ts.SyntaxKind.Identifier) {
+        // Only identifiers are valid for assertion targets, so skip over
+        // anything like `{ destructuring: parameter }: T`
+        continue;
+      }
+
+      // we've found a match between the "target"s in
+      // `function asserts(target: T): asserts target;`
+      if (parameter.name.text === assertionTarget.text) {
+        assertedParameterIndexForThisSignature = index;
+        break;
+      }
+    }
+
+    if (assertedParameterIndexForThisSignature == null) {
+      // Didn't find an assertion target in this signature that could match
+      // the call site.
+      return undefined;
+    }
+
+    if (
+      assertedParameterIndex != null &&
+      assertedParameterIndex !== assertedParameterIndexForThisSignature
+    ) {
+      // The asserted parameter we found for this signature didn't match
+      // previous signatures.
+      return undefined;
+    }
+
+    assertedParameterIndex = assertedParameterIndexForThisSignature;
+  }
+
+  // Didn't find a unique assertion index.
+  if (assertedParameterIndex == null) {
+    return undefined;
+  }
+
+  return checkableArguments[assertedParameterIndex];
+}

--- a/packages/eslint-plugin/src/util/assertionFunctionUtils.ts
+++ b/packages/eslint-plugin/src/util/assertionFunctionUtils.ts
@@ -24,7 +24,6 @@ export function findAssertedArgument(
     if (argument.type === AST_NODE_TYPES.SpreadElement) {
       break;
     }
-
     checkableArguments.push(argument);
   }
 
@@ -40,76 +39,27 @@ export function findAssertedArgument(
   const calleeType = getConstrainedTypeAtLocation(services, node.callee);
   const callSignatures = tsutils.getCallSignaturesOfType(calleeType);
 
+  const checker = services.program.getTypeChecker();
+
   let assertedParameterIndex: number | undefined = undefined;
   for (const signature of callSignatures) {
-    const declaration = signature.getDeclaration();
-    const returnTypeAnnotation = declaration.type;
+    const predicateInfo = checker.getTypePredicateOfSignature(signature);
+    if (predicateInfo == null) {
+      return undefined;
+    }
 
-    // Be sure we're dealing with a truthiness assertion function.
+    // Be sure we're dealing with a truthiness assertion function, in other words,
+    // `asserts x` (but not `asserts x is T`, and also not `asserts this is T`).
     if (
       !(
-        returnTypeAnnotation != null &&
-        ts.isTypePredicateNode(returnTypeAnnotation) &&
-        // This eliminates things like `x is string` and `asserts x is T`
-        // leaving us with just the `asserts x` cases.
-        returnTypeAnnotation.type == null &&
-        // I think this is redundant but, still, it needs to be true
-        returnTypeAnnotation.assertsModifier != null
+        predicateInfo.kind === ts.TypePredicateKind.AssertsIdentifier &&
+        predicateInfo.type == null
       )
     ) {
       return undefined;
     }
 
-    const assertionTarget = returnTypeAnnotation.parameterName;
-    if (assertionTarget.kind !== ts.SyntaxKind.Identifier) {
-      // This can happen when asserting on `this`. Ignore!
-      return undefined;
-    }
-
-    // If the first parameter is `this`, skip it, so that our index matches
-    // the index of the argument at the call site.
-    const firstParameter = declaration.parameters.at(0);
-    const nonThisParameters =
-      firstParameter?.name.kind === ts.SyntaxKind.Identifier &&
-      firstParameter.name.text === 'this'
-        ? declaration.parameters.slice(1)
-        : declaration.parameters;
-
-    // Don't bother inspecting parameters past the number of
-    // arguments we have at the call site.
-    const checkableNonThisParameters = nonThisParameters.slice(
-      0,
-      checkableArguments.length,
-    );
-
-    let assertedParameterIndexForThisSignature: number | undefined;
-    for (const [index, parameter] of checkableNonThisParameters.entries()) {
-      if (parameter.dotDotDotToken != null) {
-        // Cannot assert a rest parameter, and can't have a rest parameter
-        // before the asserted parameter. It's not only a TS error, it's
-        // not something we can logically make sense of, so give up here.
-        return undefined;
-      }
-
-      if (parameter.name.kind !== ts.SyntaxKind.Identifier) {
-        // Only identifiers are valid for assertion targets, so skip over
-        // anything like `{ destructuring: parameter }: T`
-        continue;
-      }
-
-      // we've found a match between the "target"s in
-      // `function asserts(target: T): asserts target;`
-      if (parameter.name.text === assertionTarget.text) {
-        assertedParameterIndexForThisSignature = index;
-        break;
-      }
-    }
-
-    if (assertedParameterIndexForThisSignature == null) {
-      // Didn't find an assertion target in this signature that could match
-      // the call site.
-      return undefined;
-    }
+    const assertedParameterIndexForThisSignature = predicateInfo.parameterIndex;
 
     if (
       assertedParameterIndex != null &&
@@ -121,6 +71,10 @@ export function findAssertedArgument(
     }
 
     assertedParameterIndex = assertedParameterIndexForThisSignature;
+
+    if (assertedParameterIndex >= checkableArguments.length) {
+      return undefined;
+    }
   }
 
   // Didn't find a unique assertion index.

--- a/packages/eslint-plugin/src/util/assertionFunctionUtils.ts
+++ b/packages/eslint-plugin/src/util/assertionFunctionUtils.ts
@@ -78,7 +78,7 @@ export function findTruthinessAssertedArgument(
 
 /**
  * Inspect a call expression to see if it's a call to an assertion function.
- * If it is, return the node of the argument that is asserted.
+ * If it is, return the node of the argument that is asserted and other useful info.
  */
 export function findTypeGuardAssertedArgument(
   services: ParserServicesWithTypeInformation,

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
@@ -68,7 +68,7 @@ do {} while (true);
 `;
 
 exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 4`] = `
-"Options: { "checkTruthinessAssertions": true }
+"Options: { "checkTypePredicates": true }
 
 function assert(condition: unknown): asserts condition {
   if (!condition) {

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
@@ -82,5 +82,25 @@ assert(false); // Unnecessary; condition is always falsy.
 const neverNull = {};
 assert(neverNull); // Unnecessary; condition is always truthy.
        ~~~~~~~~~ Unnecessary conditional, value is always truthy.
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+declare const s: string;
+
+// Unnecessary; s is always a string.
+if (isString(s)) {
+             ~ Unnecessary conditional, expression already has the type being checked by the type guard.
+}
+
+function assertIsString(value: unknown): asserts value is string {
+  if (!isString(value)) {
+    throw new Error('Value is not a string');
+  }
+}
+
+assertIsString(s); // Unnecessary; s is always a string.
+               ~ Unnecessary conditional, expression already has the type being checked by the assertion function.
 "
 `;

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
@@ -66,3 +66,21 @@ for (; true; ) {}
 do {} while (true);
 "
 `;
+
+exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 4`] = `
+"Options: { "checkTruthinessAssertions": true }
+
+function assert(condition: unknown): asserts condition {
+  if (!condition) {
+    throw new Error('Condition is falsy');
+  }
+}
+
+assert(false); // Unnecessary; condition is always falsy.
+       ~~~~~ Unnecessary conditional, value is always falsy.
+
+const neverNull = {};
+assert(neverNull); // Unnecessary; condition is always truthy.
+       ~~~~~~~~~ Unnecessary conditional, value is always truthy.
+"
+`;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -976,8 +976,8 @@ isString(a);
     {
       // Technically, this has type 'falafel' and not string.
       code: `
-      declare function assertString(x: unknown): asserts x is string;
-      assertString('falafel');
+declare function assertString(x: unknown): asserts x is string;
+assertString('falafel');
       `,
       options: [{ checkTypePredicates: true }],
     },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -900,7 +900,7 @@ declare function assert(x: unknown): asserts x;
 
 assert(Math.random() > 0.5);
       `,
-      options: [{ checkTruthinessAssertions: true }],
+      options: [{ checkTypePredicates: true }],
     },
     {
       code: `
@@ -908,7 +908,7 @@ declare function assert(x: unknown, y: unknown): asserts x;
 
 assert(Math.random() > 0.5, true);
       `,
-      options: [{ checkTruthinessAssertions: true }],
+      options: [{ checkTypePredicates: true }],
     },
     {
       // should not report because option is disabled.
@@ -916,7 +916,7 @@ assert(Math.random() > 0.5, true);
 declare function assert(x: unknown): asserts x;
 assert(true);
       `,
-      options: [{ checkTruthinessAssertions: false }],
+      options: [{ checkTypePredicates: false }],
     },
     {
       // could be argued that this should report since `thisAsserter` is truthy.
@@ -928,7 +928,7 @@ class ThisAsserter {
 const thisAsserter: ThisAsserter = new ThisAsserter();
 thisAsserter.assertThis(true);
       `,
-      options: [{ checkTruthinessAssertions: true }],
+      options: [{ checkTypePredicates: true }],
     },
     {
       // could be argued that this should report since `thisAsserter` is truthy.
@@ -940,14 +940,14 @@ class ThisAsserter {
 const thisAsserter: ThisAsserter = new ThisAsserter();
 thisAsserter.assertThis(Math.random());
       `,
-      options: [{ checkTruthinessAssertions: true }],
+      options: [{ checkTypePredicates: true }],
     },
     {
       code: `
 declare function assert(x: unknown): asserts x;
 assert(...[]);
       `,
-      options: [{ checkTruthinessAssertions: true }],
+      options: [{ checkTypePredicates: true }],
     },
     {
       // ok to report if we start unpacking spread params one day.
@@ -955,7 +955,39 @@ assert(...[]);
 declare function assert(x: unknown): asserts x;
 assert(...[], {});
       `,
-      options: [{ checkTruthinessAssertions: true }],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+declare function assertString(x: unknown): asserts x is string;
+declare const a: string;
+assertString(a);
+      `,
+      options: [{ checkTypePredicates: false }],
+    },
+    {
+      code: `
+declare function isString(x: unknown): x is string;
+declare const a: string;
+isString(a);
+      `,
+      options: [{ checkTypePredicates: false }],
+    },
+    {
+      // Technically, this has type 'falafel' and not string.
+      code: `
+      declare function assertString(x: unknown): asserts x is string;
+      assertString('falafel');
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // Technically, this has type 'falafel' and not string.
+      code: `
+declare function isString(x: unknown): x is string;
+isString('falafel');
+      `,
+      options: [{ checkTypePredicates: true }],
     },
   ],
 
@@ -2380,7 +2412,7 @@ assert(true);
           messageId: 'alwaysTruthy',
         },
       ],
-      options: [{ checkTruthinessAssertions: true }],
+      options: [{ checkTypePredicates: true }],
     },
     {
       code: `
@@ -2394,7 +2426,7 @@ assert(false);
           messageId: 'alwaysFalsy',
         },
       ],
-      options: [{ checkTruthinessAssertions: true }],
+      options: [{ checkTypePredicates: true }],
     },
     {
       code: `
@@ -2402,7 +2434,7 @@ declare function assert(x: unknown, y: unknown): asserts x;
 
 assert(true, Math.random() > 0.5);
       `,
-      options: [{ checkTruthinessAssertions: true }],
+      options: [{ checkTypePredicates: true }],
       errors: [
         {
           messageId: 'alwaysTruthy',
@@ -2416,12 +2448,54 @@ assert(true, Math.random() > 0.5);
 declare function assert(x: unknown): asserts x;
 assert({});
       `,
-      options: [{ checkTruthinessAssertions: true }],
+      options: [{ checkTypePredicates: true }],
       errors: [
         {
           messageId: 'alwaysTruthy',
           line: 3,
           column: 8,
+        },
+      ],
+    },
+    {
+      code: `
+declare function assertsString(x: unknown): asserts x is string;
+declare const a: string;
+assertsString(a);
+      `,
+      options: [{ checkTypePredicates: true }],
+      errors: [
+        {
+          messageId: 'typeGuardAlreadyIsType',
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: `
+declare function isString(x: unknown): x is string;
+declare const a: string;
+isString(a);
+      `,
+      options: [{ checkTypePredicates: true }],
+      errors: [
+        {
+          messageId: 'typeGuardAlreadyIsType',
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: `
+declare function isString(x: unknown): x is string;
+declare const a: string;
+isString('fa' + 'lafel');
+      `,
+      options: [{ checkTypePredicates: true }],
+      errors: [
+        {
+          messageId: 'typeGuardAlreadyIsType',
+          line: 4,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -894,6 +894,22 @@ class ConsistentRand {
 }
       `,
     },
+    {
+      code: `
+declare function assert(x: unknown): asserts x;
+
+assert(Math.random() > 0.5);
+      `,
+      options: [{ checkTruthinessAssertions: true }],
+    },
+    {
+      // should not report because option is disabled.
+      code: `
+declare function assert(x: unknown): asserts x;
+assert(true);
+      `,
+      options: [{ checkTruthinessAssertions: false }],
+    },
   ],
   invalid: [
     // Ensure that it's checking in all the right places
@@ -2304,6 +2320,30 @@ foo?.['bar']?.().toExponential();
         }
       `,
       errors: [ruleError(3, 13, 'alwaysTruthy')],
+    },
+    {
+      code: `
+declare function assert(x: unknown): asserts x;
+assert(true);
+      `,
+      errors: [
+        {
+          messageId: 'alwaysTruthy',
+        },
+      ],
+      options: [{ checkTruthinessAssertions: true }],
+    },
+    {
+      code: `
+declare function assert(x: unknown): asserts x;
+assert(false);
+      `,
+      errors: [
+        {
+          messageId: 'alwaysFalsy',
+        },
+      ],
+      options: [{ checkTruthinessAssertions: true }],
     },
 
     // "branded" types

--- a/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/strict-boolean-expressions.test.ts
@@ -516,29 +516,6 @@ declare const nullableString: string | null;
 assert(3 as any, nullableString);
       `,
     },
-    // Intentional TS error - A rest parameter must be last in a parameter list.
-    // This is just to test that we don't crash or falsely report.
-    `
-declare function assert(...a: boolean[], b: unknown): asserts b;
-declare const nullableString: string | null;
-declare const boo: boolean;
-assert(boo, nullableString);
-    `,
-    // Intentional TS error - A type predicate cannot reference a rest parameter.
-    // This is just to test that we don't crash or falsely report.
-    `
-declare function assert(a: boolean, ...b: unknown[]): asserts b;
-declare const nullableString: string | null;
-declare const boo: boolean;
-assert(boo, nullableString);
-    `,
-    // Intentional TS error - An assertion function must have a parameter to assert.
-    // This is just to test that we don't crash or falsely report.
-    `
-declare function assert(): asserts x;
-declare const nullableString: string | null;
-assert(nullableString);
-    `,
     `
 function assert(one: unknown): asserts one;
 function assert(one: unknown, two: unknown): asserts two;

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
@@ -16,7 +16,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "description": "Whether to not error when running with a tsconfig that has strictNullChecks turned.",
         "type": "boolean"
       },
-      "checkTruthinessAssertions": {
+      "checkTypePredicates": {
         "description": "Whether to check the asserted argument of a truthiness assertion function as a conditional context",
         "type": "boolean"
       }
@@ -35,7 +35,7 @@ type Options = [
     /** Whether to not error when running with a tsconfig that has strictNullChecks turned. */
     allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
     /** Whether to check the asserted argument of a truthiness assertion function as a conditional context */
-    checkTruthinessAssertions?: boolean;
+    checkTypePredicates?: boolean;
   },
 ];
 "

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
@@ -15,6 +15,10 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
       "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
         "description": "Whether to not error when running with a tsconfig that has strictNullChecks turned.",
         "type": "boolean"
+      },
+      "checkTruthinessAssertions": {
+        "description": "Whether to check the asserted argument of a truthiness assertion function as a conditional context",
+        "type": "boolean"
       }
     },
     "type": "object"
@@ -30,6 +34,8 @@ type Options = [
     allowConstantLoopConditions?: boolean;
     /** Whether to not error when running with a tsconfig that has strictNullChecks turned. */
     allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
+    /** Whether to check the asserted argument of a truthiness assertion function as a conditional context */
+    checkTruthinessAssertions?: boolean;
   },
 ];
 "

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
@@ -17,7 +17,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "type": "boolean"
       },
       "checkTypePredicates": {
-        "description": "Whether to check the asserted argument of a truthiness assertion function as a conditional context",
+        "description": "Whether to check the asserted argument of a type predicate function for unnecessary conditions",
         "type": "boolean"
       }
     },
@@ -34,7 +34,7 @@ type Options = [
     allowConstantLoopConditions?: boolean;
     /** Whether to not error when running with a tsconfig that has strictNullChecks turned. */
     allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
-    /** Whether to check the asserted argument of a truthiness assertion function as a conditional context */
+    /** Whether to check the asserted argument of a type predicate function for unnecessary conditions */
     checkTypePredicates?: boolean;
   },
 ];

--- a/packages/type-utils/src/getTypeName.ts
+++ b/packages/type-utils/src/getTypeName.ts
@@ -23,8 +23,9 @@ export function getTypeName(
     // via AST.
     const symbol = type.getSymbol();
     const decls = symbol?.getDeclarations();
-    const typeParamDecl = decls?.[0] as ts.TypeParameterDeclaration;
+    const typeParamDecl = decls?.[0];
     if (
+      typeParamDecl != null &&
       ts.isTypeParameterDeclaration(typeParamDecl) &&
       typeParamDecl.constraint != null
     ) {

--- a/packages/typescript-estree/tests/lib/semanticInfo.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo.test.ts
@@ -172,6 +172,7 @@ describe('semanticInfo', () => {
     ).declarations[0].init!;
     const tsBinaryExpression =
       parseResult.services.esTreeNodeToTSNodeMap.get(binaryExpression);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
     expectToBeDefined(tsBinaryExpression);
     expect(tsBinaryExpression.kind).toEqual(ts.SyntaxKind.BinaryExpression);
 
@@ -181,6 +182,7 @@ describe('semanticInfo', () => {
     ).key;
     const tsComputedPropertyString =
       parseResult.services.esTreeNodeToTSNodeMap.get(computedPropertyString);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
     expectToBeDefined(tsComputedPropertyString);
     expect(tsComputedPropertyString.kind).toEqual(ts.SyntaxKind.StringLiteral);
   });
@@ -210,6 +212,7 @@ describe('semanticInfo', () => {
     expectToHaveParserServices(parseResult.services);
     const tsArrayBoundName =
       parseResult.services.esTreeNodeToTSNodeMap.get(arrayBoundName);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
     expectToBeDefined(tsArrayBoundName);
     checkNumberArrayType(checker, tsArrayBoundName);
 
@@ -235,6 +238,7 @@ describe('semanticInfo', () => {
 
     const tsBoundName =
       parseResult.services.esTreeNodeToTSNodeMap.get(boundName);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
     expectToBeDefined(tsBoundName);
     expect(tsBoundName).toBeDefined();
 
@@ -420,6 +424,7 @@ function testIsolatedFile(
   // get type checker
   expectToHaveParserServices(parseResult.services);
   const checker = parseResult.services.program.getTypeChecker();
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
   expectToBeDefined(checker);
 
   // get number node (ast shape validated by snapshot)
@@ -431,6 +436,7 @@ function testIsolatedFile(
   // get corresponding TS node
   const tsArrayMember =
     parseResult.services.esTreeNodeToTSNodeMap.get(arrayMember);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
   expectToBeDefined(tsArrayMember);
   expect(tsArrayMember.kind).toBe(ts.SyntaxKind.NumericLiteral);
   expect((tsArrayMember as ts.NumericLiteral).text).toBe('3');
@@ -451,6 +457,7 @@ function testIsolatedFile(
   const boundName = declaration.id as TSESTree.Identifier;
   expect(boundName.name).toBe('x');
   const tsBoundName = parseResult.services.esTreeNodeToTSNodeMap.get(boundName);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
   expectToBeDefined(tsBoundName);
   checkNumberArrayType(checker, tsBoundName);
   expect(parseResult.services.tsNodeToESTreeNodeMap.get(tsBoundName)).toBe(

--- a/packages/typescript-estree/tests/lib/semanticInfo.test.ts
+++ b/packages/typescript-estree/tests/lib/semanticInfo.test.ts
@@ -172,8 +172,7 @@ describe('semanticInfo', () => {
     ).declarations[0].init!;
     const tsBinaryExpression =
       parseResult.services.esTreeNodeToTSNodeMap.get(binaryExpression);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
-    expectToBeDefined(tsBinaryExpression);
+    expect(tsBinaryExpression).toBeDefined();
     expect(tsBinaryExpression.kind).toEqual(ts.SyntaxKind.BinaryExpression);
 
     const computedPropertyString = (
@@ -182,8 +181,7 @@ describe('semanticInfo', () => {
     ).key;
     const tsComputedPropertyString =
       parseResult.services.esTreeNodeToTSNodeMap.get(computedPropertyString);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
-    expectToBeDefined(tsComputedPropertyString);
+    expect(tsComputedPropertyString).toBeDefined();
     expect(tsComputedPropertyString.kind).toEqual(ts.SyntaxKind.StringLiteral);
   });
 
@@ -212,8 +210,7 @@ describe('semanticInfo', () => {
     expectToHaveParserServices(parseResult.services);
     const tsArrayBoundName =
       parseResult.services.esTreeNodeToTSNodeMap.get(arrayBoundName);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
-    expectToBeDefined(tsArrayBoundName);
+    expect(tsArrayBoundName).toBeDefined();
     checkNumberArrayType(checker, tsArrayBoundName);
 
     expect(
@@ -238,8 +235,6 @@ describe('semanticInfo', () => {
 
     const tsBoundName =
       parseResult.services.esTreeNodeToTSNodeMap.get(boundName);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
-    expectToBeDefined(tsBoundName);
     expect(tsBoundName).toBeDefined();
 
     expect(parseResult.services.tsNodeToESTreeNodeMap.get(tsBoundName)).toBe(
@@ -424,8 +419,7 @@ function testIsolatedFile(
   // get type checker
   expectToHaveParserServices(parseResult.services);
   const checker = parseResult.services.program.getTypeChecker();
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
-  expectToBeDefined(checker);
+  expect(checker).toBeDefined();
 
   // get number node (ast shape validated by snapshot)
   const declaration = (parseResult.ast.body[0] as TSESTree.VariableDeclaration)
@@ -436,8 +430,7 @@ function testIsolatedFile(
   // get corresponding TS node
   const tsArrayMember =
     parseResult.services.esTreeNodeToTSNodeMap.get(arrayMember);
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
-  expectToBeDefined(tsArrayMember);
+  expect(tsArrayMember).toBeDefined();
   expect(tsArrayMember.kind).toBe(ts.SyntaxKind.NumericLiteral);
   expect((tsArrayMember as ts.NumericLiteral).text).toBe('3');
 
@@ -457,8 +450,7 @@ function testIsolatedFile(
   const boundName = declaration.id as TSESTree.Identifier;
   expect(boundName.name).toBe('x');
   const tsBoundName = parseResult.services.esTreeNodeToTSNodeMap.get(boundName);
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally asserting that the runtime value matches the types.
-  expectToBeDefined(tsBoundName);
+  expect(tsBoundName).toBeDefined();
   checkNumberArrayType(checker, tsBoundName);
   expect(parseResult.services.tsNodeToESTreeNodeMap.get(tsBoundName)).toBe(
     boundName,

--- a/packages/typescript-estree/tests/lib/source-files.test.ts
+++ b/packages/typescript-estree/tests/lib/source-files.test.ts
@@ -13,6 +13,7 @@ describe('isSourceFile', () => {
   it('returns true when given a real source file', () => {
     const input = ts.createSourceFile('test.ts', '', ts.ScriptTarget.ESNext);
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- intentionally testing that the types match reality
     expect(isSourceFile(input)).toBe(true);
   });
 });

--- a/packages/typescript-estree/tests/test-utils/test-utils.ts
+++ b/packages/typescript-estree/tests/test-utils/test-utils.ts
@@ -83,7 +83,7 @@ export function deeplyCopy<T extends NonNullable<unknown>>(ast: T): T {
 
 type UnknownObject = Record<string, unknown>;
 
-function isObjectLike(value: unknown): value is UnknownObject {
+function isObjectLike(value: unknown): boolean {
   return (
     typeof value === 'object' && !(value instanceof RegExp) && value != null
   );
@@ -117,7 +117,6 @@ export function omitDeep(
     oNode: UnknownObject,
     parent: UnknownObject | null,
   ): UnknownObject {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- I don't know if it's safe to change this.
     if (!Array.isArray(oNode) && !isObjectLike(oNode)) {
       return oNode;
     }
@@ -140,7 +139,6 @@ export function omitDeep(
             value.push(visit(el, node));
           }
           node[prop] = value;
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- I don't know if it's safe to change this.
         } else if (isObjectLike(child)) {
           node[prop] = visit(child, node);
         }

--- a/packages/typescript-estree/tests/test-utils/test-utils.ts
+++ b/packages/typescript-estree/tests/test-utils/test-utils.ts
@@ -117,6 +117,7 @@ export function omitDeep(
     oNode: UnknownObject,
     parent: UnknownObject | null,
   ): UnknownObject {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- I don't know if it's safe to change this.
     if (!Array.isArray(oNode) && !isObjectLike(oNode)) {
       return oNode;
     }
@@ -139,6 +140,7 @@ export function omitDeep(
             value.push(visit(el, node));
           }
           node[prop] = value;
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- I don't know if it's safe to change this.
         } else if (isObjectLike(child)) {
           node[prop] = visit(child, node);
         }

--- a/packages/website/src/components/typeDetails/SimplifiedTreeView.tsx
+++ b/packages/website/src/components/typeDetails/SimplifiedTreeView.tsx
@@ -6,7 +6,7 @@ import styles from '../ast/ASTViewer.module.css';
 import PropertyName from '../ast/PropertyName';
 import { tsEnumToString } from '../ast/tsUtils';
 import type { OnHoverNodeFn } from '../ast/types';
-import { getRange, isTSNode } from '../ast/utils';
+import { getRange } from '../ast/utils';
 
 export interface SimplifiedTreeViewProps {
   readonly value: ts.Node;
@@ -31,7 +31,7 @@ function SimplifiedItem({
 
   const onHover = useCallback(
     (v: boolean) => {
-      if (isTSNode(value) && onHoverNode) {
+      if (onHoverNode) {
         return onHoverNode(v ? getRange(value, 'tsNode') : undefined);
       }
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: 
   - fixes #9076, 
   - fixes #10007
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- Basically completely rewrite the existing method `findAssertedArgument` in SBE to use `checker.getResolvedSignature()` and `checker.getTypePredicateOfSignature()`, and move it into shared location
- Put new behavior behind option "checkTypePredicates" - see [this discord conversation](https://discord.com/channels/508357248330760243/1287101496269213778) for the thought process on naming
- Add docs
- Enable internally and suppress violations