### PR TITLE
fix(scope-manager): add a reference for JSX closing element if it exists

### DIFF
--- a/packages/scope-manager/src/referencer/Referencer.ts
+++ b/packages/scope-manager/src/referencer/Referencer.ts
@@ -497,8 +497,8 @@ class Referencer extends Visitor {
     this.visit(node.value);
   }
 
-  protected JSXClosingElement(): void {
-    // should not be counted as a reference
+  protected JSXClosingElement(node: TSESTree.JSXClosingElement): void {
+    this.visit(node.name);
   }
 
   protected JSXFragment(node: TSESTree.JSXFragment): void {

--- a/packages/scope-manager/src/referencer/Referencer.ts
+++ b/packages/scope-manager/src/referencer/Referencer.ts
@@ -289,6 +289,26 @@ class Referencer extends Visitor {
     }
   }
 
+  protected visitJSXElement(
+    node: TSESTree.JSXClosingElement | TSESTree.JSXOpeningElement,
+  ): void {
+    if (node.name.type === AST_NODE_TYPES.JSXIdentifier) {
+      if (
+        node.name.name[0].toUpperCase() === node.name.name[0] ||
+        node.name.name === 'this'
+      ) {
+        // lower cased component names are always treated as "intrinsic" names, and are converted to a string,
+        // not a variable by JSX transforms:
+        // <div /> => React.createElement("div", null)
+
+        // the only case we want to visit a lower-cased component has its name as "this",
+        this.visit(node.name);
+      }
+    } else {
+      this.visit(node.name);
+    }
+  }
+
   protected visitProperty(node: TSESTree.Property): void {
     if (node.computed) {
       this.visit(node.key);
@@ -498,7 +518,7 @@ class Referencer extends Visitor {
   }
 
   protected JSXClosingElement(node: TSESTree.JSXClosingElement): void {
-    this.visit(node.name);
+    this.visitJSXElement(node);
   }
 
   protected JSXFragment(node: TSESTree.JSXFragment): void {
@@ -522,21 +542,7 @@ class Referencer extends Visitor {
   }
   protected JSXOpeningElement(node: TSESTree.JSXOpeningElement): void {
     this.referenceJsxPragma();
-    if (node.name.type === AST_NODE_TYPES.JSXIdentifier) {
-      if (
-        node.name.name[0].toUpperCase() === node.name.name[0] ||
-        node.name.name === 'this'
-      ) {
-        // lower cased component names are always treated as "intrinsic" names, and are converted to a string,
-        // not a variable by JSX transforms:
-        // <div /> => React.createElement("div", null)
-
-        // the only case we want to visit a lower-cased component has its name as "this",
-        this.visit(node.name);
-      }
-    } else {
-      this.visit(node.name);
-    }
+    this.visitJSXElement(node);
     this.visitType(node.typeArguments);
     for (const attr of node.attributes) {
       this.visit(attr);

--- a/packages/scope-manager/tests/fixtures/jsx/children.tsx.shot
+++ b/packages/scope-manager/tests/fixtures/jsx/children.tsx.shot
@@ -51,6 +51,14 @@ ScopeManager {
           resolved: null,
         },
         Reference$3,
+        Reference$4 {
+          identifier: JSXIdentifier$5,
+          isRead: true,
+          isTypeReference: false,
+          isValueReference: true,
+          isWrite: false,
+          resolved: null,
+        },
       ],
       set: Map {
         "const" => ImplicitGlobalConstTypeVariable,

--- a/packages/scope-manager/tests/fixtures/jsx/namespaced-attribute.tsx.shot
+++ b/packages/scope-manager/tests/fixtures/jsx/namespaced-attribute.tsx.shot
@@ -186,6 +186,14 @@ ScopeManager {
       references: [
         Reference$6,
         Reference$7,
+        Reference$8 {
+          identifier: JSXIdentifier$11,
+          isRead: true,
+          isTypeReference: false,
+          isValueReference: true,
+          isWrite: false,
+          resolved: null,
+        },
       ],
       set: Map {
         "arguments" => Variable$7,

--- a/packages/scope-manager/tests/fixtures/jsx/namespaced-attribute.tsx.shot
+++ b/packages/scope-manager/tests/fixtures/jsx/namespaced-attribute.tsx.shot
@@ -186,14 +186,6 @@ ScopeManager {
       references: [
         Reference$6,
         Reference$7,
-        Reference$8 {
-          identifier: JSXIdentifier$11,
-          isRead: true,
-          isTypeReference: false,
-          isValueReference: true,
-          isWrite: false,
-          resolved: null,
-        },
       ],
       set: Map {
         "arguments" => Variable$7,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9790
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Addresses #9790 and registers a reference for the closing JSX element if it exists.
