### PR TITLE
feat(eslint-plugin): [no-unsafe-call] check calls of Function

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-call.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-call.mdx
@@ -59,6 +59,34 @@ String.raw`foo`;
 </TabItem>
 </Tabs>
 
+## The Unsafe `Function` Type
+
+The `Function` type is behaves almost identically to `any` when called, so this rule also disallows calling values of type `Function`.
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+const f: Function = () => {};
+f();
+```
+
+</TabItem>
+</Tabs>
+
+Note that whereas [no-unsafe-function-type](./no-unsafe-function-type.mdx) helps prevent the _creation_ of `Function` types, this rule helps prevent the unsafe _use_ of `Function` types, which may creep into your codebase without explicitly referencing the `Function` type at all.
+See, for example, the following code:
+
+```ts
+function unsafe(maybeFunction: unknown): string {
+  if (typeof maybeFunction === 'function') {
+    // TypeScript allows this, but it's completely unsound.
+    return maybeFunction('call', 'with', 'any', 'args');
+  }
+  // etc
+}
+```
+
 ## When Not To Use It
 
 If your codebase has many existing `any`s or areas of unsafe code, it may be difficult to enable this rule.

--- a/packages/eslint-plugin/docs/rules/no-unsafe-function-type.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-function-type.mdx
@@ -60,4 +60,5 @@ You might consider using [ESLint disable comments](https://eslint.org/docs/lates
 
 - [`no-empty-object-type`](./no-empty-object-type.mdx)
 - [`no-restricted-types`](./no-restricted-types.mdx)
+- [`no-unsafe-call`](./no-unsafe-call.mdx)
 - [`no-wrapper-object-types`](./no-wrapper-object-types.mdx)

--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -107,7 +107,7 @@ export default createRule<[], MessageIds>({
             return;
           }
         } else {
-          // eslint-disable-next-line no-lonely-if -- readability
+          // eslint-disable-next-line no-lonely-if
           if (callSignatures.length > 0) {
             return;
           }

--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -98,19 +98,16 @@ export default createRule<[], MessageIds>({
 
         const callSignatures = type.getCallSignatures();
         if (messageId === 'unsafeNew') {
-          const nonVoidReturnCallSignatures = callSignatures.filter(
-            signature =>
-              !tsutils.isIntrinsicVoidType(signature.getReturnType()),
-          );
-
-          if (nonVoidReturnCallSignatures.length > 0) {
+          if (
+            callSignatures.some(
+              signature =>
+                !tsutils.isIntrinsicVoidType(signature.getReturnType()),
+            )
+          ) {
             return;
           }
-        } else {
-          // eslint-disable-next-line no-lonely-if
-          if (callSignatures.length > 0) {
-            return;
-          }
+        } else if (callSignatures.length > 0) {
+          return;
         }
 
         context.report({

--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -1,11 +1,13 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
+import type * as ts from 'typescript';
 
 import {
   createRule,
   getConstrainedTypeAtLocation,
   getParserServices,
   getThisExpression,
+  isBuiltinSymbolLike,
   isTypeAnyType,
 } from '../util';
 
@@ -25,13 +27,13 @@ export default createRule<[], MessageIds>({
       requiresTypeChecking: true,
     },
     messages: {
-      unsafeCall: 'Unsafe call of an {{type}} typed value.',
+      unsafeCall: 'Unsafe call of a(n) {{type}} typed value.',
       unsafeCallThis: [
-        'Unsafe call of an `any` typed value. `this` is typed as `any`.',
+        'Unsafe call of a(n) {{type}} typed value. `this` is typed as {{type}}.',
         'You can try to fix this by turning on the `noImplicitThis` compiler option, or adding a `this` parameter to the function.',
       ].join('\n'),
-      unsafeNew: 'Unsafe construction of an any type value.',
-      unsafeTemplateTag: 'Unsafe any typed template tag.',
+      unsafeNew: 'Unsafe construction of a(n) {{type}} typed value.',
+      unsafeTemplateTag: 'Unsafe use of a(n) {{type}} typed template tag.',
     },
     schema: [],
   },
@@ -72,6 +74,14 @@ export default createRule<[], MessageIds>({
           messageId,
           data: {
             type: isErrorType ? '`error` type' : '`any`',
+          },
+        });
+      } else if (isBuiltinSymbolLike(services.program, type, 'Function')) {
+        context.report({
+          node: reportingNode,
+          messageId,
+          data: {
+            type: '`Function`',
           },
         });
       }

--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -1,6 +1,5 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
-import type * as ts from 'typescript';
 
 import {
   createRule,

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unsafe-call.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unsafe-call.shot
@@ -7,24 +7,24 @@ declare const anyVar: any;
 declare const nestedAny: { prop: any };
 
 anyVar();
-~~~~~~ Unsafe call of an \`any\` typed value.
+~~~~~~ Unsafe call of a(n) \`any\` typed value.
 anyVar.a.b();
-~~~~~~~~~~ Unsafe call of an \`any\` typed value.
+~~~~~~~~~~ Unsafe call of a(n) \`any\` typed value.
 
 nestedAny.prop();
-~~~~~~~~~~~~~~ Unsafe call of an \`any\` typed value.
+~~~~~~~~~~~~~~ Unsafe call of a(n) \`any\` typed value.
 nestedAny.prop['a']();
-~~~~~~~~~~~~~~~~~~~ Unsafe call of an \`any\` typed value.
+~~~~~~~~~~~~~~~~~~~ Unsafe call of a(n) \`any\` typed value.
 
 new anyVar();
-~~~~~~~~~~~~ Unsafe construction of an any type value.
+~~~~~~~~~~~~ Unsafe construction of a(n) \`any\` typed value.
 new nestedAny.prop();
-~~~~~~~~~~~~~~~~~~~~ Unsafe construction of an any type value.
+~~~~~~~~~~~~~~~~~~~~ Unsafe construction of a(n) \`any\` typed value.
 
 anyVar\`foo\`;
-~~~~~~ Unsafe any typed template tag.
+~~~~~~ Unsafe use of a(n) \`any\` typed template tag.
 nestedAny.prop\`foo\`;
-~~~~~~~~~~~~~~ Unsafe any typed template tag.
+~~~~~~~~~~~~~~ Unsafe use of a(n) \`any\` typed template tag.
 "
 `;
 
@@ -42,5 +42,14 @@ typedNested.prop.a();
 new Map();
 
 String.raw\`foo\`;
+"
+`;
+
+exports[`Validating rule docs no-unsafe-call.mdx code examples ESLint output 3`] = `
+"Incorrect
+
+const f: Function = () => {};
+f();
+~ Unsafe call of a(n) \`Function\` typed value.
 "
 `;

--- a/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
@@ -67,6 +67,21 @@ interface CallGoodConstructBad extends Function {
 declare const safe: CallGoodConstructBad;
 safe();
     `,
+    `
+interface ConstructSignatureMakesSafe extends Function {
+  new (): ConstructSignatureMakesSafe;
+}
+declare const safe: ConstructSignatureMakesSafe;
+new safe();
+    `,
+    `
+interface SafeWithNonVoidCallSignature extends Function {
+  (): void;
+  (x: string): string;
+}
+declare const safe: SafeWithNonVoidCallSignature;
+safe();
+    `,
     // Function has type FunctionConstructor, so it's not within this rule's purview
     `
       new Function('lol');

--- a/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
@@ -49,8 +49,8 @@ function foo(x: { a?: () => void }) {
       // 'Function' in the global script scope.
       {
         type Function = () => void;
-        const badFunction: Function = (() => {}) as Function;
-        badFunction();
+        const notGlobalFunctionType: Function = (() => {}) as Function;
+        notGlobalFunctionType();
       }
     `,
     `

--- a/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
@@ -44,6 +44,15 @@ function foo(x: { a?: () => void }) {
         x();
       }
     `,
+    `
+      // create a scope since it's illegal to declare a duplicate identifier
+      // 'Function' in the global script scope.
+      {
+        type Function = () => void;
+        const badFunction: Function = (() => {}) as Function;
+        badFunction();
+      }
+    `,
   ],
   invalid: [
     {
@@ -247,6 +256,53 @@ value();
           endColumn: 6,
           data: {
             type: '`error` type',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+const t: Function = () => {};
+t();
+      `,
+      errors: [
+        {
+          messageId: 'unsafeCall',
+          line: 3,
+          data: {
+            type: '`Function`',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+const f: Function = () => {};
+f\`oo\`;
+      `,
+      errors: [
+        {
+          messageId: 'unsafeTemplateTag',
+          line: 3,
+          data: {
+            type: '`Function`',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+declare const maybeFunction: unknown;
+if (typeof maybeFunction === 'function') {
+  maybeFunction('call', 'with', 'any', 'args');
+}
+      `,
+      errors: [
+        {
+          messageId: 'unsafeCall',
+          line: 4,
+          data: {
+            type: '`Function`',
           },
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-call.test.ts
@@ -53,6 +53,28 @@ function foo(x: { a?: () => void }) {
         badFunction();
       }
     `,
+    `
+interface SurprisinglySafe extends Function {
+  (): string;
+}
+declare const safe: SurprisinglySafe;
+safe();
+    `,
+    `
+interface CallGoodConstructBad extends Function {
+  (): void;
+}
+declare const safe: CallGoodConstructBad;
+safe();
+    `,
+    // Function has type FunctionConstructor, so it's not within this rule's purview
+    `
+      new Function('lol');
+    `,
+    // Function has type FunctionConstructor, so it's not within this rule's purview
+    `
+      Function('lol');
+    `,
   ],
   invalid: [
     {
@@ -301,6 +323,90 @@ if (typeof maybeFunction === 'function') {
         {
           messageId: 'unsafeCall',
           line: 4,
+          data: {
+            type: '`Function`',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+interface Unsafe extends Function {}
+declare const unsafe: Unsafe;
+unsafe();
+      `,
+      errors: [
+        {
+          messageId: 'unsafeCall',
+          line: 4,
+          data: {
+            type: '`Function`',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+interface Unsafe extends Function {}
+declare const unsafe: Unsafe;
+unsafe\`bad\`;
+      `,
+      errors: [
+        {
+          messageId: 'unsafeTemplateTag',
+          line: 4,
+          data: {
+            type: '`Function`',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+interface Unsafe extends Function {}
+declare const unsafe: Unsafe;
+new unsafe();
+      `,
+      errors: [
+        {
+          messageId: 'unsafeNew',
+          line: 4,
+          data: {
+            type: '`Function`',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+interface UnsafeToConstruct extends Function {
+  (): void;
+}
+declare const unsafe: UnsafeToConstruct;
+new unsafe();
+      `,
+      errors: [
+        {
+          messageId: 'unsafeNew',
+          line: 6,
+          data: {
+            type: '`Function`',
+          },
+        },
+      ],
+    },
+    {
+      code: `
+interface StillUnsafe extends Function {
+  property: string;
+}
+declare const unsafe: StillUnsafe;
+unsafe();
+      `,
+      errors: [
+        {
+          messageId: 'unsafeCall',
+          line: 6,
           data: {
             type: '`Function`',
           },

--- a/packages/eslint-plugin/tests/rules/no-unsafe-function-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-function-type.test.ts
@@ -9,8 +9,12 @@ ruleTester.run('no-unsafe-function-type', rule, {
     'let value: () => void;',
     'let value: <T>(t: T) => T;',
     `
-      type Function = () => void;
-      let value: Function;
+      // create a scope since it's illegal to declare a duplicate identifier
+      // 'Function' in the global script scope.
+      {
+        type Function = () => void;
+        let value: Function;
+      }
     `,
   ],
   invalid: [

--- a/packages/website/src/components/lib/parseConfig.ts
+++ b/packages/website/src/components/lib/parseConfig.ts
@@ -55,7 +55,7 @@ export function parseTSConfig(code?: string): TSConfig {
 const moduleRegexp = /(module\.exports\s*=)/g;
 
 function constrainedScopeEval(obj: string): unknown {
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, @typescript-eslint/no-unsafe-call
   return new Function(`
     "use strict";
     var module = { exports: {} };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9108 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- Simply check for `Function` type in existing rule.
- Minor cleanup of some sloppiness in the report messages, to ensure that they can say "`Function` typed" rather than "`any` typed"