### PR TITLE
fix(eslint-plugin): [class-literal-property-style] don't report nodes with `override` keyword

### DIFF
--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -145,6 +145,7 @@ export default createRule<Options, MessageIds>({
         MethodDefinition(node): void {
           if (
             node.kind !== 'get' ||
+            node.override ||
             !node.value.body ||
             node.value.body.body.length === 0
           ) {
@@ -222,7 +223,7 @@ export default createRule<Options, MessageIds>({
           }
         },
         PropertyDefinition(node): void {
-          if (!node.readonly || node.declare) {
+          if (!node.readonly || node.declare || node.override) {
             return;
           }
           const { properties } =

--- a/packages/eslint-plugin/tests/rules/class-literal-property-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-literal-property-style.test.ts
@@ -257,6 +257,35 @@ class Mx {
       `,
       options: ['getters'],
     },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/3602
+      // getter with override modifier should be ignored
+      code: `
+declare abstract class BaseClass {
+  get cursor(): string;
+}
+
+class ChildClass extends BaseClass {
+  override get cursor() {
+    return 'overridden value';
+  }
+}
+      `,
+    },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/3602
+      // property with override modifier should be ignored
+      code: `
+declare abstract class BaseClass {
+  protected readonly foo: string;
+}
+
+class ChildClass extends BaseClass {
+  protected override readonly foo = 'bar';
+}
+      `,
+      options: ['getters'],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #3602 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Note that this affects both the 'getters' and 'fields' style.