### PR TITLE
fix(eslint-plugin): [switch-exhaustiveness-check] invert `considerDefaultExhaustiveForUnions`

### DIFF
--- a/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.mdx
+++ b/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.mdx
@@ -65,10 +65,7 @@ If set to true, a `switch` statement over a union type that includes a `default`
 Otherwise, the rule enforces explicitly handling every constituent of the union type with their own explicit `case`.
 Keeping this option disabled can be useful if you want to make sure every value added to the union receives explicit handling, with the `default` case reserved for reporting an error.
 
-Examples of code with `{ considerDefaultExhaustiveForUnions: true }`:
-
-<Tabs>
-<TabItem value="❌ Incorrect">
+Examples of additional **correct** code with `{ considerDefaultExhaustiveForUnions: true }`:
 
 ```ts option='{ "considerDefaultExhaustiveForUnions": true }' showPlaygroundButton
 declare const literal: 'a' | 'b';
@@ -80,37 +77,10 @@ switch (literal) {
     break;
 }
 ```
-
-</TabItem>
-
-<TabItem value="✅ Correct">
-
-```ts option='{ "considerDefaultExhaustiveForUnions": true }' showPlaygroundButton
-declare const literal: 'a' | 'b';
-
-switch (literal) {
-  case 'a':
-    break;
-  case 'b':
-    break;
-  default:
-    break;
-}
-
-switch (literal) {
-  case 'a':
-    break;
-  case 'b':
-    break;
-}
-```
-
-</TabItem>
-</Tabs>
 
 ## Examples
 
-When the switch doesn't have exhaustive cases, either filling them all out or adding a default will correct the rule's complaint.
+When the switch doesn't have exhaustive cases, either filling them all out or adding a default (if you have `considerDefaultExhaustiveForUnions` enabled) will address the rule's complaint.
 
 Here are some examples of code working with a union of literals:
 
@@ -181,7 +151,9 @@ switch (day) {
 </TabItem>
 <TabItem value="✅ Correct (Defaulted)">
 
-```ts
+```ts option='{ "considerDefaultExhaustiveForUnions": true }'
+// requires `considerDefaultExhaustiveForUnions` to be set to true
+
 type Day =
   | 'Monday'
   | 'Tuesday'
@@ -257,7 +229,9 @@ switch (fruit) {
 </TabItem>
 <TabItem value="✅ Correct (Defaulted)">
 
-```ts
+```ts option='{ "considerDefaultExhaustiveForUnions": true }'
+// requires `considerDefaultExhaustiveForUnions` to be set to true
+
 enum Fruit {
   Apple,
   Banana,

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -174,9 +174,9 @@ export default createRule<Options, MessageIds>({
       const { defaultCase, missingLiteralBranchTypes, symbolName } =
         switchMetadata;
 
-      // Unless considerDefaultExhaustiveForUnions is enabled, the presence of a default case
+      // If considerDefaultExhaustiveForUnions is enabled, the presence of a default case
       // always makes the switch exhaustive.
-      if (!considerDefaultExhaustiveForUnions && defaultCase != null) {
+      if (considerDefaultExhaustiveForUnions && defaultCase != null) {
         return;
       }
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/switch-exhaustiveness-check.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/switch-exhaustiveness-check.shot
@@ -16,13 +16,11 @@ switch (value) {
 `;
 
 exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 2`] = `
-"Incorrect
-Options: { "considerDefaultExhaustiveForUnions": true }
+"Options: { "considerDefaultExhaustiveForUnions": true }
 
 declare const literal: 'a' | 'b';
 
 switch (literal) {
-        ~~~~~~~ Switch is not exhaustive. Cases not matched: "b"
   case 'a':
     break;
   default:
@@ -32,30 +30,6 @@ switch (literal) {
 `;
 
 exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 3`] = `
-"Correct
-Options: { "considerDefaultExhaustiveForUnions": true }
-
-declare const literal: 'a' | 'b';
-
-switch (literal) {
-  case 'a':
-    break;
-  case 'b':
-    break;
-  default:
-    break;
-}
-
-switch (literal) {
-  case 'a':
-    break;
-  case 'b':
-    break;
-}
-"
-`;
-
-exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 4`] = `
 "Incorrect
 
 type Day =
@@ -79,7 +53,7 @@ switch (day) {
 "
 `;
 
-exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 5`] = `
+exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 4`] = `
 "Correct
 
 type Day =
@@ -120,8 +94,11 @@ switch (day) {
 "
 `;
 
-exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 6`] = `
+exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 5`] = `
 "Correct
+Options: { "considerDefaultExhaustiveForUnions": true }
+
+// requires \`considerDefaultExhaustiveForUnions\` to be set to true
 
 type Day =
   | 'Monday'
@@ -145,7 +122,7 @@ switch (day) {
 "
 `;
 
-exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 7`] = `
+exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 6`] = `
 "Incorrect
 
 enum Fruit {
@@ -165,7 +142,7 @@ switch (fruit) {
 "
 `;
 
-exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 8`] = `
+exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 7`] = `
 "Correct
 
 enum Fruit {
@@ -192,8 +169,11 @@ switch (fruit) {
 "
 `;
 
-exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 9`] = `
+exports[`Validating rule docs switch-exhaustiveness-check.mdx code examples ESLint output 8`] = `
 "Correct
+Options: { "considerDefaultExhaustiveForUnions": true }
+
+// requires \`considerDefaultExhaustiveForUnions\` to be set to true
 
 enum Fruit {
   Apple,

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -144,29 +144,36 @@ function test(value: Union): number {
 }
     `,
     // Switch contains default clause.
-    `
-type Day =
-  | 'Monday'
-  | 'Tuesday'
-  | 'Wednesday'
-  | 'Thursday'
-  | 'Friday'
-  | 'Saturday'
-  | 'Sunday';
+    {
+      code: `
+  type Day =
+    | 'Monday'
+    | 'Tuesday'
+    | 'Wednesday'
+    | 'Thursday'
+    | 'Friday'
+    | 'Saturday'
+    | 'Sunday';
 
-const day = 'Monday' as Day;
-let result = 0;
+  const day = 'Monday' as Day;
+  let result = 0;
 
-switch (day) {
-  case 'Monday': {
-    result = 1;
-    break;
+  switch (day) {
+    case 'Monday': {
+      result = 1;
+      break;
+    }
+    default: {
+      result = 42;
+    }
   }
-  default: {
-    result = 42;
-  }
-}
-    `,
+      `,
+      options: [
+        {
+          considerDefaultExhaustiveForUnions: true,
+        },
+      ],
+    },
     // Exhaustiveness check only works for union types...
     `
 const day = 'Monday' as string;
@@ -553,6 +560,7 @@ switch (value) {
       options: [
         {
           allowDefaultCaseForExhaustiveSwitch: true,
+          considerDefaultExhaustiveForUnions: true,
           requireDefaultForNonUnion: false,
         },
       ],
@@ -570,6 +578,7 @@ switch (value) {
       options: [
         {
           allowDefaultCaseForExhaustiveSwitch: false,
+          considerDefaultExhaustiveForUnions: true,
           requireDefaultForNonUnion: false,
         },
       ],
@@ -745,6 +754,7 @@ switch (value) {
       options: [
         {
           allowDefaultCaseForExhaustiveSwitch: true,
+          considerDefaultExhaustiveForUnions: true,
           requireDefaultForNonUnion: true,
         },
       ],
@@ -762,6 +772,7 @@ switch (value) {
       options: [
         {
           allowDefaultCaseForExhaustiveSwitch: false,
+          considerDefaultExhaustiveForUnions: true,
           requireDefaultForNonUnion: true,
         },
       ],
@@ -832,8 +843,6 @@ declare const literal: 'a' | 'b';
 switch (literal) {
   case 'a':
     break;
-  case 'b':
-    break;
   default:
     break;
 }
@@ -857,7 +866,6 @@ switch (literal) {
       options: [
         {
           allowDefaultCaseForExhaustiveSwitch: false,
-          considerDefaultExhaustiveForUnions: true,
         },
       ],
     },
@@ -876,8 +884,6 @@ switch (myEnum) {
     break;
   case MyEnum.Bar:
     break;
-  case MyEnum.Baz:
-    break;
   default: {
     break;
   }
@@ -894,8 +900,6 @@ switch (myEnum) {
 declare const value: boolean;
 switch (value) {
   case false:
-    break;
-  case true:
     break;
   default: {
     break;
@@ -2507,7 +2511,7 @@ switch (literal) {
       ],
       options: [
         {
-          considerDefaultExhaustiveForUnions: true,
+          considerDefaultExhaustiveForUnions: false,
         },
       ],
     },
@@ -2539,11 +2543,6 @@ switch (literal) {
       `,
             },
           ],
-        },
-      ],
-      options: [
-        {
-          considerDefaultExhaustiveForUnions: true,
         },
       ],
     },
@@ -2581,7 +2580,7 @@ switch (literal) {
       ],
       options: [
         {
-          considerDefaultExhaustiveForUnions: true,
+          considerDefaultExhaustiveForUnions: false,
         },
       ],
     },
@@ -2622,7 +2621,7 @@ switch (literal) {
       ],
       options: [
         {
-          considerDefaultExhaustiveForUnions: true,
+          considerDefaultExhaustiveForUnions: false,
         },
       ],
     },
@@ -2677,7 +2676,7 @@ switch (myEnum) {
       ],
       options: [
         {
-          considerDefaultExhaustiveForUnions: true,
+          considerDefaultExhaustiveForUnions: false,
         },
       ],
     },
@@ -2714,7 +2713,7 @@ switch (value) {
       ],
       options: [
         {
-          considerDefaultExhaustiveForUnions: true,
+          considerDefaultExhaustiveForUnions: false,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -146,27 +146,27 @@ function test(value: Union): number {
     // Switch contains default clause.
     {
       code: `
-  type Day =
-    | 'Monday'
-    | 'Tuesday'
-    | 'Wednesday'
-    | 'Thursday'
-    | 'Friday'
-    | 'Saturday'
-    | 'Sunday';
+type Day =
+  | 'Monday'
+  | 'Tuesday'
+  | 'Wednesday'
+  | 'Thursday'
+  | 'Friday'
+  | 'Saturday'
+  | 'Sunday';
 
-  const day = 'Monday' as Day;
-  let result = 0;
+const day = 'Monday' as Day;
+let result = 0;
 
-  switch (day) {
-    case 'Monday': {
-      result = 1;
-      break;
-    }
-    default: {
-      result = 42;
-    }
+switch (day) {
+  case 'Monday': {
+    result = 1;
+    break;
   }
+  default: {
+    result = 42;
+  }
+}
       `,
       options: [
         {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10222
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- [x] flip boolean
- [x] fix unit tests
- [x] correct docs examples