### PR TITLE
fix(eslint-plugin): [no-base-to-string] handle more robustly when multiple `toString()` declarations are present for a type

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -9,8 +9,6 @@ import {
   getConstrainedTypeAtLocation,
   getParserServices,
   getTypeName,
-  isTypeAnyType,
-  isTypeUnknownType,
   nullThrows,
 } from '../util';
 

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -210,7 +210,7 @@ export default createRule<Options, MessageIds>({
 
       const declarations = toString.getDeclarations();
 
-      if (!(declarations?.length === 1)) {
+      if (declarations == null || declarations.length !== 1) {
         // If there are multiple declarations, at least one of them must not be
         // the default object toString.
         //

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -189,16 +189,16 @@ export default createRule<Options, MessageIds>({
         return collectIntersectionTypeCertainty(type, collectToStringCertainty);
       }
 
+      if (type.isUnion()) {
+        return collectUnionTypeCertainty(type, collectToStringCertainty);
+      }
+
       // the Boolean type definition missing toString()
       if (
         type.flags & ts.TypeFlags.Boolean ||
         type.flags & ts.TypeFlags.BooleanLiteral
       ) {
         return Usefulness.Always;
-      }
-
-      if (type.isUnion()) {
-        return collectUnionTypeCertainty(type, collectToStringCertainty);
       }
 
       const toString =

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -185,20 +185,24 @@ export default createRule<Options, MessageIds>({
         return Usefulness.Always;
       }
 
-      if (type.isIntersection()) {
-        return collectIntersectionTypeCertainty(type, collectToStringCertainty);
-      }
-
-      if (type.isUnion()) {
-        return collectUnionTypeCertainty(type, collectToStringCertainty);
-      }
-
       // the Boolean type definition missing toString()
       if (
         type.flags & ts.TypeFlags.Boolean ||
         type.flags & ts.TypeFlags.BooleanLiteral
       ) {
         return Usefulness.Always;
+      }
+
+      if (ignoredTypeNames.includes(getTypeName(checker, type))) {
+        return Usefulness.Always;
+      }
+
+      if (type.isIntersection()) {
+        return collectIntersectionTypeCertainty(type, collectToStringCertainty);
+      }
+
+      if (type.isUnion()) {
+        return collectUnionTypeCertainty(type, collectToStringCertainty);
       }
 
       const toString =
@@ -217,10 +221,6 @@ export default createRule<Options, MessageIds>({
         //
         // This may only matter for older versions of TS
         // see https://github.com/typescript-eslint/typescript-eslint/issues/8585
-        return Usefulness.Always;
-      }
-
-      if (ignoredTypeNames.includes(getTypeName(checker, type))) {
         return Usefulness.Always;
       }
 

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/internal/prefer-ast-types-enum */
 import type { TSESTree } from '@typescript-eslint/utils';
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
@@ -218,10 +217,12 @@ export default createRule<Options, MessageIds>({
     function isBuiltInStringCall(node: TSESTree.CallExpression): boolean {
       if (
         node.callee.type === AST_NODE_TYPES.Identifier &&
+        // eslint-disable-next-line @typescript-eslint/internal/prefer-ast-types-enum
         node.callee.name === 'String' &&
         node.arguments[0]
       ) {
         const scope = context.sourceCode.getScope(node);
+        // eslint-disable-next-line @typescript-eslint/internal/prefer-ast-types-enum
         const variable = scope.set.get('String');
         return !variable?.defs.length;
       }
@@ -245,7 +246,10 @@ export default createRule<Options, MessageIds>({
         }
       },
       CallExpression(node: TSESTree.CallExpression): void {
-        if (isBuiltInStringCall(node)) {
+        if (
+          isBuiltInStringCall(node) &&
+          node.arguments[0].type !== AST_NODE_TYPES.SpreadElement
+        ) {
           checkExpression(node.arguments[0]);
         }
       },

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -175,6 +175,7 @@ export default createRule<Options, MessageIds>({
     }
 
     function collectToStringCertainty(type: ts.Type): Usefulness {
+      // https://github.com/JoshuaKGoldberg/ts-api-utils/issues/382
       if ((tsutils.isTypeParameter as (t: ts.Type) => boolean)(type)) {
         const constraint = type.getConstraint();
         if (constraint) {

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -68,7 +68,7 @@ export default createRule<Options, MessageIds>({
     const checker = services.program.getTypeChecker();
     const ignoredTypeNames = option.ignoredTypeNames ?? [];
 
-    function checkExpression(node: TSESTree.Node, type?: ts.Type): void {
+    function checkExpression(node: TSESTree.Expression, type?: ts.Type): void {
       if (node.type === AST_NODE_TYPES.Literal) {
         return;
       }

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -216,6 +216,32 @@ tuple.join('');
 let objects = [{}, {}];
 String(...objects);
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/8585
+    `
+type Constructable<Entity> = abstract new (...args: any[]) => Entity;
+
+interface GuildChannel {
+  toString(): \`<#\${string}>\`;
+}
+
+declare const foo: Constructable<GuildChannel & { bar: 1 }>;
+class ExtendedGuildChannel extends foo {}
+declare const bb: ExtendedGuildChannel;
+bb.toString();
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/8585 with intersection order reversed.
+    `
+type Constructable<Entity> = abstract new (...args: any[]) => Entity;
+
+interface GuildChannel {
+  toString(): \`<#\${string}>\`;
+}
+
+declare const foo: Constructable<{ bar: 1 } & GuildChannel>;
+class ExtendedGuildChannel extends foo {}
+declare const bb: ExtendedGuildChannel;
+bb.toString();
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -141,6 +141,14 @@ Number(1);
       code: 'String(/regex/);',
       options: [{ ignoredTypeNames: ['RegExp'] }],
     },
+    {
+      code: `
+type Foo = { a: string } | { b: string };
+declare const foo: Foo;
+String(foo);
+      `,
+      options: [{ ignoredTypeNames: ['Foo'] }],
+    },
     `
 function String(value) {
   return value;

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -242,6 +242,15 @@ class ExtendedGuildChannel extends foo {}
 declare const bb: ExtendedGuildChannel;
 bb.toString();
     `,
+    `
+function foo<T>(x: T) {
+  String(x);
+}
+    `,
+    `
+declare const u: unknown;
+String(u);
+    `,
   ],
   invalid: [
     {
@@ -694,10 +703,60 @@ declare const foo: Bar & Foo;
       errors: [
         {
           data: {
-            certainty: 'will',
+            certainty: 'may',
             name: 'array',
           },
           messageId: 'baseArrayJoin',
+        },
+      ],
+    },
+    {
+      code: `
+        type Bar = Record<string, string>;
+        function foo<T extends string | Bar>(array: T[]) {
+          array[0].toString();
+        }
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'array[0]',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+    },
+    {
+      code: `
+        type Bar = Record<string, string>;
+        function foo<T extends string | Bar>(value: T) {
+          value.toString();
+        }
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'value',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+    },
+    {
+      code: `
+type Bar = Record<string, string>;
+declare const foo: Bar | string;
+foo.toString();
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'foo',
+          },
+          messageId: 'baseToString',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -135,10 +135,6 @@ tag\`\${{}}\`;
     "'' += new URL();",
     "'' += new URLSearchParams();",
     `
-let numbers = [1, 2, 3];
-String(...a);
-    `,
-    `
 Number(1);
     `,
     {
@@ -215,6 +211,11 @@ class Foo {}
 declare const tuple: [string] & [Foo];
 tuple.join('');
     `,
+    // don't bother trying to interpret spread args.
+    `
+let objects = [{}, {}];
+String(...objects);
+    `,
   ],
   invalid: [
     {
@@ -272,21 +273,6 @@ tuple.join('');
           data: {
             certainty: 'will',
             name: '{}',
-          },
-          messageId: 'baseToString',
-        },
-      ],
-    },
-    {
-      code: `
-let objects = [{}, {}];
-String(...objects);
-      `,
-      errors: [
-        {
-          data: {
-            certainty: 'will',
-            name: '...objects',
           },
           messageId: 'baseToString',
         },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: 
   - fixes #10431 - ~~⌛ not yet accepting PRs~~ ✅ 
   - fixes #8585 - ✅  accepting PRs
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

#8585 only repros in TS < 5.4, so you'll want to use [the branch playground](https://deploy-preview-10432--typescript-eslint.netlify.app/play/#ts=5.3.3&fileType=.ts&code=C4TwDgpgBAwg9gOwM7AE4FcDGwCGAjAGwgB4BRBYAS1AD4oBeKfFVHbKBCAdygAoA6QTlQBzJAC4mCEAG0AugEoGdclVABuAFCbKFCKgBmbaAHF0lAgBMYACxwJOBKAG9NUKMDgBlNLpG8FSQADYgBiABJnFj8AXxogzRjtSwhMAmFoTEQUJhxJMwtrOwcIAmTU9NRM7OAoAzg4SXhkNCxcQhICq1t7RygAMhcoPGFJAEYoOK00nCQkKFIAD2AIBBTLLqLe0qgIZdXLefq4IaSUmaqoLJbhvEkllbWIDfNu4sdtHBx%2BTx9UPwCUAA9ECoHAANaaPB4H7eXwIfxKEEcOC1CGaIA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1oCMBDZRLXxdk%2BKkwDm6KImjQO0SODABfECqA&tsconfig=&tokens=false) to verify that the repro in the issue is actually fixed for TS < 5.4.

In short - we want to apply the heuristic that if more than one `toString()` declaration is present for a type, it must be useful. However - there are multiple reasons that multiple `toString()` declarations may be present. Therefore, we need to be much more careful about handling intersections and generics, lest we erroneously apply the multiple-declaration heuristic to cases it does not apply.

This is all tested for, except, ironically, for the actual repro in the issue, since that requires TS < 5.4, and I don't think we have infra for testing that. Regardless, as said, [you can see it working in the branch sandbox](https://deploy-preview-10432--typescript-eslint.netlify.app/play/#ts=5.3.3&fileType=.ts&code=C4TwDgpgBAwg9gOwM7AE4FcDGwCGAjAGwgB4BRBYAS1AD4oBeKfFVHbKBCAdygAoA6QTlQBzJAC4mCEAG0AugEoGdclVABuAFCbKFCKgBmbaAHF0lAgBMYACxwJOBKAG9NUKMDgBlNLpG8FSQADYgBiABJnFj8AXxogzRjtSwhMAmFoTEQUJhxJMwtrOwcIAmTU9NRM7OAoAzg4SXhkNCxcQhICq1t7RygAMhcoPGFJAEYoOK00nCQkKFIAD2AIBBTLLqLe0qgIZdXLefq4IaSUmaqoLJbhvEkllbWIDfNu4sdtHBx%2BTx9UPwCUAA9ECoHAANaaPB4H7eXwIfxKEEcOC1CGaIA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1oCMBDZRLXxdk%2BKkwDm6KImjQO0SODABfECqA&tsconfig=&tokens=false)