### PR TITLE
chore(eslint-plugin): use `getConstraintInfo` in no-unnecessary-template-expression

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
@@ -5,7 +5,7 @@ import * as ts from 'typescript';
 
 import {
   createRule,
-  getConstrainedTypeAtLocation,
+  getConstraintInfo,
   getMovedNodeCode,
   getParserServices,
   isTypeFlagSet,
@@ -51,21 +51,29 @@ export default createRule<[], MessageId>({
     function isUnderlyingTypeString(
       expression: TSESTree.Expression,
     ): expression is TSESTree.Identifier | TSESTree.StringLiteral {
-      const type = getConstrainedTypeAtLocation(services, expression);
+      const checker = services.program.getTypeChecker();
+      const { constraintType } = getConstraintInfo(
+        checker,
+        services.getTypeAtLocation(expression),
+      );
+
+      if (constraintType == null) {
+        return false;
+      }
 
       const isString = (t: ts.Type): boolean => {
         return isTypeFlagSet(t, ts.TypeFlags.StringLike);
       };
 
-      if (type.isUnion()) {
-        return type.types.every(isString);
+      if (constraintType.isUnion()) {
+        return constraintType.types.every(isString);
       }
 
-      if (type.isIntersection()) {
-        return type.types.some(isString);
+      if (constraintType.isIntersection()) {
+        return constraintType.types.some(isString);
       }
 
-      return isString(type);
+      return isString(constraintType);
     }
 
     function isLiteral(

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -1142,6 +1142,11 @@ this code has trailing whitespace: \${'    '}
   // intentional comment after
 }\`;
     `,
+    `
+      function getTpl<T>(input: T) {
+        return \`\${input}\`;
+      }
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION

Switches the `no-unnecessary-template-expression` rule to use `getConstraintInfo` internally.

Related #10569

Assuming I've done the right thing here, let me know and i'll happily do most of the others. I'm just using this as a way to get my head back into the codebase

## PR Checklist

- [x] Addresses an existing open issue: related #10569
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
