### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] don't flag values of an unconstrained or valid type parameter

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -673,6 +673,11 @@ export default createRule<Options, MessageId>({
           if (isPossiblyTruthy(type)) {
             hasTruthyReturnTypes = true;
           }
+
+          // bail early if both a possibly-truthy and a possibly-falsy have been detected
+          if (hasFalsyReturnTypes && hasTruthyReturnTypes) {
+            return;
+          }
         }
 
         if (!hasFalsyReturnTypes) {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -657,6 +657,11 @@ export default createRule<Options, MessageId>({
             return t;
           });
 
+        if (returnTypes.length === 0) {
+          // Not a callable function, e.g. `any`
+          return;
+        }
+
         let hasFalsyReturnTypes = false;
         let hasTruthyReturnTypes = false;
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -297,6 +297,12 @@ declare const test: <T extends boolean>() => T;
 
 [1, null].filter(test);
     `,
+    `
+[1, null].filter(1 as any);
+    `,
+    `
+[1, null].filter(1 as never);
+    `,
     // Ignores non-array methods of the same name
     `
 const notArray = {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -287,6 +287,16 @@ function count(
   return list.filter(predicate).length;
 }
     `,
+    `
+declare const test: <T>() => T;
+
+[1, null].filter(test);
+    `,
+    `
+declare const test: <T extends boolean>() => T;
+
+[1, null].filter(test);
+    `,
     // Ignores non-array methods of the same name
     `
 const notArray = {
@@ -1597,6 +1607,14 @@ function nothing3(x: [string, string]) {
         { column: 25, line: 13, messageId: 'alwaysFalsy' },
         { column: 25, line: 17, messageId: 'alwaysFalsy' },
       ],
+    },
+    {
+      code: `
+declare const test: <T extends true>() => T;
+
+[1, null].filter(test);
+      `,
+      errors: [{ column: 18, line: 4, messageId: 'alwaysTruthyFunc' }],
     },
     // Indexing cases
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10442
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10442 and handles a potential return type being a type constraint.

The PR suffers from the same issues around `getConstrainedTypeAtLocation` described by @kirkwaiblinger on #10438 and requires a small workaround.

Note that `no-unnecessary-condition` makes a lot of use of `getConstrainedTypeAtLocation`, but going over them roughly, I couldn't find additional bugs around unconstrained type parameters.