### PR TITLE
fix(typescript-estree): improve project service error message when file extension missing from extraFileExtensions

### DIFF
--- a/packages/typescript-estree/src/create-program/createProjectProgramError.ts
+++ b/packages/typescript-estree/src/create-program/createProjectProgramError.ts
@@ -1,20 +1,10 @@
 import path from 'node:path';
 
-import * as ts from 'typescript';
+import type * as ts from 'typescript';
 
 import type { ParseSettings } from '../parseSettings';
 import { describeFilePath } from './describeFilePath';
-
-const DEFAULT_EXTRA_FILE_EXTENSIONS = new Set<string>([
-  ts.Extension.Ts,
-  ts.Extension.Tsx,
-  ts.Extension.Js,
-  ts.Extension.Jsx,
-  ts.Extension.Mjs,
-  ts.Extension.Mts,
-  ts.Extension.Cjs,
-  ts.Extension.Cts,
-]);
+import { DEFAULT_EXTRA_FILE_EXTENSIONS } from './shared';
 
 export function createProjectProgramError(
   parseSettings: ParseSettings,

--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -38,6 +38,17 @@ const DEFAULT_COMPILER_OPTIONS: ts.CompilerOptions = {
   checkJs: true,
 };
 
+const DEFAULT_EXTRA_FILE_EXTENSIONS = new Set<string>([
+  ts.Extension.Ts,
+  ts.Extension.Tsx,
+  ts.Extension.Js,
+  ts.Extension.Jsx,
+  ts.Extension.Mjs,
+  ts.Extension.Mts,
+  ts.Extension.Cjs,
+  ts.Extension.Cts,
+]);
+
 function createDefaultCompilerOptionsFromExtra(
   parseSettings: ParseSettings,
 ): ts.CompilerOptions {
@@ -139,4 +150,5 @@ export {
   ensureAbsolutePath,
   getCanonicalFileName,
   getAstFromProgram,
+  DEFAULT_EXTRA_FILE_EXTENSIONS,
 };

--- a/packages/typescript-estree/src/useProgramFromProjectService.ts
+++ b/packages/typescript-estree/src/useProgramFromProjectService.ts
@@ -24,6 +24,17 @@ const log = debug(
 
 const serviceFileExtensions = new WeakMap<ts.server.ProjectService, string[]>();
 
+const DEFAULT_EXTRA_FILE_EXTENSIONS = new Set<string>([
+  ts.Extension.Ts,
+  ts.Extension.Tsx,
+  ts.Extension.Js,
+  ts.Extension.Jsx,
+  ts.Extension.Mjs,
+  ts.Extension.Mts,
+  ts.Extension.Cjs,
+  ts.Extension.Cts,
+]);
+
 const updateExtraFileExtensions = (
   service: ts.server.ProjectService,
   extraFileExtensions: string[],
@@ -72,10 +83,32 @@ function openClientFileFromProjectService(
         `${parseSettings.filePath} was included by allowDefaultProject but also was found in the project service. Consider removing it from allowDefaultProject.`,
       );
     }
-  } else if (!isDefaultProjectAllowed) {
-    throw new Error(
-      `${parseSettings.filePath} was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject.`,
-    );
+  } else {
+    const wasNotFound = `${parseSettings.filePath} was not found by the project service`;
+
+    const fileExtension = path.extname(parseSettings.filePath);
+    const extraFileExtensions = parseSettings.extraFileExtensions;
+    if (
+      !DEFAULT_EXTRA_FILE_EXTENSIONS.has(fileExtension) &&
+      !extraFileExtensions.includes(fileExtension)
+    ) {
+      const nonStandardExt = `${wasNotFound} because the extension for the file (\`${fileExtension}\`) is non-standard`;
+      if (extraFileExtensions.length > 0) {
+        throw new Error(
+          `${nonStandardExt}. It should be added to your existing \`parserOptions.extraFileExtensions\`.`,
+        );
+      } else {
+        throw new Error(
+          `${nonStandardExt}. You should add \`parserOptions.extraFileExtensions\` to your config.`,
+        );
+      }
+    }
+
+    if (!isDefaultProjectAllowed) {
+      throw new Error(
+        `${wasNotFound}. Consider either including it in the tsconfig.json or including it in allowDefaultProject.`,
+      );
+    }
   }
 
   // No a configFileName indicates this file wasn't included in a TSConfig.

--- a/packages/typescript-estree/src/useProgramFromProjectService.ts
+++ b/packages/typescript-estree/src/useProgramFromProjectService.ts
@@ -13,6 +13,7 @@ import type {
   ASTAndNoProgram,
   ASTAndProgram,
 } from './create-program/shared';
+import { DEFAULT_EXTRA_FILE_EXTENSIONS } from './create-program/shared';
 import { DEFAULT_PROJECT_FILES_ERROR_EXPLANATION } from './create-program/validateDefaultProjectForFilesGlob';
 import type { MutableParseSettings } from './parseSettings';
 
@@ -23,17 +24,6 @@ const log = debug(
 );
 
 const serviceFileExtensions = new WeakMap<ts.server.ProjectService, string[]>();
-
-const DEFAULT_EXTRA_FILE_EXTENSIONS = new Set<string>([
-  ts.Extension.Ts,
-  ts.Extension.Tsx,
-  ts.Extension.Js,
-  ts.Extension.Jsx,
-  ts.Extension.Mjs,
-  ts.Extension.Mts,
-  ts.Extension.Cjs,
-  ts.Extension.Cts,
-]);
 
 const updateExtraFileExtensions = (
   service: ts.server.ProjectService,

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -514,7 +514,7 @@ describe('parseAndGenerateServices', () => {
         it('extension matching the file name but not a file on disk', () => {
           expect(
             testExtraFileExtensions('other/unknownFileType.unknown', [
-              'unknown',
+              '.unknown',
             ]),
           ).toThrow(
             /unknownFileType\.unknown was not found by the project service/,

--- a/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
@@ -575,4 +575,56 @@ If you absolutely need more files included, set parserOptions.projectService.max
       extraFileExtensions: [],
     });
   });
+
+  it('throws an error when a nonstandard file extension is used', () => {
+    const filePath = `path/PascalCaseDirectory/vue-component.vue`;
+    const { service } = createMockProjectService();
+    service.openClientFile.mockReturnValueOnce({}).mockReturnValueOnce({});
+
+    expect(() =>
+      useProgramFromProjectService(
+        createProjectServiceSettings({
+          allowDefaultProject: [mockParseSettings.filePath],
+          service,
+        }),
+        {
+          ...mockParseSettings,
+          filePath,
+        },
+        true,
+        new Set(),
+      ),
+    ).toThrow(
+      `${filePath} was not found by the project service because the extension for the file (\`${path.extname(
+        filePath,
+      )}\`) is non-standard. You should add \`parserOptions.extraFileExtensions\` to your config.`,
+    );
+  });
+
+  it('throws an error when a nonstandard file extension is used but not included in extraFileExtensions', () => {
+    const filePath = `path/PascalCaseDirectory/vue-component.vue`;
+
+    const { service } = createMockProjectService();
+    service.openClientFile.mockReturnValueOnce({}).mockReturnValueOnce({});
+
+    expect(() =>
+      useProgramFromProjectService(
+        createProjectServiceSettings({
+          allowDefaultProject: [],
+          service,
+        }),
+        {
+          ...mockParseSettings,
+          filePath,
+          extraFileExtensions: ['.svelte'],
+        },
+        true,
+        new Set(),
+      ),
+    ).toThrow(
+      `${filePath} was not found by the project service because the extension for the file (\`${path.extname(
+        filePath,
+      )}\`) is non-standard. It should be added to your existing \`parserOptions.extraFileExtensions\`.`,
+    );
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10057 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
