### PR TITLE
fix(eslint-plugin): [array-type] autofix with conditional types needs parentheses

### DIFF
--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -64,6 +64,7 @@ function typeNeedsParentheses(node: TSESTree.Node): boolean {
     case AST_NODE_TYPES.TSTypeOperator:
     case AST_NODE_TYPES.TSInferType:
     case AST_NODE_TYPES.TSConstructorType:
+    case AST_NODE_TYPES.TSConditionalType:
       return true;
     case AST_NODE_TYPES.Identifier:
       return node.name === 'ReadonlyArray';

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -1956,7 +1956,6 @@ interface FooInterface {
       output: 'declare function foo<E extends readonly string[]>(extra: E): E;',
     },
     {
-      // https://github.com/typescript-eslint/typescript-eslint/issues/10519
       code: 'type Conditional<T> = Array<T extends string ? string : number>;',
       errors: [
         {
@@ -1968,7 +1967,6 @@ interface FooInterface {
       output: 'type Conditional<T> = (T extends string ? string : number)[];',
     },
     {
-      // https://github.com/typescript-eslint/typescript-eslint/issues/10519
       code: 'type Conditional<T> = (T extends string ? string : number)[];',
       errors: [
         {
@@ -1981,7 +1979,6 @@ interface FooInterface {
         'type Conditional<T> = Array<T extends string ? string : number>;',
     },
     {
-      // https://github.com/typescript-eslint/typescript-eslint/issues/10519
       code: 'type Conditional<T> = (T extends string ? string : number)[];',
       errors: [
         {

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -2192,6 +2192,22 @@ type BrokenArray = {
       'type T = ReadonlyArray<ReadonlyArray<string>>',
       'generic',
     );
+    // conditional types
+    testOutput(
+      'array',
+      'type Conditional<T> = Array<T extends string ? string : number>',
+      'type Conditional<T> = (T extends string ? string : number)[]',
+    );
+    testOutput(
+      'array-simple',
+      'type Conditional<T> = (T extends string ? string : number)[]',
+      'type Conditional<T> = Array<T extends string ? string : number>',
+    );
+    testOutput(
+      'generic',
+      'type Conditional<T> = (T extends string ? string : number)[]',
+      'type Conditional<T> = Array<T extends string ? string : number>',
+    );
   });
 });
 

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -1955,6 +1955,44 @@ interface FooInterface {
       options: [{ default: 'array-simple' }],
       output: 'declare function foo<E extends readonly string[]>(extra: E): E;',
     },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/10519
+      code: 'type Conditional<T> = Array<T extends string ? string : number>;',
+      errors: [
+        {
+          data: { className: 'Array', readonlyPrefix: '', type: 'T' },
+          messageId: 'errorStringArray',
+        },
+      ],
+      options: [{ default: 'array' }],
+      output: 'type Conditional<T> = (T extends string ? string : number)[];',
+    },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/10519
+      code: 'type Conditional<T> = (T extends string ? string : number)[];',
+      errors: [
+        {
+          data: { className: 'Array', readonlyPrefix: '', type: 'T' },
+          messageId: 'errorStringGenericSimple',
+        },
+      ],
+      options: [{ default: 'array-simple' }],
+      output:
+        'type Conditional<T> = Array<T extends string ? string : number>;',
+    },
+    {
+      // https://github.com/typescript-eslint/typescript-eslint/issues/10519
+      code: 'type Conditional<T> = (T extends string ? string : number)[];',
+      errors: [
+        {
+          data: { className: 'Array', readonlyPrefix: '', type: 'T' },
+          messageId: 'errorStringGeneric',
+        },
+      ],
+      options: [{ default: 'generic' }],
+      output:
+        'type Conditional<T> = Array<T extends string ? string : number>;',
+    },
   ],
 });
 
@@ -2191,22 +2229,6 @@ type BrokenArray = {
       'type T = readonly    (readonly string[])[]',
       'type T = ReadonlyArray<ReadonlyArray<string>>',
       'generic',
-    );
-    // conditional types
-    testOutput(
-      'array',
-      'type Conditional<T> = Array<T extends string ? string : number>',
-      'type Conditional<T> = (T extends string ? string : number)[]',
-    );
-    testOutput(
-      'array-simple',
-      'type Conditional<T> = (T extends string ? string : number)[]',
-      'type Conditional<T> = Array<T extends string ? string : number>',
-    );
-    testOutput(
-      'generic',
-      'type Conditional<T> = (T extends string ? string : number)[]',
-      'type Conditional<T> = Array<T extends string ? string : number>',
     );
   });
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10519
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

I added 3 new test cases that cover the auto-fix of the array-filter rule when used with conditional types. Afterwards I used the hint in the issue and added the typescript AST node "TSConditionalType" to the switch case which made the test case succeed.

I also linked my local typescript-eslint version using my package manager and check that it handles the original case in my code base, which made me open the issue, correctly.

Please feel free to provide feedback, this is my first contribution to typescript-eslint or such a big project at all for that matter.