### PR TITLE
fix(eslint-plugin): [explicit-module-boundary-types] and [explicit-function-return-type] don't report on `as const satisfies`

### DIFF
--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -260,11 +260,12 @@ function isValidFunctionExpressionReturnType(
     return false;
   }
 
-  const { body } = node;
+  let body = node.body;
+  while (body.type === AST_NODE_TYPES.TSSatisfiesExpression) {
+    body = body.expression;
+  }
 
-  return isConstAssertion(
-    body.type === AST_NODE_TYPES.TSSatisfiesExpression ? body.expression : body,
-  );
+  return isConstAssertion(body);
 }
 
 /**

--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -262,11 +262,9 @@ function isValidFunctionExpressionReturnType(
 
   const { body } = node;
 
-  if (body.type === AST_NODE_TYPES.TSSatisfiesExpression) {
-    return isConstAssertion(body.expression);
-  }
-
-  return isConstAssertion(body);
+  return isConstAssertion(
+    body.type === AST_NODE_TYPES.TSSatisfiesExpression ? body.expression : body,
+  );
 }
 
 /**

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -449,9 +449,26 @@ interface R {
 }
 
 const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
-const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
-const func = (value: number) => x as const satisfies R;
-const func = (value: number) => x as const satisfies R;
+      `,
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
+const func = (value: number) => x as const satisfies number;
+      `,
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
+const func = (value: number) => x as const satisfies string;
       `,
       options: [
         {
@@ -1732,66 +1749,6 @@ const func = (value: number) => ({ type: 'X', value }) as Action;
     },
     {
       code: `
-interface R {
-  type: string;
-  value: number;
-}
-
-const func = (value: number) => ({ type: 'X', value }) satisfies R;
-const func = (value: number) => ({ type: 'X', value }) satisfies any;
-      `,
-      errors: [
-        {
-          column: 30,
-          endColumn: 32,
-          endLine: 7,
-          line: 7,
-          messageId: 'missingReturnType',
-        },
-        {
-          column: 30,
-          endColumn: 32,
-          endLine: 8,
-          line: 8,
-          messageId: 'missingReturnType',
-        },
-      ],
-      options: [
-        {
-          allowDirectConstAssertionInArrowFunctions: true,
-        },
-      ],
-    },
-    {
-      code: `
-const func = (value: number) => ({ type: 'X', value }) as any satisfies any;
-const func = (value: number) =>
-  ({ type: 'X', value }) as Action satisfies Action;
-      `,
-      errors: [
-        {
-          column: 30,
-          endColumn: 32,
-          endLine: 2,
-          line: 2,
-          messageId: 'missingReturnType',
-        },
-        {
-          column: 30,
-          endColumn: 32,
-          endLine: 3,
-          line: 3,
-          messageId: 'missingReturnType',
-        },
-      ],
-      options: [
-        {
-          allowDirectConstAssertionInArrowFunctions: true,
-        },
-      ],
-    },
-    {
-      code: `
 const func = (value: number) => ({ type: 'X', value }) as const;
       `,
       errors: [
@@ -1822,8 +1779,8 @@ const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
         {
           column: 30,
           endColumn: 32,
-          endLine: 7,
-          line: 7,
+          endLine: 2,
+          line: 2,
           messageId: 'missingReturnType',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -1779,8 +1779,8 @@ const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
         {
           column: 30,
           endColumn: 32,
-          endLine: 2,
-          line: 2,
+          endLine: 7,
+          line: 7,
           messageId: 'missingReturnType',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -463,7 +463,8 @@ interface R {
   value: number;
 }
 
-const func = (value: number) => ({ type: 'X', value }) as const satisfies R satisfies R;
+const func = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R satisfies R;
       `,
       options: [
         {
@@ -478,7 +479,8 @@ interface R {
   value: number;
 }
 
-const func = (value: number) => ({ type: 'X', value }) as const satisfies R satisfies R satisfies R;
+const func = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R satisfies R satisfies R;
       `,
       options: [
         {

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -468,6 +468,27 @@ const func = (value: number) => x as const satisfies number;
     },
     {
       code: `
+const func = (value: number) => x as const satisfies 10 satisfies number;
+      `,
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
+const func = (value: number) =>
+  x as const satisfies 10 satisfies number satisfies any;
+      `,
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
 const func = (value: number) => x as const satisfies string;
       `,
       options: [

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -443,6 +443,24 @@ const func = (value: number) => x as const;
     },
     {
       code: `
+interface R {
+  type: string;
+  value: number;
+}
+
+const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
+const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
+const func = (value: number) => x as const satisfies R;
+const func = (value: number) => x as const satisfies R;
+      `,
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
 new Promise(resolve => {});
 new Foo(1, () => {});
       `,
@@ -1714,6 +1732,66 @@ const func = (value: number) => ({ type: 'X', value }) as Action;
     },
     {
       code: `
+interface R {
+  type: string;
+  value: number;
+}
+
+const func = (value: number) => ({ type: 'X', value }) satisfies R;
+const func = (value: number) => ({ type: 'X', value }) satisfies any;
+      `,
+      errors: [
+        {
+          column: 30,
+          endColumn: 32,
+          endLine: 7,
+          line: 7,
+          messageId: 'missingReturnType',
+        },
+        {
+          column: 30,
+          endColumn: 32,
+          endLine: 8,
+          line: 8,
+          messageId: 'missingReturnType',
+        },
+      ],
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
+const func = (value: number) => ({ type: 'X', value }) as any satisfies any;
+const func = (value: number) =>
+  ({ type: 'X', value }) as Action satisfies Action;
+      `,
+      errors: [
+        {
+          column: 30,
+          endColumn: 32,
+          endLine: 2,
+          line: 2,
+          messageId: 'missingReturnType',
+        },
+        {
+          column: 30,
+          endColumn: 32,
+          endLine: 3,
+          line: 3,
+          messageId: 'missingReturnType',
+        },
+      ],
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
 const func = (value: number) => ({ type: 'X', value }) as const;
       `,
       errors: [
@@ -1722,6 +1800,30 @@ const func = (value: number) => ({ type: 'X', value }) as const;
           endColumn: 32,
           endLine: 2,
           line: 2,
+          messageId: 'missingReturnType',
+        },
+      ],
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: false,
+        },
+      ],
+    },
+    {
+      code: `
+interface R {
+  type: string;
+  value: number;
+}
+
+const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
+      `,
+      errors: [
+        {
+          column: 30,
+          endColumn: 32,
+          endLine: 7,
+          line: 7,
           messageId: 'missingReturnType',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-function-return-type.test.ts
@@ -458,7 +458,12 @@ const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
     },
     {
       code: `
-const func = (value: number) => x as const satisfies number;
+interface R {
+  type: string;
+  value: number;
+}
+
+const func = (value: number) => ({ type: 'X', value }) as const satisfies R satisfies R;
       `,
       options: [
         {
@@ -468,28 +473,12 @@ const func = (value: number) => x as const satisfies number;
     },
     {
       code: `
-const func = (value: number) => x as const satisfies 10 satisfies number;
-      `,
-      options: [
-        {
-          allowDirectConstAssertionInArrowFunctions: true,
-        },
-      ],
-    },
-    {
-      code: `
-const func = (value: number) =>
-  x as const satisfies 10 satisfies number satisfies any;
-      `,
-      options: [
-        {
-          allowDirectConstAssertionInArrowFunctions: true,
-        },
-      ],
-    },
-    {
-      code: `
-const func = (value: number) => x as const satisfies string;
+interface R {
+  type: string;
+  value: number;
+}
+
+const func = (value: number) => ({ type: 'X', value }) as const satisfies R satisfies R satisfies R;
       `,
       options: [
         {

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -393,6 +393,17 @@ export const func4 = (value: number) => x as const satisfies number;
     },
     {
       code: `
+export const func4 = (value: number) =>
+  x as const satisfies 10 satisfies number satisfies any;
+      `,
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
 export const func4 = (value: number) => x as const satisfies string;
       `,
       options: [

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -372,7 +372,8 @@ interface R {
   value: number;
 }
 
-const func1 = (value: number) => ({ type: 'X', value }) as const satisfies R;
+export const func1 = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R;
       `,
       options: [
         {
@@ -382,7 +383,7 @@ const func1 = (value: number) => ({ type: 'X', value }) as const satisfies R;
     },
     {
       code: `
-const func4 = (value: number) => x as const satisfies number;
+export const func4 = (value: number) => x as const satisfies number;
       `,
       options: [
         {
@@ -392,7 +393,7 @@ const func4 = (value: number) => x as const satisfies number;
     },
     {
       code: `
-const func4 = (value: number) => x as const satisfies string;
+export const func4 = (value: number) => x as const satisfies string;
       `,
       options: [
         {
@@ -1244,14 +1245,15 @@ interface R {
   value: number;
 }
 
-const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
+export const func = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R;
       `,
       errors: [
         {
           column: 37,
           endColumn: 39,
-          endLine: 2,
-          line: 2,
+          endLine: 7,
+          line: 7,
           messageId: 'missingReturnType',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -372,7 +372,7 @@ interface R {
   value: number;
 }
 
-export const func1 = (value: number) =>
+export const func = (value: number) =>
   ({ type: 'X', value }) as const satisfies R;
       `,
       options: [
@@ -383,7 +383,13 @@ export const func1 = (value: number) =>
     },
     {
       code: `
-export const func4 = (value: number) => x as const satisfies number;
+interface R {
+  type: string;
+  value: number;
+}
+
+export const func = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R satisfies R;
       `,
       options: [
         {
@@ -393,18 +399,13 @@ export const func4 = (value: number) => x as const satisfies number;
     },
     {
       code: `
-export const func4 = (value: number) =>
-  x as const satisfies 10 satisfies number satisfies any;
-      `,
-      options: [
-        {
-          allowDirectConstAssertionInArrowFunctions: true,
-        },
-      ],
-    },
-    {
-      code: `
-export const func4 = (value: number) => x as const satisfies string;
+interface R {
+  type: string;
+  value: number;
+}
+
+export const func = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R satisfies R satisfies R;
       `,
       options: [
         {

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -367,6 +367,26 @@ export const func4 = (value: number) => x as const;
     },
     {
       code: `
+interface R {
+  type: string;
+  value: number;
+}
+
+export const func1 = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R;
+export const func2 = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R;
+export const func3 = (value: number) => x as const satisfies R;
+export const func4 = (value: number) => x as const satisfies R;
+      `,
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
 export const func1 = (value: string) => value;
 export const func2 = (value: number) => ({ type: 'X', value });
       `,
@@ -1185,6 +1205,68 @@ export const func2 = (value: number) => ({ type: 'X', value }) as Action;
     },
     {
       code: `
+interface R {
+  type: string;
+  value: number;
+}
+
+export const func1 = (value: number) => ({ type: 'X', value }) satisfies R;
+export const func2 = (value: number) => ({ type: 'X', value }) as any;
+      `,
+      errors: [
+        {
+          column: 38,
+          endColumn: 40,
+          endLine: 7,
+          line: 7,
+          messageId: 'missingReturnType',
+        },
+        {
+          column: 38,
+          endColumn: 40,
+          endLine: 8,
+          line: 8,
+          messageId: 'missingReturnType',
+        },
+      ],
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
+export const func1 = (value: number) =>
+  ({ type: 'X', value }) as any satisfies any;
+
+export const func2 = (value: number) =>
+  ({ type: 'X', value }) as Action satisfies Action;
+      `,
+      errors: [
+        {
+          column: 38,
+          endColumn: 40,
+          endLine: 2,
+          line: 2,
+          messageId: 'missingReturnType',
+        },
+        {
+          column: 38,
+          endColumn: 40,
+          endLine: 5,
+          line: 5,
+          messageId: 'missingReturnType',
+        },
+      ],
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
 export const func = (value: number) => ({ type: 'X', value }) as const;
       `,
       errors: [
@@ -1193,6 +1275,31 @@ export const func = (value: number) => ({ type: 'X', value }) as const;
           endColumn: 39,
           endLine: 2,
           line: 2,
+          messageId: 'missingReturnType',
+        },
+      ],
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: false,
+        },
+      ],
+    },
+    {
+      code: `
+interface R {
+  type: string;
+  value: number;
+}
+
+export const func = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R;
+      `,
+      errors: [
+        {
+          column: 37,
+          endColumn: 39,
+          endLine: 7,
+          line: 7,
           messageId: 'missingReturnType',
         },
       ],
@@ -1353,6 +1460,19 @@ export function foo(outer) {
     },
     {
       code: 'export const baz = arg => arg as const;',
+      errors: [
+        {
+          data: {
+            name: 'arg',
+          },
+          line: 1,
+          messageId: 'missingArgType',
+        },
+      ],
+      options: [{ allowDirectConstAssertionInArrowFunctions: true }],
+    },
+    {
+      code: 'export const baz = arg => arg as const satisfies unknown;',
       errors: [
         {
           data: {

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -372,12 +372,27 @@ interface R {
   value: number;
 }
 
-export const func1 = (value: number) =>
-  ({ type: 'X', value }) as const satisfies R;
-export const func2 = (value: number) =>
-  ({ type: 'X', value }) as const satisfies R;
-export const func3 = (value: number) => x as const satisfies R;
-export const func4 = (value: number) => x as const satisfies R;
+const func1 = (value: number) => ({ type: 'X', value }) as const satisfies R;
+      `,
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
+const func4 = (value: number) => x as const satisfies number;
+      `,
+      options: [
+        {
+          allowDirectConstAssertionInArrowFunctions: true,
+        },
+      ],
+    },
+    {
+      code: `
+const func4 = (value: number) => x as const satisfies string;
       `,
       options: [
         {
@@ -1205,68 +1220,6 @@ export const func2 = (value: number) => ({ type: 'X', value }) as Action;
     },
     {
       code: `
-interface R {
-  type: string;
-  value: number;
-}
-
-export const func1 = (value: number) => ({ type: 'X', value }) satisfies R;
-export const func2 = (value: number) => ({ type: 'X', value }) as any;
-      `,
-      errors: [
-        {
-          column: 38,
-          endColumn: 40,
-          endLine: 7,
-          line: 7,
-          messageId: 'missingReturnType',
-        },
-        {
-          column: 38,
-          endColumn: 40,
-          endLine: 8,
-          line: 8,
-          messageId: 'missingReturnType',
-        },
-      ],
-      options: [
-        {
-          allowDirectConstAssertionInArrowFunctions: true,
-        },
-      ],
-    },
-    {
-      code: `
-export const func1 = (value: number) =>
-  ({ type: 'X', value }) as any satisfies any;
-
-export const func2 = (value: number) =>
-  ({ type: 'X', value }) as Action satisfies Action;
-      `,
-      errors: [
-        {
-          column: 38,
-          endColumn: 40,
-          endLine: 2,
-          line: 2,
-          messageId: 'missingReturnType',
-        },
-        {
-          column: 38,
-          endColumn: 40,
-          endLine: 5,
-          line: 5,
-          messageId: 'missingReturnType',
-        },
-      ],
-      options: [
-        {
-          allowDirectConstAssertionInArrowFunctions: true,
-        },
-      ],
-    },
-    {
-      code: `
 export const func = (value: number) => ({ type: 'X', value }) as const;
       `,
       errors: [
@@ -1291,15 +1244,14 @@ interface R {
   value: number;
 }
 
-export const func = (value: number) =>
-  ({ type: 'X', value }) as const satisfies R;
+const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
       `,
       errors: [
         {
           column: 37,
           endColumn: 39,
-          endLine: 7,
-          line: 7,
+          endLine: 2,
+          line: 2,
           messageId: 'missingReturnType',
         },
       ],
@@ -1460,19 +1412,6 @@ export function foo(outer) {
     },
     {
       code: 'export const baz = arg => arg as const;',
-      errors: [
-        {
-          data: {
-            name: 'arg',
-          },
-          line: 1,
-          messageId: 'missingArgType',
-        },
-      ],
-      options: [{ allowDirectConstAssertionInArrowFunctions: true }],
-    },
-    {
-      code: 'export const baz = arg => arg as const satisfies unknown;',
       errors: [
         {
           data: {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10231
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR resolves #10231 and adjusts both `explicit-module-boundary-types` and `explicit-function-return-type` to not fail on the following when `allowDirectConstAssertionInArrowFunctions` is enabled:

```ts
type Foo = {
  foo: string,
  bar: number,
};

export const a = () => ({
  foo: "FOOO",
  bar: 123,
}as const); // <-- This works as expected.

export const b = () => ({
  foo: "FOOO",
  bar: 123,
} as const satisfies Foo); // <-- This unexpectedly causes the rules to report.
```

