### PR TITLE
fix(eslint-plugin): [no-shadow] ignore ordering of type declarations

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-shadow.mdx
+++ b/packages/eslint-plugin/docs/rules/no-shadow.mdx
@@ -17,16 +17,50 @@ It adds support for TypeScript's `this` parameters and global augmentation, and 
 This rule adds the following options:
 
 ```ts
+type AdditionalHoistOptionEntries = 'types' | 'functions-and-types';
+
+type HoistOptionEntries =
+  | BaseNoShadowHoistOptionEntries
+  | AdditionalHoistOptionEntries;
+
 interface Options extends BaseNoShadowOptions {
+  hoist?: HoistOptionEntries;
   ignoreTypeValueShadow?: boolean;
   ignoreFunctionTypeParameterNameValueShadow?: boolean;
 }
 
 const defaultOptions: Options = {
   ...baseNoShadowDefaultOptions,
+  hoist: 'functions-and-types',
   ignoreTypeValueShadow: true,
   ignoreFunctionTypeParameterNameValueShadow: true,
 };
+```
+
+### hoist: `types`
+
+Examples of incorrect code for the `{ "hoist": ["types"] }` option:
+
+```ts option='{ "hoist": ["types"] }' showPlaygroundButton
+type Bar<Foo> = 1;
+type Foo = 1;
+```
+
+### hoist: `functions-and-types`
+
+Examples of incorrect code for the `{ "hoist": ["functions-and-types"] }` option:
+
+```ts option='{ "hoist": ["functions-and-types"] }' showPlaygroundButton
+// types
+type Bar<Foo> = 1;
+type Foo = 1;
+
+// functions
+if (true) {
+  let b = 6;
+}
+
+function b() {}
 ```
 
 ### `ignoreTypeValueShadow`

--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -524,17 +524,14 @@ export default createRule<Options, MessageIds>({
         return false;
       }
 
-      // Excepts function declaration nodes if is {"hoist":"function"}.
       if (options.hoist === 'functions') {
         return !functionsHoistedNodes.has(outerDef.node.type);
       }
 
-      // Excepts type declaration nodes if is {"hoist":"types"}.
       if (options.hoist === 'types') {
         return !typesHoistedNodes.has(outerDef.node.type);
       }
 
-      // Except both if is {"hoist":"functions-and-types"}
       if (options.hoist === 'functions-and-types') {
         return (
           !functionsHoistedNodes.has(outerDef.node.type) &&

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -549,6 +549,25 @@ let y;
     },
     {
       code: `
+let x = foo((x, y) => {});
+let y;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'x',
+            shadowedColumn: 5,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaVersion: 6 } },
+      options: [{ hoist: 'functions' }],
+    },
+    {
+      code: `
 type Foo<A> = 1;
 type A = 1;
       `,
@@ -619,6 +638,273 @@ interface A {}
       ],
       options: [{ hoist: 'types' }],
     },
+    {
+      code: `
+{
+  type A = 1;
+}
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 5,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'types' }],
+    },
+    {
+      code: `
+{
+  interface A {}
+}
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 5,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'types' }],
+    },
+
+    {
+      code: `
+type Foo<A> = 1;
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'all' }],
+    },
+    {
+      code: `
+interface Foo<A> {}
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'all' }],
+    },
+    {
+      code: `
+interface Foo<A> {}
+interface A {}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 11,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'all' }],
+    },
+    {
+      code: `
+type Foo<A> = 1;
+interface A {}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 11,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'all' }],
+    },
+    {
+      code: `
+{
+  type A = 1;
+}
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 5,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'all' }],
+    },
+    {
+      code: `
+{
+  interface A {}
+}
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 5,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'all' }],
+    },
+
+    {
+      code: `
+type Foo<A> = 1;
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'functions-and-types' }],
+    },
+    {
+      code: `
+interface Foo<A> {}
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'functions-and-types' }],
+    },
+    {
+      code: `
+interface Foo<A> {}
+interface A {}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 11,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'functions-and-types' }],
+    },
+    {
+      code: `
+type Foo<A> = 1;
+interface A {}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 11,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'functions-and-types' }],
+    },
+    {
+      code: `
+{
+  type A = 1;
+}
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 5,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'functions-and-types' }],
+    },
+    {
+      code: `
+{
+  interface A {}
+}
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 5,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'functions-and-types' }],
+    },
+
     {
       code: `
 function foo<T extends (...args: any[]) => any>(fn: T, args: any[]) {}
@@ -1099,5 +1385,99 @@ const person = {
       options: [{ ignoreOnInitialization: true }],
     },
     { code: 'const [x = y => y] = [].map(y => y);' },
+
+    {
+      code: `
+type Foo<A> = 1;
+type A = 1;
+      `,
+      options: [{ hoist: 'never' }],
+    },
+    {
+      code: `
+interface Foo<A> {}
+type A = 1;
+      `,
+      options: [{ hoist: 'never' }],
+    },
+    {
+      code: `
+interface Foo<A> {}
+interface A {}
+      `,
+      options: [{ hoist: 'never' }],
+    },
+    {
+      code: `
+type Foo<A> = 1;
+interface A {}
+      `,
+      options: [{ hoist: 'never' }],
+    },
+    {
+      code: `
+{
+  type A = 1;
+}
+type A = 1;
+      `,
+      options: [{ hoist: 'never' }],
+    },
+    {
+      code: `
+{
+  interface Foo<A> {}
+}
+type A = 1;
+      `,
+      options: [{ hoist: 'never' }],
+    },
+
+    {
+      code: `
+type Foo<A> = 1;
+type A = 1;
+      `,
+      options: [{ hoist: 'functions' }],
+    },
+    {
+      code: `
+interface Foo<A> {}
+type A = 1;
+      `,
+      options: [{ hoist: 'functions' }],
+    },
+    {
+      code: `
+interface Foo<A> {}
+interface A {}
+      `,
+      options: [{ hoist: 'functions' }],
+    },
+    {
+      code: `
+type Foo<A> = 1;
+interface A {}
+      `,
+      options: [{ hoist: 'functions' }],
+    },
+    {
+      code: `
+{
+  type A = 1;
+}
+type A = 1;
+      `,
+      options: [{ hoist: 'functions' }],
+    },
+    {
+      code: `
+{
+  interface Foo<A> {}
+}
+type A = 1;
+      `,
+      options: [{ hoist: 'functions' }],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -549,6 +549,78 @@ let y;
     },
     {
       code: `
+type Foo<A> = 1;
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'types' }],
+    },
+    {
+      code: `
+interface Foo<A> {}
+type A = 1;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 6,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'types' }],
+    },
+    {
+      code: `
+interface Foo<A> {}
+interface A {}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 11,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'types' }],
+    },
+    {
+      code: `
+type Foo<A> = 1;
+interface A {}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'A',
+            shadowedColumn: 11,
+            shadowedLine: 3,
+          },
+          messageId: 'noShadow',
+          type: AST_NODE_TYPES.Identifier,
+        },
+      ],
+      options: [{ hoist: 'types' }],
+    },
+    {
+      code: `
 function foo<T extends (...args: any[]) => any>(fn: T, args: any[]) {}
       `,
       errors: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #5935
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR attempts to tackle #5935.

Some thoughts/questions:

- I've expanded the existing `hoist` configuration to include `types` and `functions-and-types`. I don't think this is optimal, as permutations need to be manually set (e.g. `functions-and-types`). It also adds some complexity to this configuration, but I'm not sure if there's a non-breaking alternative.

  Since this is an extension rule, this somewhat changes the [base rule](https://eslint.org/docs/latest/rules/no-shadow#hoist)'s option, though I did see other rules like [`no-empty-function`](https://github.com/typescript-eslint/typescript-eslint/blob/4dbf48b8eec0321babb4293a1be71b54dd00c018/packages/eslint-plugin/src/rules/no-empty-function.ts#L37-L52) which extend an enum type of their base rule).

  That said, I'm not sure if someone will ever want to configure this to just `functions` or just `types`. It may be better to have the current `functions` options include `types` behavior and rename it in a future major (although this would mean the option would diverge from the base rule).
  
  I'm a bit unsure about this, so I'll be happy to hear other opinions.
- I've changed the default from `functions` to `functions-and-types`. This seems like the most sensible option, as for both, ordering doesn't matter.
- I've included documentation for the added option, similar to how other extension tests do this. I wasn't sure whether to use the correct/incorrect `<Tabs>` or not. I have decided not to use `<Tabs>` to match the rest of the rule's documentation.