### PR TITLE
fix(eslint-plugin): [switch-exhaustiveness-check] add support for covering a missing property with `undefined`

### DIFF
--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -155,10 +155,10 @@ export default createRule<Options, MessageIds>({
             continue;
           }
 
-          // `undefined` should cover the "missing" undefined type
-          // https://github.com/microsoft/TypeScript/blob/cb44488fcec4348a448434afbf2ebcbf2b423c61/src/compiler/checker.ts/#L2059
+          // "missing", "optional" and "undefined" types are different runtime objects,
+          // but all of them have TypeFlags.Undefined type flag
           if (
-            caseTypes.has(checker.getUndefinedType()) &&
+            Array.from(caseTypes).some(tsutils.isIntrinsicUndefinedType) &&
             tsutils.isIntrinsicUndefinedType(intersectionPart)
           ) {
             continue;

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -158,7 +158,7 @@ export default createRule<Options, MessageIds>({
           // "missing", "optional" and "undefined" types are different runtime objects,
           // but all of them have TypeFlags.Undefined type flag
           if (
-            Array.from(caseTypes).some(tsutils.isIntrinsicUndefinedType) &&
+            [...caseTypes].some(tsutils.isIntrinsicUndefinedType) &&
             tsutils.isIntrinsicUndefinedType(intersectionPart)
           ) {
             continue;

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -155,6 +155,15 @@ export default createRule<Options, MessageIds>({
             continue;
           }
 
+          // `undefined` should cover the "missing" undefined type
+          // https://github.com/microsoft/TypeScript/blob/cb44488fcec4348a448434afbf2ebcbf2b423c61/src/compiler/checker.ts/#L2059
+          if (
+            caseTypes.has(checker.getUndefinedType()) &&
+            tsutils.isIntrinsicUndefinedType(intersectionPart)
+          ) {
+            continue;
+          }
+
           missingLiteralBranchTypes.push(intersectionPart);
         }
       }

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -912,6 +912,24 @@ switch (value) {
         },
       ],
     },
+    {
+      code: `
+function foo(x: string[]) {
+  switch (x[0]) {
+    case 'hi':
+      break;
+    case undefined:
+      break;
+  }
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          tsconfigRootDir: rootPath,
+        },
+      },
+    },
   ],
   invalid: [
     {
@@ -2716,6 +2734,43 @@ switch (value) {
           considerDefaultExhaustiveForUnions: false,
         },
       ],
+    },
+    {
+      code: `
+function foo(x: string[]) {
+  switch (x[0]) {
+    case 'hi':
+      break;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 11,
+          line: 3,
+          messageId: 'switchIsNotExhaustive',
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+function foo(x: string[]) {
+  switch (x[0]) {
+    case 'hi':
+      break;
+    case undefined: { throw new Error('Not implemented yet: undefined case') }
+  }
+}
+      `,
+            },
+          ],
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          tsconfigRootDir: rootPath,
+        },
+      },
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -2768,6 +2768,7 @@ function foo(x: string[]) {
       languageOptions: {
         parserOptions: {
           project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
           tsconfigRootDir: rootPath,
         },
       },

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -926,6 +926,7 @@ function foo(x: string[]) {
       languageOptions: {
         parserOptions: {
           project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
           tsconfigRootDir: rootPath,
         },
       },

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -931,6 +931,29 @@ function foo(x: string[]) {
         },
       },
     },
+    {
+      code: `
+function foo(x: string[], y: string | undefined) {
+  const a = x[0];
+  if (typeof a === 'string') {
+    return;
+  }
+  switch (y) {
+    case 'hi':
+      break;
+    case a:
+      break;
+  }
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: rootPath,
+        },
+      },
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10228
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR resolves #10228. Apparently, TypeScript has a different type [when a property could be missing](https://github.com/microsoft/TypeScript/blob/cb44488fcec4348a448434afbf2ebcbf2b423c61/src/compiler/checker.ts/#L2059) rather than the standard `undefined` type. Both types have the same object flags but different `debugIntrinsicName`, making them not match for the current equality check (along with a different `id` key). 

This issue isn't related to the recent fix in https://github.com/typescript-eslint/typescript-eslint/pull/10223 and can be tracked a while back. I didn't bother checking that the type is actually the missing type (it would require checking the currently untyped `debugIntrinsicName`) and just comparing for the standard undefined object flags (which match both the standard and the missing undefined types).