### PR TITLE
fix(eslint-plugin): correct use-at-your-own-risk type definitions

### DIFF
--- a/packages/eslint-plugin/eslint-recommended-raw.d.ts
+++ b/packages/eslint-plugin/eslint-recommended-raw.d.ts
@@ -2,4 +2,4 @@ declare const config: (style: 'glob' | 'minimatch') => {
   files: string[];
   rules: Record<string, 'off' | 'warn' | 'error'>;
 };
-export default config;
+export = config;

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -5,6 +5,7 @@
   "files": [
     "dist",
     "docs",
+    "eslint-recommended-raw.d.ts",
     "index.d.ts",
     "rules.d.ts",
     "package.json",

--- a/packages/eslint-plugin/rules.d.ts
+++ b/packages/eslint-plugin/rules.d.ts
@@ -41,7 +41,7 @@ import type {
   RuleRecommendationAcrossConfigs,
 } from '@typescript-eslint/utils/ts-eslint';
 
-export interface ESLintPluginDocs {
+interface ESLintPluginDocs {
   /**
    * Does the rule extend (or is it based off of) an ESLint code rule?
    * Alternately accepts the name of the base rule, in case the rule has been renamed.
@@ -62,16 +62,25 @@ export interface ESLintPluginDocs {
   requiresTypeChecking?: boolean;
 }
 
-export type ESLintPluginRuleModule = RuleModuleWithMetaDocs<
+type ESLintPluginRuleModule = RuleModuleWithMetaDocs<
   string,
   readonly unknown[],
   ESLintPluginDocs
 >;
 
-export type TypeScriptESLintRules = Record<
+type TypeScriptESLintRules = Record<
   string,
   RuleModuleWithMetaDocs<string, unknown[], ESLintPluginDocs>
 >;
 
 declare const rules: TypeScriptESLintRules;
-export default rules;
+
+declare namespace rules {
+  export type {
+    ESLintPluginDocs,
+    ESLintPluginRuleModule,
+    TypeScriptESLintRules,
+  };
+}
+
+export = rules;

--- a/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
+++ b/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
@@ -7,7 +7,7 @@
  * - disables rules from eslint:recommended which are already handled by TypeScript.
  * - enables rules that make sense due to TS's typechecking / transpilation.
  */
-export default (
+const config = (
   style: 'glob' | 'minimatch',
 ): {
   files: string[];
@@ -44,3 +44,5 @@ export default (
     'prefer-spread': 'error', // ts transpiles spread to apply, so no need for manual apply
   },
 });
+
+export = config;

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -21,27 +21,31 @@ const { name, version } = require('../package.json') as {
   version: string;
 };
 
+const configs = {
+  all,
+  base,
+  'disable-type-checked': disableTypeChecked,
+  'eslint-recommended': eslintRecommended,
+  recommended,
+  /** @deprecated - please use "recommended-type-checked" instead. */
+  'recommended-requiring-type-checking': recommendedTypeChecked,
+  'recommended-type-checked': recommendedTypeChecked,
+  'recommended-type-checked-only': recommendedTypeCheckedOnly,
+  strict,
+  'strict-type-checked': strictTypeChecked,
+  'strict-type-checked-only': strictTypeCheckedOnly,
+  stylistic,
+  'stylistic-type-checked': stylisticTypeChecked,
+  'stylistic-type-checked-only': stylisticTypeCheckedOnly,
+};
+
+const meta = {
+  name,
+  version,
+};
+
 export = {
-  configs: {
-    all,
-    base,
-    'disable-type-checked': disableTypeChecked,
-    'eslint-recommended': eslintRecommended,
-    recommended,
-    /** @deprecated - please use "recommended-type-checked" instead. */
-    'recommended-requiring-type-checking': recommendedTypeChecked,
-    'recommended-type-checked': recommendedTypeChecked,
-    'recommended-type-checked-only': recommendedTypeCheckedOnly,
-    strict,
-    'strict-type-checked': strictTypeChecked,
-    'strict-type-checked-only': strictTypeCheckedOnly,
-    stylistic,
-    'stylistic-type-checked': stylisticTypeChecked,
-    'stylistic-type-checked-only': stylisticTypeCheckedOnly,
-  },
-  meta: {
-    name,
-    version,
-  },
+  configs,
+  meta,
   rules,
 } satisfies Linter.Plugin;

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -128,7 +128,7 @@ import unboundMethod from './unbound-method';
 import unifiedSignatures from './unified-signatures';
 import useUnknownInCatchCallbackVariable from './use-unknown-in-catch-callback-variable';
 
-export default {
+const rules = {
   'adjacent-overload-signatures': adjacentOverloadSignatures,
   'array-type': arrayType,
   'await-thenable': awaitThenable,
@@ -258,3 +258,5 @@ export default {
   'unified-signatures': unifiedSignatures,
   'use-unknown-in-catch-callback-variable': useUnknownInCatchCallbackVariable,
 } satisfies Linter.PluginRules;
+
+export = rules;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #9967.
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

### **Before:**

![tseslint-eslint-plugin-before](https://github.com/user-attachments/assets/469ee4bb-7ca9-4858-9c0f-d5e0b98043d2)

### **After**:

![tseslint-eslint-plugin-after](https://github.com/user-attachments/assets/0bd1e0d2-0980-4729-b513-aead4269fd15)

