### PR TITLE
fix(eslint-plugin): [no-duplicate-type-constituents] handle nested types

### DIFF
--- a/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
@@ -22,6 +22,13 @@ export type Options = [
 
 export type MessageIds = 'duplicate' | 'unnecessary';
 
+export type UnionOrIntersection = 'Intersection' | 'Union';
+
+interface DuplicatedConstituentInfo {
+  duplicatedPrev: TSESTree.TypeNode;
+  constituentNode: TSESTree.TypeNode;
+}
+
 const astIgnoreKeys = new Set(['loc', 'parent', 'range']);
 
 const isSameAstNode = (actualNode: unknown, expectedNode: unknown): boolean => {
@@ -117,115 +124,192 @@ export default createRule<Options, MessageIds>({
     const parserServices = getParserServices(context);
     const { sourceCode } = context;
 
+    function report(
+      messageId: MessageIds,
+      constituentNode: TSESTree.TypeNode,
+      data?: Record<string, unknown>,
+    ): void {
+      const getUnionOrIntersectionToken = (
+        where: 'After' | 'Before',
+        at: number,
+      ): TSESTree.Token | undefined =>
+        sourceCode[`getTokens${where}`](constituentNode, {
+          filter: token =>
+            ['&', '|'].includes(token.value) &&
+            constituentNode.parent.range[0] <= token.range[0] &&
+            token.range[1] <= constituentNode.parent.range[1],
+        }).at(at);
+
+      const beforeUnionOrIntersectionToken = getUnionOrIntersectionToken(
+        'Before',
+        -1,
+      );
+      let afterUnionOrIntersectionToken: TSESTree.Token | undefined;
+      let bracketBeforeTokens;
+      let bracketAfterTokens;
+      if (beforeUnionOrIntersectionToken) {
+        bracketBeforeTokens = sourceCode.getTokensBetween(
+          beforeUnionOrIntersectionToken,
+          constituentNode,
+        );
+        bracketAfterTokens = sourceCode.getTokensAfter(constituentNode, {
+          count: bracketBeforeTokens.length,
+        });
+      } else {
+        afterUnionOrIntersectionToken = nullThrows(
+          getUnionOrIntersectionToken('After', 0),
+          NullThrowsReasons.MissingToken(
+            'union or intersection token',
+            'duplicate type constituent',
+          ),
+        );
+        bracketAfterTokens = sourceCode.getTokensBetween(
+          constituentNode,
+          afterUnionOrIntersectionToken,
+        );
+        bracketBeforeTokens = sourceCode.getTokensBefore(constituentNode, {
+          count: bracketAfterTokens.length,
+        });
+      }
+      context.report({
+        loc: {
+          start: constituentNode.loc.start,
+          end: (bracketAfterTokens.at(-1) ?? constituentNode).loc.end,
+        },
+        node: constituentNode,
+        messageId,
+        data,
+        fix: fixer =>
+          [
+            beforeUnionOrIntersectionToken,
+            ...bracketBeforeTokens,
+            constituentNode,
+            ...bracketAfterTokens,
+            afterUnionOrIntersectionToken,
+          ].flatMap(token => (token ? fixer.remove(token) : [])),
+      });
+    }
+
+    function containsEveryDuplicatedConstituents(
+      node: TSESTree.TSIntersectionType | TSESTree.TSUnionType,
+      duplicationInfos: DuplicatedConstituentInfo[],
+    ): boolean {
+      const duplicatedConstituentNodes = duplicationInfos.map(
+        ({ constituentNode }) => constituentNode,
+      );
+      return (
+        node.types.length === duplicatedConstituentNodes.length &&
+        node.types.every(constituentNode =>
+          duplicatedConstituentNodes.includes(constituentNode),
+        )
+      );
+    }
+
+    function getDuplicateTypeNodes(
+      unionOrIntersection: UnionOrIntersection,
+      constituentNode: TSESTree.TypeNode,
+      uniqueConstituents: TSESTree.TypeNode[],
+      cachedTypeMap: Map<Type, TSESTree.TypeNode>,
+      forEachNodeType?: (type: Type, node: TSESTree.TypeNode) => void,
+    ): DuplicatedConstituentInfo[] {
+      const type = parserServices.getTypeAtLocation(constituentNode);
+      if (tsutils.isIntrinsicErrorType(type)) {
+        return [];
+      }
+      const duplicatedPrev =
+        uniqueConstituents.find(ele => isSameAstNode(ele, constituentNode)) ??
+        cachedTypeMap.get(type);
+
+      if (duplicatedPrev) {
+        return [
+          {
+            constituentNode,
+            duplicatedPrev,
+          },
+        ];
+      }
+
+      forEachNodeType?.(type, constituentNode);
+      cachedTypeMap.set(type, constituentNode);
+      uniqueConstituents.push(constituentNode);
+
+      if (
+        (unionOrIntersection === 'Union' &&
+          constituentNode.type === AST_NODE_TYPES.TSUnionType) ||
+        (unionOrIntersection === 'Intersection' &&
+          constituentNode.type === AST_NODE_TYPES.TSIntersectionType)
+      ) {
+        const result: DuplicatedConstituentInfo[] = [];
+        for (const constituent of constituentNode.types) {
+          const duplications = getDuplicateTypeNodes(
+            unionOrIntersection,
+            constituent,
+            uniqueConstituents,
+            cachedTypeMap,
+            forEachNodeType,
+          );
+          result.push(...duplications);
+        }
+        if (containsEveryDuplicatedConstituents(constituentNode, result)) {
+          return [
+            {
+              constituentNode,
+              duplicatedPrev: constituentNode,
+            },
+          ];
+        }
+        return result;
+      }
+      return [];
+    }
+
     function checkDuplicate(
       node: TSESTree.TSIntersectionType | TSESTree.TSUnionType,
       forEachNodeType?: (
         constituentNodeType: Type,
-        report: (messageId: MessageIds) => void,
+        constituentNode: TSESTree.TypeNode,
       ) => void,
     ): void {
       const cachedTypeMap = new Map<Type, TSESTree.TypeNode>();
-      node.types.reduce<TSESTree.TypeNode[]>(
-        (uniqueConstituents, constituentNode) => {
-          const constituentNodeType =
-            parserServices.getTypeAtLocation(constituentNode);
-          if (tsutils.isIntrinsicErrorType(constituentNodeType)) {
-            return uniqueConstituents;
-          }
+      const uniqueConstituents: TSESTree.TypeNode[] = [];
 
-          const report = (
-            messageId: MessageIds,
-            data?: Record<string, unknown>,
-          ): void => {
-            const getUnionOrIntersectionToken = (
-              where: 'After' | 'Before',
-              at: number,
-            ): TSESTree.Token | undefined =>
-              sourceCode[`getTokens${where}`](constituentNode, {
-                filter: token => ['&', '|'].includes(token.value),
-              }).at(at);
+      const unionOrIntersection =
+        node.type === AST_NODE_TYPES.TSIntersectionType
+          ? 'Intersection'
+          : 'Union';
 
-            const beforeUnionOrIntersectionToken = getUnionOrIntersectionToken(
-              'Before',
-              -1,
-            );
-            let afterUnionOrIntersectionToken: TSESTree.Token | undefined;
-            let bracketBeforeTokens;
-            let bracketAfterTokens;
-            if (beforeUnionOrIntersectionToken) {
-              bracketBeforeTokens = sourceCode.getTokensBetween(
-                beforeUnionOrIntersectionToken,
-                constituentNode,
-              );
-              bracketAfterTokens = sourceCode.getTokensAfter(constituentNode, {
-                count: bracketBeforeTokens.length,
-              });
-            } else {
-              afterUnionOrIntersectionToken = nullThrows(
-                getUnionOrIntersectionToken('After', 0),
-                NullThrowsReasons.MissingToken(
-                  'union or intersection token',
-                  'duplicate type constituent',
-                ),
-              );
-              bracketAfterTokens = sourceCode.getTokensBetween(
-                constituentNode,
-                afterUnionOrIntersectionToken,
-              );
-              bracketBeforeTokens = sourceCode.getTokensBefore(
-                constituentNode,
-                {
-                  count: bracketAfterTokens.length,
-                },
-              );
-            }
-            context.report({
-              loc: {
-                start: constituentNode.loc.start,
-                end: (bracketAfterTokens.at(-1) ?? constituentNode).loc.end,
-              },
-              node: constituentNode,
-              messageId,
-              data,
-              fix: fixer =>
-                [
-                  beforeUnionOrIntersectionToken,
-                  ...bracketBeforeTokens,
-                  constituentNode,
-                  ...bracketAfterTokens,
-                  afterUnionOrIntersectionToken,
-                ].flatMap(token => (token ? fixer.remove(token) : [])),
-            });
-          };
-          const duplicatePrevious =
-            uniqueConstituents.find(ele =>
-              isSameAstNode(ele, constituentNode),
-            ) ?? cachedTypeMap.get(constituentNodeType);
-          if (duplicatePrevious) {
-            report('duplicate', {
-              type:
-                node.type === AST_NODE_TYPES.TSIntersectionType
-                  ? 'Intersection'
-                  : 'Union',
-              previous: sourceCode.getText(duplicatePrevious),
-            });
-            return uniqueConstituents;
-          }
-          forEachNodeType?.(constituentNodeType, report);
-          cachedTypeMap.set(constituentNodeType, constituentNode);
-          return [...uniqueConstituents, constituentNode];
-        },
-        [],
-      );
+      for (const type of node.types) {
+        const duplicationInfos = getDuplicateTypeNodes(
+          unionOrIntersection,
+          type,
+          uniqueConstituents,
+          cachedTypeMap,
+          forEachNodeType,
+        );
+        duplicationInfos.forEach(({ constituentNode, duplicatedPrev }) =>
+          report('duplicate', constituentNode, {
+            type: unionOrIntersection,
+            previous: sourceCode.getText(duplicatedPrev),
+          }),
+        );
+      }
     }
 
     return {
       ...(!ignoreIntersections && {
-        TSIntersectionType: checkDuplicate,
+        TSIntersectionType(node) {
+          if (node.parent.type === AST_NODE_TYPES.TSIntersectionType) {
+            return;
+          }
+          checkDuplicate(node);
+        },
       }),
       ...(!ignoreUnions && {
-        TSUnionType: (node): void =>
-          checkDuplicate(node, (constituentNodeType, report) => {
+        TSUnionType: (node): void => {
+          if (node.parent.type === AST_NODE_TYPES.TSUnionType) {
+            return;
+          }
+          checkDuplicate(node, (constituentNodeType, constituentNode) => {
             const maybeTypeAnnotation = node.parent;
             if (maybeTypeAnnotation.type === AST_NODE_TYPES.TSTypeAnnotation) {
               const maybeIdentifier = maybeTypeAnnotation.parent;
@@ -242,11 +326,12 @@ export default createRule<Options, MessageIds>({
                     ts.TypeFlags.Undefined,
                   )
                 ) {
-                  report('unnecessary');
+                  report('unnecessary', constituentNode);
                 }
               }
             }
-          }),
+          });
+        },
       }),
     };
   },

--- a/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
@@ -22,7 +22,7 @@ export type Options = [
 
 export type MessageIds = 'duplicate' | 'unnecessary';
 
-export type UnionOrIntersection = 'Intersection' | 'Union';
+type UnionOrIntersection = 'Intersection' | 'Union';
 
 const astIgnoreKeys = new Set(['loc', 'parent', 'range']);
 

--- a/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
@@ -196,14 +196,14 @@ export default createRule<Options, MessageIds>({
       if (tsutils.isIntrinsicErrorType(type)) {
         return;
       }
-      const duplicatedPrev =
+      const duplicatedPrevious =
         uniqueConstituents.find(ele => isSameAstNode(ele, constituentNode)) ??
         cachedTypeMap.get(type);
 
-      if (duplicatedPrev) {
+      if (duplicatedPrevious) {
         report('duplicate', constituentNode, {
           type: unionOrIntersection,
-          previous: sourceCode.getText(duplicatedPrev),
+          previous: sourceCode.getText(duplicatedPrevious),
         });
         return;
       }

--- a/packages/eslint-plugin/tests/rules/no-duplicate-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-type-constituents.test.ts
@@ -598,13 +598,6 @@ type T = A | (A | A);
           },
           messageId: 'duplicate',
         },
-        {
-          data: {
-            previous: 'A',
-            type: 'Union',
-          },
-          messageId: 'duplicate',
-        },
       ],
       output: `
 type A = 'A';
@@ -642,6 +635,72 @@ type C = 'C';
 type D = 'D';
 type F = (A | B)   | ((C | D) & (A | B))  ;
       `,
+    },
+    {
+      code: 'type A = (number | string) | number | string;',
+      errors: [
+        {
+          data: {
+            previous: 'number',
+            type: 'Union',
+          },
+          messageId: 'duplicate',
+        },
+        {
+          data: {
+            previous: 'string',
+            type: 'Union',
+          },
+          messageId: 'duplicate',
+        },
+      ],
+      output: 'type A = (number | string)    ;',
+    },
+    {
+      code: 'type A = (number | (string | null)) | (string | (null | number));',
+      errors: [
+        {
+          data: {
+            previous: 'number | (string | null)',
+            type: 'Union',
+          },
+          messageId: 'duplicate',
+        },
+      ],
+      output: 'type A = (number | (string | null))  ;',
+    },
+    {
+      code: 'type A = (number & string) & number & string;',
+      errors: [
+        {
+          data: {
+            previous: 'number',
+            type: 'Intersection',
+          },
+          messageId: 'duplicate',
+        },
+        {
+          data: {
+            previous: 'string',
+            type: 'Intersection',
+          },
+          messageId: 'duplicate',
+        },
+      ],
+      output: 'type A = (number & string)    ;',
+    },
+    {
+      code: 'type A = number & string & (number & string);',
+      errors: [
+        {
+          data: {
+            previous: 'number & string',
+            type: 'Intersection',
+          },
+          messageId: 'duplicate',
+        },
+      ],
+      output: 'type A = number & string  ;',
     },
     {
       code: `
@@ -767,6 +826,16 @@ type T = Record<string, A  >;
       code: 'type fn = (a?: string | undefined) => void;',
       errors: [{ messageId: 'unnecessary' }],
       output: 'type fn = (a?: string  ) => void;',
+    },
+    {
+      code: 'type fn = (a?: string | (undefined | number)) => void;',
+      errors: [{ messageId: 'unnecessary' }],
+      output: 'type fn = (a?: string | (  number)) => void;',
+    },
+    {
+      code: 'type fn = (a?: (undefined | number) | string) => void;',
+      errors: [{ messageId: 'unnecessary' }],
+      output: 'type fn = (a?: (  number) | string) => void;',
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-duplicate-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-duplicate-type-constituents.test.ts
@@ -637,6 +637,41 @@ type F = (A | B)   | ((C | D) & (A | B))  ;
       `,
     },
     {
+      code: `
+type A = 'A';
+type B = 'B';
+type C = (A | B) | A | B | (A | B);
+      `,
+      errors: [
+        {
+          data: {
+            previous: 'A',
+            type: 'Union',
+          },
+          messageId: 'duplicate',
+        },
+        {
+          data: {
+            previous: 'B',
+            type: 'Union',
+          },
+          messageId: 'duplicate',
+        },
+        {
+          data: {
+            previous: 'A | B',
+            type: 'Union',
+          },
+          messageId: 'duplicate',
+        },
+      ],
+      output: `
+type A = 'A';
+type B = 'B';
+type C = (A | B)      ;
+      `,
+    },
+    {
       code: 'type A = (number | string) | number | string;',
       errors: [
         {
@@ -694,13 +729,23 @@ type F = (A | B)   | ((C | D) & (A | B))  ;
       errors: [
         {
           data: {
-            previous: 'number & string',
+            previous: 'number',
+            type: 'Intersection',
+          },
+          messageId: 'duplicate',
+        },
+        {
+          data: {
+            previous: 'string',
             type: 'Intersection',
           },
           messageId: 'duplicate',
         },
       ],
-      output: 'type A = number & string  ;',
+      output: [
+        'type A = number & string & (  string);',
+        'type A = number & string    ;',
+      ],
     },
     {
       code: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #9496 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

It addresses #9496.
Changed to recursively traverse constituents to find nested duplicate types.
<!-- Description of what is changed and how the code change does that. -->
