### PR TITLE
test(eslint-plugin): fix a typo in a test, causing it to test the `error` type rather than the `unknown` type

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts
@@ -74,7 +74,7 @@ const x = [new Map<string, string>()] as const;
 foo(new Set<string>(), ...x);
     `,
     `
-declare function foo(arg1: unknown, arg2: Set<unkown>, arg3: unknown[]): void;
+declare function foo(arg1: unknown, arg2: Set<unknown>, arg3: unknown[]): void;
 foo(1 as any, new Set<any>(), [] as any[]);
     `,
     `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I was making some changes as part of another PR and noticed this. I didn't open an issue with how small this is, I hope this is OK.

Errors like this will surface once https://github.com/typescript-eslint/typescript-eslint/issues/8298 is tackled.

<!-- Description of what is changed and how the code change does that. -->
