### PR TITLE
docs: [no-unsafe-enum-comparison] clarify motivation and applicability

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-enum-comparison.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-enum-comparison.mdx
@@ -9,23 +9,82 @@ import TabItem from '@theme/TabItem';
 >
 > See **https://typescript-eslint.io/rules/no-unsafe-enum-comparison** for documentation.
 
-The TypeScript compiler can be surprisingly lenient when working with enums. String enums are widely considered to be safer than number enums, but even string enums have some pitfalls. For example, it is allowed to compare enum values against literals:
+The TypeScript compiler can be surprisingly lenient when working with enums.
+While overt unsafety problems with enums were [resolved in TypeScript 5.0](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#all-enums-are-union-enums), some logical pitfalls remain permitted:
 
-```ts
-enum Vegetable {
-  Asparagus = 'asparagus',
-}
+1. Comparing an enum to its literal runtime value:
 
-declare const vegetable: Vegetable;
+   ```ts
+   enum Vegetable {
+     Arugula = 0,
+     Spinach = 1,
+   }
 
-vegetable === 'asparagus'; // No error
-```
+   function makeSalad(vegetable: Vegetable) {
+     switch (vegetable) {
+       case 0:
+         console.log('Making Arugula Salad');
+         break;
+       case 1:
+         console.log('Making Spinach Salad');
+         break;
+     }
+   }
+   ```
 
-The above code snippet should instead be written as `vegetable === Vegetable.Asparagus`. Allowing literals in comparisons subverts the point of using enums in the first place. By enforcing comparisons with properly typed enums:
+   The above code will break if the enum values change...
 
-- It makes a codebase more resilient to enum members changing values.
-- It allows for code IDEs to use the "Rename Symbol" feature to quickly rename an enum.
-- It aligns code to the proper enum semantics of referring to them by name and treating their values as implementation details.
+   ```ts
+   enum Vegetable {
+     Arugula = 1,
+     Spinach = 0,
+   }
+
+   makeSalad(Vegetable.Spinach); // Prints 'Making Arugula Salad'
+   ```
+
+   ...whereas the code would have continued to work if written without explicit reference to the enum values:
+
+   ```ts
+   function makeSalad(vegetable: Vegetable) {
+     switch (vegetable) {
+       case Vegetable.Arugula:
+         console.log('Making Arugula Salad');
+         break;
+       case Vegetable.Spinach:
+         console.log('Making Spinach Salad');
+         break;
+     }
+   }
+   ```
+
+   Note that using this style of comparison also allows for better IDE support, such as the "Rename Symbol" feature.
+
+2. Comparing an enum to a non-enum type:
+
+   ```ts
+   enum HandleAction {
+     Open = 'OPEN',
+     Close = 'CLOSE',
+   }
+
+   function handleAction(action: string) {
+     if (action === HandleAction.Open) {
+       openFile();
+     } else if (action === HandleAction.Close) {
+       closeFile();
+     }
+   }
+   ```
+
+   This pattern is extremely brittle.
+   It will break without complaints from the compiler if the enum values change, as before, or if the caller makes a typo:
+
+   ```ts
+   handleAction('open'); // No error, but completely useless.
+   ```
+
+This rule enforces the proper enum semantics of referring to them by name and treating their values as implementation details.
 
 ## Examples
 
@@ -50,6 +109,10 @@ enum Vegetable {
 declare let vegetable: Vegetable;
 
 vegetable === 'asparagus';
+
+declare let anyString: string;
+
+anyString === Vegetable.Asparagus;
 ```
 
 </TabItem>
@@ -80,7 +143,28 @@ vegetable === Vegetable.Asparagus;
 
 ## When Not To Use It
 
-If you don't mind number and/or literal string constants being compared against enums, you likely don't need this rule.
+If you don't mind enums being treated as a namespaced bag of values, rather than opaque identifiers, you likely don't need this rule.
 
-Separately, in the rare case of relying on an third party enums that are only imported as `type`s, it may be difficult to adhere to this rule.
+Sometimes, you may want to ingest a value from an API or user input, then use it as an enum throughout your application.
+While validating the input, it may be appropriate to disable the rule; use your judgement as to what makes sense in your application.
+For example:
+
+```ts
+/* eslint-disable @typescript-eslint/no-unsafe-enum-comparison */
+function toVegetable(vegetable: string): Vegetable {
+  if (vegetable === Vegetable.Asparagus) {
+    return Vegetable.Asparagus;
+  } else if (vegetable === Vegetable.Broccoli) {
+    return Vegetable.Broccoli;
+  } /* etc */ else {
+    throw new Error('Invalid vegetable');
+  }
+}
+/* eslint-enable @typescript-eslint/no-unsafe-enum-comparison */
+```
+
+Alternately, you might consider making use of a validation library like [Zod](https://zod.dev/?id=native-enums).
+See further discussion of this topic in [#8557](https://github.com/typescript-eslint/typescript-eslint/issues/8557).
+
+Finally, in the rare case of relying on an third party enums that are only imported as `type`s, it may be difficult to adhere to this rule.
 You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unsafe-enum-comparison.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unsafe-enum-comparison.shot
@@ -25,6 +25,11 @@ declare let vegetable: Vegetable;
 
 vegetable === 'asparagus';
 ~~~~~~~~~~~~~~~~~~~~~~~~~ The two values in this comparison do not have a shared enum type.
+
+declare let anyString: string;
+
+anyString === Vegetable.Asparagus;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ The two values in this comparison do not have a shared enum type.
 "
 `;
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8557 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Updates doc page according to discussion in #8557. In short - clarifies that the rule is about preventing logical errors arising from comparisons between enums and non-enums, not just enums and literals (which is no longer _unsafe_, just a vector for _logical_ errors).