### PR TITLE
fix(utils): allow an array for the values of SharedConfig

### DIFF
--- a/packages/utils/src/ts-eslint/Config.ts
+++ b/packages/utils/src/ts-eslint/Config.ts
@@ -150,7 +150,7 @@ export namespace FlatConfig {
   export type SourceType = 'commonjs' | ParserOptionsTypes.SourceType;
 
   export interface SharedConfigs {
-    [key: string]: Config;
+    [key: string]: Config | ConfigArray;
   }
   export interface Plugin {
     /**


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10213
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

According to the docs for ESLint an array should be allowed here, and the type used by ESLint in their `ESLint.Plugin` interface is:

    Record<string, Linter.LegacyConfig | Linter.Config | Linter.Config[]> | undefined

So we should also allow an array. The helper function `tseslint.config` returns an array so without this you're not allowed to use a config returned by this function as a value in this record.

Fixes #10213

💖