### PR TITLE
chore(eslint-plugin): consistently use `it` in tests

### DIFF
--- a/packages/eslint-plugin/tests/areOptionsValid.test.ts
+++ b/packages/eslint-plugin/tests/areOptionsValid.test.ts
@@ -17,16 +17,16 @@ const exampleRule = createRule<['value-a' | 'value-b'], never>({
   name: 'my-example-rule',
 });
 
-test('returns true for valid options', () => {
+it('returns true for valid options', () => {
   expect(areOptionsValid(exampleRule, ['value-a'])).toBe(true);
 });
 
 describe('returns false for invalid options', () => {
-  test('bad enum value', () => {
+  it('bad enum value', () => {
     expect(areOptionsValid(exampleRule, ['value-c'])).toBe(false);
   });
 
-  test('bad type', () => {
+  it('bad type', () => {
     expect(areOptionsValid(exampleRule, [true])).toBe(false);
   });
 });

--- a/packages/eslint-plugin/tests/docs.test.ts
+++ b/packages/eslint-plugin/tests/docs.test.ts
@@ -221,7 +221,7 @@ describe('Validating rule docs', () => {
       const filePath = path.join(docsRoot, `${ruleName}.mdx`);
       const { fullText, tokens } = parseMarkdownFile(filePath);
 
-      test(`${ruleName}.mdx must start with frontmatter description`, () => {
+      it(`${ruleName}.mdx must start with frontmatter description`, () => {
         expect(tokens[0]).toMatchObject({
           raw: '---\n',
           type: 'hr',
@@ -235,7 +235,7 @@ describe('Validating rule docs', () => {
         });
       });
 
-      test(`${ruleName}.mdx must next have a blockquote directing to website`, () => {
+      it(`${ruleName}.mdx must next have a blockquote directing to website`, () => {
         expect(tokens[4]).toMatchObject({
           text: [
             `🛑 This file is source code, not the primary documentation location! 🛑`,
@@ -247,7 +247,7 @@ describe('Validating rule docs', () => {
         });
       });
 
-      test(`headings must be title-cased`, () => {
+      it(`headings must be title-cased`, () => {
         // Get all H2 headings objects as the other levels are variable by design.
         const headings = tokens.filter(tokenIsH2);
 
@@ -269,7 +269,7 @@ describe('Validating rule docs', () => {
         ...requiredHeadings,
       ]);
 
-      test('important headings must be h2s', () => {
+      it('important headings must be h2s', () => {
         for (const heading of headings) {
           if (importantHeadings.has(heading.raw.replaceAll('#', '').trim())) {
             expect(heading.depth).toBe(2);
@@ -278,7 +278,7 @@ describe('Validating rule docs', () => {
       });
 
       if (!rules[ruleName as keyof typeof rules].meta.docs?.extendsBaseRule) {
-        test('must include required headings', () => {
+        it('must include required headings', () => {
           const headingTexts = new Set(
             tokens.filter(tokenIsH2).map(token => token.text),
           );
@@ -314,7 +314,7 @@ describe('Validating rule docs', () => {
               for (const property of Object.keys(
                 schemaItem.properties as object,
               )) {
-                test(property, () => {
+                it(property, () => {
                   const correspondingHeadingIndex =
                     headingsAfterOptions.findIndex(heading =>
                       heading.text.includes(`\`${property}\``),
@@ -359,7 +359,7 @@ describe('Validating rule docs', () => {
         });
       }
 
-      test('must include only valid code samples', () => {
+      it('must include only valid code samples', () => {
         for (const token of tokens) {
           if (token.type !== 'code') {
             continue;
@@ -385,7 +385,7 @@ describe('Validating rule docs', () => {
         }
       });
 
-      test('code examples ESLint output', () => {
+      it('code examples ESLint output', () => {
         // TypeScript can't infer type arguments unless we provide them explicitly
         linter.defineRule<
           keyof (typeof rule)['meta']['messages'],
@@ -528,7 +528,7 @@ ${token.value}`,
   }
 });
 
-test('There should be no obsolete ESLint output snapshots', () => {
+it('There should be no obsolete ESLint output snapshots', () => {
   const files = fs.readdirSync(eslintOutputSnapshotFolder);
   const names = new Set(Object.keys(rules).map(k => `${k}.shot`));
 

--- a/packages/eslint-plugin/tests/rules/array-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/array-type.test.ts
@@ -2232,14 +2232,14 @@ type BrokenArray = {
 
 describe('schema validation', () => {
   // https://github.com/typescript-eslint/typescript-eslint/issues/6852
-  test("array-type does not accept 'simple-array' option", () => {
+  it("array-type does not accept 'simple-array' option", () => {
     if (areOptionsValid(rule, [{ default: 'simple-array' }])) {
       throw new Error(`Options succeeded validation for bad options`);
     }
   });
 
   // https://github.com/typescript-eslint/typescript-eslint/issues/6892
-  test('array-type does not accept non object option', () => {
+  it('array-type does not accept non object option', () => {
     if (areOptionsValid(rule, ['array'])) {
       throw new Error(`Options succeeded validation for bad options`);
     }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -964,7 +964,7 @@ describe('fixer should not change runtime value', () => {
       continue;
     }
 
-    test(code, () => {
+    it(code, () => {
       expect(eval(code)).toEqual(
         eval(Array.isArray(output) ? output.at(-1)! : output),
       );

--- a/packages/eslint-plugin/tests/schemas.test.ts
+++ b/packages/eslint-plugin/tests/schemas.test.ts
@@ -104,7 +104,7 @@ describe('Rule schemas should be convertible to TS types for documentation purpo
   }
 });
 
-test('There should be no old snapshots for rules that have been deleted', () => {
+it('There should be no old snapshots for rules that have been deleted', () => {
   const files = fs.readdirSync(snapshotFolder);
   const names = new Set(
     Object.keys(rules)
@@ -191,7 +191,7 @@ describe('Rule schemas should validate options correctly', () => {
   };
 
   for (const [ruleName, rule] of Object.entries(rules)) {
-    test(`${ruleName} must accept valid options`, () => {
+    it(`${ruleName} must accept valid options`, () => {
       if (
         !areOptionsValid(
           rule,
@@ -202,7 +202,7 @@ describe('Rule schemas should validate options correctly', () => {
       }
     });
 
-    test(`${ruleName} rejects arbitrary options`, () => {
+    it(`${ruleName} rejects arbitrary options`, () => {
       if (areOptionsValid(rule, [{ 'arbitrary-schemas.test.ts': true }])) {
         throw new Error(`Options succeeded validation for arbitrary options`);
       }


### PR DESCRIPTION
Changes a few occurrences of `test(name, fn)` to use `it(name, fn)` for consistency with the rest of the codebase.

## PR Checklist

- [x] Addresses an existing open issue: #7112
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
