### PR TITLE
fix(types): parent property type annotation in the ImportAttribute node

### DIFF
--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -51,7 +51,10 @@ declare module './generated/ast-spec' {
   }
 
   interface ImportAttribute {
-    parent: TSESTree.ImportDeclaration | TSESTree.ImportExpression;
+    parent:
+      | TSESTree.ExportAllDeclaration
+      | TSESTree.ExportNamedDeclaration
+      | TSESTree.ImportDeclaration;
   }
 
   interface ImportDefaultSpecifier {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10254
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR fixes the `ImportAttribute#parent` type.
