### PR TITLE
feat(eslint-plugin): [consistent-type-assertions] add arrayLiteralTypeAssertions options

### DIFF
--- a/packages/eslint-plugin/docs/rules/consistent-type-assertions.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-type-assertions.mdx
@@ -117,6 +117,8 @@ const foo = <Foo props={{ bar: 1 } as Bar} />;
 
 ### `arrayLiteralTypeAssertions`
 
+{/* insert option description */}
+
 Always prefer `const x: T[] = [ ... ];` to `const x = [ ... ] as T[];` (or similar with angle brackets). The rationale for this is exactly the same as for `objectLiteralTypeAssertions`.
 
 The const assertion `const x = [1, 2, 3] as const`, introduced in TypeScript 3.4, is considered beneficial and is ignored by this option.

--- a/packages/eslint-plugin/docs/rules/consistent-type-assertions.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-type-assertions.mdx
@@ -115,6 +115,74 @@ const foo = <Foo props={{ bar: 1 } as Bar} />;
 </TabItem>
 </Tabs>
 
+### `arrayLiteralTypeAssertions`
+
+Always prefer `const x: T[] = [ ... ];` to `const x = [ ... ] as T[];` (or similar with angle brackets). The rationale for this is exactly the same as for `objectLiteralTypeAssertions`.
+
+The const assertion `const x = [1, 2, 3] as const`, introduced in TypeScript 3.4, is considered beneficial and is ignored by this option.
+
+Assertions to `any` are also ignored by this option.
+
+Examples of code for `{ assertionStyle: 'as', arrayLiteralTypeAssertions: 'never' }`:
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts option='{ "assertionStyle": "as", "arrayLiteralTypeAssertions": "never" }'
+const x = ['foo'] as T;
+
+function bar() {
+  return ['foo'] as T;
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts option='{ "assertionStyle": "as", "arrayLiteralTypeAssertions": "never" }'
+const x: T = ['foo'];
+const y = ['foo'] as any;
+const z = ['foo'] as unknown;
+
+function bar(): T {
+  return ['foo'];
+}
+```
+
+</TabItem>
+</Tabs>
+
+Examples of code for `{ assertionStyle: 'as', arrayLiteralTypeAssertions: 'allow-as-parameter' }`:
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts option='{ "assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter" }'
+const x = ['foo'] as T;
+
+function bar() {
+  return ['foo'] as T;
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```tsx option='{ "assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter" }'
+const x: T = ['foo'];
+const y = ['foo'] as any;
+const z = ['foo'] as unknown;
+bar(['foo'] as T);
+new Clazz(['foo'] as T);
+function bar() {
+  throw ['foo'] as Foo;
+}
+const foo = <Foo props={['foo'] as Bar} />;
+```
+
+</TabItem>
+</Tabs>
+
 ## When Not To Use It
 
 If you do not want to enforce consistent type assertions.

--- a/packages/eslint-plugin/docs/rules/consistent-type-assertions.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-type-assertions.mdx
@@ -119,7 +119,10 @@ const foo = <Foo props={{ bar: 1 } as Bar} />;
 
 {/* insert option description */}
 
-Always prefer `const x: T[] = [ ... ];` to `const x = [ ... ] as T[];` (or similar with angle brackets). The rationale for this is exactly the same as for `objectLiteralTypeAssertions`.
+Always prefer `const x: T[] = [ ... ];` to `const x = [ ... ] as T[];` (or similar with angle brackets).
+
+The compiler will warn for excess properties of elements with this syntax, but not missing _required_ fields of those objects.
+For example: `const x: {foo: number}[] = [{}];` will fail to compile, but `const x = [{}] as [{ foo: number }]` will succeed.
 
 The const assertion `const x = [1, 2, 3] as const`, introduced in TypeScript 3.4, is considered beneficial and is ignored by this option.
 

--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -81,7 +81,8 @@ export default createRule<Options, MessageIds>({
             properties: {
               arrayLiteralTypeAssertions: {
                 type: 'string',
-                description: 'TBD',
+                description:
+                  'Whether to always prefer type declarations for array literals used as variable initializers, rather than type assertions.',
                 enum: ['allow', 'allow-as-parameter', 'never'],
               },
               assertionStyle: {

--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -208,18 +208,18 @@ export default createRule<Options, MessageIds>({
       }
     }
 
-    function getSuggests(
+    function getSuggestions(
       node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
       annotationMessageId: MessageIds,
       satisfiesMessageId: MessageIds,
     ): TSESLint.ReportSuggestionArray<MessageIds> {
-      const suggest: TSESLint.ReportSuggestionArray<MessageIds> = [];
+      const suggestions: TSESLint.ReportSuggestionArray<MessageIds> = [];
       if (
         node.parent.type === AST_NODE_TYPES.VariableDeclarator &&
         !node.parent.id.typeAnnotation
       ) {
         const { parent } = node;
-        suggest.push({
+        suggestions.push({
           messageId: annotationMessageId,
           data: { cast: context.sourceCode.getText(node.typeAnnotation) },
           fix: fixer => [
@@ -234,7 +234,7 @@ export default createRule<Options, MessageIds>({
           ],
         });
       }
-      suggest.push({
+      suggestions.push({
         messageId: satisfiesMessageId,
         data: { cast: context.sourceCode.getText(node.typeAnnotation) },
         fix: fixer => [
@@ -248,7 +248,7 @@ export default createRule<Options, MessageIds>({
           ),
         ],
       });
-      return suggest;
+      return suggestions;
     }
 
     function isAsParameter(
@@ -291,7 +291,7 @@ export default createRule<Options, MessageIds>({
       }
 
       if (checkType(node.typeAnnotation)) {
-        const suggest = getSuggests(
+        const suggest = getSuggestions(
           node,
           'replaceObjectTypeAssertionWithAnnotation',
           'replaceObjectTypeAssertionWithSatisfies',
@@ -324,7 +324,7 @@ export default createRule<Options, MessageIds>({
       }
 
       if (checkType(node.typeAnnotation)) {
-        const suggest = getSuggests(
+        const suggest = getSuggestions(
           node,
           'replaceArrayTypeAssertionWithAnnotation',
           'replaceArrayTypeAssertionWithSatisfies',

--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -18,13 +18,17 @@ export type MessageIds =
   | 'angle-bracket'
   | 'as'
   | 'never'
+  | 'replaceArrayTypeAssertionWithAnnotation'
+  | 'replaceArrayTypeAssertionWithSatisfies'
   | 'replaceObjectTypeAssertionWithAnnotation'
   | 'replaceObjectTypeAssertionWithSatisfies'
+  | 'unexpectedArrayTypeAssertion'
   | 'unexpectedObjectTypeAssertion';
 type OptUnion =
   | {
       assertionStyle: 'angle-bracket' | 'as';
       objectLiteralTypeAssertions?: 'allow' | 'allow-as-parameter' | 'never';
+      arrayLiteralTypeAssertions?: 'allow' | 'allow-as-parameter' | 'never';
     }
   | {
       assertionStyle: 'never';
@@ -45,10 +49,15 @@ export default createRule<Options, MessageIds>({
       'angle-bracket': "Use '<{{cast}}>' instead of 'as {{cast}}'.",
       as: "Use 'as {{cast}}' instead of '<{{cast}}>'.",
       never: 'Do not use any type assertions.',
+      replaceArrayTypeAssertionWithAnnotation:
+        'Use const x: [{cast}] = [ ... ] instead.',
+      replaceArrayTypeAssertionWithSatisfies:
+        'Use const x = [ ... ] satisfies [{cast}] instead.',
       replaceObjectTypeAssertionWithAnnotation:
         'Use const x: {{cast}} = { ... } instead.',
       replaceObjectTypeAssertionWithSatisfies:
         'Use const x = { ... } satisfies {{cast}} instead.',
+      unexpectedArrayTypeAssertion: 'Always prefer const x: T[] = [ ... ].',
       unexpectedObjectTypeAssertion: 'Always prefer const x: T = { ... }.',
     },
     schema: [
@@ -70,6 +79,11 @@ export default createRule<Options, MessageIds>({
             type: 'object',
             additionalProperties: false,
             properties: {
+              arrayLiteralTypeAssertions: {
+                type: 'string',
+                description: 'TBD',
+                enum: ['allow', 'allow-as-parameter', 'never'],
+              },
               assertionStyle: {
                 type: 'string',
                 description: 'The expected assertion style to enforce.',
@@ -89,6 +103,7 @@ export default createRule<Options, MessageIds>({
   },
   defaultOptions: [
     {
+      arrayLiteralTypeAssertions: 'allow',
       assertionStyle: 'as',
       objectLiteralTypeAssertions: 'allow',
     },
@@ -192,7 +207,64 @@ export default createRule<Options, MessageIds>({
       }
     }
 
-    function checkExpression(
+    function getSuggests(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+      annotationMessageId: MessageIds,
+      satisfiesMessageId: MessageIds,
+    ): TSESLint.ReportSuggestionArray<MessageIds> {
+      const suggest: TSESLint.ReportSuggestionArray<MessageIds> = [];
+      if (
+        node.parent.type === AST_NODE_TYPES.VariableDeclarator &&
+        !node.parent.id.typeAnnotation
+      ) {
+        const { parent } = node;
+        suggest.push({
+          messageId: annotationMessageId,
+          data: { cast: context.sourceCode.getText(node.typeAnnotation) },
+          fix: fixer => [
+            fixer.insertTextAfter(
+              parent.id,
+              `: ${context.sourceCode.getText(node.typeAnnotation)}`,
+            ),
+            fixer.replaceText(
+              node,
+              getTextWithParentheses(context.sourceCode, node.expression),
+            ),
+          ],
+        });
+      }
+      suggest.push({
+        messageId: satisfiesMessageId,
+        data: { cast: context.sourceCode.getText(node.typeAnnotation) },
+        fix: fixer => [
+          fixer.replaceText(
+            node,
+            getTextWithParentheses(context.sourceCode, node.expression),
+          ),
+          fixer.insertTextAfter(
+            node,
+            ` satisfies ${context.sourceCode.getText(node.typeAnnotation)}`,
+          ),
+        ],
+      });
+      return suggest;
+    }
+
+    function isAsParameter(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+    ): boolean {
+      return (
+        node.parent.type === AST_NODE_TYPES.NewExpression ||
+        node.parent.type === AST_NODE_TYPES.CallExpression ||
+        node.parent.type === AST_NODE_TYPES.ThrowStatement ||
+        node.parent.type === AST_NODE_TYPES.AssignmentPattern ||
+        node.parent.type === AST_NODE_TYPES.JSXExpressionContainer ||
+        (node.parent.type === AST_NODE_TYPES.TemplateLiteral &&
+          node.parent.parent.type === AST_NODE_TYPES.TaggedTemplateExpression)
+      );
+    }
+
+    function checkExpressionForObjectAssertion(
       node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
     ): void {
       if (
@@ -218,45 +290,48 @@ export default createRule<Options, MessageIds>({
       }
 
       if (checkType(node.typeAnnotation)) {
-        const suggest: TSESLint.ReportSuggestionArray<MessageIds> = [];
-        if (
-          node.parent.type === AST_NODE_TYPES.VariableDeclarator &&
-          !node.parent.id.typeAnnotation
-        ) {
-          const { parent } = node;
-          suggest.push({
-            messageId: 'replaceObjectTypeAssertionWithAnnotation',
-            data: { cast: context.sourceCode.getText(node.typeAnnotation) },
-            fix: fixer => [
-              fixer.insertTextAfter(
-                parent.id,
-                `: ${context.sourceCode.getText(node.typeAnnotation)}`,
-              ),
-              fixer.replaceText(
-                node,
-                getTextWithParentheses(context.sourceCode, node.expression),
-              ),
-            ],
-          });
-        }
-        suggest.push({
-          messageId: 'replaceObjectTypeAssertionWithSatisfies',
-          data: { cast: context.sourceCode.getText(node.typeAnnotation) },
-          fix: fixer => [
-            fixer.replaceText(
-              node,
-              getTextWithParentheses(context.sourceCode, node.expression),
-            ),
-            fixer.insertTextAfter(
-              node,
-              ` satisfies ${context.sourceCode.getText(node.typeAnnotation)}`,
-            ),
-          ],
-        });
+        const suggest = getSuggests(
+          node,
+          'replaceObjectTypeAssertionWithAnnotation',
+          'replaceObjectTypeAssertionWithSatisfies',
+        );
 
         context.report({
           node,
           messageId: 'unexpectedObjectTypeAssertion',
+          suggest,
+        });
+      }
+    }
+
+    function checkExpressionForArrayAssertion(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+    ): void {
+      if (
+        options.assertionStyle === 'never' ||
+        options.arrayLiteralTypeAssertions === 'allow' ||
+        node.expression.type !== AST_NODE_TYPES.ArrayExpression
+      ) {
+        return;
+      }
+
+      if (
+        options.arrayLiteralTypeAssertions === 'allow-as-parameter' &&
+        isAsParameter(node)
+      ) {
+        return;
+      }
+
+      if (checkType(node.typeAnnotation)) {
+        const suggest = getSuggests(
+          node,
+          'replaceArrayTypeAssertionWithAnnotation',
+          'replaceArrayTypeAssertionWithSatisfies',
+        );
+
+        context.report({
+          node,
+          messageId: 'unexpectedArrayTypeAssertion',
           suggest,
         });
       }
@@ -269,7 +344,8 @@ export default createRule<Options, MessageIds>({
           return;
         }
 
-        checkExpression(node);
+        checkExpressionForObjectAssertion(node);
+        checkExpressionForArrayAssertion(node);
       },
       TSTypeAssertion(node): void {
         if (options.assertionStyle !== 'angle-bracket') {
@@ -277,7 +353,8 @@ export default createRule<Options, MessageIds>({
           return;
         }
 
-        checkExpression(node);
+        checkExpressionForObjectAssertion(node);
+        checkExpressionForArrayAssertion(node);
       },
     };
   },

--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -50,9 +50,9 @@ export default createRule<Options, MessageIds>({
       as: "Use 'as {{cast}}' instead of '<{{cast}}>'.",
       never: 'Do not use any type assertions.',
       replaceArrayTypeAssertionWithAnnotation:
-        'Use const x: [{cast}] = [ ... ] instead.',
+        'Use const x: {{cast}} = [ ... ] instead.',
       replaceArrayTypeAssertionWithSatisfies:
-        'Use const x = [ ... ] satisfies [{cast}] instead.',
+        'Use const x = [ ... ] satisfies {{cast}} instead.',
       replaceObjectTypeAssertionWithAnnotation:
         'Use const x: {{cast}} = { ... } instead.',
       replaceObjectTypeAssertionWithSatisfies:

--- a/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
+++ b/packages/eslint-plugin/src/rules/consistent-type-assertions.ts
@@ -35,6 +35,10 @@ type OptUnion =
     };
 export type Options = readonly [OptUnion];
 
+type AsExpressionOrTypeAssertion =
+  | TSESTree.TSAsExpression
+  | TSESTree.TSTypeAssertion;
+
 export default createRule<Options, MessageIds>({
   name: 'consistent-type-assertions',
   meta: {
@@ -122,7 +126,7 @@ export default createRule<Options, MessageIds>({
     }
 
     function reportIncorrectAssertionType(
-      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+      node: AsExpressionOrTypeAssertion,
     ): void {
       const messageId = options.assertionStyle;
 
@@ -209,7 +213,7 @@ export default createRule<Options, MessageIds>({
     }
 
     function getSuggestions(
-      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+      node: AsExpressionOrTypeAssertion,
       annotationMessageId: MessageIds,
       satisfiesMessageId: MessageIds,
     ): TSESLint.ReportSuggestionArray<MessageIds> {
@@ -251,9 +255,7 @@ export default createRule<Options, MessageIds>({
       return suggestions;
     }
 
-    function isAsParameter(
-      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
-    ): boolean {
+    function isAsParameter(node: AsExpressionOrTypeAssertion): boolean {
       return (
         node.parent.type === AST_NODE_TYPES.NewExpression ||
         node.parent.type === AST_NODE_TYPES.CallExpression ||
@@ -266,7 +268,7 @@ export default createRule<Options, MessageIds>({
     }
 
     function checkExpressionForObjectAssertion(
-      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+      node: AsExpressionOrTypeAssertion,
     ): void {
       if (
         options.assertionStyle === 'never' ||
@@ -278,14 +280,7 @@ export default createRule<Options, MessageIds>({
 
       if (
         options.objectLiteralTypeAssertions === 'allow-as-parameter' &&
-        (node.parent.type === AST_NODE_TYPES.NewExpression ||
-          node.parent.type === AST_NODE_TYPES.CallExpression ||
-          node.parent.type === AST_NODE_TYPES.ThrowStatement ||
-          node.parent.type === AST_NODE_TYPES.AssignmentPattern ||
-          node.parent.type === AST_NODE_TYPES.JSXExpressionContainer ||
-          (node.parent.type === AST_NODE_TYPES.TemplateLiteral &&
-            node.parent.parent.type ===
-              AST_NODE_TYPES.TaggedTemplateExpression))
+        isAsParameter(node)
       ) {
         return;
       }
@@ -306,7 +301,7 @@ export default createRule<Options, MessageIds>({
     }
 
     function checkExpressionForArrayAssertion(
-      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+      node: AsExpressionOrTypeAssertion,
     ): void {
       if (
         options.assertionStyle === 'never' ||

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/consistent-type-assertions.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/consistent-type-assertions.shot
@@ -57,3 +57,61 @@ function bar() {
 const foo = <Foo props={{ bar: 1 } as Bar} />;
 "
 `;
+
+exports[`Validating rule docs consistent-type-assertions.mdx code examples ESLint output 5`] = `
+"Incorrect
+Options: { "assertionStyle": "as", "arrayLiteralTypeAssertions": "never" }
+
+const x = ['foo'] as T;
+          ~~~~~~~~~~~~ Always prefer const x: T[] = [ ... ].
+
+function bar() {
+  return ['foo'] as T;
+         ~~~~~~~~~~~~ Always prefer const x: T[] = [ ... ].
+}
+"
+`;
+
+exports[`Validating rule docs consistent-type-assertions.mdx code examples ESLint output 6`] = `
+"Correct
+Options: { "assertionStyle": "as", "arrayLiteralTypeAssertions": "never" }
+
+const x: T = ['foo'];
+const y = ['foo'] as any;
+const z = ['foo'] as unknown;
+
+function bar(): T {
+  return ['foo'];
+}
+"
+`;
+
+exports[`Validating rule docs consistent-type-assertions.mdx code examples ESLint output 7`] = `
+"Incorrect
+Options: { "assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter" }
+
+const x = ['foo'] as T;
+          ~~~~~~~~~~~~ Always prefer const x: T[] = [ ... ].
+
+function bar() {
+  return ['foo'] as T;
+         ~~~~~~~~~~~~ Always prefer const x: T[] = [ ... ].
+}
+"
+`;
+
+exports[`Validating rule docs consistent-type-assertions.mdx code examples ESLint output 8`] = `
+"Correct
+Options: { "assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter" }
+
+const x: T = ['foo'];
+const y = ['foo'] as any;
+const z = ['foo'] as unknown;
+bar(['foo'] as T);
+new Clazz(['foo'] as T);
+function bar() {
+  throw ['foo'] as Foo;
+}
+const foo = <Foo props={['foo'] as Bar} />;
+"
+`;

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -137,13 +137,7 @@ ruleTester.run('consistent-type-assertions', rule, {
       ],
     }),
     {
-      code: `
-const x = [] as string[];
-const x = ['a'] as string[];
-const x = [] as Array<string>;
-const x = ['a'] as Array<string>;
-const x = [Math.random() ? 'a' : 'b'] as 'a'[];
-      `,
+      code: 'const x = [] as string[];',
       options: [
         {
           assertionStyle: 'as',
@@ -151,13 +145,15 @@ const x = [Math.random() ? 'a' : 'b'] as 'a'[];
       ],
     },
     {
-      code: `
-const x = <string[]>[];
-const x = <string[]>['a'];
-const x = <Array<string>>[];
-const x = <Array<string>>['a'];
-const x = <'a'[]>[Math.random() ? 'a' : 'b'];
-      `,
+      code: "const x = ['a'] as Array<string>;",
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
+      code: 'const x = <string[]>[];',
       options: [
         {
           assertionStyle: 'angle-bracket',
@@ -165,18 +161,15 @@ const x = <'a'[]>[Math.random() ? 'a' : 'b'];
       ],
     },
     {
-      code: `
-print([5] as Foo);
-new print([5] as Foo);
-function foo() {
-  throw [5] as Foo;
-}
-function b(x = [5] as Foo.Bar) {}
-function c(x = [5] as Foo) {}
-print?.([5] as Foo);
-print?.call([5] as Foo);
-print\`\${[5] as Foo}\`;
-      `,
+      code: 'const x = <Array<string>>[];',
+      options: [
+        {
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
+    {
+      code: 'print([5] as Foo);',
       options: [
         {
           arrayLiteralTypeAssertions: 'allow-as-parameter',
@@ -186,15 +179,104 @@ print\`\${[5] as Foo}\`;
     },
     {
       code: `
-print(<Foo>[5]);
-new print(<Foo>[5]);
+function foo() {
+  throw [5] as Foo;
+}
+      `,
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
+      code: 'function b(x = [5] as Foo.Bar) {}',
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
+      code: 'print?.([5] as Foo);',
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
+      code: 'print?.call([5] as Foo);',
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
+      code: 'print`${[5] as Foo}`;',
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
+      code: 'print(<Foo>[5]);',
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
+    {
+      code: `
 function foo() {
   throw <Foo>[5];
 }
-print?.(<Foo>[5]);
-print?.call(<Foo>[5]);
-print\`\${<Foo>[5]}\`;
       `,
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
+    {
+      code: 'function b(x = <Foo.Bar>[5]) {}',
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
+    {
+      code: 'print?.(<Foo>[5]);',
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
+    {
+      code: 'print?.call(<Foo>[5]);',
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
+    {
+      code: 'print`${<Foo>[5]}`;',
       options: [
         {
           arrayLiteralTypeAssertions: 'allow-as-parameter',
@@ -906,6 +988,56 @@ const bs = (x <<= y) as any;
       ],
     },
     {
+      code: `
+function foo() {
+  throw [5] as Foo;
+}
+      `,
+      errors: [
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `
+function foo() {
+  throw [5] satisfies Foo;
+}
+      `,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
+      code: 'print`${[5] as Foo}`;',
+      errors: [
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: 'print`${[5] satisfies Foo}`;',
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
       code: 'new print(<Foo>[5]);',
       errors: [
         {
@@ -936,6 +1068,56 @@ const bs = (x <<= y) as any;
               data: { cast: 'Foo.Bar' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: `function b(x = [5] satisfies Foo.Bar) {}`,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
+    {
+      code: `
+function foo() {
+  throw <Foo>[5];
+}
+      `,
+      errors: [
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `
+function foo() {
+  throw [5] satisfies Foo;
+}
+      `,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
+    {
+      code: 'print`${<Foo>[5]}`;',
+      errors: [
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: 'print`${[5] satisfies Foo}`;',
             },
           ],
         },

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -85,6 +85,38 @@ print?.(<Foo>{ bar: 5 })
 print?.call(<Foo>{ bar: 5 })
 print\`\${<Foo>{ bar: 5 }}\`
 `;
+const ARRAY_LITERAL_AS_CASTS = `
+const x = [] as string[];
+const x = ['a'] as string[];
+const x = [] as Array<string>;
+const x = ['a'] as Array<string>;
+const x = [Math.random() ? 'a' : 'b'] as 'a'[];
+`;
+const ARRAY_LITERAL_ANGLE_BRACKET_CASTS = `
+const x = <string[]>[];
+const x = <string[]>['a'];
+const x = <Array<string>>[];
+const x = <Array<string>>['a'];
+const x = <'a'[]>[Math.random() ? 'a' : 'b'];
+`;
+const ARRAY_LITERAL_ARGUMENT_AS_CASTS = `
+print([5] as Foo);
+new print([5] as Foo);
+function foo() { throw [5] as Foo }
+function b(x = [5] as Foo.Bar) {}
+function c(x = [5] as Foo) {}
+print?.([5] as Foo);
+print?.call([5] as Foo);
+print\`\${[5] as Foo}\`;
+`;
+const ARRAY_LITERAL_ARGUMENT_BRACKET_CASTS = `
+print(<Foo>[5]);
+new print(<Foo>[5]);
+function foo() { throw <Foo>[5] }
+print?.(<Foo>[5]);
+print?.call(<Foo>[5]);
+print\`\${<Foo>[5]}\`;
+`;
 
 ruleTester.run('consistent-type-assertions', rule, {
   valid: [
@@ -133,6 +165,40 @@ ruleTester.run('consistent-type-assertions', rule, {
         {
           assertionStyle: 'angle-bracket',
           objectLiteralTypeAssertions: 'allow-as-parameter',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests<Options>({
+      code: ARRAY_LITERAL_AS_CASTS,
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests<Options>({
+      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+      options: [
+        {
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests<Options>({
+      code: ARRAY_LITERAL_ARGUMENT_AS_CASTS,
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'as',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests<Options>({
+      code: ARRAY_LITERAL_ARGUMENT_BRACKET_CASTS,
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'angle-bracket',
         },
       ],
     }),
@@ -671,5 +737,485 @@ const bs = (x <<= y) as any;
       ],
       output: 'const ternary = (true ? x : y) as any;',
     },
+    ...batchedSingleLineTests<MessageIds, Options>({
+      code: ARRAY_LITERAL_AS_CASTS,
+      errors: [
+        {
+          line: 2,
+          messageId: 'never',
+        },
+        {
+          line: 3,
+          messageId: 'never',
+        },
+        {
+          line: 4,
+          messageId: 'never',
+        },
+        {
+          line: 5,
+          messageId: 'never',
+        },
+        {
+          line: 6,
+          messageId: 'never',
+        },
+      ],
+      options: [
+        {
+          assertionStyle: 'never',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests<MessageIds, Options>({
+      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+      errors: [
+        {
+          line: 2,
+          messageId: 'never',
+        },
+        {
+          line: 3,
+          messageId: 'never',
+        },
+        {
+          line: 4,
+          messageId: 'never',
+        },
+        {
+          line: 5,
+          messageId: 'never',
+        },
+        {
+          line: 6,
+          messageId: 'never',
+        },
+      ],
+      options: [
+        {
+          assertionStyle: 'never',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests<MessageIds, Options>({
+      code: ARRAY_LITERAL_AS_CASTS,
+      errors: [
+        {
+          line: 2,
+          messageId: 'angle-bracket',
+        },
+        {
+          line: 3,
+          messageId: 'angle-bracket',
+        },
+        {
+          line: 4,
+          messageId: 'angle-bracket',
+        },
+        {
+          line: 5,
+          messageId: 'angle-bracket',
+        },
+        {
+          line: 6,
+          messageId: 'angle-bracket',
+        },
+      ],
+      options: [
+        {
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+      output: null,
+    }),
+    ...batchedSingleLineTests<MessageIds, Options>({
+      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+      errors: [
+        {
+          line: 2,
+          messageId: 'as',
+        },
+        {
+          line: 3,
+          messageId: 'as',
+        },
+        {
+          line: 4,
+          messageId: 'as',
+        },
+        {
+          line: 5,
+          messageId: 'as',
+        },
+        {
+          line: 6,
+          messageId: 'as',
+        },
+      ],
+      options: [
+        {
+          assertionStyle: 'as',
+        },
+      ],
+      output: ARRAY_LITERAL_AS_CASTS,
+    }),
+    ...batchedSingleLineTests<MessageIds, Options>({
+      code: ARRAY_LITERAL_AS_CASTS,
+      errors: [
+        {
+          line: 2,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: 'const x: string[] = [];',
+            },
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: 'const x = [] satisfies string[];',
+            },
+          ],
+        },
+        {
+          line: 3,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: `const x: string[] = ['a'];`,
+            },
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `const x = ['a'] satisfies string[];`,
+            },
+          ],
+        },
+        {
+          line: 4,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: 'const x: Array<string> = [];',
+            },
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: 'const x = [] satisfies Array<string>;',
+            },
+          ],
+        },
+        {
+          line: 5,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: `const x: Array<string> = ['a'];`,
+            },
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `const x = ['a'] satisfies Array<string>;`,
+            },
+          ],
+        },
+        {
+          line: 6,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: `const x: 'a'[] = [Math.random() ? 'a' : 'b'];`,
+            },
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `const x = [Math.random() ? 'a' : 'b'] satisfies 'a'[];`,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'as',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests<MessageIds, Options>({
+      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+      errors: [
+        {
+          line: 2,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: 'const x: string[] = [];',
+            },
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: 'const x = [] satisfies string[];',
+            },
+          ],
+        },
+        {
+          line: 3,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: `const x: string[] = ['a'];`,
+            },
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `const x = ['a'] satisfies string[];`,
+            },
+          ],
+        },
+        {
+          line: 4,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: 'const x: Array<string> = [];',
+            },
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: 'const x = [] satisfies Array<string>;',
+            },
+          ],
+        },
+        {
+          line: 5,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: `const x: Array<string> = ['a'];`,
+            },
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `const x = ['a'] satisfies Array<string>;`,
+            },
+          ],
+        },
+        {
+          line: 6,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: `const x: 'a'[] = [Math.random() ? 'a' : 'b'];`,
+            },
+            {
+              data: { cast: 'string' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `const x = [Math.random() ? 'a' : 'b'] satisfies 'a'[];`,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests<MessageIds, Options>({
+      code: ARRAY_LITERAL_ARGUMENT_AS_CASTS,
+      errors: [
+        {
+          line: 2,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `print([5] satisfies Foo);`,
+            },
+          ],
+        },
+        {
+          line: 3,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `new print([5] satisfies Foo);`,
+            },
+          ],
+        },
+        {
+          line: 4,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `function foo() { throw [5] satisfies Foo }`,
+            },
+          ],
+        },
+        {
+          line: 5,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `function b(x = [5] satisfies Foo.Bar) {}`,
+            },
+          ],
+        },
+        {
+          line: 6,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `function c(x = [5] satisfies Foo) {}`,
+            },
+          ],
+        },
+        {
+          line: 7,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `print?.([5] satisfies Foo);`,
+            },
+          ],
+        },
+        {
+          line: 8,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `print?.call([5] satisfies Foo);`,
+            },
+          ],
+        },
+        {
+          line: 9,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `print\`\${[5] satisfies Foo}\`;`,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'as',
+        },
+      ],
+    }),
+    ...batchedSingleLineTests<MessageIds, Options>({
+      code: ARRAY_LITERAL_ARGUMENT_BRACKET_CASTS,
+      errors: [
+        {
+          line: 2,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `print([5] satisfies Foo);`,
+            },
+          ],
+        },
+        {
+          line: 3,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `new print([5] satisfies Foo);`,
+            },
+          ],
+        },
+        {
+          line: 4,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `function foo() { throw [5] satisfies Foo }`,
+            },
+          ],
+        },
+        {
+          line: 5,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `print?.([5] satisfies Foo);`,
+            },
+          ],
+        },
+        {
+          line: 6,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `print?.call([5] satisfies Foo);`,
+            },
+          ],
+        },
+        {
+          line: 7,
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `print\`\${[5] satisfies Foo}\`;`,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    }),
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -867,12 +867,12 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'string' },
+              data: { cast: 'string[]' },
               messageId: 'replaceArrayTypeAssertionWithAnnotation',
               output: 'const x: string[] = [];',
             },
             {
-              data: { cast: 'string' },
+              data: { cast: 'string[]' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: 'const x = [] satisfies string[];',
             },
@@ -883,12 +883,12 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'string' },
+              data: { cast: 'string[]' },
               messageId: 'replaceArrayTypeAssertionWithAnnotation',
               output: `const x: string[] = ['a'];`,
             },
             {
-              data: { cast: 'string' },
+              data: { cast: 'string[]' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: `const x = ['a'] satisfies string[];`,
             },
@@ -899,12 +899,12 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'string' },
+              data: { cast: 'Array<string>' },
               messageId: 'replaceArrayTypeAssertionWithAnnotation',
               output: 'const x: Array<string> = [];',
             },
             {
-              data: { cast: 'string' },
+              data: { cast: 'Array<string>' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: 'const x = [] satisfies Array<string>;',
             },
@@ -915,12 +915,12 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'string' },
+              data: { cast: 'Array<string>' },
               messageId: 'replaceArrayTypeAssertionWithAnnotation',
               output: `const x: Array<string> = ['a'];`,
             },
             {
-              data: { cast: 'string' },
+              data: { cast: 'Array<string>' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: `const x = ['a'] satisfies Array<string>;`,
             },
@@ -931,12 +931,12 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'string' },
+              data: { cast: "'a'[]" },
               messageId: 'replaceArrayTypeAssertionWithAnnotation',
               output: `const x: 'a'[] = [Math.random() ? 'a' : 'b'];`,
             },
             {
-              data: { cast: 'string' },
+              data: { cast: "'a'[]" },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: `const x = [Math.random() ? 'a' : 'b'] satisfies 'a'[];`,
             },
@@ -958,12 +958,12 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'string' },
+              data: { cast: 'string[]' },
               messageId: 'replaceArrayTypeAssertionWithAnnotation',
               output: 'const x: string[] = [];',
             },
             {
-              data: { cast: 'string' },
+              data: { cast: 'string[]' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: 'const x = [] satisfies string[];',
             },
@@ -974,12 +974,12 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'string' },
+              data: { cast: 'string[]' },
               messageId: 'replaceArrayTypeAssertionWithAnnotation',
               output: `const x: string[] = ['a'];`,
             },
             {
-              data: { cast: 'string' },
+              data: { cast: 'string[]' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: `const x = ['a'] satisfies string[];`,
             },
@@ -990,12 +990,12 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'string' },
+              data: { cast: 'Array<string>' },
               messageId: 'replaceArrayTypeAssertionWithAnnotation',
               output: 'const x: Array<string> = [];',
             },
             {
-              data: { cast: 'string' },
+              data: { cast: 'Array<string>' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: 'const x = [] satisfies Array<string>;',
             },
@@ -1006,12 +1006,12 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'string' },
+              data: { cast: 'Array<string>' },
               messageId: 'replaceArrayTypeAssertionWithAnnotation',
               output: `const x: Array<string> = ['a'];`,
             },
             {
-              data: { cast: 'string' },
+              data: { cast: 'Array<string>' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: `const x = ['a'] satisfies Array<string>;`,
             },
@@ -1022,12 +1022,12 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'string' },
+              data: { cast: "'a'[]" },
               messageId: 'replaceArrayTypeAssertionWithAnnotation',
               output: `const x: 'a'[] = [Math.random() ? 'a' : 'b'];`,
             },
             {
-              data: { cast: 'string' },
+              data: { cast: "'a'[]" },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: `const x = [Math.random() ? 'a' : 'b'] satisfies 'a'[];`,
             },
@@ -1082,7 +1082,7 @@ const bs = (x <<= y) as any;
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
-              data: { cast: 'Foo' },
+              data: { cast: 'Foo.Bar' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: `function b(x = [5] satisfies Foo.Bar) {}`,
             },

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -227,6 +227,25 @@ function foo() {
       ],
     },
     {
+      code: 'new Print([5] as Foo);',
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
+      code: 'const bar = <Foo style={[5] as Bar} />;',
+      languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } },
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
       code: 'print(<Foo>[5]);',
       options: [
         {
@@ -277,6 +296,15 @@ function foo() {
     },
     {
       code: 'print`${<Foo>[5]}`;',
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
+    {
+      code: 'new Print(<Foo>[5]);',
       options: [
         {
           arrayLiteralTypeAssertions: 'allow-as-parameter',
@@ -1038,6 +1066,27 @@ function foo() {
       ],
     },
     {
+      code: 'const foo = () => [5] as Foo;',
+      errors: [
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: 'const foo = () => [5] satisfies Foo;',
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
       code: 'new print(<Foo>[5]);',
       errors: [
         {
@@ -1125,6 +1174,32 @@ function foo() {
       options: [
         {
           arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
+    {
+      code: 'const foo = <Foo>[5];',
+      errors: [
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithAnnotation',
+              output: 'const foo: Foo = [5];',
+            },
+            {
+              data: { cast: 'Foo' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: 'const foo = [5] satisfies Foo;',
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'allow-as-parameter',
           assertionStyle: 'angle-bracket',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -85,38 +85,6 @@ print?.(<Foo>{ bar: 5 })
 print?.call(<Foo>{ bar: 5 })
 print\`\${<Foo>{ bar: 5 }}\`
 `;
-const ARRAY_LITERAL_AS_CASTS = `
-const x = [] as string[];
-const x = ['a'] as string[];
-const x = [] as Array<string>;
-const x = ['a'] as Array<string>;
-const x = [Math.random() ? 'a' : 'b'] as 'a'[];
-`;
-const ARRAY_LITERAL_ANGLE_BRACKET_CASTS = `
-const x = <string[]>[];
-const x = <string[]>['a'];
-const x = <Array<string>>[];
-const x = <Array<string>>['a'];
-const x = <'a'[]>[Math.random() ? 'a' : 'b'];
-`;
-const ARRAY_LITERAL_ARGUMENT_AS_CASTS = `
-print([5] as Foo);
-new print([5] as Foo);
-function foo() { throw [5] as Foo }
-function b(x = [5] as Foo.Bar) {}
-function c(x = [5] as Foo) {}
-print?.([5] as Foo);
-print?.call([5] as Foo);
-print\`\${[5] as Foo}\`;
-`;
-const ARRAY_LITERAL_ARGUMENT_BRACKET_CASTS = `
-print(<Foo>[5]);
-new print(<Foo>[5]);
-function foo() { throw <Foo>[5] }
-print?.(<Foo>[5]);
-print?.call(<Foo>[5]);
-print\`\${<Foo>[5]}\`;
-`;
 
 ruleTester.run('consistent-type-assertions', rule, {
   valid: [
@@ -168,40 +136,72 @@ ruleTester.run('consistent-type-assertions', rule, {
         },
       ],
     }),
-    ...batchedSingleLineTests<Options>({
-      code: ARRAY_LITERAL_AS_CASTS,
+    {
+      code: `
+const x = [] as string[];
+const x = ['a'] as string[];
+const x = [] as Array<string>;
+const x = ['a'] as Array<string>;
+const x = [Math.random() ? 'a' : 'b'] as 'a'[];
+      `,
       options: [
         {
           assertionStyle: 'as',
         },
       ],
-    }),
-    ...batchedSingleLineTests<Options>({
-      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+    },
+    {
+      code: `
+const x = <string[]>[];
+const x = <string[]>['a'];
+const x = <Array<string>>[];
+const x = <Array<string>>['a'];
+const x = <'a'[]>[Math.random() ? 'a' : 'b'];
+      `,
       options: [
         {
           assertionStyle: 'angle-bracket',
         },
       ],
-    }),
-    ...batchedSingleLineTests<Options>({
-      code: ARRAY_LITERAL_ARGUMENT_AS_CASTS,
+    },
+    {
+      code: `
+print([5] as Foo);
+new print([5] as Foo);
+function foo() {
+  throw [5] as Foo;
+}
+function b(x = [5] as Foo.Bar) {}
+function c(x = [5] as Foo) {}
+print?.([5] as Foo);
+print?.call([5] as Foo);
+print\`\${[5] as Foo}\`;
+      `,
       options: [
         {
           arrayLiteralTypeAssertions: 'allow-as-parameter',
           assertionStyle: 'as',
         },
       ],
-    }),
-    ...batchedSingleLineTests<Options>({
-      code: ARRAY_LITERAL_ARGUMENT_BRACKET_CASTS,
+    },
+    {
+      code: `
+print(<Foo>[5]);
+new print(<Foo>[5]);
+function foo() {
+  throw <Foo>[5];
+}
+print?.(<Foo>[5]);
+print?.call(<Foo>[5]);
+print\`\${<Foo>[5]}\`;
+      `,
       options: [
         {
           arrayLiteralTypeAssertions: 'allow-as-parameter',
           assertionStyle: 'angle-bracket',
         },
       ],
-    }),
+    },
     { code: 'const x = <const>[1];', options: [{ assertionStyle: 'never' }] },
     { code: 'const x = [1] as const;', options: [{ assertionStyle: 'never' }] },
     {
@@ -737,27 +737,10 @@ const bs = (x <<= y) as any;
       ],
       output: 'const ternary = (true ? x : y) as any;',
     },
-    ...batchedSingleLineTests<MessageIds, Options>({
-      code: ARRAY_LITERAL_AS_CASTS,
+    {
+      code: 'const x = [] as string[];',
       errors: [
         {
-          line: 2,
-          messageId: 'never',
-        },
-        {
-          line: 3,
-          messageId: 'never',
-        },
-        {
-          line: 4,
-          messageId: 'never',
-        },
-        {
-          line: 5,
-          messageId: 'never',
-        },
-        {
-          line: 6,
           messageId: 'never',
         },
       ],
@@ -766,28 +749,11 @@ const bs = (x <<= y) as any;
           assertionStyle: 'never',
         },
       ],
-    }),
-    ...batchedSingleLineTests<MessageIds, Options>({
-      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+    },
+    {
+      code: 'const x = <string[]>[];',
       errors: [
         {
-          line: 2,
-          messageId: 'never',
-        },
-        {
-          line: 3,
-          messageId: 'never',
-        },
-        {
-          line: 4,
-          messageId: 'never',
-        },
-        {
-          line: 5,
-          messageId: 'never',
-        },
-        {
-          line: 6,
           messageId: 'never',
         },
       ],
@@ -796,28 +762,11 @@ const bs = (x <<= y) as any;
           assertionStyle: 'never',
         },
       ],
-    }),
-    ...batchedSingleLineTests<MessageIds, Options>({
-      code: ARRAY_LITERAL_AS_CASTS,
+    },
+    {
+      code: 'const x = [] as string[];',
       errors: [
         {
-          line: 2,
-          messageId: 'angle-bracket',
-        },
-        {
-          line: 3,
-          messageId: 'angle-bracket',
-        },
-        {
-          line: 4,
-          messageId: 'angle-bracket',
-        },
-        {
-          line: 5,
-          messageId: 'angle-bracket',
-        },
-        {
-          line: 6,
           messageId: 'angle-bracket',
         },
       ],
@@ -826,29 +775,11 @@ const bs = (x <<= y) as any;
           assertionStyle: 'angle-bracket',
         },
       ],
-      output: null,
-    }),
-    ...batchedSingleLineTests<MessageIds, Options>({
-      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+    },
+    {
+      code: 'const x = <string[]>[];',
       errors: [
         {
-          line: 2,
-          messageId: 'as',
-        },
-        {
-          line: 3,
-          messageId: 'as',
-        },
-        {
-          line: 4,
-          messageId: 'as',
-        },
-        {
-          line: 5,
-          messageId: 'as',
-        },
-        {
-          line: 6,
           messageId: 'as',
         },
       ],
@@ -857,13 +788,12 @@ const bs = (x <<= y) as any;
           assertionStyle: 'as',
         },
       ],
-      output: ARRAY_LITERAL_AS_CASTS,
-    }),
-    ...batchedSingleLineTests<MessageIds, Options>({
-      code: ARRAY_LITERAL_AS_CASTS,
+      output: 'const x = [] as string[];',
+    },
+    {
+      code: 'const x = [] as string[];',
       errors: [
         {
-          line: 2,
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
@@ -878,70 +808,6 @@ const bs = (x <<= y) as any;
             },
           ],
         },
-        {
-          line: 3,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'string[]' },
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
-              output: `const x: string[] = ['a'];`,
-            },
-            {
-              data: { cast: 'string[]' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `const x = ['a'] satisfies string[];`,
-            },
-          ],
-        },
-        {
-          line: 4,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Array<string>' },
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
-              output: 'const x: Array<string> = [];',
-            },
-            {
-              data: { cast: 'Array<string>' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: 'const x = [] satisfies Array<string>;',
-            },
-          ],
-        },
-        {
-          line: 5,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Array<string>' },
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
-              output: `const x: Array<string> = ['a'];`,
-            },
-            {
-              data: { cast: 'Array<string>' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `const x = ['a'] satisfies Array<string>;`,
-            },
-          ],
-        },
-        {
-          line: 6,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: "'a'[]" },
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
-              output: `const x: 'a'[] = [Math.random() ? 'a' : 'b'];`,
-            },
-            {
-              data: { cast: "'a'[]" },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `const x = [Math.random() ? 'a' : 'b'] satisfies 'a'[];`,
-            },
-          ],
-        },
       ],
       options: [
         {
@@ -949,12 +815,11 @@ const bs = (x <<= y) as any;
           assertionStyle: 'as',
         },
       ],
-    }),
-    ...batchedSingleLineTests<MessageIds, Options>({
-      code: ARRAY_LITERAL_ANGLE_BRACKET_CASTS,
+    },
+    {
+      code: 'const x = <string[]>[];',
       errors: [
         {
-          line: 2,
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
@@ -969,70 +834,6 @@ const bs = (x <<= y) as any;
             },
           ],
         },
-        {
-          line: 3,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'string[]' },
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
-              output: `const x: string[] = ['a'];`,
-            },
-            {
-              data: { cast: 'string[]' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `const x = ['a'] satisfies string[];`,
-            },
-          ],
-        },
-        {
-          line: 4,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Array<string>' },
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
-              output: 'const x: Array<string> = [];',
-            },
-            {
-              data: { cast: 'Array<string>' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: 'const x = [] satisfies Array<string>;',
-            },
-          ],
-        },
-        {
-          line: 5,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Array<string>' },
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
-              output: `const x: Array<string> = ['a'];`,
-            },
-            {
-              data: { cast: 'Array<string>' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `const x = ['a'] satisfies Array<string>;`,
-            },
-          ],
-        },
-        {
-          line: 6,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: "'a'[]" },
-              messageId: 'replaceArrayTypeAssertionWithAnnotation',
-              output: `const x: 'a'[] = [Math.random() ? 'a' : 'b'];`,
-            },
-            {
-              data: { cast: "'a'[]" },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `const x = [Math.random() ? 'a' : 'b'] satisfies 'a'[];`,
-            },
-          ],
-        },
       ],
       options: [
         {
@@ -1040,12 +841,11 @@ const bs = (x <<= y) as any;
           assertionStyle: 'angle-bracket',
         },
       ],
-    }),
-    ...batchedSingleLineTests<MessageIds, Options>({
-      code: ARRAY_LITERAL_ARGUMENT_AS_CASTS,
+    },
+    {
+      code: 'print([5] as Foo);',
       errors: [
         {
-          line: 2,
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
@@ -1055,8 +855,18 @@ const bs = (x <<= y) as any;
             },
           ],
         },
+      ],
+      options: [
         {
-          line: 3,
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'as',
+        },
+      ],
+    },
+    {
+      code: 'new print([5] as Foo);',
+      errors: [
+        {
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
@@ -1066,19 +876,18 @@ const bs = (x <<= y) as any;
             },
           ],
         },
+      ],
+      options: [
         {
-          line: 4,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Foo' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `function foo() { throw [5] satisfies Foo }`,
-            },
-          ],
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'as',
         },
+      ],
+    },
+    {
+      code: 'function b(x = [5] as Foo.Bar) {}',
+      errors: [
         {
-          line: 5,
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
@@ -1088,50 +897,6 @@ const bs = (x <<= y) as any;
             },
           ],
         },
-        {
-          line: 6,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Foo' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `function c(x = [5] satisfies Foo) {}`,
-            },
-          ],
-        },
-        {
-          line: 7,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Foo' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `print?.([5] satisfies Foo);`,
-            },
-          ],
-        },
-        {
-          line: 8,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Foo' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `print?.call([5] satisfies Foo);`,
-            },
-          ],
-        },
-        {
-          line: 9,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Foo' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `print\`\${[5] satisfies Foo}\`;`,
-            },
-          ],
-        },
       ],
       options: [
         {
@@ -1139,73 +904,17 @@ const bs = (x <<= y) as any;
           assertionStyle: 'as',
         },
       ],
-    }),
-    ...batchedSingleLineTests<MessageIds, Options>({
-      code: ARRAY_LITERAL_ARGUMENT_BRACKET_CASTS,
+    },
+    {
+      code: 'new print(<Foo>[5]);',
       errors: [
         {
-          line: 2,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Foo' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `print([5] satisfies Foo);`,
-            },
-          ],
-        },
-        {
-          line: 3,
           messageId: 'unexpectedArrayTypeAssertion',
           suggestions: [
             {
               data: { cast: 'Foo' },
               messageId: 'replaceArrayTypeAssertionWithSatisfies',
               output: `new print([5] satisfies Foo);`,
-            },
-          ],
-        },
-        {
-          line: 4,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Foo' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `function foo() { throw [5] satisfies Foo }`,
-            },
-          ],
-        },
-        {
-          line: 5,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Foo' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `print?.([5] satisfies Foo);`,
-            },
-          ],
-        },
-        {
-          line: 6,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Foo' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `print?.call([5] satisfies Foo);`,
-            },
-          ],
-        },
-        {
-          line: 7,
-          messageId: 'unexpectedArrayTypeAssertion',
-          suggestions: [
-            {
-              data: { cast: 'Foo' },
-              messageId: 'replaceArrayTypeAssertionWithSatisfies',
-              output: `print\`\${[5] satisfies Foo}\`;`,
             },
           ],
         },
@@ -1216,6 +925,27 @@ const bs = (x <<= y) as any;
           assertionStyle: 'angle-bracket',
         },
       ],
-    }),
+    },
+    {
+      code: 'function b(x = <Foo.Bar>[5]) {}',
+      errors: [
+        {
+          messageId: 'unexpectedArrayTypeAssertion',
+          suggestions: [
+            {
+              data: { cast: 'Foo.Bar' },
+              messageId: 'replaceArrayTypeAssertionWithSatisfies',
+              output: `function b(x = [5] satisfies Foo.Bar) {}`,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          arrayLiteralTypeAssertions: 'never',
+          assertionStyle: 'angle-bracket',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/schema-snapshots/consistent-type-assertions.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/consistent-type-assertions.shot
@@ -22,6 +22,11 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
       {
         "additionalProperties": false,
         "properties": {
+          "arrayLiteralTypeAssertions": {
+            "description": "Whether to always prefer type declarations for array literals used as variable initializers, rather than type assertions.",
+            "enum": ["allow", "allow-as-parameter", "never"],
+            "type": "string"
+          },
           "assertionStyle": {
             "description": "The expected assertion style to enforce.",
             "enum": ["angle-bracket", "as"],
@@ -49,6 +54,12 @@ type Options = [
       'never';
     }
   | {
+      /** Whether to always prefer type declarations for array literals used as variable initializers, rather than type assertions. */
+      arrayLiteralTypeAssertions?:
+        | 'allow-as-parameter'
+        | 'never'
+        /** Whether to always prefer type declarations for array literals used as variable initializers, rather than type assertions. */
+        | 'allow';
       /** The expected assertion style to enforce. */
       assertionStyle?:
         | 'as'


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6374
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This pr addresses #6374 and adds `arrayLiteralTypeAssertions` option to the `consistent-type-assertions` rule.
It starts from #6749, which was previously closed, and adds `allow-as-parameter` to the `arrayLiteralTypeAssertions` option. (https://github.com/typescript-eslint/typescript-eslint/pull/6749#discussion_r1161060475)

<!-- Description of what is changed and how the code change does that. -->
Co-authored-by: @danvk