### PR TITLE
fix(type-utils): support matching intersection types in `TypeOrValueSpecifier` with a `PackageSpecifier`

### DIFF
--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -167,42 +167,50 @@ export function typeMatchesSpecifier(
   specifier: TypeOrValueSpecifier,
   program: ts.Program,
 ): boolean {
-  if (tsutils.isIntrinsicErrorType(type)) {
-    return false;
-  }
-  if (tsutils.isIntersectionType(type)) {
-    const somePartMatches = tsutils
-      .intersectionTypeParts(type)
-      .some(part => typeMatchesSpecifier(part, specifier, program));
-
-    if (somePartMatches) {
-      return true;
+  const wholeTypeMatches = ((): boolean => {
+    if (tsutils.isIntrinsicErrorType(type)) {
+      return false;
     }
+    if (typeof specifier === 'string') {
+      return specifierNameMatches(type, specifier);
+    }
+    if (!specifierNameMatches(type, specifier.name)) {
+      return false;
+    }
+    const symbol = type.getSymbol() ?? type.aliasSymbol;
+    const declarations = symbol?.getDeclarations() ?? [];
+    const declarationFiles = declarations.map(declaration =>
+      declaration.getSourceFile(),
+    );
+    switch (specifier.from) {
+      case 'file':
+        return typeDeclaredInFile(specifier.path, declarationFiles, program);
+      case 'lib':
+        return typeDeclaredInLib(declarationFiles, program);
+      case 'package':
+        return typeDeclaredInPackageDeclarationFile(
+          specifier.package,
+          declarations,
+          declarationFiles,
+          program,
+        );
+    }
+  })();
+
+  if (wholeTypeMatches) {
+    return true;
   }
-  if (typeof specifier === 'string') {
-    return specifierNameMatches(type, specifier);
+
+  if (
+    tsutils.isIntersectionType(type) &&
+    tsutils
+      .intersectionTypeParts(type)
+      .some(part => typeMatchesSpecifier(part, specifier, program))
+  ) {
+    return true;
   }
-  if (!specifierNameMatches(type, specifier.name)) {
-    return false;
-  }
-  const symbol = type.getSymbol() ?? type.aliasSymbol;
-  const declarations = symbol?.getDeclarations() ?? [];
-  const declarationFiles = declarations.map(declaration =>
-    declaration.getSourceFile(),
-  );
-  switch (specifier.from) {
-    case 'file':
-      return typeDeclaredInFile(specifier.path, declarationFiles, program);
-    case 'lib':
-      return typeDeclaredInLib(declarationFiles, program);
-    case 'package':
-      return typeDeclaredInPackageDeclarationFile(
-        specifier.package,
-        declarations,
-        declarationFiles,
-        program,
-      );
-  }
+
+  return false;
 }
 
 export const typeMatchesSomeSpecifier = (

--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -170,6 +170,15 @@ export function typeMatchesSpecifier(
   if (tsutils.isIntrinsicErrorType(type)) {
     return false;
   }
+  if (tsutils.isIntersectionType(type)) {
+    const somePartMatches = tsutils
+      .intersectionTypeParts(type)
+      .some(part => typeMatchesSpecifier(part, specifier, program));
+
+    if (somePartMatches) {
+      return true;
+    }
+  }
   if (typeof specifier === 'string') {
     return specifierNameMatches(type, specifier);
   }
@@ -200,18 +209,5 @@ export const typeMatchesSomeSpecifier = (
   type: ts.Type,
   specifiers: TypeOrValueSpecifier[] = [],
   program: ts.Program,
-): boolean => {
-  if (
-    specifiers.some(specifier => typeMatchesSpecifier(type, specifier, program))
-  ) {
-    return true;
-  }
-
-  if (tsutils.isIntersectionType(type)) {
-    return tsutils
-      .intersectionTypeParts(type)
-      .some(part => typeMatchesSomeSpecifier(part, specifiers, program));
-  }
-
-  return false;
-};
+): boolean =>
+  specifiers.some(specifier => typeMatchesSpecifier(type, specifier, program));

--- a/packages/type-utils/src/TypeOrValueSpecifier.ts
+++ b/packages/type-utils/src/TypeOrValueSpecifier.ts
@@ -200,5 +200,18 @@ export const typeMatchesSomeSpecifier = (
   type: ts.Type,
   specifiers: TypeOrValueSpecifier[] = [],
   program: ts.Program,
-): boolean =>
-  specifiers.some(specifier => typeMatchesSpecifier(type, specifier, program));
+): boolean => {
+  if (
+    specifiers.some(specifier => typeMatchesSpecifier(type, specifier, program))
+  ) {
+    return true;
+  }
+
+  if (tsutils.isIntersectionType(type)) {
+    return tsutils
+      .intersectionTypeParts(type)
+      .some(part => typeMatchesSomeSpecifier(part, specifiers, program));
+  }
+
+  return false;
+};

--- a/packages/type-utils/src/typeOrValueSpecifiers/specifierNameMatches.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/specifierNameMatches.ts
@@ -1,7 +1,5 @@
 import type * as ts from 'typescript';
 
-import * as tsutils from 'ts-api-utils';
-
 export function specifierNameMatches(
   type: ts.Type,
   names: string | string[],
@@ -17,10 +15,6 @@ export function specifierNameMatches(
 
   if (names.some(item => candidateNames.includes(item))) {
     return true;
-  }
-
-  if (tsutils.isIntersectionType(type)) {
-    return type.types.some(subType => specifierNameMatches(subType, names));
   }
 
   return false;

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 
 import type { TypeOrValueSpecifier } from '../src/TypeOrValueSpecifier';
 
-import { typeMatchesSomeSpecifier, typeOrValueSpecifiersSchema } from '../src';
+import { typeMatchesSpecifier, typeOrValueSpecifiersSchema } from '../src';
 
 describe('TypeOrValueSpecifier', () => {
   describe('Schema', () => {
@@ -122,7 +122,7 @@ describe('TypeOrValueSpecifier', () => {
     ])("doesn't match a malformed package specifier: %s", runTestNegative);
   });
 
-  describe('typeMatchesSomeSpecifier', () => {
+  describe('typeMatchesSpecifier', () => {
     function runTests(
       code: string,
       specifier: TypeOrValueSpecifier,
@@ -143,9 +143,9 @@ describe('TypeOrValueSpecifier', () => {
               .id,
           ),
         );
-      expect(
-        typeMatchesSomeSpecifier(type, [specifier], services.program!),
-      ).toBe(expected);
+      expect(typeMatchesSpecifier(type, specifier, services.program!)).toBe(
+        expected,
+      );
     }
 
     function runTestPositive(


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10665
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR attempts to tackle #10665 and adds support for matching intersection types with `TypeOrValueSpecifier` with a [`PackageSpecifier`](https://typescript-eslint.io/packages/type-utils/type-or-value-specifier/#packagespecifier).

I've written my thoughts about this issue on https://github.com/typescript-eslint/typescript-eslint/issues/10665#issuecomment-2596137452.

---

Some more thoughts:

- This also affects [`LibSpecifier`](https://typescript-eslint.io/packages/type-utils/type-or-value-specifier/#libspecifier) (which I think is correct), though I couldn't find an actual type on TypeScript's built-in lib types to test this on.

- It seems that for nested intersections the specifier won't match (I think this is [mentioned here too](https://github.com/typescript-eslint/typescript-eslint/blob/70f3092d7d4b039317735a0c8abe2229d5678dd6/packages/type-utils/tests/TypeOrValueSpecifier.test.ts#L380-L381)).

- This is somewhat related to https://github.com/typescript-eslint/typescript-eslint/issues/9303.