### PR TITLE
fix(eslint-plugin): remove references to "extendDefaults" in no-restricted-types

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-restricted-types.mdx
+++ b/packages/eslint-plugin/docs/rules/no-restricted-types.mdx
@@ -26,7 +26,6 @@ The type can either be a type name literal (`OldType`) or a a type name with gen
 The values can be:
 
 - A string, which is the error message to be reported; or
-- `false` to specifically un-ban this type (useful when you are using `extendDefaults`); or
 - An object with the following properties:
   - `message: string`: the message to display when the type is matched.
   - `fixWith?: string`: a string to replace the banned type with when the fixer is run. If this is omitted, no fix will be done.

--- a/packages/eslint-plugin/src/rules/no-restricted-types.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-types.ts
@@ -18,7 +18,6 @@ type Types = Record<
 
 export type Options = [
   {
-    extendDefaults?: boolean;
     types?: Types;
   },
 ];


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

It seems like the `extendDefaults` setting from `ban-types` was ported into `no-restricted-types`, but that setting isn't part of the new rule's documentation nor it's used in its implementation.
