### PR TITLE
feat(scope-manager): only populate implicit globals whose names appear in the file

### DIFF
--- a/packages/scope-manager/tests/lib.test.ts
+++ b/packages/scope-manager/tests/lib.test.ts
@@ -11,29 +11,110 @@ describe('implicit lib definitions', () => {
     expect(variables).toHaveLength(1);
   });
 
-  it('should define an implicit variable if there is a reference', () => {
+  it('should define an implicit variable if there is a value reference', () => {
     const { scopeManager } = parseAndAnalyze('new ArrayBuffer();', {
       lib: ['es2015'],
     });
 
     const variables = scopeManager.variables;
-    expect(
-      variables.some(
-        v => v instanceof ImplicitLibVariable && v.name === 'ArrayBuffer',
-      ),
-    ).toEqual(true);
+    const arrayBufferVariables = variables.filter(
+      v => v.name === 'ArrayBuffer',
+    );
+    expect(arrayBufferVariables).toHaveLength(1);
+    expect(arrayBufferVariables[0]).toBeInstanceOf(ImplicitLibVariable);
   });
 
-  it('should define an implicit variable if there is a collision', () => {
-    const { scopeManager } = parseAndAnalyze('var Symbol = {};', {
+  it('should define an implicit variable if there is a type reference', () => {
+    const { scopeManager } = parseAndAnalyze('type T = ArrayBuffer;', {
       lib: ['es2015'],
     });
 
     const variables = scopeManager.variables;
-    expect(
-      variables.some(
-        v => v instanceof ImplicitLibVariable && v.name === 'Symbol',
-      ),
-    ).toEqual(true);
+    const arrayBufferVariables = variables.filter(
+      v => v.name === 'ArrayBuffer',
+    );
+    expect(arrayBufferVariables).toHaveLength(1);
+    expect(arrayBufferVariables[0]).toBeInstanceOf(ImplicitLibVariable);
+  });
+
+  it('should define an implicit variable if there is a nested value reference', () => {
+    const { scopeManager } = parseAndAnalyze(
+      'var f = () => new ArrayBuffer();',
+      {
+        lib: ['es2015'],
+      },
+    );
+
+    const variables = scopeManager.variables;
+    const arrayBufferVariables = variables.filter(
+      v => v.name === 'ArrayBuffer',
+    );
+    expect(arrayBufferVariables).toHaveLength(1);
+    expect(arrayBufferVariables[0]).toBeInstanceOf(ImplicitLibVariable);
+  });
+
+  it('should define an implicit variable if there is a nested type reference', () => {
+    const { scopeManager } = parseAndAnalyze(
+      'var f = <T extends ArrayBuffer>(): T => undefined as T;',
+      {
+        lib: ['es2015'],
+      },
+    );
+
+    const variables = scopeManager.variables;
+    const arrayBufferVariables = variables.filter(
+      v => v.name === 'ArrayBuffer',
+    );
+    expect(arrayBufferVariables).toHaveLength(1);
+    expect(arrayBufferVariables[0]).toBeInstanceOf(ImplicitLibVariable);
+  });
+
+  it('should define an implicit variable if there is a value collision', () => {
+    const { scopeManager } = parseAndAnalyze('var Symbol = 1;', {
+      lib: ['es2015'],
+    });
+
+    const variables = scopeManager.variables;
+    const symbolVariables = variables.filter(v => v.name === 'Symbol');
+    expect(symbolVariables).toHaveLength(1);
+    expect(symbolVariables[0]).toBeInstanceOf(ImplicitLibVariable);
+  });
+
+  it('should define an implicit variable if there is a type collision', () => {
+    const { scopeManager } = parseAndAnalyze('type Symbol = 1;', {
+      lib: ['es2015'],
+    });
+
+    const variables = scopeManager.variables;
+    const symbolVariables = variables.filter(v => v.name === 'Symbol');
+    expect(symbolVariables).toHaveLength(1);
+    expect(symbolVariables[0]).toBeInstanceOf(ImplicitLibVariable);
+  });
+
+  it('should define an implicit variable if there is a nested value collision', () => {
+    const { scopeManager } = parseAndAnalyze('var f = (Symbol) => Symbol;', {
+      lib: ['es2015'],
+    });
+
+    const variables = scopeManager.variables;
+    const symbolVariables = variables.filter(v => v.name === 'Symbol');
+    expect(symbolVariables).toHaveLength(2);
+    expect(symbolVariables.some(v => v instanceof ImplicitLibVariable)).toBe(
+      true,
+    );
+    expect(symbolVariables.some(v => !(v instanceof ImplicitLibVariable))).toBe(
+      true,
+    );
+  });
+
+  it('should define an implicit variable if there is a nested type collision', () => {
+    const { scopeManager } = parseAndAnalyze('var f = (a: Symbol) => a;', {
+      lib: ['es2015'],
+    });
+
+    const variables = scopeManager.variables;
+    const symbolVariables = variables.filter(v => v.name === 'Symbol');
+    expect(symbolVariables).toHaveLength(1);
+    expect(symbolVariables[0]).toBeInstanceOf(ImplicitLibVariable);
   });
 });

--- a/packages/scope-manager/tests/lib.test.ts
+++ b/packages/scope-manager/tests/lib.test.ts
@@ -11,15 +11,29 @@ describe('implicit lib definitions', () => {
     expect(variables).toHaveLength(1);
   });
 
-  it('should define implicit variables', () => {
-    const { scopeManager } = parseAndAnalyze('', {
+  it('should define an implicit variable if there is a reference', () => {
+    const { scopeManager } = parseAndAnalyze('new ArrayBuffer();', {
       lib: ['es2015'],
     });
 
     const variables = scopeManager.variables;
-    expect(variables.length).toBeGreaterThan(1);
+    expect(
+      variables.some(
+        v => v instanceof ImplicitLibVariable && v.name === 'ArrayBuffer',
+      ),
+    ).toEqual(true);
+  });
 
-    const variable = variables[0];
-    expect(variable).toBeInstanceOf(ImplicitLibVariable);
+  it('should define an implicit variable if there is a collision', () => {
+    const { scopeManager } = parseAndAnalyze('var Symbol = {};', {
+      lib: ['es2015'],
+    });
+
+    const variables = scopeManager.variables;
+    expect(
+      variables.some(
+        v => v instanceof ImplicitLibVariable && v.name === 'Symbol',
+      ),
+    ).toEqual(true);
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9575
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR optimizes `populateGlobalsFromLib` by deduplicating work to calculate the set of variables available in the configured `libs` array, and by only injecting implicit variable definitions for variables whose names appear in the file being analyzed.

As a consequence of only injecting implicit variables that are actually used in the file, we can avoid the overhead of lint rules spending time processing irrelevant injected globals, for example in `typescript-eslint/no-redeclare` and `typescript-eslint/naming-convention`.

## Before
![populateGlobalsFromLib took 8.556 seconds](https://github.com/user-attachments/assets/288a17a0-f031-4632-b426-717ba586f264)
![findVariablesInScope took 4.077 seconds](https://github.com/user-attachments/assets/71644883-2484-425b-8851-e8ac75b7625d)

## After
![populateGlobalsFromLib took 0.312 seconds](https://github.com/user-attachments/assets/e680485b-d978-49bc-a334-da2235f4ff96)
![findVariablesInScope took 0.662 seconds](https://github.com/user-attachments/assets/63730200-72fe-4617-878a-64ced4f5d7be)
