### PR TITLE
chore: standardized on inline named exports (mostly)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,12 @@ import tseslint from 'typescript-eslint';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 const compat = new FlatCompat({ baseDirectory: __dirname });
 
+const restrictNamedDeclarations = {
+  message:
+    'Prefer a named export (e.g. `export const ...`) over an object export (e.g. `export { ... }`).',
+  selector: 'ExportNamedDeclaration[declaration=null][source=null]',
+};
+
 export default tseslint.config(
   // register all of the plugins up-front
   {
@@ -194,6 +200,7 @@ export default tseslint.config(
         'error',
       '@typescript-eslint/internal/no-typescript-default-import': 'error',
       '@typescript-eslint/internal/prefer-ast-types-enum': 'error',
+      'no-restricted-syntax': ['error', restrictNamedDeclarations],
 
       //
       // eslint-base
@@ -503,6 +510,7 @@ export default tseslint.config(
           selector:
             'ExportDefaultDeclaration Property[key.name="create"] MemberExpression[object.name="context"][property.name="options"]',
         },
+        restrictNamedDeclarations,
       ],
     },
   },

--- a/packages/ast-spec/tests/util/serializers/Node.ts
+++ b/packages/ast-spec/tests/util/serializers/Node.ts
@@ -38,7 +38,7 @@ function hasValidType(type: unknown): type is string {
   return typeof type === 'string';
 }
 
-const serializer: NewPlugin = {
+export const serializer: NewPlugin = {
   serialize(
     node: Record<string, unknown> & TSESTree.Node,
     config,
@@ -91,5 +91,3 @@ const serializer: NewPlugin = {
     return isObject(val) && hasValidType(val.type);
   },
 };
-
-export { serializer };

--- a/packages/ast-spec/tests/util/serializers/string.ts
+++ b/packages/ast-spec/tests/util/serializers/string.ts
@@ -2,7 +2,7 @@ import type { NewPlugin } from 'pretty-format';
 
 // custom string serializer so that we can use single-quoted strings instead of double quoted strings
 // this plays nicer with the way that the snapshot diff result, which is a pure string
-const serializer: NewPlugin = {
+export const serializer: NewPlugin = {
   serialize(
     str: string,
     // config,
@@ -17,5 +17,3 @@ const serializer: NewPlugin = {
     return typeof val === 'string';
   },
 };
-
-export { serializer };

--- a/packages/eslint-plugin-internal/src/util/createRule.ts
+++ b/packages/eslint-plugin-internal/src/util/createRule.ts
@@ -8,9 +8,7 @@ export interface ESLintPluginInternalDocs {
   requiresTypeChecking?: true;
 }
 
-const createRule = ESLintUtils.RuleCreator<ESLintPluginInternalDocs>(
+export const createRule = ESLintUtils.RuleCreator<ESLintPluginInternalDocs>(
   name =>
     `https://github.com/typescript-eslint/typescript-eslint/blob/v${version}/packages/eslint-plugin-internal/src/rules/${name}.ts`,
 );
-
-export { createRule };

--- a/packages/eslint-plugin-internal/tests/RuleTester.ts
+++ b/packages/eslint-plugin-internal/tests/RuleTester.ts
@@ -1,8 +1,7 @@
 import path from 'node:path';
 
-function getFixturesRootDir(): string {
+export function getFixturesRootDir(): string {
   return path.join(__dirname, 'fixtures');
 }
 
 export { RuleTester } from '@typescript-eslint/rule-tester';
-export { getFixturesRootDir };

--- a/packages/eslint-plugin/rules.d.ts
+++ b/packages/eslint-plugin/rules.d.ts
@@ -34,6 +34,7 @@ The inferred type of 'default' cannot be named without a reference to
 This is likely not portable. A type annotation is necessary. ts(2742)
 ```
 */
+/* eslint-disable no-restricted-syntax */
 
 import type {
   RuleModuleWithMetaDocs,

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/enums.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/enums.ts
@@ -1,4 +1,4 @@
-enum PredefinedFormats {
+export enum PredefinedFormats {
   camelCase = 1,
   strictCamelCase,
   PascalCase,
@@ -6,9 +6,9 @@ enum PredefinedFormats {
   snake_case,
   UPPER_CASE,
 }
-type PredefinedFormatsString = keyof typeof PredefinedFormats;
+export type PredefinedFormatsString = keyof typeof PredefinedFormats;
 
-enum UnderscoreOptions {
+export enum UnderscoreOptions {
   forbid = 1,
   allow,
   require,
@@ -18,9 +18,9 @@ enum UnderscoreOptions {
   allowDouble,
   allowSingleOrDouble,
 }
-type UnderscoreOptionsString = keyof typeof UnderscoreOptions;
+export type UnderscoreOptionsString = keyof typeof UnderscoreOptions;
 
-enum Selectors {
+export enum Selectors {
   // variableLike
   variable = 1 << 0,
   function = 1 << 1,
@@ -48,9 +48,9 @@ enum Selectors {
   // other
   import = 1 << 18,
 }
-type SelectorsString = keyof typeof Selectors;
+export type SelectorsString = keyof typeof Selectors;
 
-enum MetaSelectors {
+export enum MetaSelectors {
   /* eslint-disable @typescript-eslint/prefer-literal-enum-member */
   default = -1,
   variableLike = 0 |
@@ -85,10 +85,12 @@ enum MetaSelectors {
   accessor = 0 | Selectors.classicAccessor | Selectors.autoAccessor,
   /* eslint-enable @typescript-eslint/prefer-literal-enum-member */
 }
-type MetaSelectorsString = keyof typeof MetaSelectors;
-type IndividualAndMetaSelectorsString = MetaSelectorsString | SelectorsString;
+export type MetaSelectorsString = keyof typeof MetaSelectors;
+export type IndividualAndMetaSelectorsString =
+  | MetaSelectorsString
+  | SelectorsString;
 
-enum Modifiers {
+export enum Modifiers {
   // const variable
   const = 1 << 0,
   // readonly members
@@ -122,29 +124,13 @@ enum Modifiers {
 
   // make sure TypeModifiers starts at Modifiers + 1 or else sorting won't work
 }
-type ModifiersString = keyof typeof Modifiers;
+export type ModifiersString = keyof typeof Modifiers;
 
-enum TypeModifiers {
+export enum TypeModifiers {
   boolean = 1 << 17,
   string = 1 << 18,
   number = 1 << 19,
   function = 1 << 20,
   array = 1 << 21,
 }
-type TypeModifiersString = keyof typeof TypeModifiers;
-
-export {
-  type IndividualAndMetaSelectorsString,
-  MetaSelectors,
-  type MetaSelectorsString,
-  Modifiers,
-  type ModifiersString,
-  PredefinedFormats,
-  type PredefinedFormatsString,
-  Selectors,
-  type SelectorsString,
-  TypeModifiers,
-  type TypeModifiersString,
-  UnderscoreOptions,
-  type UnderscoreOptionsString,
-};
+export type TypeModifiersString = keyof typeof TypeModifiers;

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/format.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/format.ts
@@ -96,7 +96,7 @@ function validateUnderscores(name: string): boolean {
   return !wasUnderscore;
 }
 
-const PredefinedFormatToCheckFunction: Readonly<
+export const PredefinedFormatToCheckFunction: Readonly<
   Record<PredefinedFormats, (name: string) => boolean>
 > = {
   [PredefinedFormats.camelCase]: isCamelCase,
@@ -106,5 +106,3 @@ const PredefinedFormatToCheckFunction: Readonly<
   [PredefinedFormats.StrictPascalCase]: isStrictPascalCase,
   [PredefinedFormats.UPPER_CASE]: isUpperCase,
 };
-
-export { PredefinedFormatToCheckFunction };

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/parse-options.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/parse-options.ts
@@ -80,7 +80,7 @@ function normalizeOption(option: Selector): NormalizedSelector[] {
   }));
 }
 
-function parseOptions(context: Context): ParsedOptions {
+export function parseOptions(context: Context): ParsedOptions {
   const normalizedOptions = context.options.flatMap(normalizeOption);
 
   return Object.fromEntries(
@@ -90,5 +90,3 @@ function parseOptions(context: Context): ParsedOptions {
     ]),
   ) as ParsedOptions;
 }
-
-export { parseOptions };

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/schema.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/schema.ts
@@ -185,7 +185,7 @@ function selectorsSchema(): JSONSchema.JSONSchema4 {
   };
 }
 
-const SCHEMA: JSONSchema.JSONSchema4 = {
+export const SCHEMA: JSONSchema.JSONSchema4 = {
   $defs: $DEFS,
   additionalItems: false,
   items: {
@@ -329,5 +329,3 @@ const SCHEMA: JSONSchema.JSONSchema4 = {
   },
   type: 'array',
 };
-
-export { SCHEMA };

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/shared.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/shared.ts
@@ -7,27 +7,23 @@ import type {
 
 import { MetaSelectors } from './enums';
 
-function selectorTypeToMessageString(selectorType: SelectorsString): string {
+export function selectorTypeToMessageString(
+  selectorType: SelectorsString,
+): string {
   const notCamelCase = selectorType.replaceAll(/([A-Z])/g, ' $1');
   return notCamelCase.charAt(0).toUpperCase() + notCamelCase.slice(1);
 }
 
-function isMetaSelector(
+export function isMetaSelector(
   selector: IndividualAndMetaSelectorsString | MetaSelectors | Selectors,
 ): selector is MetaSelectorsString {
   return selector in MetaSelectors;
 }
 
-function isMethodOrPropertySelector(
+export function isMethodOrPropertySelector(
   selector: IndividualAndMetaSelectorsString | MetaSelectors | Selectors,
 ): boolean {
   return (
     selector === MetaSelectors.method || selector === MetaSelectors.property
   );
 }
-
-export {
-  isMetaSelector,
-  isMethodOrPropertySelector,
-  selectorTypeToMessageString,
-};

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/types.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/types.ts
@@ -16,12 +16,12 @@ import type {
   UnderscoreOptionsString,
 } from './enums';
 
-interface MatchRegex {
+export interface MatchRegex {
   match: boolean;
   regex: string;
 }
 
-interface Selector {
+export interface Selector {
   custom?: MatchRegex;
   filter?: string | MatchRegex;
   // format options
@@ -38,12 +38,12 @@ interface Selector {
   types?: TypeModifiersString[];
 }
 
-interface NormalizedMatchRegex {
+export interface NormalizedMatchRegex {
   match: boolean;
   regex: RegExp;
 }
 
-interface NormalizedSelector {
+export interface NormalizedSelector {
   custom: NormalizedMatchRegex | null;
   filter: NormalizedMatchRegex | null;
   // format options
@@ -60,17 +60,9 @@ interface NormalizedSelector {
   types: TypeModifiers[] | null;
 }
 
-type ValidatorFunction = (
+export type ValidatorFunction = (
   node: TSESTree.Identifier | TSESTree.Literal | TSESTree.PrivateIdentifier,
   modifiers?: Set<Modifiers>,
 ) => void;
-type ParsedOptions = Record<SelectorsString, ValidatorFunction>;
-type Context = Readonly<TSESLint.RuleContext<MessageIds, Options>>;
-
-export type {
-  Context,
-  NormalizedSelector,
-  ParsedOptions,
-  Selector,
-  ValidatorFunction,
-};
+export type ParsedOptions = Record<SelectorsString, ValidatorFunction>;
+export type Context = Readonly<TSESLint.RuleContext<MessageIds, Options>>;

--- a/packages/eslint-plugin/src/rules/naming-convention-utils/validator.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/validator.ts
@@ -22,7 +22,7 @@ import {
   selectorTypeToMessageString,
 } from './shared';
 
-function createValidator(
+export function createValidator(
   type: SelectorsString,
   context: Context,
   allConfigs: NormalizedSelector[],
@@ -495,5 +495,3 @@ function isAllTypesMatch(
 
   return cb(type);
 }
-
-export { createValidator };

--- a/packages/eslint-plugin/src/rules/naming-convention.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention.ts
@@ -21,7 +21,7 @@ import {
 } from '../util';
 import { Modifiers, parseOptions, SCHEMA } from './naming-convention-utils';
 
-type MessageIds =
+export type MessageIds =
   | 'doesNotMatchFormat'
   | 'doesNotMatchFormatTrimmed'
   | 'missingAffix'
@@ -32,7 +32,7 @@ type MessageIds =
 // Note that this intentionally does not strictly type the modifiers/types properties.
 // This is because doing so creates a huge headache, as the rule's code doesn't need to care.
 // The JSON Schema strictly types these properties, so we know the user won't input invalid config.
-type Options = Selector[];
+export type Options = Selector[];
 
 // This essentially mirrors ESLint's `camelcase` rule
 // note that that rule ignores leading and trailing underscores and only checks those in the middle of a variable name
@@ -789,5 +789,3 @@ function requiresQuoting(
       : `${node.value}`;
   return _requiresQuoting(name, target);
 }
-
-export type { MessageIds, Options };

--- a/packages/eslint-plugin/src/util/collectUnusedVariables.ts
+++ b/packages/eslint-plugin/src/util/collectUnusedVariables.ts
@@ -818,7 +818,7 @@ function isUsedVariable(variable: ScopeVariable): boolean {
  * - variables within declaration files
  * - variables within ambient module declarations
  */
-function collectVariables<
+export function collectVariables<
   MessageIds extends string,
   Options extends readonly unknown[],
 >(
@@ -832,5 +832,3 @@ function collectVariables<
     ),
   );
 }
-
-export { collectVariables };

--- a/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
+++ b/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts
@@ -9,10 +9,10 @@ import {
 import { isConstructor, isSetter, isTypeAssertion } from './astUtils';
 import { getFunctionHeadLoc } from './getFunctionHeadLoc';
 
-type FunctionExpression =
+export type FunctionExpression =
   | TSESTree.ArrowFunctionExpression
   | TSESTree.FunctionExpression;
-type FunctionNode = FunctionExpression | TSESTree.FunctionDeclaration;
+export type FunctionNode = FunctionExpression | TSESTree.FunctionDeclaration;
 
 export interface FunctionInfo<T extends FunctionNode> {
   node: T;
@@ -153,7 +153,7 @@ function isPropertyOfObjectWithType(
  * function fn() { return function() { ... } }
  * ```
  */
-function doesImmediatelyReturnFunctionExpression({
+export function doesImmediatelyReturnFunctionExpression({
   node,
   returns,
 }: FunctionInfo<FunctionNode>): boolean {
@@ -206,7 +206,7 @@ interface Options {
 /**
  * True when the provided function expression is typed.
  */
-function isTypedFunctionExpression(
+export function isTypedFunctionExpression(
   node: FunctionExpression,
   options: Options,
 ): boolean {
@@ -230,7 +230,7 @@ function isTypedFunctionExpression(
  * Check whether the function expression return type is either typed or valid
  * with the provided options.
  */
-function isValidFunctionExpressionReturnType(
+export function isValidFunctionExpressionReturnType(
   node: FunctionExpression,
   options: Options,
 ): boolean {
@@ -292,7 +292,7 @@ function isValidFunctionReturnType(
 /**
  * Checks if a function declaration/expression has a return type.
  */
-function checkFunctionReturnType(
+export function checkFunctionReturnType(
   { node, returns }: FunctionInfo<FunctionNode>,
   options: Options,
   sourceCode: TSESLint.SourceCode,
@@ -308,7 +308,7 @@ function checkFunctionReturnType(
 /**
  * Checks if a function declaration/expression has a return type.
  */
-function checkFunctionExpressionReturnType(
+export function checkFunctionExpressionReturnType(
   info: FunctionInfo<FunctionExpression>,
   options: Options,
   sourceCode: TSESLint.SourceCode,
@@ -324,7 +324,7 @@ function checkFunctionExpressionReturnType(
 /**
  * Check whether any ancestor of the provided function has a valid return type.
  */
-function ancestorHasReturnType(node: FunctionNode): boolean {
+export function ancestorHasReturnType(node: FunctionNode): boolean {
   let ancestor: TSESTree.Node | undefined = node.parent;
 
   if (ancestor.type === AST_NODE_TYPES.Property) {
@@ -366,14 +366,3 @@ function ancestorHasReturnType(node: FunctionNode): boolean {
 
   return false;
 }
-
-export {
-  ancestorHasReturnType,
-  checkFunctionExpressionReturnType,
-  checkFunctionReturnType,
-  doesImmediatelyReturnFunctionExpression,
-  type FunctionExpression,
-  type FunctionNode,
-  isTypedFunctionExpression,
-  isValidFunctionExpressionReturnType,
-};

--- a/packages/eslint-plugin/src/util/index.ts
+++ b/packages/eslint-plugin/src/util/index.ts
@@ -36,16 +36,15 @@ const {
   nullThrows,
   NullThrowsReasons,
 } = ESLintUtils;
-type InferMessageIdsTypeFromRule<T> =
+export type InferMessageIdsTypeFromRule<T> =
   ESLintUtils.InferMessageIdsTypeFromRule<T>;
-type InferOptionsTypeFromRule<T> = ESLintUtils.InferOptionsTypeFromRule<T>;
+export type InferOptionsTypeFromRule<T> =
+  ESLintUtils.InferOptionsTypeFromRule<T>;
 
 export {
   applyDefault,
   deepMerge,
   getParserServices,
-  type InferMessageIdsTypeFromRule,
-  type InferOptionsTypeFromRule,
   isObjectNotArray,
   nullThrows,
   NullThrowsReasons,

--- a/packages/eslint-plugin/src/util/index.ts
+++ b/packages/eslint-plugin/src/util/index.ts
@@ -28,7 +28,7 @@ export * from './getConstraintInfo';
 // this is done for convenience - saves migrating all of the old rules
 export * from '@typescript-eslint/type-utils';
 
-const {
+export const {
   applyDefault,
   deepMerge,
   getParserServices,
@@ -40,12 +40,3 @@ export type InferMessageIdsTypeFromRule<T> =
   ESLintUtils.InferMessageIdsTypeFromRule<T>;
 export type InferOptionsTypeFromRule<T> =
   ESLintUtils.InferOptionsTypeFromRule<T>;
-
-export {
-  applyDefault,
-  deepMerge,
-  getParserServices,
-  isObjectNotArray,
-  nullThrows,
-  NullThrowsReasons,
-};

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -18,7 +18,7 @@ const DEFINITION_EXTENSIONS = [
 /**
  * Check if the context file name is *.d.ts or *.d.tsx
  */
-function isDefinitionFile(fileName: string): boolean {
+export function isDefinitionFile(fileName: string): boolean {
   const lowerFileName = fileName.toLowerCase();
   for (const definitionExt of DEFINITION_EXTENSIONS) {
     if (lowerFileName.endsWith(definitionExt)) {
@@ -31,11 +31,11 @@ function isDefinitionFile(fileName: string): boolean {
 /**
  * Upper cases the first character or the string
  */
-function upperCaseFirst(str: string): string {
+export function upperCaseFirst(str: string): string {
   return str[0].toUpperCase() + str.slice(1);
 }
 
-function arrayGroupByToMap<T, Key extends number | string>(
+export function arrayGroupByToMap<T, Key extends number | string>(
   array: T[],
   getKey: (item: T) => Key,
 ): Map<Key, T[]> {
@@ -56,9 +56,9 @@ function arrayGroupByToMap<T, Key extends number | string>(
 }
 
 /** Return true if both parameters are equal. */
-type Equal<T> = (a: T, b: T) => boolean;
+export type Equal<T> = (a: T, b: T) => boolean;
 
-function arraysAreEqual<T>(
+export function arraysAreEqual<T>(
   a: T[] | undefined,
   b: T[] | undefined,
   eq: (a: T, b: T) => boolean,
@@ -73,7 +73,7 @@ function arraysAreEqual<T>(
 }
 
 /** Returns the first non-`undefined` result. */
-function findFirstResult<T, U>(
+export function findFirstResult<T, U>(
   inputs: T[],
   getResult: (t: T) => U | undefined,
 ): U | undefined {
@@ -90,7 +90,9 @@ function findFirstResult<T, U>(
 /**
  * Gets a string representation of the name of the index signature.
  */
-function getNameFromIndexSignature(node: TSESTree.TSIndexSignature): string {
+export function getNameFromIndexSignature(
+  node: TSESTree.TSIndexSignature,
+): string {
   const propName: TSESTree.PropertyName | undefined = node.parameters.find(
     (parameter: TSESTree.Parameter): parameter is TSESTree.Identifier =>
       parameter.type === AST_NODE_TYPES.Identifier,
@@ -98,7 +100,7 @@ function getNameFromIndexSignature(node: TSESTree.TSIndexSignature): string {
   return propName ? propName.name : '(index signature)';
 }
 
-enum MemberNameType {
+export enum MemberNameType {
   Private = 1,
   Quoted = 2,
   Normal = 3,
@@ -109,7 +111,7 @@ enum MemberNameType {
  * Gets a string name representation of the name of the given MethodDefinition
  * or PropertyDefinition node, with handling for computed property names.
  */
-function getNameFromMember(
+export function getNameFromMember(
   member:
     | TSESTree.AccessorProperty
     | TSESTree.MethodDefinition
@@ -154,16 +156,18 @@ function getNameFromMember(
   };
 }
 
-type ExcludeKeys<
+export type ExcludeKeys<
   Obj extends Record<string, unknown>,
   Keys extends keyof Obj,
 > = { [k in Exclude<keyof Obj, Keys>]: Obj[k] };
-type RequireKeys<
+export type RequireKeys<
   Obj extends Record<string, unknown>,
   Keys extends keyof Obj,
 > = { [k in Keys]-?: Exclude<Obj[k], undefined> } & ExcludeKeys<Obj, Keys>;
 
-function getEnumNames<T extends string>(myEnum: Record<T, unknown>): T[] {
+export function getEnumNames<T extends string>(
+  myEnum: Record<T, unknown>,
+): T[] {
   return Object.keys(myEnum).filter(x => isNaN(Number(x))) as T[];
 }
 
@@ -173,7 +177,7 @@ function getEnumNames<T extends string>(myEnum: Record<T, unknown>): T[] {
  *
  * Example: ['foo', 'bar', 'baz' ] returns the string "foo, bar, and baz".
  */
-function formatWordList(words: string[]): string {
+export function formatWordList(words: string[]): string {
   if (!words.length) {
     return '';
   }
@@ -191,7 +195,7 @@ function formatWordList(words: string[]): string {
  *
  * @returns Returns the index of the element if it finds it or -1 otherwise.
  */
-function findLastIndex<T>(
+export function findLastIndex<T>(
   members: T[],
   predicate: (member: T) => boolean | null | undefined,
 ): number {
@@ -208,7 +212,7 @@ function findLastIndex<T>(
   return -1;
 }
 
-function typeNodeRequiresParentheses(
+export function typeNodeRequiresParentheses(
   node: TSESTree.TypeNode,
   text: string,
 ): boolean {
@@ -221,11 +225,11 @@ function typeNodeRequiresParentheses(
   );
 }
 
-function isRestParameterDeclaration(decl: ts.Declaration): boolean {
+export function isRestParameterDeclaration(decl: ts.Declaration): boolean {
   return ts.isParameter(decl) && decl.dotDotDotToken != null;
 }
 
-function isParenlessArrowFunction(
+export function isParenlessArrowFunction(
   node: TSESTree.ArrowFunctionExpression,
   sourceCode: TSESLint.SourceCode,
 ): boolean {
@@ -234,7 +238,7 @@ function isParenlessArrowFunction(
   );
 }
 
-type NodeWithKey =
+export type NodeWithKey =
   | TSESTree.MemberExpression
   | TSESTree.MethodDefinition
   | TSESTree.Property
@@ -287,7 +291,7 @@ type NodeWithKey =
  * }
  * ```
  */
-function getStaticMemberAccessValue(
+export function getStaticMemberAccessValue(
   node: NodeWithKey,
   { sourceCode }: RuleContext<string, unknown[]>,
 ): string | symbol | undefined {
@@ -314,7 +318,7 @@ function getStaticMemberAccessValue(
  * `x.value`, `x['value']`,
  * or even `const v = 'value'; x[v]` (or optional variants thereof).
  */
-const isStaticMemberAccessOfValue = (
+export const isStaticMemberAccessOfValue = (
   memberExpression: NodeWithKey,
   context: RuleContext<string, unknown[]>,
   ...values: (string | symbol)[]
@@ -322,25 +326,3 @@ const isStaticMemberAccessOfValue = (
   (values as (string | symbol | undefined)[]).includes(
     getStaticMemberAccessValue(memberExpression, context),
   );
-
-export {
-  arrayGroupByToMap,
-  arraysAreEqual,
-  type Equal,
-  type ExcludeKeys,
-  findFirstResult,
-  findLastIndex,
-  formatWordList,
-  getEnumNames,
-  getNameFromIndexSignature,
-  getNameFromMember,
-  getStaticMemberAccessValue,
-  isDefinitionFile,
-  isParenlessArrowFunction,
-  isRestParameterDeclaration,
-  isStaticMemberAccessOfValue,
-  MemberNameType,
-  type RequireKeys,
-  typeNodeRequiresParentheses,
-  upperCaseFirst,
-};

--- a/packages/eslint-plugin/src/util/objectIterators.ts
+++ b/packages/eslint-plugin/src/util/objectIterators.ts
@@ -1,4 +1,4 @@
-function objectForEachKey<T extends Record<string, unknown>>(
+export function objectForEachKey<T extends Record<string, unknown>>(
   obj: T,
   callback: (key: keyof T) => void,
 ): void {
@@ -8,7 +8,7 @@ function objectForEachKey<T extends Record<string, unknown>>(
   }
 }
 
-function objectMapKey<T extends Record<string, unknown>, Return>(
+export function objectMapKey<T extends Record<string, unknown>, Return>(
   obj: T,
   callback: (key: keyof T) => Return,
 ): Return[] {
@@ -19,7 +19,7 @@ function objectMapKey<T extends Record<string, unknown>, Return>(
   return values;
 }
 
-function objectReduceKey<T extends Record<string, unknown>, Accumulator>(
+export function objectReduceKey<T extends Record<string, unknown>, Accumulator>(
   obj: T,
   callback: (acc: Accumulator, key: keyof T) => Accumulator,
   initial: Accumulator,
@@ -30,5 +30,3 @@ function objectReduceKey<T extends Record<string, unknown>, Accumulator>(
   });
   return accumulator;
 }
-
-export { objectForEachKey, objectMapKey, objectReduceKey };

--- a/packages/integration-tests/tools/pack-packages.ts
+++ b/packages/integration-tests/tools/pack-packages.ts
@@ -27,7 +27,7 @@ const tarFolder = tmp.dirSync({
   keep: true,
 }).name;
 
-const tseslintPackages: PackageJSON['devDependencies'] = {};
+export const tseslintPackages: PackageJSON['devDependencies'] = {};
 for (const pkg of PACKAGES) {
   const packageDir = path.join(PACKAGES_DIR, pkg);
   const packagePath = path.join(packageDir, 'package.json');
@@ -52,4 +52,3 @@ for (const pkg of PACKAGES) {
 }
 
 console.log('Finished packing local packages.');
-export { tseslintPackages };

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -80,14 +80,14 @@ function getLib(compilerOptions: ts.CompilerOptions): Lib[] {
   }
 }
 
-function parse(
+export function parse(
   code: string | ts.SourceFile,
   options?: ParserOptions,
 ): ParseForESLintResult['ast'] {
   return parseForESLint(code, options).ast;
 }
 
-function parseForESLint(
+export function parseForESLint(
   code: string | ts.SourceFile,
   parserOptions?: ParserOptions | null,
 ): ParseForESLintResult {
@@ -187,7 +187,5 @@ function parseForESLint(
 
   return { ast, scopeManager, services, visitorKeys };
 }
-
-export { parse, parseForESLint };
 
 export type { ParserOptions } from '@typescript-eslint/types';

--- a/packages/scope-manager/src/ID.ts
+++ b/packages/scope-manager/src/ID.ts
@@ -1,7 +1,7 @@
 const ID_CACHE = new Map<number, number>();
 let NEXT_KEY = 0;
 
-function createIdGenerator(): () => number {
+export function createIdGenerator(): () => number {
   const key = (NEXT_KEY += 1);
   ID_CACHE.set(key, 0);
 
@@ -13,8 +13,6 @@ function createIdGenerator(): () => number {
   };
 }
 
-function resetIds(): void {
+export function resetIds(): void {
   ID_CACHE.clear();
 }
-
-export { createIdGenerator, resetIds };

--- a/packages/scope-manager/src/ScopeManager.ts
+++ b/packages/scope-manager/src/ScopeManager.ts
@@ -35,7 +35,7 @@ interface ScopeManagerOptions {
 /**
  * @see https://eslint.org/docs/latest/developer-guide/scope-manager-interface#scopemanager-interface
  */
-class ScopeManager {
+export class ScopeManager {
   readonly #options: ScopeManagerOptions;
 
   public currentScope: Scope | null;
@@ -271,5 +271,3 @@ class ScopeManager {
     return scope;
   }
 }
-
-export { ScopeManager };

--- a/packages/scope-manager/src/analyze.ts
+++ b/packages/scope-manager/src/analyze.ts
@@ -11,7 +11,7 @@ import { ScopeManager } from './ScopeManager';
 // MAKE SURE THIS IS KEPT IN SYNC WITH THE WEBSITE DOCS //
 //////////////////////////////////////////////////////////
 
-interface AnalyzeOptions {
+export interface AnalyzeOptions {
   /**
    * Known visitor keys.
    */
@@ -80,7 +80,7 @@ const DEFAULT_OPTIONS: Required<AnalyzeOptions> = {
 /**
  * Takes an AST and returns the analyzed scopes.
  */
-function analyze(
+export function analyze(
   tree: TSESTree.Node,
   providedOptions?: AnalyzeOptions,
 ): ScopeManager {
@@ -112,5 +112,3 @@ function analyze(
 
   return scopeManager;
 }
-
-export { analyze, type AnalyzeOptions };

--- a/packages/scope-manager/src/assert.ts
+++ b/packages/scope-manager/src/assert.ts
@@ -1,8 +1,6 @@
 // the base assert module doesn't use ts assertion syntax
-function assert(value: unknown, message?: string): asserts value {
+export function assert(value: unknown, message?: string): asserts value {
   if (value == null) {
     throw new Error(message);
   }
 }
-
-export { assert };

--- a/packages/scope-manager/src/definition/CatchClauseDefinition.ts
+++ b/packages/scope-manager/src/definition/CatchClauseDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class CatchClauseDefinition extends DefinitionBase<
+export class CatchClauseDefinition extends DefinitionBase<
   DefinitionType.CatchClause,
   TSESTree.CatchClause,
   null,
@@ -16,5 +16,3 @@ class CatchClauseDefinition extends DefinitionBase<
     super(DefinitionType.CatchClause, name, node, null);
   }
 }
-
-export { CatchClauseDefinition };

--- a/packages/scope-manager/src/definition/ClassNameDefinition.ts
+++ b/packages/scope-manager/src/definition/ClassNameDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class ClassNameDefinition extends DefinitionBase<
+export class ClassNameDefinition extends DefinitionBase<
   DefinitionType.ClassName,
   TSESTree.ClassDeclaration | TSESTree.ClassExpression,
   null,
@@ -16,5 +16,3 @@ class ClassNameDefinition extends DefinitionBase<
     super(DefinitionType.ClassName, name, node, null);
   }
 }
-
-export { ClassNameDefinition };

--- a/packages/scope-manager/src/definition/Definition.ts
+++ b/packages/scope-manager/src/definition/Definition.ts
@@ -10,7 +10,7 @@ import type { TSModuleNameDefinition } from './TSModuleNameDefinition';
 import type { TypeDefinition } from './TypeDefinition';
 import type { VariableDefinition } from './VariableDefinition';
 
-type Definition =
+export type Definition =
   | CatchClauseDefinition
   | ClassNameDefinition
   | FunctionNameDefinition
@@ -22,5 +22,3 @@ type Definition =
   | TSModuleNameDefinition
   | TypeDefinition
   | VariableDefinition;
-
-export type { Definition };

--- a/packages/scope-manager/src/definition/DefinitionBase.ts
+++ b/packages/scope-manager/src/definition/DefinitionBase.ts
@@ -6,7 +6,7 @@ import { createIdGenerator } from '../ID';
 
 const generator = createIdGenerator();
 
-abstract class DefinitionBase<
+export abstract class DefinitionBase<
   Type extends DefinitionType,
   Node extends TSESTree.Node,
   Parent extends TSESTree.Node | null,
@@ -54,5 +54,3 @@ abstract class DefinitionBase<
    */
   public abstract readonly isVariableDefinition: boolean;
 }
-
-export { DefinitionBase };

--- a/packages/scope-manager/src/definition/DefinitionType.ts
+++ b/packages/scope-manager/src/definition/DefinitionType.ts
@@ -1,4 +1,4 @@
-enum DefinitionType {
+export enum DefinitionType {
   CatchClause = 'CatchClause',
   ClassName = 'ClassName',
   FunctionName = 'FunctionName',
@@ -11,5 +11,3 @@ enum DefinitionType {
   Type = 'Type',
   Variable = 'Variable',
 }
-
-export { DefinitionType };

--- a/packages/scope-manager/src/definition/FunctionNameDefinition.ts
+++ b/packages/scope-manager/src/definition/FunctionNameDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class FunctionNameDefinition extends DefinitionBase<
+export class FunctionNameDefinition extends DefinitionBase<
   DefinitionType.FunctionName,
   | TSESTree.FunctionDeclaration
   | TSESTree.FunctionExpression
@@ -19,5 +19,3 @@ class FunctionNameDefinition extends DefinitionBase<
     super(DefinitionType.FunctionName, name, node, null);
   }
 }
-
-export { FunctionNameDefinition };

--- a/packages/scope-manager/src/definition/ImplicitGlobalVariableDefinition.ts
+++ b/packages/scope-manager/src/definition/ImplicitGlobalVariableDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class ImplicitGlobalVariableDefinition extends DefinitionBase<
+export class ImplicitGlobalVariableDefinition extends DefinitionBase<
   DefinitionType.ImplicitGlobalVariable,
   TSESTree.Node,
   null,
@@ -19,5 +19,3 @@ class ImplicitGlobalVariableDefinition extends DefinitionBase<
     super(DefinitionType.ImplicitGlobalVariable, name, node, null);
   }
 }
-
-export { ImplicitGlobalVariableDefinition };

--- a/packages/scope-manager/src/definition/ImportBindingDefinition.ts
+++ b/packages/scope-manager/src/definition/ImportBindingDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class ImportBindingDefinition extends DefinitionBase<
+export class ImportBindingDefinition extends DefinitionBase<
   DefinitionType.ImportBinding,
   | TSESTree.ImportDefaultSpecifier
   | TSESTree.ImportNamespaceSpecifier
@@ -36,5 +36,3 @@ class ImportBindingDefinition extends DefinitionBase<
     super(DefinitionType.ImportBinding, name, node, decl);
   }
 }
-
-export { ImportBindingDefinition };

--- a/packages/scope-manager/src/definition/ParameterDefinition.ts
+++ b/packages/scope-manager/src/definition/ParameterDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class ParameterDefinition extends DefinitionBase<
+export class ParameterDefinition extends DefinitionBase<
   DefinitionType.Parameter,
   | TSESTree.ArrowFunctionExpression
   | TSESTree.FunctionDeclaration
@@ -34,5 +34,3 @@ class ParameterDefinition extends DefinitionBase<
     this.rest = rest;
   }
 }
-
-export { ParameterDefinition };

--- a/packages/scope-manager/src/definition/TSEnumMemberDefinition.ts
+++ b/packages/scope-manager/src/definition/TSEnumMemberDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class TSEnumMemberDefinition extends DefinitionBase<
+export class TSEnumMemberDefinition extends DefinitionBase<
   DefinitionType.TSEnumMember,
   TSESTree.TSEnumMember,
   null,
@@ -19,5 +19,3 @@ class TSEnumMemberDefinition extends DefinitionBase<
     super(DefinitionType.TSEnumMember, name, node, null);
   }
 }
-
-export { TSEnumMemberDefinition };

--- a/packages/scope-manager/src/definition/TSEnumNameDefinition.ts
+++ b/packages/scope-manager/src/definition/TSEnumNameDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class TSEnumNameDefinition extends DefinitionBase<
+export class TSEnumNameDefinition extends DefinitionBase<
   DefinitionType.TSEnumName,
   TSESTree.TSEnumDeclaration,
   null,
@@ -16,5 +16,3 @@ class TSEnumNameDefinition extends DefinitionBase<
     super(DefinitionType.TSEnumName, name, node, null);
   }
 }
-
-export { TSEnumNameDefinition };

--- a/packages/scope-manager/src/definition/TSModuleNameDefinition.ts
+++ b/packages/scope-manager/src/definition/TSModuleNameDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class TSModuleNameDefinition extends DefinitionBase<
+export class TSModuleNameDefinition extends DefinitionBase<
   DefinitionType.TSModuleName,
   TSESTree.TSModuleDeclaration,
   null,
@@ -16,5 +16,3 @@ class TSModuleNameDefinition extends DefinitionBase<
     super(DefinitionType.TSModuleName, name, node, null);
   }
 }
-
-export { TSModuleNameDefinition };

--- a/packages/scope-manager/src/definition/TypeDefinition.ts
+++ b/packages/scope-manager/src/definition/TypeDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class TypeDefinition extends DefinitionBase<
+export class TypeDefinition extends DefinitionBase<
   DefinitionType.Type,
   | TSESTree.TSInterfaceDeclaration
   | TSESTree.TSMappedType
@@ -19,5 +19,3 @@ class TypeDefinition extends DefinitionBase<
     super(DefinitionType.Type, name, node, null);
   }
 }
-
-export { TypeDefinition };

--- a/packages/scope-manager/src/definition/VariableDefinition.ts
+++ b/packages/scope-manager/src/definition/VariableDefinition.ts
@@ -3,7 +3,7 @@ import type { TSESTree } from '@typescript-eslint/types';
 import { DefinitionBase } from './DefinitionBase';
 import { DefinitionType } from './DefinitionType';
 
-class VariableDefinition extends DefinitionBase<
+export class VariableDefinition extends DefinitionBase<
   DefinitionType.Variable,
   TSESTree.VariableDeclarator,
   TSESTree.VariableDeclaration,
@@ -20,5 +20,3 @@ class VariableDefinition extends DefinitionBase<
     super(DefinitionType.Variable, name, node, decl);
   }
 }
-
-export { VariableDefinition };

--- a/packages/scope-manager/src/lib/index.ts
+++ b/packages/scope-manager/src/lib/index.ts
@@ -109,7 +109,7 @@ import { webworker_asynciterable } from './webworker.asynciterable';
 import { webworker_importscripts } from './webworker.importscripts';
 import { webworker_iterable } from './webworker.iterable';
 
-const lib = {
+export const lib = {
   decorators,
   'decorators.legacy': decorators_legacy,
   dom,
@@ -216,5 +216,3 @@ const lib = {
   'webworker.importscripts': webworker_importscripts,
   'webworker.iterable': webworker_iterable,
 } as const;
-
-export { lib };

--- a/packages/scope-manager/src/referencer/ClassVisitor.ts
+++ b/packages/scope-manager/src/referencer/ClassVisitor.ts
@@ -8,7 +8,7 @@ import { ClassNameDefinition, ParameterDefinition } from '../definition';
 import { TypeVisitor } from './TypeVisitor';
 import { Visitor } from './Visitor';
 
-class ClassVisitor extends Visitor {
+export class ClassVisitor extends Visitor {
   readonly #classNode: TSESTree.ClassDeclaration | TSESTree.ClassExpression;
   readonly #referencer: Referencer;
 
@@ -373,5 +373,3 @@ function getLiteralMethodKeyName(
   }
   return null;
 }
-
-export { ClassVisitor };

--- a/packages/scope-manager/src/referencer/ExportVisitor.ts
+++ b/packages/scope-manager/src/referencer/ExportVisitor.ts
@@ -6,12 +6,12 @@ import type { Referencer } from './Referencer';
 
 import { Visitor } from './Visitor';
 
-type ExportNode =
+export type ExportNode =
   | TSESTree.ExportAllDeclaration
   | TSESTree.ExportDefaultDeclaration
   | TSESTree.ExportNamedDeclaration;
 
-class ExportVisitor extends Visitor {
+export class ExportVisitor extends Visitor {
   readonly #exportNode: ExportNode;
   readonly #referencer: Referencer;
 
@@ -85,5 +85,3 @@ class ExportVisitor extends Visitor {
     }
   }
 }
-
-export { ExportVisitor };

--- a/packages/scope-manager/src/referencer/ImportVisitor.ts
+++ b/packages/scope-manager/src/referencer/ImportVisitor.ts
@@ -5,7 +5,7 @@ import type { Referencer } from './Referencer';
 import { ImportBindingDefinition } from '../definition';
 import { Visitor } from './Visitor';
 
-class ImportVisitor extends Visitor {
+export class ImportVisitor extends Visitor {
   readonly #declaration: TSESTree.ImportDeclaration;
   readonly #referencer: Referencer;
 
@@ -57,5 +57,3 @@ class ImportVisitor extends Visitor {
       );
   }
 }
-
-export { ImportVisitor };

--- a/packages/scope-manager/src/referencer/PatternVisitor.ts
+++ b/packages/scope-manager/src/referencer/PatternVisitor.ts
@@ -6,7 +6,7 @@ import type { VisitorOptions } from './VisitorBase';
 
 import { VisitorBase } from './VisitorBase';
 
-type PatternVisitorCallback = (
+export type PatternVisitorCallback = (
   pattern: TSESTree.Identifier,
   info: {
     assignments: (TSESTree.AssignmentExpression | TSESTree.AssignmentPattern)[];
@@ -15,8 +15,8 @@ type PatternVisitorCallback = (
   },
 ) => void;
 
-type PatternVisitorOptions = VisitorOptions;
-class PatternVisitor extends VisitorBase {
+export type PatternVisitorOptions = VisitorOptions;
+export class PatternVisitor extends VisitorBase {
   readonly #assignments: (
     | TSESTree.AssignmentExpression
     | TSESTree.AssignmentPattern
@@ -140,9 +140,3 @@ class PatternVisitor extends VisitorBase {
     // we don't want to visit types
   }
 }
-
-export {
-  PatternVisitor,
-  type PatternVisitorCallback,
-  type PatternVisitorOptions,
-};

--- a/packages/scope-manager/src/referencer/Reference.ts
+++ b/packages/scope-manager/src/referencer/Reference.ts
@@ -5,13 +5,13 @@ import type { Variable } from '../variable';
 
 import { createIdGenerator } from '../ID';
 
-enum ReferenceFlag {
+export enum ReferenceFlag {
   Read = 0x1,
   Write = 0x2,
   ReadWrite = 0x3,
 }
 
-interface ReferenceImplicitGlobal {
+export interface ReferenceImplicitGlobal {
   node: TSESTree.Node;
   pattern: TSESTree.BindingName;
   ref?: Reference;
@@ -19,7 +19,7 @@ interface ReferenceImplicitGlobal {
 
 const generator = createIdGenerator();
 
-enum ReferenceTypeFlag {
+export enum ReferenceTypeFlag {
   Value = 0x1,
   Type = 0x2,
 }
@@ -27,7 +27,7 @@ enum ReferenceTypeFlag {
 /**
  * A Reference represents a single occurrence of an identifier in code.
  */
-class Reference {
+export class Reference {
   /**
    * A unique ID for this instance - primarily used to help debugging and testing
    */
@@ -152,10 +152,3 @@ class Reference {
     return this.#flag === ReferenceFlag.ReadWrite;
   }
 }
-
-export {
-  Reference,
-  ReferenceFlag,
-  type ReferenceImplicitGlobal,
-  ReferenceTypeFlag,
-};

--- a/packages/scope-manager/src/referencer/Referencer.ts
+++ b/packages/scope-manager/src/referencer/Referencer.ts
@@ -27,14 +27,14 @@ import { ReferenceFlag } from './Reference';
 import { TypeVisitor } from './TypeVisitor';
 import { Visitor } from './Visitor';
 
-interface ReferencerOptions extends VisitorOptions {
+export interface ReferencerOptions extends VisitorOptions {
   jsxFragmentName: string | null;
   jsxPragma: string | null;
   lib: Lib[];
 }
 
 // Referencing variables and creating bindings.
-class Referencer extends Visitor {
+export class Referencer extends Visitor {
   #hasReferencedJsxFactory = false;
   #hasReferencedJsxFragmentFactory = false;
   #jsxFragmentName: string | null;
@@ -819,5 +819,3 @@ class Referencer extends Visitor {
     return left;
   }
 }
-
-export { Referencer, type ReferencerOptions };

--- a/packages/scope-manager/src/referencer/TypeVisitor.ts
+++ b/packages/scope-manager/src/referencer/TypeVisitor.ts
@@ -9,7 +9,7 @@ import { ParameterDefinition, TypeDefinition } from '../definition';
 import { ScopeType } from '../scope';
 import { Visitor } from './Visitor';
 
-class TypeVisitor extends Visitor {
+export class TypeVisitor extends Visitor {
   readonly #referencer: Referencer;
 
   constructor(referencer: Referencer) {
@@ -297,5 +297,3 @@ class TypeVisitor extends Visitor {
     this.visit(node.typeArguments);
   }
 }
-
-export { TypeVisitor };

--- a/packages/scope-manager/src/referencer/Visitor.ts
+++ b/packages/scope-manager/src/referencer/Visitor.ts
@@ -12,7 +12,7 @@ import { VisitorBase } from './VisitorBase';
 interface VisitPatternOptions extends PatternVisitorOptions {
   processRightHandNodes?: boolean;
 }
-class Visitor extends VisitorBase {
+export class Visitor extends VisitorBase {
   readonly #options: VisitorOptions;
   constructor(optionsOrVisitor: Visitor | VisitorOptions) {
     super(
@@ -43,7 +43,5 @@ class Visitor extends VisitorBase {
     }
   }
 }
-
-export { Visitor };
 
 export { VisitorBase, type VisitorOptions } from './VisitorBase';

--- a/packages/scope-manager/src/referencer/VisitorBase.ts
+++ b/packages/scope-manager/src/referencer/VisitorBase.ts
@@ -3,7 +3,7 @@ import type { VisitorKeys } from '@typescript-eslint/visitor-keys';
 
 import { visitorKeys } from '@typescript-eslint/visitor-keys';
 
-interface VisitorOptions {
+export interface VisitorOptions {
   childVisitorKeys?: VisitorKeys | null;
   visitChildrenEvenIfSelectorExists?: boolean;
 }
@@ -19,7 +19,7 @@ type NodeVisitor = Partial<
   Record<AST_NODE_TYPES, (node: TSESTree.Node) => void>
 >;
 
-abstract class VisitorBase {
+export abstract class VisitorBase {
   readonly #childVisitorKeys: VisitorKeys;
   readonly #visitChildrenEvenIfSelectorExists: boolean;
   constructor(options: VisitorOptions) {
@@ -84,7 +84,5 @@ abstract class VisitorBase {
     this.visitChildren(node);
   }
 }
-
-export { VisitorBase, type VisitorOptions };
 
 export type { VisitorKeys } from '@typescript-eslint/visitor-keys';

--- a/packages/scope-manager/src/scope/BlockScope.ts
+++ b/packages/scope-manager/src/scope/BlockScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class BlockScope extends ScopeBase<
+export class BlockScope extends ScopeBase<
   ScopeType.block,
   TSESTree.BlockStatement,
   Scope
@@ -19,5 +19,3 @@ class BlockScope extends ScopeBase<
     super(scopeManager, ScopeType.block, upperScope, block, false);
   }
 }
-
-export { BlockScope };

--- a/packages/scope-manager/src/scope/CatchScope.ts
+++ b/packages/scope-manager/src/scope/CatchScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class CatchScope extends ScopeBase<
+export class CatchScope extends ScopeBase<
   ScopeType.catch,
   TSESTree.CatchClause,
   Scope
@@ -19,5 +19,3 @@ class CatchScope extends ScopeBase<
     super(scopeManager, ScopeType.catch, upperScope, block, false);
   }
 }
-
-export { CatchScope };

--- a/packages/scope-manager/src/scope/ClassFieldInitializerScope.ts
+++ b/packages/scope-manager/src/scope/ClassFieldInitializerScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class ClassFieldInitializerScope extends ScopeBase<
+export class ClassFieldInitializerScope extends ScopeBase<
   ScopeType.classFieldInitializer,
   // the value expression itself is the block
   TSESTree.Expression,
@@ -26,5 +26,3 @@ class ClassFieldInitializerScope extends ScopeBase<
     );
   }
 }
-
-export { ClassFieldInitializerScope };

--- a/packages/scope-manager/src/scope/ClassScope.ts
+++ b/packages/scope-manager/src/scope/ClassScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class ClassScope extends ScopeBase<
+export class ClassScope extends ScopeBase<
   ScopeType.class,
   TSESTree.ClassDeclaration | TSESTree.ClassExpression,
   Scope
@@ -19,5 +19,3 @@ class ClassScope extends ScopeBase<
     super(scopeManager, ScopeType.class, upperScope, block, false);
   }
 }
-
-export { ClassScope };

--- a/packages/scope-manager/src/scope/ClassStaticBlockScope.ts
+++ b/packages/scope-manager/src/scope/ClassStaticBlockScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class ClassStaticBlockScope extends ScopeBase<
+export class ClassStaticBlockScope extends ScopeBase<
   ScopeType.classStaticBlock,
   TSESTree.StaticBlock,
   Scope
@@ -19,5 +19,3 @@ class ClassStaticBlockScope extends ScopeBase<
     super(scopeManager, ScopeType.classStaticBlock, upperScope, block, false);
   }
 }
-
-export { ClassStaticBlockScope };

--- a/packages/scope-manager/src/scope/ConditionalTypeScope.ts
+++ b/packages/scope-manager/src/scope/ConditionalTypeScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class ConditionalTypeScope extends ScopeBase<
+export class ConditionalTypeScope extends ScopeBase<
   ScopeType.conditionalType,
   TSESTree.TSConditionalType,
   Scope
@@ -19,5 +19,3 @@ class ConditionalTypeScope extends ScopeBase<
     super(scopeManager, ScopeType.conditionalType, upperScope, block, false);
   }
 }
-
-export { ConditionalTypeScope };

--- a/packages/scope-manager/src/scope/ForScope.ts
+++ b/packages/scope-manager/src/scope/ForScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class ForScope extends ScopeBase<
+export class ForScope extends ScopeBase<
   ScopeType.for,
   TSESTree.ForInStatement | TSESTree.ForOfStatement | TSESTree.ForStatement,
   Scope
@@ -19,5 +19,3 @@ class ForScope extends ScopeBase<
     super(scopeManager, ScopeType.for, upperScope, block, false);
   }
 }
-
-export { ForScope };

--- a/packages/scope-manager/src/scope/FunctionExpressionNameScope.ts
+++ b/packages/scope-manager/src/scope/FunctionExpressionNameScope.ts
@@ -7,7 +7,7 @@ import { FunctionNameDefinition } from '../definition';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class FunctionExpressionNameScope extends ScopeBase<
+export class FunctionExpressionNameScope extends ScopeBase<
   ScopeType.functionExpressionName,
   TSESTree.FunctionExpression,
   Scope
@@ -34,5 +34,3 @@ class FunctionExpressionNameScope extends ScopeBase<
     this.functionExpressionScope = true;
   }
 }
-
-export { FunctionExpressionNameScope };

--- a/packages/scope-manager/src/scope/FunctionScope.ts
+++ b/packages/scope-manager/src/scope/FunctionScope.ts
@@ -10,7 +10,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class FunctionScope extends ScopeBase<
+export class FunctionScope extends ScopeBase<
   ScopeType.function,
   | TSESTree.ArrowFunctionExpression
   | TSESTree.FunctionDeclaration
@@ -65,5 +65,3 @@ class FunctionScope extends ScopeBase<
     );
   }
 }
-
-export { FunctionScope };

--- a/packages/scope-manager/src/scope/FunctionTypeScope.ts
+++ b/packages/scope-manager/src/scope/FunctionTypeScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class FunctionTypeScope extends ScopeBase<
+export class FunctionTypeScope extends ScopeBase<
   ScopeType.functionType,
   | TSESTree.TSCallSignatureDeclaration
   | TSESTree.TSConstructorType
@@ -23,5 +23,3 @@ class FunctionTypeScope extends ScopeBase<
     super(scopeManager, ScopeType.functionType, upperScope, block, false);
   }
 }
-
-export { FunctionTypeScope };

--- a/packages/scope-manager/src/scope/GlobalScope.ts
+++ b/packages/scope-manager/src/scope/GlobalScope.ts
@@ -13,7 +13,7 @@ import { ImplicitLibVariable } from '../variable';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class GlobalScope extends ScopeBase<
+export class GlobalScope extends ScopeBase<
   ScopeType.global,
   TSESTree.Program,
   /**
@@ -78,5 +78,3 @@ class GlobalScope extends ScopeBase<
     );
   }
 }
-
-export { GlobalScope };

--- a/packages/scope-manager/src/scope/MappedTypeScope.ts
+++ b/packages/scope-manager/src/scope/MappedTypeScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class MappedTypeScope extends ScopeBase<
+export class MappedTypeScope extends ScopeBase<
   ScopeType.mappedType,
   TSESTree.TSMappedType,
   Scope
@@ -19,5 +19,3 @@ class MappedTypeScope extends ScopeBase<
     super(scopeManager, ScopeType.mappedType, upperScope, block, false);
   }
 }
-
-export { MappedTypeScope };

--- a/packages/scope-manager/src/scope/ModuleScope.ts
+++ b/packages/scope-manager/src/scope/ModuleScope.ts
@@ -6,7 +6,11 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class ModuleScope extends ScopeBase<ScopeType.module, TSESTree.Program, Scope> {
+export class ModuleScope extends ScopeBase<
+  ScopeType.module,
+  TSESTree.Program,
+  Scope
+> {
   constructor(
     scopeManager: ScopeManager,
     upperScope: ModuleScope['upper'],
@@ -15,5 +19,3 @@ class ModuleScope extends ScopeBase<ScopeType.module, TSESTree.Program, Scope> {
     super(scopeManager, ScopeType.module, upperScope, block, false);
   }
 }
-
-export { ModuleScope };

--- a/packages/scope-manager/src/scope/Scope.ts
+++ b/packages/scope-manager/src/scope/Scope.ts
@@ -17,7 +17,7 @@ import type { TSModuleScope } from './TSModuleScope';
 import type { TypeScope } from './TypeScope';
 import type { WithScope } from './WithScope';
 
-type Scope =
+export type Scope =
   | BlockScope
   | CatchScope
   | ClassFieldInitializerScope
@@ -36,5 +36,3 @@ type Scope =
   | TSModuleScope
   | TypeScope
   | WithScope;
-
-export type { Scope };

--- a/packages/scope-manager/src/scope/ScopeBase.ts
+++ b/packages/scope-manager/src/scope/ScopeBase.ts
@@ -134,7 +134,7 @@ const VARIABLE_SCOPE_TYPES = new Set([
 ]);
 
 type AnyScope = ScopeBase<ScopeType, TSESTree.Node, Scope | null>;
-abstract class ScopeBase<
+export abstract class ScopeBase<
   Type extends ScopeType,
   Block extends TSESTree.Node,
   Upper extends Scope | null,
@@ -492,5 +492,3 @@ abstract class ScopeBase<
     this.leftToResolve?.push(ref);
   }
 }
-
-export { ScopeBase };

--- a/packages/scope-manager/src/scope/ScopeType.ts
+++ b/packages/scope-manager/src/scope/ScopeType.ts
@@ -1,4 +1,4 @@
-enum ScopeType {
+export enum ScopeType {
   block = 'block',
   catch = 'catch',
   class = 'class',
@@ -18,5 +18,3 @@ enum ScopeType {
   type = 'type',
   with = 'with',
 }
-
-export { ScopeType };

--- a/packages/scope-manager/src/scope/SwitchScope.ts
+++ b/packages/scope-manager/src/scope/SwitchScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class SwitchScope extends ScopeBase<
+export class SwitchScope extends ScopeBase<
   ScopeType.switch,
   TSESTree.SwitchStatement,
   Scope
@@ -19,5 +19,3 @@ class SwitchScope extends ScopeBase<
     super(scopeManager, ScopeType.switch, upperScope, block, false);
   }
 }
-
-export { SwitchScope };

--- a/packages/scope-manager/src/scope/TSEnumScope.ts
+++ b/packages/scope-manager/src/scope/TSEnumScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class TSEnumScope extends ScopeBase<
+export class TSEnumScope extends ScopeBase<
   ScopeType.tsEnum,
   TSESTree.TSEnumDeclaration,
   Scope
@@ -19,5 +19,3 @@ class TSEnumScope extends ScopeBase<
     super(scopeManager, ScopeType.tsEnum, upperScope, block, false);
   }
 }
-
-export { TSEnumScope };

--- a/packages/scope-manager/src/scope/TSModuleScope.ts
+++ b/packages/scope-manager/src/scope/TSModuleScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class TSModuleScope extends ScopeBase<
+export class TSModuleScope extends ScopeBase<
   ScopeType.tsModule,
   TSESTree.TSModuleDeclaration,
   Scope
@@ -19,5 +19,3 @@ class TSModuleScope extends ScopeBase<
     super(scopeManager, ScopeType.tsModule, upperScope, block, false);
   }
 }
-
-export { TSModuleScope };

--- a/packages/scope-manager/src/scope/TypeScope.ts
+++ b/packages/scope-manager/src/scope/TypeScope.ts
@@ -6,7 +6,7 @@ import type { Scope } from './Scope';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class TypeScope extends ScopeBase<
+export class TypeScope extends ScopeBase<
   ScopeType.type,
   TSESTree.TSInterfaceDeclaration | TSESTree.TSTypeAliasDeclaration,
   Scope
@@ -19,5 +19,3 @@ class TypeScope extends ScopeBase<
     super(scopeManager, ScopeType.type, upperScope, block, false);
   }
 }
-
-export { TypeScope };

--- a/packages/scope-manager/src/scope/WithScope.ts
+++ b/packages/scope-manager/src/scope/WithScope.ts
@@ -7,7 +7,7 @@ import { assert } from '../assert';
 import { ScopeBase } from './ScopeBase';
 import { ScopeType } from './ScopeType';
 
-class WithScope extends ScopeBase<
+export class WithScope extends ScopeBase<
   ScopeType.with,
   TSESTree.WithStatement,
   Scope
@@ -29,5 +29,3 @@ class WithScope extends ScopeBase<
     return this.upper;
   }
 }
-
-export { WithScope };

--- a/packages/scope-manager/src/variable/ESLintScopeVariable.ts
+++ b/packages/scope-manager/src/variable/ESLintScopeVariable.ts
@@ -4,9 +4,9 @@ import { VariableBase } from './VariableBase';
 
 /**
  * ESLint defines global variables using the eslint-scope Variable class
- * This is declared her for consumers to use
+ * This is declared here for consumers to use
  */
-class ESLintScopeVariable extends VariableBase {
+export class ESLintScopeVariable extends VariableBase {
   /**
    * Written to by ESLint.
    * If this key exists, this variable is a global variable added by ESLint.
@@ -35,5 +35,3 @@ class ESLintScopeVariable extends VariableBase {
    */
   public eslintExplicitGlobalComments?: TSESTree.Comment[];
 }
-
-export { ESLintScopeVariable };

--- a/packages/scope-manager/src/variable/ImplicitLibVariable.ts
+++ b/packages/scope-manager/src/variable/ImplicitLibVariable.ts
@@ -3,7 +3,7 @@ import type { Variable } from './Variable';
 
 import { ESLintScopeVariable } from './ESLintScopeVariable';
 
-interface ImplicitLibVariableOptions {
+export interface ImplicitLibVariableOptions {
   readonly eslintImplicitGlobalSetting?: ESLintScopeVariable['eslintImplicitGlobalSetting'];
   readonly isTypeVariable?: boolean;
   readonly isValueVariable?: boolean;
@@ -13,7 +13,10 @@ interface ImplicitLibVariableOptions {
 /**
  * An variable implicitly defined by the TS Lib
  */
-class ImplicitLibVariable extends ESLintScopeVariable implements Variable {
+export class ImplicitLibVariable
+  extends ESLintScopeVariable
+  implements Variable
+{
   /**
    * `true` if the variable is valid in a type context, false otherwise
    */
@@ -42,5 +45,3 @@ class ImplicitLibVariable extends ESLintScopeVariable implements Variable {
       eslintImplicitGlobalSetting ?? 'readonly';
   }
 }
-
-export { ImplicitLibVariable, type ImplicitLibVariableOptions };

--- a/packages/scope-manager/src/variable/Variable.ts
+++ b/packages/scope-manager/src/variable/Variable.ts
@@ -3,7 +3,7 @@ import { VariableBase } from './VariableBase';
 /**
  * A Variable represents a locally scoped identifier. These include arguments to functions.
  */
-class Variable extends VariableBase {
+export class Variable extends VariableBase {
   /**
    * `true` if the variable is valid in a type context, false otherwise
    * @public
@@ -30,5 +30,3 @@ class Variable extends VariableBase {
     return this.defs.some(def => def.isVariableDefinition);
   }
 }
-
-export { Variable };

--- a/packages/scope-manager/src/variable/VariableBase.ts
+++ b/packages/scope-manager/src/variable/VariableBase.ts
@@ -8,7 +8,7 @@ import { createIdGenerator } from '../ID';
 
 const generator = createIdGenerator();
 
-class VariableBase {
+export class VariableBase {
   /**
    * A unique ID for this instance - primarily used to help debugging and testing
    */
@@ -51,5 +51,3 @@ class VariableBase {
     this.scope = scope;
   }
 }
-
-export { VariableBase };

--- a/packages/scope-manager/tests/test-utils/expect.ts
+++ b/packages/scope-manager/tests/test-utils/expect.ts
@@ -34,116 +34,104 @@ import { ScopeType } from '../../src/scope';
 // EXPECT SCOPE //
 //////////////////
 
-function expectToBeBlockScope(scope: Scope): asserts scope is BlockScope {
+export function expectToBeBlockScope(
+  scope: Scope,
+): asserts scope is BlockScope {
   expect(scope.type).toBe(ScopeType.block);
 }
-function expectToBeCatchScope(scope: Scope): asserts scope is CatchScope {
+export function expectToBeCatchScope(
+  scope: Scope,
+): asserts scope is CatchScope {
   expect(scope.type).toBe(ScopeType.catch);
 }
-function expectToBeClassFieldInitializerScope(
+export function expectToBeClassFieldInitializerScope(
   scope: Scope,
 ): asserts scope is ClassFieldInitializerScope {
   expect(scope.type).toBe(ScopeType.classFieldInitializer);
 }
-function expectToBeClassScope(scope: Scope): asserts scope is ClassScope {
+export function expectToBeClassScope(
+  scope: Scope,
+): asserts scope is ClassScope {
   expect(scope.type).toBe(ScopeType.class);
 }
-function expectToBeForScope(scope: Scope): asserts scope is ForScope {
+export function expectToBeForScope(scope: Scope): asserts scope is ForScope {
   expect(scope.type).toBe(ScopeType.for);
 }
-function expectToBeFunctionScope(scope: Scope): asserts scope is FunctionScope {
+export function expectToBeFunctionScope(
+  scope: Scope,
+): asserts scope is FunctionScope {
   expect(scope.type).toBe(ScopeType.function);
 }
-function expectToBeFunctionExpressionNameScope(
+export function expectToBeFunctionExpressionNameScope(
   scope: Scope,
 ): asserts scope is FunctionExpressionNameScope {
   expect(scope.type).toBe(ScopeType.functionExpressionName);
 }
-function expectToBeGlobalScope(scope: Scope): asserts scope is GlobalScope {
+export function expectToBeGlobalScope(
+  scope: Scope,
+): asserts scope is GlobalScope {
   expect(scope.type).toBe(ScopeType.global);
 }
-function expectToBeModuleScope(scope: Scope): asserts scope is ModuleScope {
+export function expectToBeModuleScope(
+  scope: Scope,
+): asserts scope is ModuleScope {
   expect(scope.type).toBe(ScopeType.module);
 }
-function expectToBeSwitchScope(scope: Scope): asserts scope is SwitchScope {
+export function expectToBeSwitchScope(
+  scope: Scope,
+): asserts scope is SwitchScope {
   expect(scope.type).toBe(ScopeType.switch);
 }
-function expectToBeWithScope(scope: Scope): asserts scope is WithScope {
+export function expectToBeWithScope(scope: Scope): asserts scope is WithScope {
   expect(scope.type).toBe(ScopeType.with);
 }
-
-export {
-  expectToBeBlockScope,
-  expectToBeCatchScope,
-  expectToBeClassFieldInitializerScope,
-  expectToBeClassScope,
-  expectToBeForScope,
-  expectToBeFunctionExpressionNameScope,
-  expectToBeFunctionScope,
-  expectToBeGlobalScope,
-  expectToBeModuleScope,
-  expectToBeSwitchScope,
-  expectToBeWithScope,
-};
 
 ///////////////////////
 // EXPECT DEFINITION //
 ///////////////////////
 
-function expectToBeCatchClauseDefinition(
+export function expectToBeCatchClauseDefinition(
   def: Definition,
 ): asserts def is CatchClauseDefinition {
   expect(def.type).toBe(DefinitionType.CatchClause);
 }
-function expectToBeClassNameDefinition(
+export function expectToBeClassNameDefinition(
   def: Definition,
 ): asserts def is ClassNameDefinition {
   expect(def.type).toBe(DefinitionType.ClassName);
 }
-function expectToBeFunctionNameDefinition(
+export function expectToBeFunctionNameDefinition(
   def: Definition,
 ): asserts def is FunctionNameDefinition {
   expect(def.type).toBe(DefinitionType.FunctionName);
 }
-function expectToBeImplicitGlobalVariableDefinition(
+export function expectToBeImplicitGlobalVariableDefinition(
   def: Definition,
 ): asserts def is ImplicitGlobalVariableDefinition {
   expect(def.type).toBe(DefinitionType.ImplicitGlobalVariable);
 }
-function expectToBeImportBindingDefinition(
+export function expectToBeImportBindingDefinition(
   def: Definition,
 ): asserts def is ImportBindingDefinition {
   expect(def.type).toBe(DefinitionType.ImportBinding);
 }
-function expectToBeParameterDefinition(
+export function expectToBeParameterDefinition(
   def: Definition,
 ): asserts def is ParameterDefinition {
   expect(def.type).toBe(DefinitionType.Parameter);
 }
-function expectToBeVariableDefinition(
+export function expectToBeVariableDefinition(
   def: Definition,
 ): asserts def is VariableDefinition {
   expect(def.type).toBe(DefinitionType.Variable);
 }
 
-export {
-  expectToBeCatchClauseDefinition,
-  expectToBeClassNameDefinition,
-  expectToBeFunctionNameDefinition,
-  expectToBeImplicitGlobalVariableDefinition,
-  expectToBeImportBindingDefinition,
-  expectToBeParameterDefinition,
-  expectToBeVariableDefinition,
-};
-
 /////////////////
 // EXPECT MISC //
 /////////////////
 
-function expectToBeIdentifier(
+export function expectToBeIdentifier(
   node: TSESTree.Node | null | undefined,
 ): asserts node is TSESTree.Identifier {
   expect(node?.type).toBe(AST_NODE_TYPES.Identifier);
 }
-
-export { expectToBeIdentifier };

--- a/packages/scope-manager/tests/test-utils/getSpecificNode.ts
+++ b/packages/scope-manager/tests/test-utils/getSpecificNode.ts
@@ -2,7 +2,7 @@ import type { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/types';
 
 import { simpleTraverse } from '@typescript-eslint/typescript-estree';
 
-function getSpecificNode<
+export function getSpecificNode<
   Selector extends AST_NODE_TYPES,
   Node extends Extract<TSESTree.Node, { type: Selector }>,
 >(
@@ -10,7 +10,7 @@ function getSpecificNode<
   selector: Selector,
   cb?: (node: Node) => boolean | null | undefined,
 ): Node;
-function getSpecificNode<
+export function getSpecificNode<
   Selector extends AST_NODE_TYPES,
   ReturnType extends TSESTree.Node,
 >(
@@ -21,7 +21,7 @@ function getSpecificNode<
   ) => ReturnType | null | undefined,
 ): ReturnType;
 
-function getSpecificNode(
+export function getSpecificNode(
   ast: TSESTree.Node,
   selector: AST_NODE_TYPES,
   cb?: (node: TSESTree.Node) => boolean | TSESTree.Node | null | undefined,
@@ -49,5 +49,3 @@ function getSpecificNode(
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   return node!;
 }
-
-export { getSpecificNode };

--- a/packages/scope-manager/tests/test-utils/misc.ts
+++ b/packages/scope-manager/tests/test-utils/misc.ts
@@ -2,8 +2,6 @@ import type { Variable } from '../../src';
 
 import { ImplicitLibVariable } from '../../src';
 
-function getRealVariables(variables: Variable[]): Variable[] {
+export function getRealVariables(variables: Variable[]): Variable[] {
   return variables.filter(v => !(v instanceof ImplicitLibVariable));
 }
-
-export { getRealVariables };

--- a/packages/scope-manager/tests/test-utils/parse.ts
+++ b/packages/scope-manager/tests/test-utils/parse.ts
@@ -4,7 +4,7 @@ import type { AnalyzeOptions } from '../../src/analyze';
 
 import { analyze } from '../../src/analyze';
 
-type SourceType = AnalyzeOptions['sourceType'];
+export type SourceType = AnalyzeOptions['sourceType'];
 
 const DEFAULT_PARSER_OPTIONS = {
   // the analyser requires ranges to work
@@ -15,7 +15,7 @@ const DEFAULT_ANALYZE_OPTIONS = {
   lib: [],
 };
 
-function parse(
+export function parse(
   code: string,
   sourceTypeOrParserOptions:
     | SourceType
@@ -31,17 +31,20 @@ function parse(
   });
 }
 
-interface ParseAndAnalyze {
+export interface ParseAndAnalyze {
   ast: ReturnType<typeof tseslint.parse>;
   scopeManager: ReturnType<typeof analyze>;
 }
-function parseAndAnalyze(code: string, sourceType: SourceType): ParseAndAnalyze;
-function parseAndAnalyze(
+export function parseAndAnalyze(
+  code: string,
+  sourceType: SourceType,
+): ParseAndAnalyze;
+export function parseAndAnalyze(
   code: string,
   analyzeOptions?: AnalyzeOptions,
   parserOptions?: tseslint.TSESTreeOptions,
 ): ParseAndAnalyze;
-function parseAndAnalyze(
+export function parseAndAnalyze(
   code: string,
   sourceTypeOrAnalyzeOption:
     | AnalyzeOptions
@@ -60,7 +63,5 @@ function parseAndAnalyze(
 
   return { ast, scopeManager };
 }
-
-export { parse, parseAndAnalyze };
 
 export type { AnalyzeOptions } from '../../src/analyze';

--- a/packages/scope-manager/tests/test-utils/serializers/DefinitionBase.ts
+++ b/packages/scope-manager/tests/test-utils/serializers/DefinitionBase.ts
@@ -15,7 +15,7 @@ class DefinitionInstance extends DefinitionBase<
   isTypeDefinition = false;
   isVariableDefinition = false;
 }
-const serializer = createSerializer(
+export const serializer = createSerializer(
   DefinitionBase,
   [
     //
@@ -24,5 +24,3 @@ const serializer = createSerializer(
   ],
   DefinitionInstance,
 );
-
-export { serializer };

--- a/packages/scope-manager/tests/test-utils/serializers/Reference.ts
+++ b/packages/scope-manager/tests/test-utils/serializers/Reference.ts
@@ -1,7 +1,7 @@
 import { Reference } from '../../../src/referencer/Reference';
 import { createSerializer } from './baseSerializer';
 
-const serializer = createSerializer(Reference, [
+export const serializer = createSerializer(Reference, [
   'identifier',
   'init',
   'isRead',
@@ -11,5 +11,3 @@ const serializer = createSerializer(Reference, [
   'resolved',
   'writeExpr',
 ]);
-
-export { serializer };

--- a/packages/scope-manager/tests/test-utils/serializers/ScopeBase.ts
+++ b/packages/scope-manager/tests/test-utils/serializers/ScopeBase.ts
@@ -4,7 +4,7 @@ import { createSerializer } from './baseSerializer';
 // hacking around the fact that you can't use abstract classes generically
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 class ScopeInstance extends ScopeBase<any, any, any> {}
-const serializer = createSerializer(
+export const serializer = createSerializer(
   ScopeBase,
   [
     //
@@ -18,5 +18,3 @@ const serializer = createSerializer(
   ],
   ScopeInstance,
 );
-
-export { serializer };

--- a/packages/scope-manager/tests/test-utils/serializers/ScopeManager.ts
+++ b/packages/scope-manager/tests/test-utils/serializers/ScopeManager.ts
@@ -1,10 +1,8 @@
 import { ScopeManager } from '../../../src/ScopeManager';
 import { createSerializer } from './baseSerializer';
 
-const serializer = createSerializer(ScopeManager, [
+export const serializer = createSerializer(ScopeManager, [
   // purposely put variables first
   'variables',
   'scopes',
 ]);
-
-export { serializer };

--- a/packages/scope-manager/tests/test-utils/serializers/TSESTreeNode.ts
+++ b/packages/scope-manager/tests/test-utils/serializers/TSESTreeNode.ts
@@ -20,7 +20,7 @@ type Node = { type: AST_NODE_TYPES } & Record<string, unknown>;
 type Identifier = { name: string; type: AST_NODE_TYPES.Identifier } & Node;
 const SEEN_NODES = new Map<Node, number>();
 
-const serializer: NewPlugin = {
+export const serializer: NewPlugin = {
   serialize(node: Node): string {
     if (node.type === AST_NODE_TYPES.Identifier) {
       return `Identifier<"${(node as Identifier).name}">`;
@@ -50,5 +50,3 @@ const serializer: NewPlugin = {
     );
   },
 };
-
-export { serializer };

--- a/packages/scope-manager/tests/test-utils/serializers/Variable.ts
+++ b/packages/scope-manager/tests/test-utils/serializers/Variable.ts
@@ -1,7 +1,7 @@
 import { ImplicitLibVariable, Variable } from '../../../src/variable';
 import { createSerializer } from './baseSerializer';
 
-const serializer = createSerializer(Variable, [
+export const serializer = createSerializer(Variable, [
   //
   'defs',
   'name',
@@ -9,7 +9,7 @@ const serializer = createSerializer(Variable, [
   'isValueVariable',
   'isTypeVariable',
 ]);
-const implicitLibVarSerializer = createSerializer(ImplicitLibVariable, [
+export const implicitLibVarSerializer = createSerializer(ImplicitLibVariable, [
   //
   'defs',
   'name',
@@ -17,5 +17,3 @@ const implicitLibVarSerializer = createSerializer(ImplicitLibVariable, [
   'isValueVariable',
   'isTypeVariable',
 ]);
-
-export { implicitLibVarSerializer, serializer };

--- a/packages/scope-manager/tests/test-utils/serializers/baseSerializer.ts
+++ b/packages/scope-manager/tests/test-utils/serializers/baseSerializer.ts
@@ -2,18 +2,18 @@ import type { NewPlugin } from 'pretty-format';
 
 type ConstructorSignature = new (...args: never) => unknown;
 
-function createSerializer<Constructor extends ConstructorSignature>(
+export function createSerializer<Constructor extends ConstructorSignature>(
   type: Constructor,
   keys: (keyof InstanceType<Constructor>)[],
 ): NewPlugin;
 // A hack of signature to enable this to work with abstract classes
-function createSerializer<Constructor extends ConstructorSignature>(
+export function createSerializer<Constructor extends ConstructorSignature>(
   abstractConstructor: unknown,
   keys: (keyof InstanceType<Constructor>)[],
   instanceConstructorThatsNeverUsed: Constructor,
 ): NewPlugin;
 
-function createSerializer<Constructor extends ConstructorSignature>(
+export function createSerializer<Constructor extends ConstructorSignature>(
   type: Constructor,
   keys: (keyof InstanceType<Constructor>)[],
 ): NewPlugin {
@@ -81,5 +81,3 @@ function createSerializer<Constructor extends ConstructorSignature>(
     },
   };
 }
-
-export { createSerializer };

--- a/packages/type-utils/src/isTypeReadonly.ts
+++ b/packages/type-utils/src/isTypeReadonly.ts
@@ -331,7 +331,7 @@ function isTypeReadonlyRecurser(
 /**
  * Checks if the given type is readonly
  */
-function isTypeReadonly(
+export function isTypeReadonly(
   program: ts.Program,
   type: ts.Type,
   options: ReadonlynessOptions = readonlynessOptionsDefaults,
@@ -341,5 +341,3 @@ function isTypeReadonly(
     Readonlyness.Readonly
   );
 }
-
-export { isTypeReadonly };

--- a/packages/type-utils/src/requiresQuoting.ts
+++ b/packages/type-utils/src/requiresQuoting.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 /*** Indicates whether identifiers require the use of quotation marks when accessing property definitions and dot notation. */
-function requiresQuoting(
+export function requiresQuoting(
   name: string,
   target: ts.ScriptTarget = ts.ScriptTarget.ESNext,
 ): boolean {
@@ -20,5 +20,3 @@ function requiresQuoting(
 
   return false;
 }
-
-export { requiresQuoting };

--- a/packages/types/src/lib.ts
+++ b/packages/types/src/lib.ts
@@ -3,7 +3,7 @@
 // RUN THE FOLLOWING COMMAND FROM THE WORKSPACE ROOT TO REGENERATE:
 // npx nx generate-lib repo
 
-type Lib =
+export type Lib =
   | 'decorators'
   | 'decorators.legacy'
   | 'dom'
@@ -109,5 +109,3 @@ type Lib =
   | 'webworker.asynciterable'
   | 'webworker.importscripts'
   | 'webworker.iterable';
-
-export { Lib };

--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -2,10 +2,12 @@ import type { Program } from 'typescript';
 
 import type { Lib } from './lib';
 
-type DebugLevel = boolean | ('eslint' | 'typescript' | 'typescript-eslint')[];
-type CacheDurationSeconds = number | 'Infinity';
+export type DebugLevel =
+  | boolean
+  | ('eslint' | 'typescript' | 'typescript-eslint')[];
+export type CacheDurationSeconds = number | 'Infinity';
 
-type EcmaVersion =
+export type EcmaVersion =
   | 'latest'
   | 3
   | 5
@@ -33,15 +35,15 @@ type EcmaVersion =
   | 2025
   | undefined;
 
-type SourceTypeClassic = 'module' | 'script';
-type SourceType = 'commonjs' | SourceTypeClassic;
+export type SourceTypeClassic = 'module' | 'script';
+export type SourceType = 'commonjs' | SourceTypeClassic;
 
-type JSDocParsingMode = 'all' | 'none' | 'type-info';
+export type JSDocParsingMode = 'all' | 'none' | 'type-info';
 
 /**
  * Granular options to configure the project service.
  */
-interface ProjectServiceOptions {
+export interface ProjectServiceOptions {
   /**
    * Globs of files to allow running with the default project compiler options
    * despite not being matched by the project service.
@@ -70,7 +72,7 @@ interface ProjectServiceOptions {
 }
 
 // If you add publicly visible options here, make sure they're also documented in `docs/packages/Parser.mdx`
-interface ParserOptions {
+export interface ParserOptions {
   [additionalProperties: string]: unknown;
   cacheLifetime?: {
     glob?: CacheDurationSeconds;
@@ -112,13 +114,3 @@ interface ParserOptions {
 
   warnOnUnsupportedTypeScriptVersion?: boolean;
 }
-
-export type {
-  CacheDurationSeconds,
-  DebugLevel,
-  EcmaVersion,
-  JSDocParsingMode,
-  ParserOptions,
-  ProjectServiceOptions,
-  SourceType,
-};

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -19,7 +19,7 @@ import stylisticConfig from './configs/stylistic';
 import stylisticTypeCheckedConfig from './configs/stylistic-type-checked';
 import stylisticTypeCheckedOnlyConfig from './configs/stylistic-type-checked-only';
 
-const parser: TSESLint.FlatConfig.Parser = {
+export const parser: TSESLint.FlatConfig.Parser = {
   meta: parserBase.meta,
   parseForESLint: parserBase.parseForESLint,
 };
@@ -47,12 +47,12 @@ use our new package); however legacy configs consumed via `@eslint/eslintrc`
 would never be able to satisfy this constraint and thus users would be blocked
 from using them.
 */
-const plugin: TSESLint.FlatConfig.Plugin = pluginBase as Omit<
+export const plugin: TSESLint.FlatConfig.Plugin = pluginBase as Omit<
   typeof pluginBase,
   'configs'
 >;
 
-const configs = {
+export const configs = {
   /**
    * Enables each the rules provided as a part of typescript-eslint. Note that many rules are not applicable in all codebases, or are meant to be configured.
    * @see {@link https://typescript-eslint.io/users/configs#all}
@@ -184,7 +184,6 @@ export default {
   parser,
   plugin,
 };
-export { configs, parser, plugin };
 
 export {
   config,

--- a/packages/typescript-estree/src/create-program/WatchCompilerHostOfConfigFile.ts
+++ b/packages/typescript-estree/src/create-program/WatchCompilerHostOfConfigFile.ts
@@ -27,12 +27,10 @@ interface CachedDirectoryStructureHost extends DirectoryStructureHost {
 }
 
 // https://github.com/microsoft/TypeScript/blob/5d36aab06f12b0a3ba6197eb14e98204ec0195fb/src/compiler/watch.ts#L548-L554
-interface WatchCompilerHostOfConfigFile<T extends ts.BuilderProgram>
+export interface WatchCompilerHostOfConfigFile<T extends ts.BuilderProgram>
   extends ts.WatchCompilerHostOfConfigFile<T> {
   extraFileExtensions?: readonly ts.FileExtensionInfo[];
   onCachedDirectoryStructureHostCreate(
     host: CachedDirectoryStructureHost,
   ): void;
 }
-
-export type { WatchCompilerHostOfConfigFile };

--- a/packages/typescript-estree/src/create-program/createIsolatedProgram.ts
+++ b/packages/typescript-estree/src/create-program/createIsolatedProgram.ts
@@ -12,7 +12,7 @@ const log = debug('typescript-eslint:typescript-estree:createIsolatedProgram');
 /**
  * @returns Returns a new source file and program corresponding to the linted code
  */
-function createIsolatedProgram(
+export function createIsolatedProgram(
   parseSettings: ParseSettings,
 ): ASTAndDefiniteProgram {
   log(
@@ -83,5 +83,3 @@ function createIsolatedProgram(
 
   return { ast, program };
 }
-
-export { createIsolatedProgram };

--- a/packages/typescript-estree/src/create-program/createSourceFile.ts
+++ b/packages/typescript-estree/src/create-program/createSourceFile.ts
@@ -9,7 +9,7 @@ import { getScriptKind } from './getScriptKind';
 
 const log = debug('typescript-eslint:typescript-estree:createSourceFile');
 
-function createSourceFile(parseSettings: ParseSettings): ts.SourceFile {
+export function createSourceFile(parseSettings: ParseSettings): ts.SourceFile {
   log(
     'Getting AST without type information in %s mode for: %s',
     parseSettings.jsx ? 'TSX' : 'TS',
@@ -31,11 +31,9 @@ function createSourceFile(parseSettings: ParseSettings): ts.SourceFile {
       );
 }
 
-function createNoProgram(parseSettings: ParseSettings): ASTAndNoProgram {
+export function createNoProgram(parseSettings: ParseSettings): ASTAndNoProgram {
   return {
     ast: createSourceFile(parseSettings),
     program: null,
   };
 }
-
-export { createNoProgram, createSourceFile };

--- a/packages/typescript-estree/src/create-program/getParsedConfigFile.ts
+++ b/packages/typescript-estree/src/create-program/getParsedConfigFile.ts
@@ -11,7 +11,7 @@ import { CORE_COMPILER_OPTIONS } from './shared';
  * @param configFile the path to the tsconfig.json file, relative to `projectDirectory`
  * @param projectDirectory the project directory to use as the CWD, defaults to `process.cwd()`
  */
-function getParsedConfigFile(
+export function getParsedConfigFile(
   tsserver: typeof ts,
   configFile: string,
   projectDirectory?: string,
@@ -61,5 +61,3 @@ function getParsedConfigFile(
     });
   }
 }
-
-export { getParsedConfigFile };

--- a/packages/typescript-estree/src/create-program/getScriptKind.ts
+++ b/packages/typescript-estree/src/create-program/getScriptKind.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import * as ts from 'typescript';
 
-function getScriptKind(filePath: string, jsx: boolean): ts.ScriptKind {
+export function getScriptKind(filePath: string, jsx: boolean): ts.ScriptKind {
   const extension = path.extname(filePath).toLowerCase() as ts.Extension;
   // note - we only respect the user's jsx setting for unknown extensions
   // this is so that we always match TS's internal script kind logic, preventing
@@ -33,7 +33,9 @@ function getScriptKind(filePath: string, jsx: boolean): ts.ScriptKind {
   }
 }
 
-function getLanguageVariant(scriptKind: ts.ScriptKind): ts.LanguageVariant {
+export function getLanguageVariant(
+  scriptKind: ts.ScriptKind,
+): ts.LanguageVariant {
   // https://github.com/microsoft/TypeScript/blob/d6e483b8dabd8fd37c00954c3f2184bb7f1eb90c/src/compiler/utilities.ts#L6281-L6285
   switch (scriptKind) {
     case ts.ScriptKind.JS:
@@ -46,5 +48,3 @@ function getLanguageVariant(scriptKind: ts.ScriptKind): ts.LanguageVariant {
       return ts.LanguageVariant.Standard;
   }
 }
-
-export { getLanguageVariant, getScriptKind };

--- a/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
+++ b/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
@@ -53,7 +53,7 @@ const parsedFilesSeenHash = new Map<CanonicalPath, string>();
  * Clear all of the parser caches.
  * This should only be used in testing to ensure the parser is clean between tests.
  */
-function clearWatchCaches(): void {
+export function clearWatchCaches(): void {
   knownWatchProgramMap.clear();
   fileWatchCallbackTrackingMap.clear();
   folderWatchCallbackTrackingMap.clear();
@@ -125,7 +125,7 @@ function updateCachedFileList(
  * @param parseSettings Internal settings for parsing the file
  * @returns The programs corresponding to the supplied tsconfig paths
  */
-function getWatchProgramsForProjects(
+export function getWatchProgramsForProjects(
   parseSettings: ParseSettings,
 ): ts.Program[] {
   const filePath = getCanonicalFileName(parseSettings.filePath);
@@ -489,5 +489,3 @@ function maybeInvalidateProgram(
   );
   return null;
 }
-
-export { clearWatchCaches, getWatchProgramsForProjects };

--- a/packages/typescript-estree/src/create-program/shared.ts
+++ b/packages/typescript-estree/src/create-program/shared.ts
@@ -5,20 +5,20 @@ import * as ts from 'typescript';
 
 import type { ParseSettings } from '../parseSettings';
 
-interface ASTAndNoProgram {
+export interface ASTAndNoProgram {
   ast: ts.SourceFile;
   program: null;
 }
-interface ASTAndDefiniteProgram {
+export interface ASTAndDefiniteProgram {
   ast: ts.SourceFile;
   program: ts.Program;
 }
-type ASTAndProgram = ASTAndDefiniteProgram | ASTAndNoProgram;
+export type ASTAndProgram = ASTAndDefiniteProgram | ASTAndNoProgram;
 
 /**
  * Compiler options required to avoid critical functionality issues
  */
-const CORE_COMPILER_OPTIONS: ts.CompilerOptions = {
+export const CORE_COMPILER_OPTIONS: ts.CompilerOptions = {
   noEmit: true, // required to avoid parse from causing emit to occur
 
   /**
@@ -38,7 +38,7 @@ const DEFAULT_COMPILER_OPTIONS: ts.CompilerOptions = {
   checkJs: true,
 };
 
-const DEFAULT_EXTRA_FILE_EXTENSIONS = new Set<string>([
+export const DEFAULT_EXTRA_FILE_EXTENSIONS = new Set<string>([
   ts.Extension.Cjs,
   ts.Extension.Cts,
   ts.Extension.Js,
@@ -49,7 +49,7 @@ const DEFAULT_EXTRA_FILE_EXTENSIONS = new Set<string>([
   ts.Extension.Tsx,
 ]);
 
-function createDefaultCompilerOptionsFromExtra(
+export function createDefaultCompilerOptionsFromExtra(
   parseSettings: ParseSettings,
 ): ts.CompilerOptions {
   if (parseSettings.debugLevel.has('typescript')) {
@@ -63,7 +63,7 @@ function createDefaultCompilerOptionsFromExtra(
 }
 
 // This narrows the type so we can be sure we're passing canonical names in the correct places
-type CanonicalPath = { __brand: unknown } & string;
+export type CanonicalPath = { __brand: unknown } & string;
 
 // typescript doesn't provide a ts.sys implementation for browser environments
 const useCaseSensitiveFileNames =
@@ -73,7 +73,7 @@ const correctPathCasing = useCaseSensitiveFileNames
   ? (filePath: string): string => filePath
   : (filePath: string): string => filePath.toLowerCase();
 
-function getCanonicalFileName(filePath: string): CanonicalPath {
+export function getCanonicalFileName(filePath: string): CanonicalPath {
   let normalized = path.normalize(filePath);
   if (normalized.endsWith(path.sep)) {
     normalized = normalized.slice(0, -1);
@@ -81,13 +81,13 @@ function getCanonicalFileName(filePath: string): CanonicalPath {
   return correctPathCasing(normalized) as CanonicalPath;
 }
 
-function ensureAbsolutePath(p: string, tsconfigRootDir: string): string {
+export function ensureAbsolutePath(p: string, tsconfigRootDir: string): string {
   return path.isAbsolute(p)
     ? p
     : path.join(tsconfigRootDir || process.cwd(), p);
 }
 
-function canonicalDirname(p: CanonicalPath): CanonicalPath {
+export function canonicalDirname(p: CanonicalPath): CanonicalPath {
   return path.dirname(p) as CanonicalPath;
 }
 
@@ -108,7 +108,7 @@ function getExtension(fileName: string | undefined): string | null {
   );
 }
 
-function getAstFromProgram(
+export function getAstFromProgram(
   currentProgram: Program,
   filePath: string,
 ): ASTAndDefiniteProgram | undefined {
@@ -129,7 +129,7 @@ function getAstFromProgram(
  * @param content hashed contend
  * @returns hashed result
  */
-function createHash(content: string): string {
+export function createHash(content: string): string {
   // No ts.sys in browser environments.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (ts.sys?.createHash) {
@@ -137,18 +137,3 @@ function createHash(content: string): string {
   }
   return content;
 }
-
-export {
-  type ASTAndDefiniteProgram,
-  type ASTAndNoProgram,
-  type ASTAndProgram,
-  canonicalDirname,
-  type CanonicalPath,
-  CORE_COMPILER_OPTIONS,
-  createDefaultCompilerOptionsFromExtra,
-  createHash,
-  DEFAULT_EXTRA_FILE_EXTENSIONS,
-  ensureAbsolutePath,
-  getAstFromProgram,
-  getCanonicalFileName,
-};

--- a/packages/typescript-estree/src/create-program/useProvidedPrograms.ts
+++ b/packages/typescript-estree/src/create-program/useProvidedPrograms.ts
@@ -10,7 +10,7 @@ import { getAstFromProgram } from './shared';
 
 const log = debug('typescript-eslint:typescript-estree:useProvidedProgram');
 
-function useProvidedPrograms(
+export function useProvidedPrograms(
   programInstances: Iterable<ts.Program>,
   parseSettings: ParseSettings,
 ): ASTAndDefiniteProgram | undefined {
@@ -57,7 +57,7 @@ function useProvidedPrograms(
  * @param configFile the path to the tsconfig.json file, relative to `projectDirectory`
  * @param projectDirectory the project directory to use as the CWD, defaults to `process.cwd()`
  */
-function createProgramFromConfigFile(
+export function createProgramFromConfigFile(
   configFile: string,
   projectDirectory?: string,
 ): ts.Program {
@@ -65,5 +65,3 @@ function createProgramFromConfigFile(
   const host = ts.createCompilerHost(parsed.options, true);
   return ts.createProgram(parsed.fileNames, parsed.options, host);
 }
-
-export { createProgramFromConfigFile, useProvidedPrograms };

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -37,12 +37,12 @@ const log = debug('typescript-eslint:typescript-estree:parser');
  * clearProgramCache() is only intended to be used in testing to ensure the parser is clean between tests.
  */
 const existingPrograms = new Map<CanonicalPath, ts.Program>();
-function clearProgramCache(): void {
+export function clearProgramCache(): void {
   existingPrograms.clear();
 }
 
 const defaultProjectMatchedFiles = new Set<string>();
-function clearDefaultProjectMatchedFiles(): void {
+export function clearDefaultProjectMatchedFiles(): void {
   defaultProjectMatchedFiles.clear();
 }
 
@@ -90,14 +90,14 @@ function getProgramAndAST(
 }
 
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-type AST<T extends TSESTreeOptions> = (T['comment'] extends true
+export type AST<T extends TSESTreeOptions> = (T['comment'] extends true
   ? { comments: TSESTree.Comment[] }
   : {}) &
   (T['tokens'] extends true ? { tokens: TSESTree.Token[] } : {}) &
   TSESTree.Program;
 /* eslint-enable @typescript-eslint/no-empty-object-type */
 
-interface ParseAndGenerateServicesResult<T extends TSESTreeOptions> {
+export interface ParseAndGenerateServicesResult<T extends TSESTreeOptions> {
   ast: AST<T>;
   services: ParserServices;
 }
@@ -106,7 +106,7 @@ interface ParseWithNodeMapsResult<T extends TSESTreeOptions>
   ast: AST<T>;
 }
 
-function parse<T extends TSESTreeOptions = TSESTreeOptions>(
+export function parse<T extends TSESTreeOptions = TSESTreeOptions>(
   code: string,
   options?: T,
 ): AST<T> {
@@ -156,11 +156,13 @@ function parseWithNodeMapsInternal<T extends TSESTreeOptions = TSESTreeOptions>(
 
 let parseAndGenerateServicesCalls: Record<string, number> = {};
 // Privately exported utility intended for use in typescript-eslint unit tests only
-function clearParseAndGenerateServicesCalls(): void {
+export function clearParseAndGenerateServicesCalls(): void {
   parseAndGenerateServicesCalls = {};
 }
 
-function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
+export function parseAndGenerateServices<
+  T extends TSESTreeOptions = TSESTreeOptions,
+>(
   code: string | ts.SourceFile,
   tsestreeOptions: T,
 ): ParseAndGenerateServicesResult<T> {
@@ -275,13 +277,3 @@ function parseAndGenerateServices<T extends TSESTreeOptions = TSESTreeOptions>(
     services: createParserServices(astMaps, program),
   };
 }
-
-export {
-  type AST,
-  clearDefaultProjectMatchedFiles,
-  clearParseAndGenerateServicesCalls,
-  clearProgramCache,
-  parse,
-  parseAndGenerateServices,
-  type ParseAndGenerateServicesResult,
-};

--- a/packages/typescript-estree/src/version-check.ts
+++ b/packages/typescript-estree/src/version-check.ts
@@ -23,9 +23,7 @@ const versions = [
 ] as const;
 type Versions = typeof versions extends ArrayLike<infer U> ? U : never;
 
-const typescriptVersionIsAtLeast = {} as Record<Versions, boolean>;
+export const typescriptVersionIsAtLeast = {} as Record<Versions, boolean>;
 for (const version of versions) {
   typescriptVersionIsAtLeast[version] = semverCheck(version);
 }
-
-export { typescriptVersionIsAtLeast };

--- a/packages/utils/src/ast-utils/eslint-utils/PatternMatcher.ts
+++ b/packages/utils/src/ast-utils/eslint-utils/PatternMatcher.ts
@@ -49,9 +49,7 @@ interface PatternMatcher {
  *
  * @see {@link https://eslint-community.github.io/eslint-utils/api/ast-utils.html#patternmatcher-class}
  */
-const PatternMatcher = eslintUtils.PatternMatcher as new (
+export const PatternMatcher = eslintUtils.PatternMatcher as new (
   pattern: RegExp,
   options?: { escaped?: boolean },
 ) => PatternMatcher;
-
-export { PatternMatcher };

--- a/packages/utils/src/ast-utils/eslint-utils/ReferenceTracker.ts
+++ b/packages/utils/src/ast-utils/eslint-utils/ReferenceTracker.ts
@@ -94,6 +94,5 @@ namespace ReferenceTracker {
  *
  * @see {@link https://eslint-community.github.io/eslint-utils/api/scope-utils.html#referencetracker-class}
  */
-const ReferenceTracker = eslintUtils.ReferenceTracker as ReferenceTrackerStatic;
-
-export { ReferenceTracker };
+export const ReferenceTracker =
+  eslintUtils.ReferenceTracker as ReferenceTrackerStatic;

--- a/packages/utils/src/ast-utils/eslint-utils/astUtilities.ts
+++ b/packages/utils/src/ast-utils/eslint-utils/astUtilities.ts
@@ -8,7 +8,7 @@ import type { TSESTree } from '../../ts-estree';
  *
  * @see {@link https://eslint-community.github.io/eslint-utils/api/ast-utils.html#getfunctionheadlocation}
  */
-const getFunctionHeadLocation = eslintUtils.getFunctionHeadLocation as (
+export const getFunctionHeadLocation = eslintUtils.getFunctionHeadLocation as (
   node:
     | TSESTree.ArrowFunctionExpression
     | TSESTree.FunctionDeclaration
@@ -21,7 +21,7 @@ const getFunctionHeadLocation = eslintUtils.getFunctionHeadLocation as (
  *
  * @see {@link https://eslint-community.github.io/eslint-utils/api/ast-utils.html#getfunctionnamewithkind}
  */
-const getFunctionNameWithKind = eslintUtils.getFunctionNameWithKind as (
+export const getFunctionNameWithKind = eslintUtils.getFunctionNameWithKind as (
   node:
     | TSESTree.ArrowFunctionExpression
     | TSESTree.FunctionDeclaration
@@ -36,7 +36,7 @@ const getFunctionNameWithKind = eslintUtils.getFunctionNameWithKind as (
  * @see {@link https://eslint-community.github.io/eslint-utils/api/ast-utils.html#getpropertyname}
  * @returns The property name of the node. If the property name is not constant then it returns `null`.
  */
-const getPropertyName = eslintUtils.getPropertyName as (
+export const getPropertyName = eslintUtils.getPropertyName as (
   node:
     | TSESTree.MemberExpression
     | TSESTree.MethodDefinition
@@ -56,7 +56,7 @@ const getPropertyName = eslintUtils.getPropertyName as (
  * @returns The `{ value: any }` shaped object. The `value` property is the static value. If it couldn't compute the
  * static value of the node, it returns `null`.
  */
-const getStaticValue = eslintUtils.getStaticValue as (
+export const getStaticValue = eslintUtils.getStaticValue as (
   node: TSESTree.Node,
   initialScope?: TSESLint.Scope.Scope,
 ) => { value: unknown } | null;
@@ -67,7 +67,7 @@ const getStaticValue = eslintUtils.getStaticValue as (
  *
  * @see {@link https://eslint-community.github.io/eslint-utils/api/ast-utils.html#getstringifconstant}
  */
-const getStringIfConstant = eslintUtils.getStringIfConstant as (
+export const getStringIfConstant = eslintUtils.getStringIfConstant as (
   node: TSESTree.Node,
   initialScope?: TSESLint.Scope.Scope,
 ) => string | null;
@@ -95,7 +95,7 @@ const getStringIfConstant = eslintUtils.getStringIfConstant as (
  *
  * @see {@link https://eslint-community.github.io/eslint-utils/api/ast-utils.html#hassideeffect}
  */
-const hasSideEffect = eslintUtils.hasSideEffect as (
+export const hasSideEffect = eslintUtils.hasSideEffect as (
   node: TSESTree.Node,
   sourceCode: TSESLint.SourceCode,
   options?: {
@@ -104,7 +104,7 @@ const hasSideEffect = eslintUtils.hasSideEffect as (
   },
 ) => boolean;
 
-const isParenthesized = eslintUtils.isParenthesized as {
+export const isParenthesized = eslintUtils.isParenthesized as {
   (
     times: number,
     node: TSESTree.Node,
@@ -121,14 +121,4 @@ const isParenthesized = eslintUtils.isParenthesized as {
    * For example, `isParenthesized(2, node, sourceCode)` returns true for `((foo))`, but not for `(foo)`.
    */
   (node: TSESTree.Node, sourceCode: TSESLint.SourceCode): boolean;
-};
-
-export {
-  getFunctionHeadLocation,
-  getFunctionNameWithKind,
-  getPropertyName,
-  getStaticValue,
-  getStringIfConstant,
-  hasSideEffect,
-  isParenthesized,
 };

--- a/packages/utils/src/ast-utils/eslint-utils/predicates.ts
+++ b/packages/utils/src/ast-utils/eslint-utils/predicates.ts
@@ -18,82 +18,57 @@ type IsPunctuatorTokenWithValueFunction<Value extends string> =
 type IsNotPunctuatorTokenWithValueFunction<Value extends string> =
   IsNotSpecificTokenFunction<PunctuatorTokenWithValue<Value>>;
 
-const isArrowToken =
+export const isArrowToken =
   eslintUtils.isArrowToken as IsPunctuatorTokenWithValueFunction<'=>'>;
-const isNotArrowToken =
+export const isNotArrowToken =
   eslintUtils.isNotArrowToken as IsNotPunctuatorTokenWithValueFunction<'=>'>;
 
-const isClosingBraceToken =
+export const isClosingBraceToken =
   eslintUtils.isClosingBraceToken as IsPunctuatorTokenWithValueFunction<'}'>;
-const isNotClosingBraceToken =
+export const isNotClosingBraceToken =
   eslintUtils.isNotClosingBraceToken as IsNotPunctuatorTokenWithValueFunction<'}'>;
 
-const isClosingBracketToken =
+export const isClosingBracketToken =
   eslintUtils.isClosingBracketToken as IsPunctuatorTokenWithValueFunction<']'>;
-const isNotClosingBracketToken =
+export const isNotClosingBracketToken =
   eslintUtils.isNotClosingBracketToken as IsNotPunctuatorTokenWithValueFunction<']'>;
 
-const isClosingParenToken =
+export const isClosingParenToken =
   eslintUtils.isClosingParenToken as IsPunctuatorTokenWithValueFunction<')'>;
-const isNotClosingParenToken =
+export const isNotClosingParenToken =
   eslintUtils.isNotClosingParenToken as IsNotPunctuatorTokenWithValueFunction<')'>;
 
-const isColonToken =
+export const isColonToken =
   eslintUtils.isColonToken as IsPunctuatorTokenWithValueFunction<':'>;
-const isNotColonToken =
+export const isNotColonToken =
   eslintUtils.isNotColonToken as IsNotPunctuatorTokenWithValueFunction<':'>;
 
-const isCommaToken =
+export const isCommaToken =
   eslintUtils.isCommaToken as IsPunctuatorTokenWithValueFunction<','>;
-const isNotCommaToken =
+export const isNotCommaToken =
   eslintUtils.isNotCommaToken as IsNotPunctuatorTokenWithValueFunction<','>;
 
-const isCommentToken =
+export const isCommentToken =
   eslintUtils.isCommentToken as IsSpecificTokenFunction<TSESTree.Comment>;
-const isNotCommentToken =
+export const isNotCommentToken =
   eslintUtils.isNotCommentToken as IsNotSpecificTokenFunction<TSESTree.Comment>;
 
-const isOpeningBraceToken =
+export const isOpeningBraceToken =
   eslintUtils.isOpeningBraceToken as IsPunctuatorTokenWithValueFunction<'{'>;
-const isNotOpeningBraceToken =
+export const isNotOpeningBraceToken =
   eslintUtils.isNotOpeningBraceToken as IsNotPunctuatorTokenWithValueFunction<'{'>;
 
-const isOpeningBracketToken =
+export const isOpeningBracketToken =
   eslintUtils.isOpeningBracketToken as IsPunctuatorTokenWithValueFunction<'['>;
-const isNotOpeningBracketToken =
+export const isNotOpeningBracketToken =
   eslintUtils.isNotOpeningBracketToken as IsNotPunctuatorTokenWithValueFunction<'['>;
 
-const isOpeningParenToken =
+export const isOpeningParenToken =
   eslintUtils.isOpeningParenToken as IsPunctuatorTokenWithValueFunction<'('>;
-const isNotOpeningParenToken =
+export const isNotOpeningParenToken =
   eslintUtils.isNotOpeningParenToken as IsNotPunctuatorTokenWithValueFunction<'('>;
 
-const isSemicolonToken =
+export const isSemicolonToken =
   eslintUtils.isSemicolonToken as IsPunctuatorTokenWithValueFunction<';'>;
-const isNotSemicolonToken =
+export const isNotSemicolonToken =
   eslintUtils.isNotSemicolonToken as IsNotPunctuatorTokenWithValueFunction<';'>;
-
-export {
-  isArrowToken,
-  isClosingBraceToken,
-  isClosingBracketToken,
-  isClosingParenToken,
-  isColonToken,
-  isCommaToken,
-  isCommentToken,
-  isNotArrowToken,
-  isNotClosingBraceToken,
-  isNotClosingBracketToken,
-  isNotClosingParenToken,
-  isNotColonToken,
-  isNotCommaToken,
-  isNotCommentToken,
-  isNotOpeningBraceToken,
-  isNotOpeningBracketToken,
-  isNotOpeningParenToken,
-  isNotSemicolonToken,
-  isOpeningBraceToken,
-  isOpeningBracketToken,
-  isOpeningParenToken,
-  isSemicolonToken,
-};

--- a/packages/utils/src/ast-utils/eslint-utils/scopeAnalysis.ts
+++ b/packages/utils/src/ast-utils/eslint-utils/scopeAnalysis.ts
@@ -8,7 +8,7 @@ import type { TSESTree } from '../../ts-estree';
  *
  * @see {@link https://eslint-community.github.io/eslint-utils/api/scope-utils.html#findvariable}
  */
-const findVariable = eslintUtils.findVariable as (
+export const findVariable = eslintUtils.findVariable as (
   initialScope: TSESLint.Scope.Scope,
   nameOrNode: string | TSESTree.Identifier,
 ) => TSESLint.Scope.Variable | null;
@@ -20,9 +20,7 @@ const findVariable = eslintUtils.findVariable as (
  * @returns The innermost scope which contains the given node.
  * If such scope doesn't exist then it returns the 1st argument `initialScope`.
  */
-const getInnermostScope = eslintUtils.getInnermostScope as (
+export const getInnermostScope = eslintUtils.getInnermostScope as (
   initialScope: TSESLint.Scope.Scope,
   node: TSESTree.Node,
 ) => TSESLint.Scope.Scope;
-
-export { findVariable, getInnermostScope };

--- a/packages/utils/src/ast-utils/misc.ts
+++ b/packages/utils/src/ast-utils/misc.ts
@@ -1,15 +1,13 @@
 import type { TSESTree } from '../ts-estree';
 
-const LINEBREAK_MATCHER = /\r\n|[\r\n\u2028\u2029]/;
+export const LINEBREAK_MATCHER = /\r\n|[\r\n\u2028\u2029]/;
 
 /**
  * Determines whether two adjacent tokens are on the same line
  */
-function isTokenOnSameLine(
+export function isTokenOnSameLine(
   left: TSESTree.Node | TSESTree.Token,
   right: TSESTree.Node | TSESTree.Token,
 ): boolean {
   return left.loc.end.line === right.loc.start.line;
 }
-
-export { isTokenOnSameLine, LINEBREAK_MATCHER };

--- a/packages/utils/src/ast-utils/predicates.ts
+++ b/packages/utils/src/ast-utils/predicates.ts
@@ -9,22 +9,22 @@ import {
   isTokenOfTypeWithConditions,
 } from './helpers';
 
-const isOptionalChainPunctuator = isTokenOfTypeWithConditions(
+export const isOptionalChainPunctuator = isTokenOfTypeWithConditions(
   AST_TOKEN_TYPES.Punctuator,
   { value: '?.' },
 );
 
-const isNotOptionalChainPunctuator = isNotTokenOfTypeWithConditions(
+export const isNotOptionalChainPunctuator = isNotTokenOfTypeWithConditions(
   AST_TOKEN_TYPES.Punctuator,
   { value: '?.' },
 );
 
-const isNonNullAssertionPunctuator = isTokenOfTypeWithConditions(
+export const isNonNullAssertionPunctuator = isTokenOfTypeWithConditions(
   AST_TOKEN_TYPES.Punctuator,
   { value: '!' },
 );
 
-const isNotNonNullAssertionPunctuator = isNotTokenOfTypeWithConditions(
+export const isNotNonNullAssertionPunctuator = isNotTokenOfTypeWithConditions(
   AST_TOKEN_TYPES.Punctuator,
   { value: '!' },
 );
@@ -32,7 +32,7 @@ const isNotNonNullAssertionPunctuator = isNotTokenOfTypeWithConditions(
 /**
  * Returns true if and only if the node represents: foo?.() or foo.bar?.()
  */
-const isOptionalCallExpression = isNodeOfTypeWithConditions(
+export const isOptionalCallExpression = isNodeOfTypeWithConditions(
   AST_NODE_TYPES.CallExpression,
   // this flag means the call expression itself is option
   // i.e. it is foo.bar?.() and not foo?.bar()
@@ -42,7 +42,7 @@ const isOptionalCallExpression = isNodeOfTypeWithConditions(
 /**
  * Returns true if and only if the node represents logical OR
  */
-const isLogicalOrOperator = isNodeOfTypeWithConditions(
+export const isLogicalOrOperator = isNodeOfTypeWithConditions(
   AST_NODE_TYPES.LogicalExpression,
   { operator: '||' },
 );
@@ -54,19 +54,21 @@ const isLogicalOrOperator = isNodeOfTypeWithConditions(
  * <foo>x
  * ```
  */
-const isTypeAssertion = isNodeOfTypes([
+export const isTypeAssertion = isNodeOfTypes([
   AST_NODE_TYPES.TSAsExpression,
   AST_NODE_TYPES.TSTypeAssertion,
 ] as const);
 
-const isVariableDeclarator = isNodeOfType(AST_NODE_TYPES.VariableDeclarator);
+export const isVariableDeclarator = isNodeOfType(
+  AST_NODE_TYPES.VariableDeclarator,
+);
 
 const functionTypes = [
   AST_NODE_TYPES.ArrowFunctionExpression,
   AST_NODE_TYPES.FunctionDeclaration,
   AST_NODE_TYPES.FunctionExpression,
 ] as const;
-const isFunction = isNodeOfTypes(functionTypes);
+export const isFunction = isNodeOfTypes(functionTypes);
 
 const functionTypeTypes = [
   AST_NODE_TYPES.TSCallSignatureDeclaration,
@@ -77,18 +79,20 @@ const functionTypeTypes = [
   AST_NODE_TYPES.TSFunctionType,
   AST_NODE_TYPES.TSMethodSignature,
 ] as const;
-const isFunctionType = isNodeOfTypes(functionTypeTypes);
+export const isFunctionType = isNodeOfTypes(functionTypeTypes);
 
-const isFunctionOrFunctionType = isNodeOfTypes([
+export const isFunctionOrFunctionType = isNodeOfTypes([
   ...functionTypes,
   ...functionTypeTypes,
 ] as const);
 
-const isTSFunctionType = isNodeOfType(AST_NODE_TYPES.TSFunctionType);
+export const isTSFunctionType = isNodeOfType(AST_NODE_TYPES.TSFunctionType);
 
-const isTSConstructorType = isNodeOfType(AST_NODE_TYPES.TSConstructorType);
+export const isTSConstructorType = isNodeOfType(
+  AST_NODE_TYPES.TSConstructorType,
+);
 
-const isClassOrTypeElement = isNodeOfTypes([
+export const isClassOrTypeElement = isNodeOfTypes([
   // ClassElement
   AST_NODE_TYPES.PropertyDefinition,
   AST_NODE_TYPES.FunctionExpression,
@@ -108,7 +112,7 @@ const isClassOrTypeElement = isNodeOfTypes([
 /**
  * Checks if a node is a constructor method.
  */
-const isConstructor = isNodeOfTypeWithConditions(
+export const isConstructor = isNodeOfTypeWithConditions(
   AST_NODE_TYPES.MethodDefinition,
   { kind: 'constructor' },
 );
@@ -116,7 +120,7 @@ const isConstructor = isNodeOfTypeWithConditions(
 /**
  * Checks if a node is a setter method.
  */
-function isSetter(
+export function isSetter(
   node: TSESTree.Node | undefined,
 ): node is { kind: 'set' } & (TSESTree.MethodDefinition | TSESTree.Property) {
   return (
@@ -127,63 +131,41 @@ function isSetter(
   );
 }
 
-const isIdentifier = isNodeOfType(AST_NODE_TYPES.Identifier);
+export const isIdentifier = isNodeOfType(AST_NODE_TYPES.Identifier);
 
 /**
  * Checks if a node represents an `await …` expression.
  */
-const isAwaitExpression = isNodeOfType(AST_NODE_TYPES.AwaitExpression);
+export const isAwaitExpression = isNodeOfType(AST_NODE_TYPES.AwaitExpression);
 
 /**
  * Checks if a possible token is the `await` keyword.
  */
-const isAwaitKeyword = isTokenOfTypeWithConditions(AST_TOKEN_TYPES.Identifier, {
-  value: 'await',
-});
+export const isAwaitKeyword = isTokenOfTypeWithConditions(
+  AST_TOKEN_TYPES.Identifier,
+  { value: 'await' },
+);
 
 /**
  * Checks if a possible token is the `type` keyword.
  */
-const isTypeKeyword = isTokenOfTypeWithConditions(AST_TOKEN_TYPES.Identifier, {
-  value: 'type',
-});
+export const isTypeKeyword = isTokenOfTypeWithConditions(
+  AST_TOKEN_TYPES.Identifier,
+  { value: 'type' },
+);
 
 /**
  * Checks if a possible token is the `import` keyword.
  */
-const isImportKeyword = isTokenOfTypeWithConditions(AST_TOKEN_TYPES.Keyword, {
-  value: 'import',
-});
+export const isImportKeyword = isTokenOfTypeWithConditions(
+  AST_TOKEN_TYPES.Keyword,
+  { value: 'import' },
+);
 
-const isLoop = isNodeOfTypes([
+export const isLoop = isNodeOfTypes([
   AST_NODE_TYPES.DoWhileStatement,
   AST_NODE_TYPES.ForStatement,
   AST_NODE_TYPES.ForInStatement,
   AST_NODE_TYPES.ForOfStatement,
   AST_NODE_TYPES.WhileStatement,
 ] as const);
-
-export {
-  isAwaitExpression,
-  isAwaitKeyword,
-  isClassOrTypeElement,
-  isConstructor,
-  isFunction,
-  isFunctionOrFunctionType,
-  isFunctionType,
-  isIdentifier,
-  isImportKeyword,
-  isLogicalOrOperator,
-  isLoop,
-  isNonNullAssertionPunctuator,
-  isNotNonNullAssertionPunctuator,
-  isNotOptionalChainPunctuator,
-  isOptionalCallExpression,
-  isOptionalChainPunctuator,
-  isSetter,
-  isTSConstructorType,
-  isTSFunctionType,
-  isTypeAssertion,
-  isTypeKeyword,
-  isVariableDeclarator,
-};

--- a/packages/utils/src/eslint-utils/InferTypesFromRule.ts
+++ b/packages/utils/src/eslint-utils/InferTypesFromRule.ts
@@ -3,7 +3,7 @@ import type { RuleCreateFunction, RuleModule } from '../ts-eslint';
 /**
  * Uses type inference to fetch the Options type from the given RuleModule
  */
-type InferOptionsTypeFromRule<T> =
+export type InferOptionsTypeFromRule<T> =
   T extends RuleModule<infer _MessageIds, infer Options>
     ? Options
     : T extends RuleCreateFunction<infer _MessageIds, infer Options>
@@ -13,11 +13,9 @@ type InferOptionsTypeFromRule<T> =
 /**
  * Uses type inference to fetch the MessageIds type from the given RuleModule
  */
-type InferMessageIdsTypeFromRule<T> =
+export type InferMessageIdsTypeFromRule<T> =
   T extends RuleModule<infer MessageIds, infer _TOptions>
     ? MessageIds
     : T extends RuleCreateFunction<infer MessageIds, infer _TOptions>
       ? MessageIds
       : unknown;
-
-export type { InferMessageIdsTypeFromRule, InferOptionsTypeFromRule };

--- a/packages/utils/src/eslint-utils/applyDefault.ts
+++ b/packages/utils/src/eslint-utils/applyDefault.ts
@@ -7,7 +7,10 @@ import { deepMerge, isObjectNotArray } from './deepMerge';
  * @param userOptions the user opts
  * @returns the options with defaults
  */
-function applyDefault<User extends readonly unknown[], Default extends User>(
+export function applyDefault<
+  User extends readonly unknown[],
+  Default extends User,
+>(
   defaultOptions: Readonly<Default>,
   userOptions: Readonly<User> | null,
 ): Default {
@@ -39,5 +42,3 @@ function applyDefault<User extends readonly unknown[], Default extends User>(
 type AsMutable<T extends readonly unknown[]> = {
   -readonly [Key in keyof T]: T[Key];
 };
-
-export { applyDefault };

--- a/packages/utils/src/eslint-utils/deepMerge.ts
+++ b/packages/utils/src/eslint-utils/deepMerge.ts
@@ -4,7 +4,7 @@ export type ObjectLike<T = unknown> = Record<string, T>;
  * Check if the variable contains an object strictly rejecting arrays
  * @returns `true` if obj is an object
  */
-function isObjectNotArray(obj: unknown): obj is ObjectLike {
+export function isObjectNotArray(obj: unknown): obj is ObjectLike {
   return typeof obj === 'object' && obj != null && !Array.isArray(obj);
 }
 
@@ -47,5 +47,3 @@ export function deepMerge(
     }),
   );
 }
-
-export { isObjectNotArray };

--- a/packages/utils/src/eslint-utils/getParserServices.ts
+++ b/packages/utils/src/eslint-utils/getParserServices.ts
@@ -17,7 +17,7 @@ const ERROR_MESSAGE_UNKNOWN_PARSER =
  * Try to retrieve type-aware parser service from context.
  * This **_will_** throw if it is not available.
  */
-function getParserServices<
+export function getParserServices<
   MessageIds extends string,
   Options extends readonly unknown[],
 >(
@@ -27,7 +27,7 @@ function getParserServices<
  * Try to retrieve type-aware parser service from context.
  * This **_will_** throw if it is not available.
  */
-function getParserServices<
+export function getParserServices<
   MessageIds extends string,
   Options extends readonly unknown[],
 >(
@@ -38,7 +38,7 @@ function getParserServices<
  * Try to retrieve type-aware parser service from context.
  * This **_will not_** throw if it is not available.
  */
-function getParserServices<
+export function getParserServices<
   MessageIds extends string,
   Options extends readonly unknown[],
 >(
@@ -49,7 +49,7 @@ function getParserServices<
  * Try to retrieve type-aware parser service from context.
  * This may or may not throw if it is not available, depending on if `allowWithoutFullTypeInformation` is `true`
  */
-function getParserServices<
+export function getParserServices<
   MessageIds extends string,
   Options extends readonly unknown[],
 >(
@@ -57,7 +57,7 @@ function getParserServices<
   allowWithoutFullTypeInformation: boolean,
 ): ParserServices;
 
-function getParserServices(
+export function getParserServices(
   context: Readonly<TSESLint.RuleContext<string, unknown[]>>,
   allowWithoutFullTypeInformation = false,
 ): ParserServices {
@@ -103,5 +103,3 @@ function throwError(parser: string | undefined): never {
 
   throw new Error(messages.join('\n'));
 }
-
-export { getParserServices };

--- a/packages/utils/src/eslint-utils/nullThrows.ts
+++ b/packages/utils/src/eslint-utils/nullThrows.ts
@@ -1,7 +1,7 @@
 /**
  * A set of common reasons for calling nullThrows
  */
-const NullThrowsReasons = {
+export const NullThrowsReasons = {
   MissingParent: 'Expected node to have a parent.',
   MissingToken: (token: string, thing: string) =>
     `Expected to find a ${token} for the ${thing}.`,
@@ -11,12 +11,10 @@ const NullThrowsReasons = {
  * Assert that a value must not be null or undefined.
  * This is a nice explicit alternative to the non-null assertion operator.
  */
-function nullThrows<T>(value: T, message: string): NonNullable<T> {
+export function nullThrows<T>(value: T, message: string): NonNullable<T> {
   if (value == null) {
     throw new Error(`Non-null Assertion Failed: ${message}`);
   }
 
   return value;
 }
-
-export { nullThrows, NullThrowsReasons };

--- a/packages/utils/src/ts-eslint/AST.ts
+++ b/packages/utils/src/ts-eslint/AST.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-namespace, no-restricted-syntax */
 
 import type { AST_TOKEN_TYPES, TSESTree } from '../ts-estree';
 

--- a/packages/utils/src/ts-eslint/Linter.ts
+++ b/packages/utils/src/ts-eslint/Linter.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-namespace, no-restricted-syntax */
 
 import { Linter as ESLintLinter } from 'eslint';
 

--- a/packages/utils/src/ts-eslint/RuleTester.ts
+++ b/packages/utils/src/ts-eslint/RuleTester.ts
@@ -15,7 +15,7 @@ import type {
 /**
  * @deprecated Use `@typescript-eslint/rule-tester` instead.
  */
-interface ValidTestCase<Options extends readonly unknown[]> {
+export interface ValidTestCase<Options extends readonly unknown[]> {
   /**
    * Code for the test case.
    */
@@ -61,7 +61,7 @@ interface ValidTestCase<Options extends readonly unknown[]> {
 /**
  * @deprecated Use `@typescript-eslint/rule-tester` instead.
  */
-interface SuggestionOutput<MessageIds extends string> {
+export interface SuggestionOutput<MessageIds extends string> {
   /**
    * The data used to fill the message template.
    */
@@ -83,7 +83,7 @@ interface SuggestionOutput<MessageIds extends string> {
 /**
  * @deprecated Use `@typescript-eslint/rule-tester` instead.
  */
-interface InvalidTestCase<
+export interface InvalidTestCase<
   MessageIds extends string,
   Options extends readonly unknown[],
 > extends ValidTestCase<Options> {
@@ -100,7 +100,7 @@ interface InvalidTestCase<
 /**
  * @deprecated Use `@typescript-eslint/rule-tester` instead.
  */
-interface TestCaseError<MessageIds extends string> {
+export interface TestCaseError<MessageIds extends string> {
   /**
    * The 1-based column number of the reported start location.
    */
@@ -142,7 +142,7 @@ interface TestCaseError<MessageIds extends string> {
  * @param text a string describing the rule
  * @deprecated Use `@typescript-eslint/rule-tester` instead.
  */
-type RuleTesterTestFrameworkFunction = (
+export type RuleTesterTestFrameworkFunction = (
   text: string,
   callback: () => void,
 ) => void;
@@ -150,7 +150,7 @@ type RuleTesterTestFrameworkFunction = (
 /**
  * @deprecated Use `@typescript-eslint/rule-tester` instead.
  */
-interface RunTests<
+export interface RunTests<
   MessageIds extends string,
   Options extends readonly unknown[],
 > {
@@ -162,7 +162,7 @@ interface RunTests<
 /**
  * @deprecated Use `@typescript-eslint/rule-tester` instead.
  */
-interface RuleTesterConfig extends ClassicConfig.Config {
+export interface RuleTesterConfig extends ClassicConfig.Config {
   // should be require.resolve(parserPackageName)
   readonly parser: string;
   readonly parserOptions?: Readonly<ParserOptions>;
@@ -226,15 +226,4 @@ declare class RuleTesterBase {
 /**
  * @deprecated Use `@typescript-eslint/rule-tester` instead.
  */
-class RuleTester extends (ESLintRuleTester as typeof RuleTesterBase) {}
-
-export {
-  type InvalidTestCase,
-  RuleTester,
-  type RuleTesterConfig,
-  type RuleTesterTestFrameworkFunction,
-  type RunTests,
-  type SuggestionOutput,
-  type TestCaseError,
-  type ValidTestCase,
-};
+export class RuleTester extends (ESLintRuleTester as typeof RuleTesterBase) {}

--- a/packages/utils/src/ts-eslint/Scope.ts
+++ b/packages/utils/src/ts-eslint/Scope.ts
@@ -2,7 +2,7 @@
 
 import * as scopeManager from '@typescript-eslint/scope-manager';
 
-namespace Scope {
+export namespace Scope {
   export type ScopeManager = scopeManager.ScopeManager;
   export type Reference = scopeManager.Reference;
   export type Variable = scopeManager.ScopeVariable;
@@ -47,5 +47,3 @@ namespace Scope {
     export type WithScope = scopeManager.WithScope;
   }
 }
-
-export { Scope };

--- a/packages/utils/src/ts-eslint/SourceCode.ts
+++ b/packages/utils/src/ts-eslint/SourceCode.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-namespace, no-restricted-syntax */
 
 import { SourceCode as ESLintSourceCode } from 'eslint';
 

--- a/packages/utils/typings/eslint.d.ts
+++ b/packages/utils/typings/eslint.d.ts
@@ -6,15 +6,11 @@ instead of the ones declared within this package
 */
 
 declare module 'eslint' {
-  const Linter: unknown;
-  const RuleTester: unknown;
-  const SourceCode: unknown;
-
-  export { Linter, RuleTester, SourceCode };
+  export const Linter: unknown;
+  export const RuleTester: unknown;
+  export const SourceCode: unknown;
 }
 declare module 'eslint/use-at-your-own-risk' {
-  const FlatESLint: unknown;
-  const LegacyESLint: unknown;
-
-  export { FlatESLint, LegacyESLint };
+  export const FlatESLint: unknown;
+  export const LegacyESLint: unknown;
 }

--- a/packages/visitor-keys/src/get-keys.ts
+++ b/packages/visitor-keys/src/get-keys.ts
@@ -2,6 +2,5 @@ import type { TSESTree } from '@typescript-eslint/types';
 
 import { getKeys as getKeysOriginal } from 'eslint-visitor-keys';
 
-const getKeys: (node: TSESTree.Node) => readonly string[] = getKeysOriginal;
-
-export { getKeys };
+export const getKeys: (node: TSESTree.Node) => readonly string[] =
+  getKeysOriginal;

--- a/packages/visitor-keys/src/visitor-keys.ts
+++ b/packages/visitor-keys/src/visitor-keys.ts
@@ -2,7 +2,7 @@ import type { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/types';
 
 import * as eslintVisitorKeys from 'eslint-visitor-keys';
 
-type VisitorKeys = Record<string, readonly string[] | undefined>;
+export type VisitorKeys = Record<string, readonly string[] | undefined>;
 
 type GetNodeTypeKeys<T extends AST_NODE_TYPES> = Exclude<
   keyof Extract<TSESTree.Node, { type: T }>,
@@ -268,6 +268,5 @@ const additionalKeys: AdditionalKeys = {
   TSVoidKeyword: [],
 };
 
-const visitorKeys: VisitorKeys = eslintVisitorKeys.unionWith(additionalKeys);
-
-export { visitorKeys, type VisitorKeys };
+export const visitorKeys: VisitorKeys =
+  eslintVisitorKeys.unionWith(additionalKeys);

--- a/packages/website-eslint/src/mock/empty.js
+++ b/packages/website-eslint/src/mock/empty.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line no-restricted-syntax
 export {};

--- a/packages/website/src/components/Playground.tsx
+++ b/packages/website/src/components/Playground.tsx
@@ -21,7 +21,7 @@ import { EditorEmbed } from './editor/EditorEmbed';
 import { LoadingEditor } from './editor/LoadingEditor';
 import { ErrorsViewer, ErrorViewer } from './ErrorsViewer';
 import { ESQueryFilter } from './ESQueryFilter';
-import useHashState from './hooks/useHashState';
+import { useHashState } from './hooks/useHashState';
 import EditorTabs from './layout/EditorTabs';
 import Loader from './layout/Loader';
 import { defaultConfig, detailTabs } from './options';

--- a/packages/website/src/components/hooks/useHashState.ts
+++ b/packages/website/src/components/hooks/useHashState.ts
@@ -190,7 +190,7 @@ const writeStateToLocalStorage = (newState: ConfigModel): void => {
   window.localStorage.setItem('config', JSON.stringify(config));
 };
 
-function useHashState(
+export function useHashState(
   initialState: ConfigModel,
 ): [ConfigModel, (cfg: Partial<ConfigModel>) => void] {
   const history = useHistory();
@@ -229,5 +229,3 @@ function useHashState(
 
   return [state, updateState];
 }
-
-export default useHashState;

--- a/packages/website/src/components/hooks/useResizeObserver.ts
+++ b/packages/website/src/components/hooks/useResizeObserver.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
-const useResizeObserver = (
+export const useResizeObserver = (
   element: HTMLElement | null,
   callback: () => void,
 ): void => {
@@ -21,5 +21,3 @@ const useResizeObserver = (
     };
   }, [element, resizeObserver]);
 };
-
-export { useResizeObserver };

--- a/tools/dummypkg/index.d.ts
+++ b/tools/dummypkg/index.d.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line no-restricted-syntax
 export {};

--- a/tools/scripts/generate-lib.mts
+++ b/tools/scripts/generate-lib.mts
@@ -266,7 +266,7 @@ async function main(): Promise<void> {
 
   // generate and write a barrel file
   const barrelImports = []; // use a separate way so everything is in the same order
-  const barrelCode = ['', `const lib = {`];
+  const barrelCode = ['', `export const lib = {`];
   for (const lib of libMap.keys()) {
     const name = sanitize(lib);
     if (name === 'lib') {
@@ -280,8 +280,6 @@ async function main(): Promise<void> {
   barrelCode.unshift(...barrelImports);
   barrelCode.push('} as const;');
 
-  barrelCode.push('', 'export { lib };');
-
   const formattedBarrelCode = await formatCode(barrelCode);
 
   fs.writeFileSync(BARREL_PATH, formattedBarrelCode);
@@ -290,9 +288,7 @@ async function main(): Promise<void> {
   // generate a string union type for the lib names
 
   const libUnionCode = [
-    `type Lib = ${[...libMap.keys()].map(k => `'${k}'`).join(' | ')};`,
-    '',
-    'export { Lib };',
+    `export type Lib = ${[...libMap.keys()].map(k => `'${k}'`).join(' | ')};`,
   ];
   const formattedLibUnionCode = await formatCode(libUnionCode);
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5871
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Consolidates exports style in the repo to be inline -as opposed to `export { ByName };`- and named -as opposed to `default`-. 

The main exceptions are:

* Rules: still always `default`-exported
* Website components: since Docusaurus default-exports pages and swizzled components

Includes a change to the `generate-lib` generation to apply this style preference.

💖 