### PR TITLE
fix(eslint-plugin): [consistent-indexed-object-style] use a suggestion over an auto-fix if can't reliably determine that produced index signature is valid

### DIFF
--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -401,6 +401,57 @@ interface Foo {
       output: 'type Foo = Generic<{ [key: string]: any }>;',
     },
 
+    // Record with an index node that may potentially break index-signature style
+    {
+      code: 'type Foo = Record<string | number, any>;',
+      errors: [
+        {
+          column: 12,
+          line: 1,
+          messageId: 'preferIndexSignature',
+          suggestions: [
+            {
+              messageId: 'preferIndexSignatureSuggestion',
+              output: 'type Foo = { [key: string | number]: any };',
+            },
+          ],
+        },
+      ],
+      options: ['index-signature'],
+    },
+    {
+      code: "type Foo = Record<Exclude<'a' | 'b' | 'c', 'a'>, any>;",
+      errors: [
+        {
+          column: 12,
+          line: 1,
+          messageId: 'preferIndexSignature',
+          suggestions: [
+            {
+              messageId: 'preferIndexSignatureSuggestion',
+              output:
+                "type Foo = { [key: Exclude<'a' | 'b' | 'c', 'a'>]: any };",
+            },
+          ],
+        },
+      ],
+      options: ['index-signature'],
+    },
+
+    // Record with valid index node should use an auto-fix
+    {
+      code: 'type Foo = Record<number, any>;',
+      errors: [{ column: 12, line: 1, messageId: 'preferIndexSignature' }],
+      options: ['index-signature'],
+      output: 'type Foo = { [key: number]: any };',
+    },
+    {
+      code: 'type Foo = Record<symbol, any>;',
+      errors: [{ column: 12, line: 1, messageId: 'preferIndexSignature' }],
+      options: ['index-signature'],
+      output: 'type Foo = { [key: symbol]: any };',
+    },
+
     // Function types
     {
       code: 'function foo(arg: Record<string, any>) {}',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #4730
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #4730 and adjusts the rule so it uses a suggestion instead of an auto-fix if the change may create an invalid index signature.

Some thoughts:

_Even if the rule uses a suggestion, it can still flag records that can't be fixed to a valid index signature. Developers may need to add `eslint-disable` comments for these these. As long as the rule [isn't type aware](https://github.com/typescript-eslint/typescript-eslint/issues/4730#issuecomment-1078753745), I think that's the best alternative._
