### PR TITLE
fix(eslint-plugin): use consistent naming for asserting types and casting values

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.mdx
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.mdx
@@ -161,7 +161,7 @@ let funcExpr: FuncType = function () {
 };
 
 let asTyped = (() => '') as () => string;
-let castTyped = <() => string>(() => '');
+let assertTyped = <() => string>(() => '');
 
 interface ObjectType {
   foo(): number;
@@ -172,7 +172,7 @@ let objectProp: ObjectType = {
 let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-let objectPropCast = <ObjectType>{
+let objectPropAssertion = <ObjectType>{
   foo: () => 1,
 };
 

--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.mdx
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.mdx
@@ -161,7 +161,6 @@ let funcExpr: FuncType = function () {
 };
 
 let asTyped = (() => '') as () => string;
-let assertTyped = <() => string>(() => '');
 
 interface ObjectType {
   foo(): number;
@@ -172,9 +171,6 @@ let objectProp: ObjectType = {
 let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-let objectPropAssert = <ObjectType>{
-  foo: () => 1,
-};
 
 declare function functionWithArg(arg: () => number);
 functionWithArg(() => 1);

--- a/packages/eslint-plugin/docs/rules/explicit-function-return-type.mdx
+++ b/packages/eslint-plugin/docs/rules/explicit-function-return-type.mdx
@@ -172,7 +172,7 @@ let objectProp: ObjectType = {
 let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-let objectPropAssertion = <ObjectType>{
+let objectPropAssert = <ObjectType>{
   foo: () => 1,
 };
 

--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
@@ -253,7 +253,7 @@ export let objectProp: ObjectType = {
 export let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-export let objectPropAssertion = <ObjectType>{
+export let objectPropAssert = <ObjectType>{
   foo: () => 1,
 };
 

--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
@@ -242,7 +242,7 @@ export let funcExpr: FuncType = function () {
 };
 
 export let asTyped = (() => '') as () => string;
-export let castTyped = <() => string>(() => '');
+export let assertTyped = <() => string>(() => '');
 
 interface ObjectType {
   foo(): number;
@@ -253,7 +253,7 @@ export let objectProp: ObjectType = {
 export let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-export let objectPropCast = <ObjectType>{
+export let objectPropAssertion = <ObjectType>{
   foo: () => 1,
 };
 

--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
@@ -242,7 +242,6 @@ export let funcExpr: FuncType = function () {
 };
 
 export let asTyped = (() => '') as () => string;
-export let assertTyped = <() => string>(() => '');
 
 interface ObjectType {
   foo(): number;
@@ -253,9 +252,6 @@ export let objectProp: ObjectType = {
 export let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-export let objectPropAssert = <ObjectType>{
-  foo: () => 1,
-};
 
 type FooType = (bar: string) => void;
 export const foo: FooType = bar => {};

--- a/packages/eslint-plugin/docs/rules/non-nullable-type-assertion-style.mdx
+++ b/packages/eslint-plugin/docs/rules/non-nullable-type-assertion-style.mdx
@@ -15,7 +15,7 @@ There are two common ways to assert to TypeScript that a value is its type witho
 - `as`: Traditional type assertion with a coincidentally equivalent type
 
 `!` non-null assertions are generally preferred for requiring less code and being harder to fall out of sync as types change.
-This rule reports when an `as` cast is doing the same job as a `!` would, and suggests fixing the code to be an `!`.
+This rule reports when an `as` assertion is doing the same job as a `!` would, and suggests fixing the code to be an `!`.
 
 ## Examples
 

--- a/packages/eslint-plugin/docs/rules/non-nullable-type-assertion-style.mdx
+++ b/packages/eslint-plugin/docs/rules/non-nullable-type-assertion-style.mdx
@@ -1,5 +1,5 @@
 ---
-description: 'Enforce non-null assertions over explicit type casts.'
+description: 'Enforce non-null assertions over explicit type assertions.'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
@@ -176,7 +176,7 @@ Also, if you would like to ignore all primitives types, you can set `ignorePrimi
 
 {/* insert option description */}
 
-Whether to ignore expressions that cast a value into a boolean: `Boolean(...)`.
+Whether to ignore expressions that coerce a value into a boolean: `Boolean(...)`.
 
 Incorrect code for `ignoreBooleanCoercion: false`, and correct code for `ignoreBooleanCoercion: true`:
 

--- a/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-nullish-coalescing.mdx
@@ -176,7 +176,7 @@ Also, if you would like to ignore all primitives types, you can set `ignorePrimi
 
 {/* insert option description */}
 
-Whether to ignore expressions that coerce a value into a boolean: `Boolean(...)`.
+Whether to ignore expressions that cast a value into a boolean: `Boolean(...)`.
 
 Incorrect code for `ignoreBooleanCoercion: false`, and correct code for `ignoreBooleanCoercion: true`:
 

--- a/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.mdx
@@ -19,7 +19,7 @@ A common solution to this problem is to use an `as` assertion on the initial val
 While this will work, it's not the most optimal solution as type assertions have subtle effects on the underlying types that can allow bugs to slip in.
 
 A better solution is to pass the type in as a generic type argument to `Array#reduce` explicitly.
-This means that TypeScript doesn't have to try to infer the type, and avoids the common pitfalls that come with casting.
+This means that TypeScript doesn't have to try to infer the type, and avoids the common pitfalls that come with assertions.
 
 This rule looks for calls to `Array#reduce`, and reports if an initial value is being passed & asserted.
 It will suggest instead pass the asserted type to `Array#reduce` as a generic type argument.

--- a/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.mdx
@@ -1,5 +1,5 @@
 ---
-description: 'Enforce using type parameter when calling `Array#reduce` instead of casting.'
+description: 'Enforce using type parameter when calling `Array#reduce` instead of using a type assertion.'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.mdx
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.mdx
@@ -84,7 +84,7 @@ function foo(bool?: boolean) {
   }
 }
 
-// `any` types should be cast to boolean explicitly
+// `any` types should be converted to boolean explicitly
 const foo = (arg: any) => (Boolean(arg) ? 1 : 0);
 ```
 
@@ -176,14 +176,14 @@ This rule provides following fixes and suggestions for particular types in boole
 - `string` - (when `allowString` is `false`) - Provides following suggestions:
   - Change condition to check string's length (`str` → `str.length > 0`)
   - Change condition to check for empty string (`str` → `str !== ""`)
-  - Explicitly cast value to a boolean (`str` → `Boolean(str)`)
+  - Explicitly convert value to a boolean (`str` → `Boolean(str)`)
 - `number` - (when `allowNumber` is `false`):
   - For `array.length` - Provides **autofix**:
     - Change condition to check for 0 (`array.length` → `array.length > 0`)
   - For other number values - Provides following suggestions:
     - Change condition to check for 0 (`num` → `num !== 0`)
     - Change condition to check for NaN (`num` → `!Number.isNaN(num)`)
-    - Explicitly cast value to a boolean (`num` → `Boolean(num)`)
+    - Explicitly convert value to a boolean (`num` → `Boolean(num)`)
 - `object | null | undefined` - (when `allowNullableObject` is `false`) - Provides **autofix**:
   - Change condition to check for null/undefined (`maybeObj` → `maybeObj != null`)
 - `boolean | null | undefined` - Provides following suggestions:
@@ -192,13 +192,13 @@ This rule provides following fixes and suggestions for particular types in boole
 - `string | null | undefined` - Provides following suggestions:
   - Change condition to check for null/undefined (`maybeStr` → `maybeStr != null`)
   - Explicitly treat nullish value the same as an empty string (`maybeStr` → `maybeStr ?? ""`)
-  - Explicitly cast value to a boolean (`maybeStr` → `Boolean(maybeStr)`)
+  - Explicitly convert value to a boolean (`maybeStr` → `Boolean(maybeStr)`)
 - `number | null | undefined` - Provides following suggestions:
   - Change condition to check for null/undefined (`maybeNum` → `maybeNum != null`)
   - Explicitly treat nullish value the same as 0 (`maybeNum` → `maybeNum ?? 0`)
-  - Explicitly cast value to a boolean (`maybeNum` → `Boolean(maybeNum)`)
+  - Explicitly convert value to a boolean (`maybeNum` → `Boolean(maybeNum)`)
 - `any` and `unknown` - Provides following suggestions:
-  - Explicitly cast value to a boolean (`value` → `Boolean(value)`)
+  - Explicitly convert value to a boolean (`value` → `Boolean(value)`)
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
@@ -62,7 +62,7 @@ export default createRule({
         return;
       }
 
-      // handle cases when casting unknown ==> any.
+      // handle cases when asserting unknown ==> any.
       if (isTypeAnyType(assertedType) && isTypeUnknownType(expressionType)) {
         context.report({
           node,

--- a/packages/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-type-assertion.ts
@@ -22,9 +22,9 @@ export default createRule({
     },
     messages: {
       unsafeOfAnyTypeAssertion:
-        'Unsafe cast from {{type}} detected: consider using type guards or a safer cast.',
+        'Unsafe assertion from {{type}} detected: consider using type guards or a safer assertion.',
       unsafeToAnyTypeAssertion:
-        'Unsafe cast to {{type}} detected: consider using a more specific type to ensure safety.',
+        'Unsafe assertion to {{type}} detected: consider using a more specific type to ensure safety.',
       unsafeTypeAssertion:
         "Unsafe type assertion: type '{{type}}' is more narrow than the original type.",
     },

--- a/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
+++ b/packages/eslint-plugin/src/rules/non-nullable-type-assertion-style.ts
@@ -16,7 +16,7 @@ export default createRule({
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforce non-null assertions over explicit type casts',
+      description: 'Enforce non-null assertions over explicit type assertions',
       recommended: 'stylistic',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts
+++ b/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts
@@ -28,7 +28,7 @@ export default createRule({
     fixable: 'code',
     messages: {
       preferTypeParameter:
-        'Unnecessary cast: Array#reduce accepts a type parameter for the default value.',
+        'Unnecessary assertion: Array#reduce accepts a type parameter for the default value.',
     },
     schema: [],
   },

--- a/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts
+++ b/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts
@@ -21,7 +21,7 @@ export default createRule({
     type: 'problem',
     docs: {
       description:
-        'Enforce using type parameter when calling `Array#reduce` instead of casting',
+        'Enforce using type parameter when calling `Array#reduce` instead of using a type assertion',
       recommended: 'strict',
       requiresTypeChecking: true,
     },

--- a/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
+++ b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts
@@ -68,7 +68,7 @@ export default createRule<Options, MessageId>({
     messages: {
       conditionErrorAny:
         'Unexpected any value in conditional. ' +
-        'An explicit comparison or type cast is required.',
+        'An explicit comparison or type conversion is required.',
       conditionErrorNullableBoolean:
         'Unexpected nullable boolean value in conditional. ' +
         'Please handle the nullish case explicitly.',
@@ -100,7 +100,7 @@ export default createRule<Options, MessageId>({
         'Unexpected string value in conditional. ' +
         'An explicit empty string check is required.',
       conditionFixCastBoolean:
-        'Explicitly cast value to a boolean (`Boolean(value)`)',
+        'Explicitly convert value to a boolean (`Boolean(value)`)',
 
       conditionFixCompareEmptyString:
         'Change condition to check for empty string (`value !== ""`)',

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-function-return-type.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-function-return-type.shot
@@ -124,7 +124,7 @@ let objectProp: ObjectType = {
 let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-let objectPropAssertion = <ObjectType>{
+let objectPropAssert = <ObjectType>{
   foo: () => 1,
 };
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-function-return-type.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-function-return-type.shot
@@ -113,7 +113,7 @@ let funcExpr: FuncType = function () {
 };
 
 let asTyped = (() => '') as () => string;
-let castTyped = <() => string>(() => '');
+let assertTyped = <() => string>(() => '');
 
 interface ObjectType {
   foo(): number;
@@ -124,7 +124,7 @@ let objectProp: ObjectType = {
 let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-let objectPropCast = <ObjectType>{
+let objectPropAssertion = <ObjectType>{
   foo: () => 1,
 };
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-function-return-type.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-function-return-type.shot
@@ -113,7 +113,6 @@ let funcExpr: FuncType = function () {
 };
 
 let asTyped = (() => '') as () => string;
-let assertTyped = <() => string>(() => '');
 
 interface ObjectType {
   foo(): number;
@@ -124,9 +123,6 @@ let objectProp: ObjectType = {
 let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-let objectPropAssert = <ObjectType>{
-  foo: () => 1,
-};
 
 declare function functionWithArg(arg: () => number);
 functionWithArg(() => 1);

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-module-boundary-types.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-module-boundary-types.shot
@@ -188,7 +188,7 @@ export let objectProp: ObjectType = {
 export let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-export let objectPropAssertion = <ObjectType>{
+export let objectPropAssert = <ObjectType>{
   foo: () => 1,
 };
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-module-boundary-types.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-module-boundary-types.shot
@@ -177,7 +177,7 @@ export let funcExpr: FuncType = function () {
 };
 
 export let asTyped = (() => '') as () => string;
-export let castTyped = <() => string>(() => '');
+export let assertTyped = <() => string>(() => '');
 
 interface ObjectType {
   foo(): number;
@@ -188,7 +188,7 @@ export let objectProp: ObjectType = {
 export let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-export let objectPropCast = <ObjectType>{
+export let objectPropAssertion = <ObjectType>{
   foo: () => 1,
 };
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-module-boundary-types.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-module-boundary-types.shot
@@ -177,7 +177,6 @@ export let funcExpr: FuncType = function () {
 };
 
 export let asTyped = (() => '') as () => string;
-export let assertTyped = <() => string>(() => '');
 
 interface ObjectType {
   foo(): number;
@@ -188,9 +187,6 @@ export let objectProp: ObjectType = {
 export let objectPropAs = {
   foo: () => 1,
 } as ObjectType;
-export let objectPropAssert = <ObjectType>{
-  foo: () => 1,
-};
 
 type FooType = (bar: string) => void;
 export const foo: FooType = bar => {};

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/prefer-reduce-type-parameter.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/prefer-reduce-type-parameter.shot
@@ -4,7 +4,7 @@ exports[`Validating rule docs prefer-reduce-type-parameter.mdx code examples ESL
 "Incorrect
 
 [1, 2, 3].reduce((arr, num) => arr.concat(num * 2), [] as number[]);
-                                                    ~~~~~~~~~~~~~~ Unnecessary cast: Array#reduce accepts a type parameter for the default value.
+                                                    ~~~~~~~~~~~~~~ Unnecessary assertion: Array#reduce accepts a type parameter for the default value.
 
 ['a', 'b'].reduce(
   (accum, name) => ({
@@ -12,7 +12,7 @@ exports[`Validating rule docs prefer-reduce-type-parameter.mdx code examples ESL
     [name]: true,
   }),
   {} as Record<string, boolean>,
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Unnecessary cast: Array#reduce accepts a type parameter for the default value.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Unnecessary assertion: Array#reduce accepts a type parameter for the default value.
 );
 "
 `;

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/strict-boolean-expressions.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/strict-boolean-expressions.shot
@@ -27,7 +27,7 @@ function foo(bool?: boolean) {
 
 // \`any\`, unconstrained generics and unions of more than one primitive type are disallowed
 const foo = <T>(arg: T) => (arg ? 1 : 0);
-                            ~~~ Unexpected any value in conditional. An explicit comparison or type cast is required.
+                            ~~~ Unexpected any value in conditional. An explicit comparison or type conversion is required.
 
 // always-truthy and always-falsy types are disallowed
 let obj = {};
@@ -64,7 +64,7 @@ function foo(bool?: boolean) {
   }
 }
 
-// \`any\` types should be cast to boolean explicitly
+// \`any\` types should be converted to boolean explicitly
 const foo = (arg: any) => (Boolean(arg) ? 1 : 0);
 "
 `;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10458
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10458 and makes consistent use of asserting vs casting.

There is some inconsistency for casting values: to cast ([`no-extra-boolean-cast`](https://eslint.org/docs/latest/rules/no-extra-boolean-cast)), to coerce (e.g. [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion), [MDN](https://developer.mozilla.org/en-US/docs/Glossary/Type_coercion)), to convert (upcoming [`no-unnecessary-type-conversion`](https://github.com/typescript-eslint/typescript-eslint/pull/10182#issuecomment-2453282643)). To my understanding, these all mean the same thing.

I've used consistent language for casting a value (currently using `to cast`). Please let me know if this sounds OK or if I should change it back.