### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-arguments] handle type args on jsx

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
@@ -143,7 +143,8 @@ function getTypeParametersFromNode(
     ts.isCallExpression(tsNode) ||
     ts.isNewExpression(tsNode) ||
     ts.isTaggedTemplateExpression(tsNode) ||
-    ts.isJsxOpeningElement(tsNode)
+    ts.isJsxOpeningElement(tsNode) ||
+    ts.isJsxSelfClosingElement(tsNode)
   ) {
     return getTypeParametersFromCall(node, tsNode, checker);
   }
@@ -193,6 +194,7 @@ function getTypeParametersFromCall(
   tsNode:
     | ts.CallExpression
     | ts.JsxOpeningElement
+    | ts.JsxSelfClosingElement
     | ts.NewExpression
     | ts.TaggedTemplateExpression,
   checker: ts.TypeChecker,

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
@@ -142,7 +142,8 @@ function getTypeParametersFromNode(
   if (
     ts.isCallExpression(tsNode) ||
     ts.isNewExpression(tsNode) ||
-    ts.isTaggedTemplateExpression(tsNode)
+    ts.isTaggedTemplateExpression(tsNode) ||
+    ts.isJsxOpeningElement(tsNode)
   ) {
     return getTypeParametersFromCall(node, tsNode, checker);
   }
@@ -189,7 +190,11 @@ function getTypeParametersFromType(
 
 function getTypeParametersFromCall(
   node: TSESTree.TSTypeParameterInstantiation,
-  tsNode: ts.CallExpression | ts.NewExpression | ts.TaggedTemplateExpression,
+  tsNode:
+    | ts.CallExpression
+    | ts.JsxOpeningElement
+    | ts.NewExpression
+    | ts.TaggedTemplateExpression,
   checker: ts.TypeChecker,
 ): readonly ts.TypeParameterDeclaration[] | undefined {
   const sig = checker.getResolvedSignature(tsNode);

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
@@ -179,6 +179,21 @@ namespace Foo {
 }
 class Bar extends Foo<string> {}
     `,
+    {
+      code: `
+function Button<T>() {
+  return <div></div>;
+}
+const button = <Button<string>></Button>;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
   ],
   invalid: [
     {
@@ -558,6 +573,33 @@ namespace Foo {
   export class Bar {}
 }
 class Bar extends Foo {}
+      `,
+    },
+    {
+      code: `
+function Button<T = string>() {
+  return <div></div>;
+}
+const button = <Button<string>></Button>;
+      `,
+      errors: [
+        {
+          line: 5,
+          messageId: 'unnecessaryTypeParameter',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+      output: `
+function Button<T = string>() {
+  return <div></div>;
+}
+const button = <Button></Button>;
       `,
     },
   ],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
@@ -194,6 +194,21 @@ const button = <Button<string>></Button>;
         },
       },
     },
+    {
+      code: `
+function Button<T>() {
+  return <div></div>;
+}
+const button = <Button<string> />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
   ],
   invalid: [
     {
@@ -600,6 +615,33 @@ function Button<T = string>() {
   return <div></div>;
 }
 const button = <Button></Button>;
+      `,
+    },
+    {
+      code: `
+function Button<T = string>() {
+  return <div></div>;
+}
+const button = <Button<string> />;
+      `,
+      errors: [
+        {
+          line: 5,
+          messageId: 'unnecessaryTypeParameter',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+      output: `
+function Button<T = string>() {
+  return <div></div>;
+}
+const button = <Button />;
       `,
     },
   ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10629
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
