### PR TITLE
fix(eslint-plugin): [no-shadow] report correctly on parameters of functions declared with the `declare` keyword

### DIFF
--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -24,6 +24,7 @@ const allowedFunctionVariableDefTypes = new Set([
   AST_NODE_TYPES.TSMethodSignature,
   AST_NODE_TYPES.TSEmptyBodyFunctionExpression,
   AST_NODE_TYPES.TSDeclareFunction,
+  AST_NODE_TYPES.TSConstructSignatureDeclaration,
 ]);
 
 export default createRule<Options, MessageIds>({

--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -274,13 +274,14 @@ export default createRule<Options, MessageIds>({
       );
     }
 
-    function isParameterOfFunctionDeclaration(
+    function isParameterOfTypeOnlyFunctionDeclaration(
       variable: TSESLint.Scope.Variable,
     ): boolean {
       return (
-        variable.scope.block.type === AST_NODE_TYPES.TSDeclareFunction ||
-        variable.scope.block.type ===
-          AST_NODE_TYPES.TSEmptyBodyFunctionExpression
+        (variable.scope.block.type === AST_NODE_TYPES.TSDeclareFunction ||
+          variable.scope.block.type ===
+            AST_NODE_TYPES.TSEmptyBodyFunctionExpression) &&
+        variable.defs[0].type === DefinitionType.Parameter
       );
     }
 
@@ -575,7 +576,7 @@ export default createRule<Options, MessageIds>({
         }
 
         // ignore variables of function declarations or function/method overloads
-        if (isParameterOfFunctionDeclaration(variable)) {
+        if (isParameterOfTypeOnlyFunctionDeclaration(variable)) {
           continue;
         }
 

--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -274,6 +274,16 @@ export default createRule<Options, MessageIds>({
       );
     }
 
+    function isParameterOfFunctionDeclaration(
+      variable: TSESLint.Scope.Variable,
+    ): boolean {
+      return (
+        variable.scope.block.type === AST_NODE_TYPES.TSDeclareFunction ||
+        variable.scope.block.type ===
+          AST_NODE_TYPES.TSEmptyBodyFunctionExpression
+      );
+    }
+
     /**
      * Check if variable name is allowed.
      * @param variable The variable to check.
@@ -561,6 +571,11 @@ export default createRule<Options, MessageIds>({
 
         // this params are pseudo-params that cannot be shadowed
         if (isThisParam(variable)) {
+          continue;
+        }
+
+        // ignore variables of function declarations or function/method overloads
+        if (isParameterOfFunctionDeclaration(variable)) {
           continue;
         }
 

--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -25,6 +25,7 @@ const allowedFunctionVariableDefTypes = new Set([
   AST_NODE_TYPES.TSEmptyBodyFunctionExpression,
   AST_NODE_TYPES.TSDeclareFunction,
   AST_NODE_TYPES.TSConstructSignatureDeclaration,
+  AST_NODE_TYPES.TSConstructorType,
 ]);
 
 export default createRule<Options, MessageIds>({

--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -22,6 +22,8 @@ const allowedFunctionVariableDefTypes = new Set([
   AST_NODE_TYPES.TSCallSignatureDeclaration,
   AST_NODE_TYPES.TSFunctionType,
   AST_NODE_TYPES.TSMethodSignature,
+  AST_NODE_TYPES.TSEmptyBodyFunctionExpression,
+  AST_NODE_TYPES.TSDeclareFunction,
 ]);
 
 export default createRule<Options, MessageIds>({
@@ -271,17 +273,6 @@ export default createRule<Options, MessageIds>({
         secondDefinition.node.type === AST_NODE_TYPES.TSInterfaceDeclaration &&
         secondDefinition.node.parent.type ===
           AST_NODE_TYPES.ExportNamedDeclaration
-      );
-    }
-
-    function isParameterOfTypeOnlyFunctionDeclaration(
-      variable: TSESLint.Scope.Variable,
-    ): boolean {
-      return (
-        (variable.scope.block.type === AST_NODE_TYPES.TSDeclareFunction ||
-          variable.scope.block.type ===
-            AST_NODE_TYPES.TSEmptyBodyFunctionExpression) &&
-        variable.defs[0].type === DefinitionType.Parameter
       );
     }
 
@@ -572,11 +563,6 @@ export default createRule<Options, MessageIds>({
 
         // this params are pseudo-params that cannot be shadowed
         if (isThisParam(variable)) {
-          continue;
-        }
-
-        // ignore variables of function declarations or function/method overloads
-        if (isParameterOfTypeOnlyFunctionDeclaration(variable)) {
           continue;
         }
 

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -281,6 +281,24 @@ declare const Test: {
       code: `
 const arg = 0;
 
+type Bar = new (arg: number) => typeof arg;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'arg',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }],
+    },
+    {
+      code: `
+const arg = 0;
+
 declare namespace Lib {
   function test(arg: string): typeof arg;
 }
@@ -750,6 +768,14 @@ const arg = 0;
 declare const Test: {
   new (arg: string): typeof arg;
 };
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
+    },
+    {
+      code: `
+const arg = 0;
+
+type Bar = new (arg: number) => typeof arg;
       `,
       options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
     },

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -203,6 +203,82 @@ interface Test {
     },
     {
       code: `
+const arg = 0;
+
+declare function test(arg: string): typeof arg;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'arg',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }],
+    },
+    {
+      code: `
+const arg = 0;
+
+declare const test: (arg: string) => typeof arg;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'arg',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }],
+    },
+    {
+      code: `
+const arg = 0;
+
+declare class Test {
+  p1(arg: string): typeof arg;
+}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'arg',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }],
+    },
+    {
+      code: `
+const arg = 0;
+
+declare namespace Lib {
+  function test(arg: string): typeof arg;
+}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'arg',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }],
+    },
+    {
+      code: `
 import type { foo } from './foo';
 function doThing(foo: number) {}
       `,
@@ -459,71 +535,6 @@ function foo<T extends (...args: any[]) => any>(fn: T, args: any[]) {}
         },
       ],
     },
-    {
-      code: `
-const methodParam = 1;
-
-class SomeClass {
-  someMethod(): number;
-  someMethod(methodParam: boolean): boolean;
-  someMethod(methodParam?: boolean): boolean | number {
-    return 10;
-  }
-}
-      `,
-      errors: [
-        {
-          data: {
-            name: 'methodParam',
-            shadowedColumn: 7,
-            shadowedLine: 2,
-          },
-          messageId: 'noShadow',
-        },
-      ],
-    },
-    {
-      code: `
-const methodParam = 1;
-
-function someFunction(): number;
-function someFunction(methodParam: boolean): boolean;
-function someFunction(methodParam?: boolean): boolean | number {
-  return 10;
-}
-      `,
-      errors: [
-        {
-          data: {
-            name: 'methodParam',
-            shadowedColumn: 7,
-            shadowedLine: 2,
-          },
-          messageId: 'noShadow',
-        },
-      ],
-    },
-    {
-      code: `
-type T = 1;
-
-function someFunction(): number;
-function someFunction<T>(methodParam: boolean): T;
-function someFunction(methodParam?: boolean): boolean | number {
-  return 10;
-}
-      `,
-      errors: [
-        {
-          data: {
-            name: 'T',
-            shadowedColumn: 6,
-            shadowedLine: 2,
-          },
-          messageId: 'noShadow',
-        },
-      ],
-    },
   ],
   valid: [
     'function foo<T = (arg: any) => any>(arg: T) {}',
@@ -682,6 +693,42 @@ const arg = 0;
 
 interface Test {
   p1(arg: string): typeof arg;
+}
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
+    },
+    {
+      code: `
+const arg = 0;
+
+declare function test(arg: string): typeof arg;
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
+    },
+    {
+      code: `
+const arg = 0;
+
+declare const test: (arg: string) => typeof arg;
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
+    },
+    {
+      code: `
+const arg = 0;
+
+declare class Test {
+  p1(arg: string): typeof arg;
+}
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
+    },
+    {
+      code: `
+const arg = 0;
+
+declare namespace Lib {
+  function test(arg: string): typeof arg;
 }
       `,
       options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
@@ -924,29 +971,5 @@ const person = {
       options: [{ ignoreOnInitialization: true }],
     },
     { code: 'const [x = y => y] = [].map(y => y);' },
-    {
-      code: `
-const functionParam = 1;
-declare function someFunction(functionParam: any): void;
-      `,
-    },
-    {
-      code: `
-const constructorParam = 1;
-
-declare class SomeClass {
-  constructor(constructorParam: number);
-}
-      `,
-    },
-    {
-      code: `
-const functionParam = 1;
-
-declare namespace myLib {
-  function someFunction(functionParam: string): string;
-}
-      `,
-    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -503,6 +503,48 @@ function someFunction(methodParam?: boolean): boolean | number {
         },
       ],
     },
+    {
+      code: `
+const methodParam = 1;
+
+function someFunction(): number;
+function someFunction([methodParam]: [boolean]): boolean;
+function someFunction(methodParam?: [boolean]): boolean | number {
+  return 10;
+}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'methodParam',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+    },
+    {
+      code: `
+type T = 1;
+
+function someFunction(): number;
+function someFunction<T>(methodParam: boolean): T extends true ? 1 : 2;
+function someFunction(methodParam?: boolean): boolean | number {
+  return 10;
+}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'T',
+            shadowedColumn: 6,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+    },
   ],
   valid: [
     'function foo<T = (arg: any) => any>(arg: T) {}',

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -459,6 +459,50 @@ function foo<T extends (...args: any[]) => any>(fn: T, args: any[]) {}
         },
       ],
     },
+    {
+      code: `
+const methodParam = 1;
+
+class SomeClass {
+  someMethod(): number;
+  someMethod(methodParam: boolean): boolean;
+  someMethod(methodParam?: boolean): boolean | number {
+    return 10;
+  }
+}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'methodParam',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+    },
+    {
+      code: `
+const methodParam = 1;
+
+function someFunction(): number;
+function someFunction(methodParam: boolean): boolean;
+function someFunction(methodParam?: boolean): boolean | number {
+  return 10;
+}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'methodParam',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+    },
   ],
   valid: [
     'function foo<T = (arg: any) => any>(arg: T) {}',
@@ -859,5 +903,29 @@ const person = {
       options: [{ ignoreOnInitialization: true }],
     },
     { code: 'const [x = y => y] = [].map(y => y);' },
+    {
+      code: `
+const functionParam = 1;
+declare function someFunction(functionParam: any): void;
+      `,
+    },
+    {
+      code: `
+const constructorParam = 1;
+
+declare class SomeClass {
+  constructor(constructorParam: number);
+}
+      `,
+    },
+    {
+      code: `
+const functionParam = 1;
+
+declare namespace myLib {
+  function someFunction(functionParam: string): string;
+}
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -508,7 +508,7 @@ function someFunction(methodParam?: boolean): boolean | number {
 type T = 1;
 
 function someFunction(): number;
-function someFunction<T>(methodParam: boolean): T extends true ? 1 : 2;
+function someFunction<T>(methodParam: boolean): T;
 function someFunction(methodParam?: boolean): boolean | number {
   return 10;
 }

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -261,6 +261,26 @@ declare class Test {
       code: `
 const arg = 0;
 
+declare const Test: {
+  new (arg: string): typeof arg;
+};
+      `,
+      errors: [
+        {
+          data: {
+            name: 'arg',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }],
+    },
+    {
+      code: `
+const arg = 0;
+
 declare namespace Lib {
   function test(arg: string): typeof arg;
 }
@@ -720,6 +740,16 @@ const arg = 0;
 declare class Test {
   p1(arg: string): typeof arg;
 }
+      `,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
+    },
+    {
+      code: `
+const arg = 0;
+
+declare const Test: {
+  new (arg: string): typeof arg;
+};
       `,
       options: [{ ignoreFunctionTypeParameterNameValueShadow: true }],
     },

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -505,27 +505,6 @@ function someFunction(methodParam?: boolean): boolean | number {
     },
     {
       code: `
-const methodParam = 1;
-
-function someFunction(): number;
-function someFunction([methodParam]: [boolean]): boolean;
-function someFunction(methodParam?: [boolean]): boolean | number {
-  return 10;
-}
-      `,
-      errors: [
-        {
-          data: {
-            name: 'methodParam',
-            shadowedColumn: 7,
-            shadowedLine: 2,
-          },
-          messageId: 'noShadow',
-        },
-      ],
-    },
-    {
-      code: `
 type T = 1;
 
 function someFunction(): number;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10539
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10539 and adjusts the rule to include the following ways of defining functions (and their parameters) behind the `ignoreFunctionTypeParameterNameValueShadow` flag: 

```ts
const arg1 = 0;
declare function test1(arg1: string): typeof arg1;

const arg2 = 0;
declare class Test3 {
  p2(arg2: string): typeof arg2;
}
```