### PR TITLE
fix(rule-tester): merge provided `linteOptions`

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -713,7 +713,10 @@ export class RuleTester extends TestFramework {
               ...configWithoutCustomKeys.languageOptions?.parserOptions,
             },
           },
-          linterOptions: { reportUnusedDisableDirectives: 1 },
+          linterOptions: {
+            reportUnusedDisableDirectives: 1,
+            ...configWithoutCustomKeys.linterOptions,
+          },
         });
         messages = this.#linter.verify(code, actualConfig, filename);
       } finally {

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -347,6 +347,21 @@ describe('RuleTester', () => {
     expect(mockedParserClearCaches).toHaveBeenCalledTimes(1);
   });
 
+  it('provided linterOptions should be respected', () => {
+    const ruleTester = new RuleTester({
+      linterOptions: {
+        reportUnusedDisableDirectives: 0,
+      },
+    });
+
+    expect(() => {
+      ruleTester.run('my-rule', NOOP_RULE, {
+        invalid: [],
+        valid: ['// eslint-disable-next-line'],
+      });
+    }).not.toThrow();
+  });
+
   it('throws an error if you attempt to set the parser to ts-eslint at the test level', () => {
     const ruleTester = new RuleTester({
       languageOptions: {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10071
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

When creating the `actualConfig`, `linterOptions` is merged instead of overridden.