### PR TITLE
docs: fix the Dependency Versions lists

### DIFF
--- a/docs/users/Dependency_Versions.mdx
+++ b/docs/users/Dependency_Versions.mdx
@@ -3,14 +3,15 @@ id: dependency-versions
 title: Dependency Versions
 ---
 
-import packageJson from '../../package.json';
+import rootPackageJson from '../../package.json';
+import eslintPluginPackageJson from '../../packages/eslint-plugin/package.json';
 
 ## ESLint
 
 <blockquote>
   <p>
     The version range of ESLint currently supported is{' '}
-    <code>{packageJson.devDependencies.eslint}</code>.
+    <code>{eslintPluginPackageJson.peerDependencies.eslint}</code>.
   </p>
 </blockquote>
 
@@ -21,7 +22,7 @@ We generally support at least the latest two major versions of ESLint; though so
 <blockquote>
   <p>
     The version range of NodeJS currently supported is{' '}
-    <code>{packageJson.engines.node}</code>.
+    <code>{rootPackageJson.engines.node}</code>.
   </p>
 </blockquote>
 
@@ -33,7 +34,7 @@ Support for specific Current status releases are considered periodically.
 <blockquote>
   <p>
     The version range of TypeScript currently supported is{' '}
-    <code>{packageJson.devDependencies.typescript}</code>.
+    <code>{rootPackageJson.devDependencies.typescript}</code>.
   </p>
 </blockquote>
 

--- a/docs/users/Dependency_Versions.mdx
+++ b/docs/users/Dependency_Versions.mdx
@@ -22,7 +22,7 @@ We generally support at least the latest two major versions of ESLint; though so
 <blockquote>
   <p>
     The version range of NodeJS currently supported is{' '}
-    <code>{rootPackageJson.engines.node}</code>.
+    <code>{eslintPluginPackageJson.engines.node}</code>.
   </p>
 </blockquote>
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10170
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
eslint's supported version range information has been modified to refer to peerDependencies in package.json of the eslint-plugin package.

<img width="963" alt="스크린샷 2024-10-20 오후 2 43 46" src="https://github.com/user-attachments/assets/534ddb2a-5a98-4d60-be89-c95ad3ee3aec">