### PR TITLE
test(eslint-plugin): adjust tests to verify `no-unnecessary-type-assertion` doesn't report template literals with expressions

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -294,12 +294,12 @@ function bar(items: string[]) {
     },
     // https://github.com/typescript-eslint/typescript-eslint/issues/8737
     `
-let myString = 'foo';
+const myString = 'foo';
 const templateLiteral = \`\${myString}-somethingElse\` as const;
     `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/8737
     `
-let myString = 'foo';
+const myString = 'foo';
 const templateLiteral = <const>\`\${myString}-somethingElse\`;
     `,
     'let a = `a` as const;',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -294,13 +294,17 @@ function bar(items: string[]) {
     },
     // https://github.com/typescript-eslint/typescript-eslint/issues/8737
     `
-const myString = 'foo';
+declare const myString: 'foo';
 const templateLiteral = \`\${myString}-somethingElse\` as const;
     `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/8737
     `
-const myString = 'foo';
+declare const myString: 'foo';
 const templateLiteral = <const>\`\${myString}-somethingElse\`;
+    `,
+    `
+const myString = 'foo';
+const templateLiteral = \`\${myString}-somethingElse\` as const;
     `,
     'let a = `a` as const;',
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

I've noticed this while reviewing https://github.com/typescript-eslint/typescript-eslint/pull/10618.

To my understanding, these tests should make sure the rule [doesn't report on template literals with expressions](https://github.com/typescript-eslint/typescript-eslint/blob/31be0532065491d9141cbddfe42dd771eadc0a82/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts#L171-L175).

It seems that even if this check is removed, these tests still pass. I think it's related to "fresh literals" ([more on this here](https://github.com/typescript-eslint/typescript-eslint/pull/10631)), as is shown below ([playground link](https://typescript-eslint.io/play/#ts=5.7.3&fileType=.ts&code=MYewdgzgLgBAZiEMC8MDkCRoNwChcD0BMUAFgKYwAGFANrUgCQDemAvlTOQB4AOATuQgQAluBgATEEJigArmFgBDCDCUxaIqOX5LauUJFjboARhTU6DGC3acVs8NDxEYb9wD0A-PlrlYAEZK-BZoQfw4%2BK5klDTk9EzM4RxcfILCYmCS0hBgaLDyimqq6prauvquDlpoqiJgcDqCEsWW8dYs0Pz1AOYcBk7GQlAATBZxCTZJwSkOhs6ExO5u3rhAA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Jge1tiacTJTIAhtEK0ipWkOTJE0fJQ5N0UOdA7RI4MAF8QOoA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)):

```ts
const foo = 'foo';

// the `hello ${foo}` expression does count as a literal
const test1 = `hello ${foo}` as const;
//      ^?

let bar = 'bar';

// the `hello ${bar}` expression doesn't count as a literal
// as it's inferred as `hello ${string}`
const test2 = `hello ${bar}` as const;
//      ^?
```

The expression coming from a widened `let` variable [doesn't count as a literal](https://github.com/typescript-eslint/typescript-eslint/blob/31be0532065491d9141cbddfe42dd771eadc0a82/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts#L227), and it falls back to [being checked as a non-literal](https://github.com/typescript-eslint/typescript-eslint/blob/31be0532065491d9141cbddfe42dd771eadc0a82/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts#L229) (which always allows `as const` assertions).

This PR adjusts the tests to fail if this check is removed or changed incorrectly (this seems correct [according to the original issue](https://github.com/typescript-eslint/typescript-eslint/issues/8737)).