### PR TITLE
chore: switch from explicit-function-return-type to explicit-module-boundary-types internally

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -125,10 +125,7 @@ export default tseslint.config(
         'error',
         { prefer: 'type-imports', disallowTypeAnnotations: true },
       ],
-      '@typescript-eslint/explicit-function-return-type': [
-        'error',
-        { allowIIFEs: true },
-      ],
+      '@typescript-eslint/explicit-module-boundary-types': 'error',
       '@typescript-eslint/no-explicit-any': 'error',
       'no-constant-condition': 'off',
       '@typescript-eslint/no-unnecessary-condition': [

--- a/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type -- Fancy mocks */
 import path from 'node:path';
 import * as ts from 'typescript';
 

--- a/packages/website-eslint/src/mock/path.js
+++ b/packages/website-eslint/src/mock/path.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a

--- a/packages/website/src/theme/prism-include-languages.js
+++ b/packages/website/src/theme/prism-include-languages.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import siteConfig from '@generated/docusaurus.config';
 
 export default function prismIncludeLanguages(PrismObject) {

--- a/packages/website/tools/typedoc-plugin-no-inherit-fork.mjs
+++ b/packages/website/tools/typedoc-plugin-no-inherit-fork.mjs
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-plus-operands */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-plus-operands */
 // Internal fork of https://github.com/jonchardy/typedoc-plugin-no-inherit,
 // pending https://github.com/jonchardy/typedoc-plugin-no-inherit/issues/34
 // https://github.com/jonchardy/typedoc-plugin-no-inherit/tree/c799761733e31198107db87d33aea0e673a996c3


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9419
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Purely switches the ESLint config and some necessary inline comments. Doesn't attempt to remove existing annotations.

💖 