### PR TITLE
fix(types): add `NewExpression` as a parent of `SpreadElement`

### DIFF
--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -138,6 +138,7 @@ declare module './generated/ast-spec' {
     parent:
       | TSESTree.ArrayExpression
       | TSESTree.CallExpression
+      | TSESTree.NewExpression
       | TSESTree.ObjectExpression;
   }
 


### PR DESCRIPTION
`new` expressions may contain a spread, e.g. `new Array(...[])`.

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10023
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds `TSESTree.NewExpression` as an allowed parent type of `SpreadElement`, since `SpreadElement` can contain `NewExpression`s. This regressed in https://github.com/typescript-eslint/typescript-eslint/pull/9560.