### PR TITLE
fix(eslint-plugin): [consistent-type-definitions] don't leave trailing parens when fixing type to interface

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-definitions.ts
@@ -1,7 +1,6 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 
-import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
-import * as ts from 'typescript';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import { createRule, nullThrows, NullThrowsReasons } from '../util';
 

--- a/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
@@ -97,6 +97,18 @@ export type W<T> = {
       output: `interface T { x: number; }`,
     },
     {
+      code: noFormat`type T /* comment */={ x: number; };`,
+      errors: [
+        {
+          column: 6,
+          line: 1,
+          messageId: 'interfaceOverType',
+        },
+      ],
+      options: ['interface'],
+      output: `interface T /* comment */ { x: number; }`,
+    },
+    {
       code: `
 export type W<T> = {
   x: T;

--- a/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
@@ -417,5 +417,49 @@ interface Foo {
 }
       `,
     },
+    {
+      // no closing semicolon; ensure we don't erase subsequent code.
+      code: noFormat`
+type Foo = {
+  a: string;
+}
+type Bar = string;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'interfaceOverType',
+        },
+      ],
+      output: `
+interface Foo {
+  a: string;
+}
+type Bar = string;
+      `,
+    },
+    {
+      // no closing semicolon; ensure we don't erase subsequent code.
+      code: noFormat`
+type Foo = ((({
+  a: string;
+})))
+
+const bar = 1;
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'interfaceOverType',
+        },
+      ],
+      output: `
+interface Foo {
+  a: string;
+}
+
+const bar = 1;
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
@@ -386,5 +386,24 @@ interface Foo {
 }
       `,
     },
+    {
+      // no closing semicolon
+      code: noFormat`
+type Foo = {
+  a: string;
+}
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'interfaceOverType',
+        },
+      ],
+      output: `
+interface Foo {
+  a: string;
+}
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-definitions.test.ts
@@ -350,5 +350,41 @@ export declare type Test = {
 }
       `,
     },
+    {
+      code: noFormat`
+type Foo = ({
+  a: string;
+});
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'interfaceOverType',
+        },
+      ],
+      output: `
+interface Foo {
+  a: string;
+}
+      `,
+    },
+    {
+      code: noFormat`
+type Foo = ((((((((({
+  a: string;
+})))))))));
+      `,
+      errors: [
+        {
+          line: 2,
+          messageId: 'interfaceOverType',
+        },
+      ],
+      output: `
+interface Foo {
+  a: string;
+}
+      `,
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10233 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

rewrite the fixer to be more robust