### PR TITLE
fix(eslint-plugin): [prefer-literal-enum-member] allow nested bitwise operations

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
+++ b/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
@@ -77,69 +77,68 @@ export default createRule({
       return false;
     }
 
-    function isAllowedBitwiseOperand(
-      decl: TSESTree.TSEnumDeclaration,
-      node: TSESTree.Node,
-    ): boolean {
-      return (
-        node.type === AST_NODE_TYPES.Literal || isSelfEnumMember(decl, node)
-      );
-    }
-
     return {
       TSEnumMember(node): void {
         // If there is no initializer, then this node is just the name of the member, so ignore.
         if (node.initializer == null) {
           return;
         }
-        // any old literal
-        if (node.initializer.type === AST_NODE_TYPES.Literal) {
-          return;
-        }
-        // TemplateLiteral without expressions
-        if (
-          node.initializer.type === AST_NODE_TYPES.TemplateLiteral &&
-          node.initializer.expressions.length === 0
-        ) {
-          return;
-        }
         const declaration = node.parent.parent;
 
-        // -1 and +1
-        if (node.initializer.type === AST_NODE_TYPES.UnaryExpression) {
-          if (
-            node.initializer.argument.type === AST_NODE_TYPES.Literal &&
-            ['+', '-'].includes(node.initializer.operator)
-          ) {
-            return;
+        function isAllowedInitializerExpressionRecursive(
+          node: TSESTree.Expression | TSESTree.PrivateIdentifier,
+          partOfBitwiseComputation: boolean,
+        ): boolean {
+          // You can only refer to an enum member if it's part of a bitwise computation.
+          // so C = B isn't allowed (special case), but C = A | B is.
+          if (partOfBitwiseComputation && isSelfEnumMember(declaration, node)) {
+            return true;
           }
 
-          if (
-            allowBitwiseExpressions &&
-            node.initializer.operator === '~' &&
-            isAllowedBitwiseOperand(declaration, node.initializer.argument)
-          ) {
-            return;
+          switch (node.type) {
+            // any old literal
+            case AST_NODE_TYPES.Literal:
+              return true;
+
+            // TemplateLiteral without expressions
+            case AST_NODE_TYPES.TemplateLiteral:
+              return node.expressions.length === 0;
+
+            // +123, -123, etc.
+            case AST_NODE_TYPES.UnaryExpression:
+              if (['+', '-'].includes(node.operator)) {
+                return isAllowedInitializerExpressionRecursive(
+                  node.argument,
+                  partOfBitwiseComputation,
+                );
+              }
+
+              if (allowBitwiseExpressions && node.operator === '~') {
+                return isAllowedInitializerExpressionRecursive(
+                  node.argument,
+                  true,
+                );
+              }
+              return false;
+
+            case AST_NODE_TYPES.BinaryExpression:
+              if (
+                allowBitwiseExpressions &&
+                ['|', '&', '^', '<<', '>>', '>>>'].includes(node.operator)
+              ) {
+                return (
+                  isAllowedInitializerExpressionRecursive(node.left, true) &&
+                  isAllowedInitializerExpressionRecursive(node.right, true)
+                );
+              }
+              return false;
+
+            default:
+              return false;
           }
         }
-        if (
-          node.initializer.type === AST_NODE_TYPES.UnaryExpression &&
-          node.initializer.argument.type === AST_NODE_TYPES.Literal &&
-          (['+', '-'].includes(node.initializer.operator) ||
-            (allowBitwiseExpressions && node.initializer.operator === '~'))
-        ) {
-          return;
-        }
 
-        if (
-          allowBitwiseExpressions &&
-          node.initializer.type === AST_NODE_TYPES.BinaryExpression &&
-          ['|', '&', '^', '<<', '>>', '>>>'].includes(
-            node.initializer.operator,
-          ) &&
-          isAllowedBitwiseOperand(declaration, node.initializer.left) &&
-          isAllowedBitwiseOperand(declaration, node.initializer.right)
-        ) {
+        if (isAllowedInitializerExpressionRecursive(node.initializer, false)) {
           return;
         }
 

--- a/packages/eslint-plugin/tests/rules/prefer-literal-enum-member.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-literal-enum-member.test.ts
@@ -114,6 +114,50 @@ enum Foo {
       `,
       options: [{ allowBitwiseExpressions: true }],
     },
+    {
+      code: `
+enum Foo {
+  A = 1 << 0,
+  B = 1 << 1,
+  C = 1 << 2,
+  D = A | B | C,
+}
+      `,
+      options: [{ allowBitwiseExpressions: true }],
+    },
+    {
+      code: `
+enum Foo {
+  A = 1 << 0,
+  B = 1 << 1,
+  C = 1 << 2,
+  D = Foo.A | Foo.B | Foo.C,
+}
+      `,
+      options: [{ allowBitwiseExpressions: true }],
+    },
+    {
+      code: `
+enum Foo {
+  A = 1 << 0,
+  B = 1 << 1,
+  C = 1 << 2,
+  D = Foo.A | (Foo.B & ~Foo.C),
+}
+      `,
+      options: [{ allowBitwiseExpressions: true }],
+    },
+    {
+      code: `
+enum Foo {
+  A = 1 << 0,
+  B = 1 << 1,
+  C = 1 << 2,
+  D = Foo.A | -Foo.B,
+}
+      `,
+      options: [{ allowBitwiseExpressions: true }],
+    },
   ],
   invalid: [
     {
@@ -430,6 +474,20 @@ enum Foo {
           messageId: 'notLiteral',
           line: 6,
           column: 3,
+        },
+      ],
+    },
+    {
+      code: `
+enum Foo {
+  A,
+  B = +A,
+}
+      `,
+      errors: [
+        {
+          messageId: 'notLiteral',
+          line: 4,
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9166 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

just a lil recursion