### PR TITLE
fix(typescript-estree): fix crash when running from a `node --eval` script

### DIFF
--- a/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
+++ b/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
@@ -51,6 +51,7 @@ export function inferSingleRun(options: TSESTreeOptions | undefined): boolean {
       process.env.CI === 'true' ||
       // This will be true for invocations such as `npx eslint ...` and `./node_modules/.bin/eslint ...`
       possibleEslintBinPaths.some(binPath =>
+        process.argv.length > 1 &&
         process.argv[1].endsWith(path.normalize(binPath)),
       )
     ) {

--- a/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
+++ b/packages/typescript-estree/src/parseSettings/inferSingleRun.ts
@@ -50,9 +50,10 @@ export function inferSingleRun(options: TSESTreeOptions | undefined): boolean {
       // Default to single runs for CI processes. CI=true is set by most CI providers by default.
       process.env.CI === 'true' ||
       // This will be true for invocations such as `npx eslint ...` and `./node_modules/.bin/eslint ...`
-      possibleEslintBinPaths.some(binPath =>
-        process.argv.length > 1 &&
-        process.argv[1].endsWith(path.normalize(binPath)),
+      possibleEslintBinPaths.some(
+        binPath =>
+          process.argv.length > 1 &&
+          process.argv[1].endsWith(path.normalize(binPath)),
       )
     ) {
       return !process.argv.includes('--fix');


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

I just ran into this at work.
Our codebase runs ESLint via a script that is eval'd.
So we run `node --eval "code goes here"`
In this instance `process.argv.length === 1` -- so our single run infer code crashes!
