### PR TITLE
docs: [no-misused-spread] fix sample code

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-misused-spread.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misused-spread.mdx
@@ -54,7 +54,7 @@ declare class Box {
 const boxSpread = { ...Box };
 
 declare const instance: Box;
-const instanceSpread = { ...box };
+const instanceSpread = { ...instance };
 ```
 
 </TabItem>


### PR DESCRIPTION
## Overview

Fix wrong variable name

```typescript
declare const instance: Box;
const instanceSpread = { ...box };
// 2552: Cannot find name 'box'. Did you mean 'Box'? 7:29 - 7:32
```

[Current playground](https://typescript-eslint.io/play/#eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1oFtLlZkiACa1kxaIgCGQ9FETRoHaJHBgAviDVA&code=CYUwxgNghgTiAEkoGdnwEIHsAe8DeAUPPAG5QQCuIAXPAHYUC2ARiDANwEC%2BBYmdyAC7xmOAMoAHOFGDwAvPngA6FVlxdOBUEjiJ%2BQ%2BAEsBgqHTA0MOTnxNGTZi5OmyFeZStHr2QA&fileType=.ts)