### PR TITLE
fix(eslint-plugin): [no-for-in-array] report on any type which may be an array or array-like

### DIFF
--- a/packages/eslint-plugin/src/rules/no-for-in-array.ts
+++ b/packages/eslint-plugin/src/rules/no-for-in-array.ts
@@ -1,10 +1,10 @@
+import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
 import {
   createRule,
   getConstrainedTypeAtLocation,
   getParserServices,
-  isTypeArrayTypeOrUnionOfArrayTypes,
 } from '../util';
 import { getForStatementHeadLoc } from '../util/getForStatementHeadLoc';
 
@@ -45,3 +45,20 @@ export default createRule({
     };
   },
 });
+
+function isTypeArrayTypeOrUnionOfArrayTypes(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+): boolean {
+  for (const t of tsutils.unionTypeParts(type)) {
+    if (tsutils.isTypeFlagSet(t, ts.TypeFlags.Undefined | ts.TypeFlags.Null)) {
+      continue;
+    }
+
+    if (!checker.isArrayType(t)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/eslint-plugin/src/rules/no-for-in-array.ts
+++ b/packages/eslint-plugin/src/rules/no-for-in-array.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import type * as ts from 'typescript';
 
 import {
   createRule,
@@ -35,7 +35,7 @@ export default createRule({
         if (
           isArray(checker, type) ||
           isRegExpExecArrayLike(services.program, type) ||
-          isArgumentsObjectType(type)
+          isArgumentsObjectType(services.program, type)
         ) {
           context.report({
             loc: getForStatementHeadLoc(context.sourceCode, node),
@@ -47,10 +47,8 @@ export default createRule({
   },
 });
 
-function isArgumentsObjectType(type: ts.Type): boolean {
-  return (
-    type.getSymbol()?.escapedName === ts.escapeLeadingUnderscores('IArguments')
-  );
+function isArgumentsObjectType(program: ts.Program, type: ts.Type): boolean {
+  return isBuiltinSymbolLike(program, type, 'IArguments');
 }
 
 function isRegExpExecArrayLike(program: ts.Program, type: ts.Type): boolean {

--- a/packages/eslint-plugin/src/rules/no-for-in-array.ts
+++ b/packages/eslint-plugin/src/rules/no-for-in-array.ts
@@ -32,11 +32,7 @@ export default createRule({
 
         const type = getConstrainedTypeAtLocation(services, node.right);
 
-        if (
-          isArray(checker, type) ||
-          isRegExpExecArrayLike(services.program, type) ||
-          isArgumentsObjectType(services.program, type)
-        ) {
+        if (isArray(checker, type) || isArrayLike(services.program, type)) {
           context.report({
             loc: getForStatementHeadLoc(context.sourceCode, node),
             messageId: 'forInViolation',
@@ -47,13 +43,14 @@ export default createRule({
   },
 });
 
-function isArgumentsObjectType(program: ts.Program, type: ts.Type): boolean {
-  return isBuiltinSymbolLike(program, type, 'IArguments');
-}
-
-function isRegExpExecArrayLike(program: ts.Program, type: ts.Type): boolean {
+function isArrayLike(program: ts.Program, type: ts.Type): boolean {
   return isTypeRecurser(type, t =>
-    isBuiltinSymbolLike(program, t, 'RegExpExecArray'),
+    isBuiltinSymbolLike(program, t, [
+      'IArguments',
+      'HTMLCollection',
+      'RegExpExecArray',
+      'NodeList',
+    ]),
   );
 }
 

--- a/packages/eslint-plugin/tests/eslint-rules/no-undef.test.ts
+++ b/packages/eslint-plugin/tests/eslint-rules/no-undef.test.ts
@@ -219,7 +219,7 @@ const links = document.querySelectorAll(selector) as NodeListOf<HTMLElement>;
       `,
       languageOptions: {
         parserOptions: {
-          lib: ['dom'],
+          lib: ['es2023'],
         },
       },
     },

--- a/packages/eslint-plugin/tests/eslint-rules/no-undef.test.ts
+++ b/packages/eslint-plugin/tests/eslint-rules/no-undef.test.ts
@@ -219,7 +219,7 @@ const links = document.querySelectorAll(selector) as NodeListOf<HTMLElement>;
       `,
       languageOptions: {
         parserOptions: {
-          lib: ['es2023'],
+          lib: ['dom'],
         },
       },
     },

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.lib-dom.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.lib-dom.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2015", "es2017", "esnext", "dom"]
+  }
+}

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -177,5 +177,59 @@ for (const x
         },
       ],
     },
+    {
+      code: `
+declare const arr: string[] | null;
+
+for (const x in arr) {
+  console.log(x);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 21,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const arr: number[] | undefined;
+
+for (const x in arr) {
+  console.log(x);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 21,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const arr: boolean[] | undefined | null;
+
+for (const x in arr) {
+  console.log(x);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 21,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -331,6 +331,7 @@ for (const x in arrayLike) {
       languageOptions: {
         parserOptions: {
           project: './tsconfig.lib-dom.json',
+          projectService: false,
           tsconfigRootDir: rootDir,
         },
       },
@@ -355,6 +356,7 @@ for (const x in arrayLike) {
       languageOptions: {
         parserOptions: {
           project: './tsconfig.lib-dom.json',
+          projectService: false,
           tsconfigRootDir: rootDir,
         },
       },

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -25,6 +25,14 @@ for (const x in { a: 1, b: 2, c: 3 }) {
   console.log(x);
 }
     `,
+    // this is normally a type error, this test is here to make sure the rule
+    // doesn't include an "extra" report for it
+    `
+declare const nullish: null | undefined;
+// @ts-expect-error
+for (const k in nullish) {
+}
+    `,
   ],
 
   invalid: [
@@ -215,7 +223,7 @@ for (const x in arr) {
     },
     {
       code: `
-declare const arr: boolean[] | undefined | null;
+declare const arr: boolean[] | { a: 1; b: 2; c: 3 };
 
 for (const x in arr) {
   console.log(x);
@@ -227,6 +235,96 @@ for (const x in arr) {
           endColumn: 21,
           endLine: 4,
           line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const arr: [number, string];
+
+for (const x in arr) {
+  console.log(x);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 21,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const arr: [number, string] | { a: 1; b: 2; c: 3 };
+
+for (const x in arr) {
+  console.log(x);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 21,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: string[] | Record<number, string>;
+
+for (const k in x) {
+  console.log(k);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 19,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+const reArray = /fe/.exec('foo');
+
+for (const x in reArray) {
+  console.log(x);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 25,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+function foo() {
+  for (const a in arguments) {
+    console.log(a);
+  }
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          endColumn: 29,
+          endLine: 3,
+          line: 3,
           messageId: 'forInViolation',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -7,7 +7,7 @@ const rootDir = getFixturesRootDir();
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      project: './tsconfig.json',
+      project: './tsconfig.lib-dom.json',
       tsconfigRootDir: rootDir,
     },
   },
@@ -187,124 +187,160 @@ for (const x
     },
     {
       code: `
-declare const arr: string[] | null;
+declare const array: string[] | null;
 
-for (const x in arr) {
-  console.log(x);
-}
-      `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 21,
-          endLine: 4,
-          line: 4,
-          messageId: 'forInViolation',
-        },
-      ],
-    },
-    {
-      code: `
-declare const arr: number[] | undefined;
-
-for (const x in arr) {
-  console.log(x);
-}
-      `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 21,
-          endLine: 4,
-          line: 4,
-          messageId: 'forInViolation',
-        },
-      ],
-    },
-    {
-      code: `
-declare const arr: boolean[] | { a: 1; b: 2; c: 3 };
-
-for (const x in arr) {
-  console.log(x);
-}
-      `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 21,
-          endLine: 4,
-          line: 4,
-          messageId: 'forInViolation',
-        },
-      ],
-    },
-    {
-      code: `
-declare const arr: [number, string];
-
-for (const x in arr) {
-  console.log(x);
-}
-      `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 21,
-          endLine: 4,
-          line: 4,
-          messageId: 'forInViolation',
-        },
-      ],
-    },
-    {
-      code: `
-declare const arr: [number, string] | { a: 1; b: 2; c: 3 };
-
-for (const x in arr) {
-  console.log(x);
-}
-      `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 21,
-          endLine: 4,
-          line: 4,
-          messageId: 'forInViolation',
-        },
-      ],
-    },
-    {
-      code: `
-declare const x: string[] | Record<number, string>;
-
-for (const k in x) {
-  console.log(k);
-}
-      `,
-      errors: [
-        {
-          column: 1,
-          endColumn: 19,
-          endLine: 4,
-          line: 4,
-          messageId: 'forInViolation',
-        },
-      ],
-    },
-    {
-      code: `
-const reArray = /fe/.exec('foo');
-
-for (const x in reArray) {
-  console.log(x);
+for (const key in array) {
+  console.log(key);
 }
       `,
       errors: [
         {
           column: 1,
           endColumn: 25,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const array: number[] | undefined;
+
+for (const key in array) {
+  console.log(key);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 25,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const array: boolean[] | { a: 1; b: 2; c: 3 };
+
+for (const key in array) {
+  console.log(key);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 25,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const array: [number, string];
+
+for (const key in array) {
+  console.log(key);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 25,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const array: [number, string] | { a: 1; b: 2; c: 3 };
+
+for (const key in array) {
+  console.log(key);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 25,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const array: string[] | Record<number, string>;
+
+for (const key in array) {
+  console.log(key);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 25,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+const arrayLike = /fe/.exec('foo');
+
+for (const x in arrayLike) {
+  console.log(x);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 27,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const arrayLike: HTMLCollection;
+
+for (const x in arrayLike) {
+  console.log(x);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 27,
+          endLine: 4,
+          line: 4,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const arrayLike: NodeList;
+
+for (const x in arrayLike) {
+  console.log(x);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 27,
           endLine: 4,
           line: 4,
           messageId: 'forInViolation',
@@ -331,18 +367,18 @@ function foo() {
     },
     {
       code: `
-declare const x:
+declare const array:
   | (({ a: string } & string[]) | Record<string, boolean>)
   | Record<number, string>;
 
-for (const k in x) {
-  console.log(k);
+for (const key in array) {
+  console.log(key);
 }
       `,
       errors: [
         {
           column: 1,
-          endColumn: 19,
+          endColumn: 25,
           endLine: 6,
           line: 6,
           messageId: 'forInViolation',
@@ -351,18 +387,18 @@ for (const k in x) {
     },
     {
       code: `
-declare const x:
+declare const array:
   | (({ a: string } & RegExpExecArray) | Record<string, boolean>)
   | Record<number, string>;
 
-for (const k in x) {
+for (const key in array) {
   console.log(k);
 }
       `,
       errors: [
         {
           column: 1,
-          endColumn: 19,
+          endColumn: 25,
           endLine: 6,
           line: 6,
           messageId: 'forInViolation',

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -7,7 +7,7 @@ const rootDir = getFixturesRootDir();
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {
-      project: './tsconfig.lib-dom.json',
+      project: './tsconfig.json',
       tsconfigRootDir: rootDir,
     },
   },
@@ -328,6 +328,12 @@ for (const x in arrayLike) {
           messageId: 'forInViolation',
         },
       ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.lib-dom.json',
+          tsconfigRootDir: rootDir,
+        },
+      },
     },
     {
       code: `
@@ -346,6 +352,12 @@ for (const x in arrayLike) {
           messageId: 'forInViolation',
         },
       ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.lib-dom.json',
+          tsconfigRootDir: rootDir,
+        },
+      },
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -329,5 +329,45 @@ function foo() {
         },
       ],
     },
+    {
+      code: `
+declare const x:
+  | (({ a: string } & string[]) | Record<string, boolean>)
+  | Record<number, string>;
+
+for (const k in x) {
+  console.log(k);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 19,
+          endLine: 6,
+          line: 6,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const x:
+  | (({ a: string } & RegExpExecArray) | Record<string, boolean>)
+  | Record<number, string>;
+
+for (const k in x) {
+  console.log(k);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 19,
+          endLine: 6,
+          line: 6,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -33,6 +33,15 @@ declare const nullish: null | undefined;
 for (const k in nullish) {
 }
     `,
+    `
+declare const obj: {
+  [key: number]: number;
+};
+
+for (const key in obj) {
+  console.log(key);
+}
+    `,
   ],
 
   invalid: [
@@ -415,6 +424,27 @@ for (const key in array) {
           endColumn: 25,
           endLine: 6,
           line: 6,
+          messageId: 'forInViolation',
+        },
+      ],
+    },
+    {
+      code: `
+declare const obj: {
+  [key: number]: number;
+  length: 1;
+};
+
+for (const key in obj) {
+  console.log(key);
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 23,
+          endLine: 7,
+          line: 7,
           messageId: 'forInViolation',
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10534
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

See https://github.com/typescript-eslint/typescript-eslint/pull/10535#issuecomment-2564044282 for the updated contents of this PR.

~~This PR tackles #10534 and reports on cases such as:~~

```ts
declare const maybeArr: string[] | undefined;
declare const arr: string[];

// fails correctly
for (const item in arr) {}

// should fail, same with `T[] | null`
for (const item in maybeArr) {}
```
