### PR TITLE
fix: typescript peer dependency

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -98,12 +98,8 @@
   },
   "peerDependencies": {
     "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-    "eslint": "^8.57.0 || ^9.0.0"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
+    "eslint": "^8.57.0 || ^9.0.0",
+    "typescript": ">=4.8.4 <5.8.0"
   },
   "funding": {
     "type": "opencollective",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -49,7 +49,8 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "eslint": "^8.57.0 || ^9.0.0"
+    "eslint": "^8.57.0 || ^9.0.0",
+    "typescript": ">=4.8.4 <5.8.0"
   },
   "dependencies": {
     "@typescript-eslint/scope-manager": "8.17.0",
@@ -67,11 +68,6 @@
     "prettier": "^3.2.5",
     "rimraf": "*",
     "typescript": "*"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
   },
   "funding": {
     "type": "opencollective",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -52,7 +52,8 @@
     "ts-api-utils": "^1.3.0"
   },
   "peerDependencies": {
-    "eslint": "^8.57.0 || ^9.0.0"
+    "eslint": "^8.57.0 || ^9.0.0",
+    "typescript": ">=4.8.4 <5.8.0"
   },
   "devDependencies": {
     "@jest/types": "29.6.3",
@@ -63,11 +64,6 @@
     "prettier": "^3.2.5",
     "rimraf": "*",
     "typescript": "*"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
   },
   "funding": {
     "type": "opencollective",

--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -57,7 +57,8 @@
     "@typescript-eslint/utils": "8.17.0"
   },
   "peerDependencies": {
-    "eslint": "^8.57.0 || ^9.0.0"
+    "eslint": "^8.57.0 || ^9.0.0",
+    "typescript": ">=4.8.4 <5.8.0"
   },
   "devDependencies": {
     "@jest/types": "29.6.3",
@@ -66,11 +67,6 @@
     "prettier": "^3.2.5",
     "rimraf": "*",
     "typescript": "*"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
   },
   "funding": {
     "type": "opencollective",

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -72,10 +72,8 @@
     "tmp": "*",
     "typescript": "*"
   },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
+  "peerDependencies": {
+    "typescript": ">=4.8.4 <5.8.0"
   },
   "funding": {
     "type": "opencollective",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -69,7 +69,8 @@
     "@typescript-eslint/typescript-estree": "8.17.0"
   },
   "peerDependencies": {
-    "eslint": "^8.57.0 || ^9.0.0"
+    "eslint": "^8.57.0 || ^9.0.0",
+    "typescript": ">=4.8.4 <5.8.0"
   },
   "devDependencies": {
     "downlevel-dts": "*",
@@ -77,11 +78,6 @@
     "prettier": "^3.2.5",
     "rimraf": "*",
     "typescript": "*"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
   },
   "funding": {
     "type": "opencollective",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5751,9 +5751,7 @@ __metadata:
   peerDependencies:
     "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
     eslint: ^8.57.0 || ^9.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
+    typescript: ">=4.8.4 <5.8.0"
   languageName: unknown
   linkType: soft
 
@@ -5788,9 +5786,7 @@ __metadata:
     typescript: "*"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
+    typescript: ">=4.8.4 <5.8.0"
   languageName: unknown
   linkType: soft
 
@@ -5870,9 +5866,7 @@ __metadata:
     typescript: "*"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
+    typescript: ">=4.8.4 <5.8.0"
   languageName: unknown
   linkType: soft
 
@@ -5987,9 +5981,8 @@ __metadata:
     tmp: "*"
     ts-api-utils: ^1.3.0
     typescript: "*"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
+  peerDependencies:
+    typescript: ">=4.8.4 <5.8.0"
   languageName: unknown
   linkType: soft
 
@@ -6008,9 +6001,7 @@ __metadata:
     typescript: "*"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
+    typescript: ">=4.8.4 <5.8.0"
   languageName: unknown
   linkType: soft
 
@@ -19550,9 +19541,7 @@ __metadata:
     typescript: "*"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
+    typescript: ">=4.8.4 <5.8.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9224
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`typescript` is a mandatory peer dependency (_peerDepedency_ of `ts-api-utils`) and not optional peer dependency (it needs to be removed from _peerDepedencyMeta_).

## Info
- `ts-api-utils` has `typescript` as peer dependency:

  ```json5
  // ts-api-utils/package.json
  {
    "peerDependencies": {
      "typescript": ">=4.2.0"
    }
  }
  ```

## Changes
- `@typescript-eslint/typescript-estree` uses `ts-api-utils` dependency that has `typescript` as peer dependency (see _Info_)

- `@typescript-eslint/utils` uses `@typescript-eslint/typescript-estree` dependency that uses `ts-api-utils` dependency. It needs `typescript` peer dependency

- `@typescript-eslint/parser` uses `@typescript-eslint/typescript-estree` dependency that uses `ts-api-utils` dependency. It needs `typescript` peer dependency

- `@typescript-eslint/type-utils` uses `@typescript-eslint/typescript-estree` and `@typescript-eslint/utils` dependencies that use `ts-api-utils` dependency. It needs `typescript` peer dependency

- `@typescript-eslint/eslint-plugin` uses `@typescript-eslint/utils` dependency that uses `@typescript-eslint/typescript-estree` dependency that has `typescript` as peer dependency

- `typescript-eslint` uses `@typescript-eslint/parser` and `@typescript-eslint/utils` dependencies that uses `@typescript-eslint/typescript-estree` dependency that has `typescript` as peer dependency

## Issue Reproduction
Case where `typescript` is omitted by `eslint-plugin-solid` because `@typescript-eslint/utils` din't has `typescript` as mandatory peer dependency.
- `yarn init -y`
- `yarn set version berry`
- `yarn add -D eslint typescript eslint-plugin-solid`
- (optional) `yarn explain peer-requirements` and see logs
  ```console
  pcc27b → ✘ eslint-plugin-solid@npm:0.14.4 [3223e] doesn't provide typescript to @typescript-eslint/utils@npm:8.15.0 [e3d25] and 2 other dependencies
  ```
- (detailed) `yarn explain peer-requirements pcc27b` and see logs
  ```console
  Package eslint-plugin-solid@npm:0.14.4 [3223e] is requested to provide typescript by its descendants

  eslint-plugin-solid@npm:0.14.4 [3223e]
  └─ @typescript-eslint/utils@npm:8.15.0 [e3d25] (via *)
     └─ @typescript-eslint/typescript-estree@npm:8.15.0 [0f560] (via *)
        └─ ts-api-utils@npm:1.3.0 [37728] (via >=4.2.0)
  
  ✘ Package eslint-plugin-solid@npm:0.14.4 [3223e] does not provide typescript.
  ```