### PR TITLE
fix(eslint-plugin): [prefer-reduce-type-parameter] don't report cases in which the fix results in a type error

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts
+++ b/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts
@@ -75,7 +75,7 @@ export default createRule({
             assertedType,
           );
 
-          // don't report an unnecessary assertion if the resulting fix will be a type error
+          // don't report this if the resulting fix will be a type error
           if (isAssertionNecessary) {
             return;
           }

--- a/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts
+++ b/packages/eslint-plugin/src/rules/prefer-reduce-type-parameter.ts
@@ -57,7 +57,29 @@ export default createRule({
 
         const [, secondArg] = callee.parent.arguments;
 
-        if (callee.parent.arguments.length < 2 || !isTypeAssertion(secondArg)) {
+        if (callee.parent.arguments.length < 2) {
+          return;
+        }
+
+        if (isTypeAssertion(secondArg)) {
+          const initializerType = services.getTypeAtLocation(
+            secondArg.expression,
+          );
+
+          const assertedType = services.getTypeAtLocation(
+            secondArg.typeAnnotation,
+          );
+
+          const isAssertionNecessary = !checker.isTypeAssignableTo(
+            initializerType,
+            assertedType,
+          );
+
+          // don't report an unnecessary assertion if the resulting fix will be a type error
+          if (isAssertionNecessary) {
+            return;
+          }
+        } else {
           return;
         }
 

--- a/packages/eslint-plugin/tests/rules/prefer-reduce-type-parameter.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-reduce-type-parameter.test.ts
@@ -101,6 +101,9 @@ ruleTester.run('prefer-reduce-type-parameter', rule, {
         );
       }
     `,
+    `
+      ['a', 'b'].reduce((accum, name) => \`\${accum} | hello \${name}!\`);
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/prefer-reduce-type-parameter.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-reduce-type-parameter.test.ts
@@ -57,23 +57,67 @@ ruleTester.run('prefer-reduce-type-parameter', rule, {
         return a.concat(1);
       }, [] as number[]);
     `,
+    `
+      ['a', 'b'].reduce(
+        (accum, name) => ({
+          ...accum,
+          [name]: true,
+        }),
+        {} as Record<'a' | 'b', boolean>,
+      );
+    `,
+    // Object literal may only specify known properties, and 'c' does not exist in
+    // type 'Record<"a" | "b", boolean>'.
+    `
+      ['a', 'b'].reduce(
+        (accum, name) => ({
+          ...accum,
+          [name]: true,
+        }),
+        { a: true, b: false, c: true } as Record<'a' | 'b', boolean>,
+      );
+    `,
+    // '{}' is assignable to the constraint of type 'T', but 'T' could be
+    // instantiated with a different subtype of constraint 'Record<string, boolean>'.
+    `
+      function f<T extends Record<string, boolean>>() {
+        ['a', 'b'].reduce(
+          (accum, name) => ({
+            ...accum,
+            [name]: true,
+          }),
+          {} as T,
+        );
+      }
+    `,
+    `
+      function f<T>() {
+        ['a', 'b'].reduce(
+          (accum, name) => ({
+            ...accum,
+            [name]: true,
+          }),
+          {} as T,
+        );
+      }
+    `,
   ],
   invalid: [
     {
       code: `
 declare const arr: string[];
-arr.reduce<string>(acc => acc, arr.shift() as string);
+arr.reduce<string | undefined>(acc => acc, arr.shift() as string | undefined);
       `,
       errors: [
         {
-          column: 32,
+          column: 44,
           line: 3,
           messageId: 'preferTypeParameter',
         },
       ],
       output: `
 declare const arr: string[];
-arr.reduce<string>(acc => acc, arr.shift());
+arr.reduce<string | undefined>(acc => acc, arr.shift());
       `,
     },
     {
@@ -273,6 +317,64 @@ tuple.reduce((a, s) => a.concat(s * 2), [] as number[]);
       output: `
 declare const tuple: [number, number, number] & number[];
 tuple.reduce<number[]>((a, s) => a.concat(s * 2), []);
+      `,
+    },
+    {
+      code: `
+['a', 'b'].reduce(
+  (accum, name) => ({
+    ...accum,
+    [name]: true,
+  }),
+  {} as Record<string, boolean>,
+);
+      `,
+      errors: [
+        {
+          column: 3,
+          line: 7,
+          messageId: 'preferTypeParameter',
+        },
+      ],
+      output: `
+['a', 'b'].reduce<Record<string, boolean>>(
+  (accum, name) => ({
+    ...accum,
+    [name]: true,
+  }),
+  {},
+);
+      `,
+    },
+    {
+      code: `
+function f<T extends Record<string, boolean>>(t: T) {
+  ['a', 'b'].reduce(
+    (accum, name) => ({
+      ...accum,
+      [name]: true,
+    }),
+    t as Record<string, boolean | number>,
+  );
+}
+      `,
+      errors: [
+        {
+          column: 5,
+          line: 8,
+          messageId: 'preferTypeParameter',
+        },
+      ],
+      output: `
+function f<T extends Record<string, boolean>>(t: T) {
+  ['a', 'b'].reduce<Record<string, boolean | number>>(
+    (accum, name) => ({
+      ...accum,
+      [name]: true,
+    }),
+    t,
+  );
+}
       `,
     },
   ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #3440
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR tackles #3440 and makes the rule skip cases where the type assertion is necessary and auto-fixing to using `reduce()`'s type parameter will result in a type error.

Alternatively, as code that does this isn't exactly safe, the rule can still report such cases but use a suggestion instead of an auto-fix (although `no-unsafe-type-assertion` will report the assertion as unsafe).
