### PR TITLE
fix(typescript-eslint): propagate `name` field to extended configs in `config` helper

### DIFF
--- a/packages/typescript-eslint/src/config-helper.ts
+++ b/packages/typescript-eslint/src/config-helper.ts
@@ -94,6 +94,7 @@ export function config(
     const extension = {
       ...(config.files && { files: config.files }),
       ...(config.ignores && { ignores: config.ignores }),
+      ...(config.name && { name: config.name }),
     };
 
     return [

--- a/packages/typescript-eslint/src/config-helper.ts
+++ b/packages/typescript-eslint/src/config-helper.ts
@@ -91,17 +91,16 @@ export function config(
       return config;
     }
 
-    const extension = {
-      ...(config.files && { files: config.files }),
-      ...(config.ignores && { ignores: config.ignores }),
-      ...(config.name && { name: config.name }),
-    };
-
     return [
-      ...extendsArr.map(conf => ({
-        ...conf,
-        ...extension,
-      })),
+      ...extendsArr.map(extension => {
+        const name = [config.name, extension.name].filter(Boolean).join('__');
+        return {
+          ...extension,
+          ...(config.files && { files: config.files }),
+          ...(config.ignores && { ignores: config.ignores }),
+          ...(name && { name }),
+        };
+      }),
       config,
     ];
   });

--- a/packages/typescript-eslint/tests/configs.test.ts
+++ b/packages/typescript-eslint/tests/configs.test.ts
@@ -398,4 +398,69 @@ describe('config helper', () => {
       },
     ]);
   });
+
+  it('flattens extended configs with names if base config is unnamed', () => {
+    expect(
+      plugin.config({
+        extends: [
+          { name: 'extension-1', rules: { rule1: 'error' } },
+          { rules: { rule2: 'error' } },
+        ],
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        rules: { rule: 'error' },
+      }),
+    ).toEqual([
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        name: 'extension-1',
+        rules: { rule1: 'error' },
+      },
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        rules: { rule2: 'error' },
+      },
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        rules: { rule: 'error' },
+      },
+    ]);
+  });
+
+  it('merges config items names', () => {
+    expect(
+      plugin.config({
+        extends: [
+          { name: 'extension-1', rules: { rule1: 'error' } },
+          { rules: { rule2: 'error' } },
+        ],
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        name: 'my-config',
+        rules: { rule: 'error' },
+      }),
+    ).toEqual([
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        name: 'my-config__extension-1',
+        rules: { rule1: 'error' },
+      },
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        name: 'my-config',
+        rules: { rule2: 'error' },
+      },
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        name: 'my-config',
+        rules: { rule: 'error' },
+      },
+    ]);
+  });
 });

--- a/packages/typescript-eslint/tests/configs.test.ts
+++ b/packages/typescript-eslint/tests/configs.test.ts
@@ -367,4 +367,35 @@ describe('config helper', () => {
       },
     ]);
   });
+
+  it('flattens extended configs with config name', () => {
+    expect(
+      plugin.config({
+        extends: [{ rules: { rule1: 'error' } }, { rules: { rule2: 'error' } }],
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        name: 'my-config',
+        rules: { rule: 'error' },
+      }),
+    ).toEqual([
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        name: 'my-config',
+        rules: { rule1: 'error' },
+      },
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        name: 'my-config',
+        rules: { rule2: 'error' },
+      },
+      {
+        files: ['common-file'],
+        ignores: ['common-ignored'],
+        name: 'my-config',
+        rules: { rule: 'error' },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #10086
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
