### PR TITLE
fix(type-utils): check for type parameters on `isBuiltinSymbolLikeRecurser()`

### DIFF
--- a/packages/eslint-plugin/tests/rules/only-throw-error.test.ts
+++ b/packages/eslint-plugin/tests/rules/only-throw-error.test.ts
@@ -134,6 +134,11 @@ function fun(value: unknown) {
   throw value;
 }
     `,
+    `
+function fun<T extends Error>(t: T): void {
+  throw t;
+}
+    `,
   ],
   invalid: [
     {
@@ -465,6 +470,18 @@ function fun(value: unknown) {
       options: [
         {
           allowThrowingUnknown: false,
+        },
+      ],
+    },
+    {
+      code: `
+function fun<T extends number>(t: T): void {
+  throw t;
+}
+      `,
+      errors: [
+        {
+          messageId: 'object',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/prefer-promise-reject-errors.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-promise-reject-errors.test.ts
@@ -275,6 +275,12 @@ ruleTester.run('prefer-promise-reject-errors', rule, {
         }
       }
     `,
+    `
+      declare const foo: PromiseConstructor;
+      function fun<T extends Error>(t: T): void {
+        foo.reject(t);
+      }
+    `,
   ],
   invalid: [
     {
@@ -1440,6 +1446,24 @@ Bar.reject(5);
           endLine: 4,
           column: 1,
           endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: PromiseConstructor;
+function fun<T extends number>(t: T): void {
+  foo.reject(t);
+}
+      `,
+      errors: [
+        {
+          messageId: 'rejectAnError',
+          type: AST_NODE_TYPES.CallExpression,
+          line: 4,
+          endLine: 4,
+          column: 3,
+          endColumn: 16,
         },
       ],
     },

--- a/packages/type-utils/src/builtinSymbolLikes.ts
+++ b/packages/type-utils/src/builtinSymbolLikes.ts
@@ -158,6 +158,13 @@ export function isBuiltinSymbolLikeRecurser(
       isBuiltinSymbolLikeRecurser(program, t, predicate),
     );
   }
+  if (type.isTypeParameter()) {
+    const t = type.getConstraint();
+
+    if (t) {
+      return isBuiltinSymbolLikeRecurser(program, t, predicate);
+    }
+  }
 
   const predicateResult = predicate(type);
   if (typeof predicateResult === 'boolean') {

--- a/packages/type-utils/src/builtinSymbolLikes.ts
+++ b/packages/type-utils/src/builtinSymbolLikes.ts
@@ -1,3 +1,4 @@
+import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
 import { isSymbolFromDefaultLibrary } from './isSymbolFromDefaultLibrary';
@@ -158,12 +159,15 @@ export function isBuiltinSymbolLikeRecurser(
       isBuiltinSymbolLikeRecurser(program, t, predicate),
     );
   }
-  if (type.isTypeParameter()) {
+  // https://github.com/JoshuaKGoldberg/ts-api-utils/issues/382
+  if ((tsutils.isTypeParameter as (type: ts.Type) => boolean)(type)) {
     const t = type.getConstraint();
 
     if (t) {
       return isBuiltinSymbolLikeRecurser(program, t, predicate);
     }
+
+    return false;
   }
 
   const predicateResult = predicate(type);


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9882
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #9882 along with a similar issue for `@typescript-eslint/prefer-promise-reject-errors`:

```typescript
// @typescript-eslint/only-throw-error
function fun1<T extends Error>(t: T): void {
  throw t;
}

// @typescript-eslint/prefer-promise-reject-errors
function fun2<T extends Error>(t: T): void {
  Promise.reject(t);
}
```

Since this changes a function that's being used in a lot of other places (`isBuiltinSymbolLikeRecurser()`), this can affect other rules (for better or worse).

Please let me know if you think this isn't the correct way to approach this.