### PR TITLE
feat(rule-tester): run method - avoid to infer type parameter from `tests` param

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -2,7 +2,7 @@
 // Forked from https://github.com/eslint/eslint/blob/ad9dd6a933fd098a0d99c6a9aa059850535c23ee/lib/rule-tester/rule-tester.js
 
 import type * as ParserType from '@typescript-eslint/parser';
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree, TSUtils } from '@typescript-eslint/utils';
 import type {
   AnyRuleCreateFunction,
   AnyRuleModule,
@@ -482,7 +482,7 @@ export class RuleTester extends TestFramework {
   run<MessageIds extends string, Options extends readonly unknown[]>(
     ruleName: string,
     rule: RuleModule<MessageIds, Options>,
-    test: RunTests<MessageIds, Options>,
+    test: RunTests<TSUtils.NoInfer<MessageIds>, TSUtils.NoInfer<Options>>,
   ): void {
     const constructor = this.constructor as typeof RuleTester;
 
@@ -537,7 +537,7 @@ export class RuleTester extends TestFramework {
     const normalizedTests = this.#normalizeTests(test);
 
     function getTestMethod(
-      test: ValidTestCase<Options>,
+      test: ValidTestCase<TSUtils.NoInfer<Options>>,
     ): 'it' | 'itOnly' | 'itSkip' {
       if (test.skip) {
         return 'itSkip';
@@ -594,7 +594,8 @@ export class RuleTester extends TestFramework {
                 this.#testInvalidTemplate(
                   ruleName,
                   rule,
-                  invalid,
+                  // no need to pass no infer type parameter down to private methods
+                  invalid as InvalidTestCase<MessageIds, Options>,
                   seenInvalidTestCases,
                 );
               } finally {

--- a/packages/utils/src/ts-utils/NoInfer.ts
+++ b/packages/utils/src/ts-utils/NoInfer.ts
@@ -1,0 +1,9 @@
+/**
+ * We could use NoInfer typescript build-in utility
+ * introduced in typescript 5.4, however at the moment of creation
+ * the supported ts versions are >=4.8.4 <5.7.0
+ * so for the moment we have to stick to this polyfill.
+ *
+ * @see https://github.com/millsp/ts-toolbelt/blob/master/sources/Function/NoInfer.ts
+ */
+export type NoInfer<A> = [A][A extends unknown ? 0 : never];

--- a/packages/utils/src/ts-utils/index.ts
+++ b/packages/utils/src/ts-utils/index.ts
@@ -1,1 +1,2 @@
 export * from './isArray';
+export * from './NoInfer';


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10321
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)

> [!CAUTION]
> The issue is not marked with the label "accepting prs" right now but [there is a comment about making this change](https://github.com/typescript-eslint/typescript-eslint/issues/10321#issuecomment-2469603873)

## Overview

Added `NoInfer` on `RuleTester#run` `tests` parameter. 
This change prevent to infer `MessageIds` and `Options` type parameters from the `tests` parameter which may cause  incorrect types when using helper functions.

> [!NOTE]
> [Currently typescript version range (`>=4.8.4 <5.7.0`)](https://typescript-eslint.io/users/dependency-versions/#typescript) supports versions that do not have the `NoInfer` utility type included ([`>= 5.4`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#the-noinfer-utility-type)).
> To solve the problem I added a `NoInfer` utility inside  `@typescript-eslint/utils` package.

😅
