### PR TITLE
fix: ignore when constructor is  typed array

### DIFF
--- a/packages/eslint-plugin/tests/rules/consistent-generic-constructors.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-generic-constructors.test.ts
@@ -40,6 +40,16 @@ class A {
     `
 const a = function (a: Foo = new Foo<string>()) {};
     `,
+    'let a: Uint8Array<ArrayBufferLike> = new Uint8Array();',
+    'let a: Uint8ClampedArray<ArrayBufferLike> = new Uint8ClampedArray();',
+    'let a: Int16Array<ArrayBufferLike> = new Int16Array();',
+    'let a: Uint16Array<ArrayBufferLike> = new Uint16Array();',
+    'let a: Int32Array<ArrayBufferLike> = new Int32Array();',
+    'let a: Uint32Array<ArrayBufferLike> = new Uint32Array();',
+    'let a: BigInt64Array<ArrayBufferLike> = new BigInt64Array();',
+    'let a: BigUint64Array<ArrayBufferLike> = new BigUint64Array();',
+    'let a: Float32Array<ArrayBufferLike> = new Float32Array();',
+    'let a: Float64Array<ArrayBufferLike> = new Float64Array();',
     // type-annotation
     {
       code: 'const a = new Foo();',


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10445
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Hard-code the typed arrays and added code to skip check if the type is a typed array.
