### PR TITLE
fix(eslint-plugin): [no-unnecessary-template-expression] don't report when an expression includes comment

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
@@ -92,12 +92,16 @@ export default createRule<[], MessageId>({
       );
     }
 
-    function hasCommentsBetween(
-      startOffset: number,
-      endOffset: number,
+    function hasCommentsBetweenQuasi(
+      startQuasi: TSESTree.TemplateElement,
+      endQuasi: TSESTree.TemplateElement,
     ): boolean {
-      const startToken = context.sourceCode.getTokenByRangeStart(startOffset);
-      const endToken = context.sourceCode.getTokenByRangeStart(endOffset);
+      const startToken = context.sourceCode.getTokenByRangeStart(
+        startQuasi.range[0],
+      );
+      const endToken = context.sourceCode.getTokenByRangeStart(
+        endQuasi.range[0],
+      );
 
       if (startToken && endToken) {
         return context.sourceCode.commentsExistBetween(startToken, endToken);
@@ -120,9 +124,7 @@ export default createRule<[], MessageId>({
           isUnderlyingTypeString(node.expressions[0]);
 
         if (hasSingleStringVariable) {
-          if (
-            hasCommentsBetween(node.quasis[0].range[0], node.quasis[1].range[0])
-          ) {
+          if (hasCommentsBetweenQuasi(node.quasis[0], node.quasis[1])) {
             return;
           }
 
@@ -162,7 +164,7 @@ export default createRule<[], MessageId>({
             }
 
             // allow expressions that include comments
-            if (hasCommentsBetween(prevQuasi.range[0], nextQuasi.range[0])) {
+            if (hasCommentsBetweenQuasi(prevQuasi, nextQuasi)) {
               return false;
             }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
@@ -107,6 +107,7 @@ export default createRule<[], MessageId>({
         return context.sourceCode.commentsExistBetween(startToken, endToken);
       }
 
+      /* istanbul ignore next */
       return false;
     }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
@@ -10,6 +10,8 @@ import {
   getParserServices,
   isTypeFlagSet,
   isUndefinedIdentifier,
+  nullThrows,
+  NullThrowsReasons,
 } from '../util';
 import { rangeToLoc } from '../util/rangeToLoc';
 
@@ -96,19 +98,16 @@ export default createRule<[], MessageId>({
       startQuasi: TSESTree.TemplateElement,
       endQuasi: TSESTree.TemplateElement,
     ): boolean {
-      const startToken = context.sourceCode.getTokenByRangeStart(
-        startQuasi.range[0],
+      const startToken = nullThrows(
+        context.sourceCode.getTokenByRangeStart(startQuasi.range[0]),
+        NullThrowsReasons.MissingToken('`${', 'opening template literal'),
       );
-      const endToken = context.sourceCode.getTokenByRangeStart(
-        endQuasi.range[0],
+      const endToken = nullThrows(
+        context.sourceCode.getTokenByRangeStart(endQuasi.range[0]),
+        NullThrowsReasons.MissingToken('}', 'closing template literal'),
       );
 
-      if (startToken && endToken) {
-        return context.sourceCode.commentsExistBetween(startToken, endToken);
-      }
-
-      /* istanbul ignore next */
-      return false;
+      return context.sourceCode.commentsExistBetween(startToken, endToken);
     }
 
     return {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -1130,6 +1130,18 @@ this code has trailing whitespace: \${'    '}
     `
 \`\${/* intentional comment before */ 'bar' /* intentional comment after */}\`;
     `,
+    `
+\`\${
+  // intentional comment before
+  'bar'
+}\`;
+    `,
+    `
+\`\${
+  'bar'
+  // intentional comment after
+}\`;
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -311,10 +311,6 @@ const invalidCases: readonly InvalidTestCase<
       `,
     errors: [
       {
-        line: 2,
-        messageId: 'noUnnecessaryTemplateExpression',
-      },
-      {
         column: 2,
         endColumn: 2,
         endLine: 8,
@@ -331,12 +327,18 @@ const invalidCases: readonly InvalidTestCase<
     ],
     output: [
       `
-\`use\${
-  \`less\`
-}\`;
+\`u\${
+  // hopefully this comment is not needed.
+  'se'
+
+}le\${  \`ss\`  }\`;
       `,
       `
-\`useless\`;
+\`u\${
+  // hopefully this comment is not needed.
+  'se'
+
+}less\`;
       `,
     ],
   },
@@ -1103,6 +1105,21 @@ this code has trailing whitespace: \${'    '}
     `
 \`trailing position interpolated empty string also makes whitespace clear    \${''}
 \`;
+    `,
+    `
+\`
+\${/* intentional comment before */ 'bar'}
+...\`;
+    `,
+    `
+\`
+\${'bar' /* intentional comment after */}
+...\`;
+    `,
+    `
+\`
+\${/* intentional comment before */ 'bar' /* intentional comment after */}
+...\`;
     `,
   ],
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -1121,6 +1121,9 @@ this code has trailing whitespace: \${'    '}
 \${/* intentional comment before */ 'bar' /* intentional comment after */}
 ...\`;
     `,
+    `
+\`\${'bar' /* intentional comment */}\`;
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -1122,7 +1122,13 @@ this code has trailing whitespace: \${'    '}
 ...\`;
     `,
     `
-\`\${'bar' /* intentional comment */}\`;
+\`\${/* intentional  before */ 'bar'}\`;
+    `,
+    `
+\`\${'bar' /* intentional comment after */}\`;
+    `,
+    `
+\`\${/* intentional comment before */ 'bar' /* intentional comment after */}\`;
     `,
   ],
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10434
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10434 and stops the rule from reporting on expressions that include comments:

```ts
`
${/* intentional comment */ 'foo'}
...`;
```