### PR TITLE
fix(eslint-plugin): [consistent-indexed-object-style] don't report on indirect circular references

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -46,14 +46,13 @@ export default createRule<Options, MessageIds>({
   defaultOptions: ['record'],
   create(context, [mode]) {
     function checkMembers(
+      members: TSESTree.TypeElement[],
       node: TSESTree.TSInterfaceDeclaration | TSESTree.TSTypeLiteral,
       parentId: TSESTree.Identifier | undefined,
       prefix: string,
       postfix: string,
       safeFix = true,
     ): void {
-      const members = getMembers(node);
-
       if (members.length !== 1) {
         return;
       }
@@ -159,6 +158,7 @@ export default createRule<Options, MessageIds>({
           }
 
           checkMembers(
+            node.body.body,
             node,
             node.id,
             `type ${node.id.name}${genericTypes} = `,
@@ -249,7 +249,7 @@ export default createRule<Options, MessageIds>({
         },
         TSTypeLiteral(node): void {
           const parent = findParentDeclaration(node);
-          checkMembers(node, parent?.id, '', '');
+          checkMembers(node.members, node, parent?.id, '', '');
         },
       }),
     };
@@ -266,16 +266,6 @@ function findParentDeclaration(
     return findParentDeclaration(node.parent);
   }
   return undefined;
-}
-
-function getMembers(
-  node: TSESTree.TSInterfaceDeclaration | TSESTree.TSTypeLiteral,
-): TSESTree.TypeElement[] {
-  if (node.type === AST_NODE_TYPES.TSInterfaceDeclaration) {
-    return node.body.body;
-  }
-
-  return node.members;
 }
 
 function isDeeplyReferencingType(

--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -6,9 +6,9 @@ import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 
 import {
   createRule,
+  getFixOrSuggest,
   isNodeEqual,
   isParenthesized,
-  getFixOrSuggest,
   nullThrows,
 } from '../util';
 

--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -1,3 +1,4 @@
+import type { ScopeVariable } from '@typescript-eslint/scope-manager';
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import type { ReportFixFunction } from '@typescript-eslint/utils/ts-eslint';
 
@@ -5,8 +6,9 @@ import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 
 import {
   createRule,
-  getFixOrSuggest,
+  isNodeEqual,
   isParenthesized,
+  getFixOrSuggest,
   nullThrows,
 } from '../util';
 
@@ -44,13 +46,14 @@ export default createRule<Options, MessageIds>({
   defaultOptions: ['record'],
   create(context, [mode]) {
     function checkMembers(
-      members: TSESTree.TypeElement[],
       node: TSESTree.TSInterfaceDeclaration | TSESTree.TSTypeLiteral,
       parentId: TSESTree.Identifier | undefined,
       prefix: string,
       postfix: string,
       safeFix = true,
     ): void {
+      const members = getMembers(node);
+
       if (members.length !== 1) {
         return;
       }
@@ -78,16 +81,12 @@ export default createRule<Options, MessageIds>({
       if (parentId) {
         const scope = context.sourceCode.getScope(parentId);
         const superVar = ASTUtils.findVariable(scope, parentId.name);
-        if (superVar) {
-          const isCircular = superVar.references.some(
-            item =>
-              item.isTypeReference &&
-              node.range[0] <= item.identifier.range[0] &&
-              node.range[1] >= item.identifier.range[1],
-          );
-          if (isCircular) {
-            return;
-          }
+
+        if (
+          superVar &&
+          isDeeplyReferencingType(node, superVar, new Set([parentId]))
+        ) {
+          return;
         }
       }
 
@@ -160,7 +159,6 @@ export default createRule<Options, MessageIds>({
           }
 
           checkMembers(
-            node.body.body,
             node,
             node.id,
             `type ${node.id.name}${genericTypes} = `,
@@ -251,7 +249,7 @@ export default createRule<Options, MessageIds>({
         },
         TSTypeLiteral(node): void {
           const parent = findParentDeclaration(node);
-          checkMembers(node.members, node, parent?.id, '', '');
+          checkMembers(node, parent?.id, '', '');
         },
       }),
     };
@@ -268,4 +266,100 @@ function findParentDeclaration(
     return findParentDeclaration(node.parent);
   }
   return undefined;
+}
+
+function getMembers(
+  node: TSESTree.TSInterfaceDeclaration | TSESTree.TSTypeLiteral,
+): TSESTree.TypeElement[] {
+  if (node.type === AST_NODE_TYPES.TSInterfaceDeclaration) {
+    return node.body.body;
+  }
+
+  return node.members;
+}
+
+function isDeeplyReferencingType(
+  node: TSESTree.Node,
+  superVar: ScopeVariable,
+  visited: Set<TSESTree.Node>,
+): boolean {
+  if (visited.has(node)) {
+    // something on the chain is circular but it's not the reference being checked
+    return false;
+  }
+
+  visited.add(node);
+
+  switch (node.type) {
+    case AST_NODE_TYPES.TSTypeLiteral:
+      return node.members.some(member =>
+        isDeeplyReferencingType(member, superVar, visited),
+      );
+    case AST_NODE_TYPES.TSTypeAliasDeclaration:
+      return isDeeplyReferencingType(node.typeAnnotation, superVar, visited);
+    case AST_NODE_TYPES.TSIndexedAccessType:
+      return [node.indexType, node.objectType].some(type =>
+        isDeeplyReferencingType(type, superVar, visited),
+      );
+    case AST_NODE_TYPES.TSConditionalType:
+      return [
+        node.checkType,
+        node.extendsType,
+        node.falseType,
+        node.trueType,
+      ].some(type => isDeeplyReferencingType(type, superVar, visited));
+    case AST_NODE_TYPES.TSUnionType:
+    case AST_NODE_TYPES.TSIntersectionType:
+      return node.types.some(type =>
+        isDeeplyReferencingType(type, superVar, visited),
+      );
+    case AST_NODE_TYPES.TSInterfaceDeclaration:
+      return node.body.body.some(type =>
+        isDeeplyReferencingType(type, superVar, visited),
+      );
+    case AST_NODE_TYPES.TSTypeAnnotation:
+      return isDeeplyReferencingType(node.typeAnnotation, superVar, visited);
+    case AST_NODE_TYPES.TSIndexSignature: {
+      if (node.typeAnnotation) {
+        return isDeeplyReferencingType(node.typeAnnotation, superVar, visited);
+      }
+      break;
+    }
+    case AST_NODE_TYPES.TSTypeParameterInstantiation: {
+      return node.params.some(param =>
+        isDeeplyReferencingType(param, superVar, visited),
+      );
+    }
+    case AST_NODE_TYPES.TSTypeReference: {
+      if (isDeeplyReferencingType(node.typeName, superVar, visited)) {
+        return true;
+      }
+
+      if (
+        node.typeArguments &&
+        isDeeplyReferencingType(node.typeArguments, superVar, visited)
+      ) {
+        return true;
+      }
+
+      break;
+    }
+    case AST_NODE_TYPES.Identifier: {
+      // check if the identifier is a reference of the type being checked
+      if (superVar.references.some(ref => isNodeEqual(ref.identifier, node))) {
+        return true;
+      }
+
+      // otherwise, follow its definition(s)
+      const refVar = ASTUtils.findVariable(superVar.scope, node.name);
+
+      if (refVar) {
+        return refVar.defs.some(def =>
+          isDeeplyReferencingType(def.node, superVar, visited),
+        );
+      }
+    }
+  }
+
+  return false;
 }

--- a/packages/eslint-plugin/src/util/isNodeEqual.ts
+++ b/packages/eslint-plugin/src/util/isNodeEqual.ts
@@ -22,6 +22,12 @@ export function isNodeEqual(a: TSESTree.Node, b: TSESTree.Node): boolean {
     return a.name === b.name;
   }
   if (
+    a.type === AST_NODE_TYPES.TSTypeReference &&
+    b.type === AST_NODE_TYPES.TSTypeReference
+  ) {
+    return isNodeEqual(a.typeName, b.typeName);
+  }
+  if (
     a.type === AST_NODE_TYPES.MemberExpression &&
     b.type === AST_NODE_TYPES.MemberExpression
   ) {

--- a/packages/eslint-plugin/src/util/isNodeEqual.ts
+++ b/packages/eslint-plugin/src/util/isNodeEqual.ts
@@ -22,12 +22,6 @@ export function isNodeEqual(a: TSESTree.Node, b: TSESTree.Node): boolean {
     return a.name === b.name;
   }
   if (
-    a.type === AST_NODE_TYPES.TSTypeReference &&
-    b.type === AST_NODE_TYPES.TSTypeReference
-  ) {
-    return isNodeEqual(a.typeName, b.typeName);
-  }
-  if (
     a.type === AST_NODE_TYPES.MemberExpression &&
     b.type === AST_NODE_TYPES.MemberExpression
   ) {

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -165,6 +165,15 @@ interface Foo3 {
   [key: string]: Foo1;
 }
     `,
+    `
+type ExampleUnion = boolean | number;
+
+type ExampleRoot = ExampleUnion | ExampleObject;
+
+interface ExampleObject {
+  [key: string]: ExampleRoot;
+}
+    `,
 
     // Type literal
     'type Foo = {};',
@@ -211,6 +220,7 @@ interface Foo {
   [];
 }
     `,
+
     // 'index-signature'
     // Unhandled type
     {

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -865,5 +865,34 @@ function f(): Record<keyof ParseResult, unknown> {
 }
       `,
     },
+
+    // missing index signature type annotation while checking for a recursive type
+    {
+      code: `
+interface Foo {
+  [key: string]: Bar;
+}
+
+interface Bar {
+  [key: string];
+}
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 2,
+          endLine: 4,
+          line: 2,
+          messageId: 'preferRecord',
+        },
+      ],
+      output: `
+type Foo = Record<string, Bar>;
+
+interface Bar {
+  [key: string];
+}
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -49,6 +49,123 @@ interface Foo<T> {
   [key: string]: Foo<T> | string;
 }
     `,
+    `
+interface Foo {
+  [s: string]: Foo & {};
+}
+    `,
+    `
+interface Foo {
+  [s: string]: Foo | string;
+}
+    `,
+    `
+interface Foo<T> {
+  [s: string]: Foo extends T ? string : number;
+}
+    `,
+    `
+interface Foo<T> {
+  [s: string]: T extends Foo ? string : number;
+}
+    `,
+    `
+interface Foo<T> {
+  [s: string]: T extends true ? Foo : number;
+}
+    `,
+    `
+interface Foo<T> {
+  [s: string]: T extends true ? string : Foo;
+}
+    `,
+    `
+interface Foo {
+  [s: string]: Foo[number];
+}
+    `,
+    `
+interface Foo {
+  [s: string]: {}[Foo];
+}
+    `,
+
+    // circular (indirect)
+    `
+interface Foo1 {
+  [key: string]: Foo2;
+}
+
+interface Foo2 {
+  [key: string]: Foo1;
+}
+    `,
+    `
+interface Foo1 {
+  [key: string]: Foo2;
+}
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Foo1;
+}
+    `,
+    `
+interface Foo1 {
+  [key: string]: Foo2;
+}
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Record<string, Foo1>;
+}
+    `,
+    `
+type Foo1 = {
+  [key: string]: Foo2;
+};
+
+type Foo2 = {
+  [key: string]: Foo3;
+};
+
+type Foo3 = {
+  [key: string]: Foo1;
+};
+    `,
+    `
+interface Foo1 {
+  [key: string]: Foo2;
+}
+
+type Foo2 = {
+  [key: string]: Foo3;
+};
+
+interface Foo3 {
+  [key: string]: Foo1;
+}
+    `,
+    `
+type Foo1 = {
+  [key: string]: Foo2;
+};
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Foo1;
+}
+    `,
+
     // Type literal
     'type Foo = {};',
     `
@@ -390,6 +507,133 @@ interface Foo {
 interface Foo {
   [k: string]: Record<string, Foo>;
 }
+      `,
+    },
+    {
+      code: `
+interface Foo {
+  [key: string]: { foo: Foo };
+}
+      `,
+      errors: [{ column: 1, line: 2, messageId: 'preferRecord' }],
+      output: `
+type Foo = Record<string, { foo: Foo }>;
+      `,
+    },
+    {
+      code: `
+interface Foo {
+  [key: string]: Foo[];
+}
+      `,
+      errors: [{ column: 1, line: 2, messageId: 'preferRecord' }],
+      output: `
+type Foo = Record<string, Foo[]>;
+      `,
+    },
+    {
+      code: `
+interface Foo {
+  [key: string]: () => Foo;
+}
+      `,
+      errors: [{ column: 1, line: 2, messageId: 'preferRecord' }],
+      output: `
+type Foo = Record<string, () => Foo>;
+      `,
+    },
+    {
+      code: `
+interface Foo {
+  [s: string]: [Foo];
+}
+      `,
+      errors: [{ column: 1, line: 2, messageId: 'preferRecord' }],
+      output: `
+type Foo = Record<string, [Foo]>;
+      `,
+    },
+
+    // Circular (indirect)
+    {
+      code: `
+interface Foo1 {
+  [key: string]: Foo2;
+}
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Foo2;
+}
+      `,
+      errors: [{ column: 1, line: 2, messageId: 'preferRecord' }],
+      output: `
+type Foo1 = Record<string, Foo2>;
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Foo2;
+}
+      `,
+    },
+    {
+      code: `
+interface Foo1 {
+  [key: string]: Record<string, Foo2>;
+}
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Foo2;
+}
+      `,
+      errors: [{ column: 1, line: 2, messageId: 'preferRecord' }],
+      output: `
+type Foo1 = Record<string, Record<string, Foo2>>;
+
+interface Foo2 {
+  [key: string]: Foo3;
+}
+
+interface Foo3 {
+  [key: string]: Foo2;
+}
+      `,
+    },
+    {
+      code: `
+type Foo1 = {
+  [key: string]: { foo2: Foo2 };
+};
+
+type Foo2 = {
+  [key: string]: Foo3;
+};
+
+type Foo3 = {
+  [key: string]: Record<string, Foo1>;
+};
+      `,
+      errors: [
+        { column: 13, line: 2, messageId: 'preferRecord' },
+        { column: 13, line: 6, messageId: 'preferRecord' },
+        { column: 13, line: 10, messageId: 'preferRecord' },
+      ],
+      output: `
+type Foo1 = Record<string, { foo2: Foo2 }>;
+
+type Foo2 = Record<string, Foo3>;
+
+type Foo3 = Record<string, Record<string, Foo1>>;
       `,
     },
 

--- a/packages/utils/src/json-schema.ts
+++ b/packages/utils/src/json-schema.ts
@@ -32,8 +32,6 @@ export type JSONSchema4TypeExtended =
   | JSONSchema4Object
   | JSONSchema4Type;
 
-// Workaround for infinite type recursion
-// Also, https://github.com/typescript-eslint/typescript-eslint/issues/7863
 export interface JSONSchema4Object {
   [key: string]: JSONSchema4TypeExtended;
 }

--- a/packages/utils/src/json-schema.ts
+++ b/packages/utils/src/json-schema.ts
@@ -34,7 +34,6 @@ export type JSONSchema4TypeExtended =
 
 // Workaround for infinite type recursion
 // Also, https://github.com/typescript-eslint/typescript-eslint/issues/7863
-// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 export interface JSONSchema4Object {
   [key: string]: JSONSchema4TypeExtended;
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7863
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR tackles #7863 and replaces the current logic for detecting circular references with one that also checks for indirect cycles:

```ts
export type ExampleUnion = boolean | number;

export type ExampleRoot = ExampleUnion | ExampleObject;

export interface ExampleObject {
  [key: string]: ExampleRoot;
}
```

The PR also flags some recursive patterns that are valid as a type reference (and can be fixed into a `Record<...>` form), which currently the rule doesn't flag ([playground link](https://typescript-eslint.io/play/#ts=5.7.2&fileType=.ts&code=JYOwLgpgTgZghgYwgAgCoQM5gIzIN4BQyyA2gNYQCeAXMllKAOYC6teyMA9p7elrgF8A3AQEECAegnIwACxRwARpwBuKYBmQB5ANLI4muDMoAHFFAgxoEEEmSKArmGQaQAcmcWTnKJAAmBGCmKHxgAEzIALzIAEoQCD5%2BADz0TAA0%2BBzcvJjhyAIAfCIEoJCwiCG5AMz4RKQUNHRgDCAsOVhVJMwiYpLScgrKai6auvqGxmbIFlYWtiiOzq4e0xDevhABQVOhACxRsfGJKc3paLm7XUXipdDwdqEArLXE5FS0qa2syAAUAJRRArnLCPHriKQyeT6IbqUZ6Az6SbmSzWeb2JwjdyeNY%2BfyBYLAsAANgOcQSUGSn0YGX%2BgMJROuQA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6MgeyeUuX0Ra1mAE0QAPRMNocARgCtEZOn0JJ0URNGgdokcGAC%2BIA0A&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)). There is no open issue for this, but it made sense to me. This means the rule will flag certain recursive patterns that it currently doesn't.