### PR TITLE
fix(eslint-plugin): [consistent-type-assertions] allow default assertionStyle option

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -82,7 +82,6 @@ export default createRule<Options, MessageIds>({
                 enum: ['allow', 'allow-as-parameter', 'never'],
               },
             },
-            required: ['assertionStyle'],
           },
         ],
       },

--- a/packages/eslint-plugin/tests/schema-snapshots/consistent-type-assertions.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/consistent-type-assertions.shot
@@ -33,7 +33,6 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
             "type": "string"
           }
         },
-        "required": ["assertionStyle"],
         "type": "object"
       }
     ]
@@ -46,7 +45,12 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 type Options = [
   | {
       /** The expected assertion style to enforce. */
-      assertionStyle:
+      assertionStyle: /** The expected assertion style to enforce. */
+      'never';
+    }
+  | {
+      /** The expected assertion style to enforce. */
+      assertionStyle?:
         | 'as'
         /** The expected assertion style to enforce. */
         | 'angle-bracket';
@@ -56,11 +60,6 @@ type Options = [
         | 'never'
         /** Whether to always prefer type declarations for object literals used as variable initializers, rather than type assertions. */
         | 'allow';
-    }
-  | {
-      /** The expected assertion style to enforce. */
-      assertionStyle: /** The expected assertion style to enforce. */
-      'never';
     },
 ];
 "


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10463
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Removes the schema requirement for `assertionStyle` to be provided, on the basis that when the `defaultOptions` are merged, an `assertionStyle` value of "as" will be used if none was provided.

This allows a user to supply partial options in their config, for example to override `objectLiteralTypeAssertions: 'never'` but retain the default `assertionStyle: 'as'`, e.g. the following now works:

```js
{
  '@typescript-eslint/consistent-type-assertions: [
    'error',
    { objectLiteralTypeAssertions: 'never' }
  ]
}
```


Note: I had intended to include a test case that omits the `assertionStyle` option, but I have a suspicion that the rule tester doesn't merge defaults, as I was unable to get the test to pass schema validation despite the fact that I had manually tested the change and can confirm that it works.  Please let me know if a test case is still required for this.