### PR TITLE
docs: fix typo

### DIFF
--- a/docs/users/What_About_Formatting.mdx
+++ b/docs/users/What_About_Formatting.mdx
@@ -23,7 +23,7 @@ Linters are designed to run in a parse, check, report, fix cycle. This means tha
 
 Additionally linters typically run each rule isolated from one another. This has several problems with it such as:
 
-- any two lint rules can't share config meaning one lint rule's fixer might introduce a violation of another lint rule's fixer (eg one lint rule might use the incorrect indentation character).
+- any two lint rules can't share config, meaning one lint rule's fixer might introduce a violation of another lint rule's fixer (eg one lint rule might use the incorrect indentation character).
 - lint rule fixers can conflict (apply to the same code range), forcing the linter to perform an additional cycle to attempt to apply a fixer to a clean set of code.
 
 These problems cause a linter to be much slower - which can be much more of a problem in projects that enable [typed linting](../getting-started/Typed_Linting.mdx).


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue:
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

That comma makes the sentence less confusing, especially for non-native English-readers