### PR TITLE
feat(types): add strict `parent` types for function-declaration, default-export and named-export nodes

### DIFF
--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -72,6 +72,34 @@ declare module './generated/ast-spec' {
       | TSESTree.ImportDeclaration;
   }
 
+  interface ExportDefaultDeclaration {
+    parent: TSESTree.BlockStatement | TSESTree.Program | TSESTree.TSModuleBlock;
+  }
+
+  interface ExportNamedDeclarationWithoutSourceWithMultiple {
+    parent: TSESTree.BlockStatement | TSESTree.Program | TSESTree.TSModuleBlock;
+  }
+
+  interface ExportNamedDeclarationWithoutSourceWithSingle {
+    parent: TSESTree.BlockStatement | TSESTree.Program | TSESTree.TSModuleBlock;
+  }
+
+  interface ExportNamedDeclarationWithSource {
+    parent: TSESTree.BlockStatement | TSESTree.Program | TSESTree.TSModuleBlock;
+  }
+
+  interface FunctionDeclarationWithName {
+    parent:
+      | TSESTree.BlockStatement
+      | TSESTree.ExportDefaultDeclaration
+      | TSESTree.ExportNamedDeclaration
+      | TSESTree.Program;
+  }
+
+  interface FunctionDeclarationWithOptionalName {
+    parent: TSESTree.ExportDefaultDeclaration;
+  }
+
   interface JSXAttribute {
     parent: TSESTree.JSXOpeningElement;
   }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10682
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10682, follows #9560 up, and adds strict `parent` types for the proposed changes.