### PR TITLE
fix(typescript-eslint): export types so that declarations can be named for dts files

### DIFF
--- a/packages/typescript-eslint/src/config-helper.ts
+++ b/packages/typescript-eslint/src/config-helper.ts
@@ -66,6 +66,9 @@ export interface ConfigWithExtends extends TSESLint.FlatConfig.Config {
   extends?: InfiniteDepthConfigWithExtends[];
 }
 
+// exported so that users that make configs with tsconfig `declaration: true` can name the type
+export type ConfigArray = TSESLint.FlatConfig.ConfigArray;
+
 /**
  * Utility function to make it easy to strictly type your "Flat" config file
  * @example
@@ -88,7 +91,7 @@ export interface ConfigWithExtends extends TSESLint.FlatConfig.Config {
  */
 export function config(
   ...configs: InfiniteDepthConfigWithExtends[]
-): TSESLint.FlatConfig.ConfigArray {
+): ConfigArray {
   const flattened =
     // @ts-expect-error -- intentionally an infinite type
     configs.flat(Infinity) as ConfigWithExtends[];

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -186,4 +186,9 @@ export default {
 };
 export { configs, parser, plugin };
 
-export { config, type ConfigWithExtends } from './config-helper';
+export {
+  config,
+  type ConfigWithExtends,
+  type InfiniteDepthConfigWithExtends,
+  type ConfigArray,
+} from './config-helper';


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10508
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Names and exports the types so that projects using `declaration: true` will not see errors