### PR TITLE
fix(eslint-plugin): [no-deprecated] doesn't report on shorthand property in an object expression

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -312,9 +312,17 @@ export default createRule({
         const property = services
           .getTypeAtLocation(node.parent.parent)
           .getProperty(node.name);
-        const symbol = services.getSymbolAtLocation(node);
-        return getJsDocDeprecation(property) ?? getJsDocDeprecation(symbol);
+        const propertySymbol = services.getSymbolAtLocation(node);
+        const valueSymbol = checker.getShorthandAssignmentValueSymbol(
+          propertySymbol?.valueDeclaration,
+        );
+        return (
+          getJsDocDeprecation(property) ??
+          getJsDocDeprecation(propertySymbol) ??
+          getJsDocDeprecation(valueSymbol)
+        );
       }
+
       return searchForDeprecationInAliasesChain(
         services.getSymbolAtLocation(node),
         true,

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -312,6 +312,10 @@ ruleTester.run('no-deprecated', rule, {
       }
       <foo bar={1} />;
     `,
+    `
+      declare const test: string;
+      const bar = { test };
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -713,6 +713,25 @@ ruleTester.run('no-deprecated', rule, {
     },
     {
       code: `
+        /** @deprecated */
+        declare const test: string;
+        const bar = {
+          test,
+        };
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { name: 'test' },
+          endColumn: 15,
+          endLine: 5,
+          line: 5,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
         /** @deprecated */ const a = { b: 1 };
         const { c = 'd' } = a.b;
       `,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10545
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

I have fixed the bug in the title.

🐛