### PR TITLE
fix(eslint-plugin): [no-base-to-string] short circuit on unions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -143,7 +143,10 @@ export default createRule<Options, MessageIds>({
           return Usefulness.Sometimes;
         }
       }
-      return usefulness ?? Usefulness.Sometimes;
+      return nullThrows(
+        usefulness,
+        'loop should have run at least once, since unions must have multiple constituents',
+      );
     }
 
     function collectIntersectionTypeCertainty(


### PR DESCRIPTION
I haven't measured or anything, but I'm hoping this is slightly helpful for performance in some cases. I wonder if it might also prevent infinite recursion on some recursive types 🤷 

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
