### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] don't flag optional chaining for union types with an unconstrained type parameters

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -143,6 +143,24 @@ function test<T>(t: T | []) {
   return t ? 'yes' : 'no';
 }
     `,
+    `
+function test<T>(arg: T, key: keyof T) {
+  if (arg[key]?.toString()) {
+  }
+}
+    `,
+    `
+function test<T>(arg: T, key: keyof T) {
+  if (arg?.toString()) {
+  }
+}
+    `,
+    `
+function test<T>(arg: T | { value: string }) {
+  if (arg?.value) {
+  }
+}
+    `,
 
     // Boolean expressions
     `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10600
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR resolves #10600 and removes some duplicated logic for checking special-case types in a union (`any`, `unknown`, or types with the `TypeVariable` type flag).

The current implementation seems to pick up unconstrained type parameters by checking the presence of the `TypeVariable` type flag. I think this is necessary (over `getConstraintInfo`) as the check needs to detect types such as the following:

```ts
function test<T>(arg: T, key: keyof T) {
  if (arg[key]) {
    //
  }
}
```