### PR TITLE
fix(eslint-plugin): [switch-exhaustiveness-check] suggest with qualified name

### DIFF
--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -142,6 +142,16 @@ export default createRule<Options, MessageIds>({
       return;
     }
 
+    function typeToString(type: ts.Type): string {
+      return checker.typeToString(
+        type,
+        undefined,
+        ts.TypeFormatFlags.AllowUniqueESSymbolType |
+          ts.TypeFormatFlags.UseAliasDefinedOutsideCurrentScope |
+          ts.TypeFormatFlags.UseFullyQualifiedType,
+      );
+    }
+
     function getSwitchMetadata(node: TSESTree.SwitchStatement): SwitchMetadata {
       const defaultCase = node.cases.find(
         switchCase => switchCase.test == null,
@@ -230,7 +240,7 @@ export default createRule<Options, MessageIds>({
               .map(missingType =>
                 tsutils.isTypeFlagSet(missingType, ts.TypeFlags.ESSymbolLike)
                   ? `typeof ${missingType.getSymbol()?.escapedName as string}`
-                  : checker.typeToString(missingType),
+                  : typeToString(missingType),
               )
               .join(' | '),
           },
@@ -280,9 +290,8 @@ export default createRule<Options, MessageIds>({
           missingBranchType,
           ts.TypeFlags.ESSymbolLike,
         )
-          ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            missingBranchName!
-          : checker.typeToString(missingBranchType);
+          ? missingBranchName!
+          : typeToString(missingBranchType);
 
         if (
           symbolName &&

--- a/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/src/rules/switch-exhaustiveness-check.ts
@@ -290,7 +290,8 @@ export default createRule<Options, MessageIds>({
           missingBranchType,
           ts.TypeFlags.ESSymbolLike,
         )
-          ? missingBranchName!
+          ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            missingBranchName!
           : typeToString(missingBranchType);
 
         if (

--- a/packages/eslint-plugin/tests/fixtures/switch-exhaustiveness-check.ts
+++ b/packages/eslint-plugin/tests/fixtures/switch-exhaustiveness-check.ts
@@ -1,0 +1,6 @@
+export namespace A {
+  export enum B {
+    C,
+    D,
+  }
+}

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.json
@@ -15,6 +15,7 @@
     "mixed-enums-decl.ts",
     "react.tsx",
     "var-declaration.ts",
-    "errors.ts"
+    "errors.ts",
+    "switch-exhaustiveness-check.ts"
   ]
 }

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -2993,5 +2993,41 @@ switch (literal) {
         },
       ],
     },
+    {
+      code: `
+        import { A } from './switch-exhaustiveness-check';
+        declare const foo: A.B;
+        switch (foo) {
+          case A.B.C: {
+            break;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          data: {
+            missingBranches: 'A.B.D',
+          },
+          line: 4,
+          column: 17,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+        import { A } from './switch-exhaustiveness-check';
+        declare const foo: A.B;
+        switch (foo) {
+          case A.B.C: {
+            break;
+          }
+          case A.B.D: { throw new Error('Not implemented yet: A.B.D case') }
+        }
+      `,
+            },
+          ],
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -2964,12 +2964,12 @@ switch (literal) {
       `,
       errors: [
         {
-          messageId: 'switchIsNotExhaustive',
+          column: 17,
           data: {
             missingBranches: 'A.B.D',
           },
           line: 9,
-          column: 17,
+          messageId: 'switchIsNotExhaustive',
           suggestions: [
             {
               messageId: 'addMissingCases',
@@ -3005,12 +3005,12 @@ switch (literal) {
       `,
       errors: [
         {
-          messageId: 'switchIsNotExhaustive',
+          column: 17,
           data: {
             missingBranches: 'A.B.D',
           },
           line: 4,
-          column: 17,
+          messageId: 'switchIsNotExhaustive',
           suggestions: [
             {
               messageId: 'addMissingCases',

--- a/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
+++ b/packages/eslint-plugin/tests/rules/switch-exhaustiveness-check.test.ts
@@ -2947,5 +2947,51 @@ switch (literal) {
         },
       ],
     },
+    {
+      code: `
+        export namespace A {
+          export enum B {
+            C,
+            D,
+          }
+        }
+        declare const foo: A.B;
+        switch (foo) {
+          case A.B.C: {
+            break;
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: 'switchIsNotExhaustive',
+          data: {
+            missingBranches: 'A.B.D',
+          },
+          line: 9,
+          column: 17,
+          suggestions: [
+            {
+              messageId: 'addMissingCases',
+              output: `
+        export namespace A {
+          export enum B {
+            C,
+            D,
+          }
+        }
+        declare const foo: A.B;
+        switch (foo) {
+          case A.B.C: {
+            break;
+          }
+          case A.B.D: { throw new Error('Not implemented yet: A.B.D case') }
+        }
+      `,
+            },
+          ],
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7747
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This pr addresses #7747.
The default `TypeFormatFlags` for the `typeToString` method is `AllowUniqueESSymbolType | UseAliasDefinedOutsideCurrentScope`.
This pr adds `UseFullyQualifiedType` to change the type to a qualified name.

- [TypeScript/src/compiler/checker.ts](https://github.com/microsoft/TypeScript/blame/main/src/compiler/checker.ts)
```ts
function typeToString(
        type: Type,
        enclosingDeclaration?: Node,
        flags: TypeFormatFlags = TypeFormatFlags.AllowUniqueESSymbolType | TypeFormatFlags.UseAliasDefinedOutsideCurrentScope,
      // ...
    ): string {
        const noTruncation =
```

https://github.com/microsoft/TypeScript/blob/1c4083f4edc71cb1744a62013732e3c95d05a035/src/compiler/types.ts#L5538-L5540

```ts
    UseFullyQualifiedType                   = 1 << 6,  // Write out the fully qualified type name (eg. Module.Type, instead of Type)

```

<!-- Description of what is changed and how the code change does that. -->
