### PR TITLE
fix(typescript-estree): replace `fast-glob` with `tinyglobby`

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@types/babel__code-frame": "^7.0.6",
     "@types/babel__core": "^7.20.5",
     "@types/debug": "^4.1.12",
-    "@types/is-glob": "^4.0.4",
     "@types/jest": "29.5.13",
     "@types/jest-specific-snapshot": "^0.5.9",
     "@types/natural-compare": "^1.4.3",

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -57,7 +57,6 @@
     "@typescript-eslint/types": "8.18.1",
     "@typescript-eslint/visitor-keys": "8.18.1",
     "debug": "^4.3.4",
-    "is-glob": "^4.0.3",
     "minimatch": "^9.0.4",
     "semver": "^7.6.0",
     "tinyglobby": "^0.2.10",

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -57,10 +57,10 @@
     "@typescript-eslint/types": "8.18.1",
     "@typescript-eslint/visitor-keys": "8.18.1",
     "debug": "^4.3.4",
-    "fast-glob": "^3.3.2",
     "is-glob": "^4.0.3",
     "minimatch": "^9.0.4",
     "semver": "^7.6.0",
+    "tinyglobby": "^0.2.10",
     "ts-api-utils": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
+++ b/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
@@ -84,8 +84,12 @@ export function resolveProjectList(
   }
 
   // Transform glob patterns into paths
-  const nonGlobProjects = sanitizedProjects.filter(project => !isGlob(project));
-  const globProjects = sanitizedProjects.filter(project => isGlob(project));
+  const nonGlobProjects = sanitizedProjects.filter(
+    project => !isDynamicPattern(project),
+  );
+  const globProjects = sanitizedProjects.filter(project =>
+    isDynamicPattern(project),
+  );
 
   let globProjectPaths: string[] = [];
 

--- a/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
+++ b/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
@@ -59,8 +59,7 @@ export function resolveProjectList(
     options.projectFolderIgnoreList ?? ['**/node_modules/**']
   )
     .filter(folder => typeof folder === 'string')
-    // prefix with a ! for not match glob
-    .map(folder => (folder.startsWith('!') ? folder : `!${folder}`));
+    .map(folder => (folder.startsWith('!') ? folder.slice(1) : folder));
 
   const cacheKey = getHash({
     project: sanitizedProjects,

--- a/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
+++ b/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
@@ -1,6 +1,5 @@
 import debug from 'debug';
-import isGlob from 'is-glob';
-import { globSync } from 'tinyglobby';
+import { globSync, isDynamicPattern } from 'tinyglobby';
 
 import type { CanonicalPath } from '../create-program/shared';
 import type { TSESTreeOptions } from '../parser-options';

--- a/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
+++ b/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
@@ -1,6 +1,6 @@
 import debug from 'debug';
-import { sync as globSync } from 'fast-glob';
 import isGlob from 'is-glob';
+import { globSync } from 'tinyglobby';
 
 import type { CanonicalPath } from '../create-program/shared';
 import type { TSESTreeOptions } from '../parser-options';
@@ -92,9 +92,6 @@ export function resolveProjectList(
   let globProjectPaths: string[] = [];
 
   if (globProjects.length > 0) {
-    // Although fast-glob supports multiple patterns, fast-glob returns arbitrary order of results
-    // to improve performance. To ensure the order is correct, we need to call fast-glob for each pattern
-    // separately and then concatenate the results in patterns' order.
     globProjectPaths = globProjects.flatMap(pattern =>
       globSync(pattern, {
         cwd: options.tsconfigRootDir,

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -44,7 +44,7 @@ jest.mock('tinyglobby', () => {
   const tg = jest.requireActual<typeof tinyglobby>('tinyglobby');
   return {
     ...tg,
-    globSync: jest.fn(tinyglobby.globSync),
+    globSync: jest.fn(tg.globSync),
   };
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5213,13 +5213,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/is-glob@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "@types/is-glob@npm:4.0.4"
-  checksum: c790125e2d133d15c9783f6468995841cb06b5634b5c7b30aa32d23129f19d7dc271ec1a904bea4ca1e6a5ba19218a6602753d558f343b4fb8402fed25d17219
-  languageName: node
-  linkType: hard
-
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
   version: 2.0.4
   resolution: "@types/istanbul-lib-coverage@npm:2.0.4"
@@ -5816,7 +5809,6 @@ __metadata:
     "@types/babel__code-frame": ^7.0.6
     "@types/babel__core": ^7.20.5
     "@types/debug": ^4.1.12
-    "@types/is-glob": ^4.0.4
     "@types/jest": 29.5.13
     "@types/jest-specific-snapshot": ^0.5.9
     "@types/natural-compare": ^1.4.3
@@ -5880,7 +5872,6 @@ __metadata:
     "@typescript-eslint/visitor-keys": 8.18.1
     debug: ^4.3.4
     glob: "*"
-    is-glob: ^4.0.3
     jest: 29.7.0
     minimatch: ^9.0.4
     prettier: ^3.2.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -5879,7 +5879,6 @@ __metadata:
     "@typescript-eslint/types": 8.18.1
     "@typescript-eslint/visitor-keys": 8.18.1
     debug: ^4.3.4
-    fast-glob: ^3.3.2
     glob: "*"
     is-glob: ^4.0.3
     jest: 29.7.0
@@ -5887,6 +5886,7 @@ __metadata:
     prettier: ^3.2.5
     rimraf: "*"
     semver: ^7.6.0
+    tinyglobby: ^0.2.10
     tmp: "*"
     ts-api-utils: ^1.3.0
     typescript: "*"


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10533
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR migrates from `fast-glob` to `tinyglobby`. For more information, you can see the issue that this PR fixes: #10533
