### PR TITLE
feat(eslint-plugin): [no-unnecessary-condition] make `allowConstantLoopConditions` more granular

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -124,21 +124,21 @@ do {
 } while (true);
 ```
 
-#### `'neverExceptWhileTrue'`
+#### `'only-true'`
 
 Disallow constant conditions in all loops except `while` loops with expression `true`.
 
-Example of correct code for `{ allowConstantLoopConditions: 'neverExceptWhileTrue' }`:
+Example of correct code for `{ allowConstantLoopConditions: 'only-true' }`:
 
-```ts option='{ "allowConstantLoopConditions": "neverExceptWhileTrue" }' showPlaygroundButton
+```ts option='{ "allowConstantLoopConditions": "only-true" }' showPlaygroundButton
 while (true) {
   // ...
 }
 ```
 
-Example of incorrect code for `{ allowConstantLoopConditions: 'neverExceptWhileTrue' }`:
+Example of incorrect code for `{ allowConstantLoopConditions: 'only-true' }`:
 
-```ts option='{ "allowConstantLoopConditions": "neverExceptWhileTrue" }' showPlaygroundButton
+```ts option='{ "allowConstantLoopConditions": "only-true" }' showPlaygroundButton
 for (; true; ) {
   // ...
 }

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -141,13 +141,23 @@ while (true) {
 Example of incorrect code for `{ allowConstantLoopConditions: 'only-allowed-literals' }`:
 
 ```ts option='{ "allowConstantLoopConditions": "only-allowed-literals" }' showPlaygroundButton
-for (; true; ) {
+declare const alwaysTrue: true;
+
+// `alwaysTrue` has the type `true` (which isn't allowed)
+// as only the literal value of `true` is allowed
+
+while (alwaysTrue) {
   // ...
 }
 
-do {
+// same for booleans as only the literal value of `true` or `false`
+// are allowed
+
+declare const bool: boolean;
+
+while (bool) {
   // ...
-} while (true);
+}
 ```
 
 ### `checkTypePredicates`

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -124,21 +124,23 @@ do {
 } while (true);
 ```
 
-#### `'only-true'`
+#### `'only-allowed-literals'`
 
-Disallow constant conditions in all loops except `while` loops with expression `true`.
+Disallow constant conditions in all loops except `while` loops with certain literal expressions.
 
-Example of correct code for `{ allowConstantLoopConditions: 'only-true' }`:
+Specifically, `true`, `false`, `0`, and `1` are allowed despite always being truthy or falsy, as these are common patterns and are not likely to represent developer errors.
 
-```ts option='{ "allowConstantLoopConditions": "only-true" }' showPlaygroundButton
+Example of correct code for `{ allowConstantLoopConditions: 'only-allowed-literals' }`:
+
+```ts option='{ "allowConstantLoopConditions": "only-allowed-literals" }' showPlaygroundButton
 while (true) {
   // ...
 }
 ```
 
-Example of incorrect code for `{ allowConstantLoopConditions: 'only-true' }`:
+Example of incorrect code for `{ allowConstantLoopConditions: 'only-allowed-literals' }`:
 
-```ts option='{ "allowConstantLoopConditions": "only-true" }' showPlaygroundButton
+```ts option='{ "allowConstantLoopConditions": "only-allowed-literals" }' showPlaygroundButton
 for (; true; ) {
   // ...
 }

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -84,9 +84,9 @@ function bar(arg?: string | null) {
 
 {/* insert option description */}
 
-#### `'never'` or `false`
+#### `'never'`
 
-Disallow constant conditions in loops.
+Disallow constant conditions in loops. Same as `false`.
 
 Example of incorrect code for `{ allowConstantLoopConditions: 'never' }`:
 
@@ -104,9 +104,9 @@ do {
 } while (true);
 ```
 
-#### `'always'` or `true`
+#### `'always'`
 
-Allow constant conditions in loops.
+Allow constant conditions in loops. Same as `true`.
 
 Example of correct code for `{ allowConstantLoopConditions: 'always' }`:
 
@@ -141,21 +141,21 @@ while (true) {
 Example of incorrect code for `{ allowConstantLoopConditions: 'only-allowed-literals' }`:
 
 ```ts option='{ "allowConstantLoopConditions": "only-allowed-literals" }' showPlaygroundButton
-declare const alwaysTrue: true;
+// `alwaysTrue` has the type of `true` (which isn't allowed)
+// as only the literal value of `true` is allowed.
 
-// `alwaysTrue` has the type `true` (which isn't allowed)
-// as only the literal value of `true` is allowed
+declare const alwaysTrue: true;
 
 while (alwaysTrue) {
   // ...
 }
 
-// same for booleans as only the literal value of `true` or `false`
-// are allowed
+// not even a variable that references the value of `true` is allowed, only
+// the literal value of `true` used directly.
 
-declare const bool: boolean;
+const thisIsTrue = true;
 
-while (bool) {
+while (thisIsTrue) {
   // ...
 }
 ```

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -126,7 +126,7 @@ do {
 
 #### `'only-allowed-literals'`
 
-Disallow constant conditions in all loops except `while` loops with certain literal expressions.
+Permit idiomatic constant literal conditions in `while` loop conditions.
 
 Specifically, `true`, `false`, `0`, and `1` are allowed despite always being truthy or falsy, as these are common patterns and are not likely to represent developer errors.
 

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -84,12 +84,68 @@ function bar(arg?: string | null) {
 
 {/* insert option description */}
 
-Example of correct code for `{ allowConstantLoopConditions: true }`:
+#### `'never'` or `false`
 
-```ts option='{ "allowConstantLoopConditions": true }' showPlaygroundButton
-while (true) {}
-for (; true; ) {}
-do {} while (true);
+Disallow constant conditions in loops.
+
+Example of incorrect code for `{ allowConstantLoopConditions: 'never' }`:
+
+```ts option='{ "allowConstantLoopConditions": "never" }' showPlaygroundButton
+while (true) {
+  // ...
+}
+
+for (; true; ) {
+  // ...
+}
+
+do {
+  // ...
+} while (true);
+```
+
+#### `'always'` or `true`
+
+Allow constant conditions in loops.
+
+Example of correct code for `{ allowConstantLoopConditions: 'always' }`:
+
+```ts option='{ "allowConstantLoopConditions": "always" }' showPlaygroundButton
+while (true) {
+  // ...
+}
+
+for (; true; ) {
+  // ...
+}
+
+do {
+  // ...
+} while (true);
+```
+
+#### `'neverExceptWhileTrue'`
+
+Disallow constant conditions in all loops except `while` loops with expression `true`.
+
+Example of correct code for `{ allowConstantLoopConditions: 'neverExceptWhileTrue' }`:
+
+```ts option='{ "allowConstantLoopConditions": "neverExceptWhileTrue" }' showPlaygroundButton
+while (true) {
+  // ...
+}
+```
+
+Example of incorrect code for `{ allowConstantLoopConditions: 'neverExceptWhileTrue' }`:
+
+```ts option='{ "allowConstantLoopConditions": "neverExceptWhileTrue" }' showPlaygroundButton
+for (; true; ) {
+  // ...
+}
+
+do {
+  // ...
+} while (true);
 ```
 
 ### `checkTypePredicates`

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -221,11 +221,11 @@ export default createRule<Options, MessageId>({
         additionalProperties: false,
         properties: {
           allowConstantLoopConditions: {
+            description:
+              'Whether to ignore constant loop conditions, such as `while (true)`.',
             oneOf: [
               {
                 type: 'boolean',
-                description:
-                  'Whether to ignore constant loop conditions, such as `while (true)`.',
               },
               {
                 type: 'string',
@@ -249,7 +249,7 @@ export default createRule<Options, MessageId>({
   },
   defaultOptions: [
     {
-      allowConstantLoopConditions: 'always',
+      allowConstantLoopConditions: 'never',
       allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
       checkTypePredicates: false,
     },
@@ -563,12 +563,7 @@ export default createRule<Options, MessageId>({
     function checkIfWhileLoopIsNecessaryConditional(
       node: TSESTree.WhileStatement,
     ): void {
-      /**
-       * Allow:
-       *   while (true) {}
-       *   for (;true;) {}
-       *   do {} while (true)
-       */
+      // allow: `while (true) {}`
       if (
         allowConstantLoopConditionsOption === 'neverExceptWhileTrue' &&
         node.test.type === AST_NODE_TYPES.Literal &&

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -156,7 +156,7 @@ function booleanComparison(
 
 type LegacyAllowConstantLoopConditions = boolean;
 
-type AllowConstantLoopConditions = 'always' | 'never' | 'neverExceptWhileTrue';
+type AllowConstantLoopConditions = 'always' | 'never' | 'only-true';
 
 export type Options = [
   {
@@ -229,7 +229,7 @@ export default createRule<Options, MessageId>({
               },
               {
                 type: 'string',
-                enum: ['always', 'never', 'neverExceptWhileTrue'],
+                enum: ['always', 'never', 'only-true'],
               },
             ],
           },
@@ -565,7 +565,7 @@ export default createRule<Options, MessageId>({
     ): void {
       // allow: `while (true) {}`
       if (
-        allowConstantLoopConditionsOption === 'neverExceptWhileTrue' &&
+        allowConstantLoopConditionsOption === 'only-true' &&
         node.test.type === AST_NODE_TYPES.Literal &&
         node.test.value === true
       ) {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -156,7 +156,14 @@ function booleanComparison(
 
 type LegacyAllowConstantLoopConditions = boolean;
 
-type AllowConstantLoopConditions = 'always' | 'never' | 'only-true';
+type AllowConstantLoopConditions = 'always' | 'never' | 'only-allowed-literals';
+
+const constantLoopConditionsAllowedLiterals = new Set<unknown>([
+  true,
+  false,
+  1,
+  0,
+]);
 
 export type Options = [
   {
@@ -229,7 +236,7 @@ export default createRule<Options, MessageId>({
               },
               {
                 type: 'string',
-                enum: ['always', 'never', 'only-true'],
+                enum: ['always', 'never', 'only-allowed-literals'],
               },
             ],
           },
@@ -563,11 +570,10 @@ export default createRule<Options, MessageId>({
     function checkIfWhileLoopIsNecessaryConditional(
       node: TSESTree.WhileStatement,
     ): void {
-      // allow: `while (true) {}`
       if (
-        allowConstantLoopConditionsOption === 'only-true' &&
+        allowConstantLoopConditionsOption === 'only-allowed-literals' &&
         node.test.type === AST_NODE_TYPES.Literal &&
-        node.test.value === true
+        constantLoopConditionsAllowedLiterals.has(node.test.value)
       ) {
         return;
       }

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
@@ -107,15 +107,25 @@ while (true) {
 exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 6`] = `
 "Options: { "allowConstantLoopConditions": "only-allowed-literals" }
 
-for (; true; ) {
-       ~~~~ Unnecessary conditional, value is always truthy.
+// \`alwaysTrue\` has the type of \`true\` (which isn't allowed)
+// as only the literal value of \`true\` is allowed.
+
+declare const alwaysTrue: true;
+
+while (alwaysTrue) {
+       ~~~~~~~~~~ Unnecessary conditional, value is always truthy.
   // ...
 }
 
-do {
+// not even a variable that references the value of \`true\` is allowed, only
+// the literal value of \`true\` used directly.
+
+const thisIsTrue = true;
+
+while (thisIsTrue) {
+       ~~~~~~~~~~ Unnecessary conditional, value is always truthy.
   // ...
-} while (true);
-         ~~~~ Unnecessary conditional, value is always truthy.
+}
 "
 `;
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
@@ -96,7 +96,7 @@ do {
 `;
 
 exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 5`] = `
-"Options: { "allowConstantLoopConditions": "only-true" }
+"Options: { "allowConstantLoopConditions": "only-allowed-literals" }
 
 while (true) {
   // ...
@@ -105,7 +105,7 @@ while (true) {
 `;
 
 exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 6`] = `
-"Options: { "allowConstantLoopConditions": "only-true" }
+"Options: { "allowConstantLoopConditions": "only-allowed-literals" }
 
 for (; true; ) {
        ~~~~ Unnecessary conditional, value is always truthy.

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
@@ -96,7 +96,7 @@ do {
 `;
 
 exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 5`] = `
-"Options: { "allowConstantLoopConditions": "neverExceptWhileTrue" }
+"Options: { "allowConstantLoopConditions": "only-true" }
 
 while (true) {
   // ...
@@ -105,7 +105,7 @@ while (true) {
 `;
 
 exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 6`] = `
-"Options: { "allowConstantLoopConditions": "neverExceptWhileTrue" }
+"Options: { "allowConstantLoopConditions": "only-true" }
 
 for (; true; ) {
        ~~~~ Unnecessary conditional, value is always truthy.

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
@@ -59,7 +59,7 @@ function bar(arg?: string | null) {
 `;
 
 exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 3`] = `
-"Options: { "allowConstantLoopConditions": true }
+"Options: { "allowConstantLoopConditions": "always" }
 
 while (true) {}
 for (; true; ) {}
@@ -68,6 +68,45 @@ do {} while (true);
 `;
 
 exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 4`] = `
+"Options: { "allowConstantLoopConditions": "never" }
+
+while (true) {
+       ~~~~ Unnecessary conditional, value is always truthy.
+  doSomething();
+}
+
+for (; true; ) {
+       ~~~~ Unnecessary conditional, value is always truthy.
+  doSomething();
+}
+
+do {
+  doSomething();
+} while (true);
+         ~~~~ Unnecessary conditional, value is always truthy.
+"
+`;
+
+exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 5`] = `
+"Options: { "allowConstantLoopConditions": "neverExceptWhileTrue" }
+
+while (true) {
+  doSomething();
+}
+
+for (; true; ) {
+       ~~~~ Unnecessary conditional, value is always truthy.
+  doSomething();
+}
+
+do {
+  doSomething();
+} while (true);
+         ~~~~ Unnecessary conditional, value is always truthy.
+"
+`;
+
+exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 6`] = `
 "Options: { "checkTypePredicates": true }
 
 function assert(condition: unknown): asserts condition {

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-condition.shot
@@ -59,31 +59,39 @@ function bar(arg?: string | null) {
 `;
 
 exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 3`] = `
-"Options: { "allowConstantLoopConditions": "always" }
-
-while (true) {}
-for (; true; ) {}
-do {} while (true);
-"
-`;
-
-exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 4`] = `
 "Options: { "allowConstantLoopConditions": "never" }
 
 while (true) {
        ~~~~ Unnecessary conditional, value is always truthy.
-  doSomething();
+  // ...
 }
 
 for (; true; ) {
        ~~~~ Unnecessary conditional, value is always truthy.
-  doSomething();
+  // ...
 }
 
 do {
-  doSomething();
+  // ...
 } while (true);
          ~~~~ Unnecessary conditional, value is always truthy.
+"
+`;
+
+exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 4`] = `
+"Options: { "allowConstantLoopConditions": "always" }
+
+while (true) {
+  // ...
+}
+
+for (; true; ) {
+  // ...
+}
+
+do {
+  // ...
+} while (true);
 "
 `;
 
@@ -91,22 +99,27 @@ exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint 
 "Options: { "allowConstantLoopConditions": "neverExceptWhileTrue" }
 
 while (true) {
-  doSomething();
+  // ...
 }
+"
+`;
+
+exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 6`] = `
+"Options: { "allowConstantLoopConditions": "neverExceptWhileTrue" }
 
 for (; true; ) {
        ~~~~ Unnecessary conditional, value is always truthy.
-  doSomething();
+  // ...
 }
 
 do {
-  doSomething();
+  // ...
 } while (true);
          ~~~~ Unnecessary conditional, value is always truthy.
 "
 `;
 
-exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 6`] = `
+exports[`Validating rule docs no-unnecessary-condition.mdx code examples ESLint output 7`] = `
 "Options: { "checkTypePredicates": true }
 
 function assert(condition: unknown): asserts condition {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -2016,6 +2016,13 @@ while ((shouldRun = true)) {}
       options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
     },
     {
+      code: `
+while (false) {}
+      `,
+      errors: [{ column: 8, line: 2, messageId: 'alwaysFalsy' }],
+      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+    },
+    {
       code: noFormat`
 let foo = { bar: true };
 foo?.bar;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -464,7 +464,25 @@ do {} while (true);
       code: `
 while (true) {}
       `,
-      options: [{ allowConstantLoopConditions: 'only-true' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
+    },
+    {
+      code: `
+while (1) {}
+      `,
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
+    },
+    {
+      code: `
+while (false) {}
+      `,
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
+    },
+    {
+      code: `
+while (0) {}
+      `,
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
     },
     `
 let variable = 'abc' as string | void;
@@ -1972,7 +1990,16 @@ declare const test: true;
 while (test) {}
       `,
       errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'only-true' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
+    },
+    {
+      code: `
+declare const test: 1;
+
+while (test) {}
+      `,
+      errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
     },
     {
       code: `
@@ -1981,7 +2008,7 @@ declare const test: true;
 for (; test; ) {}
       `,
       errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'only-true' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
     },
     {
       code: `
@@ -1990,21 +2017,28 @@ declare const test: true;
 do {} while (test);
       `,
       errors: [{ column: 14, line: 4, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'only-true' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
     },
     {
       code: `
 for (; true; ) {}
       `,
       errors: [{ column: 8, line: 2, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'only-true' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
     },
     {
       code: `
-do {} while (true);
+for (; 0; ) {}
       `,
-      errors: [{ column: 14, line: 2, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'only-true' }],
+      errors: [{ column: 8, line: 2, messageId: 'alwaysFalsy' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
+    },
+    {
+      code: `
+do {} while (0);
+      `,
+      errors: [{ column: 14, line: 2, messageId: 'alwaysFalsy' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
     },
     {
       code: `
@@ -2013,14 +2047,21 @@ let shouldRun = true;
 while ((shouldRun = true)) {}
       `,
       errors: [{ column: 9, line: 4, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'only-true' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
     },
     {
       code: `
-while (false) {}
+while (2) {}
       `,
-      errors: [{ column: 8, line: 2, messageId: 'alwaysFalsy' }],
-      options: [{ allowConstantLoopConditions: 'only-true' }],
+      errors: [{ column: 8, line: 2, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
+    },
+    {
+      code: `
+while ('truthy') {}
+      `,
+      errors: [{ column: 8, line: 2, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
     },
     {
       code: noFormat`

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -464,7 +464,7 @@ do {} while (true);
       code: `
 while (true) {}
       `,
-      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+      options: [{ allowConstantLoopConditions: 'only-true' }],
     },
     `
 let variable = 'abc' as string | void;
@@ -1972,7 +1972,7 @@ declare const test: true;
 while (test) {}
       `,
       errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+      options: [{ allowConstantLoopConditions: 'only-true' }],
     },
     {
       code: `
@@ -1981,7 +1981,7 @@ declare const test: true;
 for (; test; ) {}
       `,
       errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+      options: [{ allowConstantLoopConditions: 'only-true' }],
     },
     {
       code: `
@@ -1990,21 +1990,21 @@ declare const test: true;
 do {} while (test);
       `,
       errors: [{ column: 14, line: 4, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+      options: [{ allowConstantLoopConditions: 'only-true' }],
     },
     {
       code: `
 for (; true; ) {}
       `,
       errors: [{ column: 8, line: 2, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+      options: [{ allowConstantLoopConditions: 'only-true' }],
     },
     {
       code: `
 do {} while (true);
       `,
       errors: [{ column: 14, line: 2, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+      options: [{ allowConstantLoopConditions: 'only-true' }],
     },
     {
       code: `
@@ -2013,14 +2013,14 @@ let shouldRun = true;
 while ((shouldRun = true)) {}
       `,
       errors: [{ column: 9, line: 4, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+      options: [{ allowConstantLoopConditions: 'only-true' }],
     },
     {
       code: `
 while (false) {}
       `,
       errors: [{ column: 8, line: 2, messageId: 'alwaysFalsy' }],
-      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+      options: [{ allowConstantLoopConditions: 'only-true' }],
     },
     {
       code: noFormat`

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -427,10 +427,44 @@ const x = b1 && b2;
     {
       code: `
 while (true) {}
+      `,
+      options: [{ allowConstantLoopConditions: true }],
+    },
+    {
+      code: `
 for (; true; ) {}
+      `,
+      options: [{ allowConstantLoopConditions: true }],
+    },
+    {
+      code: `
 do {} while (true);
       `,
       options: [{ allowConstantLoopConditions: true }],
+    },
+    {
+      code: `
+while (true) {}
+      `,
+      options: [{ allowConstantLoopConditions: 'always' }],
+    },
+    {
+      code: `
+for (; true; ) {}
+      `,
+      options: [{ allowConstantLoopConditions: 'always' }],
+    },
+    {
+      code: `
+do {} while (true);
+      `,
+      options: [{ allowConstantLoopConditions: 'always' }],
+    },
+    {
+      code: `
+while (true) {}
+      `,
+      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
     },
     `
 let variable = 'abc' as string | void;
@@ -1879,16 +1913,98 @@ function falsy() {}
     //     },
     {
       code: `
-while (true) {}
+declare const test: true;
+
+while (test) {}
+      `,
+      errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: false }],
+    },
+    {
+      code: `
+declare const test: true;
+
+for (; test; ) {}
+      `,
+      errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: false }],
+    },
+    {
+      code: `
+declare const test: true;
+
+do {} while (test);
+      `,
+      errors: [{ column: 14, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: false }],
+    },
+    {
+      code: `
+declare const test: true;
+
+while (test) {}
+      `,
+      errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'never' }],
+    },
+    {
+      code: `
+declare const test: true;
+
+for (; test; ) {}
+      `,
+      errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'never' }],
+    },
+    {
+      code: `
+declare const test: true;
+
+do {} while (test);
+      `,
+      errors: [{ column: 14, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'never' }],
+    },
+    {
+      code: `
+declare const test: true;
+
+while (test) {}
+      `,
+      errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+    },
+    {
+      code: `
+declare const test: true;
+
+for (; test; ) {}
+      `,
+      errors: [{ column: 8, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+    },
+    {
+      code: `
+declare const test: true;
+
+do {} while (test);
+      `,
+      errors: [{ column: 14, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+    },
+    {
+      code: `
 for (; true; ) {}
+      `,
+      errors: [{ column: 8, line: 2, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+    },
+    {
+      code: `
 do {} while (true);
       `,
-      errors: [
-        { column: 8, line: 2, messageId: 'alwaysTruthy' },
-        { column: 8, line: 3, messageId: 'alwaysTruthy' },
-        { column: 14, line: 4, messageId: 'alwaysTruthy' },
-      ],
-      options: [{ allowConstantLoopConditions: false }],
+      errors: [{ column: 14, line: 2, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
     },
     {
       code: noFormat`

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -2007,6 +2007,15 @@ do {} while (true);
       options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
     },
     {
+      code: `
+let shouldRun = true;
+
+while ((shouldRun = true)) {}
+      `,
+      errors: [{ column: 9, line: 4, messageId: 'alwaysTruthy' }],
+      options: [{ allowConstantLoopConditions: 'neverExceptWhileTrue' }],
+    },
+    {
       code: noFormat`
 let foo = { bar: true };
 foo?.bar;

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
@@ -15,7 +15,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
             "type": "boolean"
           },
           {
-            "enum": ["always", "never", "neverExceptWhileTrue"],
+            "enum": ["always", "never", "only-true"],
             "type": "string"
           }
         ]
@@ -42,7 +42,7 @@ type Options = [
     allowConstantLoopConditions?:
       | 'always'
       | 'never'
-      | 'neverExceptWhileTrue'
+      | 'only-true'
       /** Whether to ignore constant loop conditions, such as \`while (true)\`. */
       | boolean;
     /** Whether to not error when running with a tsconfig that has strictNullChecks turned. */

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
@@ -9,9 +9,9 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowConstantLoopConditions": {
+        "description": "Whether to ignore constant loop conditions, such as \`while (true)\`.",
         "oneOf": [
           {
-            "description": "Whether to ignore constant loop conditions, such as \`while (true)\`.",
             "type": "boolean"
           },
           {
@@ -38,6 +38,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
+    /** Whether to ignore constant loop conditions, such as \`while (true)\`. */
     allowConstantLoopConditions?:
       | 'always'
       | 'never'

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
@@ -15,7 +15,7 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
             "type": "boolean"
           },
           {
-            "enum": ["always", "never", "only-true"],
+            "enum": ["always", "never", "only-allowed-literals"],
             "type": "string"
           }
         ]
@@ -42,7 +42,7 @@ type Options = [
     allowConstantLoopConditions?:
       | 'always'
       | 'never'
-      | 'only-true'
+      | 'only-allowed-literals'
       /** Whether to ignore constant loop conditions, such as \`while (true)\`. */
       | boolean;
     /** Whether to not error when running with a tsconfig that has strictNullChecks turned. */

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-condition.shot
@@ -9,8 +9,16 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
     "additionalProperties": false,
     "properties": {
       "allowConstantLoopConditions": {
-        "description": "Whether to ignore constant loop conditions, such as \`while (true)\`.",
-        "type": "boolean"
+        "oneOf": [
+          {
+            "description": "Whether to ignore constant loop conditions, such as \`while (true)\`.",
+            "type": "boolean"
+          },
+          {
+            "enum": ["always", "never", "neverExceptWhileTrue"],
+            "type": "string"
+          }
+        ]
       },
       "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
         "description": "Whether to not error when running with a tsconfig that has strictNullChecks turned.",
@@ -30,8 +38,12 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
 
 type Options = [
   {
-    /** Whether to ignore constant loop conditions, such as \`while (true)\`. */
-    allowConstantLoopConditions?: boolean;
+    allowConstantLoopConditions?:
+      | 'always'
+      | 'never'
+      | 'neverExceptWhileTrue'
+      /** Whether to ignore constant loop conditions, such as \`while (true)\`. */
+      | boolean;
     /** Whether to not error when running with a tsconfig that has strictNullChecks turned. */
     allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
     /** Whether to check the asserted argument of a type predicate function for unnecessary conditions */


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7047
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR attempts to tackle #7047 and changes `allowConstantLoopConditions` from a `boolean` to the following `enum`:
- `'never'`: same as the current `false`
- `'neverExceptWhileTrue'`: disallows constant conditions in all loops except `while` loops with the literal `true`.
- `'always'`: same as the current `true`

This is a non-breaking change as the existing options map to the new option (minus `neverExceptWhileTrue`).

---

Some thoughts:

I've used a similar option name for `'neverExceptWhileTrue'` as [`no-constant-condition`'s `checkLoops`](https://eslint.org/docs/latest/rules/no-constant-condition#checkloops). The option name is somewhat limiting because it's so specific, it may be better to have an option name that's a bit less specific to allow future changes(?).

The original issue suggests that the default may be changed on a future major. However, since `'neverExceptWhileTrue'` is similar to the current default (`'never'`) but allows for an additional use-case, I think it can be considered to become the new default, especially since the pattern it allows is relatively common (or so I think).