### PR TITLE
fix(eslint-plugin): report deprecations used in default export

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -127,7 +127,6 @@ export default createRule({
       while (true) {
         switch (current.type) {
           case AST_NODE_TYPES.ExportAllDeclaration:
-          case AST_NODE_TYPES.ExportDefaultDeclaration:
           case AST_NODE_TYPES.ExportNamedDeclaration:
           case AST_NODE_TYPES.ImportDeclaration:
             return true;

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -101,6 +101,23 @@ ruleTester.run('no-deprecated', rule, {
       a('b');
     `,
     `
+      function a(value: 'b' | undefined): void;
+      /** @deprecated */
+      function a(value: 'c' | undefined): void;
+      function a(value: string | undefined): void {
+        // ...
+      }
+
+      export default a('b');
+    `,
+    `
+      function notDeprecated(): object {
+        return {};
+      }
+
+      export default notDeprecated();
+    `,
+    `
       import { deprecatedFunctionWithOverloads } from './deprecated';
 
       const foo = deprecatedFunctionWithOverloads();
@@ -2459,6 +2476,26 @@ ruleTester.run('no-deprecated', rule, {
           endColumn: 19,
           endLine: 5,
           line: 5,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        /** @deprecated */
+        function a(): object {
+          return {};
+        }
+
+        export default a();
+      `,
+      errors: [
+        {
+          column: 24,
+          data: { name: 'a' },
+          endColumn: 25,
+          endLine: 7,
+          line: 7,
           messageId: 'deprecated',
         },
       ],


### PR DESCRIPTION


<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #10327
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Report deprecations which are used in default exports - this is the way typescript compiler reports deprecations.
