### PR TITLE
fix(eslint-plugin): [no-base-to-string] don't crash for recursive array or tuple types

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -93,9 +93,8 @@ export default createRule<Options, MessageIds>({
     function checkExpressionForArrayJoin(
       node: TSESTree.Node,
       type: ts.Type,
-      visited: Set<ts.Type>,
     ): void {
-      const certainty = collectJoinCertainty(type, visited);
+      const certainty = collectJoinCertainty(type, new Set());
 
       if (certainty === Usefulness.Always) {
         return;
@@ -319,7 +318,7 @@ export default createRule<Options, MessageIds>({
       ): void {
         const memberExpr = node.parent as TSESTree.MemberExpression;
         const type = getConstrainedTypeAtLocation(services, memberExpr.object);
-        checkExpressionForArrayJoin(memberExpr.object, type, new Set());
+        checkExpressionForArrayJoin(memberExpr.object, type);
       },
       'CallExpression > MemberExpression.callee > Identifier[name = /^(toLocaleString|toString)$/].property'(
         node: TSESTree.Expression,

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -496,7 +496,13 @@ declare const v: Value;
 String(v);
     `,
     `
-type Value = [Value, Value];
+type Value = Value[];
+declare const v: Value;
+
+String(v);
+    `,
+    `
+type Value = [Value];
 declare const v: Value;
 
 String(v);

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -483,6 +483,34 @@ function foo<T>(x: T) {
 declare const u: unknown;
 String(u);
     `,
+    `
+type Value = boolean | Value[];
+
+declare const v: Value;
+
+String(v);
+    `,
+    `
+type Value = (boolean | Value)[];
+
+declare const v: Value;
+
+String(v);
+    `,
+    `
+type Value = [Value];
+
+declare const v: Value;
+
+String(v);
+    `,
+    `
+type Value = [Value | number];
+
+declare const v: Value;
+
+String(v);
+    `,
   ],
   invalid: [
     {
@@ -1808,6 +1836,36 @@ foo.toString();
             name: "foo([{ foo: 'foo' }, 'bar'])",
           },
           messageId: 'baseArrayJoin',
+        },
+      ],
+    },
+    {
+      code: `
+type Value =
+  | boolean
+  | number
+  | string
+  | Date
+  | Struct
+  | Uint8Array
+  | Value[]
+  | undefined;
+
+interface Struct {
+  [key: string]: Value;
+}
+
+function foo(v: Value) {
+  return \`Hi \${v}\`;
+}
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'v',
+          },
+          messageId: 'baseToString',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -1905,22 +1905,5 @@ v.join();
         },
       ],
     },
-    {
-      code: `
-type Value = [{ value: Vallue }];
-declare const v: Value;
-
-String(v);
-      `,
-      errors: [
-        {
-          data: {
-            certainty: 'will',
-            name: 'v',
-          },
-          messageId: 'baseToString',
-        },
-      ],
-    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -484,31 +484,25 @@ declare const u: unknown;
 String(u);
     `,
     `
-type Value = boolean | Value[];
-
+type Value = string | Value[];
 declare const v: Value;
 
 String(v);
     `,
     `
-type Value = (boolean | Value)[];
-
+type Value = (string | Value)[];
 declare const v: Value;
 
 String(v);
     `,
     `
-type Value = [Value];
-
+type Value = [Value, Value];
 declare const v: Value;
 
 String(v);
     `,
     `
-type Value = [Value | number];
-
-declare const v: Value;
-
+declare const v: ('foo' | 'bar')[][];
 String(v);
     `,
   ],
@@ -1841,28 +1835,81 @@ foo.toString();
     },
     {
       code: `
-type Value =
-  | boolean
-  | number
-  | string
-  | Date
-  | Struct
-  | Uint8Array
-  | Value[]
-  | undefined;
+type Value = { foo: string } | Value[];
+declare const v: Value;
 
-interface Struct {
-  [key: string]: Value;
-}
-
-function foo(v: Value) {
-  return \`Hi \${v}\`;
-}
+String(v);
       `,
       errors: [
         {
           data: {
             certainty: 'may',
+            name: 'v',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+    },
+    {
+      code: `
+type Value = ({ foo: string } | Value)[];
+declare const v: Value;
+
+String(v);
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'v',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+    },
+    {
+      code: `
+type Value = [{ foo: string }, Value];
+declare const v: Value;
+
+String(v);
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'will',
+            name: 'v',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+    },
+    {
+      code: `
+declare const v: { foo: string }[][];
+v.join();
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'will',
+            name: 'v',
+          },
+          messageId: 'baseArrayJoin',
+        },
+      ],
+    },
+    {
+      code: `
+type Value = [{ value: Vallue }];
+declare const v: Value;
+
+String(v);
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'will',
             name: 'v',
           },
           messageId: 'baseToString',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10632
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10632 and fixes the rule so it does not fail on recursive array or tuple types. It looks like this regression has been introduced in #10437.

---

Not directly related: It seems not intentional, but since #10437, the rule reports invalid nested array types (which it didn't previously):

```ts
declare const s: { foo: 'bar' }[][];

// [object Object]
s.join();
```

Previously, the array check (which used to run only on `array.join()`) never checked for nested array types. This changed on #10437, and the recursive check also runs as part of `array.join()` (which means the crash reproduces on recursive `array.join()` too, [playground link](https://typescript-eslint.io/play/#ts=5.7.2&fileType=.tsx&code=KYDwDg9gTgLgBDAnmYcBqBDANgV1QXgCg44AfOHAOwBNgAzAS0uGuLLgCMIItgNK25SjgC2HYFEFwAzjChMA5lIAiGGMCkBVJjAAcAQShQMiKZlzAA2gF0pAZTk4AxjADchQqEiwEyVA6hneHw4AG84SwBrYEQALhk5RWt48zw4AF93QjoqFwYISjg6bgAKADcU7DwASjC2Bjo4EsNjRAA6BmkWk3Lq2tC2EjK2gCsIJhLq9xJ0wnSgA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1oCMBDZRLXxdk%2BKkwDm6KImjQO0SODABfECqA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)).

There's no test that checks this behavior (which I think is intended), so I've added a couple of tests for this. Please let me know if this isn't intended behavior or if this should be done on a separate PR.