### PR TITLE
docs: add syntax highlighting for bash and diff blocks

### DIFF
--- a/packages/website/docusaurus.config.mts
+++ b/packages/website/docusaurus.config.mts
@@ -184,7 +184,7 @@ const themeConfig: AlgoliaThemeConfig & ThemeCommonConfig = {
     title: 'typescript-eslint',
   },
   prism: {
-    additionalLanguages: ['ignore'],
+    additionalLanguages: ['bash', 'diff', 'ignore'],
     magicComments: [
       {
         block: { end: 'highlight-end', start: 'highlight-start' },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hi there👋

I've noticed the code blocks with the languages `bash` and `diff` were missing syntax highlighting in the docs. These languages need to be manually added in the `docusaurus` config file. This PR fixes this issue.

Let me know if I should create an issue ticket, I thought this is a minor enough change^^

Getting started page before & after:
![image](https://github.com/user-attachments/assets/960e1fdc-2556-46c1-b7fb-06c5f411296c)
![image](https://github.com/user-attachments/assets/c5f8e576-eeae-42f0-a472-4accb7de4f7b)

Troubleshooting before & after:
![image](https://github.com/user-attachments/assets/5c6fe44e-5060-4dd6-bbef-16c19a22a60b)
![image](https://github.com/user-attachments/assets/d2480418-f02e-4068-9660-502345332baa)

