### PR TITLE
docs(eslint-plugin): [no-unused-vars] add types-only values FAQ

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
@@ -103,7 +103,7 @@ const schema = z.object({
   value: z.number(),
 });
 
-export type Box = z.infer<typeof box>;
+export type Box = z.infer<typeof schema>;
 ```
 
 Instead, it's often cleaner and less code to write out the types directly:

--- a/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
@@ -57,7 +57,7 @@ Also see similar rules provided by ESLint:
 - [`no-unused-private-class-members`](https://eslint.org/docs/latest/rules/no-unused-private-class-members)
 - [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels)
 
-### Why does this rule report variables used for types?
+### Why does this rule report variables used only for types?
 
 This rule does not count type-only uses when determining whether a variable is used.
 Declaring variables only to use them for types adds code and runtime complexity.

--- a/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
@@ -12,7 +12,11 @@ import TabItem from '@theme/TabItem';
 This rule extends the base [`eslint/no-unused-vars`](https://eslint.org/docs/rules/no-unused-vars) rule.
 It adds support for TypeScript features, such as types.
 
-## Benefits Over TypeScript
+## Options
+
+## FAQs
+
+### What benefits does this rule have over TypeScript?
 
 TypeScript provides [`noUnusedLocals`](https://www.typescriptlang.org/tsconfig#noUnusedLocals) and [`noUnusedParameters`](https://www.typescriptlang.org/tsconfig#noUnusedParameters) compiler options that can report errors on unused local variables or parameters, respectively.
 Those compiler options can be convenient to use if you don't want to set up ESLint and typescript-eslint.
@@ -52,3 +56,66 @@ Also see similar rules provided by ESLint:
 
 - [`no-unused-private-class-members`](https://eslint.org/docs/latest/rules/no-unused-private-class-members)
 - [`no-unused-labels`](https://eslint.org/docs/latest/rules/no-unused-labels)
+
+### Why does this rule report variables used for types?
+
+This rule does not count type-only uses when determining whether a variable is used.
+Declaring variables only to use them for types adds code and runtime complexity.
+The variables are never actually used at runtime.
+They can be misleading to readers of the code.
+
+<Tabs>
+
+<TabItem value="typeof Variables">
+
+For example, if a variable is only used for `typeof`, this rule will report:
+
+```ts
+const box = {
+  //  ~~~
+  //  'box' is assigned a value but only used as a type.
+  value: 123,
+};
+
+export type Box = typeof box;
+```
+
+Instead, it's often cleaner and less code to write out the types directly:
+
+```ts
+export interface Box {
+  value: number;
+}
+```
+
+</TabItem>
+
+<TabItem value="Zod Schemas">
+
+For example, if a Zod schema variable is only used for `typeof`, this rule will report:
+
+```ts
+import { z } from 'zod';
+
+const schema = z.object({
+  //  ~~~~~~
+  //  'schema' is assigned a value but only used as a type.
+  value: z.number(),
+});
+
+export type Box = z.infer<typeof box>;
+```
+
+Instead, it's often cleaner and less code to write out the types directly:
+
+```ts
+export interface Box {
+  value: number;
+}
+```
+
+</TabItem>
+
+</Tabs>
+
+If you find yourself writing runtime values only for types, consider refactoring your code to declare types directly.

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unused-vars.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unused-vars.shot
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Validating rule docs no-unused-vars.mdx code examples ESLint output 1`] = `
+"
+
+const box = {
+      ~~~ 'box' is assigned a value but only used as a type.
+  //  ~~~
+  //  'box' is assigned a value but only used as a type.
+  value: 123,
+};
+
+export type Box = typeof box;
+"
+`;
+
+exports[`Validating rule docs no-unused-vars.mdx code examples ESLint output 2`] = `
+"
+
+export interface Box {
+  value: number;
+}
+"
+`;
+
+exports[`Validating rule docs no-unused-vars.mdx code examples ESLint output 3`] = `
+"
+
+import { z } from 'zod';
+
+const schema = z.object({
+      ~~~~~~ 'schema' is assigned a value but never used.
+  //  ~~~~~~
+  //  'schema' is assigned a value but only used as a type.
+  value: z.number(),
+});
+
+export type Box = z.infer<typeof box>;
+"
+`;
+
+exports[`Validating rule docs no-unused-vars.mdx code examples ESLint output 4`] = `
+"
+
+export interface Box {
+  value: number;
+}
+"
+`;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10266
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Explains the broad overview of type-only variables being extra code + runtime complexity.

Adds a couple of straightforward examples in tags. I'm up for adding more on request, just didn't want to overload the page at first.

Uses a blank `## Options` section to push the FAQs to after `## How to Use` and `## Options`. Especially given https://github.com/eslint/eslint.org/pull/664 likely releasing soon, I feel less pressure than a few years ago to prioritize emphasizing why to use the rule over TS options.

💖 