### PR TITLE
chore: fix incorrect licenses

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/typescript-eslint/typescript-eslint/issues"
   },
   "homepage": "https://typescript-eslint.io/packages/parser",
-  "license": "MITClause",
+  "license": "MIT",
   "keywords": [
     "ast",
     "ecmascript",


### PR DESCRIPTION
`MITClause` is not valid, it should be `MIT` instead.

This is blocking us to update due to invalid license.