### PR TITLE
chore: control coverage by COLLECT_COVERAGE env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,9 +205,10 @@ jobs:
         run: npx nx test ${{ matrix.package }}
         env:
           CI: true
+          COLLECT_COVERAGE: true
       - name: Run unit tests for ${{ matrix.package }}
         if: env.PRIMARY_NODE_VERSION != matrix.node-version || matrix.os != 'ubuntu-latest'
-        run: npx nx test ${{ matrix.package }} --coverage=false
+        run: npx nx test ${{ matrix.package }}
         env:
           CI: true
 

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -6,7 +6,7 @@ const path = require('node:path');
 // @ts-check
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  collectCoverage: true,
+  collectCoverage: process.env.COLLECT_COVERAGE === 'true',
   collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
   coverageReporters: ['lcov'],
   moduleFileExtensions: [

--- a/packages/eslint-plugin-internal/package.json
+++ b/packages/eslint-plugin-internal/package.json
@@ -19,7 +19,7 @@
     "postclean": "rimraf dist && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "lint": "npx nx lint",
-    "test": "jest --coverage",
+    "test": "jest",
     "typecheck": "npx tsc --noEmit"
   },
   "dependencies": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -55,8 +55,8 @@
     "generate:breaking-changes": "tsx tools/generate-breaking-changes.mts",
     "generate:configs": "npx nx generate-configs repo",
     "lint": "npx nx lint",
-    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest --coverage --logHeapUsage",
-    "test-single": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest --no-coverage",
+    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest --logHeapUsage",
+    "test-single": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" jest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "lint": "npx nx lint",
-    "test": "jest --no-coverage",
+    "test": "jest",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -45,7 +45,7 @@
     "postclean": "rimraf dist && rimraf _ts4.3 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "lint": "npx nx lint",
-    "test": "jest --coverage",
+    "test": "jest",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/rule-schema-to-typescript-types/package.json
+++ b/packages/rule-schema-to-typescript-types/package.json
@@ -30,7 +30,7 @@
     "generate-sponsors": "tsx ./src/generate-sponsors.ts",
     "lint": "npx nx lint",
     "postinstall-script": "tsx ./src/postinstall.ts",
-    "test": "npx jest --coverage",
+    "test": "jest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@jest/types": "29.6.3",
+    "jest": "29.7.0",
     "typescript": "*"
   },
   "funding": {

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -43,7 +43,7 @@
     "lint": "npx nx lint",
     "pretest-eslint-base": "tsc -b tsconfig.build.json",
     "test-eslint-base": "mocha --require source-map-support/register ./tests/eslint-base/eslint-base.test.js",
-    "test": "npx jest --coverage",
+    "test": "jest",
     "typecheck": "tsc --noEmit"
   },
   "//": "NOTE - AJV is out-of-date, but it's intentionally synced with ESLint - https://github.com/eslint/eslint/blob/ad9dd6a933fd098a0d99c6a9aa059850535c23ee/package.json#L70",
@@ -67,6 +67,7 @@
     "eslint-visitor-keys": "^4.2.0",
     "espree": "^10.3.0",
     "esprima": "^4.0.1",
+    "jest": "29.7.0",
     "mocha": "^10.4.0",
     "sinon": "^16.1.3",
     "source-map-support": "^0.5.21",

--- a/packages/scope-manager/package.json
+++ b/packages/scope-manager/package.json
@@ -42,7 +42,7 @@
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "generate-lib": "npx nx generate-lib repo",
     "lint": "npx nx lint",
-    "test": "npx nx test --code-coverage",
+    "test": "npx nx test",
     "typecheck": "npx nx typecheck"
   },
   "dependencies": {

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -42,7 +42,7 @@
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf _ts4.3 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "lint": "npx nx lint",
-    "test": "jest --coverage",
+    "test": "jest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -48,7 +48,7 @@
     "postclean": "rimraf dist && rimraf _ts4.3 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "lint": "nx lint",
-    "test": "jest --coverage --passWithNoTests",
+    "test": "jest --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -50,7 +50,7 @@
     "postclean": "rimraf dist && rimraf _ts4.3 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "lint": "npx nx lint",
-    "test": "jest --coverage --runInBand --verbose",
+    "test": "jest --runInBand --verbose",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -59,7 +59,7 @@
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf _ts4.3 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "lint": "npx nx lint",
-    "test": "jest --coverage",
+    "test": "jest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/visitor-keys/package.json
+++ b/packages/visitor-keys/package.json
@@ -43,7 +43,7 @@
     "postclean": "rimraf dist && rimraf _ts3.4 && rimraf _ts4.3 && rimraf coverage",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
     "lint": "npx nx lint",
-    "test": "jest --coverage",
+    "test": "jest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5816,6 +5816,7 @@ __metadata:
     "@jest/types": 29.6.3
     "@typescript-eslint/type-utils": 8.21.0
     "@typescript-eslint/utils": 8.21.0
+    jest: 29.7.0
     natural-compare: ^1.4.0
     prettier: ^3.2.5
     typescript: "*"
@@ -5837,6 +5838,7 @@ __metadata:
     eslint-visitor-keys: ^4.2.0
     espree: ^10.3.0
     esprima: ^4.0.1
+    jest: 29.7.0
     json-stable-stringify-without-jsonify: ^1.0.1
     lodash.merge: 4.6.2
     mocha: ^10.4.0


### PR DESCRIPTION
Changes the CI and package scripts such that there is no longer a forced `--coverage` flag in some packages. Instead, it is now determined by the `COLLECT_COVERAGE` environment variable.

This is the alternative to #10582 

## PR Checklist

- [x] Addresses an existing open issue
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
