### PR TITLE
chore(eslint-plugin): [no-for-in-array] use `getConstraintInfo`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-for-in-array.ts
+++ b/packages/eslint-plugin/src/rules/no-for-in-array.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 
 import {
   createRule,
-  getConstrainedTypeAtLocation,
+  getConstraintInfo,
   getParserServices,
   isTypeArrayTypeOrUnionOfArrayTypes,
 } from '../util';
@@ -30,11 +30,15 @@ export default createRule({
         const services = getParserServices(context);
         const checker = services.program.getTypeChecker();
 
-        const type = getConstrainedTypeAtLocation(services, node.right);
+        const { constraintType } = getConstraintInfo(
+          checker,
+          services.getTypeAtLocation(node.right),
+        );
 
         if (
-          isTypeArrayTypeOrUnionOfArrayTypes(type, checker) ||
-          (type.flags & ts.TypeFlags.StringLike) !== 0
+          constraintType != null &&
+          (isTypeArrayTypeOrUnionOfArrayTypes(constraintType, checker) ||
+            (constraintType.flags & ts.TypeFlags.StringLike) !== 0)
         ) {
           context.report({
             loc: getForStatementHeadLoc(context.sourceCode, node),

--- a/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-for-in-array.test.ts
@@ -25,6 +25,13 @@ for (const x in { a: 1, b: 2, c: 3 }) {
   console.log(x);
 }
     `,
+    `
+function f<T>(input: T) {
+  for (const x in input) {
+    console.log(x);
+  }
+}
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
Uses `getConstraintInfo` for determining if the right hand side of the `for..in` is constrained or not.

## PR Checklist

- [x] Addresses an existing open issue: Relates to #10569
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

