### PR TITLE
[prefer-literal-enum-member] report message should reflect bitwise expression option

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
+++ b/packages/eslint-plugin/src/rules/prefer-literal-enum-member.ts
@@ -14,6 +14,7 @@ export default createRule({
     },
     messages: {
       notLiteral: `Explicit enum value must only be a literal value (string or number).`,
+      notLiteralOrBitwiseExpression: `Explicit enum value must only be a literal value (string or number) or a bitwise expression.`,
     },
     schema: [
       {
@@ -142,7 +143,9 @@ export default createRule({
 
         context.report({
           node: node.id,
-          messageId: 'notLiteral',
+          messageId: allowBitwiseExpressions
+            ? 'notLiteralOrBitwiseExpression'
+            : 'notLiteral',
         });
       },
     };

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/prefer-literal-enum-member.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/prefer-literal-enum-member.shot
@@ -39,19 +39,19 @@ Options: { "allowBitwiseExpressions": true }
 const x = 1;
 enum Foo {
   A = x << 0,
-  ~ Explicit enum value must only be a literal value (string or number).
+  ~ Explicit enum value must only be a literal value (string or number) or a bitwise expression.
   B = x >> 0,
-  ~ Explicit enum value must only be a literal value (string or number).
+  ~ Explicit enum value must only be a literal value (string or number) or a bitwise expression.
   C = x >>> 0,
-  ~ Explicit enum value must only be a literal value (string or number).
+  ~ Explicit enum value must only be a literal value (string or number) or a bitwise expression.
   D = x | 0,
-  ~ Explicit enum value must only be a literal value (string or number).
+  ~ Explicit enum value must only be a literal value (string or number) or a bitwise expression.
   E = x & 0,
-  ~ Explicit enum value must only be a literal value (string or number).
+  ~ Explicit enum value must only be a literal value (string or number) or a bitwise expression.
   F = x ^ 0,
-  ~ Explicit enum value must only be a literal value (string or number).
+  ~ Explicit enum value must only be a literal value (string or number) or a bitwise expression.
   G = ~x,
-  ~ Explicit enum value must only be a literal value (string or number).
+  ~ Explicit enum value must only be a literal value (string or number) or a bitwise expression.
 }
 "
 `;

--- a/packages/eslint-plugin/tests/rules/prefer-literal-enum-member.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-literal-enum-member.test.ts
@@ -418,37 +418,37 @@ enum Foo {
       options: [{ allowBitwiseExpressions: true }],
       errors: [
         {
-          messageId: 'notLiteral',
+          messageId: 'notLiteralOrBitwiseExpression',
           line: 4,
           column: 3,
         },
         {
-          messageId: 'notLiteral',
+          messageId: 'notLiteralOrBitwiseExpression',
           line: 5,
           column: 3,
         },
         {
-          messageId: 'notLiteral',
+          messageId: 'notLiteralOrBitwiseExpression',
           line: 6,
           column: 3,
         },
         {
-          messageId: 'notLiteral',
+          messageId: 'notLiteralOrBitwiseExpression',
           line: 7,
           column: 3,
         },
         {
-          messageId: 'notLiteral',
+          messageId: 'notLiteralOrBitwiseExpression',
           line: 8,
           column: 3,
         },
         {
-          messageId: 'notLiteral',
+          messageId: 'notLiteralOrBitwiseExpression',
           line: 9,
           column: 3,
         },
         {
-          messageId: 'notLiteral',
+          messageId: 'notLiteralOrBitwiseExpression',
           line: 10,
           column: 3,
         },
@@ -466,12 +466,12 @@ enum Foo {
       options: [{ allowBitwiseExpressions: true }],
       errors: [
         {
-          messageId: 'notLiteral',
+          messageId: 'notLiteralOrBitwiseExpression',
           line: 5,
           column: 3,
         },
         {
-          messageId: 'notLiteral',
+          messageId: 'notLiteralOrBitwiseExpression',
           line: 6,
           column: 3,
         },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10090
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Rather straight-forward and adds a slightly different message when bitwise `@typescript-eslint/prefer-literal-enum-member` when `allowBitwiseExpressions` is enabled.
