### PR TITLE
docs: fix "the a" typo in FAQ

### DIFF
--- a/docs/troubleshooting/faqs/General.mdx
+++ b/docs/troubleshooting/faqs/General.mdx
@@ -15,7 +15,7 @@ First make sure you've read the docs and understand ESLint configuration files:
 - [Checkout ESLint's documentation on configuring rules](https://eslint.org/docs/latest/use/configure/rules) to ensure you understand how to configure rules.
 
 Our [rule docs](/rules) detail the options each rule supports under the "Options" heading.
-We use TypeScript types to describe an `Options` tuple type for the rule which you can use to configure the a rule.
+We use TypeScript types to describe an `Options` tuple type for the rule which you can use to configure the rule.
 In your config file the keys of the `rules` object are the names of the rules you wish to configure and the values follow the following form:
 
 ```ts


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This a documentation change. It makes the General FAQ less confusing