### PR TITLE
fix(scope-manager): [no-use-before-define] do not treat nested namespace aliases as variable references

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-use-before-define.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-use-before-define.test.ts
@@ -583,6 +583,13 @@ const baz = '';
       `,
       options: [{ ignoreTypeReferences: true }],
     },
+    `
+namespace A.X.Y {}
+
+import Z = A.X.Y;
+
+const X = 23;
+    `,
   ],
   invalid: [
     {

--- a/packages/scope-manager/src/referencer/Referencer.ts
+++ b/packages/scope-manager/src/referencer/Referencer.ts
@@ -647,7 +647,11 @@ class Referencer extends Visitor {
     );
 
     if (node.moduleReference.type === AST_NODE_TYPES.TSQualifiedName) {
-      this.visit(node.moduleReference.left);
+      let moduleIdentifier = node.moduleReference.left;
+      while (moduleIdentifier.type === AST_NODE_TYPES.TSQualifiedName) {
+        moduleIdentifier = moduleIdentifier.left;
+      }
+      this.visit(moduleIdentifier);
     } else {
       this.visit(node.moduleReference);
     }

--- a/packages/scope-manager/tests/fixtures/ts-module/nested-namespace-alias.ts
+++ b/packages/scope-manager/tests/fixtures/ts-module/nested-namespace-alias.ts
@@ -1,0 +1,9 @@
+export namespace A {
+  export namespace X {
+    export const Y = 1;
+  }
+}
+
+import Z = A.X.Y;
+
+const X = 23;

--- a/packages/scope-manager/tests/fixtures/ts-module/nested-namespace-alias.ts.shot
+++ b/packages/scope-manager/tests/fixtures/ts-module/nested-namespace-alias.ts.shot
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ts-module nested-namespace-alias 1`] = `
+ScopeManager {
+  variables: [
+    ImplicitGlobalConstTypeVariable,
+    Variable$2 {
+      defs: [
+        TSModuleNameDefinition$1 {
+          name: Identifier<"A">,
+          node: TSModuleDeclaration$1,
+        },
+      ],
+      name: "A",
+      references: [
+        Reference$2 {
+          identifier: Identifier<"A">,
+          isRead: true,
+          isTypeReference: false,
+          isValueReference: true,
+          isWrite: false,
+          resolved: Variable$2,
+        },
+      ],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+    Variable$3 {
+      defs: [
+        TSModuleNameDefinition$2 {
+          name: Identifier<"X">,
+          node: TSModuleDeclaration$2,
+        },
+      ],
+      name: "X",
+      references: [],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+    Variable$4 {
+      defs: [
+        VariableDefinition$3 {
+          name: Identifier<"Y">,
+          node: VariableDeclarator$3,
+        },
+      ],
+      name: "Y",
+      references: [
+        Reference$1 {
+          identifier: Identifier<"Y">,
+          init: true,
+          isRead: false,
+          isTypeReference: false,
+          isValueReference: true,
+          isWrite: true,
+          resolved: Variable$4,
+          writeExpr: Literal$4,
+        },
+      ],
+      isValueVariable: true,
+      isTypeVariable: false,
+    },
+    Variable$5 {
+      defs: [
+        ImportBindingDefinition$4 {
+          name: Identifier<"Z">,
+          node: TSImportEqualsDeclaration$5,
+        },
+      ],
+      name: "Z",
+      references: [],
+      isValueVariable: true,
+      isTypeVariable: true,
+    },
+    Variable$6 {
+      defs: [
+        VariableDefinition$5 {
+          name: Identifier<"X">,
+          node: VariableDeclarator$6,
+        },
+      ],
+      name: "X",
+      references: [
+        Reference$3 {
+          identifier: Identifier<"X">,
+          init: true,
+          isRead: false,
+          isTypeReference: false,
+          isValueReference: true,
+          isWrite: true,
+          resolved: Variable$6,
+          writeExpr: Literal$7,
+        },
+      ],
+      isValueVariable: true,
+      isTypeVariable: false,
+    },
+  ],
+  scopes: [
+    GlobalScope$1 {
+      block: Program$8,
+      isStrict: false,
+      references: [
+        Reference$2,
+        Reference$3,
+      ],
+      set: Map {
+        "const" => ImplicitGlobalConstTypeVariable,
+        "A" => Variable$2,
+        "Z" => Variable$5,
+        "X" => Variable$6,
+      },
+      type: "global",
+      upper: null,
+      variables: [
+        ImplicitGlobalConstTypeVariable,
+        Variable$2,
+        Variable$5,
+        Variable$6,
+      ],
+    },
+    TSModuleScope$2 {
+      block: TSModuleDeclaration$1,
+      isStrict: true,
+      references: [],
+      set: Map {
+        "X" => Variable$3,
+      },
+      type: "tsModule",
+      upper: GlobalScope$1,
+      variables: [
+        Variable$3,
+      ],
+    },
+    TSModuleScope$3 {
+      block: TSModuleDeclaration$2,
+      isStrict: true,
+      references: [
+        Reference$1,
+      ],
+      set: Map {
+        "Y" => Variable$4,
+      },
+      type: "tsModule",
+      upper: TSModuleScope$2,
+      variables: [
+        Variable$4,
+      ],
+    },
+  ],
+}
+`;


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #10087
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`A.X.Y` is `TSQualifiedName`

Before:

Visit `A.X` (another `TSQualifiedName`), this will create extra reference for `X` variable. Therefore, the `const X` variable has two references instead of one.

```ts
import Z = A.X.Y
//         ^^^
```

Now:

Visit only `A` (`Identifier`)

```ts
import Z = A.X.Y
//         ^
```