### PR TITLE
chore: export all Options and MessageIds types from rule files

### DIFF
--- a/packages/eslint-plugin/src/rules/array-type.ts
+++ b/packages/eslint-plugin/src/rules/array-type.ts
@@ -73,13 +73,13 @@ function typeNeedsParentheses(node: TSESTree.Node): boolean {
 }
 
 export type OptionString = 'array' | 'array-simple' | 'generic';
-type Options = [
+export type Options = [
   {
     default: OptionString;
     readonly?: OptionString;
   },
 ];
-type MessageIds =
+export type MessageIds =
   | 'errorStringArray'
   | 'errorStringArrayReadonly'
   | 'errorStringArraySimple'

--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -15,7 +15,7 @@ import {
 } from '../util';
 import { getForStatementHeadLoc } from '../util/getForStatementHeadLoc';
 
-type MessageId =
+export type MessageId =
   | 'await'
   | 'awaitUsingOfNonAsyncDisposable'
   | 'convertToOrdinaryFor'

--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -19,7 +19,7 @@ interface Options {
 
 const defaultMinimumDescriptionLength = 3;
 
-type MessageIds =
+export type MessageIds =
   | 'replaceTsIgnoreWithTsExpectError'
   | 'tsDirectiveComment'
   | 'tsDirectiveCommentDescriptionNotMatchPattern'

--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -4,12 +4,14 @@ import { AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 
 import { createRule, getStringLength, nullThrows } from '../util';
 
-type DirectiveConfig =
+const defaultMinimumDescriptionLength = 3;
+
+export type DirectiveConfig =
   | boolean
   | 'allow-with-description'
   | { descriptionFormat: string };
 
-interface Options {
+export interface OptionsShape {
   minimumDescriptionLength?: number;
   'ts-check'?: DirectiveConfig;
   'ts-expect-error'?: DirectiveConfig;
@@ -17,7 +19,7 @@ interface Options {
   'ts-nocheck'?: DirectiveConfig;
 }
 
-const defaultMinimumDescriptionLength = 3;
+export type Options = [OptionsShape];
 
 export type MessageIds =
   | 'replaceTsIgnoreWithTsExpectError'
@@ -31,7 +33,7 @@ interface MatchedTSDirective {
   directive: string;
 }
 
-export default createRule<[Options], MessageIds>({
+export default createRule<Options, MessageIds>({
   name: 'ban-ts-comment',
   meta: {
     type: 'problem',
@@ -203,7 +205,7 @@ export default createRule<[Options], MessageIds>({
             return;
           }
 
-          const fullDirective = `ts-${directive}` as keyof Options;
+          const fullDirective = `ts-${directive}` as keyof OptionsShape;
 
           const option = options[fullDirective];
           if (option === true) {

--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -11,8 +11,8 @@ import {
   nullThrows,
 } from '../util';
 
-type Options = ['fields' | 'getters'];
-type MessageIds =
+export type Options = ['fields' | 'getters'];
+export type MessageIds =
   | 'preferFieldStyle'
   | 'preferFieldStyleSuggestion'
   | 'preferGetterStyle'

--- a/packages/eslint-plugin/src/rules/class-methods-use-this.ts
+++ b/packages/eslint-plugin/src/rules/class-methods-use-this.ts
@@ -9,7 +9,7 @@ import {
   getStaticMemberAccessValue,
 } from '../util';
 
-type Options = [
+export type Options = [
   {
     enforceForClassFields?: boolean;
     exceptMethods?: string[];
@@ -17,7 +17,7 @@ type Options = [
     ignoreOverrideMethods?: boolean;
   },
 ];
-type MessageIds = 'missingThis';
+export type MessageIds = 'missingThis';
 
 export default createRule<Options, MessageIds>({
   name: 'class-methods-use-this',

--- a/packages/eslint-plugin/src/rules/consistent-generic-constructors.ts
+++ b/packages/eslint-plugin/src/rules/consistent-generic-constructors.ts
@@ -4,8 +4,8 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import { createRule, nullThrows, NullThrowsReasons } from '../util';
 
-type MessageIds = 'preferConstructor' | 'preferTypeAnnotation';
-type Options = ['constructor' | 'type-annotation'];
+export type MessageIds = 'preferConstructor' | 'preferTypeAnnotation';
+export type Options = ['constructor' | 'type-annotation'];
 
 export default createRule<Options, MessageIds>({
   name: 'consistent-generic-constructors',

--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -10,11 +10,11 @@ import {
   nullThrows,
 } from '../util';
 
-type MessageIds =
+export type MessageIds =
   | 'preferIndexSignature'
   | 'preferIndexSignatureSuggestion'
   | 'preferRecord';
-type Options = ['index-signature' | 'record'];
+export type Options = ['index-signature' | 'record'];
 
 export default createRule<Options, MessageIds>({
   name: 'consistent-indexed-object-style',

--- a/packages/eslint-plugin/src/rules/consistent-return.ts
+++ b/packages/eslint-plugin/src/rules/consistent-return.ts
@@ -13,8 +13,8 @@ import { getESLintCoreRule } from '../util/getESLintCoreRule';
 
 const baseRule = getESLintCoreRule('consistent-return');
 
-type Options = InferOptionsTypeFromRule<typeof baseRule>;
-type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+export type Options = InferOptionsTypeFromRule<typeof baseRule>;
+export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
 
 type FunctionNode =
   | TSESTree.ArrowFunctionExpression

--- a/packages/eslint-plugin/src/rules/consistent-type-exports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-exports.ts
@@ -14,7 +14,7 @@ import {
   NullThrowsReasons,
 } from '../util';
 
-type Options = [
+export type Options = [
   {
     fixMixedExportsWithInlineTypeSpecifier: boolean;
   },
@@ -34,7 +34,7 @@ interface ReportValueExport {
   valueSpecifiers: TSESTree.ExportSpecifier[];
 }
 
-type MessageIds =
+export type MessageIds =
   | 'multipleExportsAreTypes'
   | 'singleExportIsType'
   | 'typeOverValue';

--- a/packages/eslint-plugin/src/rules/consistent-type-imports.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-imports.ts
@@ -19,7 +19,7 @@ import {
 type Prefer = 'no-type-imports' | 'type-imports';
 type FixStyle = 'inline-type-imports' | 'separate-type-imports';
 
-type Options = [
+export type Options = [
   {
     disallowTypeAnnotations?: boolean;
     fixStyle?: FixStyle;
@@ -45,7 +45,7 @@ interface ReportValueImport {
   valueSpecifiers: TSESTree.ImportClause[];
 }
 
-type MessageIds =
+export type MessageIds =
   | 'avoidImportType'
   | 'noImportTypeAnnotations'
   | 'someImportsAreOnlyTypes'

--- a/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
+++ b/packages/eslint-plugin/src/rules/explicit-function-return-type.ts
@@ -11,7 +11,7 @@ import {
   isValidFunctionExpressionReturnType,
 } from '../util/explicitReturnTypeUtils';
 
-type Options = [
+export type Options = [
   {
     allowConciseArrowFunctionExpressionsStartingWithVoid?: boolean;
     allowDirectConstAssertionInArrowFunctions?: boolean;
@@ -23,7 +23,7 @@ type Options = [
     allowTypedFunctionExpressions?: boolean;
   },
 ];
-type MessageIds = 'missingReturnType';
+export type MessageIds = 'missingReturnType';
 
 type FunctionNode =
   | TSESTree.ArrowFunctionExpression

--- a/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
+++ b/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
@@ -31,9 +31,9 @@ interface Config {
   };
 }
 
-type Options = [Config];
+export type Options = [Config];
 
-type MessageIds =
+export type MessageIds =
   | 'addExplicitAccessibility'
   | 'missingAccessibility'
   | 'unwantedPublicAccessibility';

--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -18,7 +18,7 @@ import {
   isTypedFunctionExpression,
 } from '../util/explicitReturnTypeUtils';
 
-type Options = [
+export type Options = [
   {
     allowArgumentsExplicitlyTypedAsAny?: boolean;
     allowDirectConstAssertionInArrowFunctions?: boolean;
@@ -27,7 +27,7 @@ type Options = [
     allowTypedFunctionExpressions?: boolean;
   },
 ];
-type MessageIds =
+export type MessageIds =
   | 'anyTypedArg'
   | 'anyTypedArgUnnamed'
   | 'missingArgType'

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -789,5 +789,3 @@ function requiresQuoting(
       : `${node.value}`;
   return _requiresQuoting(name, target);
 }
-
-export type { MessageIds, Options };

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -21,7 +21,7 @@ import {
 } from '../util';
 import { Modifiers, parseOptions, SCHEMA } from './naming-convention-utils';
 
-type MessageIds =
+export type MessageIds =
   | 'doesNotMatchFormat'
   | 'doesNotMatchFormatTrimmed'
   | 'missingAffix'
@@ -32,7 +32,7 @@ type MessageIds =
 // Note that this intentionally does not strictly type the modifiers/types properties.
 // This is because doing so creates a huge headache, as the rule's code doesn't need to care.
 // The JSON Schema strictly types these properties, so we know the user won't input invalid config.
-type Options = Selector[];
+export type Options = Selector[];
 
 // This essentially mirrors ESLint's `camelcase` rule
 // note that that rule ignores leading and trailing underscores and only checks those in the middle of a variable name

--- a/packages/eslint-plugin/src/rules/no-array-delete.ts
+++ b/packages/eslint-plugin/src/rules/no-array-delete.ts
@@ -9,7 +9,7 @@ import {
   getParserServices,
 } from '../util';
 
-type MessageId = 'noArrayDelete' | 'useSplice';
+export type MessageId = 'noArrayDelete' | 'useSplice';
 
 export default createRule<[], MessageId>({
   name: 'no-array-delete',

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -18,12 +18,12 @@ enum Usefulness {
   Sometimes = 'may',
 }
 
-type Options = [
+export type Options = [
   {
     ignoredTypeNames?: string[];
   },
 ];
-type MessageIds = 'baseArrayJoin' | 'baseToString';
+export type MessageIds = 'baseArrayJoin' | 'baseToString';
 
 export default createRule<Options, MessageIds>({
   name: 'no-base-to-string',

--- a/packages/eslint-plugin/src/rules/no-confusing-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-non-null-assertion.ts
@@ -8,7 +8,7 @@ import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 
 import { createRule } from '../util';
 
-type MessageId =
+export type MessageId =
   | 'confusingAssign'
   | 'confusingEqual'
   | 'confusingOperator'

--- a/packages/eslint-plugin/src/rules/no-dupe-class-members.ts
+++ b/packages/eslint-plugin/src/rules/no-dupe-class-members.ts
@@ -12,8 +12,8 @@ import { getESLintCoreRule } from '../util/getESLintCoreRule';
 
 const baseRule = getESLintCoreRule('no-dupe-class-members');
 
-type Options = InferOptionsTypeFromRule<typeof baseRule>;
-type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+export type Options = InferOptionsTypeFromRule<typeof baseRule>;
+export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
 
 export default createRule<Options, MessageIds>({
   name: 'no-dupe-class-members',

--- a/packages/eslint-plugin/src/rules/no-empty-function.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-function.ts
@@ -13,8 +13,8 @@ import { getESLintCoreRule } from '../util/getESLintCoreRule';
 
 const baseRule = getESLintCoreRule('no-empty-function');
 
-type Options = InferOptionsTypeFromRule<typeof baseRule>;
-type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+export type Options = InferOptionsTypeFromRule<typeof baseRule>;
+export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
 
 const defaultOptions: Options = [
   {

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -5,12 +5,12 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import { createRule, isDefinitionFile } from '../util';
 
-type Options = [
+export type Options = [
   {
     allowSingleExtends?: boolean;
   },
 ];
-type MessageIds = 'noEmpty' | 'noEmptyWithSuper';
+export type MessageIds = 'noEmpty' | 'noEmptyWithSuper';
 
 export default createRule<Options, MessageIds>({
   name: 'no-empty-interface',

--- a/packages/eslint-plugin/src/rules/no-extraneous-class.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-class.ts
@@ -4,7 +4,7 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import { createRule } from '../util';
 
-type Options = [
+export type Options = [
   {
     allowConstructorOnly?: boolean;
     allowEmpty?: boolean;
@@ -12,7 +12,7 @@ type Options = [
     allowWithDecorator?: boolean;
   },
 ];
-type MessageIds = 'empty' | 'onlyConstructor' | 'onlyStatic';
+export type MessageIds = 'empty' | 'onlyConstructor' | 'onlyStatic';
 
 export default createRule<Options, MessageIds>({
   name: 'no-extraneous-class',

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -28,7 +28,7 @@ export type Options = [
   },
 ];
 
-type MessageId =
+export type MessageId =
   | 'floating'
   | 'floatingFixAwait'
   | 'floatingFixVoid'

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -18,7 +18,7 @@ import {
   typeMatchesSomeSpecifier,
 } from '../util';
 
-type Options = [
+export type Options = [
   {
     allowForKnownSafeCalls?: TypeOrValueSpecifier[];
     allowForKnownSafePromises?: TypeOrValueSpecifier[];

--- a/packages/eslint-plugin/src/rules/no-import-type-side-effects.ts
+++ b/packages/eslint-plugin/src/rules/no-import-type-side-effects.ts
@@ -10,8 +10,8 @@ import {
   NullThrowsReasons,
 } from '../util';
 
-type Options = [];
-type MessageIds = 'useTopLevelQualifier';
+export type Options = [];
+export type MessageIds = 'useTopLevelQualifier';
 
 export default createRule<Options, MessageIds>({
   name: 'no-import-type-side-effects',

--- a/packages/eslint-plugin/src/rules/no-inferrable-types.ts
+++ b/packages/eslint-plugin/src/rules/no-inferrable-types.ts
@@ -5,13 +5,13 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import { createRule, nullThrows, NullThrowsReasons } from '../util';
 
-type Options = [
+export type Options = [
   {
     ignoreParameters?: boolean;
     ignoreProperties?: boolean;
   },
 ];
-type MessageIds = 'noInferrableType';
+export type MessageIds = 'noInferrableType';
 
 export default createRule<Options, MessageIds>({
   name: 'no-inferrable-types',

--- a/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-void-type.ts
@@ -9,7 +9,7 @@ interface Options {
   allowInGenericTypeArguments?: boolean | [string, ...string[]];
 }
 
-type MessageIds =
+export type MessageIds =
   | 'invalidVoidForGeneric'
   | 'invalidVoidNotReturn'
   | 'invalidVoidNotReturnOrGeneric'

--- a/packages/eslint-plugin/src/rules/no-loop-func.ts
+++ b/packages/eslint-plugin/src/rules/no-loop-func.ts
@@ -12,8 +12,8 @@ import { getESLintCoreRule } from '../util/getESLintCoreRule';
 
 const baseRule = getESLintCoreRule('no-loop-func');
 
-type Options = InferOptionsTypeFromRule<typeof baseRule>;
-type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+export type Options = InferOptionsTypeFromRule<typeof baseRule>;
+export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
 
 export default createRule<Options, MessageIds>({
   name: 'no-loop-func',

--- a/packages/eslint-plugin/src/rules/no-loss-of-precision.ts
+++ b/packages/eslint-plugin/src/rules/no-loss-of-precision.ts
@@ -8,8 +8,10 @@ import { getESLintCoreRule } from '../util/getESLintCoreRule';
 
 const baseRule = getESLintCoreRule('no-loss-of-precision');
 
-type Options = InferOptionsTypeFromRule<NonNullable<typeof baseRule>>;
-type MessageIds = InferMessageIdsTypeFromRule<NonNullable<typeof baseRule>>;
+export type Options = InferOptionsTypeFromRule<NonNullable<typeof baseRule>>;
+export type MessageIds = InferMessageIdsTypeFromRule<
+  NonNullable<typeof baseRule>
+>;
 
 export default createRule<Options, MessageIds>({
   name: 'no-loss-of-precision',

--- a/packages/eslint-plugin/src/rules/no-magic-numbers.ts
+++ b/packages/eslint-plugin/src/rules/no-magic-numbers.ts
@@ -13,8 +13,8 @@ import { getESLintCoreRule } from '../util/getESLintCoreRule';
 
 const baseRule = getESLintCoreRule('no-magic-numbers');
 
-type Options = InferOptionsTypeFromRule<typeof baseRule>;
-type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+export type Options = InferOptionsTypeFromRule<typeof baseRule>;
+export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
 
 // Extend base schema with additional property to ignore TS numeric literal types
 const schema = deepMerge(

--- a/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
+++ b/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
@@ -6,7 +6,7 @@ import * as ts from 'typescript';
 
 import { createRule } from '../util';
 
-type Options = [
+export type Options = [
   {
     checkNever: boolean;
   },

--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -32,7 +32,7 @@ interface ChecksVoidReturnOptions {
   variables?: boolean;
 }
 
-type MessageId =
+export type MessageId =
   | 'conditional'
   | 'predicate'
   | 'spread'

--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -15,7 +15,7 @@ import {
   NullThrowsReasons,
 } from '../util';
 
-type Options = [
+export type Options = [
   {
     checksConditionals?: boolean;
     checksSpreads?: boolean;

--- a/packages/eslint-plugin/src/rules/no-namespace.ts
+++ b/packages/eslint-plugin/src/rules/no-namespace.ts
@@ -4,13 +4,13 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import { createRule, isDefinitionFile } from '../util';
 
-type Options = [
+export type Options = [
   {
     allowDeclarations?: boolean;
     allowDefinitionFiles?: boolean;
   },
 ];
-type MessageIds = 'moduleSyntaxIsPreferred';
+export type MessageIds = 'moduleSyntaxIsPreferred';
 
 export default createRule<Options, MessageIds>({
   name: 'no-namespace',

--- a/packages/eslint-plugin/src/rules/no-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-assertion.ts
@@ -9,7 +9,7 @@ import {
   NullThrowsReasons,
 } from '../util';
 
-type MessageIds = 'noNonNull' | 'suggestOptionalChain';
+export type MessageIds = 'noNonNull' | 'suggestOptionalChain';
 
 export default createRule<[], MessageIds>({
   name: 'no-non-null-assertion',

--- a/packages/eslint-plugin/src/rules/no-redeclare.ts
+++ b/packages/eslint-plugin/src/rules/no-redeclare.ts
@@ -5,8 +5,11 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import { createRule, getNameLocationInGlobalDirectiveComment } from '../util';
 
-type MessageIds = 'redeclared' | 'redeclaredAsBuiltin' | 'redeclaredBySyntax';
-type Options = [
+export type MessageIds =
+  | 'redeclared'
+  | 'redeclaredAsBuiltin'
+  | 'redeclaredBySyntax';
+export type Options = [
   {
     builtinGlobals?: boolean;
     ignoreDeclarationMerge?: boolean;

--- a/packages/eslint-plugin/src/rules/no-require-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-require-imports.ts
@@ -4,13 +4,13 @@ import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 
 import * as util from '../util';
 
-type Options = [
+export type Options = [
   {
     allow?: string[];
     allowAsImport?: boolean;
   },
 ];
-type MessageIds = 'noRequireImports';
+export type MessageIds = 'noRequireImports';
 
 export default util.createRule<Options, MessageIds>({
   name: 'no-require-imports',

--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -6,8 +6,8 @@ import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 import { createRule } from '../util';
 import { isTypeImport } from '../util/isTypeImport';
 
-type MessageIds = 'noShadow' | 'noShadowGlobal';
-type Options = [
+export type MessageIds = 'noShadow' | 'noShadowGlobal';
+export type Options = [
   {
     allow?: string[];
     builtinGlobals?: boolean;

--- a/packages/eslint-plugin/src/rules/no-this-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-this-alias.ts
@@ -4,13 +4,13 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import { createRule } from '../util';
 
-type Options = [
+export type Options = [
   {
     allowDestructuring?: boolean;
     allowedNames?: string[];
   },
 ];
-type MessageIds = 'thisAssignment' | 'thisDestructure';
+export type MessageIds = 'thisAssignment' | 'thisDestructure';
 
 export default createRule<Options, MessageIds>({
   name: 'no-this-alias',

--- a/packages/eslint-plugin/src/rules/no-type-alias.ts
+++ b/packages/eslint-plugin/src/rules/no-type-alias.ts
@@ -11,7 +11,7 @@ type Values =
   | 'in-unions-and-intersections'
   | 'never';
 
-type Options = [
+export type Options = [
   {
     allowAliases?: Values;
     allowCallbacks?: 'always' | 'never';
@@ -23,7 +23,7 @@ type Options = [
     allowTupleTypes?: Values;
   },
 ];
-type MessageIds = 'noCompositionAlias' | 'noTypeAlias';
+export type MessageIds = 'noCompositionAlias' | 'noTypeAlias';
 
 type CompositionType =
   | AST_NODE_TYPES.TSIntersectionType

--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -11,14 +11,14 @@ import {
   isStrongPrecedenceNode,
 } from '../util';
 
-type MessageIds =
+export type MessageIds =
   | 'comparingNullableToFalse'
   | 'comparingNullableToTrueDirect'
   | 'comparingNullableToTrueNegated'
   | 'direct'
   | 'negated';
 
-type Options = [
+export type Options = [
   {
     allowComparingNullableBooleansToFalse?: boolean;
     allowComparingNullableBooleansToTrue?: boolean;

--- a/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
@@ -15,7 +15,7 @@ import {
 } from '../util';
 import { rangeToLoc } from '../util/rangeToLoc';
 
-type MessageId = 'noUnnecessaryTemplateExpression';
+export type MessageId = 'noUnnecessaryTemplateExpression';
 
 const evenNumOfBackslashesRegExp = /(?<!(?:[^\\]|^)(?:\\\\)*\\)/;
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
@@ -22,7 +22,7 @@ type ParameterCapableTSNode =
   | ts.TypeQueryNode
   | ts.TypeReferenceNode;
 
-type MessageIds = 'unnecessaryTypeParameter';
+export type MessageIds = 'unnecessaryTypeParameter';
 
 export default createRule<[], MessageIds>({
   name: 'no-unnecessary-type-arguments',

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -19,12 +19,12 @@ import {
   NullThrowsReasons,
 } from '../util';
 
-type Options = [
+export type Options = [
   {
     typesToIgnore?: string[];
   },
 ];
-type MessageIds = 'contextuallyUnnecessary' | 'unnecessaryAssertion';
+export type MessageIds = 'contextuallyUnnecessary' | 'unnecessaryAssertion';
 
 export default createRule<Options, MessageIds>({
   name: 'no-unnecessary-type-assertion',

--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -14,7 +14,7 @@ import {
   nullThrows,
 } from '../util';
 
-type MessageIds =
+export type MessageIds =
   | 'unsafeArgument'
   | 'unsafeArraySpread'
   | 'unsafeSpread'

--- a/packages/eslint-plugin/src/rules/no-unsafe-call.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-call.ts
@@ -11,7 +11,7 @@ import {
   isTypeAnyType,
 } from '../util';
 
-type MessageIds =
+export type MessageIds =
   | 'unsafeCall'
   | 'unsafeCallThis'
   | 'unsafeNew'

--- a/packages/eslint-plugin/src/rules/no-unsafe-unary-minus.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-unary-minus.ts
@@ -3,8 +3,8 @@ import * as ts from 'typescript';
 
 import * as util from '../util';
 
-type Options = [];
-type MessageIds = 'unaryMinus';
+export type Options = [];
+export type MessageIds = 'unaryMinus';
 
 export default util.createRule<Options, MessageIds>({
   name: 'no-unsafe-unary-minus',

--- a/packages/eslint-plugin/src/rules/no-unused-expressions.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-expressions.ts
@@ -10,8 +10,8 @@ import { getESLintCoreRule } from '../util/getESLintCoreRule';
 
 const baseRule = getESLintCoreRule('no-unused-expressions');
 
-type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
-type Options = InferOptionsTypeFromRule<typeof baseRule>;
+export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+export type Options = InferOptionsTypeFromRule<typeof baseRule>;
 
 const defaultOptions: Options = [
   {

--- a/packages/eslint-plugin/src/rules/no-use-before-define.ts
+++ b/packages/eslint-plugin/src/rules/no-use-before-define.ts
@@ -212,8 +212,8 @@ interface Config {
   typedefs?: boolean;
   variables?: boolean;
 }
-type Options = ['nofunc' | Config];
-type MessageIds = 'noUseBeforeDefine';
+export type Options = ['nofunc' | Config];
+export type MessageIds = 'noUseBeforeDefine';
 
 export default createRule<Options, MessageIds>({
   name: 'no-use-before-define',

--- a/packages/eslint-plugin/src/rules/no-useless-constructor.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-constructor.ts
@@ -12,8 +12,8 @@ import { getESLintCoreRule } from '../util/getESLintCoreRule';
 
 const baseRule = getESLintCoreRule('no-useless-constructor');
 
-type Options = InferOptionsTypeFromRule<typeof baseRule>;
-type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+export type Options = InferOptionsTypeFromRule<typeof baseRule>;
+export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
 
 /**
  * Check if method with accessibility is not useless

--- a/packages/eslint-plugin/src/rules/no-var-requires.ts
+++ b/packages/eslint-plugin/src/rules/no-var-requires.ts
@@ -4,12 +4,12 @@ import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 
 import { createRule, getStaticStringValue } from '../util';
 
-type Options = [
+export type Options = [
   {
     allow: string[];
   },
 ];
-type MessageIds = 'noVarReqs';
+export type MessageIds = 'noVarReqs';
 
 export default createRule<Options, MessageIds>({
   name: 'no-var-requires',

--- a/packages/eslint-plugin/src/rules/only-throw-error.ts
+++ b/packages/eslint-plugin/src/rules/only-throw-error.ts
@@ -15,9 +15,9 @@ import {
   typeOrValueSpecifiersSchema,
 } from '../util';
 
-type MessageIds = 'object' | 'undef';
+export type MessageIds = 'object' | 'undef';
 
-type Options = [
+export type Options = [
   {
     allow?: TypeOrValueSpecifier[];
     allowThrowingAny?: boolean;

--- a/packages/eslint-plugin/src/rules/parameter-properties.ts
+++ b/packages/eslint-plugin/src/rules/parameter-properties.ts
@@ -15,14 +15,14 @@ type Modifier =
 
 type Prefer = 'class-property' | 'parameter-property';
 
-type Options = [
+export type Options = [
   {
     allow?: Modifier[];
     prefer?: Prefer;
   },
 ];
 
-type MessageIds = 'preferClassProperty' | 'preferParameterProperty';
+export type MessageIds = 'preferClassProperty' | 'preferParameterProperty';
 
 export default createRule<Options, MessageIds>({
   name: 'parameter-properties',

--- a/packages/eslint-plugin/src/rules/prefer-destructuring.ts
+++ b/packages/eslint-plugin/src/rules/prefer-destructuring.ts
@@ -19,9 +19,9 @@ type BaseOptions = InferOptionsTypeFromRule<typeof baseRule>;
 type EnforcementOptions = {
   enforceForDeclarationWithTypeAnnotation?: boolean;
 } & BaseOptions[1];
-type Options = [BaseOptions[0], EnforcementOptions];
+export type Options = [BaseOptions[0], EnforcementOptions];
 
-type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
 
 const destructuringTypeConfig: JSONSchema4 = {
   type: 'object',

--- a/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts
+++ b/packages/eslint-plugin/src/rules/prefer-enum-initializers.ts
@@ -2,7 +2,7 @@ import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 
 import { createRule } from '../util';
 
-type MessageIds = 'defineInitializer' | 'defineInitializerSuggestion';
+export type MessageIds = 'defineInitializer' | 'defineInitializerSuggestion';
 
 export default createRule<[], MessageIds>({
   name: 'prefer-enum-initializers',

--- a/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
@@ -12,7 +12,7 @@ import {
   readonlynessOptionsSchema,
 } from '../util';
 
-type Options = [
+export type Options = [
   {
     allow?: TypeOrValueSpecifier[];
     checkParameterProperties?: boolean;
@@ -20,7 +20,7 @@ type Options = [
     treatMethodsAsReadonly?: boolean;
   },
 ];
-type MessageIds = 'shouldBeReadonly';
+export type MessageIds = 'shouldBeReadonly';
 
 export default createRule<Options, MessageIds>({
   name: 'prefer-readonly-parameter-types',

--- a/packages/eslint-plugin/src/rules/prefer-readonly.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly.ts
@@ -15,8 +15,8 @@ import {
   getParameterPropertyHeadLoc,
 } from '../util/getMemberHeadLoc';
 
-type MessageIds = 'preferReadonly';
-type Options = [
+export type MessageIds = 'preferReadonly';
+export type Options = [
   {
     onlyInlineLambdas?: boolean;
   },

--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -26,7 +26,7 @@ export type Options = [
   },
 ];
 
-type MessageIds = 'preferEndsWith' | 'preferStartsWith';
+export type MessageIds = 'preferEndsWith' | 'preferStartsWith';
 
 export default createRule<Options, MessageIds>({
   name: 'prefer-string-starts-ends-with',

--- a/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
+++ b/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
@@ -5,7 +5,7 @@ import { AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 
 import { createRule } from '../util';
 
-type MessageIds = 'preferExpectErrorComment';
+export type MessageIds = 'preferExpectErrorComment';
 
 export default createRule<[], MessageIds>({
   name: 'prefer-ts-expect-error',

--- a/packages/eslint-plugin/src/rules/promise-function-async.ts
+++ b/packages/eslint-plugin/src/rules/promise-function-async.ts
@@ -13,7 +13,7 @@ import {
   NullThrowsReasons,
 } from '../util';
 
-type Options = [
+export type Options = [
   {
     allowAny?: boolean;
     allowedPromiseNames?: string[];
@@ -23,7 +23,7 @@ type Options = [
     checkMethodDeclarations?: boolean;
   },
 ];
-type MessageIds = 'missingAsync';
+export type MessageIds = 'missingAsync';
 
 export default createRule<Options, MessageIds>({
   name: 'promise-function-async',

--- a/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
+++ b/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
@@ -12,7 +12,7 @@ import {
   isTypeFlagSet,
 } from '../util';
 
-type Options = [
+export type Options = [
   {
     allowAny?: boolean;
     allowBoolean?: boolean;
@@ -23,7 +23,7 @@ type Options = [
   },
 ];
 
-type MessageIds = 'bigintAndNumber' | 'invalid' | 'mismatched';
+export type MessageIds = 'bigintAndNumber' | 'invalid' | 'mismatched';
 
 export default createRule<Options, MessageIds>({
   name: 'restrict-plus-operands',

--- a/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
+++ b/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
@@ -56,13 +56,14 @@ const optionTesters = (
   option: `allow${type}` as const,
   tester,
 }));
+
 export type Options = [
   {
     allow?: TypeOrValueSpecifier[];
   } & Partial<Record<(typeof optionTesters)[number]['option'], boolean>>,
 ];
 
-type MessageId = 'invalidType';
+export type MessageId = 'invalidType';
 
 export default createRule<Options, MessageId>({
   name: 'restrict-template-expressions',

--- a/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
+++ b/packages/eslint-plugin/src/rules/restrict-template-expressions.ts
@@ -56,7 +56,7 @@ const optionTesters = (
   option: `allow${type}` as const,
   tester,
 }));
-type Options = [
+export type Options = [
   {
     allow?: TypeOrValueSpecifier[];
   } & Partial<Record<(typeof optionTesters)[number]['option'], boolean>>,

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -23,7 +23,7 @@ interface SwitchMetadata {
   readonly symbolName: string | undefined;
 }
 
-type Options = [
+export type Options = [
   {
     /**
      * If `true`, allow `default` cases on switch statements with exhaustive
@@ -54,7 +54,7 @@ type Options = [
   },
 ];
 
-type MessageIds =
+export type MessageIds =
   | 'addMissingCases'
   | 'dangerousDefaultCase'
   | 'switchIsNotExhaustive';

--- a/packages/eslint-plugin/src/rules/triple-slash-reference.ts
+++ b/packages/eslint-plugin/src/rules/triple-slash-reference.ts
@@ -4,14 +4,14 @@ import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 
 import { createRule } from '../util';
 
-type Options = [
+export type Options = [
   {
     lib?: 'always' | 'never';
     path?: 'always' | 'never';
     types?: 'always' | 'never' | 'prefer-import';
   },
 ];
-type MessageIds = 'tripleSlashReference';
+export type MessageIds = 'tripleSlashReference';
 
 export default createRule<Options, MessageIds>({
   name: 'triple-slash-reference',

--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -15,9 +15,9 @@ const enum OptionKeys {
   VariableDeclarationIgnoreFunction = 'variableDeclarationIgnoreFunction',
 }
 
-type Options = Partial<Record<OptionKeys, boolean>>;
+export type Options = Partial<Record<OptionKeys, boolean>>;
 
-type MessageIds = 'expectedTypedef' | 'expectedTypedefNamed';
+export type MessageIds = 'expectedTypedef' | 'expectedTypedefNamed';
 
 export default createRule<[Options], MessageIds>({
   name: 'typedef',

--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -15,11 +15,11 @@ const enum OptionKeys {
   VariableDeclarationIgnoreFunction = 'variableDeclarationIgnoreFunction',
 }
 
-export type Options = Partial<Record<OptionKeys, boolean>>;
+export type Options = [Partial<Record<OptionKeys, boolean>>];
 
 export type MessageIds = 'expectedTypedef' | 'expectedTypedefNamed';
 
-export default createRule<[Options], MessageIds>({
+export default createRule<Options, MessageIds>({
   name: 'typedef',
   meta: {
     type: 'suggestion',

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -53,12 +53,12 @@ type MethodDefinition =
   | TSESTree.MethodDefinition
   | TSESTree.TSAbstractMethodDefinition;
 
-type MessageIds =
+export type MessageIds =
   | 'omittingRestParameter'
   | 'omittingSingleParameter'
   | 'singleParameterDifference';
 
-type Options = [
+export type Options = [
   {
     ignoreDifferentlyNamedParameters?: boolean;
   },

--- a/packages/eslint-plugin/src/rules/use-unknown-in-catch-callback-variable.ts
+++ b/packages/eslint-plugin/src/rules/use-unknown-in-catch-callback-variable.ts
@@ -14,7 +14,7 @@ import {
   nullThrows,
 } from '../util';
 
-type MessageIds =
+export type MessageIds =
   | 'addUnknownRestTypeAnnotationSuggestion'
   | 'addUnknownTypeAnnotationSuggestion'
   | 'useUnknown'


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10555
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Doesn't export _all_ types that will be flagged by #10554. I think it'll still be useful to make sure the PR's added rule correctly flags internal violations.

💖 