### PR TITLE
fix(eslint-plugin): handle unions in await...for

### DIFF
--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -79,9 +79,8 @@ export default createRule<[], MessageId>({
           return;
         }
 
-        const types = tsutils.unionTypeParts(type);
-
-        const asyncIteratorSymbol = types
+        const asyncIteratorSymbol = tsutils
+          .unionTypeParts(type)
           .map(t =>
             tsutils.getWellKnownSymbolPropertyOfType(
               t,
@@ -91,7 +90,7 @@ export default createRule<[], MessageId>({
           )
           .find(symbol => symbol != null);
 
-        if (asyncIteratorSymbol === undefined) {
+        if (asyncIteratorSymbol == null) {
           context.report({
             loc: getForStatementHeadLoc(context.sourceCode, node),
             messageId: 'forAwaitOfNonThenable',

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -79,11 +79,18 @@ export default createRule<[], MessageId>({
           return;
         }
 
-        const asyncIteratorSymbol = tsutils.getWellKnownSymbolPropertyOfType(
-          type,
-          'asyncIterator',
-          checker,
-        );
+        const types = type.isUnion() ? type.types : [type];
+
+        const asyncIteratorSymbol =
+          types
+            .map(t =>
+              tsutils.getWellKnownSymbolPropertyOfType(
+                t,
+                'asyncIterator',
+                checker,
+              ),
+            )
+            .find(symbol => symbol) ?? null;
 
         if (asyncIteratorSymbol == null) {
           context.report({

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -79,20 +79,19 @@ export default createRule<[], MessageId>({
           return;
         }
 
-        const types = type.isUnion() ? type.types : [type];
+        const types = tsutils.unionTypeParts(type);
 
-        const asyncIteratorSymbol =
-          types
-            .map(t =>
-              tsutils.getWellKnownSymbolPropertyOfType(
-                t,
-                'asyncIterator',
-                checker,
-              ),
-            )
-            .find(symbol => symbol) ?? null;
+        const asyncIteratorSymbol = types
+          .map(t =>
+            tsutils.getWellKnownSymbolPropertyOfType(
+              t,
+              'asyncIterator',
+              checker,
+            ),
+          )
+          .find(symbol => symbol != null);
 
-        if (asyncIteratorSymbol == null) {
+        if (asyncIteratorSymbol === undefined) {
           context.report({
             loc: getForStatementHeadLoc(context.sourceCode, node),
             messageId: 'forAwaitOfNonThenable',

--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -220,6 +220,13 @@ async function forAwait() {
 }
       `,
     },
+    {
+      code: `
+const asyncIter: AsyncIterable<string> | Iterable<string>;
+for await (const s of asyncIter) {
+}
+      `,
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -222,7 +222,7 @@ async function forAwait() {
     },
     {
       code: `
-const asyncIter: AsyncIterable<string> | Iterable<string>;
+declare const asyncIter: AsyncIterable<string> | Iterable<string>;
 for await (const s of asyncIter) {
 }
       `,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10080 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Handle Union types in in the for-statement of the `await-thenable` rule.
If type is Union, we loop through each types to check if it contains an async Iterator.
If that's the case, we don't report an error.


