### PR TITLE
fix(eslint-plugin): [promise-function-async] handle function overloading

### DIFF
--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -122,7 +122,7 @@ export default createRule<Options, MessageIds>({
         return;
       }
 
-      const returnType = signature.getReturnType();
+      const returnType = checker.getReturnTypeOfSignature(signature);
 
       if (
         !containsAllTypesByName(

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -157,8 +157,7 @@ export default createRule<Options, MessageIds>({
         returnTypes.every(type =>
           containsAllTypesByName(
             type,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            allowAny!,
+            true,
             allAllowedPromiseNames,
             // If no return type is explicitly set, we check if any parts of the return type match a Promise (instead of requiring all to match).
             node.returnType == null,

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -153,7 +153,7 @@ export default createRule<Options, MessageIds>({
       }
 
       if (
-        // require at least one return type to be promise/any/unknown
+        // require all potential return types to be promise/any/unknown
         returnTypes.some(
           type =>
             !containsAllTypesByName(

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -116,10 +116,10 @@ export default createRule<Options, MessageIds>({
         | TSESTree.FunctionExpression,
     ): void {
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-      const signature = checker.getSignatureFromDeclaration(tsNode);
-      if (!signature) {
-        return;
-      }
+      const signature = nullThrows(
+        checker.getSignatureFromDeclaration(tsNode),
+        'Signature should always be defined for function-like nodes',
+      );
       const returnType = checker.getReturnTypeOfSignature(signature);
 
       if (

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -115,11 +115,6 @@ export default createRule<Options, MessageIds>({
         | TSESTree.FunctionDeclaration
         | TSESTree.FunctionExpression,
     ): void {
-      const signatures = services.getTypeAtLocation(node).getCallSignatures();
-      if (!signatures.length) {
-        return;
-      }
-
       if (node.parent.type === AST_NODE_TYPES.TSAbstractMethodDefinition) {
         // Abstract method can't be async
         return;
@@ -131,6 +126,11 @@ export default createRule<Options, MessageIds>({
         (node.parent.kind === 'get' || node.parent.kind === 'set')
       ) {
         // Getters and setters can't be async
+        return;
+      }
+
+      const signatures = services.getTypeAtLocation(node).getCallSignatures();
+      if (!signatures.length) {
         return;
       }
 

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -117,11 +117,9 @@ export default createRule<Options, MessageIds>({
     ): void {
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
       const signature = checker.getSignatureFromDeclaration(tsNode);
-
       if (!signature) {
         return;
       }
-
       const returnType = checker.getReturnTypeOfSignature(signature);
 
       if (

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -140,7 +140,6 @@ export default createRule<Options, MessageIds>({
 
       if (
         !allowAny &&
-        // `any` and `unknown` override other types in a union so it's safe to check one
         returnTypes.some(type =>
           isTypeFlagSet(type, ts.TypeFlags.Any | ts.TypeFlags.Unknown),
         )

--- a/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
+++ b/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
@@ -182,6 +182,44 @@ async function asyncFunctionReturningUnion(p: boolean) {
   return p ? Promise.resolve(5) : 5;
 }
     `,
+    `
+function overloadingThatCanReturnPromise(): Promise<number>;
+function overloadingThatCanReturnPromise(a: boolean): number;
+function overloadingThatCanReturnPromise(
+  a?: boolean,
+): Promise<number> | number {
+  return Promise.resolve(5);
+}
+    `,
+    `
+function overloadingThatCanReturnPromise(a: boolean): number;
+function overloadingThatCanReturnPromise(): Promise<number>;
+function overloadingThatCanReturnPromise(
+  a?: boolean,
+): Promise<number> | number {
+  return Promise.resolve(5);
+}
+    `,
+    {
+      code: `
+export function overloadingThatIncludeUnknown(): number;
+export function overloadingThatIncludeUnknown(a: boolean): unknown;
+export function overloadingThatIncludeUnknown(a?: boolean): unknown | number {
+  return Promise.resolve(5);
+}
+      `,
+      options: [{ allowAny: true }],
+    },
+    {
+      code: `
+export function overloadingThatIncludeAny(): number;
+export function overloadingThatIncludeAny(a: boolean): unknown;
+export function overloadingThatIncludeAny(a?: boolean): unknown | number {
+  return Promise.resolve(5);
+}
+      `,
+      options: [{ allowAny: true }],
+    },
   ],
   invalid: [
     {
@@ -787,6 +825,61 @@ async function promiseInUnionWithoutExplicitReturnType(p: boolean) {
   return p ? Promise.resolve(5) : 5;
 }
       `,
+    },
+    {
+      code: `
+function overloadingThatCanReturnPromise(): Promise<number>;
+function overloadingThatCanReturnPromise(a: boolean): Promise<string>;
+function overloadingThatCanReturnPromise(
+  a?: boolean,
+): Promise<number | string> {
+  return Promise.resolve(5);
+}
+      `,
+      errors: [
+        {
+          messageId,
+        },
+      ],
+      output: `
+function overloadingThatCanReturnPromise(): Promise<number>;
+function overloadingThatCanReturnPromise(a: boolean): Promise<string>;
+async function overloadingThatCanReturnPromise(
+  a?: boolean,
+): Promise<number | string> {
+  return Promise.resolve(5);
+}
+      `,
+    },
+    {
+      code: `
+export function overloadingThatIncludeAny(): number;
+export function overloadingThatIncludeAny(a: boolean): any;
+export function overloadingThatIncludeAny(a?: boolean): any | number {
+  return Promise.resolve(5);
+}
+      `,
+      errors: [
+        {
+          messageId,
+        },
+      ],
+      options: [{ allowAny: false }],
+    },
+    {
+      code: `
+function overloadingThatIncludeUnknown(): number;
+function overloadingThatIncludeUnknown(a: boolean): unknown;
+function overloadingThatIncludeUnknown(a?: boolean): unknown | number {
+  return Promise.resolve(5);
+}
+      `,
+      errors: [
+        {
+          messageId,
+        },
+      ],
+      options: [{ allowAny: false }],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
+++ b/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
@@ -201,18 +201,18 @@ function overloadingThatCanReturnPromise(
 }
     `,
     `
-export function a(): Promise<void>;
-export function a(x: boolean): void;
-export function a(x?: boolean) {
+function a(): Promise<void>;
+function a(x: boolean): void;
+function a(x?: boolean) {
   if (x == null) return Promise.reject(new Error());
   throw new Error();
 }
     `,
     {
       code: `
-export function overloadingThatIncludeUnknown(): number;
-export function overloadingThatIncludeUnknown(a: boolean): unknown;
-export function overloadingThatIncludeUnknown(a?: boolean): unknown | number {
+function overloadingThatIncludeUnknown(): number;
+function overloadingThatIncludeUnknown(a: boolean): unknown;
+function overloadingThatIncludeUnknown(a?: boolean): unknown | number {
   return Promise.resolve(5);
 }
       `,
@@ -220,9 +220,9 @@ export function overloadingThatIncludeUnknown(a?: boolean): unknown | number {
     },
     {
       code: `
-export function overloadingThatIncludeAny(): number;
-export function overloadingThatIncludeAny(a: boolean): unknown;
-export function overloadingThatIncludeAny(a?: boolean): unknown | number {
+function overloadingThatIncludeAny(): number;
+function overloadingThatIncludeAny(a: boolean): unknown;
+function overloadingThatIncludeAny(a?: boolean): unknown | number {
   return Promise.resolve(5);
 }
       `,
@@ -861,9 +861,9 @@ async function overloadingThatCanReturnPromise(
     },
     {
       code: `
-export function overloadingThatIncludeAny(): number;
-export function overloadingThatIncludeAny(a: boolean): any;
-export function overloadingThatIncludeAny(a?: boolean): any | number {
+function overloadingThatIncludeAny(): number;
+function overloadingThatIncludeAny(a: boolean): any;
+function overloadingThatIncludeAny(a?: boolean): any | number {
   return Promise.resolve(5);
 }
       `,

--- a/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
+++ b/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
@@ -200,6 +200,14 @@ function overloadingThatCanReturnPromise(
   return Promise.resolve(5);
 }
     `,
+    `
+export function a(): Promise<void>;
+export function a(x: boolean): void;
+export function a(x?: boolean) {
+  if (x == null) return Promise.reject(new Error());
+  throw new Error();
+}
+    `,
     {
       code: `
 export function overloadingThatIncludeUnknown(): number;

--- a/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
+++ b/packages/eslint-plugin/tests/rules/promise-function-async.test.ts
@@ -221,8 +221,8 @@ function overloadingThatIncludeUnknown(a?: boolean): unknown | number {
     {
       code: `
 function overloadingThatIncludeAny(): number;
-function overloadingThatIncludeAny(a: boolean): unknown;
-function overloadingThatIncludeAny(a?: boolean): unknown | number {
+function overloadingThatIncludeAny(a: boolean): any;
+function overloadingThatIncludeAny(a?: boolean): any | number {
   return Promise.resolve(5);
 }
       `,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5709
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR resolves #5709 and takes function overloading into consideration.

Currently, the rule flags the following as an issue and auto-fixes it with `async`, even though the actual return type of the function is `Promise<number> | number`:

```ts
function b(): Promise<number>
function b(a: boolean): number
function b(a?: boolean): Promise<number> | number {
  return Promise.resolve(1);
}
```

This PR changes the rule to treat the above similarly to how it treats the following:

```ts
function b(a?: boolean): Promise<number> | number {
  return Promise.resolve(1);
}
```