### PR TITLE
docs(website): Open in Playground button should not cover text

### DIFF
--- a/packages/website/src/theme/CodeBlock/Content/styles.module.css
+++ b/packages/website/src/theme/CodeBlock/Content/styles.module.css
@@ -43,7 +43,8 @@
   /* rtl:ignore */
   float: left;
   min-width: 100%;
-  padding: var(--ifm-pre-padding);
+  padding: var(--ifm-pre-padding) var(--ifm-pre-padding)
+    calc(var(--ifm-pre-padding) * 2.5);
 }
 
 .codeBlockLinesWithNumbering {
@@ -102,5 +103,9 @@
   .playgroundButton {
     position: static;
     margin: calc(var(--ifm-pre-padding) / 2);
+  }
+
+  .codeBlockLines {
+    padding: var(--ifm-pre-padding);
   }
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9998 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I increased the padding-bottom value when there was a possibility of the 'Open in Playground' button overlapping with the code text.

Before
![Screenshot 2024-09-19 at 7 36 20 PM](https://github.com/user-attachments/assets/3d58be14-b490-4653-b646-482796839b1c)

After
![Screenshot 2024-09-19 at 7 35 53 PM](https://github.com/user-attachments/assets/3bd2cef9-8bb2-4c8c-bc18-f8adbfea9709)

