### PR TITLE
fix(rule-tester): use cwd option to set base path for tests with file name

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -1276,7 +1276,7 @@ export class RuleTester extends TestFramework {
 
                     // Verify if suggestion fix makes a syntax error or not.
                     const errorMessageInSuggestion = this.#getLinterForFilename(
-                      undefined,
+                      item.filename,
                     )
                       .verify(
                         codeWithAppliedSuggestion,

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -201,19 +201,20 @@ export class RuleTester extends TestFramework {
   #getLinterForFilename(filename: string | undefined): Linter {
     let basePath: string | undefined =
       this.#testerConfig.languageOptions.parserOptions?.tsconfigRootDir;
-    if (filename !== undefined) {
-      // For an absolute path (`/foo.ts`), or a path that steps
-      // up (`../foo.ts`), resolve the path relative to the base
-      // path (using the current working directory if the parser
-      // options did not specify a base path) and use the file's
-      // root as the base path so that the file is under the base
-      // path. For any other path, which would just be a plain
-      // file name (`foo.ts`), don't change the base path.
-      if (filename.startsWith('/') || filename.startsWith('..')) {
-        basePath = path.parse(
-          path.resolve(basePath ?? process.cwd(), filename),
-        ).root;
-      }
+    // For an absolute path (`/foo.ts`), or a path that steps
+    // up (`../foo.ts`), resolve the path relative to the base
+    // path (using the current working directory if the parser
+    // options did not specify a base path) and use the file's
+    // root as the base path so that the file is under the base
+    // path. For any other path, which would just be a plain
+    // file name (`foo.ts`), don't change the base path.
+    if (
+      filename !== undefined &&
+      (filename.startsWith('/') || filename.startsWith('..'))
+    ) {
+      basePath = path.parse(
+        path.resolve(basePath ?? process.cwd(), filename),
+      ).root;
     }
 
     let linterForBasePath = this.#lintersByBasePath.get(basePath);

--- a/packages/rule-tester/tests/filename.test.ts
+++ b/packages/rule-tester/tests/filename.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable perfectionist/sort-objects */
-import { RuleTester } from '@typescript-eslint/rule-tester';
 import { ESLintUtils } from '@typescript-eslint/utils';
+
+import { RuleTester } from '../src/RuleTester';
 
 const rule = ESLintUtils.RuleCreator.withoutDocs({
   meta: {

--- a/packages/rule-tester/tests/filename.test.ts
+++ b/packages/rule-tester/tests/filename.test.ts
@@ -2,8 +2,6 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 import { ESLintUtils } from '@typescript-eslint/utils';
 
-const ruleTester = new RuleTester();
-
 const rule = ESLintUtils.RuleCreator.withoutDocs({
   meta: {
     docs: {
@@ -24,6 +22,8 @@ const rule = ESLintUtils.RuleCreator.withoutDocs({
 });
 
 describe('rule tester filename', () => {
+  const ruleTester = new RuleTester();
+
   ruleTester.run('absolute path', rule, {
     invalid: [
       {
@@ -36,6 +36,34 @@ describe('rule tester filename', () => {
   });
 
   ruleTester.run('relative path', rule, {
+    invalid: [
+      {
+        code: '_',
+        errors: [{ messageId: 'foo' }],
+        filename: '../foo.js',
+      },
+    ],
+    valid: [],
+  });
+
+  const ruleTesterWithRootDir = new RuleTester({
+    languageOptions: {
+      parserOptions: { tsconfigRootDir: '/some/path/that/totally/exists/' },
+    },
+  });
+
+  ruleTesterWithRootDir.run('absolute path with root dir', rule, {
+    invalid: [
+      {
+        code: '_',
+        errors: [{ messageId: 'foo' }],
+        filename: '/an-absolute-path/foo.js',
+      },
+    ],
+    valid: [],
+  });
+
+  ruleTesterWithRootDir.run('relative path with root dir', rule, {
     invalid: [
       {
         code: '_',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10191
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

If the `filename` specified in a test is absolute or steps up at least one directory, then the `Linter`'s `cwd` option is used to specify the base path.

When creating a `FlatConfigArray`, ESLint uses the linter's `cwd` option to specify the base path:
https://github.com/eslint/eslint/blob/725962731538eaa38d5d78b9e82ce3fccc9762d0/lib/linter/linter.js#L1524

The `cwd` option is specified when creating the `Linter` object:
https://github.com/eslint/eslint/blob/3a4eaf921543b1cd5d1df4ea9dec02fab396af2a/lib/linter/linter.js#L1304

That means the `RuleTester` may need to create multiple `Linter` objects. I've created a Map of `Linter` objects keyed by their base path. 

For absolute paths and paths that step up a directory, the base path is calculated by resolving the file name relative to either the `tsconfigRootDir` specified in the parser options, or `process.cwd()`. The root of that path is used as the base path. This is equivalent to what #10174 was fixing. For any other paths, the filename does not affect the base path, meaning the behavior prior to #10174 is used.

> [!WARNING]
> This bug only exists after ESLint v9.5 (see https://github.com/typescript-eslint/typescript-eslint/issues/10191#issuecomment-2427832579).

I have tested these changes locally against ESLint v9.13.0, but haven't updated the version in this PR. I'm not sure what the desired solution is in regards to testing against multiple ESLint versions.