### PR TITLE
docs(eslint-plugin): [no-confusing-void-expression] add a default value for `ignoreVoidReturningFunctions`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -97,7 +97,13 @@ export default createRule<Options, MessageId>({
       },
     ],
   },
-  defaultOptions: [{ ignoreArrowShorthand: false, ignoreVoidOperator: false }],
+  defaultOptions: [
+    {
+      ignoreArrowShorthand: false,
+      ignoreVoidOperator: false,
+      ignoreVoidReturningFunctions: false,
+    },
+  ],
 
   create(context, [options]) {
     const services = getParserServices(context);


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10335
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

My ooops on #10067.

Would it make sense to use a generic ([here](https://github.com/typescript-eslint/typescript-eslint/blob/746560aab8b8df6fed02219f03e866795cdc58c6/packages/utils/src/eslint-utils/RuleCreator.ts#L29)) to enforce that every rule provides default values for every one of its options (so that mistakes like this don't repeat)?