### PR TITLE
fix(eslint-plugin): [no-deprecated] not reporting usages of deprecated declared constants as object value

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -292,24 +292,6 @@ export default createRule({
       return getJsDocDeprecation(symbol);
     }
 
-    function checkDeprecatedInObjectValue(
-      node: TSESTree.Identifier | TSESTree.JSXIdentifier,
-    ): string | undefined {
-      const symbol = services.getSymbolAtLocation(node);
-      if (symbol === undefined) {
-        return undefined;
-      }
-
-      const jsDocTags = symbol.getJsDocTags(checker);
-      const deprecatedTag = jsDocTags.find(tag => tag.name === 'deprecated');
-      if (deprecatedTag === undefined) {
-        return undefined;
-      }
-
-      const displayParts = deprecatedTag.text;
-      return displayParts ? ts.displayPartsToString(displayParts) : '';
-    }
-
     function getDeprecationReason(node: IdentifierLike): string | undefined {
       const callLikeNode = getCallLikeNode(node);
       if (callLikeNode) {
@@ -330,9 +312,8 @@ export default createRule({
         const property = services
           .getTypeAtLocation(node.parent.parent)
           .getProperty(node.name);
-        return (
-          getJsDocDeprecation(property) ?? checkDeprecatedInObjectValue(node)
-        );
+        const symbol = services.getSymbolAtLocation(node);
+        return getJsDocDeprecation(property) ?? getJsDocDeprecation(symbol);
       }
       return searchForDeprecationInAliasesChain(
         services.getSymbolAtLocation(node),

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -683,6 +683,36 @@ ruleTester.run('no-deprecated', rule, {
     },
     {
       code: `
+        /** @deprecated */
+        declare const test: string;
+        const myObj = {
+          prop: test,
+          deep: {
+            prop: test,
+          },
+        };
+      `,
+      errors: [
+        {
+          column: 17,
+          data: { name: 'test' },
+          endColumn: 21,
+          endLine: 5,
+          line: 5,
+          messageId: 'deprecated',
+        },
+        {
+          column: 19,
+          data: { name: 'test' },
+          endColumn: 23,
+          endLine: 7,
+          line: 7,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
         /** @deprecated */ const a = { b: 1 };
         const { c = 'd' } = a.b;
       `,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10487 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I have fixed the bug in the title.

🐝
