### PR TITLE
fix(eslint-plugin): [await-thenable, return-await] don't flag awaiting unconstrained type parameter as unnecessary

### DIFF
--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -58,8 +58,9 @@ export default createRule<[], MessageId>({
         }
 
         const originalNode = services.esTreeNodeToTSNodeMap.get(node);
+        const certainty = needsToBeAwaited(checker, originalNode, type);
 
-        if (needsToBeAwaited(checker, originalNode, type) === Awaitable.Never) {
+        if (certainty === Awaitable.Never) {
           context.report({
             node,
             messageId: 'await',

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -3,12 +3,14 @@ import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 
 import {
+  Awaitable,
   createRule,
   getFixOrSuggest,
   getParserServices,
   isAwaitKeyword,
   isTypeAnyType,
   isTypeUnknownType,
+  needsToBeAwaited,
   nullThrows,
   NullThrowsReasons,
 } from '../util';
@@ -57,7 +59,7 @@ export default createRule<[], MessageId>({
 
         const originalNode = services.esTreeNodeToTSNodeMap.get(node);
 
-        if (!tsutils.isThenableType(checker, originalNode.expression, type)) {
+        if (needsToBeAwaited(checker, originalNode, type) === Awaitable.Never) {
           context.report({
             node,
             messageId: 'await',

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -9,7 +9,6 @@ import {
   getParserServices,
   isAwaitKeyword,
   isTypeAnyType,
-  isTypeUnknownType,
   needsToBeAwaited,
   nullThrows,
   NullThrowsReasons,
@@ -53,9 +52,6 @@ export default createRule<[], MessageId>({
     return {
       AwaitExpression(node): void {
         const type = services.getTypeAtLocation(node.argument);
-        if (isTypeAnyType(type) || isTypeUnknownType(type)) {
-          return;
-        }
 
         const originalNode = services.esTreeNodeToTSNodeMap.get(node);
         const certainty = needsToBeAwaited(checker, originalNode, type);

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -303,13 +303,13 @@ export default createRule({
       }
 
       const type = checker.getTypeAtLocation(child);
-      const awaited = needsToBeAwaited(checker, expression, type);
+      const certainty = needsToBeAwaited(checker, expression, type);
 
       // handle awaited _non_thenables
 
-      if (awaited !== Awaitable.Always) {
+      if (certainty !== Awaitable.Always) {
         if (isAwait) {
-          if (awaited === Awaitable.May) {
+          if (certainty === Awaitable.May) {
             return;
           }
 

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -312,7 +312,6 @@ export default createRule({
           if (certainty === Awaitable.May) {
             return;
           }
-
           context.report({
             node,
             messageId: 'nonPromiseAwait',

--- a/packages/eslint-plugin/src/rules/return-await.ts
+++ b/packages/eslint-plugin/src/rules/return-await.ts
@@ -1,17 +1,16 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
-import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
 import {
+  Awaitable,
   createRule,
   getFixOrSuggest,
   getParserServices,
   isAwaitExpression,
   isAwaitKeyword,
-  isTypeAnyType,
-  isTypeUnknownType,
+  needsToBeAwaited,
   nullThrows,
 } from '../util';
 import { getOperatorPrecedence } from '../util/getOperatorPrecedence';
@@ -304,16 +303,16 @@ export default createRule({
       }
 
       const type = checker.getTypeAtLocation(child);
-      const isThenable = tsutils.isThenableType(checker, expression, type);
+      const awaited = needsToBeAwaited(checker, expression, type);
 
       // handle awaited _non_thenables
 
-      if (!isThenable) {
+      if (awaited !== Awaitable.Always) {
         if (isAwait) {
-          // any/unknown could be thenable; do not enforce whether they are `await`ed.
-          if (isTypeAnyType(type) || isTypeUnknownType(type)) {
+          if (awaited === Awaitable.May) {
             return;
           }
+
           context.report({
             node,
             messageId: 'nonPromiseAwait',

--- a/packages/eslint-plugin/src/util/index.ts
+++ b/packages/eslint-plugin/src/util/index.ts
@@ -20,6 +20,7 @@ export * from './isUndefinedIdentifier';
 export * from './misc';
 export * from './needsPrecedingSemiColon';
 export * from './objectIterators';
+export * from './needsToBeAwaited';
 export * from './scopeUtils';
 export * from './types';
 

--- a/packages/eslint-plugin/src/util/needsToBeAwaited.ts
+++ b/packages/eslint-plugin/src/util/needsToBeAwaited.ts
@@ -1,0 +1,44 @@
+import type * as ts from 'typescript';
+
+import {
+  isTypeAnyType,
+  isTypeUnknownType,
+} from '@typescript-eslint/type-utils';
+import * as tsutils from 'ts-api-utils';
+
+export enum Awaitable {
+  Always,
+  Never,
+  May,
+}
+
+export function needsToBeAwaited(
+  checker: ts.TypeChecker,
+  node: ts.Node,
+  type: ts.Type,
+): Awaitable {
+  // `any` and `unknown` types may need to be awaited
+  if (isTypeAnyType(type) || isTypeUnknownType(type)) {
+    return Awaitable.May;
+  }
+
+  // 'thenable' values should always be be awaited
+  if (tsutils.isThenableType(checker, node, type)) {
+    return Awaitable.Always;
+  }
+
+  // recurse into a type parameter constraint
+  if (tsutils.isTypeParameter(type)) {
+    const constraint = type.getConstraint();
+
+    // if there's no constraint, this may need to be awaited
+    if (!constraint) {
+      return Awaitable.May;
+    }
+
+    return needsToBeAwaited(checker, node, constraint);
+  }
+
+  // anything else should not be awaited
+  return Awaitable.Never;
+}

--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -313,6 +313,22 @@ async function wrapper<T extends number | Promise<unknown>>(value: T) {
 }
       `,
     },
+    {
+      code: `
+async function wrapper<T extends number | unknown>(value: T) {
+  return await value;
+}
+      `,
+    },
+    {
+      code: `
+class C<T> {
+  async wrapper<T>(value: T) {
+    return await value;
+  }
+}
+      `,
+    },
   ],
 
   invalid: [
@@ -693,6 +709,36 @@ async function wrapper<T extends number>(value: T) {
               output: `
 async function wrapper<T extends number>(value: T) {
   return  value;
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class C<T> {
+  async wrapper<T extends string>(value: T) {
+    return await value;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 12,
+          endColumn: 23,
+          endLine: 4,
+          line: 4,
+          messageId: 'await',
+          suggestions: [
+            {
+              messageId: 'removeAwait',
+              output: `
+class C<T> {
+  async wrapper<T extends string>(value: T) {
+    return  value;
+  }
 }
       `,
             },

--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -278,6 +278,41 @@ async function iterateUsing(arr: Array<AsyncDisposable>) {
 }
       `,
     },
+    {
+      code: `
+async function wrapper<T>(value: T) {
+  return await value;
+}
+      `,
+    },
+    {
+      code: `
+async function wrapper<T extends unknown>(value: T) {
+  return await value;
+}
+      `,
+    },
+    {
+      code: `
+async function wrapper<T extends any>(value: T) {
+  return await value;
+}
+      `,
+    },
+    {
+      code: `
+async function wrapper<T extends Promise<unknown>>(value: T) {
+  return await value;
+}
+      `,
+    },
+    {
+      code: `
+async function wrapper<T extends number | Promise<unknown>>(value: T) {
+  return await value;
+}
+      `,
+    },
   ],
 
   invalid: [
@@ -636,6 +671,32 @@ async function foo() {
           endLine: 6,
           line: 6,
           messageId: 'awaitUsingOfNonAsyncDisposable',
+        },
+      ],
+    },
+    {
+      code: `
+async function wrapper<T extends number>(value: T) {
+  return await value;
+}
+      `,
+      errors: [
+        {
+          column: 10,
+          endColumn: 21,
+          endLine: 3,
+          line: 3,
+          messageId: 'await',
+          suggestions: [
+            {
+              messageId: 'removeAwait',
+              output: `
+async function wrapper<T extends number>(value: T) {
+  return  value;
+}
+      `,
+            },
+          ],
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -315,13 +315,6 @@ async function wrapper<T extends number | Promise<unknown>>(value: T) {
     },
     {
       code: `
-async function wrapper<T extends number | unknown>(value: T) {
-  return await value;
-}
-      `,
-    },
-    {
-      code: `
 class C<T> {
   async wrapper<T>(value: T) {
     return await value;

--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -322,6 +322,24 @@ class C<T> {
 }
       `,
     },
+    {
+      code: `
+class C<R> {
+  async wrapper<T extends R>(value: T) {
+    return await value;
+  }
+}
+      `,
+    },
+    {
+      code: `
+class C<R extends unknown> {
+  async wrapper<T extends R>(value: T) {
+    return await value;
+  }
+}
+      `,
+    },
   ],
 
   invalid: [
@@ -730,6 +748,36 @@ class C<T> {
               output: `
 class C<T> {
   async wrapper<T extends string>(value: T) {
+    return  value;
+  }
+}
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+class C<R extends number> {
+  async wrapper<T extends R>(value: T) {
+    return await value;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 12,
+          endColumn: 23,
+          endLine: 4,
+          line: 4,
+          messageId: 'await',
+          suggestions: [
+            {
+              messageId: 'removeAwait',
+              output: `
+class C<R extends number> {
+  async wrapper<T extends R>(value: T) {
     return  value;
   }
 }

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -478,6 +478,24 @@ class C<T> {
 }
       `,
     },
+    {
+      code: `
+class C<R> {
+  async wrapper<T extends R>(value: T) {
+    return await value;
+  }
+}
+      `,
+    },
+    {
+      code: `
+class C<R extends unknown> {
+  async wrapper<T extends R>(value: T) {
+    return await value;
+  }
+}
+      `,
+    },
   ],
   invalid: [
     {
@@ -1597,6 +1615,68 @@ async function outerFunction() {
   };
 
   const innerFunction = async () => asyncFn();
+}
+      `,
+    },
+    {
+      code: `
+async function wrapper<T extends number>(value: T) {
+  return await value;
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'nonPromiseAwait',
+        },
+      ],
+      output: `
+async function wrapper<T extends number>(value: T) {
+  return value;
+}
+      `,
+    },
+    {
+      code: `
+class C<T> {
+  async wrapper<T extends string>(value: T) {
+    return await value;
+  }
+}
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'nonPromiseAwait',
+        },
+      ],
+      output: `
+class C<T> {
+  async wrapper<T extends string>(value: T) {
+    return value;
+  }
+}
+      `,
+    },
+    {
+      code: `
+class C<R extends number> {
+  async wrapper<T extends R>(value: T) {
+    return await value;
+  }
+}
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'nonPromiseAwait',
+        },
+      ],
+      output: `
+class C<R extends number> {
+  async wrapper<T extends R>(value: T) {
+    return value;
+  }
 }
       `,
     },

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -448,6 +448,36 @@ return Promise.resolve(42);
 }
       `,
     },
+    {
+      code: `
+async function wrapper<T>(value: T) {
+  return await value;
+}
+      `,
+    },
+    {
+      code: `
+async function wrapper<T extends unknown>(value: T) {
+  return await value;
+}
+      `,
+    },
+    {
+      code: `
+async function wrapper<T extends any>(value: T) {
+  return await value;
+}
+      `,
+    },
+    {
+      code: `
+class C<T> {
+  async wrapper<T>(value: T) {
+    return await value;
+  }
+}
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10311
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR resolves #10311 and stops reporting on some type constraints (see [playground link](https://typescript-eslint.io/play/#ts=5.6.2&fileType=.ts&code=PTAEBcE8AcFNWgQwE6ILa3LZoDuBLcAC1ADsB7UAY3NIGdxV9TwAoROyUq0AMwFdu4fLQiwGARgA8AFQB8ACgBuiADb9YALlAyAlKADerUKGSZ%2ByUqES5EhUCvWwA3KwC%2BrViAgx4SVBhYOATEoAAGiKSQYaDkOGGCANYUuKQxNPSMdizsnNx8glTColgMAEyyoLAAHlikACZ0oEkppIqOGtp6hsam5pbWtvYdLu6eHFw8AkIiVqXgAMyVNXWN1lHtap06%2BkYmZuAWVjZ24A5box5eYPX4ZkXhkdGx8S3kqTFQcAgcdOK5kwKMxK4nAABZlBdtG9UrtegcjoNTucnK4rhN8tMirMxAwAKyQpzaJ5w-b9Y5DM4jNGsIA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6AQwHd3K78ALRE3YAjJOiiJo0APbRI4MAF8QSoA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)).

As per @kirkwaiblinger's [comment](https://github.com/typescript-eslint/typescript-eslint/issues/10311#issuecomment-2466115554), I shared common logic between `await-thenable` and `return-await`, so this fixes similar issues with both ([playground link for `return-await`](https://typescript-eslint.io/play/#ts=5.6.2&fileType=.ts&code=PTAEBcE8AcFNWgQwE6ILa3LZoDuBLcAC1ADsB7UAY3NIGdxV9TwAoROyUq0AMwFdu4fLQiwGARgA8AFQB8ACgBuiADb9YALlAyAlKADerUKGSZ%2ByUqES5EhUCvWwA3KwC%2BrViAgx4SVBhYOATEoAAGiKSQYaDkOGGCANYUuKQxNPSMdizsnNx8glTColgMAEyyoLAAHlikACZ0oEkppIqOGtp6hsam5pbWtvYdLu6eHFw8AkIiVqXgAMyVNXWN1lHtap06%2BkYmZuAWVjZ24A5box5eYPX4ZkXhkdGx8S3kqTFQcAgcdOK5kwKMxK4nAABZlBdtG9UrtegcjoNTucnK4rhN8tMirMxAwAKyQpzaJ5w-b9Y5DM4jNGsIA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEIHodQAEAXATwAcUBjaASzKIFoV4aA7InAQwHdObGiAC0StOAIyToovaK0gAacNkjFyVWvSbIW7HNERFYshjz5EpkRNGgB7aJCUBfEI6A&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)).

On top of not reporting on unconstrained type parameters, this also stops reporting on type parameters with valid constraints like `unknown` or `any` (not part of the original issue); please let me know if this is OK.

```ts
// type parameter with no constraint
async function test1<T>(value: T) {
  return await value;
}

// type parameter with `any` or `unknown` constraint
async function test2<T extends unknown>(value: T) {
  return await value;
}

async function test3<T extends any>(value: T) {
  return await value;
}

// direct `any` or `unknown` type pass
async function test4(value: unknown) {
  return await value;
}

async function test5(value: any) {
  return await value;
}
```