### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] should report readonly class properties with a literal initializer 

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -177,6 +177,14 @@ export default createRule<Options, MessageIds>({
       );
     }
 
+    function isReadonlyClassProperty({
+      parent,
+    }: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion) {
+      return (
+        parent.type === AST_NODE_TYPES.PropertyDefinition && parent.readonly
+      );
+    }
+
     function isTypeUnchanged(uncast: ts.Type, cast: ts.Type): boolean {
       if (uncast === cast) {
         return true;
@@ -230,7 +238,8 @@ export default createRule<Options, MessageIds>({
 
         const wouldSameTypeBeInferred =
           castType.isLiteral() || isAssertionTypeUnionStringlike
-            ? isImplicitlyNarrowedConstDeclaration(node)
+            ? isImplicitlyNarrowedConstDeclaration(node) ||
+              isReadonlyClassProperty(node)
             : !isConstAssertion(node.typeAnnotation);
 
         if (typeIsUnchanged && wouldSameTypeBeInferred) {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -154,6 +154,21 @@ class Foo {
 }
     `,
     `
+type S = 10;
+
+class T {
+  a = 'a' as const;
+  b = 3 as 3;
+  c = 10 as S;
+}
+    `,
+    `
+class T {
+  readonly a = 'a';
+  readonly b = 3;
+}
+    `,
+    `
       declare const y: number | null;
       console.log(y!);
     `,

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -1158,12 +1158,46 @@ var x = 1;
     },
     {
       code: `
+class T {
+  readonly a = 'a' as const;
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: `
+class T {
+  readonly a = 'a';
+}
+      `,
+    },
+    {
+      code: `
+class T {
+  readonly a = 3 as 3;
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: `
+class T {
+  readonly a = 3;
+}
+      `,
+    },
+    {
+      code: `
 type S = 10;
 
 class T {
-  readonly a = 'a' as const;
-  readonly b = 3 as 3;
-  readonly c = 10 as S;
+  readonly a = 10 as S;
 }
       `,
       errors: [
@@ -1171,22 +1205,12 @@ class T {
           line: 5,
           messageId: 'unnecessaryAssertion',
         },
-        {
-          line: 6,
-          messageId: 'unnecessaryAssertion',
-        },
-        {
-          line: 7,
-          messageId: 'unnecessaryAssertion',
-        },
       ],
       output: `
 type S = 10;
 
 class T {
-  readonly a = 'a';
-  readonly b = 3;
-  readonly c = 10;
+  readonly a = 10;
 }
       `,
     },

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -1148,6 +1148,40 @@ var x = 1;
     },
     {
       code: `
+type S = 10;
+
+class T {
+  readonly a = 'a' as const;
+  readonly b = 3 as 3;
+  readonly c = 10 as S;
+}
+      `,
+      errors: [
+        {
+          line: 5,
+          messageId: 'unnecessaryAssertion',
+        },
+        {
+          line: 6,
+          messageId: 'unnecessaryAssertion',
+        },
+        {
+          line: 7,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: `
+type S = 10;
+
+class T {
+  readonly a = 'a';
+  readonly b = 3;
+  readonly c = 10;
+}
+      `,
+    },
+    {
+      code: `
 const a = '';
 const b: string | undefined = (a ? undefined : a)!;
       `,

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -162,12 +162,17 @@ class T {
   c = 10 as S;
 }
     `,
-    `
+    {
+      code: `
+const foo = 'foo';
+
 class T {
   readonly a = 'a';
   readonly b = 3;
+  readonly test = \`\${foo}\` as const;
 }
-    `,
+      `,
+    },
     `
       declare const y: number | null;
       console.log(y!);

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -164,20 +164,10 @@ class T {
 }
     `,
     `
-class T {
-  a = 10;
-}
-    `,
-    `
 const foo = 'foo';
 
 class T {
   readonly test = \`\${foo}\` as const;
-}
-    `,
-    `
-class T {
-  readonly a = 3 + 5;
 }
     `,
     `

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -154,25 +154,37 @@ class Foo {
 }
     `,
     `
-type S = 10;
-
 class T {
   a = 'a' as const;
-  b = 3 as 3;
-  c = 10 as S;
 }
     `,
-    {
-      code: `
+    `
+class T {
+  a = 3 as 3;
+}
+    `,
+    `
+class T {
+  a = 10;
+}
+    `,
+    `
 const foo = 'foo';
 
 class T {
-  readonly a = 'a';
-  readonly b = 3;
   readonly test = \`\${foo}\` as const;
 }
-      `,
-    },
+    `,
+    `
+class T {
+  readonly a = 3 + 5;
+}
+    `,
+    `
+class T {
+  readonly a = { foo: 'foo' } as const;
+}
+    `,
     `
       declare const y: number | null;
       console.log(y!);
@@ -1211,6 +1223,24 @@ type S = 10;
 
 class T {
   readonly a = 10;
+}
+      `,
+    },
+    {
+      code: `
+class T {
+  readonly a = (3 + 5) as number;
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: `
+class T {
+  readonly a = (3 + 5);
 }
       `,
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10617
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Fixed the bug described in the title.

🐛
