### PR TITLE
test(eslint-plugin): add extra tests

### DIFF
--- a/packages/eslint-plugin/tests/rules/class-methods-use-this/class-methods-use-this.test.ts
+++ b/packages/eslint-plugin/tests/rules/class-methods-use-this/class-methods-use-this.test.ts
@@ -549,6 +549,22 @@ class Foo implements Bar {
         },
       ],
     },
+    {
+      code: `
+function fn() {
+  this.foo = 303;
+
+  class Foo {
+    method() {}
+  }
+}
+      `,
+      errors: [
+        {
+          messageId: 'missingThis',
+        },
+      ],
+    },
   ],
   valid: [
     {

--- a/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-assertions.test.ts
@@ -157,6 +157,18 @@ ruleTester.run('consistent-type-assertions', rule, {
         },
       },
     },
+    {
+      code: `
+const x = { key: 'value' } as any;
+      `,
+      options: [{ assertionStyle: 'as', objectLiteralTypeAssertions: 'never' }],
+    },
+    {
+      code: `
+const x = { key: 'value' } as unknown;
+      `,
+      options: [{ assertionStyle: 'as', objectLiteralTypeAssertions: 'never' }],
+    },
   ],
   invalid: [
     ...dedupeTestCases(

--- a/packages/eslint-plugin/tests/rules/no-array-delete.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-array-delete.test.ts
@@ -55,6 +55,10 @@ ruleTester.run('no-array-delete', rule, {
       declare const test: never;
       delete test[0];
     `,
+    // Shouldn't ever happen but to ensure we require member expressions
+    `
+      delete console.log();
+    `,
   ],
 
   invalid: [
@@ -590,6 +594,29 @@ ruleTester.run('no-array-delete', rule, {
         declare const b: number;
 
         a.splice((b + 1) * (b + 2), 1);
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `
+        declare const arr: string & Array<number>;
+        delete arr[0];
+      `,
+      errors: [
+        {
+          column: 9,
+          endColumn: 22,
+          line: 3,
+          messageId: 'noArrayDelete',
+          suggestions: [
+            {
+              messageId: 'useSplice',
+              output: `
+        declare const arr: string & Array<number>;
+        arr.splice(0, 1);
       `,
             },
           ],

--- a/packages/eslint-plugin/tests/rules/no-array-delete.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-array-delete.test.ts
@@ -55,7 +55,6 @@ ruleTester.run('no-array-delete', rule, {
       declare const test: never;
       delete test[0];
     `,
-    // Shouldn't ever happen but to ensure we require member expressions
     `
       delete console.log();
     `,


### PR DESCRIPTION
Adds a couple of extra test cases for these rules:

- `class-methods-use-this`
- `consistent-type-assertions`
- `no-array-delete`

wasn't sure why you have a `core` tests file for `class-methods-use-this`. so let me know which one this test belongs in

## PR Checklist

- [ ] Addresses an existing open issue: none, tests-only pr
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken