### PR TITLE
fix(eslint-plugin): [use-unknown-in-catch-callback-variable] only flag function literals

### DIFF
--- a/packages/eslint-plugin/src/rules/use-unknown-in-catch-callback-variable.ts
+++ b/packages/eslint-plugin/src/rules/use-unknown-in-catch-callback-variable.ts
@@ -113,7 +113,7 @@ export default createRule<[], MessageIds>({
           return collectFlaggedNodes(
             nullThrows(
               node.expressions.at(-1),
-              'seuence expression must have multiple expressions',
+              'sequence expression must have multiple expressions',
             ),
           );
         case AST_NODE_TYPES.ConditionalExpression:

--- a/packages/eslint-plugin/src/rules/use-unknown-in-catch-callback-variable.ts
+++ b/packages/eslint-plugin/src/rules/use-unknown-in-catch-callback-variable.ts
@@ -102,7 +102,7 @@ export default createRule<[], MessageIds>({
 
     function collectFlaggedNodes(
       node: Exclude<TSESTree.Node, TSESTree.SpreadElement>,
-    ): Exclude<TSESTree.Node, TSESTree.SpreadElement>[] {
+    ): (TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression)[] {
       switch (node.type) {
         case AST_NODE_TYPES.LogicalExpression:
           return [
@@ -145,18 +145,8 @@ export default createRule<[], MessageIds>({
      * rule _is reporting_, so it is not guaranteed to be sound to call otherwise.
      */
     function refineReportIfPossible(
-      argument: Exclude<TSESTree.Node, TSESTree.SpreadElement>,
+      argument: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
     ): Partial<ReportDescriptor<MessageIds>> | undefined {
-      // Only know how to be helpful if a function literal has been provided.
-      if (
-        !(
-          argument.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-          argument.type === AST_NODE_TYPES.FunctionExpression
-        )
-      ) {
-        return undefined;
-      }
-
       const catchVariableOuterWithIncorrectTypes = nullThrows(
         argument.params.at(0),
         'There should have been at least one parameter for the rule to have flagged.',

--- a/packages/eslint-plugin/src/rules/use-unknown-in-catch-callback-variable.ts
+++ b/packages/eslint-plugin/src/rules/use-unknown-in-catch-callback-variable.ts
@@ -100,10 +100,41 @@ export default createRule<[], MessageIds>({
       return false;
     }
 
-    function shouldFlagArgument(node: TSESTree.Expression): boolean {
-      const argument = esTreeNodeToTSNodeMap.get(node);
-      const typeOfArgument = checker.getTypeAtLocation(argument);
-      return isFlaggableHandlerType(typeOfArgument);
+    function collectFlaggedNodes(
+      node: Exclude<TSESTree.Node, TSESTree.SpreadElement>,
+    ): Exclude<TSESTree.Node, TSESTree.SpreadElement>[] {
+      switch (node.type) {
+        case AST_NODE_TYPES.LogicalExpression:
+          return [
+            ...collectFlaggedNodes(node.left),
+            ...collectFlaggedNodes(node.right),
+          ];
+        case AST_NODE_TYPES.SequenceExpression:
+          return collectFlaggedNodes(
+            nullThrows(
+              node.expressions.at(-1),
+              'seuence expression must have multiple expressions',
+            ),
+          );
+        case AST_NODE_TYPES.ConditionalExpression:
+          return [
+            ...collectFlaggedNodes(node.consequent),
+            ...collectFlaggedNodes(node.alternate),
+          ];
+        case AST_NODE_TYPES.ArrowFunctionExpression:
+        case AST_NODE_TYPES.FunctionExpression:
+          {
+            const argument = esTreeNodeToTSNodeMap.get(node);
+            const typeOfArgument = checker.getTypeAtLocation(argument);
+            if (isFlaggableHandlerType(typeOfArgument)) {
+              return [node];
+            }
+          }
+          break;
+        default:
+          break;
+      }
+      return [];
     }
 
     /**
@@ -114,7 +145,7 @@ export default createRule<[], MessageIds>({
      * rule _is reporting_, so it is not guaranteed to be sound to call otherwise.
      */
     function refineReportIfPossible(
-      argument: TSESTree.Expression,
+      argument: Exclude<TSESTree.Node, TSESTree.SpreadElement>,
     ): Partial<ReportDescriptor<MessageIds>> | undefined {
       // Only know how to be helpful if a function literal has been provided.
       if (
@@ -277,11 +308,12 @@ export default createRule<[], MessageIds>({
         }
 
         // the `some` check above has already excluded `SpreadElement`, so we are safe to assert the same
-        const node = argsToCheck[argIndexToCheck] as Exclude<
-          (typeof argsToCheck)[number],
+        const argToCheck = argsToCheck[argIndexToCheck] as Exclude<
+          TSESTree.Node,
           TSESTree.SpreadElement
         >;
-        if (shouldFlagArgument(node)) {
+
+        for (const node of collectFlaggedNodes(argToCheck)) {
           // We are now guaranteed to report, but we have a bit of work to do
           // to determine exactly where, and whether we can fix it.
           const overrides = refineReportIfPossible(node);

--- a/packages/eslint-plugin/tests/rules/use-unknown-in-catch-callback-variable.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-unknown-in-catch-callback-variable.test.ts
@@ -163,6 +163,21 @@ Promise.resolve().catch(...x);
 declare const thenArgs: [() => {}, (err: any) => {}];
 Promise.resolve().then(...thenArgs);
     `,
+    // this is valid, because the `any` is a passed-in handler, not a function literal.
+    // https://github.com/typescript-eslint/typescript-eslint/issues/9057
+    `
+declare const yoloHandler: (x: any) => void;
+Promise.reject(new Error('I will reject!')).catch(yoloHandler);
+    `,
+    // type assertion is not a function literal.
+    `
+type InvalidHandler = (arg: any) => void;
+Promise.resolve().catch(<InvalidHandler>(
+  function (err /* awkward spot for comment */) {
+    throw err;
+  }
+));
+    `,
   ],
 
   invalid: [
@@ -343,25 +358,6 @@ Promise.resolve().catch(function (err: unknown /* awkward spot for comment */) {
       `,
             },
           ],
-        },
-      ],
-    },
-
-    {
-      code: `
-type InvalidHandler = (arg: any) => void;
-Promise.resolve().catch(<InvalidHandler>(
-  function (err /* awkward spot for comment */) {
-    throw err;
-  }
-));
-      `,
-      errors: [
-        {
-          line: 3,
-          messageId: 'useUnknown',
-          // We should _not_ make a suggestion due to the type assertion.
-          suggestions: null,
         },
       ],
     },
@@ -600,19 +596,6 @@ Promise.reject(new Error('I will reject!')).catch(([err]: [unknown]) => {
 
     {
       code: `
-declare const yoloHandler: (x: any) => void;
-Promise.reject(new Error('I will reject!')).catch(yoloHandler);
-      `,
-      errors: [
-        {
-          line: 3,
-          messageId: 'useUnknown',
-        },
-      ],
-    },
-
-    {
-      code: `
 Promise.resolve(' a string ').catch(
   (a: any, b: () => any, c: (x: string & number) => void) => {},
 );
@@ -742,6 +725,133 @@ Promise.resolve().catch((...{ find }: [string]) => {
 Promise.resolve().catch((...{ find }: [unknown]) => {
   console.log(find);
 });
+      `,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      code: `
+declare const condition: boolean;
+Promise.resolve('foo').then(() => {}, condition ? err => {} : err => {});
+      `,
+      errors: [
+        {
+          column: 51,
+          endColumn: 60,
+          endLine: 3,
+          line: 3,
+
+          messageId: 'useUnknown',
+
+          suggestions: [
+            {
+              messageId: 'addUnknownTypeAnnotationSuggestion',
+              output: `
+declare const condition: boolean;
+Promise.resolve('foo').then(() => {}, condition ? (err: unknown) => {} : err => {});
+      `,
+            },
+          ],
+        },
+        {
+          column: 63,
+          endColumn: 72,
+          endLine: 3,
+          line: 3,
+
+          messageId: 'useUnknown',
+
+          suggestions: [
+            {
+              messageId: 'addUnknownTypeAnnotationSuggestion',
+              output: `
+declare const condition: boolean;
+Promise.resolve('foo').then(() => {}, condition ? err => {} : (err: unknown) => {});
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+declare const condition: boolean;
+declare const maybeNullishHandler: null | ((err: any) => void);
+Promise.resolve('foo').catch(
+  condition
+    ? (err => {}, err => {}, maybeNullishHandler) ?? (err => {})
+    : (condition && (err => {})) || (err => {}),
+);
+      `,
+      errors: [
+        {
+          column: 55,
+          endColumn: 64,
+          endLine: 6,
+          line: 6,
+
+          messageId: 'useUnknown',
+
+          suggestions: [
+            {
+              messageId: 'addUnknownTypeAnnotationSuggestion',
+              output: `
+declare const condition: boolean;
+declare const maybeNullishHandler: null | ((err: unknown) => void);
+Promise.resolve('foo').catch(
+  condition
+    ? (err => {}, err => {}, maybeNullishHandler) ?? ((err: unknown) => {})
+    : (condition && (err => {})) || (err => {}),
+);
+      `,
+            },
+          ],
+        },
+        {
+          column: 22,
+          endColumn: 31,
+          endLine: 7,
+          line: 7,
+
+          messageId: 'useUnknown',
+
+          suggestions: [
+            {
+              messageId: 'addUnknownTypeAnnotationSuggestion',
+              output: `
+declare const condition: boolean;
+declare const maybeNullishHandler: null | (err => void);
+Promise.resolve('foo').catch(
+  condition
+    ? (err => {}, err => {}, maybeNullishHandler) ?? ((err: unknown) => {})
+    : (condition && ((err: unknown) => {})) || (err => {}),
+);
+      `,
+            },
+          ],
+        },
+        {
+          column: 38,
+          endColumn: 47,
+          endLine: 7,
+          line: 7,
+
+          messageId: 'useUnknown',
+
+          suggestions: [
+            {
+              messageId: 'addUnknownTypeAnnotationSuggestion',
+              output: `
+declare const condition: boolean;
+declare const maybeNullishHandler: null | (err => void);
+Promise.resolve('foo').catch(
+  condition
+    ? (err => {}, err => {}, maybeNullishHandler) ?? ((err: unknown) => {})
+    : (condition && (err => {})) || ((err: unknown) => {}),
+);
       `,
             },
           ],

--- a/packages/eslint-plugin/tests/rules/use-unknown-in-catch-callback-variable.test.ts
+++ b/packages/eslint-plugin/tests/rules/use-unknown-in-catch-callback-variable.test.ts
@@ -740,7 +740,7 @@ Promise.resolve('foo').then(() => {}, condition ? err => {} : err => {});
       errors: [
         {
           column: 51,
-          endColumn: 60,
+          endColumn: 54,
           endLine: 3,
           line: 3,
 
@@ -758,7 +758,7 @@ Promise.resolve('foo').then(() => {}, condition ? (err: unknown) => {} : err => 
         },
         {
           column: 63,
-          endColumn: 72,
+          endColumn: 66,
           endLine: 3,
           line: 3,
 
@@ -789,7 +789,7 @@ Promise.resolve('foo').catch(
       errors: [
         {
           column: 55,
-          endColumn: 64,
+          endColumn: 58,
           endLine: 6,
           line: 6,
 
@@ -800,7 +800,7 @@ Promise.resolve('foo').catch(
               messageId: 'addUnknownTypeAnnotationSuggestion',
               output: `
 declare const condition: boolean;
-declare const maybeNullishHandler: null | ((err: unknown) => void);
+declare const maybeNullishHandler: null | ((err: any) => void);
 Promise.resolve('foo').catch(
   condition
     ? (err => {}, err => {}, maybeNullishHandler) ?? ((err: unknown) => {})
@@ -812,7 +812,7 @@ Promise.resolve('foo').catch(
         },
         {
           column: 22,
-          endColumn: 31,
+          endColumn: 25,
           endLine: 7,
           line: 7,
 
@@ -823,10 +823,10 @@ Promise.resolve('foo').catch(
               messageId: 'addUnknownTypeAnnotationSuggestion',
               output: `
 declare const condition: boolean;
-declare const maybeNullishHandler: null | (err => void);
+declare const maybeNullishHandler: null | ((err: any) => void);
 Promise.resolve('foo').catch(
   condition
-    ? (err => {}, err => {}, maybeNullishHandler) ?? ((err: unknown) => {})
+    ? (err => {}, err => {}, maybeNullishHandler) ?? (err => {})
     : (condition && ((err: unknown) => {})) || (err => {}),
 );
       `,
@@ -835,7 +835,7 @@ Promise.resolve('foo').catch(
         },
         {
           column: 38,
-          endColumn: 47,
+          endColumn: 41,
           endLine: 7,
           line: 7,
 
@@ -846,10 +846,10 @@ Promise.resolve('foo').catch(
               messageId: 'addUnknownTypeAnnotationSuggestion',
               output: `
 declare const condition: boolean;
-declare const maybeNullishHandler: null | (err => void);
+declare const maybeNullishHandler: null | ((err: any) => void);
 Promise.resolve('foo').catch(
   condition
-    ? (err => {}, err => {}, maybeNullishHandler) ?? ((err: unknown) => {})
+    ? (err => {}, err => {}, maybeNullishHandler) ?? (err => {})
     : (condition && (err => {})) || ((err: unknown) => {}),
 );
       `,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9057 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Since we're no longer generally flagging expressions that have type `(e: any) => whatever`, I added in recursion to catch function literals not passed directly, but whose type is still inferred. So, `promise.catch(e => condition ? (e) => {} : (e) => {});` still can and does trigger the rule, since `e` is inferred as `any` in both locations. Plus, the rule reports them each individually and consequently offers a suggestion now.