### PR TITLE
docs: [no-deprecated] awkward wording about TypeScript visualizing deprecated code

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-deprecated.mdx
+++ b/packages/eslint-plugin/docs/rules/no-deprecated.mdx
@@ -14,7 +14,7 @@ It's best to avoid using code marked as deprecated.
 This rule reports on any references to code marked as `@deprecated`.
 
 :::note
-[TypeScript recognizes the `@deprecated` tag](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#deprecated) and visualizes deprecated code with a ~strikethrough~.
+[TypeScript recognizes the `@deprecated` tag](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#deprecated) and editors usually visualizes deprecated code with a ~strikethrough~.
 However, TypeScript doesn't report type errors for deprecated code on its own.
 :::
 

--- a/packages/eslint-plugin/docs/rules/no-deprecated.mdx
+++ b/packages/eslint-plugin/docs/rules/no-deprecated.mdx
@@ -14,7 +14,7 @@ It's best to avoid using code marked as deprecated.
 This rule reports on any references to code marked as `@deprecated`.
 
 :::note
-[TypeScript recognizes the `@deprecated` tag](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#deprecated) and editors usually visualizes deprecated code with a ~strikethrough~.
+[TypeScript recognizes the `@deprecated` tag](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#deprecated), allowing editors to visually indicate deprecated code — usually with a ~strikethrough~.
 However, TypeScript doesn't report type errors for deprecated code on its own.
 :::
 


### PR DESCRIPTION
TypeScript can't visualize deprecated code, editors can.

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
