### PR TITLE
docs: fix incorrect variable name in a comment in code example

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -62,7 +62,7 @@ function head<T>(items: T[]) {
 }
 
 function foo(arg: string) {
-  // Necessary, since foo might be ''.
+  // Necessary, since arg might be ''.
   if (arg) {
   }
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

A small change to fix an incorrect variable name used in a comment in one of the code examples
