### PR TITLE
chore: throw error in generate-configs if rule is deprecated and recommended

### DIFF
--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -19,6 +19,7 @@ export default createRule<Options, MessageIds>({
     deprecated: true,
     docs: {
       description: 'Disallow the declaration of empty interfaces',
+      recommended: 'recommended',
     },
     fixable: 'code',
     hasSuggestions: true,

--- a/packages/eslint-plugin/src/rules/no-empty-interface.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-interface.ts
@@ -19,7 +19,6 @@ export default createRule<Options, MessageIds>({
     deprecated: true,
     docs: {
       description: 'Disallow the declaration of empty interfaces',
-      recommended: 'recommended',
     },
     fixable: 'code',
     hasSuggestions: true,

--- a/tools/scripts/generate-configs.mts
+++ b/tools/scripts/generate-configs.mts
@@ -119,8 +119,13 @@ async function main(): Promise<void> {
     [key, value]: RuleEntry,
     settings: ConfigRuleSettings = {},
   ): LinterConfigRules {
-    if (settings.deprecated && value.meta.deprecated) {
-      return config;
+    if (value.meta.deprecated) {
+      if (value.meta.docs.recommended) {
+        throw new Error(`${key} is both deprecated and recommended.`);
+      }
+      if (settings.deprecated) {
+        return config;
+      }
     }
 
     // Explicitly exclude rules requiring type-checking


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8348
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I keep forgetting to do this quick little fixup...

💖 