### PR TITLE
chore: upgrade to ts-api-utils 2.0

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -68,7 +68,7 @@
     "graphemer": "^1.4.0",
     "ignore": "^5.3.1",
     "natural-compare": "^1.4.0",
-    "ts-api-utils": "^1.3.0"
+    "ts-api-utils": "^2.0.0"
   },
   "devDependencies": {
     "@jest/types": "29.6.3",

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -175,8 +175,7 @@ export default createRule<Options, MessageIds>({
     }
 
     function collectToStringCertainty(type: ts.Type): Usefulness {
-      // https://github.com/JoshuaKGoldberg/ts-api-utils/issues/382
-      if ((tsutils.isTypeParameter as (t: ts.Type) => boolean)(type)) {
+      if (tsutils.isTypeParameter(type)) {
         const constraint = type.getConstraint();
         if (constraint) {
           return collectToStringCertainty(constraint);

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -41,13 +41,6 @@ const getValueOfLiteralType = (
   return type.value;
 };
 
-const isFalsyBigInt = (type: ts.Type): boolean => {
-  return (
-    tsutils.isLiteralType(type) &&
-    valueIsPseudoBigInt(type.value) &&
-    !getValueOfLiteralType(type)
-  );
-};
 const isTruthyLiteral = (type: ts.Type): boolean =>
   tsutils.isTrueLiteralType(type) ||
   (type.isLiteral() && !!getValueOfLiteralType(type));
@@ -70,13 +63,7 @@ const isPossiblyTruthy = (type: ts.Type): boolean =>
     .some(intersectionParts =>
       // It is possible to define intersections that are always falsy,
       // like `"" & { __brand: string }`.
-      intersectionParts.every(
-        type =>
-          !tsutils.isFalsyType(type) &&
-          // below is a workaround for ts-api-utils bug
-          // see https://github.com/JoshuaKGoldberg/ts-api-utils/issues/544
-          !isFalsyBigInt(type),
-      ),
+      intersectionParts.every(type => !tsutils.isFalsyType(type)),
     );
 
 // Nullish utilities
@@ -97,10 +84,7 @@ function toStaticValue(
   | undefined {
   // type.isLiteral() only covers numbers/bigints and strings, hence the rest of the branches.
   if (tsutils.isBooleanLiteralType(type)) {
-    // Using `type.intrinsicName` instead of `type.value` because `type.value`
-    // is `undefined`, contrary to what the type guard tells us.
-    // See https://github.com/JoshuaKGoldberg/ts-api-utils/issues/528
-    return { value: type.intrinsicName === 'true' };
+    return { value: tsutils.isTrueLiteralType(type) };
   }
   if (type.flags === ts.TypeFlags.Undefined) {
     return { value: undefined };

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-parameters.ts
@@ -334,8 +334,7 @@ function collectTypeParameterUsageCounts(
       return;
     }
 
-    // https://github.com/JoshuaKGoldberg/ts-api-utils/issues/382
-    if ((tsutils.isTypeParameter as (type: ts.Type) => boolean)(type)) {
+    if (tsutils.isTypeParameter(type)) {
       const declaration = type.getSymbol()?.getDeclarations()?.[0] as
         | ts.TypeParameterDeclaration
         | undefined;

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -49,7 +49,7 @@
     "@typescript-eslint/typescript-estree": "8.18.2",
     "@typescript-eslint/utils": "8.18.2",
     "debug": "^4.3.4",
-    "ts-api-utils": "^1.3.0"
+    "ts-api-utils": "^2.0.0"
   },
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0",

--- a/packages/type-utils/src/builtinSymbolLikes.ts
+++ b/packages/type-utils/src/builtinSymbolLikes.ts
@@ -159,8 +159,7 @@ export function isBuiltinSymbolLikeRecurser(
       isBuiltinSymbolLikeRecurser(program, t, predicate),
     );
   }
-  // https://github.com/JoshuaKGoldberg/ts-api-utils/issues/382
-  if ((tsutils.isTypeParameter as (type: ts.Type) => boolean)(type)) {
+  if (tsutils.isTypeParameter(type)) {
     const t = type.getConstraint();
 
     if (t) {

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -61,7 +61,7 @@
     "is-glob": "^4.0.3",
     "minimatch": "^9.0.4",
     "semver": "^7.6.0",
-    "ts-api-utils": "^1.3.0"
+    "ts-api-utils": "^2.0.0"
   },
   "devDependencies": {
     "@jest/types": "29.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5654,7 +5654,7 @@ __metadata:
     prettier: ^3.2.5
     rimraf: "*"
     title-case: ^3.0.3
-    ts-api-utils: ^1.3.0
+    ts-api-utils: ^2.0.0
     tsx: "*"
     typescript: "*"
     unist-util-visit: ^5.0.0
@@ -5772,7 +5772,7 @@ __metadata:
     jest: 29.7.0
     prettier: ^3.2.5
     rimraf: "*"
-    ts-api-utils: ^1.3.0
+    ts-api-utils: ^2.0.0
     typescript: "*"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
@@ -5889,7 +5889,7 @@ __metadata:
     rimraf: "*"
     semver: ^7.6.0
     tmp: "*"
-    ts-api-utils: ^1.3.0
+    ts-api-utils: ^2.0.0
     typescript: "*"
   peerDependencies:
     typescript: ">=4.8.4 <5.8.0"
@@ -19036,12 +19036,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^1.3.0":
-  version: 1.4.0
-  resolution: "ts-api-utils@npm:1.4.0"
+"ts-api-utils@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ts-api-utils@npm:2.0.0"
   peerDependencies:
-    typescript: ">=4.2.0"
-  checksum: 477601317dc8a6d961788663ee76984005ed20c70689bd6f807eed2cad258d3731edcc4162d438ce04782ca62a05373ba51e484180fc2a081d8dab2bf693a5af
+    typescript: ">=4.8.4"
+  checksum: f16f3e4e3308e7ad7ccf0bec3e0cb2e06b46c2d6919c40b6439e37912409c72f14340d231343b2b1b8cc17c2b8b01c5f2418690ea788312db6ca4e72cf2df6d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #10564
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Bump the version. Also remove workarounds for several fixed bugs (they were all fixed by v1.4.3 already).