### PR TITLE
fix(eslint-plugin): [no-unnecessary-template-expressions] allow template expressions used to make trailing whitespace visible

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
@@ -304,7 +304,15 @@ export default createRule<[], MessageId>({
 });
 
 function isWhitespace(x: string): boolean {
-  return /^\s+$/.test(x);
+  // allow empty string too since we went to allow
+  // `      ${''}
+  // `;
+  //
+  // in addition to
+  // `${'        '}
+  // `;
+  //
+  return /^\s*$/.test(x);
 }
 
 function startsWithNewLine(x: string): boolean {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -885,6 +885,38 @@ const invalidCases: readonly InvalidTestCase<
     errors: [{ messageId: 'noUnnecessaryTemplateExpression' }],
     output: '` \\ud83d\\udc68 `;',
   },
+  {
+    code: `
+\`
+this code does not have trailing whitespace: \${' '}\\n even though it might look it.\`;
+    `,
+    errors: [
+      {
+        messageId: 'noUnnecessaryTemplateExpression',
+      },
+    ],
+    output: `
+\`
+this code does not have trailing whitespace:  \\n even though it might look it.\`;
+    `,
+  },
+  {
+    code: `
+\`
+this code has trailing position template expression \${'but it isn\\'t whitespace'}
+    \`;
+    `,
+    errors: [
+      {
+        messageId: 'noUnnecessaryTemplateExpression',
+      },
+    ],
+    output: `
+\`
+this code has trailing position template expression but it isn\\'t whitespace
+    \`;
+    `,
+  },
 ];
 
 describe('fixer should not change runtime value', () => {
@@ -1022,6 +1054,16 @@ ruleTester.run('no-unnecessary-template-expression', rule, {
 
     `
 \`not a useless \${String.raw\`nested interpolation \${a}\`}\`;
+    `,
+    `
+\`
+this code has trailing whitespace: \${'    '}
+    \`;
+    `,
+    `
+\`
+this code has trailing whitespace: \${' '}
+    \`;
     `,
   ],
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -1073,11 +1073,6 @@ ruleTester.run('no-unnecessary-template-expression', rule, {
 this code has trailing whitespace: \${'    '}
     \`;
     `,
-    `
-\`
-this code has trailing whitespace: \${' '}
-    \`;
-    `,
     noFormat`
 \`this code has trailing whitespace with a windows \\\r new line: \${' '}\r\n\`;
     `,

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -917,6 +917,19 @@ this code has trailing position template expression but it isn\\'t whitespace
     \`;
     `,
   },
+  {
+    code: noFormat`
+\`trailing whitespace followed by escaped windows newline: \${' '}\\r\\n\`;
+    `,
+    errors: [
+      {
+        messageId: 'noUnnecessaryTemplateExpression',
+      },
+    ],
+    output: `
+\`trailing whitespace followed by escaped windows newline:  \\r\\n\`;
+    `,
+  },
 ];
 
 describe('fixer should not change runtime value', () => {
@@ -1064,6 +1077,9 @@ this code has trailing whitespace: \${'    '}
 \`
 this code has trailing whitespace: \${' '}
     \`;
+    `,
+    noFormat`
+\`this code has trailing whitespace with a windows \\\r new line: \${' '}\r\n\`;
     `,
   ],
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -930,6 +930,30 @@ this code has trailing position template expression but it isn\\'t whitespace
 \`trailing whitespace followed by escaped windows newline:  \\r\\n\`;
     `,
   },
+  {
+    code: `
+\`template literal with interpolations followed by newline: \${\` \${'interpolation'} \`}
+\`;
+    `,
+    errors: [
+      {
+        messageId: 'noUnnecessaryTemplateExpression',
+      },
+      {
+        messageId: 'noUnnecessaryTemplateExpression',
+      },
+    ],
+    output: [
+      `
+\`template literal with interpolations followed by newline:  \${'interpolation'}${' '}
+\`;
+    `,
+      `
+\`template literal with interpolations followed by newline:  interpolation${' '}
+\`;
+    `,
+    ],
+  },
 ];
 
 describe('fixer should not change runtime value', () => {
@@ -1075,6 +1099,10 @@ this code has trailing whitespace: \${'    '}
     `,
     noFormat`
 \`this code has trailing whitespace with a windows \\\r new line: \${' '}\r\n\`;
+    `,
+    `
+\`trailing position interpolated empty string also makes whitespace clear    \${''}
+\`;
     `,
   ],
 

--- a/packages/eslint-plugin/tests/rules/no-useless-constructor.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-constructor.test.ts
@@ -209,8 +209,6 @@ class A extends Object {
     `,
   ],
   invalid: [
-    /* eslint-disable @typescript-eslint/no-unnecessary-template-expression -- trailing whitespace */
-
     {
       code: `
 class A {
@@ -432,6 +430,5 @@ ${'  '}
         },
       ],
     },
-    /* eslint-enable @typescript-eslint/no-unnecessary-template-expression */
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10360
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Basically just checks for an unescaped new line literal following the expression, and checks whether the expression is a whitespace literal

I used as a guiding principle "If the user has explicitly provided whitespace to end a line we won't report". This is different from "we won't ever write report on an interpolation fixing which would result in terminal whitespace". For example, this code
```ts
`this has ${'whitespace after fixing       '}
`;
```
fixes to
```
`this has whitespace after fixing       
`;
```
and that is intentional.

It's up to a user to explicitly specify 
```ts
`this has whitespace after fixing${'       '}
`;
// or
`this has whitespace after fixing       ${''}
`;
```
if that's what they want to do

🫡 