### PR TITLE
fix(eslint-plugin): check JSX spread elements for misused spread usage

### DIFF
--- a/packages/eslint-plugin/src/rules/no-misused-spread.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-spread.ts
@@ -99,7 +99,9 @@ export default createRule<Options, MessageIds>({
       }
     }
 
-    function checkObjectSpread(node: TSESTree.SpreadElement): void {
+    function checkObjectSpread(
+      node: TSESTree.JSXSpreadAttribute | TSESTree.SpreadElement,
+    ): void {
       const type = getConstrainedTypeAtLocation(services, node.argument);
 
       if (typeMatchesSomeSpecifier(type, options.allow, services.program)) {
@@ -175,6 +177,7 @@ export default createRule<Options, MessageIds>({
     return {
       'ArrayExpression > SpreadElement': checkArrayOrCallSpread,
       'CallExpression > SpreadElement': checkArrayOrCallSpread,
+      JSXSpreadAttribute: checkObjectSpread,
       'ObjectExpression > SpreadElement': checkObjectSpread,
     };
   },

--- a/packages/eslint-plugin/tests/rules/no-misused-spread.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-spread.test.ts
@@ -133,6 +133,32 @@ ruleTester.run('no-misused-spread', rule, {
 
       const o = { ...promiseLike };
     `,
+    {
+      code: `
+        const obj = { a: 1, b: 2 };
+        const o = <div {...x} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+        declare const obj: { a: number; b: number } | any;
+        const o = <div {...x} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
 
     {
       code: `
@@ -1492,6 +1518,155 @@ ruleTester.run('no-misused-spread', rule, {
           messageId: 'noClassInstanceSpreadInObject',
         },
       ],
+    },
+
+    {
+      code: `
+        const o = <div {...[1, 2, 3]} />;
+      `,
+      errors: [
+        {
+          column: 24,
+          endColumn: 38,
+          line: 2,
+          messageId: 'noArraySpreadInObject',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+        class A {}
+
+        const o = <div {...A} />;
+      `,
+      errors: [
+        {
+          column: 24,
+          endColumn: 30,
+          line: 4,
+          messageId: 'noClassDeclarationSpreadInObject',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+        const o = <div {...new Date()} />;
+      `,
+      errors: [
+        {
+          column: 24,
+          endColumn: 39,
+          line: 2,
+          messageId: 'noClassInstanceSpreadInObject',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+        function f() {}
+
+        const o = <div {...f} />;
+      `,
+      errors: [
+        {
+          column: 24,
+          endColumn: 30,
+          line: 4,
+          messageId: 'noFunctionSpreadInObject',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+        const o = <div {...new Set([1, 2, 3])} />;
+      `,
+      errors: [
+        {
+          column: 24,
+          endColumn: 47,
+          line: 2,
+          messageId: 'noIterableSpreadInObject',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+        declare const map: Map<string, number>;
+
+        const o = <div {...map} />;
+      `,
+      errors: [
+        {
+          column: 24,
+          endColumn: 32,
+          line: 4,
+          messageId: 'noMapSpreadInObject',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+        const promise = new Promise(() => {});
+
+        const o = <div {...promise} />;
+      `,
+      errors: [
+        {
+          column: 24,
+          endColumn: 36,
+          line: 4,
+          messageId: 'noPromiseSpreadInObject',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
     },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10648
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR addresses #10648 and adjusts the rule to check `JSXSpreadAttribute` nodes for being valid object-spread.

I didn't add any check for the other type of JSX spread node, `JSXSpreadChild`, as it seems TypeScript always flags it if it isn't an array:

```ts
<div>{...x}</div>
```

Even if the type being spread is a `string`, it still gets reported by TypeScript ([playground link](https://typescript-eslint.io/play/#ts=4.8.4&fileType=.tsx&code=CYUwxgNghgTiAEYD2A7AzgF3gDwFz0xgEsUBzAbgChKAeYIgNwD4BvAOg%2BwF8aB6e5lSA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1oFtLlZkiACa1kxaIgCGQ9FETRoHaJHBgAviDVA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)). I've checked this is reported on the lowest version of TypeScript on the playground (`v4.8.4`).