### PR TITLE
feat(eslint-plugin): [no-deprecated] add allow options

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-deprecated.mdx
+++ b/packages/eslint-plugin/docs/rules/no-deprecated.mdx
@@ -59,6 +59,12 @@ const url2 = new URL('/foo', 'http://www.example.com');
 </TabItem>
 </Tabs>
 
+## Options
+
+### `allow`
+
+{/* insert option description */}
+
 ## When Not To Use It
 
 If portions of your project heavily use deprecated APIs and have no plan for moving to non-deprecated ones, you might want to disable this rule in those portions.

--- a/packages/eslint-plugin/docs/rules/no-deprecated.mdx
+++ b/packages/eslint-plugin/docs/rules/no-deprecated.mdx
@@ -65,6 +65,53 @@ const url2 = new URL('/foo', 'http://www.example.com');
 
 {/* insert option description */}
 
+This option takes the shared [`TypeOrValueSpecifier` format](/packages/type-utils/type-or-value-specifier).
+
+Examples of code for this rule with:
+
+```json
+{
+  "allow": [
+    { "from": "file", "name": "apiV1" },
+    { "from": "lib", "name": "HTMLFrameElement" },
+    { "from": "package", "name": "Bar", "package": "bar-lib" }
+  ]
+}
+```
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts option='{"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"HTMLFrameElement"},{"from":"package","name":"Bar","package":"bar-lib"}]}'
+/** @deprecated */
+declare function apiV2(): Promise<string>;
+
+await apiV2();
+
+function foo(
+  element: HTMLFrameSetElement, // HTMLFrameSetElement is deprecated (not specified in the option)
+) {}
+```
+
+</TabItem>
+
+<TabItem value="✅ Correct">
+
+```ts option='{"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"HTMLFrameElement"},{"from":"package","name":"Bar","package":"bar-lib"}]}'
+import { Bar } from 'bar-lib';
+/** @deprecated */
+declare function apiV1(): Promise<string>;
+
+await apiV1();
+
+function foo(
+  element: HTMLFrameElement, // HTMLFrameElement is deprecated (specified in the option)
+) {}
+```
+
+</TabItem>
+</Tabs>
+
 ## When Not To Use It
 
 If portions of your project heavily use deprecated APIs and have no plan for moving to non-deprecated ones, you might want to disable this rule in those portions.

--- a/packages/eslint-plugin/docs/rules/no-deprecated.mdx
+++ b/packages/eslint-plugin/docs/rules/no-deprecated.mdx
@@ -65,8 +65,6 @@ const url2 = new URL('/foo', 'http://www.example.com');
 
 {/* insert option description */}
 
-Whether to allow the use of deprecated types or values.
-
 This option takes the shared [`TypeOrValueSpecifier` format](/packages/type-utils/type-or-value-specifier).
 
 Examples of code for this rule with:
@@ -75,7 +73,7 @@ Examples of code for this rule with:
 {
   "allow": [
     { "from": "file", "name": "apiV1" },
-    { "from": "lib", "name": "HTMLFrameElement" },
+    { "from": "lib", "name": "escape" },
     { "from": "package", "name": "Bar", "package": "bar-lib" }
   ]
 }
@@ -84,31 +82,29 @@ Examples of code for this rule with:
 <Tabs>
 <TabItem value="❌ Incorrect">
 
-```ts option='{"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"HTMLFrameElement"},{"from":"package","name":"Bar","package":"bar-lib"}]}'
+```ts option='{"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"},{"from":"package","name":"Bar","package":"bar-lib"}]}'
 /** @deprecated */
 declare function apiV2(): Promise<string>;
 
 await apiV2();
 
-function foo(
-  element: HTMLFrameSetElement, // HTMLFrameSetElement is deprecated (not specified in the option)
-) {}
+// `unescape` has been deprecated since ES5.
+unescape('...');
 ```
 
 </TabItem>
 
 <TabItem value="✅ Correct">
 
-```ts option='{"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"HTMLFrameElement"},{"from":"package","name":"Bar","package":"bar-lib"}]}'
+```ts option='{"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"},{"from":"package","name":"Bar","package":"bar-lib"}]}'
 import { Bar } from 'bar-lib';
 /** @deprecated */
 declare function apiV1(): Promise<string>;
 
 await apiV1();
 
-function foo(
-  element: HTMLFrameElement, // HTMLFrameElement is deprecated (specified in the option)
-) {}
+// `escape` has been deprecated since ES5.
+escape('...');
 ```
 
 </TabItem>

--- a/packages/eslint-plugin/docs/rules/no-deprecated.mdx
+++ b/packages/eslint-plugin/docs/rules/no-deprecated.mdx
@@ -65,6 +65,8 @@ const url2 = new URL('/foo', 'http://www.example.com');
 
 {/* insert option description */}
 
+Whether to allow the use of deprecated types or values.
+
 This option takes the shared [`TypeOrValueSpecifier` format](/packages/type-utils/type-or-value-specifier).
 
 Examples of code for this rule with:

--- a/packages/eslint-plugin/docs/rules/no-deprecated.mdx
+++ b/packages/eslint-plugin/docs/rules/no-deprecated.mdx
@@ -73,8 +73,7 @@ Examples of code for this rule with:
 {
   "allow": [
     { "from": "file", "name": "apiV1" },
-    { "from": "lib", "name": "escape" },
-    { "from": "package", "name": "Bar", "package": "bar-lib" }
+    { "from": "lib", "name": "escape" }
   ]
 }
 ```
@@ -82,7 +81,7 @@ Examples of code for this rule with:
 <Tabs>
 <TabItem value="❌ Incorrect">
 
-```ts option='{"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"},{"from":"package","name":"Bar","package":"bar-lib"}]}'
+```ts option='{"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"}]}'
 /** @deprecated */
 declare function apiV2(): Promise<string>;
 
@@ -96,7 +95,7 @@ unescape('...');
 
 <TabItem value="✅ Correct">
 
-```ts option='{"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"},{"from":"package","name":"Bar","package":"bar-lib"}]}'
+```ts option='{"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"}]}'
 import { Bar } from 'bar-lib';
 /** @deprecated */
 declare function apiV1(): Promise<string>;

--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -4,14 +4,30 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
-import { createRule, getParserServices, nullThrows } from '../util';
+import type { TypeOrValueSpecifier } from '../util';
+
+import {
+  createRule,
+  getParserServices,
+  nullThrows,
+  typeOrValueSpecifiersSchema,
+  typeMatchesSomeSpecifier,
+} from '../util';
 
 type IdentifierLike =
   | TSESTree.Identifier
   | TSESTree.JSXIdentifier
   | TSESTree.Super;
 
-export default createRule({
+type MessageIds = 'deprecated' | 'deprecatedWithReason';
+
+type Options = [
+  {
+    allow?: TypeOrValueSpecifier[];
+  },
+];
+
+export default createRule<Options, MessageIds>({
   name: 'no-deprecated',
   meta: {
     type: 'problem',
@@ -24,11 +40,27 @@ export default createRule({
       deprecated: `\`{{name}}\` is deprecated.`,
       deprecatedWithReason: `\`{{name}}\` is deprecated. {{reason}}`,
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          allow: {
+            ...typeOrValueSpecifiersSchema,
+            description: 'Type specifiers that can be allowed.',
+          },
+        },
+      },
+    ],
   },
-  defaultOptions: [],
-  create(context) {
+  defaultOptions: [
+    {
+      allow: [],
+    },
+  ],
+  create(context, [options]) {
     const { jsDocParsingMode } = context.parserOptions;
+    const allow = options.allow;
     if (jsDocParsingMode === 'none' || jsDocParsingMode === 'type-info') {
       throw new Error(
         `Cannot be used with jsDocParsingMode: '${jsDocParsingMode}'.`,
@@ -332,6 +364,11 @@ export default createRule({
       }
 
       const name = node.type === AST_NODE_TYPES.Super ? 'super' : node.name;
+
+      const type = services.getTypeAtLocation(node);
+      if (typeMatchesSomeSpecifier(type, allow, services.program)) {
+        return;
+      }
 
       context.report({
         ...(reason

--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -363,12 +363,12 @@ export default createRule<Options, MessageIds>({
         return;
       }
 
-      const name = node.type === AST_NODE_TYPES.Super ? 'super' : node.name;
-
       const type = services.getTypeAtLocation(node);
       if (typeMatchesSomeSpecifier(type, allow, services.program)) {
         return;
       }
+
+      const name = node.type === AST_NODE_TYPES.Super ? 'super' : node.name;
 
       context.report({
         ...(reason

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-deprecated.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-deprecated.shot
@@ -46,7 +46,7 @@ const url2 = new URL('/foo', 'http://www.example.com');
 
 exports[`Validating rule docs no-deprecated.mdx code examples ESLint output 5`] = `
 "Incorrect
-Options: {"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"HTMLFrameElement"},{"from":"package","name":"Bar","package":"bar-lib"}]}
+Options: {"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"},{"from":"package","name":"Bar","package":"bar-lib"}]}
 
 /** @deprecated */
 declare function apiV2(): Promise<string>;
@@ -54,15 +54,15 @@ declare function apiV2(): Promise<string>;
 await apiV2();
       ~~~~~ \`apiV2\` is deprecated.
 
-function foo(
-  element: HTMLFrameSetElement, // HTMLFrameSetElement is deprecated (not specified in the option)
-) {}
+// \`unescape\` has been deprecated since ES5.
+unescape('...');
+~~~~~~~~ \`unescape\` is deprecated. A legacy feature for browser compatibility
 "
 `;
 
 exports[`Validating rule docs no-deprecated.mdx code examples ESLint output 6`] = `
 "Correct
-Options: {"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"HTMLFrameElement"},{"from":"package","name":"Bar","package":"bar-lib"}]}
+Options: {"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"},{"from":"package","name":"Bar","package":"bar-lib"}]}
 
 import { Bar } from 'bar-lib';
 /** @deprecated */
@@ -70,8 +70,7 @@ declare function apiV1(): Promise<string>;
 
 await apiV1();
 
-function foo(
-  element: HTMLFrameElement, // HTMLFrameElement is deprecated (specified in the option)
-) {}
+// \`escape\` has been deprecated since ES5.
+escape('...');
 "
 `;

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-deprecated.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-deprecated.shot
@@ -43,3 +43,35 @@ exports[`Validating rule docs no-deprecated.mdx code examples ESLint output 4`] 
 const url2 = new URL('/foo', 'http://www.example.com');
 "
 `;
+
+exports[`Validating rule docs no-deprecated.mdx code examples ESLint output 5`] = `
+"Incorrect
+Options: {"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"HTMLFrameElement"},{"from":"package","name":"Bar","package":"bar-lib"}]}
+
+/** @deprecated */
+declare function apiV2(): Promise<string>;
+
+await apiV2();
+      ~~~~~ \`apiV2\` is deprecated.
+
+function foo(
+  element: HTMLFrameSetElement, // HTMLFrameSetElement is deprecated (not specified in the option)
+) {}
+"
+`;
+
+exports[`Validating rule docs no-deprecated.mdx code examples ESLint output 6`] = `
+"Correct
+Options: {"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"HTMLFrameElement"},{"from":"package","name":"Bar","package":"bar-lib"}]}
+
+import { Bar } from 'bar-lib';
+/** @deprecated */
+declare function apiV1(): Promise<string>;
+
+await apiV1();
+
+function foo(
+  element: HTMLFrameElement, // HTMLFrameElement is deprecated (specified in the option)
+) {}
+"
+`;

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-deprecated.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-deprecated.shot
@@ -46,7 +46,7 @@ const url2 = new URL('/foo', 'http://www.example.com');
 
 exports[`Validating rule docs no-deprecated.mdx code examples ESLint output 5`] = `
 "Incorrect
-Options: {"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"},{"from":"package","name":"Bar","package":"bar-lib"}]}
+Options: {"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"}]}
 
 /** @deprecated */
 declare function apiV2(): Promise<string>;
@@ -62,7 +62,7 @@ unescape('...');
 
 exports[`Validating rule docs no-deprecated.mdx code examples ESLint output 6`] = `
 "Correct
-Options: {"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"},{"from":"package","name":"Bar","package":"bar-lib"}]}
+Options: {"allow":[{"from":"file","name":"apiV1"},{"from":"lib","name":"escape"}]}
 
 import { Bar } from 'bar-lib';
 /** @deprecated */

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -312,6 +312,36 @@ ruleTester.run('no-deprecated', rule, {
       }
       <foo bar={1} />;
     `,
+    {
+      code: `
+/** @deprecated */
+declare class A {}
+
+new A();
+      `,
+      options: [
+        {
+          allow: [{ from: 'file', name: 'A' }],
+        },
+      ],
+    },
+    {
+      code: `
+import { exists } from 'fs';
+exists('/foo');
+      `,
+      options: [
+        {
+          allow: [
+            {
+              from: 'package',
+              name: 'exists',
+              package: 'fs',
+            },
+          ],
+        },
+      ],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/schema-snapshots/no-deprecated.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-deprecated.shot
@@ -4,11 +4,134 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 "
 # SCHEMA:
 
-[]
+[
+  {
+    "additionalProperties": false,
+    "properties": {
+      "allow": {
+        "description": "Type specifiers that can be allowed.",
+        "items": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "from": {
+                  "enum": ["file"],
+                  "type": "string"
+                },
+                "name": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    }
+                  ]
+                },
+                "path": {
+                  "type": "string"
+                }
+              },
+              "required": ["from", "name"],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "from": {
+                  "enum": ["lib"],
+                  "type": "string"
+                },
+                "name": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    }
+                  ]
+                }
+              },
+              "required": ["from", "name"],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "from": {
+                  "enum": ["package"],
+                  "type": "string"
+                },
+                "name": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "minItems": 1,
+                      "type": "array",
+                      "uniqueItems": true
+                    }
+                  ]
+                },
+                "package": {
+                  "type": "string"
+                }
+              },
+              "required": ["from", "name", "package"],
+              "type": "object"
+            }
+          ]
+        },
+        "type": "array"
+      }
+    },
+    "type": "object"
+  }
+]
 
 
 # TYPES:
 
-/** No options declared */
-type Options = [];"
+type Options = [
+  {
+    /** Type specifiers that can be allowed. */
+    allow?: (
+      | {
+          from: 'file';
+          name: [string, ...string[]] | string;
+          path?: string;
+        }
+      | {
+          from: 'lib';
+          name: [string, ...string[]] | string;
+        }
+      | {
+          from: 'package';
+          name: [string, ...string[]] | string;
+          package: string;
+        }
+      | string
+    )[];
+  },
+];
+"
 `;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9899 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
This PR addresses issue #9899.
Add an `allow` option of type [TypeOrValueSpecifier](https://typescript-eslint.io/packages/type-utils/type-or-value-specifier/). The types/values specified in the `allow` option are allowed to be used even if deprecated.

<!-- Description of what is changed and how the code change does that. -->
