### PR TITLE
fix(eslint-plugin): [array-type] autofix `TsConditionalType` to be wrapped with parentheses

### DIFF
--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -64,6 +64,7 @@ function typeNeedsParentheses(node: TSESTree.Node): boolean {
     case AST_NODE_TYPES.TSTypeOperator:
     case AST_NODE_TYPES.TSInferType:
     case AST_NODE_TYPES.TSConstructorType:
+    case AST_NODE_TYPES.TSConditionalType:
       return true;
     case AST_NODE_TYPES.Identifier:
       return node.name === 'ReadonlyArray';

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -434,6 +434,32 @@ function bazFunction(baz: Arr<ArrayClass<String>>) {
       output: 'let a: (string | number)[] = [];',
     },
     {
+      code: 'let a: Array<T extends string ? number : string> = [];',
+      errors: [
+        {
+          column: 8,
+          data: { className: 'Array', readonlyPrefix: '', type: 'T' },
+          line: 1,
+          messageId: 'errorStringArray',
+        },
+      ],
+      options: [{ default: 'array' }],
+      output: 'let a: (T extends string ? number : string)[] = [];',
+    },
+    {
+      code: 'let a: (T extends string ? number : string)[] = [];',
+      errors: [
+        {
+          column: 8,
+          data: { className: 'Array', readonlyPrefix: '', type: 'T' },
+          line: 1,
+          messageId: 'errorStringGeneric',
+        },
+      ],
+      options: [{ default: 'generic' }],
+      output: 'let a: Array<T extends string ? number : string> = [];',
+    },
+    {
       code: 'let a: ReadonlyArray<number> = [];',
       errors: [
         {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10519
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR tackles #10519 and adds missing parentheses when auto-fixing a `TsConditionalType`.
