### PR TITLE
fix(eslint-plugin): [no-unsafe-return] don't reiterate through all type parts for each part

### DIFF
--- a/packages/type-utils/src/predicates.ts
+++ b/packages/type-utils/src/predicates.ts
@@ -131,7 +131,7 @@ export function discriminateAnyType(
     return AnyType.AnyArray;
   }
   for (const part of tsutils.typeParts(type)) {
-    if (tsutils.isThenableType(checker, tsNode, type)) {
+    if (tsutils.isThenableType(checker, tsNode, part)) {
       const awaitedType = checker.getAwaitedType(part);
       if (awaitedType) {
         const awaitedAnyType = discriminateAnyType(


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #10196
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Prevents the whole type from being looped through `isThenableType` once for each part of the type.  