### PR TITLE
test(visitor-keys): add test to guard redundant visitor keys

### DIFF
--- a/packages/visitor-keys/src/visitor-keys.ts
+++ b/packages/visitor-keys/src/visitor-keys.ts
@@ -132,13 +132,9 @@ type AdditionalKeys = {
  */
 
 const SharedVisitorKeys = (() => {
-  const FunctionType = ['typeParameters', 'params', 'returnType'] as const;
-  const AnonymousFunction = [...FunctionType, 'body'] as const;
-  const AbstractPropertyDefinition = [
-    'decorators',
-    'key',
-    'typeAnnotation',
-  ] as const;
+  const FunctionType = ['typeParameters', 'returnType'] as const;
+  const AnonymousFunction = [...FunctionType] as const;
+  const AbstractPropertyDefinition = ['decorators', 'typeAnnotation'] as const;
 
   return {
     AbstractPropertyDefinition: ['decorators', 'key', 'typeAnnotation'],
@@ -146,47 +142,44 @@ const SharedVisitorKeys = (() => {
     AsExpression: ['expression', 'typeAnnotation'],
     ClassDeclaration: [
       'decorators',
-      'id',
       'typeParameters',
-      'superClass',
       'superTypeArguments',
       'implements',
-      'body',
     ],
-    Function: ['id', ...AnonymousFunction],
+    Function: [...AnonymousFunction],
     FunctionType,
-    PropertyDefinition: [...AbstractPropertyDefinition, 'value'],
+    PropertyDefinition: [...AbstractPropertyDefinition],
   } as const;
 })();
 
-const additionalKeys: AdditionalKeys = {
+export const additionalKeys: AdditionalKeys = {
   AccessorProperty: SharedVisitorKeys.PropertyDefinition,
-  ArrayPattern: ['decorators', 'elements', 'typeAnnotation'],
+  ArrayPattern: ['decorators', 'typeAnnotation'],
   ArrowFunctionExpression: SharedVisitorKeys.AnonymousFunction,
-  AssignmentPattern: ['decorators', 'left', 'right', 'typeAnnotation'],
-  CallExpression: ['callee', 'typeArguments', 'arguments'],
+  AssignmentPattern: ['decorators', 'typeAnnotation'],
+  CallExpression: ['typeArguments'],
   ClassDeclaration: SharedVisitorKeys.ClassDeclaration,
   ClassExpression: SharedVisitorKeys.ClassDeclaration,
   Decorator: ['expression'],
-  ExportAllDeclaration: ['exported', 'source', 'assertions'],
-  ExportNamedDeclaration: ['declaration', 'specifiers', 'source', 'assertions'],
+  ExportAllDeclaration: ['assertions'],
+  ExportNamedDeclaration: ['assertions'],
   FunctionDeclaration: SharedVisitorKeys.Function,
   FunctionExpression: SharedVisitorKeys.Function,
   Identifier: ['decorators', 'typeAnnotation'],
-  ImportAttribute: ['key', 'value'],
-  ImportDeclaration: ['specifiers', 'source', 'assertions'],
-  ImportExpression: ['source', 'options'],
+  ImportAttribute: [],
+  ImportDeclaration: ['assertions'],
+  ImportExpression: [],
   JSXClosingFragment: [],
-  JSXOpeningElement: ['name', 'typeArguments', 'attributes'],
+  JSXOpeningElement: ['typeArguments'],
   JSXOpeningFragment: [],
-  JSXSpreadChild: ['expression'],
-  MethodDefinition: ['decorators', 'key', 'value'],
-  NewExpression: ['callee', 'typeArguments', 'arguments'],
-  ObjectPattern: ['decorators', 'properties', 'typeAnnotation'],
+  JSXSpreadChild: [],
+  MethodDefinition: ['decorators'],
+  NewExpression: ['typeArguments'],
+  ObjectPattern: ['decorators', 'typeAnnotation'],
   PropertyDefinition: SharedVisitorKeys.PropertyDefinition,
-  RestElement: ['decorators', 'argument', 'typeAnnotation'],
-  StaticBlock: ['body'],
-  TaggedTemplateExpression: ['tag', 'typeArguments', 'quasi'],
+  RestElement: ['decorators', 'typeAnnotation'],
+  StaticBlock: [],
+  TaggedTemplateExpression: ['typeArguments'],
   TSAbstractAccessorProperty: SharedVisitorKeys.AbstractPropertyDefinition,
   TSAbstractKeyword: [],
   TSAbstractMethodDefinition: ['key', 'value'],

--- a/packages/visitor-keys/tests/visitor-keys.test.ts
+++ b/packages/visitor-keys/tests/visitor-keys.test.ts
@@ -1,6 +1,8 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/types';
 
 import { visitorKeys } from '../src';
+import { additionalKeys } from '../src/visitor-keys';
+import { KEYS as eslintVisitorKeys } from 'eslint-visitor-keys';
 
 const types = new Set(Object.keys(AST_NODE_TYPES));
 const keys = new Set(Object.keys(visitorKeys));
@@ -31,6 +33,16 @@ describe('Every visitor key should have an ast node type defined', () => {
 
     it(key, () => {
       expect(types.has(key)).toBeTruthy();
+    });
+  }
+});
+
+describe('No redundant additional keys', () => {
+  for (const [node, keys] of Object.entries(additionalKeys)) {
+    it(node, () => {
+      const eslintKeys = eslintVisitorKeys[node] || [];
+      const redundant = keys.filter(key => eslintKeys.includes(key));
+      expect(redundant).toEqual([]);
     });
   }
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

From #10649 I found there are quite some redundant visitor keys that mostly might due to the updates in `eslint-vistior-keys`. In order to locate them, I write a simple test to guard them - not sure if you consider them valid testing. With the tests, in this PR, I also removed the keys that are considered redundant.

Feel free to close this PR if it's not desired