### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-parameters] cannot assume variables are either type or value

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -50,9 +50,7 @@ export default createRule({
         const smTypeParameterVariable = nullThrows(
           (() => {
             const variable = scope.set.get(esTypeParameter.name.name);
-            return variable != null &&
-              variable.isTypeVariable &&
-              !variable.isValueVariable
+            return variable != null && variable.isTypeVariable
               ? variable
               : undefined;
           })(),

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-parameters.test.ts
@@ -971,6 +971,30 @@ const f = <T,>(
       ],
     },
     {
+      code: `
+declare function setItem<T>(T): T;
+      `,
+      errors: [
+        {
+          messageId: 'sole',
+          data: { descriptor: 'function', name: 'T', uses: 'used only once' },
+        },
+      ],
+    },
+    {
+      code: `
+interface StorageService {
+  setItem<T>({ key: string, value: T }): Promise<void>;
+}
+      `,
+      errors: [
+        {
+          messageId: 'sole',
+          data: { descriptor: 'function', name: 'T', uses: 'never used' },
+        },
+      ],
+    },
+    {
       // This isn't actually an important test case.
       // However, we use it as an example in the docs of code that is flagged,
       // but shouldn't necessarily be. So, if you make a change to the rule logic


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/10088
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I thought it was something in the scope manager but it turned out to be really simple: in `setItem<T>(T): T`, the variable `T` has two declarations, and it's both a type and a value. Therefore we can't assume that the type parameters declared aren't also available as values.