### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] falsey bigint should be falsey

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -39,7 +39,7 @@ const getValue = (type: ts.LiteralType): bigint | number | string => {
   return type.value;
 };
 
-const isFalseyBigInt = (type: ts.Type): boolean => {
+const isFalsyBigInt = (type: ts.Type): boolean => {
   return (
     tsutils.isLiteralType(type) &&
     valueIsPseudoBigInt(type.value) &&

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -24,12 +24,25 @@ import {
   findTypeGuardAssertedArgument,
 } from '../util/assertionFunctionUtils';
 
+const valueIsPseudoBigInt = (
+  value: number | string | ts.PseudoBigInt,
+): value is ts.PseudoBigInt => {
+  return typeof value === 'object' && 'base10Value' in value;
+};
+
+const getValue = (type: ts.LiteralType): bigint | number | string => {
+  if (valueIsPseudoBigInt(type.value)) {
+    return BigInt(type.value.base10Value);
+  }
+  return type.value;
+};
+
 // Truthiness utilities
 // #region
 const isTruthyLiteral = (type: ts.Type): boolean =>
   tsutils.isTrueLiteralType(type) ||
   //  || type.
-  (type.isLiteral() && !!type.value);
+  (type.isLiteral() && !!getValue(type));
 
 const isPossiblyFalsy = (type: ts.Type): boolean =>
   tsutils

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -29,7 +29,7 @@ import {
 const valueIsPseudoBigInt = (
   value: number | string | ts.PseudoBigInt,
 ): value is ts.PseudoBigInt => {
-  return typeof value === 'object' && 'base10Value' in value;
+  return typeof value === 'object'
 };
 
 const getValue = (type: ts.LiteralType): bigint | number | string => {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -29,7 +29,7 @@ import {
 const valueIsPseudoBigInt = (
   value: number | string | ts.PseudoBigInt,
 ): value is ts.PseudoBigInt => {
-  return typeof value === 'object'
+  return typeof value === 'object';
 };
 
 const getValue = (type: ts.LiteralType): bigint | number | string => {
@@ -69,7 +69,13 @@ const isPossiblyTruthy = (type: ts.Type): boolean =>
     .some(intersectionParts =>
       // It is possible to define intersections that are always falsy,
       // like `"" & { __brand: string }`.
-      intersectionParts.every(type => !tsutils.isFalsyType(type)),
+      intersectionParts.every(
+        type =>
+          !tsutils.isFalsyType(type) &&
+          // below is a workaround for ts-api-utils bug
+          // see https://github.com/JoshuaKGoldberg/ts-api-utils/issues/544
+          !isFalseyBigInt(type),
+      ),
     );
 
 // Nullish utilities
@@ -326,8 +332,6 @@ export default createRule<Options, MessageId>({
         messageId = !isUnaryNotArgument ? 'alwaysFalsy' : 'alwaysTruthy';
       } else if (!isPossiblyFalsy(type)) {
         messageId = !isUnaryNotArgument ? 'alwaysTruthy' : 'alwaysFalsy';
-      } else if (isFalseyBigInt(type)) {
-        messageId = 'alwaysFalsy';
       }
 
       if (messageId) {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -34,7 +34,7 @@ const valueIsPseudoBigInt = (
 
 const getValue = (type: ts.LiteralType): bigint | number | string => {
   if (valueIsPseudoBigInt(type.value)) {
-    return BigInt(type.value.base10Value);
+    return BigInt((type.value.negative ? '-' : '') + type.value.base10Value);
   }
   return type.value;
 };

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -74,7 +74,7 @@ const isPossiblyTruthy = (type: ts.Type): boolean =>
           !tsutils.isFalsyType(type) &&
           // below is a workaround for ts-api-utils bug
           // see https://github.com/JoshuaKGoldberg/ts-api-utils/issues/544
-          !isFalseyBigInt(type),
+          !isFalsyBigInt(type),
       ),
     );
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -24,6 +24,8 @@ import {
   findTypeGuardAssertedArgument,
 } from '../util/assertionFunctionUtils';
 
+// Truthiness utilities
+// #region
 const valueIsPseudoBigInt = (
   value: number | string | ts.PseudoBigInt,
 ): value is ts.PseudoBigInt => {
@@ -37,8 +39,13 @@ const getValue = (type: ts.LiteralType): bigint | number | string => {
   return type.value;
 };
 
-// Truthiness utilities
-// #region
+const isFalseyBigInt = (type: ts.Type): boolean => {
+  return (
+    tsutils.isLiteralType(type) &&
+    valueIsPseudoBigInt(type.value) &&
+    !getValue(type)
+  );
+};
 const isTruthyLiteral = (type: ts.Type): boolean =>
   tsutils.isTrueLiteralType(type) ||
   //  || type.
@@ -319,6 +326,8 @@ export default createRule<Options, MessageId>({
         messageId = !isUnaryNotArgument ? 'alwaysFalsy' : 'alwaysTruthy';
       } else if (!isPossiblyFalsy(type)) {
         messageId = !isUnaryNotArgument ? 'alwaysTruthy' : 'alwaysFalsy';
+      } else if (isFalseyBigInt(type)) {
+        messageId = 'alwaysFalsy';
       }
 
       if (messageId) {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1040,6 +1040,10 @@ switch (b1) {
     unnecessaryConditionTest('void', 'alwaysFalsy'),
     unnecessaryConditionTest('never', 'never'),
     unnecessaryConditionTest('string & number', 'never'),
+    unnecessaryConditionTest(
+      'declare const falseyBigInt: 0n; if (falseyBigInt) {}',
+      'alwaysFalsy',
+    ),
 
     // More complex logical expressions
     {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1047,7 +1047,7 @@ declare const falseyBigInt: 0n;
 if (falseyBigInt) {
 }
       `,
-      errors: [ruleError(2, 5, 'alwaysFalsy')],
+      errors: [ruleError(3, 5, 'alwaysFalsy')],
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -86,6 +86,11 @@ declare function foo(): number | void;
 const result1 = foo() === undefined;
 const result2 = foo() == null;
     `,
+    `
+declare const bigInt: 0n | 1n;
+if (bigInt) {
+}
+    `,
     necessaryConditionTest('false | 5'), // Truthy literal and falsy literal
     necessaryConditionTest('boolean | "foo"'), // boolean and truthy literal
     necessaryConditionTest('0 | boolean'), // boolean and falsy literal

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1051,6 +1051,22 @@ if (falseyBigInt) {
     },
     {
       code: `
+declare const posbigInt: 1n;
+if (posbigInt) {
+}
+      `,
+      errors: [ruleError(3, 5, 'alwaysTruthy')],
+    },
+    {
+      code: `
+declare const negBigInt: -2n;
+if (negBigInt) {
+}
+      `,
+      errors: [ruleError(3, 5, 'alwaysTruthy')],
+    },
+    {
+      code: `
 declare const b1: boolean;
 declare const b2: boolean;
 if (true && b1 && b2) {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1040,12 +1040,15 @@ switch (b1) {
     unnecessaryConditionTest('void', 'alwaysFalsy'),
     unnecessaryConditionTest('never', 'never'),
     unnecessaryConditionTest('string & number', 'never'),
-    unnecessaryConditionTest(
-      'declare const falseyBigInt: 0n; if (falseyBigInt) {}',
-      'alwaysFalsy',
-    ),
-
     // More complex logical expressions
+    {
+      code: `
+declare const falseyBigInt: 0n;
+if (falseyBigInt) {
+}
+      `,
+      errors: [ruleError(2, 5, 'alwaysFalsy')],
+    },
     {
       code: `
 declare const b1: boolean;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10197
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This adds a utility function to check for a falseyBigInt. I implemented functions to convert `type.value` to BigInt when necessary, yet this still required the extra condition in `checkNode` for the specific edge case.
