### PR TITLE
chore(eslint-plugin): no-confusing-void-expression `getConstraintInfo`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -8,11 +8,12 @@ import type { MakeRequired } from '../util';
 
 import {
   createRule,
-  getConstrainedTypeAtLocation,
+  getConstraintInfo,
   getParserServices,
   isClosingParenToken,
   isOpeningParenToken,
   isParenthesized,
+  isAwaitExpression,
   nullThrows,
   NullThrowsReasons,
 } from '../util';
@@ -116,8 +117,19 @@ export default createRule<Options, MessageId>({
           | TSESTree.CallExpression
           | TSESTree.TaggedTemplateExpression,
       ): void {
-        const type = getConstrainedTypeAtLocation(services, node);
-        if (!tsutils.isTypeFlagSet(type, ts.TypeFlags.VoidLike)) {
+        const checker = services.program.getTypeChecker();
+        const { constraintType } = getConstraintInfo(
+          checker,
+          services.getTypeAtLocation(
+            isAwaitExpression(node) ? node.argument : node,
+          ),
+        );
+
+        if (constraintType == null) {
+          return;
+        }
+
+        if (!tsutils.isTypeFlagSet(constraintType, ts.TypeFlags.VoidLike)) {
           // not a void expression
           return;
         }
@@ -420,8 +432,15 @@ export default createRule<Options, MessageId>({
           ? node.argument
           : node.body;
 
-      const type = getConstrainedTypeAtLocation(services, targetNode);
-      return tsutils.isTypeFlagSet(type, ts.TypeFlags.VoidLike);
+      const checker = services.program.getTypeChecker();
+      const { constraintType } = getConstraintInfo(
+        checker,
+        services.getTypeAtLocation(targetNode),
+      );
+      return (
+        constraintType != null &&
+        tsutils.isTypeFlagSet(constraintType, ts.TypeFlags.VoidLike)
+      );
     }
 
     function isFunctionReturnTypeIncludesVoid(functionType: ts.Type): boolean {

--- a/packages/eslint-plugin/tests/rules/no-confusing-void-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-confusing-void-expression.test.ts
@@ -410,6 +410,11 @@ test((() => {
       `,
       options: [{ ignoreVoidReturningFunctions: true }],
     },
+    `
+      async function f<T>(input: T) {
+        await input;
+      }
+    `,
   ],
 
   invalid: [
@@ -1207,6 +1212,23 @@ function test(arg?: string): any | void {
   console.log();
 }
       `,
+    },
+    {
+      code: `
+        declare const a: void;
+        const b = await a;
+      `,
+      errors: [{ column: 19, messageId: 'invalidVoidExpr' }],
+      output: null,
+    },
+    {
+      code: `
+        function fn(a: void) {
+          const b = await a;
+        }
+      `,
+      errors: [{ column: 21, messageId: 'invalidVoidExpr' }],
+      output: null,
     },
   ],
 });


### PR DESCRIPTION
Moves to using `getConstraintInfo` internally in the `no-confusing-void-expression` rule.

Also fixes a bug this uncovered, where `AwaitExpression` nodes were actually untested and not supported in the type constraint checks.

This is because we passed `node` (the `AwaitExpression` itself), rather than the thing being awaited (`node.argument`). By passing the `argument`, we check its type instead.

## PR Checklist

- [x] Addresses an existing open issue: Related #10569
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
