### PR TITLE
fix(rule-tester): allow custom filename outside directory

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -746,7 +746,15 @@ export class RuleTester extends TestFramework {
             ...configWithoutCustomKeys.linterOptions,
           },
         });
-        messages = this.#linter.verify(code, actualConfig, filename);
+        messages = this.#linter.verify(
+          code,
+          // ESLint uses an internal FlatConfigArray that extends @humanwhocodes/config-array.
+          Object.assign([], {
+            basePath: filename ? path.parse(filename).root : '',
+            getConfig: () => actualConfig,
+          }),
+          filename,
+        );
       } finally {
         SourceCode.prototype.applyInlineConfig = applyInlineConfig;
         SourceCode.prototype.applyLanguageOptions = applyLanguageOptions;

--- a/packages/rule-tester/tests/filename.test.ts
+++ b/packages/rule-tester/tests/filename.test.ts
@@ -1,0 +1,48 @@
+/* eslint-disable perfectionist/sort-objects */
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const ruleTester = new RuleTester();
+
+const rule = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    docs: {
+      description: 'some description',
+    },
+    messages: {
+      foo: 'It works',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+  create: context => ({
+    Program(node): void {
+      context.report({ node, messageId: 'foo' });
+    },
+  }),
+});
+
+describe('rule tester filename', () => {
+  ruleTester.run('absolute path', rule, {
+    invalid: [
+      {
+        code: '_',
+        errors: [{ messageId: 'foo' }],
+        filename: '/an-absolute-path/foo.js',
+      },
+    ],
+    valid: [],
+  });
+
+  ruleTester.run('relative path', rule, {
+    invalid: [
+      {
+        code: '_',
+        errors: [{ messageId: 'foo' }],
+        filename: '../foo.js',
+      },
+    ],
+    valid: [],
+  });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9906
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Allowing custom filenames outside the current directory in `RuleTester`.
Fix is similar to the one in ESLint [fix: handle absoulte file paths in RuleTester #17989](https://github.com/eslint/eslint/pull/17989).
Since we cannot directly use `FlatConfigArray`, I mock it with an Object containing a `basePath` property.
