### PR TITLE
chore: enforce repo nullish check style

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -188,6 +188,7 @@ export default tseslint.config(
       // Internal repo rules
       //
 
+      '@typescript-eslint/internal/eqeq-nullish': 'error',
       '@typescript-eslint/internal/no-poorly-typed-ts-props': 'error',
       '@typescript-eslint/internal/no-relative-paths-to-internal-packages':
         'error',

--- a/packages/ast-spec/tests/util/serializers/Node.ts
+++ b/packages/ast-spec/tests/util/serializers/Node.ts
@@ -63,6 +63,7 @@ const serializer: NewPlugin = {
 
     for (const key of keys) {
       const value = node[key];
+      // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish -- I don't know whether this is safe to fix
       if (value === undefined) {
         continue;
       }

--- a/packages/ast-spec/tests/util/serializers/Node.ts
+++ b/packages/ast-spec/tests/util/serializers/Node.ts
@@ -63,7 +63,7 @@ const serializer: NewPlugin = {
 
     for (const key of keys) {
       const value = node[key];
-      // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish -- I don't know whether this is safe to fix
+      // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish -- intentional strict equality
       if (value === undefined) {
         continue;
       }

--- a/packages/eslint-plugin-internal/src/rules/eqeq-nullish.ts
+++ b/packages/eslint-plugin-internal/src/rules/eqeq-nullish.ts
@@ -1,0 +1,88 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import {
+  nullThrows,
+  NullThrowsReasons,
+} from '@typescript-eslint/utils/eslint-utils';
+
+import { createRule } from '../util';
+
+export default createRule({
+  name: __filename,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Enforce eqeqeq preferences around nullish comparisons',
+    },
+    fixable: 'code',
+    hasSuggestions: true,
+    messages: {
+      unexpectedComparison:
+        'Unexpected strict comparison ({{strictOperator}}) with `{{nullishKind}}`. In this codebase, we prefer to use loose equality as a general-purpose nullish check when possible.',
+      useLooseComparisonSuggestion:
+        'Use loose comparison (`{{looseOperator}} null`) instead, to check both nullish values.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      BinaryExpression(node): void {
+        if (node.operator === '===' || node.operator === '!==') {
+          const offendingChild = [node.left, node.right].find(
+            child =>
+              (child.type === AST_NODE_TYPES.Identifier &&
+                child.name === 'undefined') ||
+              (child.type === AST_NODE_TYPES.Literal && child.raw === 'null'),
+          );
+
+          const operatorToken = nullThrows(
+            context.sourceCode.getFirstTokenBetween(
+              node.left,
+              node.right,
+              token => token.value === node.operator,
+            ),
+            NullThrowsReasons.MissingToken(node.operator, 'binary expression'),
+          );
+
+          if (offendingChild != null) {
+            const wasLeft = node.left === offendingChild;
+            const nullishKind =
+              offendingChild.type === AST_NODE_TYPES.Identifier
+                ? 'undefined'
+                : 'null';
+            const looseOperator = node.operator === '===' ? '==' : '!=';
+            context.report({
+              loc: wasLeft
+                ? {
+                    start: node.left.loc.start,
+                    end: operatorToken.loc.end,
+                  }
+                : {
+                    start: operatorToken.loc.start,
+                    end: node.right.loc.end,
+                  },
+
+              messageId: 'unexpectedComparison',
+              data: {
+                nullishKind,
+                strictOperator: node.operator,
+              },
+              suggest: [
+                {
+                  messageId: 'useLooseComparisonSuggestion',
+                  data: {
+                    looseOperator,
+                  },
+                  fix: fixer => [
+                    fixer.replaceText(offendingChild, 'null'),
+                    fixer.replaceText(operatorToken, looseOperator),
+                  ],
+                },
+              ],
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-internal/src/rules/eqeq-nullish.ts
+++ b/packages/eslint-plugin-internal/src/rules/eqeq-nullish.ts
@@ -17,7 +17,7 @@ export default createRule({
     hasSuggestions: true,
     messages: {
       unexpectedComparison:
-        'Unexpected strict comparison ({{strictOperator}}) with `{{nullishKind}}`. In this codebase, we prefer to use loose equality as a general-purpose nullish check when possible.',
+        'Unexpected strict comparison (`{{strictOperator}}`) with `{{nullishKind}}`. In this codebase, we prefer to use loose equality as a general-purpose nullish check when possible.',
       useLooseComparisonSuggestion:
         'Use loose comparison (`{{looseOperator}} null`) instead, to check both nullish values.',
     },

--- a/packages/eslint-plugin-internal/src/rules/index.ts
+++ b/packages/eslint-plugin-internal/src/rules/index.ts
@@ -1,5 +1,6 @@
 import type { Linter } from '@typescript-eslint/utils/ts-eslint';
 
+import eqeqNullish from './eqeq-nullish';
 import noPoorlyTypedTsProps from './no-poorly-typed-ts-props';
 import noRelativePathsToInternalPackages from './no-relative-paths-to-internal-packages';
 import noTypescriptDefaultImport from './no-typescript-default-import';
@@ -8,6 +9,7 @@ import pluginTestFormatting from './plugin-test-formatting';
 import preferASTTypesEnum from './prefer-ast-types-enum';
 
 export default {
+  'eqeq-nullish': eqeqNullish,
   'no-poorly-typed-ts-props': noPoorlyTypedTsProps,
   'no-relative-paths-to-internal-packages': noRelativePathsToInternalPackages,
   'no-typescript-default-import': noTypescriptDefaultImport,

--- a/packages/eslint-plugin-internal/tests/rules/eqeq-nullish.test.ts
+++ b/packages/eslint-plugin-internal/tests/rules/eqeq-nullish.test.ts
@@ -85,6 +85,8 @@ ruleTester.run('eqeq-nullish', rule, {
   valid: [
     'null == a;',
     'foo != null;',
+    'foo === bar;',
+    'foo !== bar;',
     // We're not trying to duplicate eqeqeq's reports.
     'a == b;',
     'something == undefined;',

--- a/packages/eslint-plugin-internal/tests/rules/eqeq-nullish.test.ts
+++ b/packages/eslint-plugin-internal/tests/rules/eqeq-nullish.test.ts
@@ -1,0 +1,93 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import rule from '../../src/rules/eqeq-nullish';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('eqeq-nullish', rule, {
+  invalid: [
+    {
+      code: 'something === undefined;',
+      errors: [
+        {
+          column: 11,
+          data: {
+            nullishKind: 'undefined',
+            strictOperator: '===',
+          },
+          endColumn: 24,
+          endLine: 1,
+          line: 1,
+          messageId: 'unexpectedComparison',
+          suggestions: [
+            {
+              data: {
+                looseOperator: '==',
+              },
+              messageId: 'useLooseComparisonSuggestion',
+              output: `something == null;`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'undefined !== something;',
+      errors: [
+        {
+          column: 1,
+          data: {
+            nullishKind: 'undefined',
+            strictOperator: '!==',
+          },
+          endColumn: 14,
+          endLine: 1,
+          line: 1,
+          messageId: 'unexpectedComparison',
+          suggestions: [
+            {
+              data: {
+                looseOperator: '!=',
+              },
+              messageId: 'useLooseComparisonSuggestion',
+              output: `null != something;`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'null !== something;',
+      errors: [
+        {
+          column: 1,
+          data: {
+            nullishKind: 'null',
+            strictOperator: '!==',
+          },
+          endColumn: 9,
+          endLine: 1,
+          line: 1,
+          messageId: 'unexpectedComparison',
+          suggestions: [
+            {
+              data: {
+                looseOperator: '!=',
+              },
+              messageId: 'useLooseComparisonSuggestion',
+              output: `null != something;`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  valid: [
+    'null == a;',
+    'foo != null;',
+    // We're not trying to duplicate eqeqeq's reports.
+    'a == b;',
+    'something == undefined;',
+    'undefined != something;',
+  ],
+});

--- a/packages/eslint-plugin/src/rules/dot-notation.ts
+++ b/packages/eslint-plugin/src/rules/dot-notation.ts
@@ -125,15 +125,12 @@ export default createRule<Options, MessageIds>({
           ) {
             return;
           }
-          if (
-            propertySymbol === undefined &&
-            allowIndexSignaturePropertyAccess
-          ) {
+          if (propertySymbol == null && allowIndexSignaturePropertyAccess) {
             const objectType = services.getTypeAtLocation(node.object);
             const indexType = objectType
               .getNonNullableType()
               .getStringIndexType();
-            if (indexType !== undefined) {
+            if (indexType != null) {
               return;
             }
           }

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/parse-options.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/parse-options.ts
@@ -40,7 +40,7 @@ function normalizeOption(option: Selector): NormalizedSelector[] {
         }
       : null,
     filter:
-      option.filter !== undefined
+      option.filter != null
         ? typeof option.filter === 'string'
           ? {
               match: true,
@@ -53,14 +53,14 @@ function normalizeOption(option: Selector): NormalizedSelector[] {
         : null,
     format: option.format ? option.format.map(f => PredefinedFormats[f]) : null,
     leadingUnderscore:
-      option.leadingUnderscore !== undefined
+      option.leadingUnderscore != null
         ? UnderscoreOptions[option.leadingUnderscore]
         : null,
     modifiers: option.modifiers?.map(m => Modifiers[m]) ?? null,
     prefix: option.prefix && option.prefix.length > 0 ? option.prefix : null,
     suffix: option.suffix && option.suffix.length > 0 ? option.suffix : null,
     trailingUnderscore:
-      option.trailingUnderscore !== undefined
+      option.trailingUnderscore != null
         ? UnderscoreOptions[option.trailingUnderscore]
         : null,
     types: option.types?.map(m => TypeModifiers[m]) ?? null,

--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -55,7 +55,7 @@ export default createRule({
       const targetSymbol = checker.getAliasedSymbol(symbol);
       while (tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)) {
         const reason = getJsDocDeprecation(symbol);
-        if (reason !== undefined) {
+        if (reason != null) {
           return reason;
         }
         const immediateAliasedSymbol: ts.Symbol | undefined =
@@ -216,8 +216,7 @@ export default createRule({
 
       const symbol = services.getSymbolAtLocation(node);
       const aliasedSymbol =
-        symbol !== undefined &&
-        tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)
+        symbol != null && tsutils.isSymbolFlagSet(symbol, ts.SymbolFlags.Alias)
           ? checker.getAliasedSymbol(symbol)
           : symbol;
       const symbolDeclarationKind = aliasedSymbol?.declarations?.[0].kind;
@@ -293,7 +292,7 @@ export default createRule({
       }
 
       const reason = getDeprecationReason(node);
-      if (reason === undefined) {
+      if (reason == null) {
         return;
       }
 

--- a/packages/eslint-plugin/src/rules/no-duplicate-enum-values.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-enum-values.ts
@@ -42,7 +42,7 @@ export default createRule({
         const seenValues = new Set<number | string>();
 
         enumMembers.forEach(member => {
-          if (member.initializer === undefined) {
+          if (member.initializer == null) {
             return;
           }
 
@@ -53,7 +53,7 @@ export default createRule({
             value = Number(member.initializer.value);
           }
 
-          if (value === undefined) {
+          if (value == null) {
             return;
           }
 

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -457,7 +457,7 @@ export default createRule<Options, MessageId>({
       //   https://github.com/ajafff/tsutils/blob/49d0d31050b44b81e918eae4fbaf1dfe7b7286af/util/type.ts#L95-L125
       for (const ty of typeParts) {
         const then = ty.getProperty('then');
-        if (then === undefined) {
+        if (then == null) {
           continue;
         }
 

--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -399,7 +399,7 @@ export default createRule<Options, MessageId>({
     function checkVariableDeclaration(node: TSESTree.VariableDeclarator): void {
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
       if (
-        tsNode.initializer === undefined ||
+        tsNode.initializer == null ||
         node.init == null ||
         node.id.typeAnnotation == null
       ) {
@@ -429,7 +429,7 @@ export default createRule<Options, MessageId>({
       if (ts.isPropertyAssignment(tsNode)) {
         const contextualType = checker.getContextualType(tsNode.initializer);
         if (
-          contextualType !== undefined &&
+          contextualType != null &&
           isVoidReturningFunctionType(
             checker,
             tsNode.initializer,
@@ -460,7 +460,7 @@ export default createRule<Options, MessageId>({
       } else if (ts.isShorthandPropertyAssignment(tsNode)) {
         const contextualType = checker.getContextualType(tsNode.name);
         if (
-          contextualType !== undefined &&
+          contextualType != null &&
           isVoidReturningFunctionType(checker, tsNode.name, contextualType) &&
           returnsThenable(checker, tsNode.name)
         ) {
@@ -489,14 +489,14 @@ export default createRule<Options, MessageId>({
           return;
         }
         const objType = checker.getContextualType(obj);
-        if (objType === undefined) {
+        if (objType == null) {
           return;
         }
         const propertySymbol = checker.getPropertyOfType(
           objType,
           tsNode.name.text,
         );
-        if (propertySymbol === undefined) {
+        if (propertySymbol == null) {
           return;
         }
 
@@ -526,7 +526,7 @@ export default createRule<Options, MessageId>({
 
     function checkReturnStatement(node: TSESTree.ReturnStatement): void {
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-      if (tsNode.expression === undefined || node.argument == null) {
+      if (tsNode.expression == null || node.argument == null) {
         return;
       }
 
@@ -548,7 +548,7 @@ export default createRule<Options, MessageId>({
 
       const contextualType = checker.getContextualType(tsNode.expression);
       if (
-        contextualType !== undefined &&
+        contextualType != null &&
         isVoidReturningFunctionType(
           checker,
           tsNode.expression,
@@ -578,7 +578,7 @@ export default createRule<Options, MessageId>({
 
       for (const nodeMember of tsNode.members) {
         const memberName = nodeMember.name?.getText();
-        if (memberName === undefined) {
+        if (memberName == null) {
           // Call/construct/index signatures don't have names. TS allows call signatures to mismatch,
           // and construct signatures can't be async.
           // TODO - Once we're able to use `checker.isTypeAssignableTo` (v8), we can check an index
@@ -617,7 +617,7 @@ export default createRule<Options, MessageId>({
       memberName: string,
     ): void {
       const heritageMember = getMemberIfExists(heritageType, memberName);
-      if (heritageMember === undefined) {
+      if (heritageMember == null) {
         return;
       }
       const memberType = checker.getTypeOfSymbolAtLocation(
@@ -649,7 +649,7 @@ export default createRule<Options, MessageId>({
       );
       const contextualType = checker.getContextualType(expressionContainer);
       if (
-        contextualType !== undefined &&
+        contextualType != null &&
         isVoidReturningFunctionType(
           checker,
           expressionContainer,
@@ -707,7 +707,7 @@ function isAlwaysThenable(checker: ts.TypeChecker, node: ts.Node): boolean {
 
     // If one of the alternates has no then property, it is not thenable in all
     // cases.
-    if (thenProp === undefined) {
+    if (thenProp == null) {
       return false;
     }
 

--- a/packages/eslint-plugin/src/rules/no-mixed-enums.ts
+++ b/packages/eslint-plugin/src/rules/no-mixed-enums.ts
@@ -138,7 +138,7 @@ export default createRule({
       // }
       for (const imported of imports) {
         const typeFromImported = getTypeFromImported(imported);
-        if (typeFromImported !== undefined) {
+        if (typeFromImported != null) {
           return typeFromImported;
         }
       }

--- a/packages/eslint-plugin/src/rules/no-restricted-types.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-types.ts
@@ -145,6 +145,7 @@ export default createRule<Options, MessageIds>({
     ): void {
       const bannedType = bannedTypes.get(name);
 
+      // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish -- unsure if this is safe to fix
       if (bannedType === undefined || bannedType === false) {
         return;
       }

--- a/packages/eslint-plugin/src/rules/no-restricted-types.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-types.ts
@@ -145,8 +145,7 @@ export default createRule<Options, MessageIds>({
     ): void {
       const bannedType = bannedTypes.get(name);
 
-      // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish -- unsure if this is safe to fix
-      if (bannedType === undefined || bannedType === false) {
+      if (bannedType == null || bannedType === false) {
         return;
       }
 

--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -229,7 +229,7 @@ export default createRule<Options, MessageIds>({
     const isValidGeneric = (type: TypeWithLabel): boolean => {
       return (
         type.node.type === AST_NODE_TYPES.TSTypeReference &&
-        type.node.typeArguments !== undefined
+        type.node.typeArguments != null
       );
     };
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -197,7 +197,7 @@ export default createRule<Options, MessageIds>({
     return {
       BinaryExpression(node): void {
         const comparison = getBooleanComparison(node);
-        if (comparison === undefined) {
+        if (comparison == null) {
           return;
         }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-qualifier.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-qualifier.ts
@@ -75,7 +75,7 @@ export default createRule({
       const namespaceSymbol = services.getSymbolAtLocation(qualifier);
 
       if (
-        namespaceSymbol === undefined ||
+        namespaceSymbol == null ||
         !symbolIsNamespaceInScope(namespaceSymbol)
       ) {
         return false;
@@ -83,7 +83,7 @@ export default createRule({
 
       const accessedSymbol = services.getSymbolAtLocation(name);
 
-      if (accessedSymbol === undefined) {
+      if (accessedSymbol == null) {
         return false;
       }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -117,9 +117,9 @@ export default createRule<Options, MessageIds>({
 
         if (
           // is it `const x!: number`
-          declaration.initializer === undefined &&
-          declaration.exclamationToken === undefined &&
-          declaration.type !== undefined
+          declaration.initializer == null &&
+          declaration.exclamationToken == null &&
+          declaration.type != null
         ) {
           // check if the defined variable type has changed since assignment
           const declarationType = checker.getTypeFromTypeNode(declaration.type);

--- a/packages/eslint-plugin/src/rules/prefer-destructuring.ts
+++ b/packages/eslint-plugin/src/rules/prefer-destructuring.ts
@@ -124,14 +124,14 @@ export default createRule<Options, MessageIds>({
     ): void {
       const rules =
         leftNode.type === AST_NODE_TYPES.Identifier &&
-        leftNode.typeAnnotation === undefined
+        leftNode.typeAnnotation == null
           ? baseRules
           : baseRulesWithoutFix();
       if (
         (leftNode.type === AST_NODE_TYPES.ArrayPattern ||
           leftNode.type === AST_NODE_TYPES.Identifier ||
           leftNode.type === AST_NODE_TYPES.ObjectPattern) &&
-        leftNode.typeAnnotation !== undefined &&
+        leftNode.typeAnnotation != null &&
         !enforceForDeclarationWithTypeAnnotation
       ) {
         return;
@@ -228,7 +228,7 @@ function isTypeAnyOrIterableType(
       'iterator',
       typeChecker,
     );
-    return iterator !== undefined;
+    return iterator != null;
   }
   return type.types.every(t => isTypeAnyOrIterableType(t, typeChecker));
 }

--- a/packages/eslint-plugin/src/rules/prefer-function-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-function-type.ts
@@ -77,7 +77,7 @@ export default createRule({
       if (
         (member.type === AST_NODE_TYPES.TSCallSignatureDeclaration ||
           member.type === AST_NODE_TYPES.TSConstructSignatureDeclaration) &&
-        member.returnType !== undefined
+        member.returnType != null
       ) {
         if (
           tsThisTypes?.length &&
@@ -125,7 +125,7 @@ export default createRule({
               }
 
               if (node.type === AST_NODE_TYPES.TSInterfaceDeclaration) {
-                if (node.typeParameters !== undefined) {
+                if (node.typeParameters != null) {
                   suggestion = `type ${context.sourceCode
                     .getText()
                     .slice(

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
@@ -354,7 +354,7 @@ export function gatherLogicalOperands(
   ): ComparisonValueType | null {
     switch (node.type) {
       case AST_NODE_TYPES.Literal:
-        // eslint-disable-next-line eqeqeq -- intentional exact comparison against null
+        // eslint-disable-next-line eqeqeq, @typescript-eslint/internal/eqeq-nullish -- intentional exact comparison against null
         if (node.value === null && node.raw === 'null') {
           return ComparisonValueType.Null;
         }

--- a/packages/eslint-plugin/src/rules/prefer-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly.ts
@@ -336,7 +336,7 @@ class ClassScope {
 
     if (
       this.onlyInlineLambdas &&
-      node.initializer !== undefined &&
+      node.initializer != null &&
       !ts.isArrowFunction(node.initializer)
     ) {
       return;

--- a/packages/eslint-plugin/src/rules/require-await.ts
+++ b/packages/eslint-plugin/src/rules/require-await.ts
@@ -198,7 +198,7 @@ export default createRule({
               messageId: 'removeAsync',
               fix: (fixer): RuleFix[] =>
                 changes.map(change =>
-                  change.replacement !== undefined
+                  change.replacement != null
                     ? fixer.replaceTextRange(change.range, change.replacement)
                     : fixer.removeRange(change.range),
                 ),
@@ -261,7 +261,7 @@ export default createRule({
           'asyncIterator',
           checker,
         );
-        if (asyncIterator !== undefined) {
+        if (asyncIterator != null) {
           scopeInfo.isAsyncYield = true;
           break;
         }

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -320,7 +320,7 @@ export default createRule<Options, MessageIds>({
 
       if (
         missingLiteralBranchTypes.length === 0 &&
-        defaultCase !== undefined &&
+        defaultCase != null &&
         !containsNonLiteralType
       ) {
         context.report({
@@ -340,7 +340,7 @@ export default createRule<Options, MessageIds>({
 
       const { containsNonLiteralType, defaultCase } = switchMetadata;
 
-      if (containsNonLiteralType && defaultCase === undefined) {
+      if (containsNonLiteralType && defaultCase == null) {
         context.report({
           node: node.discriminant,
           messageId: 'switchIsNotExhaustive',

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -108,7 +108,7 @@ export default createRule<Options, MessageIds>({
     function failureStringStart(otherLine?: number): string {
       // For only 2 overloads we don't need to specify which is the other one.
       const overloads =
-        otherLine === undefined
+        otherLine == null
           ? 'These overloads'
           : `This overload and the one on line ${otherLine}`;
       return `${overloads} can be combined into one signature`;
@@ -183,7 +183,7 @@ export default createRule<Options, MessageIds>({
             signature1 as SignatureDefinition,
             isTypeParameter,
           );
-          if (unify !== undefined) {
+          if (unify != null) {
             result.push({ only2: overloads.length === 2, unify });
           }
         });
@@ -213,9 +213,9 @@ export default createRule<Options, MessageIds>({
       // Must return the same type.
 
       const aTypeParams =
-        a.typeParameters !== undefined ? a.typeParameters.params : undefined;
+        a.typeParameters != null ? a.typeParameters.params : undefined;
       const bTypeParams =
-        b.typeParameters !== undefined ? b.typeParameters.params : undefined;
+        b.typeParameters != null ? b.typeParameters.params : undefined;
 
       if (ignoreDifferentlyNamedParameters) {
         const commonParamsLength = Math.min(a.params.length, b.params.length);
@@ -250,7 +250,7 @@ export default createRule<Options, MessageIds>({
         types2,
         parametersAreEqual,
       );
-      if (index === undefined) {
+      if (index == null) {
         return undefined;
       }
 
@@ -333,7 +333,7 @@ export default createRule<Options, MessageIds>({
     function getIsTypeParameter(
       typeParameters?: TSESTree.TSTypeParameterDeclaration,
     ): IsTypeParameter {
-      if (typeParameters === undefined) {
+      if (typeParameters == null) {
         return (() => false) as IsTypeParameter;
       }
 
@@ -444,8 +444,8 @@ export default createRule<Options, MessageIds>({
     ): boolean {
       return (
         a === b ||
-        (a !== undefined &&
-          b !== undefined &&
+        (a != null &&
+          b != null &&
           context.sourceCode.getText(a.typeAnnotation) ===
             context.sourceCode.getText(b.typeAnnotation))
       );
@@ -455,9 +455,7 @@ export default createRule<Options, MessageIds>({
       a: TSESTree.TypeNode | undefined,
       b: TSESTree.TypeNode | undefined,
     ): boolean {
-      return (
-        a === b || (a !== undefined && b !== undefined && a.type === b.type)
-      );
+      return a === b || (a != null && b != null && a.type === b.type);
     }
 
     /* Returns the first index where `a` and `b` differ. */
@@ -535,7 +533,7 @@ export default createRule<Options, MessageIds>({
         (containingNode ?? signature).parent === currentScope.parent
       ) {
         const overloads = currentScope.overloads.get(key);
-        if (overloads !== undefined) {
+        if (overloads != null) {
           overloads.push(signature);
         } else {
           currentScope.overloads.set(key, [signature]);

--- a/packages/eslint-plugin/src/util/getStaticStringValue.ts
+++ b/packages/eslint-plugin/src/util/getStaticStringValue.ts
@@ -18,7 +18,7 @@ import { isNullLiteral } from './isNullLiteral';
 export function getStaticStringValue(node: TSESTree.Node): string | null {
   switch (node.type) {
     case AST_NODE_TYPES.Literal:
-      // eslint-disable-next-line eqeqeq -- intentional strict comparison for literal value
+      // eslint-disable-next-line eqeqeq, @typescript-eslint/internal/eqeq-nullish -- intentional strict comparison for literal value
       if (node.value === null) {
         if (isNullLiteral(node)) {
           return String(node.value); // "null"

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -65,8 +65,8 @@ function arraysAreEqual<T>(
 ): boolean {
   return (
     a === b ||
-    (a !== undefined &&
-      b !== undefined &&
+    (a != null &&
+      b != null &&
       a.length === b.length &&
       a.every((x, idx) => eq(x, b[idx])))
   );
@@ -79,6 +79,7 @@ function findFirstResult<T, U>(
 ): U | undefined {
   for (const element of inputs) {
     const result = getResult(element);
+    // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
     if (result !== undefined) {
       return result;
     }

--- a/packages/eslint-plugin/tests/docs.test.ts
+++ b/packages/eslint-plugin/tests/docs.test.ts
@@ -68,11 +68,10 @@ function renderLintResults(code: string, errors: Linter.LintMessage[]): string {
 
     for (const error of errors) {
       const startLine = error.line - 1;
-      const endLine =
-        error.endLine === undefined ? startLine : error.endLine - 1;
+      const endLine = error.endLine == null ? startLine : error.endLine - 1;
       const startColumn = error.column - 1;
       const endColumn =
-        error.endColumn === undefined ? startColumn : error.endColumn - 1;
+        error.endColumn == null ? startColumn : error.endColumn - 1;
       if (i < startLine || i > endLine) {
         continue;
       }

--- a/packages/eslint-plugin/tests/rules/no-explicit-any.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-explicit-any.test.ts
@@ -1223,7 +1223,7 @@ const test = <T extends Partial<never>>() => {};
       {
         code,
         errors: testCase.errors.map(err => {
-          if (err.line === undefined) {
+          if (err.line == null) {
             return err;
           }
 

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -151,6 +151,7 @@ function parseForESLint(
       log('Resolved libs from program: %o', analyzeOptions.lib);
     }
     if (
+      // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
       analyzeOptions.jsxPragma === undefined &&
       compilerOptions.jsxFactory != null
     ) {
@@ -160,6 +161,7 @@ function parseForESLint(
       log('Resolved jsxPragma from program: %s', analyzeOptions.jsxPragma);
     }
     if (
+      // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
       analyzeOptions.jsxFragmentName === undefined &&
       compilerOptions.jsxFragmentFactory != null
     ) {

--- a/packages/rule-schema-to-typescript-types/src/generateObjectType.ts
+++ b/packages/rule-schema-to-typescript-types/src/generateObjectType.ts
@@ -17,6 +17,7 @@ export function generateObjectType(
   let indexSignature: AST | null = null;
   if (
     schema.additionalProperties === true ||
+    // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
     schema.additionalProperties === undefined
   ) {
     indexSignature = {

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -209,7 +209,7 @@ export class RuleTester extends TestFramework {
     // path. For any other path, which would just be a plain
     // file name (`foo.ts`), don't change the base path.
     if (
-      filename !== undefined &&
+      filename != null &&
       (filename.startsWith('/') || filename.startsWith('..'))
     ) {
       basePath = path.parse(
@@ -1011,7 +1011,7 @@ export class RuleTester extends TestFramework {
           // Just an error message.
           assertMessageMatches(message.message, error);
           assert.ok(
-            message.suggestions === undefined,
+            message.suggestions == null,
             `Error at index ${i} has suggestions. Please convert the test error into an object and specify 'suggestions' property on it to test suggestions.`,
           );
         } else if (typeof error === 'object' && error != null) {
@@ -1146,7 +1146,7 @@ export class RuleTester extends TestFramework {
             const expectsSuggestions = Array.isArray(error.suggestions)
               ? error.suggestions.length > 0
               : Boolean(error.suggestions);
-            const hasSuggestions = message.suggestions !== undefined;
+            const hasSuggestions = message.suggestions != null;
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const messageSuggestions = message.suggestions!;
 

--- a/packages/rule-tester/src/utils/flat-config-schema.ts
+++ b/packages/rule-tester/src/utils/flat-config-schema.ts
@@ -29,7 +29,7 @@ const ruleSeverities = new Map<SharedConfig.RuleLevel, SharedConfig.Severity>([
  * @returns `true` if the value is a non-null object.
  */
 function isNonNullObject(value: unknown): boolean {
-  // eslint-disable-next-line eqeqeq
+  // eslint-disable-next-line eqeqeq, @typescript-eslint/internal/eqeq-nullish
   return typeof value === 'object' && value !== null;
 }
 
@@ -104,6 +104,7 @@ function deepMerge<First extends object, Second extends object>(
         secondValue!,
         mergeMap,
       );
+      // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
     } else if (secondValue === undefined) {
       (result as ObjectLike)[key] = firstValue;
     }
@@ -204,7 +205,7 @@ class InvalidRuleSeverityError extends Error {
 function assertIsRuleSeverity(ruleId: string, value: unknown): void {
   const severity = ruleSeverities.get(value as SharedConfig.RuleLevel);
 
-  if (severity === undefined) {
+  if (severity == null) {
     throw new InvalidRuleSeverityError(ruleId, value);
   }
 }

--- a/packages/rule-tester/src/utils/serialization.ts
+++ b/packages/rule-tester/src/utils/serialization.ts
@@ -3,7 +3,7 @@
  */
 function isSerializablePrimitiveOrPlainObject(val: unknown): boolean {
   return (
-    // eslint-disable-next-line eqeqeq
+    // eslint-disable-next-line eqeqeq, @typescript-eslint/internal/eqeq-nullish
     val === null ||
     typeof val === 'string' ||
     typeof val === 'boolean' ||

--- a/packages/scope-manager/src/analyze.ts
+++ b/packages/scope-manager/src/analyze.ts
@@ -94,6 +94,7 @@ function analyze(
     jsxFragmentName:
       providedOptions?.jsxFragmentName ?? DEFAULT_OPTIONS.jsxFragmentName,
     jsxPragma:
+      // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
       providedOptions?.jsxPragma === undefined
         ? DEFAULT_OPTIONS.jsxPragma
         : providedOptions.jsxPragma,

--- a/packages/scope-manager/tests/test-utils/serializers/baseSerializer.ts
+++ b/packages/scope-manager/tests/test-utils/serializers/baseSerializer.ts
@@ -51,6 +51,7 @@ function createSerializer<Constructor extends ConstructorSignature>(
       const childIndentation = indentation + config.indent;
       for (const key of keys) {
         let value = thing[key as string];
+        // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
         if (value === undefined) {
           continue;
         }

--- a/packages/type-utils/src/containsAllTypesByName.ts
+++ b/packages/type-utils/src/containsAllTypesByName.ts
@@ -41,7 +41,7 @@ export function containsAllTypesByName(
   const bases = type.getBaseTypes();
 
   return (
-    bases !== undefined &&
+    bases != null &&
     (matchAnyInstead
       ? bases.some(predicate)
       : bases.length > 0 && bases.every(predicate))

--- a/packages/type-utils/src/isTypeReadonly.ts
+++ b/packages/type-utils/src/isTypeReadonly.ts
@@ -136,7 +136,7 @@ function isTypeReadonlyObject(
     for (const property of properties) {
       if (options.treatMethodsAsReadonly) {
         if (
-          property.valueDeclaration !== undefined &&
+          property.valueDeclaration != null &&
           hasSymbol(property.valueDeclaration) &&
           tsutils.isSymbolFlagSet(
             property.valueDeclaration.symbol,
@@ -148,11 +148,11 @@ function isTypeReadonlyObject(
 
         const declarations = property.getDeclarations();
         const lastDeclaration =
-          declarations !== undefined && declarations.length > 0
+          declarations != null && declarations.length > 0
             ? declarations[declarations.length - 1]
             : undefined;
         if (
-          lastDeclaration !== undefined &&
+          lastDeclaration != null &&
           hasSymbol(lastDeclaration) &&
           tsutils.isSymbolFlagSet(lastDeclaration.symbol, ts.SymbolFlags.Method)
         ) {

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInFile.ts
@@ -8,7 +8,7 @@ export function typeDeclaredInFile(
   declarationFiles: ts.SourceFile[],
   program: ts.Program,
 ): boolean {
-  if (relativePath === undefined) {
+  if (relativePath == null) {
     const cwd = getCanonicalFileName(program.getCurrentDirectory());
     return declarationFiles.some(declaration =>
       getCanonicalFileName(declaration.fileName).startsWith(cwd),

--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -37,7 +37,7 @@ function typeDeclaredInDeclarationFile(
   return declarationFiles.some(declaration => {
     const packageIdName = program.sourceFileToPackageName.get(declaration.path);
     return (
-      packageIdName !== undefined &&
+      packageIdName != null &&
       matcher.test(packageIdName) &&
       program.isSourceFileFromExternalLibrary(declaration)
     );

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -746,7 +746,7 @@ export class Converter {
     this.#checkModifiers(node);
 
     const pattern = this.allowPattern;
-    if (allowPattern !== undefined) {
+    if (allowPattern != null) {
       this.allowPattern = allowPattern;
     }
 
@@ -764,7 +764,7 @@ export class Converter {
   private convertImportAttributes(
     node: ts.ImportAttributes | undefined,
   ): TSESTree.ImportAttribute[] {
-    return node === undefined
+    return node == null
       ? []
       : node.elements.map(element => this.convertChild(element));
   }
@@ -2406,7 +2406,7 @@ export class Converter {
           type: AST_NODE_TYPES.MemberExpression,
           computed,
           object,
-          optional: node.questionDotToken !== undefined,
+          optional: node.questionDotToken != null,
           property,
         });
 
@@ -2422,7 +2422,7 @@ export class Converter {
           type: AST_NODE_TYPES.MemberExpression,
           computed,
           object,
-          optional: node.questionDotToken !== undefined,
+          optional: node.questionDotToken != null,
           property,
         });
 
@@ -2467,7 +2467,7 @@ export class Converter {
           type: AST_NODE_TYPES.CallExpression,
           arguments: args,
           callee,
-          optional: node.questionDotToken !== undefined,
+          optional: node.questionDotToken != null,
           typeArguments,
         });
 
@@ -3067,7 +3067,7 @@ export class Converter {
       case SyntaxKind.TypePredicate: {
         const result = this.createNode<TSESTree.TSTypePredicate>(node, {
           type: AST_NODE_TYPES.TSTypePredicate,
-          asserts: node.assertsModifier !== undefined,
+          asserts: node.assertsModifier != null,
           parameterName: this.convertChild(node.parameterName),
           typeAnnotation: null,
         });

--- a/packages/typescript-estree/src/create-program/getParsedConfigFile.ts
+++ b/packages/typescript-estree/src/create-program/getParsedConfigFile.ts
@@ -16,7 +16,7 @@ function getParsedConfigFile(
   configFile: string,
   projectDirectory?: string,
 ): ts.ParsedCommandLine {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/internal/eqeq-nullish
   if (tsserver.sys === undefined) {
     throw new Error(
       '`getParsedConfigFile` is only supported in a Node-like environment.',

--- a/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
+++ b/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
@@ -266,7 +266,7 @@ function createWatchProgram(
       filePath === currentLintOperationState.filePath
         ? getCodeText(currentLintOperationState.code)
         : oldReadFile(filePath, encoding);
-    if (fileContent !== undefined) {
+    if (fileContent != null) {
       parsedFilesSeenHash.set(filePath, createHash(fileContent));
     }
     return fileContent;
@@ -352,7 +352,7 @@ function hasTSConfigChanged(tsconfigPath: CanonicalPath): boolean {
 
   tsconfigLastModifiedTimestampCache.set(tsconfigPath, lastModifiedAt);
 
-  if (cachedLastModifiedAt === undefined) {
+  if (cachedLastModifiedAt == null) {
     return false;
   }
 

--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -67,7 +67,7 @@ type CanonicalPath = { __brand: unknown } & string;
 
 // typescript doesn't provide a ts.sys implementation for browser environments
 const useCaseSensitiveFileNames =
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/internal/eqeq-nullish
   ts.sys !== undefined ? ts.sys.useCaseSensitiveFileNames : true;
 const correctPathCasing = useCaseSensitiveFileNames
   ? (filePath: string): string => filePath

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -718,12 +718,14 @@ export function firstDefined<T, U>(
   array: readonly T[] | undefined,
   callback: (element: T, index: number) => U | undefined,
 ): U | undefined {
+  // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
   if (array === undefined) {
     return undefined;
   }
 
   for (let i = 0; i < array.length; i++) {
     const result = callback(array[i], i);
+    // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
     if (result !== undefined) {
       return result;
     }
@@ -764,7 +766,7 @@ export function isThisInTypeQuery(node: ts.Node): boolean {
 
 // `ts.nodeIsMissing`
 function nodeIsMissing(node: ts.Node | undefined): boolean {
-  if (node === undefined) {
+  if (node == null) {
     return true;
   }
   return (

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -120,10 +120,8 @@ export function createParseSettings(
         : undefined,
     setExternalModuleIndicator:
       tsestreeOptions.sourceType === 'module' ||
-      (tsestreeOptions.sourceType === undefined &&
-        extension === ts.Extension.Mjs) ||
-      (tsestreeOptions.sourceType === undefined &&
-        extension === ts.Extension.Mts)
+      (tsestreeOptions.sourceType == null && extension === ts.Extension.Mjs) ||
+      (tsestreeOptions.sourceType == null && extension === ts.Extension.Mts)
         ? (file): void => {
             file.externalModuleIndicator = true;
           }

--- a/packages/typescript-estree/tests/test-utils/test-utils.ts
+++ b/packages/typescript-estree/tests/test-utils/test-utils.ts
@@ -126,6 +126,7 @@ export function omitDeep(
 
     for (const prop in node) {
       if (Object.hasOwn(node, prop)) {
+        // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
         if (shouldOmit(prop, node[prop]) || node[prop] === undefined) {
           // Filter out omitted and undefined props from the node
           // eslint-disable-next-line @typescript-eslint/no-dynamic-delete

--- a/packages/utils/src/eslint-utils/applyDefault.ts
+++ b/packages/utils/src/eslint-utils/applyDefault.ts
@@ -21,6 +21,7 @@ function applyDefault<User extends readonly unknown[], Default extends User>(
   // For avoiding the type error
   //   `This expression is not callable. Type 'unknown' has no call signatures.ts(2349)`
   (options as unknown[]).forEach((opt: unknown, i: number) => {
+    // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
     if (userOptions[i] !== undefined) {
       const userOpt = userOptions[i];
 

--- a/packages/website/plugins/generated-rule-docs/insertions/insertRuleOptions.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertRuleOptions.ts
@@ -74,6 +74,7 @@ export function insertRuleOptions(page: RuleDocsPage): void {
     page.spliceChildren(
       commentInsertionIndex,
       0,
+      // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish -- I don't know whether this is safe to fix
       defaultValue !== undefined
         ? `${option.description} Default: \`${JSON.stringify(defaultValue)}\`.`
         : option.description,

--- a/packages/website/src/components/RulesTable/index.tsx
+++ b/packages/website/src/components/RulesTable/index.tsx
@@ -186,7 +186,11 @@ export default function RulesTable(): React.JSX.Element {
           match(filters.typeInformation, !!r.docs.requiresTypeChecking),
           match(filters.extension, !!r.docs.extendsBaseRule),
           match(filters.deprecated, !!r.deprecated),
-        ].filter((o): o is boolean => o !== undefined);
+        ].filter(
+          (o): o is boolean =>
+            // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish
+            o !== undefined,
+        );
         return opinions.every(o => o);
       }),
     [rules, filters],

--- a/packages/website/src/components/TypeScriptOverlap/index.tsx
+++ b/packages/website/src/components/TypeScriptOverlap/index.tsx
@@ -16,7 +16,7 @@ export default function TypeScriptOverlap({
           rule if you prefer the ESLint error messages over the TypeScript
           compiler error messages.
         </p>
-        {strict === undefined ? (
+        {strict == null ? (
           <></>
         ) : (
           <p>

--- a/packages/website/src/components/ast/utils.ts
+++ b/packages/website/src/components/ast/utils.ts
@@ -214,6 +214,7 @@ export function filterProperties(
   showTokens?: boolean,
 ): boolean {
   if (
+    // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish -- I don't know whether this is safe to fix
     value === undefined ||
     typeof value === 'function' ||
     key.startsWith('_')

--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -50,7 +50,7 @@ await releaseChangelog({
 });
 
 // An explicit null value here means that no changes were detected across any package
-// eslint-disable-next-line eqeqeq
+// eslint-disable-next-line eqeqeq, @typescript-eslint/internal/eqeq-nullish
 if (workspaceVersion === null) {
   console.log(
     '⏭️ No changes detected across any package, skipping publish step altogether',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10186 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

adds internal lint rule eqeq-null to enforce that you do `== null` instead of `=== null` or `=== undefined`.

erred on the side of disabling reports in the repo if it seemed suspicious whether it could safely be disabled