### PR TITLE
fix(eslint-plugin): stop warning on @ts-nocheck comments which aren't at the beginning of the file

### DIFF
--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -181,13 +181,6 @@ export default createRule<[Options], MessageIds>({
       );
     }
 
-    function isPositionEarlierThan(
-      a: TSESTree.Position,
-      b: TSESTree.Position,
-    ): boolean {
-      return a.line <= b.line || a.column < b.column;
-    }
-
     return {
       Program(node): void {
         const firstStatement = node.body.at(0);
@@ -204,7 +197,7 @@ export default createRule<[Options], MessageIds>({
           if (
             directive === 'nocheck' &&
             firstStatement &&
-            isPositionEarlierThan(firstStatement.loc.start, comment.loc.start)
+            firstStatement.loc.start.line <= comment.loc.start.line
           ) {
             return;
           }

--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -190,9 +190,7 @@ export default createRule<[Options], MessageIds>({
 
     return {
       Program(node): void {
-        const firstStatement = node.body[0] as
-          | TSESTree.ProgramStatement
-          | undefined;
+        const firstStatement = node.body.at(0);
 
         const comments = context.sourceCode.getAllComments();
 

--- a/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
@@ -30,14 +30,6 @@ ruleTester.run('ts-expect-error', rule, {
 /* @ts-expect-error
  * not on the last line */
     `,
-    `
-const a = 1;
-
-// @ts-nocheck - should not be reported
-
-// TS error is not actually suppressed
-const b: string = a;
-    `,
     {
       code: '// @ts-expect-error',
       options: [{ 'ts-expect-error': false }],
@@ -1000,6 +992,14 @@ ruleTester.run('ts-nocheck', rule, {
     `,
     '/** @ts-nocheck */',
     '/* @ts-nocheck */',
+    `
+const a = 1;
+
+// @ts-nocheck - should not be reported
+
+// TS error is not actually suppressed
+const b: string = a;
+    `,
   ],
   invalid: [
     {
@@ -1116,6 +1116,22 @@ ruleTester.run('ts-nocheck', rule, {
           messageId: 'tsDirectiveCommentRequiresDescription',
           line: 1,
           column: 1,
+        },
+      ],
+    },
+    {
+      // comment's colum > first statement's column
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
+      code: `
+ // @ts-nocheck
+const a: true = false;
+      `,
+      errors: [
+        {
+          data: { directive: 'nocheck', minimumDescriptionLength: 3 },
+          messageId: 'tsDirectiveComment',
+          line: 2,
+          column: 2,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
@@ -1120,7 +1120,7 @@ const b: string = a;
       ],
     },
     {
-      // comment's colum > first statement's column
+      // comment's column > first statement's column
       // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting
       code: `
  // @ts-nocheck

--- a/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
@@ -30,6 +30,14 @@ ruleTester.run('ts-expect-error', rule, {
 /* @ts-expect-error
  * not on the last line */
     `,
+    `
+const a = 1;
+
+// @ts-nocheck - should not be reported
+
+// TS error is not actually suppressed
+const b: string = a;
+    `,
     {
       code: '// @ts-expect-error',
       options: [{ 'ts-expect-error': false }],
@@ -1025,22 +1033,6 @@ ruleTester.run('ts-nocheck', rule, {
           messageId: 'tsDirectiveComment',
           line: 1,
           column: 1,
-        },
-      ],
-    },
-    {
-      code: `
-if (false) {
-  // @ts-nocheck: Unreachable code error
-  console.log('hello');
-}
-      `,
-      errors: [
-        {
-          data: { directive: 'nocheck' },
-          messageId: 'tsDirectiveComment',
-          line: 3,
-          column: 3,
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8753
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR resolves #8753 and stops warning on `// @ts-nocheck` comments which are not at the beginning of the file:

```ts
const a = 1;

// @ts-nocheck - should not be reported

// TS error is not actually suppressed
const b: string = a;
```
