### PR TITLE
fix(eslint-plugin): [no-misused-promises] `inheritedMethods` and `properties` to check all statically analyzable declarations

### DIFF
--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -455,9 +455,6 @@ export default createRule<Options, MessageId>({
           });
         }
       } else if (ts.isMethodDeclaration(tsNode)) {
-        if (ts.isComputedPropertyName(tsNode.name)) {
-          return;
-        }
         const obj = tsNode.parent;
 
         // Below condition isn't satisfied unless something goes wrong,
@@ -477,9 +474,14 @@ export default createRule<Options, MessageId>({
         if (objType === undefined) {
           return;
         }
-        const propertySymbol = checker.getPropertyOfType(
+        const staticAccessValue = getStaticMemberAccessValue(node, context);
+        if (!staticAccessValue) {
+          return;
+        }
+        const propertySymbol = getMemberIfExists(
           objType,
-          tsNode.name.text,
+          staticAccessValue,
+          checker,
         );
         if (propertySymbol === undefined) {
           return;

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -239,7 +239,9 @@ type NodeWithKey =
   | TSESTree.Property
   | TSESTree.PropertyDefinition
   | TSESTree.TSAbstractMethodDefinition
-  | TSESTree.TSAbstractPropertyDefinition;
+  | TSESTree.TSAbstractPropertyDefinition
+  | TSESTree.TSMethodSignature
+  | TSESTree.TSPropertySignature;
 
 /**
  * Gets a member being accessed or declared if its value can be determined statically, and

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -1,4 +1,4 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
 
 import rule from '../../src/rules/no-misused-promises';
 import { getFixturesRootDir } from '../RuleTester';
@@ -1042,68 +1042,6 @@ interface MyInterface extends MyCall, MyIndex, MyConstruct, MyMethods {
       `,
       options: [{ checksVoidReturn: { inheritedMethods: true } }],
     },
-    {
-      code: `
-const staticSymbol = Symbol.for('static symbol');
-
-interface Interface {
-  identifier: () => void;
-  1: () => void;
-  2: () => void;
-  stringLiteral: () => void;
-  computedStringLiteral: () => void;
-  // well known symbols
-  [Symbol.iterator]: () => void;
-  [Symbol.asyncIterator]: () => void;
-
-  // less sure if this one is possible to lint for
-  [staticSymbol]: () => void;
-}
-
-class Clazz implements Interface {
-  identifier(): void {}
-  1(): void {}
-  [2](): void {}
-  stringLiteral(): void {}
-  ['computedStringLiteral'](): void {}
-  [Symbol.iterator](): void {}
-  [Symbol.asyncIterator](): void {}
-  [staticSymbol](): void {}
-}
-      `,
-      options: [{ checksVoidReturn: { inheritedMethods: true } }],
-    },
-    {
-      code: `
-const staticSymbol = Symbol.for('static symbol');
-
-interface Interface {
-  identifier: () => void;
-  1: () => void;
-  2: () => void;
-  stringLiteral: () => void;
-  computedStringLiteral: () => void;
-  // well known symbols
-  [Symbol.iterator]: () => void;
-  [Symbol.asyncIterator]: () => void;
-
-  // less sure if this one is possible to lint for
-  [staticSymbol]: () => void;
-}
-
-class Clazz implements Interface {
-  async identifier() {}
-  async 1() {}
-  async [2]() {}
-  async stringLiteral() {}
-  async ['computedStringLiteral']() {}
-  async [Symbol.iterator]() {}
-  async [Symbol.asyncIterator]() {}
-  async [staticSymbol]() {}
-}
-      `,
-      options: [{ checksVoidReturn: { inheritedMethods: false } }],
-    },
     "const notAFn1: string = '';",
     'const notAFn2: number = 1;',
     'const notAFn3: boolean = true;',
@@ -1445,43 +1383,126 @@ const g = async () => 1,
     {
       code: `
 const obj: {
-  f?: () => void;
+  identifier?: () => void;
+  1?: () => void;
+  computedStringLiteral?: () => void;
+  [Symbol.iterator]?: () => void;
 } = {};
-obj.f = async () => {
+obj.identifier = async () => {
+  return 0;
+};
+obj[1] = async () => {
+  return 0;
+};
+obj['computedStringLiteral'] = async () => {
+  return 0;
+};
+obj[Symbol.iterator] = async () => {
   return 0;
 };
       `,
       errors: [
         {
-          line: 5,
+          line: 8,
+          messageId: 'voidReturnVariable',
+        },
+        {
+          line: 11,
+          messageId: 'voidReturnVariable',
+        },
+        {
+          line: 14,
+          messageId: 'voidReturnVariable',
+        },
+        {
+          line: 17,
           messageId: 'voidReturnVariable',
         },
       ],
     },
     {
-      code: `
-type O = { f: () => void };
+      code: noFormat`
+type O = {
+  identifier: () => void;
+  1: () => void;
+  stringLiteral: () => void;
+  computedStringLiteral: () => void;
+  [Symbol.iterator]: () => void;
+};
 const obj: O = {
-  f: async () => 'foo',
+  identifier: async () => 'foo',
+  [1]: async () => 'foo',
+  'stringLiteral': async () => 'foo',
+  ['computedStringLiteral']: async () => 'foo',
+  [Symbol.iterator]: async () => 'foo',
 };
       `,
       errors: [
         {
-          line: 4,
+          line: 10,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 11,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 12,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 13,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 14,
           messageId: 'voidReturnProperty',
         },
       ],
     },
     {
-      code: `
-type O = { f: () => void };
+      code: noFormat`
+type O = {
+  identifier: () => void;
+  1: () => void;
+  2: () => void;
+  stringLiteral: () => void;
+  computedStringLiteral: () => void;
+  [Symbol.iterator]: () => void;
+};
 const obj: O = {
-  f: async () => 'foo',
+  identifier: async () => 'foo',
+  1: async () => 'foo',
+  [2]: async () => 'foo',
+  'stringLiteral': async () => 'foo',
+  ['computedStringLiteral']: async () => 'foo',
+  [Symbol.iterator]: async () => 'foo',
+  [staticSymbol]: async () => 'foo',
 };
       `,
       errors: [
         {
-          line: 4,
+          line: 11,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 12,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 13,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 14,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 15,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 16,
           messageId: 'voidReturnProperty',
         },
       ],
@@ -1503,17 +1524,59 @@ const obj: O = {
       ],
     },
     {
-      code: `
-type O = { f: () => void };
+      code: noFormat`
+type O = {
+  identifier: () => void;
+  1: () => void;
+  2: () => void;
+  stringLiteral: () => void;
+  computedStringLiteral: () => void;
+  [Symbol.iterator]: () => void;
+};
 const obj: O = {
-  async f() {
+  async identifier() {
+    return 0;
+  },
+  async 1() {
+    return 0;
+  },
+  async [2]() {
+    return 0;
+  },
+  async 'stringLiteral'() {
+    return 0;
+  },
+  async ['computedStringLiteral']() {
+    return 0;
+  },
+  async [Symbol.iterator]() {
     return 0;
   },
 };
       `,
       errors: [
         {
-          line: 4,
+          line: 11,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 14,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 17,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 20,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 23,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 26,
           messageId: 'voidReturnProperty',
         },
       ],
@@ -2488,67 +2551,6 @@ arrayFn<() => void>(
         {
           line: 8,
           messageId: 'voidReturnArgument',
-        },
-      ],
-    },
-
-    {
-      code: `
-const staticSymbol = Symbol.for('static symbol');
-
-interface Interface {
-  identifier: () => void;
-  1: () => void;
-  2: () => void;
-  stringLiteral: () => void;
-  computedStringLiteral: () => void;
-  // well known symbols
-  [Symbol.iterator]: () => void;
-  [Symbol.asyncIterator]: () => void;
-
-  // less sure if this one is possible to lint for
-  [staticSymbol]: () => void;
-}
-
-class Clazz implements Interface {
-  async identifier() {}
-  async 1() {}
-  async [2]() {}
-  async stringLiteral() {}
-  async ['computedStringLiteral']() {}
-  async [Symbol.iterator]() {}
-  async [Symbol.asyncIterator]() {}
-  async [staticSymbol]() {}
-}
-      `,
-      errors: [
-        {
-          line: 19,
-          messageId: 'voidReturnInheritedMethod',
-        },
-        {
-          line: 20,
-          messageId: 'voidReturnInheritedMethod',
-        },
-        {
-          line: 21,
-          messageId: 'voidReturnInheritedMethod',
-        },
-        {
-          line: 22,
-          messageId: 'voidReturnInheritedMethod',
-        },
-        {
-          line: 23,
-          messageId: 'voidReturnInheritedMethod',
-        },
-        {
-          line: 24,
-          messageId: 'voidReturnInheritedMethod',
-        },
-        {
-          line: 25,
-          messageId: 'voidReturnInheritedMethod',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -2033,7 +2033,7 @@ class MyClass {
   computedStringLiteral(): void {
     return;
   }
-  [Symbol.iterator](): void {
+  [Symbol.asyncIterator](): void {
     return;
   }
 }
@@ -2054,7 +2054,7 @@ class MySubclassExtendsMyClass extends MyClass {
   async ['computedStringLiteral'](): Promise<void> {
     await Promise.resolve();
   }
-  async [Symbol.iterator](): Promise<void> {
+  async [Symbol.asyncIterator](): Promise<void> {
     await Promise.resolve();
   }
 }
@@ -2230,7 +2230,7 @@ abstract class MyAbstractClass {
   abstract 2(): void;
   abstract stringLiteral(): void;
   abstract computedStringLiteral(): void;
-  abstract [Symbol.iterator](): void;
+  abstract [Symbol.asyncIterator](): void;
 }
 
 class MySubclassExtendsMyAbstractClass extends MyAbstractClass {
@@ -2249,7 +2249,7 @@ class MySubclassExtendsMyAbstractClass extends MyAbstractClass {
   async ['computedStringLiteral'](): Promise<void> {
     await Promise.resolve();
   }
-  async [Symbol.iterator](): Promise<void> {
+  async [Symbol.asyncIterator](): Promise<void> {
     await Promise.resolve();
   }
 }
@@ -3113,7 +3113,7 @@ const MyClassExpression = class {
   computedStringLiteral(): void {
     return;
   }
-  [Symbol.iterator](): void {
+  [Symbol.asyncIterator](): void {
     return;
   }
 };
@@ -3134,7 +3134,7 @@ class MyClassExtendsMyClassExpression extends MyClassExpression {
   async ['computedStringLiteral'](): Promise<void> {
     await Promise.resolve();
   }
-  async [Symbol.iterator](): Promise<void> {
+  async [Symbol.asyncIterator](): Promise<void> {
     await Promise.resolve();
   }
 }

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -2795,43 +2795,153 @@ class MyClass {
   setThing(): void {
     return;
   }
+  1(): void {
+    return;
+  }
+  2(): void {
+    return;
+  }
+  stringLiteral(): void {
+    return;
+  }
+  computedStringLiteral(): void {
+    return;
+  }
+  [Symbol.iterator](): void {
+    return;
+  }
 }
 
 class MyOtherClass {
   setThing(): void {
     return;
   }
+  1(): void {
+    return;
+  }
+  2(): void {
+    return;
+  }
+  stringLiteral(): void {
+    return;
+  }
+  computedStringLiteral(): void {
+    return;
+  }
+  [Symbol.iterator](): void {
+    return;
+  }
 }
 
 interface MyInterface extends MyClass, MyOtherClass {
   setThing(): Promise<void>;
+  1(): Promise<void>;
+  [2](): Promise<void>;
+  'stringLiteral'(): Promise<void>;
+  ['computedStringLiteral'](): Promise<void>;
+  [Symbol.iterator](): Promise<void>;
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyClass' },
-          line: 15,
+          line: 45,
           messageId: 'voidReturnInheritedMethod',
         },
         {
           data: { heritageTypeName: 'MyOtherClass' },
-          line: 15,
+          line: 45,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 46,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyOtherClass' },
+          line: 46,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 47,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyOtherClass' },
+          line: 47,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 48,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyOtherClass' },
+          line: 48,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 49,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyOtherClass' },
+          line: 49,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 50,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyOtherClass' },
+          line: 50,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
     },
     {
-      code: `
+      code: noFormat`
 interface MyAsyncInterface {
   setThing(): Promise<void>;
+  1(): Promise<void>;
+  2(): Promise<void>;
+  stringLiteral(): Promise<void>;
+  computedStringLiteral(): Promise<void>;
+  [Symbol.iterator](): Promise<void>;
 }
 
 interface MySyncInterface {
   setThing(): void;
+  1(): void;
+  2(): void;
+  stringLiteral(): void;
+  computedStringLiteral(): void;
+  [Symbol.iterator](): void;
 }
 
 class MyClass {
   setThing(): void {
+    return;
+  }
+  1(): void {
+    return;
+  }
+  2(): void {
+    return;
+  }
+  stringLiteral(): void {
+    return;
+  }
+  computedStringLiteral(): void {
+    return;
+  }
+  [Symbol.iterator](): void {
     return;
   }
 }
@@ -2840,17 +2950,82 @@ class MySubclass extends MyClass implements MyAsyncInterface, MySyncInterface {
   async setThing(): Promise<void> {
     await Promise.resolve();
   }
+  async 1(): Promise<void> {
+    await Promise.resolve();
+  }
+  async [2](): Promise<void> {
+    await Promise.resolve();
+  }
+  async 'stringLiteral'(): Promise<void> {
+    await Promise.resolve();
+  }
+  async ['computedStringLiteral'](): Promise<void> {
+    await Promise.resolve();
+  }
+  async [Symbol.iterator](): Promise<void> {
+    await Promise.resolve();
+  }
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyClass' },
-          line: 17,
+          line: 42,
           messageId: 'voidReturnInheritedMethod',
         },
         {
           data: { heritageTypeName: 'MySyncInterface' },
-          line: 17,
+          line: 42,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 45,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MySyncInterface' },
+          line: 45,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 48,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MySyncInterface' },
+          line: 48,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 51,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MySyncInterface' },
+          line: 51,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 54,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MySyncInterface' },
+          line: 54,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 57,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MySyncInterface' },
+          line: 57,
           messageId: 'voidReturnInheritedMethod',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -1477,7 +1477,6 @@ const obj: O = {
   'stringLiteral': async () => 'foo',
   ['computedStringLiteral']: async () => 'foo',
   [Symbol.iterator]: async () => 'foo',
-  [staticSymbol]: async () => 'foo',
 };
       `,
       errors: [
@@ -1582,8 +1581,17 @@ const obj: O = {
       ],
     },
     {
-      code: `
-type O = { f: () => void; g: () => void; h: () => void };
+      code: noFormat`
+type O = {
+  f: () => void;
+  g: () => void;
+  h: () => void;
+  1: () => void;
+  2: () => void;
+  stringLiteral: () => void;
+  computedStringLiteral: () => void;
+  [Symbol.iterator]: () => void;
+};
 function f(): O {
   const h = async () => 0;
   return {
@@ -1592,20 +1600,55 @@ function f(): O {
     },
     g: async () => 0,
     h,
+    async 1() {
+      return 123;
+    },
+    async [2]() {
+      return 123;
+    },
+    async 'stringLiteral'() {
+      return 123;
+    },
+    async ['computedStringLiteral']() {
+      return 123;
+    },
+    async [Symbol.iterator]() {
+      return 123;
+    },
   };
 }
       `,
       errors: [
         {
-          line: 6,
+          line: 15,
           messageId: 'voidReturnProperty',
         },
         {
-          line: 9,
+          line: 18,
           messageId: 'voidReturnProperty',
         },
         {
-          line: 10,
+          line: 19,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 20,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 23,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 26,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 29,
+          messageId: 'voidReturnProperty',
+        },
+        {
+          line: 32,
           messageId: 'voidReturnProperty',
         },
       ],
@@ -1973,9 +2016,24 @@ consume(...cbs);
       errors: [{ line: 4, messageId: 'voidReturnArgument' }],
     },
     {
-      code: `
+      code: noFormat`
 class MyClass {
   setThing(): void {
+    return;
+  }
+  1(): void {
+    return;
+  }
+  2(): void {
+    return;
+  }
+  stringLiteral(): void {
+    return;
+  }
+  computedStringLiteral(): void {
+    return;
+  }
+  [Symbol.iterator](): void {
     return;
   }
 }
@@ -1984,32 +2042,117 @@ class MySubclassExtendsMyClass extends MyClass {
   async setThing(): Promise<void> {
     await Promise.resolve();
   }
+  async 1(): Promise<void> {
+    await Promise.resolve();
+  }
+  async [2](): Promise<void> {
+    await Promise.resolve();
+  }
+  async 'stringLiteral'(): Promise<void> {
+    await Promise.resolve();
+  }
+  async ['computedStringLiteral'](): Promise<void> {
+    await Promise.resolve();
+  }
+  async [Symbol.iterator](): Promise<void> {
+    await Promise.resolve();
+  }
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyClass' },
-          line: 9,
+          line: 24,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 27,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 30,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 33,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 36,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 39,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
     },
     {
-      code: `
+      code: noFormat`
 class MyClass {
   setThing(): void {
+    return;
+  }
+  1(): void {
+    return;
+  }
+  2(): void {
+    return;
+  }
+  stringLiteral(): void {
+    return;
+  }
+  computedStringLiteral(): void {
+    return;
+  }
+  [Symbol.iterator](): void {
     return;
   }
 }
 
 abstract class MyAbstractClassExtendsMyClass extends MyClass {
   abstract setThing(): Promise<void>;
+  abstract 1(): Promise<void>;
+  abstract [2](): Promise<void>;
+  abstract 'stringLiteral'(): Promise<void>;
+  abstract ['computedStringLiteral'](): Promise<void>;
+  abstract [Symbol.iterator](): Promise<void>;
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyClass' },
-          line: 9,
+          line: 24,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 25,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 26,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 27,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 28,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 29,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
@@ -2020,54 +2163,179 @@ class MyClass {
   setThing(): void {
     return;
   }
+  1(): void {
+    return;
+  }
+  2(): void {
+    return;
+  }
+  stringLiteral(): void {
+    return;
+  }
+  computedStringLiteral(): void {
+    return;
+  }
+  [Symbol.iterator](): void {
+    return;
+  }
 }
 
 interface MyInterfaceExtendsMyClass extends MyClass {
   setThing(): Promise<void>;
+  1(): Promise<void>;
+  [2](): Promise<void>;
+  'stringLiteral'(): Promise<void>;
+  ['computedStringLiteral'](): Promise<void>;
+  [Symbol.iterator](): Promise<void>;
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyClass' },
-          line: 9,
+          line: 24,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 25,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 26,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 27,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 28,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 29,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
     },
     {
-      code: `
+      code: noFormat`
 abstract class MyAbstractClass {
   abstract setThing(): void;
+  abstract 1(): void;
+  abstract 2(): void;
+  abstract stringLiteral(): void;
+  abstract computedStringLiteral(): void;
+  abstract [Symbol.iterator](): void;
 }
 
 class MySubclassExtendsMyAbstractClass extends MyAbstractClass {
   async setThing(): Promise<void> {
     await Promise.resolve();
   }
+  async 1(): Promise<void> {
+    await Promise.resolve();
+  }
+  async [2](): Promise<void> {
+    await Promise.resolve();
+  }
+  async 'stringLiteral'(): Promise<void> {
+    await Promise.resolve();
+  }
+  async ['computedStringLiteral'](): Promise<void> {
+    await Promise.resolve();
+  }
+  async [Symbol.iterator](): Promise<void> {
+    await Promise.resolve();
+  }
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyAbstractClass' },
-          line: 7,
+          line: 12,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 15,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 18,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 21,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 24,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 27,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
     },
     {
-      code: `
+      code: noFormat`
 abstract class MyAbstractClass {
   abstract setThing(): void;
+  abstract 1(): void;
+  abstract 2(): void;
+  abstract stringLiteral(): void;
+  abstract computedStringLiteral(): void;
+  abstract [Symbol.iterator](): void;
 }
 
 abstract class MyAbstractSubclassExtendsMyAbstractClass extends MyAbstractClass {
   abstract setThing(): Promise<void>;
+  abstract 1(): Promise<void>;
+  abstract [2](): Promise<void>;
+  abstract 'stringLiteral'(): Promise<void>;
+  abstract ['computedStringLiteral'](): Promise<void>;
+  abstract [Symbol.iterator](): Promise<void>;
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyAbstractClass' },
-          line: 7,
+          line: 12,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 13,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 14,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 15,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 16,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 17,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
@@ -2076,28 +2344,84 @@ abstract class MyAbstractSubclassExtendsMyAbstractClass extends MyAbstractClass 
       code: `
 abstract class MyAbstractClass {
   abstract setThing(): void;
+  abstract setThing(): void;
+  abstract 1(): void;
+  abstract 2(): void;
+  abstract stringLiteral(): void;
+  abstract computedStringLiteral(): void;
+  abstract [Symbol.iterator](): void;
 }
 
 interface MyInterfaceExtendsMyAbstractClass extends MyAbstractClass {
   setThing(): Promise<void>;
+  1(): Promise<void>;
+  [2](): Promise<void>;
+  'stringLiteral'(): Promise<void>;
+  ['computedStringLiteral'](): Promise<void>;
+  [Symbol.iterator](): Promise<void>;
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyAbstractClass' },
-          line: 7,
+          line: 13,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 14,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 15,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 16,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 17,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyAbstractClass' },
+          line: 18,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
     },
     {
-      code: `
+      code: noFormat`
 interface MyInterface {
   setThing(): void;
+  1(): void;
+  2(): void;
+  stringLiteral(): void;
+  computedStringLiteral(): void;
+  [Symbol.iterator](): void;
 }
 
 class MyInterfaceSubclass implements MyInterface {
   async setThing(): Promise<void> {
+    await Promise.resolve();
+  }
+  async 1(): Promise<void> {
+    await Promise.resolve();
+  }
+  async [2](): Promise<void> {
+    await Promise.resolve();
+  }
+  async 'stringLiteral'(): Promise<void> {
+    await Promise.resolve();
+  }
+  async ['computedStringLiteral'](): Promise<void> {
+    await Promise.resolve();
+  }
+  async [Symbol.iterator](): Promise<void> {
     await Promise.resolve();
   }
 }
@@ -2105,25 +2429,85 @@ class MyInterfaceSubclass implements MyInterface {
       errors: [
         {
           data: { heritageTypeName: 'MyInterface' },
-          line: 7,
+          line: 12,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 15,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 18,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 21,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 24,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 27,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
     },
     {
-      code: `
+      code: noFormat`
 interface MyInterface {
   setThing(): void;
+  1(): void;
+  2(): void;
+  stringLiteral(): void;
+  computedStringLiteral(): void;
+  [Symbol.iterator](): void;
 }
 
 abstract class MyAbstractClassImplementsMyInterface implements MyInterface {
   abstract setThing(): Promise<void>;
+  abstract 1(): Promise<void>;
+  abstract [2](): Promise<void>;
+  abstract 'stringLiteral'(): Promise<void>;
+  abstract ['computedStringLiteral'](): Promise<void>;
+  abstract [Symbol.iterator](): Promise<void>;
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyInterface' },
-          line: 7,
+          line: 12,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 13,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 14,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 15,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 16,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 17,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
@@ -2132,16 +2516,51 @@ abstract class MyAbstractClassImplementsMyInterface implements MyInterface {
       code: `
 interface MyInterface {
   setThing(): void;
+  1(): void;
+  2(): void;
+  stringLiteral(): void;
+  computedStringLiteral(): void;
+  [Symbol.iterator](): void;
 }
 
 interface MySubInterface extends MyInterface {
   setThing(): Promise<void>;
+  1(): Promise<void>;
+  [2](): Promise<void>;
+  'stringLiteral'(): Promise<void>;
+  ['computedStringLiteral'](): Promise<void>;
+  [Symbol.iterator](): Promise<void>;
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyInterface' },
-          line: 7,
+          line: 12,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 13,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 14,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 15,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 16,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 17,
           messageId: 'voidReturnInheritedMethod',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -3031,13 +3031,33 @@ class MySubclass extends MyClass implements MyAsyncInterface, MySyncInterface {
       ],
     },
     {
-      code: `
+      code: noFormat`
 interface MyInterface {
   setThing(): void;
+  1(): void;
+  2(): void;
+  stringLiteral(): void;
+  computedStringLiteral(): void;
+  [Symbol.iterator](): void;
 }
 
 const MyClassExpressionExtendsMyClass = class implements MyInterface {
   setThing(): Promise<void> {
+    await Promise.resolve();
+  }
+  1(): Promise<void> {
+    await Promise.resolve();
+  }
+  [2](): Promise<void> {
+    await Promise.resolve();
+  }
+  'stringLiteral'(): Promise<void> {
+    await Promise.resolve();
+  }
+  ['computedStringLiteral'](): Promise<void> {
+    await Promise.resolve();
+  }
+  [Symbol.iterator](): Promise<void> {
     await Promise.resolve();
   }
 };
@@ -3045,15 +3065,55 @@ const MyClassExpressionExtendsMyClass = class implements MyInterface {
       errors: [
         {
           data: { heritageTypeName: 'MyInterface' },
-          line: 7,
+          line: 12,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 15,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 18,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 21,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 24,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 27,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
     },
     {
-      code: `
+      code: noFormat`
 const MyClassExpression = class {
   setThing(): void {
+    return;
+  }
+  1(): void {
+    return;
+  }
+  2(): void {
+    return;
+  }
+  stringLiteral(): void {
+    return;
+  }
+  computedStringLiteral(): void {
+    return;
+  }
+  [Symbol.iterator](): void {
     return;
   }
 };
@@ -3062,12 +3122,52 @@ class MyClassExtendsMyClassExpression extends MyClassExpression {
   async setThing(): Promise<void> {
     await Promise.resolve();
   }
+  async 1(): Promise<void> {
+    await Promise.resolve();
+  }
+  async [2](): Promise<void> {
+    await Promise.resolve();
+  }
+  async 'stringLiteral'(): Promise<void> {
+    await Promise.resolve();
+  }
+  async ['computedStringLiteral'](): Promise<void> {
+    await Promise.resolve();
+  }
+  async [Symbol.iterator](): Promise<void> {
+    await Promise.resolve();
+  }
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyClassExpression' },
-          line: 9,
+          line: 24,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClassExpression' },
+          line: 27,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClassExpression' },
+          line: 30,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClassExpression' },
+          line: 33,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClassExpression' },
+          line: 36,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyClassExpression' },
+          line: 39,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
@@ -3078,17 +3178,57 @@ const MyClassExpression = class {
   setThing(): void {
     return;
   }
+  1(): void {
+    return;
+  }
+  2(): void {
+    return;
+  }
+  stringLiteral(): void {
+    return;
+  }
+  computedStringLiteral(): void {
+    return;
+  }
+  [Symbol.iterator](): void {
+    return;
+  }
 };
 type MyClassExpressionType = typeof MyClassExpression;
 
 interface MyInterfaceExtendsMyClassExpression extends MyClassExpressionType {
   setThing(): Promise<void>;
+  1(): Promise<void>;
+  [2](): Promise<void>;
+  'stringLiteral'(): Promise<void>;
+  ['computedStringLiteral'](): Promise<void>;
+  [Symbol.iterator](): Promise<void>;
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'typeof MyClassExpression' },
-          line: 10,
+          line: 25,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'typeof MyClassExpression' },
+          line: 26,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'typeof MyClassExpression' },
+          line: 27,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'typeof MyClassExpression' },
+          line: 28,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'typeof MyClassExpression' },
+          line: 29,
           messageId: 'voidReturnInheritedMethod',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -2566,12 +2566,34 @@ interface MySubInterface extends MyInterface {
       ],
     },
     {
-      code: `
-type MyTypeIntersection = { setThing(): void } & { thing: number };
+      code: noFormat`
+type MyTypeIntersection = {
+  setThing(): void;
+  1(): void;
+  2(): void;
+  stringLiteral(): void;
+  computedStringLiteral(): void;
+  [Symbol.iterator](): void;
+} & { thing: number };
 
 class MyClassImplementsMyTypeIntersection implements MyTypeIntersection {
   thing = 1;
   async setThing(): Promise<void> {
+    await Promise.resolve();
+  }
+  async 1(): Promise<void> {
+    await Promise.resolve();
+  }
+  async [2](): Promise<void> {
+    await Promise.resolve();
+  }
+  async 'stringLiteral'(): Promise<void> {
+    await Promise.resolve();
+  }
+  async ['computedStringLiteral'](): Promise<void> {
+    await Promise.resolve();
+  }
+  async [Symbol.iterator](): Promise<void> {
     await Promise.resolve();
   }
 }
@@ -2579,25 +2601,98 @@ class MyClassImplementsMyTypeIntersection implements MyTypeIntersection {
       errors: [
         {
           data: { heritageTypeName: 'MyTypeIntersection' },
-          line: 6,
+          line: 13,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyTypeIntersection' },
+          line: 16,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyTypeIntersection' },
+          line: 19,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyTypeIntersection' },
+          line: 22,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyTypeIntersection' },
+          line: 25,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyTypeIntersection' },
+          line: 28,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
     },
     {
       code: `
+type WhenTrue = {
+  setThing(): Promise<void>;
+  1(): Promise<void>;
+  2(): Promise<void>;
+  stringLiteral(): Promise<void>;
+  computedStringLiteral(): Promise<void>;
+  [Symbol.iterator](): Promise<void>;
+};
+
+type WhenFalse = {
+  setThing(): void;
+  1(): void;
+  2(): void;
+  stringLiteral(): void;
+  computedStringLiteral(): void;
+  [Symbol.iterator](): void;
+};
+
 type MyGenericType<IsAsync extends boolean = true> = IsAsync extends true
-  ? { setThing(): Promise<void> }
-  : { setThing(): void };
+  ? WhenTrue
+  : WhenFalse;
 
 interface MyAsyncInterface extends MyGenericType<false> {
   setThing(): Promise<void>;
+  1(): Promise<void>;
+  [2](): Promise<void>;
+  'stringLiteral'(): Promise<void>;
+  ['computedStringLiteral'](): Promise<void>;
+  [Symbol.iterator](): Promise<void>;
 }
       `,
       errors: [
         {
-          data: { heritageTypeName: '{ setThing(): void; }' },
-          line: 7,
+          data: { heritageTypeName: 'WhenFalse' },
+          line: 25,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'WhenFalse' },
+          line: 26,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'WhenFalse' },
+          line: 27,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'WhenFalse' },
+          line: 28,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'WhenFalse' },
+          line: 29,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'WhenFalse' },
+          line: 30,
           messageId: 'voidReturnInheritedMethod',
         },
       ],
@@ -2606,25 +2701,90 @@ interface MyAsyncInterface extends MyGenericType<false> {
       code: `
 interface MyInterface {
   setThing(): void;
+  1(): void;
+  2(): void;
+  stringLiteral(): void;
+  computedStringLiteral(): void;
+  [Symbol.iterator](): void;
 }
 
 interface MyOtherInterface {
   setThing(): void;
+  1(): void;
+  2(): void;
+  stringLiteral(): void;
+  computedStringLiteral(): void;
+  [Symbol.iterator](): void;
 }
 
 interface MyThirdInterface extends MyInterface, MyOtherInterface {
   setThing(): Promise<void>;
+  1(): Promise<void>;
+  [2](): Promise<void>;
+  'stringLiteral'(): Promise<void>;
+  ['computedStringLiteral'](): Promise<void>;
+  [Symbol.iterator](): Promise<void>;
 }
       `,
       errors: [
         {
           data: { heritageTypeName: 'MyInterface' },
-          line: 11,
+          line: 21,
           messageId: 'voidReturnInheritedMethod',
         },
         {
           data: { heritageTypeName: 'MyOtherInterface' },
-          line: 11,
+          line: 21,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 22,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyOtherInterface' },
+          line: 22,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 23,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyOtherInterface' },
+          line: 23,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 24,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyOtherInterface' },
+          line: 24,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 25,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyOtherInterface' },
+          line: 25,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyInterface' },
+          line: 26,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          data: { heritageTypeName: 'MyOtherInterface' },
+          line: 26,
           messageId: 'voidReturnInheritedMethod',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -1042,6 +1042,68 @@ interface MyInterface extends MyCall, MyIndex, MyConstruct, MyMethods {
       `,
       options: [{ checksVoidReturn: { inheritedMethods: true } }],
     },
+    {
+      code: `
+const staticSymbol = Symbol.for('static symbol');
+
+interface Interface {
+  identifier: () => void;
+  1: () => void;
+  2: () => void;
+  stringLiteral: () => void;
+  computedStringLiteral: () => void;
+  // well known symbols
+  [Symbol.iterator]: () => void;
+  [Symbol.asyncIterator]: () => void;
+
+  // less sure if this one is possible to lint for
+  [staticSymbol]: () => void;
+}
+
+class Clazz implements Interface {
+  identifier(): void {}
+  1(): void {}
+  [2](): void {}
+  stringLiteral(): void {}
+  ['computedStringLiteral'](): void {}
+  [Symbol.iterator](): void {}
+  [Symbol.asyncIterator](): void {}
+  [staticSymbol](): void {}
+}
+      `,
+      options: [{ checksVoidReturn: { inheritedMethods: true } }],
+    },
+    {
+      code: `
+const staticSymbol = Symbol.for('static symbol');
+
+interface Interface {
+  identifier: () => void;
+  1: () => void;
+  2: () => void;
+  stringLiteral: () => void;
+  computedStringLiteral: () => void;
+  // well known symbols
+  [Symbol.iterator]: () => void;
+  [Symbol.asyncIterator]: () => void;
+
+  // less sure if this one is possible to lint for
+  [staticSymbol]: () => void;
+}
+
+class Clazz implements Interface {
+  async identifier() {}
+  async 1() {}
+  async [2]() {}
+  async stringLiteral() {}
+  async ['computedStringLiteral']() {}
+  async [Symbol.iterator]() {}
+  async [Symbol.asyncIterator]() {}
+  async [staticSymbol]() {}
+}
+      `,
+      options: [{ checksVoidReturn: { inheritedMethods: false } }],
+    },
     "const notAFn1: string = '';",
     'const notAFn2: number = 1;',
     'const notAFn3: boolean = true;',
@@ -2440,8 +2502,9 @@ interface Interface {
   2: () => void;
   stringLiteral: () => void;
   computedStringLiteral: () => void;
-  // well known symbol
+  // well known symbols
   [Symbol.iterator]: () => void;
+  [Symbol.asyncIterator]: () => void;
 
   // less sure if this one is possible to lint for
   [staticSymbol]: () => void;
@@ -2454,14 +2517,11 @@ class Clazz implements Interface {
   async stringLiteral() {}
   async ['computedStringLiteral']() {}
   async [Symbol.iterator]() {}
+  async [Symbol.asyncIterator]() {}
   async [staticSymbol]() {}
 }
       `,
       errors: [
-        {
-          line: 18,
-          messageId: 'voidReturnInheritedMethod',
-        },
         {
           line: 19,
           messageId: 'voidReturnInheritedMethod',
@@ -2480,6 +2540,14 @@ class Clazz implements Interface {
         },
         {
           line: 23,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          line: 24,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          line: 25,
           messageId: 'voidReturnInheritedMethod',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -2429,5 +2429,60 @@ arrayFn<() => void>(
         },
       ],
     },
+
+    {
+      code: `
+const staticSymbol = Symbol.for('static symbol');
+
+interface Interface {
+  identifier: () => void;
+  1: () => void;
+  2: () => void;
+  stringLiteral: () => void;
+  computedStringLiteral: () => void;
+  // well known symbol
+  [Symbol.iterator]: () => void;
+
+  // less sure if this one is possible to lint for
+  [staticSymbol]: () => void;
+}
+
+class Clazz implements Interface {
+  async identifier() {}
+  async 1() {}
+  async [2]() {}
+  async stringLiteral() {}
+  async ['computedStringLiteral']() {}
+  async [Symbol.iterator]() {}
+  async [staticSymbol]() {}
+}
+      `,
+      errors: [
+        {
+          line: 18,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          line: 19,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          line: 20,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          line: 21,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          line: 22,
+          messageId: 'voidReturnInheritedMethod',
+        },
+        {
+          line: 23,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10211
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR resolves #10211 and uses the existing `getStaticMemberAccessValue()` utility instead of `tsutils.getPropertyOfType()` to handle most statically analyzable declarations/properties.