### PR TITLE
fix(eslint-plugin): [no-unnecessary-boolean-literal-compare] flag values of a type parameter with boolean type constraints

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -4,7 +4,12 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
-import { createRule, getParserServices, isStrongPrecedenceNode } from '../util';
+import {
+  createRule,
+  getConstrainedTypeAtLocation,
+  getParserServices,
+  isStrongPrecedenceNode,
+} from '../util';
 
 type MessageIds =
   | 'comparingNullableToFalse'
@@ -89,7 +94,10 @@ export default createRule<Options, MessageIds>({
         return undefined;
       }
 
-      const expressionType = services.getTypeAtLocation(comparison.expression);
+      const expressionType = getConstrainedTypeAtLocation(
+        services,
+        comparison.expression,
+      );
 
       if (isBooleanType(expressionType)) {
         return {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
@@ -87,7 +87,9 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
     },
     {
       code: `
-        const test: <T>(someCondition: boolean | undefined) => void = someCondition => {
+        const test: <T extends boolean | undefined>(
+          someCondition: T,
+        ) => void = someCondition => {
           if (someCondition === true) {
           }
         };
@@ -96,7 +98,9 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
     },
     {
       code: `
-        const test: <T>(someCondition: boolean | undefined) => void = someCondition => {
+        const test: <T extends boolean | undefined>(
+          someCondition: T,
+        ) => void = someCondition => {
           if (someCondition === false) {
           }
         };

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
@@ -56,6 +56,18 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
       varTrueOrStringOrUndefined == true;
     `,
     `
+      const test: <T>(someCondition: T) => void = someCondition => {
+        if (someCondition === true) {
+        }
+      };
+    `,
+    `
+      const test: <T>(someCondition: boolean | string) => void = someCondition => {
+        if (someCondition === true) {
+        }
+      };
+    `,
+    `
       declare const varBooleanOrUndefined: boolean | undefined;
       varBooleanOrUndefined === true;
     `,
@@ -70,6 +82,24 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
       code: `
         declare const varBooleanOrUndefined: boolean | undefined;
         varBooleanOrUndefined === false;
+      `,
+      options: [{ allowComparingNullableBooleansToTrue: false }],
+    },
+    {
+      code: `
+        const test: <T>(someCondition: boolean | undefined) => void = someCondition => {
+          if (someCondition === true) {
+          }
+        };
+      `,
+      options: [{ allowComparingNullableBooleansToFalse: false }],
+    },
+    {
+      code: `
+        const test: <T>(someCondition: boolean | undefined) => void = someCondition => {
+          if (someCondition === false) {
+          }
+        };
       `,
       options: [{ allowComparingNullableBooleansToTrue: false }],
     },
@@ -479,6 +509,63 @@ ruleTester.run('no-unnecessary-boolean-literal-compare', rule, {
         declare const varBoolean: boolean;
         if (!(varBoolean ?? true)) {
         }
+      `,
+    },
+    {
+      code: `
+        const test: <T extends boolean>(someCondition: T) => void = someCondition => {
+          if (someCondition === true) {
+          }
+        };
+      `,
+      errors: [
+        {
+          messageId: 'direct',
+        },
+      ],
+      output: `
+        const test: <T extends boolean>(someCondition: T) => void = someCondition => {
+          if (someCondition) {
+          }
+        };
+      `,
+    },
+    {
+      code: `
+        const test: <T extends boolean>(someCondition: T) => void = someCondition => {
+          if (!(someCondition !== false)) {
+          }
+        };
+      `,
+      errors: [
+        {
+          messageId: 'negated',
+        },
+      ],
+      output: `
+        const test: <T extends boolean>(someCondition: T) => void = someCondition => {
+          if (!someCondition) {
+          }
+        };
+      `,
+    },
+    {
+      code: `
+        const test: <T extends boolean>(someCondition: T) => void = someCondition => {
+          if (!((someCondition ?? true) !== false)) {
+          }
+        };
+      `,
+      errors: [
+        {
+          messageId: 'negated',
+        },
+      ],
+      output: `
+        const test: <T extends boolean>(someCondition: T) => void = someCondition => {
+          if (!(someCondition ?? true)) {
+          }
+        };
       `,
     },
   ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10443
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR follows-up #10443 and reports on values with a boolean type parameter that are being compared to a boolean literal:

```ts
// fails
const test1: (someCondition: boolean) => void = someCondition => {
  if (someCondition === true) {}
};

// should fail
const test2: <T extends boolean>(someCondition: T) => void = someCondition => {
  if (someCondition === true) {}
};
```