### PR TITLE
chore: coverage issues caused by using `export` assignments

### DIFF
--- a/packages/eslint-plugin-internal/jest.config.js
+++ b/packages/eslint-plugin-internal/jest.config.js
@@ -4,5 +4,5 @@
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
   ...require('../../jest.config.base.js'),
-  coveragePathIgnorePatterns: ['src/index.ts$', 'src/configs/.*.ts$'],
+  modulePathIgnorePatterns: ['src/index.ts$', 'src/configs/.*.ts$'],
 };

--- a/packages/eslint-plugin/jest.config.js
+++ b/packages/eslint-plugin/jest.config.js
@@ -4,7 +4,11 @@
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
   ...require('../../jest.config.base.js'),
-  coveragePathIgnorePatterns: ['src/index.ts$', 'src/configs/.*.ts$'],
+  modulePathIgnorePatterns: [
+    'src/index.ts$',
+    'src/configs/.*.ts$',
+    'src/rules/index.ts$',
+  ],
   // intentionally empty, to exclude node_modules from ignore (we need to transform ESM dependencies)
   transformIgnorePatterns: [],
 };


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #10146.
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Change [`coveragePathIgnorePatterns`](https://jestjs.io/docs/configuration#coveragepathignorepatterns-arraystring) to [`modulePathIgnorePatterns`](https://jestjs.io/docs/configuration#modulepathignorepatterns-arraystring) to fix #10146.
