### PR TITLE
feat(eslint-plugin): add new rule `no-extraneous-return-types`

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
@@ -9,11 +9,9 @@ import TabItem from '@theme/TabItem';
 >
 > See **https://typescript-eslint.io/rules/no-extraneous-return-types** for documentation.
 
-Explicit return type annotations are optional in TypeScript. However, explicit return types do make it visually more clear what type is returned by a function.
-
-A function can include return type annotations that are never used. This can happen when refactoring code or by mistake. Having unused return types adds unnecessary complexity because it needs to be handled by code that calls the function.
-
-This rule reports cases where a function has an unused return type annotation.
+Explicit function return type annotations can sometimes be helpful in TypeScript to describe a more precise return type than what the type checker would infer.
+Functions that can return one of multiple types of values generally use union types to describe their return type.
+This lint rule checks for "extraneous", or unnecessary, constituents of union type returns: those that don't describe a type the function can return.
 
 ## Examples
 

--- a/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
@@ -1,0 +1,67 @@
+---
+description: 'Disallow extraneous union types in return type annotations.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-extraneous-return-types** for documentation.
+
+Explicit return type annotations are optional in TypeScript. However, explicit return types do make it visually more clear what type is returned by a function.
+
+A function can include return type annotations that are never used. This can happen when refactoring code or by mistake. Unused return types also need to be handled by code that calls such a function.
+
+This rule reports cases where a function has an unused return type annotation.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+function test1(): string | null {
+  return 'string';
+}
+
+function test2(): Promise<string | null> {
+  return Promise.resolve('string');
+}
+
+class A {
+  test(): string | null {
+    return 'string';
+  }
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+function test1(): string {
+  return 'string';
+}
+
+function test2(): Promise<string> {
+  return Promise.resolve('string');
+}
+
+class A {
+  test(): string {
+    return 'string';
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## When Not To Use It
+
+This rule can be completely redundant for projects without explicit return type annotations on functions. It works best when coupled with other rules that enforce explicit return type annotations such as [`explicit-function-return-type`](https://typescript-eslint.io/rules/explicit-function-return-type) or [`explicit-module-boundary-types`](https://typescript-eslint.io/rules/explicit-module-boundary-types).
+
+```
+
+```

--- a/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
@@ -58,4 +58,5 @@ class A {
 
 ## When Not To Use It
 
-This rule can be completely redundant for projects without explicit return type annotations on functions. It works best when coupled with other rules that enforce explicit return type annotations such as [`explicit-function-return-type`](https://typescript-eslint.io/rules/explicit-function-return-type) or [`explicit-module-boundary-types`](https://typescript-eslint.io/rules/explicit-module-boundary-types).
+Some projects have early-stage functions, which are likely to evolve later on to match their declared return types.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Explicit return type annotations are optional in TypeScript. However, explicit return types do make it visually more clear what type is returned by a function.
 
-A function can include return type annotations that are never used. This can happen when refactoring code or by mistake. Unused return types also need to be handled by code that calls such a function.
+A function can include return type annotations that are never used. This can happen when refactoring code or by mistake. Having unused return types adds unnecessary complexity because it needs to be handled by code that calls the function.
 
 This rule reports cases where a function has an unused return type annotation.
 

--- a/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
@@ -62,6 +62,3 @@ class A {
 
 This rule can be completely redundant for projects without explicit return type annotations on functions. It works best when coupled with other rules that enforce explicit return type annotations such as [`explicit-function-return-type`](https://typescript-eslint.io/rules/explicit-function-return-type) or [`explicit-module-boundary-types`](https://typescript-eslint.io/rules/explicit-module-boundary-types).
 
-```
-
-```

--- a/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-return-types.mdx
@@ -61,4 +61,3 @@ class A {
 ## When Not To Use It
 
 This rule can be completely redundant for projects without explicit return type annotations on functions. It works best when coupled with other rules that enforce explicit return type annotations such as [`explicit-function-return-type`](https://typescript-eslint.io/rules/explicit-function-return-type) or [`explicit-module-boundary-types`](https://typescript-eslint.io/rules/explicit-module-boundary-types).
-

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -58,6 +58,7 @@ export = {
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-extra-non-null-assertion': 'error',
     '@typescript-eslint/no-extraneous-class': 'error',
+    '@typescript-eslint/no-extraneous-return-types': 'error',
     '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/no-for-in-array': 'error',
     'no-implied-eval': 'off',

--- a/packages/eslint-plugin/src/configs/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/disable-type-checked.ts
@@ -20,6 +20,7 @@ export = {
     '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/no-deprecated': 'off',
     '@typescript-eslint/no-duplicate-type-constituents': 'off',
+    '@typescript-eslint/no-extraneous-return-types': 'off',
     '@typescript-eslint/no-floating-promises': 'off',
     '@typescript-eslint/no-for-in-array': 'off',
     '@typescript-eslint/no-implied-eval': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -40,6 +40,7 @@ import noEmptyObjectType from './no-empty-object-type';
 import noExplicitAny from './no-explicit-any';
 import noExtraNonNullAssertion from './no-extra-non-null-assertion';
 import noExtraneousClass from './no-extraneous-class';
+import noExtraneousReturnTypes from './no-extraneous-return-types';
 import noFloatingPromises from './no-floating-promises';
 import noForInArray from './no-for-in-array';
 import noImpliedEval from './no-implied-eval';
@@ -171,6 +172,7 @@ const rules = {
   'no-explicit-any': noExplicitAny,
   'no-extra-non-null-assertion': noExtraNonNullAssertion,
   'no-extraneous-class': noExtraneousClass,
+  'no-extraneous-return-types': noExtraneousReturnTypes,
   'no-floating-promises': noFloatingPromises,
   'no-for-in-array': noForInArray,
   'no-implied-eval': noImpliedEval,

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -1,0 +1,278 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import type * as ts from 'typescript';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+
+import { createRule, forEachReturnStatement, getParserServices } from '../util';
+
+function getTypeArgumentIfPromiseNode(
+  node: TSESTree.TypeNode,
+): TSESTree.TypeNode | null {
+  if (
+    // Check for Promise<...> type reference
+    node.type === AST_NODE_TYPES.TSTypeReference &&
+    node.typeName.type === AST_NODE_TYPES.Identifier &&
+    node.typeName.name === 'Promise' &&
+    node.typeArguments?.params.length === 1
+  ) {
+    return node.typeArguments.params[0];
+  }
+
+  return null;
+}
+
+function getTypeArgumentIfArrayNode(
+  node: TSESTree.TypeNode,
+): TSESTree.TypeNode | null {
+  if (
+    // Check for Array<...> type reference
+    node.type === AST_NODE_TYPES.TSTypeReference &&
+    node.typeName.type === AST_NODE_TYPES.Identifier &&
+    node.typeName.name === 'Array' &&
+    node.typeArguments?.params.length === 1
+  ) {
+    return node.typeArguments.params[0];
+  }
+
+  if (
+    // Check for (...)[]
+    node.type === AST_NODE_TYPES.TSArrayType
+  ) {
+    return node.elementType;
+  }
+
+  return null;
+}
+
+function getTypeArgumentIfTupleNode(
+  node: TSESTree.TypeNode,
+): TSESTree.TypeNode[] | null {
+  if (
+    // Check for [...]
+    node.type === AST_NODE_TYPES.TSTupleType &&
+    node.elementTypes.length > 0
+  ) {
+    return node.elementTypes;
+  }
+
+  return null;
+}
+
+export default createRule({
+  name: 'no-extraneous-return-types',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow extraneous union types in return type annotations',
+      requiresTypeChecking: true,
+    },
+    fixable: 'code',
+    messages: {
+      unusedReturnTypes:
+        "Unused or redundant union type '{{type}}' in return type.",
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = getParserServices(context);
+    const checker = services.program.getTypeChecker();
+
+    function getRelevantReturnTypes(
+      node: TSESTree.TypeNode,
+      returnTypes: ts.Type[],
+    ): ts.Type[] | null {
+      const type = services.getTypeAtLocation(node);
+
+      const relevantReturnTypes = returnTypes.filter(returnType =>
+        checker.isTypeAssignableTo(returnType, type),
+      );
+
+      if (relevantReturnTypes.length === 0) {
+        context.report({
+          node,
+          messageId: 'unusedReturnTypes',
+          data: {
+            type: checker.typeToString(type),
+          },
+        });
+
+        return null;
+      }
+
+      return relevantReturnTypes;
+    }
+
+    function checkReturnType(
+      node: TSESTree.TypeNode,
+      returnTypes: ts.Type[],
+    ): void {
+      const tupleElementTypes = getTypeArgumentIfTupleNode(node);
+
+      if (tupleElementTypes) {
+        const relevantReturnTypes = getRelevantReturnTypes(node, returnTypes);
+
+        if (relevantReturnTypes) {
+          for (const [index, elementType] of tupleElementTypes.entries()) {
+            const returnTypes = relevantReturnTypes
+              .map(x => checker.getTypeArguments(x as ts.TupleTypeReference))
+              .map(x => x[index])
+              .flatMap(x => tsutils.unionTypeParts(x));
+
+            checkReturnType(elementType, returnTypes);
+          }
+        }
+
+        return;
+      }
+
+      const promiseTypeArgument = getTypeArgumentIfPromiseNode(node);
+
+      if (promiseTypeArgument) {
+        const relevantReturnTypes = getRelevantReturnTypes(node, returnTypes);
+
+        if (relevantReturnTypes) {
+          const returnTypes = relevantReturnTypes
+            .map(x => checker.getAwaitedType(x))
+            .filter(x => x != null)
+            .flatMap(x => tsutils.unionTypeParts(x));
+
+          checkReturnType(promiseTypeArgument, returnTypes);
+        }
+        return;
+      }
+
+      const arrayTypeArgument = getTypeArgumentIfArrayNode(node);
+
+      if (arrayTypeArgument) {
+        const relevantReturnTypes = getRelevantReturnTypes(node, returnTypes);
+
+        if (relevantReturnTypes) {
+          const returnTypes = relevantReturnTypes
+            .map(x => checker.getTypeArguments(x as ts.TupleTypeReference)[0])
+            .flatMap(x => tsutils.unionTypeParts(x));
+
+          checkReturnType(arrayTypeArgument, returnTypes);
+        }
+        return;
+      }
+
+      if (node.type === AST_NODE_TYPES.TSUnionType) {
+        for (const typeNode of node.types) {
+          checkReturnType(typeNode, returnTypes);
+        }
+
+        return;
+      }
+
+      const declaredReturnType = services.getTypeAtLocation(node);
+
+      // don't report on a potentially unused `void`, `any` or `undefined`
+      // return type
+      if (
+        tsutils.isIntrinsicVoidType(declaredReturnType) ||
+        tsutils.isIntrinsicUndefinedType(declaredReturnType) ||
+        tsutils.isIntrinsicAnyType(declaredReturnType)
+      ) {
+        return;
+      }
+
+      const hasMatchingReturnStatement = returnTypes.some(actualReturnType => {
+        return checker.isTypeAssignableTo(actualReturnType, declaredReturnType);
+      });
+
+      if (!hasMatchingReturnStatement) {
+        context.report({
+          node,
+          messageId: 'unusedReturnTypes',
+          data: {
+            type: checker.typeToString(declaredReturnType),
+          },
+        });
+      }
+
+      return;
+    }
+
+    function getPotentialReturnTypes(
+      node:
+        | TSESTree.ArrowFunctionExpression
+        | TSESTree.FunctionDeclaration
+        | TSESTree.FunctionExpression,
+    ): ts.Type[] {
+      if (node.body.type !== AST_NODE_TYPES.BlockStatement) {
+        return tsutils.typeParts(services.getTypeAtLocation(node.body));
+      }
+
+      const nodeTs = services.esTreeNodeToTSNodeMap.get(node);
+
+      const returnTypes: ts.Type[] = [];
+
+      forEachReturnStatement(nodeTs.body as ts.Block, statement => {
+        const expression = statement.expression;
+
+        // `return;`
+        if (!expression) {
+          returnTypes.push(checker.getUndefinedType());
+          return;
+        }
+
+        const typeParts = tsutils.typeParts(
+          checker.getTypeAtLocation(expression),
+        );
+
+        returnTypes.push(...typeParts);
+      });
+
+      return returnTypes;
+    }
+
+    return {
+      'FunctionDeclaration,FunctionExpression,ArrowFunctionExpression'(
+        node:
+          | TSESTree.ArrowFunctionExpression
+          | TSESTree.FunctionDeclaration
+          | TSESTree.FunctionExpression,
+      ): void {
+        if (!node.returnType || node.generator) {
+          return;
+        }
+
+        const actualReturnTypes = getPotentialReturnTypes(node);
+
+        if (actualReturnTypes.length === 0) {
+          // this is a type error unless the return type includes `void`,
+          // `undefined` or `any`
+          return;
+        }
+
+        if (node.async) {
+          const promiseTypeArgument = getTypeArgumentIfPromiseNode(
+            node.returnType.typeAnnotation,
+          );
+
+          if (!promiseTypeArgument) {
+            // this is a type error
+            return;
+          }
+
+          const promiseReturnTypes = actualReturnTypes
+            .map(x => checker.getAwaitedType(x))
+            .filter(x => x != null)
+            .flatMap(x => tsutils.unionTypeParts(x));
+
+          checkReturnType(promiseTypeArgument, [
+            // `async` functions may return promise and non-promise expressions
+            ...actualReturnTypes,
+            ...promiseReturnTypes,
+          ]);
+
+          return;
+        }
+
+        checkReturnType(node.returnType.typeAnnotation, actualReturnTypes);
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -9,6 +9,7 @@ import {
   forEachReturnStatement,
   forEachYieldExpression,
   getParserServices,
+  isFunction,
 } from '../util';
 
 export default createRule({
@@ -69,13 +70,15 @@ export default createRule({
       );
 
       if (relevantReturnTypes.length === 0) {
+        const canFix = !isFunction(node.parent.parent);
+
         context.report({
           node,
           messageId: 'unusedReturnTypes',
           data: {
             type: checker.typeToString(type),
           },
-          fix: fixer => removeTypeAnnotation(fixer, node),
+          fix: canFix ? fixer => removeTypeAnnotation(fixer, node) : null,
         });
 
         return null;
@@ -201,13 +204,15 @@ export default createRule({
       });
 
       if (!hasMatchingReturnStatement) {
+        const canFix = !isFunction(node.parent.parent);
+
         context.report({
           node,
           messageId: 'unusedReturnTypes',
           data: {
             type: checker.typeToString(constrainedReturnType),
           },
-          fix: fixer => removeTypeAnnotation(fixer, node),
+          fix: canFix ? fixer => removeTypeAnnotation(fixer, node) : null,
         });
       }
     }

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -73,11 +73,6 @@ export default createRule({
           const returnTypes: ts.Type[] = [];
 
           for (const type of relevantReturnTypes) {
-            if (tsutils.isIntrinsicAnyType(type)) {
-              returnTypes.push(type);
-              continue;
-            }
-
             if (tsutils.isTypeReference(type) && type.typeArguments) {
               const returnTypePart = type.typeArguments[index];
 

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -65,7 +65,7 @@ export default createRule({
           for (const [index, elementType] of tupleElementTypes.entries()) {
             const returnTypes = relevantReturnTypes
               .map(type => {
-                if (tsutils.isTypeReference(type)) {
+                if (checker.isTupleType(type)) {
                   return checker.getTypeArguments(type)[index];
                 }
                 return type;
@@ -103,7 +103,7 @@ export default createRule({
         if (relevantReturnTypes) {
           const returnTypes = relevantReturnTypes
             .map(type => {
-              if (tsutils.isTypeReference(type)) {
+              if (checker.isArrayType(type)) {
                 return checker.getTypeArguments(type)[0];
               }
               return type;

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -6,59 +6,6 @@ import * as tsutils from 'ts-api-utils';
 
 import { createRule, forEachReturnStatement, getParserServices } from '../util';
 
-function getTypeArgumentIfPromiseNode(
-  node: TSESTree.TypeNode,
-): TSESTree.TypeNode | null {
-  if (
-    // Check for Promise<...> type reference
-    node.type === AST_NODE_TYPES.TSTypeReference &&
-    node.typeName.type === AST_NODE_TYPES.Identifier &&
-    node.typeName.name === 'Promise' &&
-    node.typeArguments?.params.length === 1
-  ) {
-    return node.typeArguments.params[0];
-  }
-
-  return null;
-}
-
-function getTypeArgumentIfArrayNode(
-  node: TSESTree.TypeNode,
-): TSESTree.TypeNode | null {
-  if (
-    // Check for Array<...> type reference
-    node.type === AST_NODE_TYPES.TSTypeReference &&
-    node.typeName.type === AST_NODE_TYPES.Identifier &&
-    node.typeName.name === 'Array' &&
-    node.typeArguments?.params.length === 1
-  ) {
-    return node.typeArguments.params[0];
-  }
-
-  if (
-    // Check for (...)[]
-    node.type === AST_NODE_TYPES.TSArrayType
-  ) {
-    return node.elementType;
-  }
-
-  return null;
-}
-
-function getTypeArgumentIfTupleNode(
-  node: TSESTree.TypeNode,
-): TSESTree.TypeNode[] | null {
-  if (
-    // Check for [...]
-    node.type === AST_NODE_TYPES.TSTupleType &&
-    node.elementTypes.length > 0
-  ) {
-    return node.elementTypes;
-  }
-
-  return null;
-}
-
 export default createRule({
   name: 'no-extraneous-return-types',
   meta: {
@@ -276,3 +223,56 @@ export default createRule({
     };
   },
 });
+
+function getTypeArgumentIfPromiseNode(
+  node: TSESTree.TypeNode,
+): TSESTree.TypeNode | null {
+  if (
+    // Check for Promise<...> type reference
+    node.type === AST_NODE_TYPES.TSTypeReference &&
+    node.typeName.type === AST_NODE_TYPES.Identifier &&
+    node.typeName.name === 'Promise' &&
+    node.typeArguments?.params.length === 1
+  ) {
+    return node.typeArguments.params[0];
+  }
+
+  return null;
+}
+
+function getTypeArgumentIfArrayNode(
+  node: TSESTree.TypeNode,
+): TSESTree.TypeNode | null {
+  if (
+    // Check for Array<...> type reference
+    node.type === AST_NODE_TYPES.TSTypeReference &&
+    node.typeName.type === AST_NODE_TYPES.Identifier &&
+    node.typeName.name === 'Array' &&
+    node.typeArguments?.params.length === 1
+  ) {
+    return node.typeArguments.params[0];
+  }
+
+  if (
+    // Check for (...)[]
+    node.type === AST_NODE_TYPES.TSArrayType
+  ) {
+    return node.elementType;
+  }
+
+  return null;
+}
+
+function getTypeArgumentIfTupleNode(
+  node: TSESTree.TypeNode,
+): TSESTree.TypeNode[] | null {
+  if (
+    // Check for [...]
+    node.type === AST_NODE_TYPES.TSTupleType &&
+    node.elementTypes.length > 0
+  ) {
+    return node.elementTypes;
+  }
+
+  return null;
+}

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -26,7 +26,7 @@ export default createRule({
     const services = getParserServices(context);
     const checker = services.program.getTypeChecker();
 
-    function getRelevantReturnTypes(
+    function getRelevantReturnTypesOrReport(
       node: TSESTree.TypeNode,
       returnTypes: ts.Type[],
     ): ts.Type[] | null {
@@ -56,7 +56,10 @@ export default createRule({
       typeArguments: TSESTree.TypeNode[],
       returnTypes: ts.Type[],
     ): void {
-      const relevantReturnTypes = getRelevantReturnTypes(node, returnTypes);
+      const relevantReturnTypes = getRelevantReturnTypesOrReport(
+        node,
+        returnTypes,
+      );
 
       if (relevantReturnTypes) {
         for (const [index, typeParameter] of typeArguments.entries()) {
@@ -158,7 +161,7 @@ export default createRule({
       return;
     }
 
-    function getPotentialReturnTypes(
+    function getActualReturnTypes(
       node:
         | TSESTree.ArrowFunctionExpression
         | TSESTree.FunctionDeclaration
@@ -202,7 +205,7 @@ export default createRule({
           return;
         }
 
-        const actualReturnTypes = getPotentialReturnTypes(node);
+        const actualReturnTypes = getActualReturnTypes(node);
 
         if (actualReturnTypes.length === 0) {
           // this is a type error unless the return type includes `void`,

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -64,8 +64,12 @@ export default createRule({
         if (relevantReturnTypes) {
           for (const [index, elementType] of tupleElementTypes.entries()) {
             const returnTypes = relevantReturnTypes
-              .map(type => checker.getTypeArguments(type as ts.TypeReference))
-              .map(typeArguments => typeArguments[index])
+              .map(type => {
+                if (tsutils.isTypeReference(type)) {
+                  return checker.getTypeArguments(type)[index];
+                }
+                return type;
+              })
               .flatMap(type => tsutils.unionTypeParts(type));
 
             checkReturnType(elementType, returnTypes);
@@ -98,7 +102,12 @@ export default createRule({
 
         if (relevantReturnTypes) {
           const returnTypes = relevantReturnTypes
-            .map(type => checker.getTypeArguments(type as ts.TypeReference)[0])
+            .map(type => {
+              if (tsutils.isTypeReference(type)) {
+                return checker.getTypeArguments(type)[0];
+              }
+              return type;
+            })
             .flatMap(type => tsutils.unionTypeParts(type));
 
           checkReturnType(arrayTypeArgument, returnTypes);

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -353,13 +353,14 @@ export default createRule({
       // type argument
       if (!returnTypeArgument) {
         context.report({
-          node: yieldTypeArgument,
+          node: yieldTypeArgument.parent,
           messageId: 'unusedReturnTypes',
           data: {
             type: checker.typeToString(
               services.getTypeAtLocation(yieldTypeArgument),
             ),
           },
+          fix: fixer => fixer.remove(yieldTypeArgument.parent),
         });
         return;
       }

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -68,38 +68,40 @@ export default createRule({
         returnTypes,
       );
 
-      if (relevantReturnTypes) {
-        for (const [index, typeParameter] of typeArguments.entries()) {
-          const returnTypes: ts.Type[] = [];
+      if (!relevantReturnTypes) {
+        return;
+      }
 
-          for (const type of relevantReturnTypes) {
-            if (tsutils.isTypeReference(type) && type.typeArguments) {
-              const returnTypePart = type.typeArguments[index];
+      for (const [index, typeParameter] of typeArguments.entries()) {
+        const returnTypes: ts.Type[] = [];
 
-              // if these don't match, this type reference or return value
-              // may be unconventional
-              if (
-                !checker.isTypeAssignableTo(
-                  returnTypePart,
-                  services.getTypeAtLocation(typeParameter),
-                )
-              ) {
-                return;
-              }
+        for (const returnType of relevantReturnTypes) {
+          if (tsutils.isTypeReference(returnType) && returnType.typeArguments) {
+            const returnTypePart = returnType.typeArguments[index];
 
-              returnTypes.push(
-                ...tsutils.unionTypeParts(type.typeArguments[index]),
-              );
-              continue;
+            // if these don't match, this type reference or return value
+            // may be unconventional
+            if (
+              !checker.isTypeAssignableTo(
+                returnTypePart,
+                services.getTypeAtLocation(typeParameter),
+              )
+            ) {
+              return;
             }
 
-            // don't try to unbox this return type if it isn't an `any` or a
-            // boxed value itself
-            return;
+            returnTypes.push(
+              ...tsutils.unionTypeParts(returnType.typeArguments[index]),
+            );
+            continue;
           }
 
-          checkReturnType(typeParameter, returnTypes);
+          // don't try to unbox this return type if it isn't an `any` or a
+          // boxed value itself
+          return;
         }
+
+        checkReturnType(typeParameter, returnTypes);
       }
     }
 

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -64,9 +64,9 @@ export default createRule({
         if (relevantReturnTypes) {
           for (const [index, elementType] of tupleElementTypes.entries()) {
             const returnTypes = relevantReturnTypes
-              .map(x => checker.getTypeArguments(x as ts.TupleTypeReference))
-              .map(x => x[index])
-              .flatMap(x => tsutils.unionTypeParts(x));
+              .map(type => checker.getTypeArguments(type as ts.TypeReference))
+              .map(typeArguments => typeArguments[index])
+              .flatMap(type => tsutils.unionTypeParts(type));
 
             checkReturnType(elementType, returnTypes);
           }
@@ -82,9 +82,9 @@ export default createRule({
 
         if (relevantReturnTypes) {
           const returnTypes = relevantReturnTypes
-            .map(x => checker.getAwaitedType(x))
-            .filter(x => x != null)
-            .flatMap(x => tsutils.unionTypeParts(x));
+            .map(type => checker.getAwaitedType(type))
+            .filter(type => type != null)
+            .flatMap(type => tsutils.unionTypeParts(type));
 
           checkReturnType(promiseTypeArgument, returnTypes);
         }
@@ -98,8 +98,8 @@ export default createRule({
 
         if (relevantReturnTypes) {
           const returnTypes = relevantReturnTypes
-            .map(x => checker.getTypeArguments(x as ts.TupleTypeReference)[0])
-            .flatMap(x => tsutils.unionTypeParts(x));
+            .map(type => checker.getTypeArguments(type as ts.TypeReference)[0])
+            .flatMap(type => tsutils.unionTypeParts(type));
 
           checkReturnType(arrayTypeArgument, returnTypes);
         }
@@ -209,9 +209,9 @@ export default createRule({
           }
 
           const promiseReturnTypes = actualReturnTypes
-            .map(x => checker.getAwaitedType(x))
-            .filter(x => x != null)
-            .flatMap(x => tsutils.unionTypeParts(x));
+            .map(type => checker.getAwaitedType(type))
+            .filter(type => type != null)
+            .flatMap(type => tsutils.unionTypeParts(type));
 
           checkReturnType(
             promiseTypeArgument,

--- a/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-return-types.ts
@@ -370,6 +370,7 @@ export default createRule({
         context.report({
           node: yieldTypeArgument,
           messageId: 'unusedGeneratorYieldTypes',
+          fix: fixer => fixer.replaceText(yieldTypeArgument, 'unknown'),
         });
         return;
       }

--- a/packages/eslint-plugin/src/util/astUtils.ts
+++ b/packages/eslint-plugin/src/util/astUtils.ts
@@ -82,6 +82,9 @@ export function forEachReturnStatement<T>(
 
 /**
  * An adaptation of `forEachReturnStatement` for traversing `yield` expressions
+ *
+ * Warning: This has the same semantics as the forEach family of functions,
+ * in that traversal terminates in the event that 'visitor' supplies a truthy value.
  */
 export function forEachYieldExpression<T>(
   body: ts.Block,
@@ -90,10 +93,31 @@ export function forEachYieldExpression<T>(
   return traverse(body);
 
   function traverse(node: ts.Node): T | undefined {
-    if (node.kind === ts.SyntaxKind.YieldExpression) {
-      return visitor(node as ts.YieldExpression);
+    switch (node.kind) {
+      case ts.SyntaxKind.YieldExpression:
+        return visitor(node as ts.YieldExpression);
+      case ts.SyntaxKind.CaseBlock:
+      case ts.SyntaxKind.Block:
+      case ts.SyntaxKind.ExpressionStatement:
+      case ts.SyntaxKind.WhileKeyword:
+      case ts.SyntaxKind.VariableDeclaration:
+      case ts.SyntaxKind.ThrowStatement:
+      case ts.SyntaxKind.IfStatement:
+      case ts.SyntaxKind.DoStatement:
+      case ts.SyntaxKind.WhileStatement:
+      case ts.SyntaxKind.ForStatement:
+      case ts.SyntaxKind.ForInStatement:
+      case ts.SyntaxKind.ForOfStatement:
+      case ts.SyntaxKind.WithStatement:
+      case ts.SyntaxKind.SwitchStatement:
+      case ts.SyntaxKind.CaseClause:
+      case ts.SyntaxKind.DefaultClause:
+      case ts.SyntaxKind.LabeledStatement:
+      case ts.SyntaxKind.TryStatement:
+      case ts.SyntaxKind.CatchClause:
+        return ts.forEachChild(node, traverse);
     }
 
-    return ts.forEachChild(node, traverse);
+    return undefined;
   }
 }

--- a/packages/eslint-plugin/src/util/astUtils.ts
+++ b/packages/eslint-plugin/src/util/astUtils.ts
@@ -90,32 +90,10 @@ export function forEachYieldExpression<T>(
   return traverse(body);
 
   function traverse(node: ts.Node): T | undefined {
-    switch (node.kind) {
-      case ts.SyntaxKind.YieldExpression:
-        return visitor(node as ts.YieldExpression);
-      case ts.SyntaxKind.CaseBlock:
-      case ts.SyntaxKind.ReturnStatement:
-      case ts.SyntaxKind.ExpressionStatement:
-      case ts.SyntaxKind.VariableStatement:
-      case ts.SyntaxKind.Block:
-      case ts.SyntaxKind.IfStatement:
-      case ts.SyntaxKind.DoStatement:
-      case ts.SyntaxKind.WhileStatement:
-      case ts.SyntaxKind.ForStatement:
-      case ts.SyntaxKind.ForInStatement:
-      case ts.SyntaxKind.ForOfStatement:
-      case ts.SyntaxKind.WithStatement:
-      case ts.SyntaxKind.SwitchStatement:
-      case ts.SyntaxKind.VariableDeclarationList:
-      case ts.SyntaxKind.VariableDeclaration:
-      case ts.SyntaxKind.CaseClause:
-      case ts.SyntaxKind.DefaultClause:
-      case ts.SyntaxKind.LabeledStatement:
-      case ts.SyntaxKind.TryStatement:
-      case ts.SyntaxKind.CatchClause:
-        return ts.forEachChild(node, traverse);
+    if (node.kind === ts.SyntaxKind.YieldExpression) {
+      return visitor(node as ts.YieldExpression);
     }
 
-    return undefined;
+    return ts.forEachChild(node, traverse);
   }
 }

--- a/packages/eslint-plugin/src/util/astUtils.ts
+++ b/packages/eslint-plugin/src/util/astUtils.ts
@@ -79,3 +79,43 @@ export function forEachReturnStatement<T>(
     return undefined;
   }
 }
+
+/**
+ * An adaptation of `forEachReturnStatement` for traversing `yield` expressions
+ */
+export function forEachYieldExpression<T>(
+  body: ts.Block,
+  visitor: (stmt: ts.YieldExpression) => T,
+): T | undefined {
+  return traverse(body);
+
+  function traverse(node: ts.Node): T | undefined {
+    switch (node.kind) {
+      case ts.SyntaxKind.YieldExpression:
+        return visitor(node as ts.YieldExpression);
+      case ts.SyntaxKind.CaseBlock:
+      case ts.SyntaxKind.ReturnStatement:
+      case ts.SyntaxKind.ExpressionStatement:
+      case ts.SyntaxKind.VariableStatement:
+      case ts.SyntaxKind.Block:
+      case ts.SyntaxKind.IfStatement:
+      case ts.SyntaxKind.DoStatement:
+      case ts.SyntaxKind.WhileStatement:
+      case ts.SyntaxKind.ForStatement:
+      case ts.SyntaxKind.ForInStatement:
+      case ts.SyntaxKind.ForOfStatement:
+      case ts.SyntaxKind.WithStatement:
+      case ts.SyntaxKind.SwitchStatement:
+      case ts.SyntaxKind.VariableDeclarationList:
+      case ts.SyntaxKind.VariableDeclaration:
+      case ts.SyntaxKind.CaseClause:
+      case ts.SyntaxKind.DefaultClause:
+      case ts.SyntaxKind.LabeledStatement:
+      case ts.SyntaxKind.TryStatement:
+      case ts.SyntaxKind.CatchClause:
+        return ts.forEachChild(node, traverse);
+    }
+
+    return undefined;
+  }
+}

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-extraneous-return-types.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-extraneous-return-types.shot
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Validating rule docs no-extraneous-return-types.mdx code examples ESLint output 1`] = `
+"Incorrect
+
+function test1(): string | null {
+                           ~~~~ Unused or redundant union type 'null' in return type.
+  return 'string';
+}
+
+function test2(): Promise<string | null> {
+                                   ~~~~ Unused or redundant union type 'null' in return type.
+  return Promise.resolve('string');
+}
+
+class A {
+  test(): string | null {
+                   ~~~~ Unused or redundant union type 'null' in return type.
+    return 'string';
+  }
+}
+"
+`;
+
+exports[`Validating rule docs no-extraneous-return-types.mdx code examples ESLint output 2`] = `
+"Correct
+
+function test1(): string {
+  return 'string';
+}
+
+function test2(): Promise<string> {
+  return Promise.resolve('string');
+}
+
+class A {
+  test(): string {
+    return 'string';
+  }
+}
+"
+`;

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -1,0 +1,1432 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import rule from '../../src/rules/no-extraneous-return-types';
+import { getFixturesRootDir } from '../RuleTester';
+
+const rootDir = getFixturesRootDir();
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      project: './tsconfig.json',
+      tsconfigRootDir: rootDir,
+    },
+  },
+});
+
+ruleTester.run('no-extraneous-return-types', rule, {
+  valid: [
+    'function test() {}',
+    'async function test() {}',
+    'function test(): void {}',
+    'function test(): undefined {}',
+    'function test(): any {}',
+    `
+function test(): string {
+  return 'one';
+}
+    `,
+    `
+const test = (): string => {
+  return 'one';
+};
+    `,
+    `
+const test = (): string => 'one';
+    `,
+    `
+class A {
+  test(): string {
+    return 'string';
+  }
+}
+    `,
+    `
+function test(): string {
+  return 'one' as string;
+}
+    `,
+    `
+function test(a: boolean): string | undefined {
+  if (a) {
+    return;
+  }
+
+  return 'one';
+}
+    `,
+    `
+function test(): string | number {
+  return 'one' as string | number;
+}
+    `,
+    `
+function test(a: boolean): string | number {
+  if (a) {
+    return 'one';
+  }
+
+  return 1;
+}
+    `,
+    `
+function test(a: boolean): string | number {
+  if (a) {
+    return 'one' as 'one' | 'two';
+  }
+
+  return 1;
+}
+    `,
+    `
+type R = string | number;
+
+function test(a: boolean): R {
+  return 1;
+}
+    `,
+    `
+function test(): string[] {
+  return ['one'];
+}
+    `,
+    `
+function test(): string[] {
+  return ['one' as string];
+}
+    `,
+    `
+function test(): (string | number)[] {
+  return [];
+}
+    `,
+    `
+function test(): (string | number)[] {
+  return ['one' as string | number];
+}
+    `,
+    `
+function test(a: boolean): (string | number)[] {
+  if (a) {
+    return ['one'];
+  }
+
+  return [1];
+}
+    `,
+    `
+function test(a: boolean): (string | number)[] {
+  return ['one', 1];
+}
+    `,
+    `
+function test(a: boolean): (string | number)[] {
+  if (a) {
+    return ['one'] as ('one' | 'two')[];
+  }
+
+  return [1];
+}
+    `,
+    `
+type R = string | number;
+
+function test(a: boolean): R[] {
+  return [1];
+}
+    `,
+    `
+function test(): Array<string> {
+  return ['one'];
+}
+    `,
+    `
+function test(): Array {
+  return ['one'];
+}
+    `,
+
+    `
+function test(): [string] {
+  return ['one'];
+}
+    `,
+    `
+function test(): [string] {
+  return ['one' as string];
+}
+    `,
+    `
+function test(): [string | number] {
+  return ['one' as string | number];
+}
+    `,
+    `
+function test(a: boolean): [string | number] {
+  if (a) {
+    return ['one'];
+  }
+
+  return [1];
+}
+    `,
+    `
+function test(a: boolean): [string | number] {
+  if (a) {
+    return ['one' as 'one' | 'two'];
+  }
+
+  return [1];
+}
+    `,
+    `
+type R = string | number;
+
+function test(a: boolean): [R] {
+  return [1];
+}
+    `,
+    `
+type R = [string | number];
+
+function test(a: boolean): R {
+  return [1];
+}
+    `,
+
+    `
+function test(): [string, number] {
+  return ['one', 1];
+}
+    `,
+    `
+function test(): [string, number] {
+  return ['one' as string, 1 as number];
+}
+    `,
+    `
+function test(): [string | number, number] {
+  return ['one' as string | number, 1];
+}
+    `,
+    `
+function test(a: boolean): [string | number, number] {
+  if (a) {
+    return ['one', 2];
+  }
+
+  return [1, 3];
+}
+    `,
+    `
+function test(a: boolean): [string | number, number] {
+  if (a) {
+    return ['one' as 'one' | 'two', 2];
+  }
+
+  return [1, 2];
+}
+    `,
+    `
+type R = string | number;
+
+function test(a: boolean): [R, number] {
+  return [1, 2];
+}
+    `,
+    `
+type R = [string | number, number];
+
+function test(a: boolean): R {
+  return [1, 2];
+}
+    `,
+    `
+function test(): Promise<string> {
+  return Promise.resolve('one');
+}
+    `,
+    `
+function test(): Promise<string> {
+  return Promise.resolve('one') as Promise<string>;
+}
+    `,
+    `
+function test(): Promise<string | number> {
+  return Promise.resolve('one') as Promise<string | number>;
+}
+    `,
+    `
+function test(a: boolean): Promise<string | number> {
+  if (a) {
+    return Promise.resolve('one');
+  }
+
+  return Promise.resolve(1);
+}
+    `,
+    `
+function test(a: boolean): Promise<string | number> {
+  if (a) {
+    return Promise.resolve('one') as Promise<'one' | 'two'>;
+  }
+
+  return Promise.resolve(1);
+}
+    `,
+    `
+type R = string | number;
+
+function test(a: boolean): Promise<R> {
+  return Promise.resolve(1);
+}
+    `,
+    `
+type R = Promise<string | number>;
+
+function test(a: boolean): R {
+  return Promise.resolve(1);
+}
+    `,
+
+    `
+async function test(): Promise<string> {
+  return Promise.resolve('one');
+}
+    `,
+    `
+async function test(): Promise<string> {
+  return 'one';
+}
+    `,
+    `
+async function test(): Promise<string> {
+  return Promise.resolve('one') as Promise<string>;
+}
+    `,
+    `
+async function test(): Promise<string> {
+  return 'one' as string;
+}
+    `,
+    `
+async function test(): Promise<string | number> {
+  return Promise.resolve('one') as Promise<string | number>;
+}
+    `,
+    `
+async function test(): Promise<string | number> {
+  return 'one' as string | number;
+}
+    `,
+    `
+async function test(a: boolean): Promise<string | number> {
+  if (a) {
+    return Promise.resolve('one');
+  }
+
+  return Promise.resolve(1);
+}
+    `,
+    `
+async function test(a: boolean): Promise<string | number> {
+  if (a) {
+    return 'one';
+  }
+
+  return Promise.resolve(1);
+}
+    `,
+    `
+async function test(a: boolean): Promise<string | number> {
+  if (a) {
+    return Promise.resolve('one') as Promise<'one' | 'two'>;
+  }
+
+  return Promise.resolve(1);
+}
+    `,
+    `
+async function test(a: boolean): Promise<string | number> {
+  if (a) {
+    return 'one' as 'one' | 'two';
+  }
+
+  return 1;
+}
+    `,
+    `
+type R = string | number;
+
+async function test(a: boolean): Promise<R> {
+  return Promise.resolve(1);
+}
+    `,
+    `
+type R = string | number;
+
+async function test(a: boolean): Promise<R> {
+  return 1;
+}
+    `,
+    `
+type R = Promise<string | number>;
+
+async function test(a: boolean): R {
+  return Promise.resolve(1);
+}
+    `,
+    `
+type R = Promise<string | number>;
+
+async function test(a: boolean): R {
+  return 1;
+}
+    `,
+    'async function test(): Promise<void> {}',
+    'async function test(): Promise<undefined> {}',
+    'async function test(): Promise<any> {}',
+    `
+async function test(a: boolean): Promise<string | undefined> {
+  if (a) {
+    return;
+  }
+
+  return 'one';
+}
+    `,
+    `
+function test(): Promise {
+  return 'one';
+}
+    `,
+  ],
+
+  invalid: [
+    {
+      code: `
+function test(): string | number {
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+const test = (): string | number => {
+  return 'one';
+};
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+const test = (): string | number => 'one';
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+class A {
+  test(): string | number {
+    return 1;
+  }
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'string',
+          },
+          line: 3,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): string | number | boolean {
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): string | number | undefined {
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): string | number | void {
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): string | number | any {
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(a: boolean): string | number | null {
+  if (a) {
+    return 1;
+  }
+
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'null',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): string | number | boolean {
+  return 1 as string | number;
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(b: boolean): string | number | boolean | null {
+  if (b) {
+    return null;
+  }
+
+  return 1 as string | number;
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+type R = number | string;
+
+function test(): R | boolean {
+  return 1;
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 4,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+type R = number | string;
+
+function test(): R | string {
+  return 1;
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'string',
+          },
+          line: 4,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+
+    {
+      code: `
+function test(): (string | number)[] {
+  return ['one'];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): string[] | number {
+  return ['one'];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): string[] | number {
+  return 1;
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'string[]',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): (string | number | boolean)[] | string {
+  return [];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'string',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): (string | number | boolean)[] {
+  return ['one'];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(a: boolean): (string | number | null)[] {
+  if (a) {
+    return [1];
+  }
+
+  return ['one'];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'null',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): (string | number | boolean)[] {
+  return [1 as string | number];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(b: boolean): (string | number | boolean | null)[] {
+  if (b) {
+    return [null];
+  }
+
+  return [1 as string | number];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+type R = number | string;
+
+function test(): (R | boolean)[] {
+  return [1];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 4,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+type R = (number | string)[];
+
+function test(): R | boolean {
+  return [1];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 4,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+
+    {
+      code: `
+function test(): [string | number] {
+  return ['one'];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [string | number | boolean] {
+  return ['one'];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(a: boolean): [string | number | null] {
+  if (a) {
+    return [1];
+  }
+
+  return ['one'];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'null',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [string | number | boolean] {
+  return [1 as string | number];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(b: boolean): [string | number | boolean | null] {
+  if (b) {
+    return [null];
+  }
+
+  return [1 as string | number];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+type R = [number | string];
+
+function test(): R | boolean {
+  return [1];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 4,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+type R = number | string;
+
+function test(): [R | string] {
+  return [1];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'string',
+          },
+          line: 4,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [string | number, boolean] {
+  return ['one', true];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [string | number | boolean, boolean] {
+  return ['one', true];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(a: boolean): [string | number | null, boolean] {
+  if (a) {
+    return [1, false];
+  }
+
+  return ['one', true];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'null',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [string | number | boolean, boolean] {
+  return [1 as string | number, false];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(b: boolean): [string | number | boolean | null, boolean] {
+  if (b) {
+    return [null, true];
+  }
+
+  return [1 as string | number, false];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+type R = [number | string, boolean];
+
+function test(): R | boolean {
+  return [1, true];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 4,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+type R = number | string;
+
+function test(): [R | string, boolean] {
+  return [1, false];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'string',
+          },
+          line: 4,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+
+    {
+      code: `
+function test(): Promise<string | number> {
+  return Promise.resolve('one');
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): Promise<string | number | boolean> {
+  return Promise.resolve('one');
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(a: boolean): Promise<string | number | null> {
+  if (a) {
+    return Promise.resolve(1);
+  }
+
+  return Promise.resolve('one');
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'null',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): Promise<string | number | boolean> {
+  return Promise.resolve(1 as string | number);
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(b: boolean): Promise<string | number | boolean | null> {
+  if (b) {
+    return Promise.resolve(null);
+  }
+
+  return Promise.resolve(1 as string | number);
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+type R = Promise<number | string>;
+
+function test(): R | boolean {
+  return Promise.resolve(1);
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 4,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+
+    {
+      code: `
+async function test(): Promise<string | number> {
+  return Promise.resolve('one');
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+async function test(): Promise<string | number | boolean> {
+  return Promise.resolve('one');
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+async function test(a: boolean): Promise<string | number | null> {
+  if (a) {
+    return Promise.resolve(1);
+  }
+
+  return Promise.resolve('one');
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'null',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+async function test(): Promise<string | number | boolean> {
+  return Promise.resolve(1 as string | number);
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+async function test(b: boolean): Promise<string | number | boolean | null> {
+  if (b) {
+    return Promise.resolve(null);
+  }
+
+  return Promise.resolve(1 as string | number);
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+
+    {
+      code: `
+async function test(): Promise<string | number> {
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+async function test(): Promise<string | number | boolean> {
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+async function test(a: boolean): Promise<string | number | null> {
+  if (a) {
+    return 1;
+  }
+
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'null',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+async function test(): Promise<string | number | boolean> {
+  return 1 as string | number;
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+async function test(b: boolean): Promise<string | number | boolean | null> {
+  if (b) {
+    return null;
+  }
+
+  return 1 as string | number;
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+
+    {
+      code: `
+function test(): string | Promise<number> {
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'Promise<number>',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): string[] | Promise<number> {
+  return [];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'Promise<number>',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [Promise<boolean | number>][] {
+  return [[Promise.resolve(1)]];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -2589,6 +2589,11 @@ function* test(): Generator<number, string | boolean> {
           messageId: 'unusedGeneratorYieldTypes',
         },
       ],
+      output: `
+function* test(): Generator<unknown, string | boolean> {
+  return 'one' as 'one' | true;
+}
+      `,
     },
     {
       code: `
@@ -2779,6 +2784,11 @@ async function* test(): AsyncGenerator<number, string | boolean> {
           messageId: 'unusedGeneratorYieldTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator<unknown, string | boolean> {
+  return 'one' as 'one' | true;
+}
+      `,
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -21,6 +21,17 @@ ruleTester.run('no-extraneous-return-types', rule, {
     'function test(): void {}',
     'function test(): undefined {}',
     'function test(): any {}',
+    'function test(): unknown {}',
+    `
+function test(): unknown {
+  return 10;
+}
+    `,
+    `
+function test(): unknown {
+  return Promise.resolve(10);
+}
+    `,
     `
 function test(): string {
   return 'one';
@@ -107,6 +118,16 @@ type R = string | number;
 
 function test(a: boolean): R {
   return 1;
+}
+    `,
+    `
+function test<T>(): T | number {
+  return 10;
+}
+    `,
+    `
+function test<T extends string | number | boolean>(): T | number {
+  return 10;
 }
     `,
     `
@@ -501,6 +522,38 @@ class A {
             type: 'string',
           },
           line: 3,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test<T extends string>(): T | number {
+  return '';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test<T extends string | number | boolean>(): T | number {
+  return '';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
           messageId: 'unusedReturnTypes',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -27,6 +27,20 @@ function test(): string {
 }
     `,
     `
+function test(a: boolean): string | undefined {
+  if (a) {
+    return 'one';
+  }
+}
+    `,
+    `
+function test(a: boolean): string | void {
+  if (a) {
+    return 'one';
+  }
+}
+    `,
+    `
 const test = (): string => {
   return 'one';
 };
@@ -297,6 +311,20 @@ async function test(): Promise<string> {
     `
 async function test(): Promise<string> {
   return 'one';
+}
+    `,
+    `
+async function test(a: boolean): Promise<string | undefined> {
+  if (a) {
+    return 'one';
+  }
+}
+    `,
+    `
+async function test(a: boolean): Promise<string | void> {
+  if (a) {
+    return 'one';
+  }
 }
     `,
     `

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -28,6 +28,11 @@ function test(): unknown {
 }
     `,
     `
+function test(): number {
+  return 1 as any;
+}
+    `,
+    `
 function test(): unknown {
   return Promise.resolve(10);
 }
@@ -190,6 +195,16 @@ function test(): Array {
   return ['one'];
 }
     `,
+    `
+function test(): string[] {
+  return 1 as any;
+}
+    `,
+    `
+function test(): string[] {
+  return [1 as any];
+}
+    `,
 
     `
 function test(): [string] {
@@ -286,6 +301,17 @@ function test(a: boolean): R {
   return [1, 2];
 }
     `,
+    `
+function test(): [string, number] {
+  return ['one', 1 as any];
+}
+    `,
+    `
+function test(): [string, number] {
+  return 10 as any;
+}
+    `,
+
     `
 function test(): Promise<string> {
   return Promise.resolve('one');
@@ -457,6 +483,16 @@ async function test(a: boolean): Promise<string | undefined> {
     `
 function test(): Promise {
   return 'one';
+}
+    `,
+    `
+function test(): Promise<string> {
+  return 1 as any;
+}
+    `,
+    `
+function test(): Promise<string> {
+  return Promise.resolve(1 as any);
 }
     `,
   ],

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -495,6 +495,11 @@ function test(): Promise<string> {
   return Promise.resolve(1 as any);
 }
     `,
+    `
+function* test(): string | number {
+  return 1;
+}
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -946,6 +946,21 @@ async function* test(
   return 'one';
 }
     `,
+    // nested boxes
+    `
+function test(): Array<Promise<number | string>> {
+  return [Promise.resolve(1), Promise.resolve('one')];
+}
+    `,
+    `
+function test(a: boolean): Map<string | number, boolean | string> {
+  if (a) {
+    return new Map<string, boolean>();
+  }
+
+  return new Map<number, string>();
+}
+    `,
   ],
 
   invalid: [
@@ -2375,6 +2390,46 @@ async function* test(): AsyncGenerator<number | null, string | boolean> {
         {
           data: {
             type: 'boolean',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    // nested boxes
+    {
+      code: `
+async function test(): Promise<Array<string | number>> {
+  return Promise.resolve([1]);
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'string',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [[string | number], [number | boolean]] {
+  return [[1], [true]];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'string',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+        {
+          data: {
+            type: 'number',
           },
           line: 2,
           messageId: 'unusedReturnTypes',

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -1020,6 +1020,11 @@ function test(): string | number {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): string  {
+  return 'one';
+}
+      `,
     },
     {
       code: `
@@ -1036,6 +1041,11 @@ function test(): string | number | boolean {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): string | number  {
+  return 1 as string | number;
+}
+      `,
     },
     {
       code: `
@@ -1056,6 +1066,15 @@ function test(b: boolean): string | number | boolean | null {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(b: boolean): string | number  | null {
+  if (b) {
+    return null;
+  }
+
+  return 1 as string | number;
+}
+      `,
     },
 
     // various different ways to define a function
@@ -1074,6 +1093,11 @@ const test = (): string | number => {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+const test = (): string  => {
+  return 'one';
+};
+      `,
     },
     {
       code: `
@@ -1088,6 +1112,9 @@ const test = (): string | number => 'one';
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+const test = (): string  => 'one';
+      `,
     },
     {
       code: `
@@ -1106,6 +1133,13 @@ class A {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+class A {
+  test():  number {
+    return 1;
+  }
+}
+      `,
     },
 
     // unused type constraints
@@ -1124,6 +1158,11 @@ function test<T extends string>(): T | number {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test<T extends string>(): T  {
+  return '';
+}
+      `,
     },
     {
       code: `
@@ -1140,6 +1179,11 @@ function test<T extends string | number | boolean>(): T | number {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test<T extends string | number | boolean>(): T  {
+  return '';
+}
+      `,
     },
     {
       code: `
@@ -1163,6 +1207,11 @@ function test(): string | number | boolean {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): string   {
+  return 'one';
+}
+      `,
     },
 
     // potentially returning void or undefined
@@ -1181,6 +1230,11 @@ function test(): string | number | undefined {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): string  | undefined {
+  return 'one';
+}
+      `,
     },
     {
       code: `
@@ -1197,6 +1251,11 @@ function test(): string | number | void {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): string  | void {
+  return 'one';
+}
+      `,
     },
 
     // any in return type annotation
@@ -1215,6 +1274,11 @@ function test(): string | number | any {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): string  | any {
+  return 'one';
+}
+      `,
     },
 
     // referenced return types
@@ -1235,6 +1299,13 @@ function test(): R | boolean {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+type R = number | string;
+
+function test(): R  {
+  return 1;
+}
+      `,
     },
     {
       code: `
@@ -1253,6 +1324,13 @@ function test(): R | string {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+type R = number | string;
+
+function test(): R  {
+  return 1;
+}
+      `,
     },
 
     // arrays
@@ -1271,6 +1349,11 @@ function test(): (string | number)[] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): (string )[] {
+  return ['one'];
+}
+      `,
     },
     {
       code: `
@@ -1287,6 +1370,11 @@ function test(): string[] | number {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): string[]  {
+  return ['one'];
+}
+      `,
     },
     {
       code: `
@@ -1303,6 +1391,11 @@ function test(): string[] | number {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test():  number {
+  return 1;
+}
+      `,
     },
     {
       code: `
@@ -1319,6 +1412,11 @@ function test(): (string | number | boolean)[] | string {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): (string | number | boolean)[]  {
+  return [];
+}
+      `,
     },
     {
       code: `
@@ -1342,6 +1440,11 @@ function test(): (string | number | boolean)[] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): (string  )[] {
+  return ['one'];
+}
+      `,
     },
     {
       code: `
@@ -1362,6 +1465,15 @@ function test(a: boolean): (string | number | null)[] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(a: boolean): (string | number )[] {
+  if (a) {
+    return [1];
+  }
+
+  return ['one'];
+}
+      `,
     },
     {
       code: `
@@ -1378,6 +1490,11 @@ function test(): (string | number | boolean)[] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): (string | number )[] {
+  return [1 as string | number];
+}
+      `,
     },
     {
       code: `
@@ -1398,6 +1515,15 @@ function test(b: boolean): (string | number | boolean | null)[] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(b: boolean): (string | number  | null)[] {
+  if (b) {
+    return [null];
+  }
+
+  return [1 as string | number];
+}
+      `,
     },
     {
       code: `
@@ -1416,6 +1542,13 @@ function test(): (R | boolean)[] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+type R = number | string;
+
+function test(): (R )[] {
+  return [1];
+}
+      `,
     },
     {
       code: `
@@ -1434,6 +1567,13 @@ function test(): R | boolean {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+type R = (number | string)[];
+
+function test(): R  {
+  return [1];
+}
+      `,
     },
     {
       code: `
@@ -1450,6 +1590,11 @@ function test(): (string | undefined)[] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): (string )[] {
+  return ['one'];
+}
+      `,
     },
 
     // tuples
@@ -1468,6 +1613,11 @@ function test(): [string | number] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): [string ] {
+  return ['one'];
+}
+      `,
     },
     {
       code: `
@@ -1491,6 +1641,11 @@ function test(): [string | number | boolean] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): [string  ] {
+  return ['one'];
+}
+      `,
     },
     {
       code: `
@@ -1511,6 +1666,15 @@ function test(a: boolean): [string | number | null] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(a: boolean): [string | number ] {
+  if (a) {
+    return [1];
+  }
+
+  return ['one'];
+}
+      `,
     },
     {
       code: `
@@ -1527,6 +1691,11 @@ function test(): [string | number | boolean] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): [string | number ] {
+  return [1 as string | number];
+}
+      `,
     },
     {
       code: `
@@ -1547,6 +1716,15 @@ function test(b: boolean): [string | number | boolean | null] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(b: boolean): [string | number  | null] {
+  if (b) {
+    return [null];
+  }
+
+  return [1 as string | number];
+}
+      `,
     },
     {
       code: `
@@ -1565,6 +1743,13 @@ function test(): R | boolean {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+type R = [number | string];
+
+function test(): R  {
+  return [1];
+}
+      `,
     },
     {
       code: `
@@ -1583,6 +1768,13 @@ function test(): [R | string] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+type R = number | string;
+
+function test(): [R ] {
+  return [1];
+}
+      `,
     },
     {
       code: `
@@ -1599,6 +1791,11 @@ function test(): [string | number, boolean] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): [string , boolean] {
+  return ['one', true];
+}
+      `,
     },
     {
       code: `
@@ -1622,6 +1819,11 @@ function test(): [string | number | boolean, boolean] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): [string  , boolean] {
+  return ['one', true];
+}
+      `,
     },
     {
       code: `
@@ -1642,6 +1844,15 @@ function test(a: boolean): [string | number | null, boolean] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(a: boolean): [string | number , boolean] {
+  if (a) {
+    return [1, false];
+  }
+
+  return ['one', true];
+}
+      `,
     },
     {
       code: `
@@ -1658,6 +1869,11 @@ function test(): [string | number | boolean, boolean] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): [string | number , boolean] {
+  return [1 as string | number, false];
+}
+      `,
     },
     {
       code: `
@@ -1678,6 +1894,15 @@ function test(b: boolean): [string | number | boolean | null, boolean] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(b: boolean): [string | number  | null, boolean] {
+  if (b) {
+    return [null, true];
+  }
+
+  return [1 as string | number, false];
+}
+      `,
     },
     {
       code: `
@@ -1696,6 +1921,13 @@ function test(): R | boolean {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+type R = [number | string, boolean];
+
+function test(): R  {
+  return [1, true];
+}
+      `,
     },
     {
       code: `
@@ -1714,6 +1946,13 @@ function test(): [R | string, boolean] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+type R = number | string;
+
+function test(): [R , boolean] {
+  return [1, false];
+}
+      `,
     },
     {
       code: `
@@ -1730,6 +1969,11 @@ function test(): [string | undefined] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): [string ] {
+  return ['one'];
+}
+      `,
     },
 
     // promises
@@ -1748,6 +1992,11 @@ function test(): Promise<string | number> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): Promise<string > {
+  return Promise.resolve('one');
+}
+      `,
     },
     {
       code: `
@@ -1771,6 +2020,11 @@ function test(): Promise<string | number | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): Promise<string  > {
+  return Promise.resolve('one');
+}
+      `,
     },
     {
       code: `
@@ -1791,6 +2045,15 @@ function test(a: boolean): Promise<string | number | null> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(a: boolean): Promise<string | number > {
+  if (a) {
+    return Promise.resolve(1);
+  }
+
+  return Promise.resolve('one');
+}
+      `,
     },
     {
       code: `
@@ -1807,6 +2070,11 @@ function test(): Promise<string | number | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): Promise<string | number > {
+  return Promise.resolve(1 as string | number);
+}
+      `,
     },
     {
       code: `
@@ -1827,6 +2095,15 @@ function test(b: boolean): Promise<string | number | boolean | null> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(b: boolean): Promise<string | number  | null> {
+  if (b) {
+    return Promise.resolve(null);
+  }
+
+  return Promise.resolve(1 as string | number);
+}
+      `,
     },
     {
       code: `
@@ -1845,6 +2122,13 @@ function test(): R | boolean {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+type R = Promise<number | string>;
+
+function test(): R  {
+  return Promise.resolve(1);
+}
+      `,
     },
 
     // async functions
@@ -1863,6 +2147,11 @@ async function test(): Promise<string | number> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function test(): Promise<string > {
+  return Promise.resolve('one');
+}
+      `,
     },
     {
       code: `
@@ -1886,6 +2175,11 @@ async function test(): Promise<string | number | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function test(): Promise<string  > {
+  return Promise.resolve('one');
+}
+      `,
     },
     {
       code: `
@@ -1906,6 +2200,15 @@ async function test(a: boolean): Promise<string | number | null> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function test(a: boolean): Promise<string | number > {
+  if (a) {
+    return Promise.resolve(1);
+  }
+
+  return Promise.resolve('one');
+}
+      `,
     },
     {
       code: `
@@ -1922,6 +2225,11 @@ async function test(): Promise<string | number | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function test(): Promise<string | number > {
+  return Promise.resolve(1 as string | number);
+}
+      `,
     },
     {
       code: `
@@ -1942,8 +2250,16 @@ async function test(b: boolean): Promise<string | number | boolean | null> {
           messageId: 'unusedReturnTypes',
         },
       ],
-    },
+      output: `
+async function test(b: boolean): Promise<string | number  | null> {
+  if (b) {
+    return Promise.resolve(null);
+  }
 
+  return Promise.resolve(1 as string | number);
+}
+      `,
+    },
     {
       code: `
 async function test(): Promise<string | number> {
@@ -1959,6 +2275,11 @@ async function test(): Promise<string | number> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function test(): Promise<string > {
+  return 'one';
+}
+      `,
     },
     {
       code: `
@@ -1982,6 +2303,11 @@ async function test(): Promise<string | number | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function test(): Promise<string  > {
+  return 'one';
+}
+      `,
     },
     {
       code: `
@@ -2002,6 +2328,15 @@ async function test(a: boolean): Promise<string | number | null> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function test(a: boolean): Promise<string | number > {
+  if (a) {
+    return 1;
+  }
+
+  return 'one';
+}
+      `,
     },
     {
       code: `
@@ -2018,6 +2353,11 @@ async function test(): Promise<string | number | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function test(): Promise<string | number > {
+  return 1 as string | number;
+}
+      `,
     },
     {
       code: `
@@ -2038,8 +2378,16 @@ async function test(b: boolean): Promise<string | number | boolean | null> {
           messageId: 'unusedReturnTypes',
         },
       ],
-    },
+      output: `
+async function test(b: boolean): Promise<string | number  | null> {
+  if (b) {
+    return null;
+  }
 
+  return 1 as string | number;
+}
+      `,
+    },
     {
       code: `
 function test(): string | Promise<number> {
@@ -2055,6 +2403,11 @@ function test(): string | Promise<number> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): string  {
+  return 'one';
+}
+      `,
     },
     {
       code: `
@@ -2071,6 +2424,11 @@ function test(): string[] | Promise<number> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): string[]  {
+  return [];
+}
+      `,
     },
     {
       code: `
@@ -2087,6 +2445,11 @@ function test(): [Promise<boolean | number>][] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): [Promise< number>][] {
+  return [[Promise.resolve(1)]];
+}
+      `,
     },
 
     // generators
@@ -2133,6 +2496,11 @@ function* test(): Generator<string | number> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function* test(): Generator< number> {
+  yield 10;
+}
+      `,
     },
     {
       code: `
@@ -2150,6 +2518,12 @@ function* test(): Generator<string | number | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function* test(): Generator<string | number > {
+  yield 10;
+  yield 'one';
+}
+      `,
     },
     {
       code: `
@@ -2167,6 +2541,12 @@ function* test(): Generator<string | number, number> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function* test(): Generator< number, number> {
+  yield 10;
+  return 10;
+}
+      `,
     },
     {
       code: `
@@ -2184,6 +2564,12 @@ function* test(): Generator<string | number, string | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function* test(): Generator< number, string | boolean> {
+  yield 10;
+  return 'one' as 'one' | true;
+}
+      `,
     },
     {
       code: `
@@ -2213,6 +2599,11 @@ function* test(): Generator<unknown, string | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function* test(): Generator<unknown, string > {
+  return 'one';
+}
+      `,
     },
     {
       code: `
@@ -2237,6 +2628,12 @@ function* test(): Generator<number | null, string | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function* test(): Generator<number , string > {
+  yield 10;
+  return 'one';
+}
+      `,
     },
 
     // async generators
@@ -2283,6 +2680,11 @@ async function* test(): AsyncGenerator<string | number> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator< number> {
+  yield 10;
+}
+      `,
     },
     {
       code: `
@@ -2300,6 +2702,12 @@ async function* test(): AsyncGenerator<string | number | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator<string | number > {
+  yield 10;
+  yield 'one';
+}
+      `,
     },
     {
       code: `
@@ -2317,6 +2725,12 @@ async function* test(): AsyncGenerator<string | number, number> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator< number, number> {
+  yield 10;
+  return 10;
+}
+      `,
     },
     {
       code: `
@@ -2334,6 +2748,12 @@ async function* test(): AsyncGenerator<string | number, string | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator< number, string | boolean> {
+  yield 10;
+  return 'one' as 'one' | true;
+}
+      `,
     },
     {
       code: `
@@ -2363,6 +2783,11 @@ async function* test(): AsyncGenerator<unknown, string | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator<unknown, string > {
+  return 'one';
+}
+      `,
     },
     {
       code: `
@@ -2387,6 +2812,12 @@ async function* test(): AsyncGenerator<number | null, string | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator<number , string > {
+  yield 10;
+  return 'one';
+}
+      `,
     },
     {
       code: `
@@ -2411,6 +2842,12 @@ async function* test(): AsyncGenerator<number | null, string | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator<number , string > {
+  yield Promise.resolve(10);
+  return 'one';
+}
+      `,
     },
     {
       code: `
@@ -2435,6 +2872,12 @@ async function* test(): AsyncGenerator<number | null, string | boolean> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator<number , string > {
+  yield 10;
+  return Promise.resolve('one');
+}
+      `,
     },
     // nested boxes
     {
@@ -2452,6 +2895,11 @@ async function test(): Promise<Array<string | number>> {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function test(): Promise<Array< number>> {
+  return Promise.resolve([1]);
+}
+      `,
     },
     {
       code: `
@@ -2475,6 +2923,11 @@ function test(): [[string | number], [number | boolean]] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): [[ number], [ boolean]] {
+  return [[1], [true]];
+}
+      `,
     },
     {
       code: `
@@ -2491,6 +2944,11 @@ function test(): [[string | number], [number | boolean]] {
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function test(): [[string | number], [ boolean]] {
+  return [1 as any, [true]];
+}
+      `,
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -49,6 +49,16 @@ const test = (): string => {
 const test = (): string => 'one';
     `,
     `
+function test(a: boolean): number | string {
+  if (a) {
+    return test1(false);
+  }
+
+  return 10;
+}
+    `,
+
+    `
 class A {
   test(): string {
     return 'string';

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -2950,5 +2950,39 @@ function test(): [[string | number], [ boolean]] {
 }
       `,
     },
+
+    // type errors
+    {
+      code: `
+function test(): number {
+  return 'one';
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [number] {
+  return 10;
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: '[number]',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -838,6 +838,22 @@ function test(): R | boolean {
         },
       ],
     },
+    {
+      code: `
+function test(): (string | undefined)[] {
+  return ['one'];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'undefined',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
 
     {
       code: `
@@ -1097,6 +1113,38 @@ function test(): [R | string, boolean] {
             type: 'string',
           },
           line: 4,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [string | undefined] {
+  return ['one'];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'undefined',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [Promise<string | undefined>] {
+  return [Promise.resolve('one')];
+}
+      `,
+      errors: [
+        {
+          data: {
+            type: 'undefined',
+          },
+          line: 2,
           messageId: 'unusedReturnTypes',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -2466,6 +2466,9 @@ function* test(): Generator<number> {}
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function* test(): Generator {}
+      `,
     },
     {
       code: `
@@ -2480,6 +2483,9 @@ function* test(): Generator<string | number> {}
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+function* test(): Generator {}
+      `,
     },
     {
       code: `
@@ -2650,6 +2656,9 @@ async function* test(): AsyncGenerator<number> {}
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator {}
+      `,
     },
     {
       code: `
@@ -2664,6 +2673,9 @@ async function* test(): AsyncGenerator<string | number> {}
           messageId: 'unusedReturnTypes',
         },
       ],
+      output: `
+async function* test(): AsyncGenerator {}
+      `,
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-return-types.test.ts
@@ -961,8 +961,48 @@ function test(a: boolean): Map<string | number, boolean | string> {
   return new Map<number, string>();
 }
     `,
-  ],
+    `
+function test(): [[string | number], [number | boolean]] {
+  return 1 as any;
+}
+    `,
+    `
+function test(): [[string | number], [number | boolean]] {
+  return [1 as any, 2 as any];
+}
+    `,
+    // hard to tell boxed values
+    `
+class BoxClass<T> {
+  constructor(public readonly value: T) {}
+}
 
+function test(): BoxClass<number | string> {
+  return { value: 'abc' };
+}
+    `,
+    `
+interface BoxType<T> {
+  value: T;
+}
+
+function test(): BoxType<number | string> {
+  return { value: 'abc' };
+}
+    `,
+    `
+type NestedBox<T> = Array<Array<T>>;
+
+function test(): NestedBox<number | string> {
+  return [[10]];
+}
+    `,
+    `
+function test(): ReturnType<(() => number) | (() => string)> {
+  return 10;
+}
+    `,
+  ],
   invalid: [
     // simple unused return type annotations
     {
@@ -2427,6 +2467,22 @@ function test(): [[string | number], [number | boolean]] {
           line: 2,
           messageId: 'unusedReturnTypes',
         },
+        {
+          data: {
+            type: 'number',
+          },
+          line: 2,
+          messageId: 'unusedReturnTypes',
+        },
+      ],
+    },
+    {
+      code: `
+function test(): [[string | number], [number | boolean]] {
+  return [1 as any, [true]];
+}
+      `,
+      errors: [
         {
           data: {
             type: 'number',

--- a/packages/eslint-plugin/tests/schema-snapshots/no-extraneous-return-types.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-extraneous-return-types.shot
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Rule schemas should be convertible to TS types for documentation purposes no-extraneous-return-types 1`] = `
+"
+# SCHEMA:
+
+[]
+
+
+# TYPES:
+
+/** No options declared */
+type Options = [];"
+`;

--- a/packages/typescript-eslint/src/configs/all.ts
+++ b/packages/typescript-eslint/src/configs/all.ts
@@ -71,6 +71,7 @@ export default (
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-extra-non-null-assertion': 'error',
       '@typescript-eslint/no-extraneous-class': 'error',
+      '@typescript-eslint/no-extraneous-return-types': 'error',
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-for-in-array': 'error',
       'no-implied-eval': 'off',

--- a/packages/typescript-eslint/src/configs/disable-type-checked.ts
+++ b/packages/typescript-eslint/src/configs/disable-type-checked.ts
@@ -27,6 +27,7 @@ export default (
     '@typescript-eslint/no-confusing-void-expression': 'off',
     '@typescript-eslint/no-deprecated': 'off',
     '@typescript-eslint/no-duplicate-type-constituents': 'off',
+    '@typescript-eslint/no-extraneous-return-types': 'off',
     '@typescript-eslint/no-floating-promises': 'off',
     '@typescript-eslint/no-for-in-array': 'off',
     '@typescript-eslint/no-implied-eval': 'off',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6442
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR attempts to tackle #6442 and add a new rule to report on unused return type annotations:

```ts
function test (): string | null {
  return 'string'
}
```

Some of my thoughts:

- The implementation takes [the approach described here](https://github.com/typescript-eslint/typescript-eslint/issues/6442#issuecomment-2437185952), and the rule warns on inline union types but not on referenced ones. This is important since referenced union types may be harder to fix and maintain.

  Consider the following example:

   ```ts
  interface A {};
  interface B {};
  interface C {};
  interface D {};
 
  // used throughout the project
  export type Base = A | B | C | D;
 
  function getNode(): Base {
    // ...
  }
   ```

  The function may only be returning a couple of the possible types in the union type and not all of them. Returning a base type is convenient, and having the function to declare each type it may return is tedious, especially in cases with large union types (e.g. [`TSESTree.Node`](https://github.com/typescript-eslint/typescript-eslint/blob/0d0722c079cb8ad4f0b32b97063c9aa405d2a391/packages/ast-spec/src/unions/Node.ts#L175-L343)).

  Another example is using a type exposed by a third-party library that is usually used contextually, but if the function is extracted, it may have an explicit return type annotation ([vite plugins](https://github.com/vitejs/vite/blob/1bfe21b9440f318c940f90e425a18588595225fd/packages/vite/src/node/plugin.ts#L336) come to mind):

  ```ts
  export type VitePlugin = { kind: 'one' } | { kind: 'two' };

  function createVitePlugin(): VitePlugin {
    return {
      kind: 'one',
    };
  }
  ```

  In my opinion, asking functions to declare exactly the type they're returning can be tedious, especially if some of these types come from a third party and aren't exposed (an example that comes to mind is [`React.ReactNode`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/04c93eabdf4ccdf47ae2e4e45ec01c5069e7e190/types/react/index.d.ts#L426-L439)).

- The implementation includes special treatment for opening promises (also `async` functions), arrays, and tuples. Additional ones can be added (e.g. `Set`, `Map`, and potentially object-literal fields):

  ```ts
  // Unused or redundant union type 'null' in return type.
  function test(): Promise<string | null> {
    return Promise.resolve('hello');
  }
  ```

- The rule doesn't include a suggestion or an auto-fix. I think an auto-fix is correct here, but I'll be happy to hear some opinions.

- Sometimes, not all code paths return a value on a function. Because of this, the rule will not report `void` or `undefined`  being potentially unnecessary on the return type annotation:

  ```ts
  function test(a: boolean): number | undefined {
    if (a) {
      return 1;
    }
  }
  ```

- Running this on `typescript-eslint`'s code base shows what seems like 7 valid reports (some show wrong types, some highlight a problematic implementation): [1](https://github.com/typescript-eslint/typescript-eslint/blob/0d0722c079cb8ad4f0b32b97063c9aa405d2a391/packages/eslint-plugin/src/rules/consistent-return.ts#L57-L59), [2](https://github.com/typescript-eslint/typescript-eslint/blob/0d0722c079cb8ad4f0b32b97063c9aa405d2a391/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts#L247-L260), [3](https://github.com/typescript-eslint/typescript-eslint/blob/0d0722c079cb8ad4f0b32b97063c9aa405d2a391/packages/eslint-plugin/src/rules/no-array-delete.ts#L73-L104), [4](https://github.com/typescript-eslint/typescript-eslint/blob/0d0722c079cb8ad4f0b32b97063c9aa405d2a391/packages/eslint-plugin/src/rules/no-mixed-enums.ts#L129-L187), [5](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts/#L115-L123), [6](https://github.com/typescript-eslint/typescript-eslint/blob/0d0722c079cb8ad4f0b32b97063c9aa405d2a391/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts#L93-L98), [7](https://github.com/typescript-eslint/typescript-eslint/blob/0d0722c079cb8ad4f0b32b97063c9aa405d2a391/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts#L208-L215).

- I think it may be helpful to have the option to ignore module boundaries (e.g. exported functions or public methods of exported classes/objects). It's convenient to sometimes have unused return types, so calling code will need to handle potential future return types.

- When the rule reports a failure, it stringifies the name of the redundant type: `Unused or redundant union type '{{type}}' in return type.`. While this works well for flat unions (e.g. `string | number | boolean`), I'm not sure how clear this is when the rule fails on a nested box like a promise or an array: `Array<number | string | boolean>`. Wdyt? Should the message be different for box (and potentially nested box) values?

🚀 