### PR TITLE
feat(eslint-plugin): add `no-inferred-any` rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-inferred-any.mdx
+++ b/packages/eslint-plugin/docs/rules/no-inferred-any.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 > See **https://typescript-eslint.io/rules/no-inferred-any** for documentation.
 
 Even if you never explicitly use the `any` type in your own code, you might
-unknownigly write code that variables with the type `any` or calls functions
+unknowingly write code that variables with the type `any` or calls functions
 which return `any`. These `any` types might come from:
 
 - Untyped JavaScript code in the same project, in a mixed TypeScript/JavaScript project
@@ -68,7 +68,7 @@ console.log(data2.property);
 
 By default, variables, exports, and function return types are all checked by
 this rule. But specific kinds of checks can be disabled, mainly to make it
-easier to incrementically introduce the rule into an existing codebase.
+easier to incrementally introduce the rule into an existing codebase.
 
 ### `checkExports`
 

--- a/packages/eslint-plugin/docs/rules/no-inferred-any.mdx
+++ b/packages/eslint-plugin/docs/rules/no-inferred-any.mdx
@@ -1,0 +1,163 @@
+---
+description: 'Disallow implicitly inferred `any` type.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-inferred-any** for documentation.
+
+Even if you never explicitly use the `any` type in your own code, you might
+unknownigly write code that variables with the type `any` or calls functions
+which return `any`. These `any` types might come from:
+
+- Untyped JavaScript code in the same project, in a mixed TypeScript/JavaScript project
+- Imported packages that use `any` in their type declarations
+- TypeScript's built-in types for native DOM APIs
+
+When this happens, it's easy to write code that looks like it's properly typed
+because there is no explicit `any` in the code itself, but in reality has almost
+no type checking because the variables are implicitly inferred as `any`.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+// TypeScript's built-in types for `.json()` return `Promise<any>`
+declare function fetch(url: string): Promise<Response>;
+interface Response {
+  json(): Promise<any>;
+}
+
+const response = await fetch('/');
+const data = await response.json();
+// If `data` is not an object this line will throw, but TypeScript doesn't complain.
+console.log(data.property);
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+// TypeScript's built-in types for `.json()` return `Promise<any>`
+declare function fetch(url: string): Promise<Response>;
+interface Response {
+  json(): Promise<any>;
+}
+
+const response = await fetch('/');
+const data: unknown = await response.json();
+if (data && typeof data === 'object' && 'property' in data) {
+  console.log(data.property);
+}
+
+// Adding an explicit type declaration will silence the linting error, even if
+// the declared type is `any`.
+const data2: any = await response.json();
+console.log(data2.property);
+```
+
+</TabItem>
+</Tabs>
+
+## Options
+
+By default, variables, exports, and function return types are all checked by
+this rule. But specific kinds of checks can be disabled, mainly to make it
+easier to incrementically introduce the rule into an existing codebase.
+
+### `checkExports`
+
+When true, the type of any variables and return type of any functions
+`export`-ed from a module will be checked.
+
+Examples of code for this rule with `checkExports: true`:
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+const value: any = {};
+export { value };
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+const value: unknown = {};
+export { value };
+```
+
+</TabItem>
+</Tabs>
+
+### `checkReturnTypes`
+
+When true, the return type of any functions will be checked.
+
+Examples of code for this rule with `checkReturnTypes: true`:
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+function test() {
+  const value: any = {};
+  return value;
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+function test(): unknown {
+  const value: any = {};
+  return value;
+}
+```
+
+</TabItem>
+</Tabs>
+
+### `checkVariables`
+
+When true, the type of any variable declarations (i.e. variables defined using
+`var`, `let` or `const` statements will be checked).
+
+Examples of code for this rule with `checkVariables: true`:
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+const value: any = {};
+const value2 = value;
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+const value: any = {};
+const value2: unknown = value;
+```
+
+</TabItem>
+</Tabs>
+
+## When Not To Use It
+
+If you are okay with the possibility of `any` types from other code causing
+variables, return types, and exports to implicitly have an `any` type, or your
+project has or uses `any` types often enough that enabling this rule would be
+impractical.
+
+If you aggressively avoid the use of type inference and always give explicit
+type declarations to variables and return types in your code, then this rule may
+not be necessary.

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -64,6 +64,7 @@ export = {
     '@typescript-eslint/no-implied-eval': 'error',
     '@typescript-eslint/no-import-type-side-effects': 'error',
     '@typescript-eslint/no-inferrable-types': 'error',
+    '@typescript-eslint/no-inferred-any': 'error',
     'no-invalid-this': 'off',
     '@typescript-eslint/no-invalid-this': 'error',
     '@typescript-eslint/no-invalid-void-type': 'error',

--- a/packages/eslint-plugin/src/configs/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/disable-type-checked.ts
@@ -23,6 +23,7 @@ export = {
     '@typescript-eslint/no-floating-promises': 'off',
     '@typescript-eslint/no-for-in-array': 'off',
     '@typescript-eslint/no-implied-eval': 'off',
+    '@typescript-eslint/no-inferred-any': 'off',
     '@typescript-eslint/no-meaningless-void-operator': 'off',
     '@typescript-eslint/no-misused-promises': 'off',
     '@typescript-eslint/no-mixed-enums': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -45,6 +45,7 @@ import noForInArray from './no-for-in-array';
 import noImpliedEval from './no-implied-eval';
 import noImportTypeSideEffects from './no-import-type-side-effects';
 import noInferrableTypes from './no-inferrable-types';
+import noInferredAny from './no-inferred-any';
 import noInvalidThis from './no-invalid-this';
 import noInvalidVoidType from './no-invalid-void-type';
 import noLoopFunc from './no-loop-func';
@@ -174,6 +175,7 @@ const rules = {
   'no-implied-eval': noImpliedEval,
   'no-import-type-side-effects': noImportTypeSideEffects,
   'no-inferrable-types': noInferrableTypes,
+  'no-inferred-any': noInferredAny,
   'no-invalid-this': noInvalidThis,
   'no-invalid-void-type': noInvalidVoidType,
   'no-loop-func': noLoopFunc,

--- a/packages/eslint-plugin/src/rules/no-inferred-any.ts
+++ b/packages/eslint-plugin/src/rules/no-inferred-any.ts
@@ -1,0 +1,308 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as typescript from 'typescript';
+
+import { createRule, getParserServices, isTypeAnyType } from '../util';
+
+const fixMessage = 'To fix, add explicit type declaration.';
+const messages = {
+  exportedAny: `Exported variable type inferred as \`any\`. ${fixMessage}`,
+  exportedAnyFunc: `Exported function return type inferred as \`any\`. ${fixMessage}`,
+  returnedAny: `Function return type inferred as \`any\`. ${fixMessage}`,
+  variableAny: `Variable type inferred as \`any\`. ${fixMessage}`,
+};
+
+export type MessageIds = keyof typeof messages;
+
+export interface OptionsObjectType {
+  checkExports?: boolean;
+  checkReturnTypes?: boolean;
+  checkVariables?: boolean;
+}
+
+export default createRule<[OptionsObjectType], MessageIds>({
+  name: 'no-inferred-any',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow implicitly inferred `any` type',
+      requiresTypeChecking: true,
+    },
+    messages,
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          checkExports: {
+            type: 'boolean',
+          },
+          checkReturnTypes: {
+            type: 'boolean',
+          },
+          checkVariables: {
+            type: 'boolean',
+          },
+        },
+      },
+    ],
+  },
+  defaultOptions: [
+    {
+      checkExports: true,
+      checkReturnTypes: true,
+      checkVariables: true,
+    },
+  ],
+  create(context, options) {
+    const service = getParserServices(context);
+    const typeChecker = service.program.getTypeChecker();
+
+    const [
+      {
+        checkExports = true,
+        checkReturnTypes = true,
+        checkVariables = true,
+      } = {},
+    ] = options;
+
+    const isExpressionAnyType = (node: TSESTree.Node): boolean => {
+      const tsNode = service.esTreeNodeToTSNodeMap.get(node);
+
+      let symbol = typeChecker.getSymbolAtLocation(tsNode);
+
+      // Get original symbol if this is an alias (e.g. an imported variable)
+      if (symbol && symbol.getFlags() & typescript.SymbolFlags.Alias) {
+        symbol = typeChecker.getAliasedSymbol(symbol);
+      }
+
+      const type =
+        // getTypeAtLocation returns a bogus error type if called on a non-value
+        // symbol (such as a symbol that references a type alias). To avoid
+        // this, use `getDeclaredTypeOfSymbol` to get the type if the node is a
+        // symbol.
+        symbol && !(symbol.getFlags() & typescript.SymbolFlags.Value)
+          ? typeChecker.getDeclaredTypeOfSymbol(symbol)
+          : typeChecker.getTypeAtLocation(tsNode);
+
+      // TODO: Also warn about any[] (behind configurable flag)
+      // TODO: Maybe also warn about Promise<any> (behind configurable flag)
+      return isTypeAnyType(type);
+    };
+
+    type FunctionNode =
+      | TSESTree.ArrowFunctionExpression
+      | TSESTree.FunctionDeclaration
+      | TSESTree.FunctionExpression;
+
+    const findParentFunction = (node: TSESTree.Node): FunctionNode => {
+      if (!node.parent) {
+        throw new Error('Could not find parent function');
+      } else if (
+        node.parent.type === AST_NODE_TYPES.FunctionExpression ||
+        node.parent.type === AST_NODE_TYPES.FunctionDeclaration ||
+        node.parent.type === AST_NODE_TYPES.ArrowFunctionExpression
+      ) {
+        return node.parent;
+      } else {
+        return findParentFunction(node.parent);
+      }
+    };
+
+    /**
+     * This helper is for finding the top-most function for a curried function,
+     * such as `() => () => (0 as any)`
+     */
+    const findTopParentFunction = (node: TSESTree.Node): FunctionNode => {
+      const parentFunction = findParentFunction(node);
+
+      if (
+        // Function is returned from a return statement
+        parentFunction.parent.type === AST_NODE_TYPES.ReturnStatement ||
+        // Function is returned as expression from arrow function
+        (parentFunction.parent.type ===
+          AST_NODE_TYPES.ArrowFunctionExpression &&
+          parentFunction.parent.expression &&
+          parentFunction.parent.body === parentFunction)
+      ) {
+        return findTopParentFunction(parentFunction);
+      }
+
+      return parentFunction;
+    };
+
+    const returnStatementHasExplicitType = (
+      node: TSESTree.ReturnStatement,
+    ): boolean => {
+      const parentFunction = findParentFunction(node);
+
+      return functionHasExplicitReturnType(parentFunction);
+    };
+
+    const functionHasExplicitReturnType = (node: FunctionNode): boolean => {
+      // Function has direct return type, such as `(): unknown => (0 as any)`
+      if (node.returnType !== undefined) {
+        return true;
+      }
+
+      // Function is assigned to a variable which has an explicit type, such as
+      // `const f: () => unknown = () => (0 as any)`
+      if (
+        node.parent.type === AST_NODE_TYPES.VariableDeclarator &&
+        node.parent.id.typeAnnotation !== undefined
+      ) {
+        return true;
+      }
+
+      // Function is returned from an arrow function as an expression, such as
+      // `() => () => (0 as any)`
+      if (node.parent.type === AST_NODE_TYPES.ArrowFunctionExpression) {
+        if (!node.parent.expression) {
+          // This should not be possible.
+          return false;
+        }
+
+        return functionHasExplicitReturnType(node.parent);
+      }
+
+      // Function is returned from a return statement, such as
+      // `return () => (0 as any)`
+      if (node.parent.type === AST_NODE_TYPES.ReturnStatement) {
+        return returnStatementHasExplicitType(node.parent);
+      }
+
+      return false;
+    };
+
+    const variableHasExplicitType = (
+      node: TSESTree.VariableDeclarator,
+    ): boolean => node.id.typeAnnotation !== undefined;
+
+    const valueIsExported = (node: TSESTree.Node): boolean =>
+      // export function f() {}
+      (node.type === AST_NODE_TYPES.FunctionDeclaration &&
+        node.parent.type === AST_NODE_TYPES.ExportNamedDeclaration) ||
+      // export const f = () => {}
+      // export const x = 1;
+      (node.parent?.type === AST_NODE_TYPES.VariableDeclarator &&
+        node.parent.parent.parent.type ===
+          AST_NODE_TYPES.ExportNamedDeclaration);
+
+    return {
+      ArrowFunctionExpression(node): void {
+        if (!node.expression) {
+          return;
+        }
+        const shouldCheckExport =
+          checkExports && valueIsExported(findTopParentFunction(node.body));
+        if (!checkReturnTypes && !shouldCheckExport) {
+          return;
+        }
+        if (functionHasExplicitReturnType(node)) {
+          return;
+        }
+        // isExpressionAnyType looks at the type information so it is the most
+        // expensive check and should always come last.
+        if (!isExpressionAnyType(node.body)) {
+          return;
+        }
+
+        if (shouldCheckExport) {
+          context.report({
+            node: node.body,
+            messageId: 'exportedAnyFunc',
+          });
+        }
+
+        if (checkReturnTypes) {
+          context.report({
+            node: node.body,
+            messageId: 'returnedAny',
+          });
+        }
+      },
+
+      ExportSpecifier(node): void {
+        if (checkExports && isExpressionAnyType(node.local)) {
+          // For example:
+          //
+          // ```
+          // const x: any = 0;
+          //
+          // export { x };
+          // ```
+          context.report({
+            node: node.local,
+            messageId: 'exportedAny',
+          });
+        }
+      },
+
+      ReturnStatement(node): void {
+        if (!node.argument) {
+          return;
+        }
+        const shouldCheckExport =
+          checkExports && valueIsExported(findTopParentFunction(node));
+        if (!checkReturnTypes && !shouldCheckExport) {
+          return;
+        }
+        if (returnStatementHasExplicitType(node)) {
+          return;
+        }
+        // isExpressionAnyType looks at the type information so it is the most
+        // expensive check and should always come last.
+        if (!isExpressionAnyType(node.argument)) {
+          return;
+        }
+
+        if (shouldCheckExport) {
+          context.report({
+            node: node.argument,
+            messageId: 'exportedAnyFunc',
+          });
+        }
+
+        if (checkReturnTypes) {
+          context.report({
+            node: node.argument,
+            messageId: 'returnedAny',
+          });
+        }
+      },
+
+      VariableDeclarator(node): void {
+        if (!node.init) {
+          return;
+        }
+        const shouldCheckExport = checkExports && valueIsExported(node.init);
+        if (!checkVariables && !shouldCheckExport) {
+          return;
+        }
+        if (variableHasExplicitType(node)) {
+          return;
+        }
+        // isExpressionAnyType looks at the type information so it is the most
+        // expensive check and should always come last.
+        if (!isExpressionAnyType(node.init)) {
+          return;
+        }
+
+        if (shouldCheckExport) {
+          context.report({
+            node: node.init,
+            messageId: 'exportedAny',
+          });
+        }
+
+        if (checkVariables) {
+          context.report({
+            node: node.init,
+            messageId: 'variableAny',
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-inferred-any.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-inferred-any.shot
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Validating rule docs no-inferred-any.mdx code examples ESLint output 1`] = `
+"Incorrect
+
+// TypeScript's built-in types for \`.json()\` return \`Promise<any>\`
+declare function fetch(url: string): Promise<Response>;
+interface Response {
+  json(): Promise<any>;
+}
+
+const response = await fetch('/');
+const data = await response.json();
+             ~~~~~~~~~~~~~~~~~~~~~ Variable type inferred as \`any\`. To fix, add explicit type declaration.
+// If \`data\` is not an object this line will throw, but TypeScript doesn't complain.
+console.log(data.property);
+"
+`;
+
+exports[`Validating rule docs no-inferred-any.mdx code examples ESLint output 2`] = `
+"Correct
+
+// TypeScript's built-in types for \`.json()\` return \`Promise<any>\`
+declare function fetch(url: string): Promise<Response>;
+interface Response {
+  json(): Promise<any>;
+}
+
+const response = await fetch('/');
+const data: unknown = await response.json();
+if (data && typeof data === 'object' && 'property' in data) {
+  console.log(data.property);
+}
+
+// Adding an explicit type declaration will silence the linting error, even if
+// the declared type is \`any\`.
+const data2: any = await response.json();
+console.log(data2.property);
+"
+`;
+
+exports[`Validating rule docs no-inferred-any.mdx code examples ESLint output 3`] = `
+"Incorrect
+
+const value: any = {};
+export { value };
+         ~~~~~ Exported variable type inferred as \`any\`. To fix, add explicit type declaration.
+"
+`;
+
+exports[`Validating rule docs no-inferred-any.mdx code examples ESLint output 4`] = `
+"Correct
+
+const value: unknown = {};
+export { value };
+"
+`;
+
+exports[`Validating rule docs no-inferred-any.mdx code examples ESLint output 5`] = `
+"Incorrect
+
+function test() {
+  const value: any = {};
+  return value;
+         ~~~~~ Function return type inferred as \`any\`. To fix, add explicit type declaration.
+}
+"
+`;
+
+exports[`Validating rule docs no-inferred-any.mdx code examples ESLint output 6`] = `
+"Correct
+
+function test(): unknown {
+  const value: any = {};
+  return value;
+}
+"
+`;
+
+exports[`Validating rule docs no-inferred-any.mdx code examples ESLint output 7`] = `
+"Incorrect
+
+const value: any = {};
+const value2 = value;
+               ~~~~~ Variable type inferred as \`any\`. To fix, add explicit type declaration.
+"
+`;
+
+exports[`Validating rule docs no-inferred-any.mdx code examples ESLint output 8`] = `
+"Correct
+
+const value: any = {};
+const value2: unknown = value;
+"
+`;

--- a/packages/eslint-plugin/tests/fixtures/no-inferred-any/exports-any.ts
+++ b/packages/eslint-plugin/tests/fixtures/no-inferred-any/exports-any.ts
@@ -1,0 +1,2 @@
+export const good = 0;
+export const bad = 0 as any;

--- a/packages/eslint-plugin/tests/rules/no-inferred-any.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-inferred-any.test.ts
@@ -1,0 +1,300 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import type {
+  MessageIds,
+  OptionsObjectType,
+} from '../../src/rules/no-inferred-any';
+
+import rule from '../../src/rules/no-inferred-any';
+import { getFixturesRootDir } from '../RuleTester';
+
+const testCases = (
+  {
+    messageIds,
+    options,
+  }: {
+    messageIds?: MessageIds[];
+    options?: OptionsObjectType;
+  },
+  cases: string[],
+): {
+  code: string;
+  errors: { messageId: MessageIds }[];
+  options: [OptionsObjectType];
+}[] =>
+  cases.map(code => ({
+    code,
+    errors: (messageIds ?? []).map(messageId => ({ messageId })),
+    options: [
+      {
+        checkExports: false,
+        checkReturnTypes: false,
+        checkVariables: false,
+        ...options,
+      },
+    ] as const,
+  }));
+
+const rootDir = getFixturesRootDir();
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    //parser: require.resolve('@typescript-eslint/parser'),
+    parserOptions: {
+      //ecmaVersion: 2018,
+      //ecmaFeatures: {
+      //jsx: true,
+      //},
+      // Needed to use import statements in test cases
+      //sourceType: 'module',
+      project: './tsconfig.json',
+      tsconfigRootDir: rootDir,
+    },
+  },
+});
+
+ruleTester.run('no-inferred-any', rule, {
+  valid: [
+    ...testCases(
+      {
+        options: {
+          checkReturnTypes: true,
+        },
+      },
+      [
+        `
+      function f(): any {
+        return (0 as any);
+      }
+      `,
+
+        `
+      function f(): any {
+        return 0;
+      }
+      `,
+
+        `
+      function f() {
+        return 0;
+      }
+      `,
+
+        `
+      type F = () => any;
+
+      const f: F = function() { return (0 as any); };
+      `,
+
+        `
+      type F = () => () => any;
+
+      const f: F = function() { return function() { return (0 as any); } };
+      `,
+
+        `
+      type F = () => () => any;
+
+      const f: F = () => () => (0 as any);
+      `,
+
+        `
+      const f = () => (): () => number => () => (0 as any);
+      `,
+
+        `
+      function f(): () => number {
+        return () => (0 as any);
+      }
+      `,
+
+        `
+      const x = (): any => function () {
+        return (0 as any);
+      };
+      `,
+
+        `
+      class Test {
+        public test(): any {
+          return (0 as any);
+        }
+      }
+      `,
+      ],
+    ),
+
+    ...testCases(
+      {
+        options: {
+          checkVariables: true,
+        },
+      },
+      [
+        `
+      const x: any = (0 as any);
+      `,
+      ],
+    ),
+
+    ...testCases(
+      {
+        options: {
+          checkExports: true,
+        },
+      },
+      [
+        `
+      export const x: any = (0 as any);
+      `,
+
+        `
+      type T = unknown;
+
+      export { T };
+      `,
+
+        `
+      import { good } from './no-inferred-any/exports-any';
+
+      export { good };
+      `,
+
+        `
+      export { good } from './no-inferred-any/exports-any';
+      `,
+      ],
+    ),
+
+    ...testCases({}, [
+      `
+      const x = (0 as any);
+      `,
+    ]),
+  ],
+  invalid: [
+    ...testCases(
+      {
+        messageIds: ['returnedAny'],
+        options: {
+          checkReturnTypes: true,
+        },
+      },
+      [
+        `
+      function f() {
+        return (0 as any);
+      }
+      `,
+
+        `
+      function f() {
+        const x: any = {};
+        return x;
+      }
+      `,
+
+        `
+      const f = () => () => () => (0 as any);
+      `,
+
+        `
+      class Test {
+        public test() {
+          return (0 as any);
+        }
+      }
+      `,
+      ],
+    ),
+
+    ...testCases(
+      {
+        messageIds: ['variableAny'],
+        options: {
+          checkVariables: true,
+        },
+      },
+      [
+        `
+      const x = (0 as any);
+      `,
+
+        `
+      const f = (): any => (0 as any);
+
+      const x = f();
+      `,
+      ],
+    ),
+
+    ...testCases(
+      {
+        messageIds: ['exportedAny'],
+        options: {
+          checkExports: true,
+        },
+      },
+      [
+        `
+      export const x = (0 as any);
+      `,
+
+        `
+      const x = (0 as any);
+
+      export { x };
+      `,
+
+        `
+      import { good, bad } from './no-inferred-any/exports-any';
+
+      export { good, bad };
+      `,
+
+        `
+      export { good, bad } from './no-inferred-any/exports-any';
+      `,
+      ],
+    ),
+
+    ...testCases(
+      {
+        messageIds: ['exportedAnyFunc'],
+        options: {
+          checkExports: true,
+        },
+      },
+      [
+        `
+      export const f = () => (0 as any);
+      `,
+
+        `
+      export const f = () => () => (0 as any);
+      `,
+
+        `
+      export const f = () => () => () => (0 as any);
+      `,
+
+        `
+      export const f = () => () => () => () => (0 as any);
+      `,
+        `
+      export const f = () => () => () => () => () => (0 as any);
+      `,
+
+        `
+      export const f = () => () => function () { return 0 as any; };
+      `,
+
+        `
+      export const f = () => (0 as any);
+
+      export { f };
+      `,
+      ],
+    ),
+  ],
+});

--- a/packages/eslint-plugin/tests/schema-snapshots/no-inferred-any.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-inferred-any.shot
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rule schemas should be convertible to TS types for documentation purposes no-inferred-any 1`] = `
+"
+# SCHEMA:
+
+[
+  {
+    "additionalProperties": false,
+    "properties": {
+      "checkExports": {
+        "type": "boolean"
+      },
+      "checkReturnTypes": {
+        "type": "boolean"
+      },
+      "checkVariables": {
+        "type": "boolean"
+      }
+    },
+    "type": "object"
+  }
+]
+
+
+# TYPES:
+
+type Options = [
+  {
+    checkExports?: boolean;
+    checkReturnTypes?: boolean;
+    checkVariables?: boolean;
+  },
+];
+"
+`;


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I apologize in advance for creating a pull request without first creating a ticket. I considered creating a ticket to explain the linting rule first, but because this rule was already fully implemented, I figured the best way to explain the rule might be to share implementation and tests themselves. Please let me know if you would like me to create a ticket anyway.

This linting rule is one that I created at work about 4 years ago (I have permission from my bosses to share this code), and we've been using it in our relatively large mixed TypeScript/JavaScript project to help catch accidental usages of `any`. I wanted to share it when I first created it, but completely forgot to and just remembered it recently. 😅

In a nutshell, the rule tries to catch cases where an `any` type is accidentally used due to type inference. For example:

```ts
const response = await fetch('/');
const data = await response.json();
// Oops, I forgot that TypeScript's built-in DOM API return types often use `any` instead of `unknown`!
// Ideally I should be forced to assert that the data matches the shape I expect,
// but `data` is inferred as `any` so there's essentially no type checking here.
data.nested.property;
```

It's particularly useful in projects with a mix of untyped JavaScript code and typed TypeScript code that use `allowJs`, because importing from JS modules will implicitly use the `any` type. But because it's relatively common for NPM packages or even TypeScript's built-in DOM types to use `any`, I think it could be useful in any TypeScript project.

Does this seem like a rule that would be worth adding to `typescript-eslint`?