### PR TITLE
fix(typescript-estree): update conditions for unsupported version warning

### DIFF
--- a/packages/typescript-estree/src/parseSettings/warnAboutTSVersion.ts
+++ b/packages/typescript-estree/src/parseSettings/warnAboutTSVersion.ts
@@ -6,7 +6,7 @@ import type { ParseSettings } from './index';
 /**
  * This needs to be kept in sync with package.json in the typescript-eslint monorepo
  */
-const SUPPORTED_TYPESCRIPT_VERSIONS = '>=4.7.4 <5.7.0';
+const SUPPORTED_TYPESCRIPT_VERSIONS = '>=4.8.4 <5.8.0';
 
 /*
  * The semver package will ignore prerelease ranges, and we don't want to explicitly document every one


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10115 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I don't really know what I'm doing (this is my first PR to this repository), but I think that in https://github.com/typescript-eslint/typescript-eslint/pull/10372 , the update to version list in `typescript-estree` might have slipped through, `typescript-estree` was still declaring that it only supports TS versions below 5.7.0 (so users of TS 5.7 are currently still getting warnings about unsupported TS version even on the latest typescript-eslint at 8.15.1-alpha.6).

Seeing how for previous TS versions, const SUPPORTED_TYPESCRIPT_VERSIONS was updated in the same "feat: support TypeScript X.Y" pull requests as everything else, it seems that it should have went there, but it didn't, so I'm creating a separate PR for it.

I also took a liberty of upgrading the lowest supported version from 4.7.4 to 4.8.4, because the comment says "This needs to be kept in sync with package.json in the typescript-eslint monorepo", and lowest supported `typescript` version in package.json in the typescript-eslint monorepo was updated from 4.7.4 to 4.8.4 in #8973 but didn't make its way to `warnAboutTSVersion.ts`.