### PR TITLE
chore(eslint-plugin): [no-array-delete] use `getConstraintInfo`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-array-delete.ts
+++ b/packages/eslint-plugin/src/rules/no-array-delete.ts
@@ -3,11 +3,7 @@ import type * as ts from 'typescript';
 
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 
-import {
-  createRule,
-  getConstrainedTypeAtLocation,
-  getParserServices,
-} from '../util';
+import { createRule, getConstraintInfo, getParserServices } from '../util';
 
 type MessageId = 'noArrayDelete' | 'useSplice';
 
@@ -58,9 +54,16 @@ export default createRule<[], MessageId>({
           return;
         }
 
-        const type = getConstrainedTypeAtLocation(services, argument.object);
+        const { constraintType } = getConstraintInfo(
+          checker,
+          services.getTypeAtLocation(argument.object),
+        );
 
-        if (!isUnderlyingTypeArray(type)) {
+        if (constraintType == null) {
+          return;
+        }
+
+        if (!isUnderlyingTypeArray(constraintType)) {
           return;
         }
 

--- a/packages/eslint-plugin/tests/rules/no-array-delete.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-array-delete.test.ts
@@ -55,6 +55,11 @@ ruleTester.run('no-array-delete', rule, {
       declare const test: never;
       delete test[0];
     `,
+    `
+      function f<T>(input: T) {
+        delete input[0];
+      }
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
Uses `getConstraintInfo` to determine if the object being deleted is a constrained type or not.

## PR Checklist

- [x] Addresses an existing open issue: Relates to #10569 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
