### PR TITLE
fix(eslint-plugin): [no-unused-vars] never report the naming of an enum member

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -522,7 +522,13 @@ export default createRule<Options, MessageIds>({
           def.name.type === AST_NODE_TYPES.Identifier &&
           options.varsIgnorePattern?.test(def.name.name)
         ) {
-          if (options.reportUsedIgnorePattern && used) {
+          if (
+            options.reportUsedIgnorePattern &&
+            used &&
+            /* enum members are always marked as 'used' by `collectVariables`, but in reality they may be used or
+               unused. either way, don't complain about their naming. */
+            def.type !== TSESLint.Scope.DefinitionType.TSEnumMember
+          ) {
             context.report({
               node: def.name,
               messageId: 'usedIgnoredVar',

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -2266,5 +2266,13 @@ import { foo } from 'foo';
 
 export type Bar = typeof foo;
     `,
+    {
+      code: `
+export enum Foo {
+  _A,
+}
+      `,
+      options: [{ reportUsedIgnorePattern: true, varsIgnorePattern: '_' }],
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10116 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Ensure that `no-unused-vars` never complains about the naming of an enum member, whether it is used or unused.
