### PR TITLE
PoC: Use a custom debugForFile(filename) instead of debug('...')

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@types/semver": "^7.5.8",
     "@types/tmp": "^0.2.6",
     "@types/yargs": "^17.0.32",
+    "@typescript-eslint/debug-for-file": "workspace:^",
     "@typescript-eslint/eslint-plugin": "workspace:^",
     "@typescript-eslint/eslint-plugin-internal": "workspace:^",
     "@typescript-eslint/scope-manager": "workspace:^",

--- a/packages/debug-for-file/LICENSE
+++ b/packages/debug-for-file/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 typescript-eslint and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/debug-for-file/README.md
+++ b/packages/debug-for-file/README.md
@@ -1,0 +1,10 @@
+# `@typescript-eslint/debug-for-file`
+
+> A `debug()` wrapper used internally in this project to ensure consistent log namespaces.
+
+## ✋ Internal Package
+
+This is an _internal package_ to the [typescript-eslint monorepo](https://github.com/typescript-eslint/typescript-eslint).
+You likely don't want to use it directly.
+
+👉 See **https://typescript-eslint.io** for docs on typescript-eslint.

--- a/packages/debug-for-file/jest.config.js
+++ b/packages/debug-for-file/jest.config.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// @ts-check
+/** @type {import('@jest/types').Config.InitialOptions} */
+module.exports = require('../../jest.config.base.js');

--- a/packages/debug-for-file/package.json
+++ b/packages/debug-for-file/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@typescript-eslint/parser",
+  "name": "@typescript-eslint/debug-for-file",
   "version": "8.19.0",
-  "description": "An ESLint custom parser which leverages TypeScript ESTree",
+  "description": "A `debug()` wrapper used internally in this project to ensure consistent log namespaces.",
   "files": [
     "dist",
-    "_ts4.3",
+    "package.json",
     "README.md",
     "LICENSE"
   ],
@@ -22,48 +22,27 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/typescript-eslint/typescript-eslint.git",
-    "directory": "packages/parser"
+    "directory": "packages/debug-for-file"
   },
   "bugs": {
     "url": "https://github.com/typescript-eslint/typescript-eslint/issues"
   },
-  "homepage": "https://typescript-eslint.io/packages/parser",
+  "homepage": "https://typescript-eslint.io",
   "license": "MIT",
-  "keywords": [
-    "ast",
-    "ecmascript",
-    "javascript",
-    "typescript",
-    "parser",
-    "syntax",
-    "eslint"
-  ],
   "scripts": {
     "build": "tsc -b tsconfig.build.json",
-    "postbuild": "downlevel-dts dist _ts4.3/dist --to=4.3",
     "clean": "tsc -b tsconfig.build.json --clean",
-    "postclean": "rimraf dist && rimraf _ts4.3 && rimraf coverage",
+    "postclean": "rimraf dist && rimraf _ts3.4 && rimraf _ts4.3 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "lint": "npx nx lint",
     "test": "jest --coverage",
     "typecheck": "tsc --noEmit"
   },
-  "peerDependencies": {
-    "eslint": "^8.57.0 || ^9.0.0",
-    "typescript": ">=4.8.4 <5.8.0"
-  },
   "dependencies": {
-    "@typescript-eslint/debug-for-file": "workspace:*",
-    "@typescript-eslint/scope-manager": "8.19.0",
-    "@typescript-eslint/types": "8.19.0",
-    "@typescript-eslint/typescript-estree": "8.19.0",
-    "@typescript-eslint/visitor-keys": "8.19.0"
+    "find-up": "5.0.0"
   },
   "devDependencies": {
     "@jest/types": "29.6.3",
-    "@types/glob": "*",
-    "downlevel-dts": "*",
-    "glob": "*",
     "jest": "29.7.0",
     "prettier": "^3.2.5",
     "rimraf": "*",
@@ -72,12 +51,5 @@
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/typescript-eslint"
-  },
-  "typesVersions": {
-    "<4.7": {
-      "*": [
-        "_ts4.3/*"
-      ]
-    }
   }
 }

--- a/packages/debug-for-file/project.json
+++ b/packages/debug-for-file/project.json
@@ -1,0 +1,12 @@
+{
+  "name": "debug-for-file",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "type": "library",
+  "implicitDependencies": [],
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    }
+  }
+}

--- a/packages/debug-for-file/src/debugForFile.ts
+++ b/packages/debug-for-file/src/debugForFile.ts
@@ -1,0 +1,6 @@
+import { debug } from 'debug';
+import { filePathToNamespace } from './filePathToNamespace';
+
+export function debugForFile(filePath: string) {
+  return debug(filePathToNamespace(filePath));
+}

--- a/packages/debug-for-file/src/filePathToNamespace.ts
+++ b/packages/debug-for-file/src/filePathToNamespace.ts
@@ -1,0 +1,13 @@
+export function filePathToNamespace(filePath: string) {
+  const matched = /@typescript-eslint[\\\/]+([a-z-]+)[\\\/]+(.+)/g.exec(
+    filePath,
+  )!;
+  const [, packageName, relativeFilePath] = matched;
+
+  const relativeFilePathProcessed = relativeFilePath
+    .replace(/^(?:dist|lib|src)\//, '')
+    .replace(/\.\w+$/g, '')
+    .replaceAll(/[^a-z0-9-]+/gi, ':');
+
+  return `typescript-eslint:${packageName}:${relativeFilePathProcessed}`;
+}

--- a/packages/debug-for-file/src/generateNamespace.ts
+++ b/packages/debug-for-file/src/generateNamespace.ts
@@ -1,0 +1,12 @@
+export function generateNamespace(filePath: string, packageName?: string) {
+  const filePathProcessed = filePath
+    .replace(/^(?:dist|lib|src)\//, '')
+    .replace(/\.\w+$/g, '');
+
+  const packageNameProcessed = packageName?.replace('@', '');
+
+  return [packageNameProcessed, filePathProcessed]
+    .filter(Boolean)
+    .join(':')
+    .replaceAll(/[^a-z0-9-]+/gi, ':');
+}

--- a/packages/debug-for-file/src/index.ts
+++ b/packages/debug-for-file/src/index.ts
@@ -1,0 +1,1 @@
+export * from './debugForFile.js';

--- a/packages/debug-for-file/tests/generateNamespace.test.ts
+++ b/packages/debug-for-file/tests/generateNamespace.test.ts
@@ -1,0 +1,28 @@
+import { filePathToNamespace } from '../src/filePathToNamespace';
+
+describe('filePathToNamespace', () => {
+  test.each([
+    [
+      'node_modules/@typescript-eslint/example/dist/index.js',
+      'typescript-eslint:example:index',
+    ],
+    [
+      'node_modules/@typescript-eslint/example/dist/index.cjs',
+      'typescript-eslint:example:index',
+    ],
+    [
+      'node_modules/@typescript-eslint/example/dist/index.mjs',
+      'typescript-eslint:example:index',
+    ],
+    [
+      'node_modules/@typescript-eslint/example/dist/abc/def.js',
+      'typescript-eslint:example:abc:def',
+    ],
+    [
+      'node_modules/@typescript-eslint/typescript-estree/dist/parseSettings/resolveProjectList.js',
+      'typescript-eslint:typescript-estree:parseSettings:resolveProjectList',
+    ],
+  ])('%s becomes %s', (filePath, expected) => {
+    expect(filePathToNamespace(filePath)).toBe(expected);
+  });
+});

--- a/packages/debug-for-file/tsconfig.build.json
+++ b/packages/debug-for-file/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/packages/debug-for-file/tsconfig.json
+++ b/packages/debug-for-file/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "composite": false,
+    "rootDir": "."
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -14,10 +14,10 @@ import type * as ts from 'typescript';
 import { analyze } from '@typescript-eslint/scope-manager';
 import { parseAndGenerateServices } from '@typescript-eslint/typescript-estree';
 import { visitorKeys } from '@typescript-eslint/visitor-keys';
-import debug from 'debug';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import { ScriptTarget } from 'typescript';
 
-const log = debug('typescript-eslint:parser:parser');
+const log = debugForFile(__filename);
 
 interface ESLintProgram extends AST<{ comment: true; tokens: true }> {
   comments: TSESTree.Comment[];

--- a/packages/parser/tsconfig.build.json
+++ b/packages/parser/tsconfig.build.json
@@ -8,6 +8,7 @@
   },
   "include": ["src"],
   "references": [
+    { "path": "../debug-for-file/tsconfig.build.json" },
     { "path": "../scope-manager/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../typescript-estree/tsconfig.build.json" }

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -7,6 +7,7 @@
   "include": ["src", "tests", "tools"],
   "exclude": ["tests/fixtures"],
   "references": [
+    { "path": "../debug-for-file/tsconfig.build.json" },
     { "path": "../scope-manager/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../typescript-estree/tsconfig.build.json" }

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "@typescript-eslint/typescript-estree": "8.19.0",
     "@typescript-eslint/utils": "8.19.0",
-    "debug": "^4.3.4",
     "ts-api-utils": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/type-utils/src/predicates.ts
+++ b/packages/type-utils/src/predicates.ts
@@ -1,10 +1,10 @@
-import debug from 'debug';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
 import { isTypeFlagSet } from './typeFlagUtils';
 
-const log = debug('typescript-eslint:eslint-plugin:utils:types');
+const log = debugForFile(__filename);
 
 /**
  * Checks if the given type is (or accepts) nullable

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -54,9 +54,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@typescript-eslint/debug-for-file": "workspace:*",
     "@typescript-eslint/types": "8.19.0",
     "@typescript-eslint/visitor-keys": "8.19.0",
-    "debug": "^4.3.4",
     "fast-glob": "^3.3.2",
     "is-glob": "^4.0.3",
     "minimatch": "^9.0.4",

--- a/packages/typescript-estree/src/create-program/createIsolatedProgram.ts
+++ b/packages/typescript-estree/src/create-program/createIsolatedProgram.ts
@@ -1,5 +1,5 @@
-import debug from 'debug';
 import * as ts from 'typescript';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 
 import type { ParseSettings } from '../parseSettings';
 import type { ASTAndDefiniteProgram } from './shared';
@@ -7,7 +7,7 @@ import type { ASTAndDefiniteProgram } from './shared';
 import { getScriptKind } from './getScriptKind';
 import { createDefaultCompilerOptionsFromExtra } from './shared';
 
-const log = debug('typescript-eslint:typescript-estree:createIsolatedProgram');
+const log = debugForFile(__filename);
 
 /**
  * @returns Returns a new source file and program corresponding to the linted code

--- a/packages/typescript-estree/src/create-program/createProjectProgram.ts
+++ b/packages/typescript-estree/src/create-program/createProjectProgram.ts
@@ -1,6 +1,6 @@
 import type * as ts from 'typescript';
 
-import debug from 'debug';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 
 import type { ParseSettings } from '../parseSettings';
 import type { ASTAndDefiniteProgram } from './shared';
@@ -9,7 +9,7 @@ import { firstDefined } from '../node-utils';
 import { createProjectProgramError } from './createProjectProgramError';
 import { getAstFromProgram } from './shared';
 
-const log = debug('typescript-eslint:typescript-estree:createProjectProgram');
+const log = debugForFile(__filename);
 
 /**
  * @param parseSettings Internal settings for parsing the file

--- a/packages/typescript-estree/src/create-program/createProjectService.ts
+++ b/packages/typescript-estree/src/create-program/createProjectService.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function -- for TypeScript APIs*/
 import type * as ts from 'typescript/lib/tsserverlibrary';
 
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import debug from 'debug';
 
 import type { ProjectServiceOptions } from '../parser-options';
@@ -10,7 +11,7 @@ import { validateDefaultProjectForFilesGlob } from './validateDefaultProjectForF
 
 const DEFAULT_PROJECT_MATCHED_FILES_THRESHOLD = 8;
 
-const log = debug('typescript-eslint:typescript-estree:createProjectService');
+const log = debugForFile(__filename);
 const logTsserverErr = debug(
   'typescript-eslint:typescript-estree:tsserver:err',
 );

--- a/packages/typescript-estree/src/create-program/createSourceFile.ts
+++ b/packages/typescript-estree/src/create-program/createSourceFile.ts
@@ -1,4 +1,4 @@
-import debug from 'debug';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import * as ts from 'typescript';
 
 import type { ParseSettings } from '../parseSettings';
@@ -7,7 +7,7 @@ import type { ASTAndNoProgram } from './shared';
 import { isSourceFile } from '../source-files';
 import { getScriptKind } from './getScriptKind';
 
-const log = debug('typescript-eslint:typescript-estree:createSourceFile');
+const log = debugForFile(__filename);
 
 function createSourceFile(parseSettings: ParseSettings): ts.SourceFile {
   log(

--- a/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
+++ b/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
@@ -1,4 +1,4 @@
-import debug from 'debug';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import fs from 'node:fs';
 import * as ts from 'typescript';
 
@@ -14,7 +14,7 @@ import {
   getCanonicalFileName,
 } from './shared';
 
-const log = debug('typescript-eslint:typescript-estree:createWatchProgram');
+const log = debugForFile(__filename);
 
 /**
  * Maps tsconfig paths to their corresponding file contents and resulting watches

--- a/packages/typescript-estree/src/create-program/useProvidedPrograms.ts
+++ b/packages/typescript-estree/src/create-program/useProvidedPrograms.ts
@@ -1,4 +1,4 @@
-import debug from 'debug';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import * as path from 'node:path';
 import * as ts from 'typescript';
 
@@ -8,7 +8,7 @@ import type { ASTAndDefiniteProgram } from './shared';
 import { getParsedConfigFile } from './getParsedConfigFile';
 import { getAstFromProgram } from './shared';
 
-const log = debug('typescript-eslint:typescript-estree:useProvidedProgram');
+const log = debugForFile(__filename);
 
 function useProvidedPrograms(
   programInstances: Iterable<ts.Program>,

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -1,3 +1,4 @@
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import debug from 'debug';
 import path from 'node:path';
 import * as ts from 'typescript';
@@ -18,9 +19,7 @@ import { inferSingleRun } from './inferSingleRun';
 import { resolveProjectList } from './resolveProjectList';
 import { warnAboutTSVersion } from './warnAboutTSVersion';
 
-const log = debug(
-  'typescript-eslint:typescript-estree:parser:parseSettings:createParseSettings',
-);
+const log = debugForFile(__filename);
 
 let TSCONFIG_MATCH_CACHE: ExpiringCache<string, string> | null;
 let TSSERVER_PROJECT_SERVICE: ProjectServiceSettings | null = null;

--- a/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
+++ b/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
@@ -1,11 +1,11 @@
-import debug from 'debug';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import type { TSESTreeOptions } from '../parser-options';
 import type { ParseSettings } from './index';
 
-const log = debug('typescript-eslint:typescript-estree:getProjectConfigFiles');
+const log = debugForFile(__filename);
 
 /**
  * Checks for a matching TSConfig to a file including its parent directories,

--- a/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
+++ b/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
@@ -1,4 +1,4 @@
-import debug from 'debug';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import { sync as globSync } from 'fast-glob';
 import isGlob from 'is-glob';
 
@@ -15,9 +15,7 @@ import {
   ExpiringCache,
 } from './ExpiringCache';
 
-const log = debug(
-  'typescript-eslint:typescript-estree:parser:parseSettings:resolveProjectList',
-);
+const log = debugForFile(__filename);
 
 let RESOLUTION_CACHE: ExpiringCache<
   string,

--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -1,6 +1,6 @@
 import type * as ts from 'typescript';
 
-import debug from 'debug';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 
 import type { ASTAndProgram, CanonicalPath } from './create-program/shared';
 import type {
@@ -29,7 +29,7 @@ import { createParseSettings } from './parseSettings/createParseSettings';
 import { getFirstSemanticOrSyntacticError } from './semantic-or-syntactic-errors';
 import { useProgramFromProjectService } from './useProgramFromProjectService';
 
-const log = debug('typescript-eslint:typescript-estree:parser');
+const log = debugForFile(__filename);
 
 /**
  * Cache existing programs for the single run use-case.

--- a/packages/typescript-estree/src/useProgramFromProjectService.ts
+++ b/packages/typescript-estree/src/useProgramFromProjectService.ts
@@ -1,4 +1,4 @@
-import debug from 'debug';
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import { minimatch } from 'minimatch';
 import path from 'node:path';
 import util from 'node:util';
@@ -19,9 +19,7 @@ import { DEFAULT_PROJECT_FILES_ERROR_EXPLANATION } from './create-program/valida
 
 const RELOAD_THROTTLE_MS = 250;
 
-const log = debug(
-  'typescript-eslint:typescript-estree:useProgramFromProjectService',
-);
+const log = debugForFile(__filename);
 
 const serviceFileExtensions = new WeakMap<ts.server.ProjectService, string[]>();
 

--- a/packages/typescript-estree/tests/lib/createProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/createProjectService.test.ts
@@ -1,3 +1,4 @@
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import debug from 'debug';
 import * as ts from 'typescript';
 

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -1,6 +1,7 @@
 import type { CacheDurationSeconds } from '@typescript-eslint/types';
 import type * as typescriptModule from 'typescript';
 
+import { debugForFile } from '@typescript-eslint/debug-for-file';
 import debug from 'debug';
 import * as fastGlobModule from 'fast-glob';
 import { join, resolve } from 'node:path';

--- a/packages/typescript-estree/tsconfig.build.json
+++ b/packages/typescript-estree/tsconfig.build.json
@@ -9,6 +9,7 @@
   },
   "include": ["src", "typings"],
   "references": [
+    { "path": "../debug-for-file/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../visitor-keys/tsconfig.build.json" }
   ]

--- a/packages/typescript-estree/tsconfig.json
+++ b/packages/typescript-estree/tsconfig.json
@@ -7,6 +7,7 @@
   "include": ["src", "typings", "tests", "tools"],
   "exclude": ["tests/fixtures/**/*"],
   "references": [
+    { "path": "../debug-for-file/tsconfig.build.json" },
     { "path": "../types/tsconfig.build.json" },
     { "path": "../visitor-keys/tsconfig.build.json" }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5675,6 +5675,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@typescript-eslint/debug-for-file@workspace:*, @typescript-eslint/debug-for-file@workspace:^, @typescript-eslint/debug-for-file@workspace:packages/debug-for-file":
+  version: 0.0.0-use.local
+  resolution: "@typescript-eslint/debug-for-file@workspace:packages/debug-for-file"
+  dependencies:
+    "@jest/types": 29.6.3
+    find-up: 5.0.0
+    jest: 29.7.0
+    prettier: ^3.2.5
+    rimraf: "*"
+    typescript: "*"
+  languageName: unknown
+  linkType: soft
+
 "@typescript-eslint/eslint-plugin-internal@workspace:^, @typescript-eslint/eslint-plugin-internal@workspace:packages/eslint-plugin-internal":
   version: 0.0.0-use.local
   resolution: "@typescript-eslint/eslint-plugin-internal@workspace:packages/eslint-plugin-internal"
@@ -5753,11 +5766,11 @@ __metadata:
   dependencies:
     "@jest/types": 29.6.3
     "@types/glob": "*"
+    "@typescript-eslint/debug-for-file": "workspace:*"
     "@typescript-eslint/scope-manager": 8.19.0
     "@typescript-eslint/types": 8.19.0
     "@typescript-eslint/typescript-estree": 8.19.0
     "@typescript-eslint/visitor-keys": 8.19.0
-    debug: ^4.3.4
     downlevel-dts: "*"
     glob: "*"
     jest: 29.7.0
@@ -5837,7 +5850,6 @@ __metadata:
     "@typescript-eslint/typescript-estree": 8.19.0
     "@typescript-eslint/utils": 8.19.0
     ajv: ^6.12.6
-    debug: ^4.3.4
     downlevel-dts: "*"
     jest: 29.7.0
     prettier: ^3.2.5
@@ -5896,6 +5908,7 @@ __metadata:
     "@types/semver": ^7.5.8
     "@types/tmp": ^0.2.6
     "@types/yargs": ^17.0.32
+    "@typescript-eslint/debug-for-file": "workspace:^"
     "@typescript-eslint/eslint-plugin": "workspace:^"
     "@typescript-eslint/eslint-plugin-internal": "workspace:^"
     "@typescript-eslint/scope-manager": "workspace:^"
@@ -5947,9 +5960,9 @@ __metadata:
   resolution: "@typescript-eslint/typescript-estree@workspace:packages/typescript-estree"
   dependencies:
     "@jest/types": 29.6.3
+    "@typescript-eslint/debug-for-file": "workspace:*"
     "@typescript-eslint/types": 8.19.0
     "@typescript-eslint/visitor-keys": 8.19.0
-    debug: ^4.3.4
     fast-glob: ^3.3.2
     glob: "*"
     is-glob: ^4.0.3
@@ -8605,7 +8618,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.6, debug@npm:^4.3.7":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.5, debug@npm:^4.3.6, debug@npm:^4.3.7":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -10448,6 +10461,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"find-up@npm:5.0.0, find-up@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "find-up@npm:5.0.0"
+  dependencies:
+    locate-path: ^6.0.0
+    path-exists: ^4.0.0
+  checksum: 07955e357348f34660bde7920783204ff5a26ac2cafcaa28bace494027158a97b9f56faaf2d89a6106211a8174db650dd9f503f9c0d526b1202d5554a00b9095
+  languageName: node
+  linkType: hard
+
 "find-up@npm:^3.0.0":
   version: 3.0.0
   resolution: "find-up@npm:3.0.0"
@@ -10464,16 +10487,6 @@ __metadata:
     locate-path: ^5.0.0
     path-exists: ^4.0.0
   checksum: 4c172680e8f8c1f78839486e14a43ef82e9decd0e74145f40707cc42e7420506d5ec92d9a11c22bd2c48fb0c384ea05dd30e10dd152fefeec6f2f75282a8b844
-  languageName: node
-  linkType: hard
-
-"find-up@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "find-up@npm:5.0.0"
-  dependencies:
-    locate-path: ^6.0.0
-    path-exists: ^4.0.0
-  checksum: 07955e357348f34660bde7920783204ff5a26ac2cafcaa28bace494027158a97b9f56faaf2d89a6106211a8174db650dd9f503f9c0d526b1202d5554a00b9095
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5872
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Replaces debug loggers with a bespoke function that applies the logic suggested in #5872:

```diff
- import debug from 'debug';
+ import { debugForFile } from "@typescript-eslint/debug-for-file";

- const log = debug('typescript-eslint:typescript-estree:someFile:functionName');
+ const log = debugForFile(__filename)
```

I also made a standalone package for fun: https://github.com/JoshuaKGoldberg/debug-for-file. It's not used here because after playing around with the source file changes I didn't like the lack of explicit searchable string constants for namespaces. 

Sending this PR as a draft for reference. Unless everyone just _loves_ it I don't plan on trying to push it forward. I'll post in #5872 that I think a lint rule preferring consistent `debug()` namespaces is better.

💖 
