### PR TITLE
fix(eslint-plugin): [no-shadow] ignore declare variables in definition files shadowing global variables

### DIFF
--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -3,7 +3,7 @@ import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { DefinitionType, ScopeType } from '@typescript-eslint/scope-manager';
 import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 
-import { createRule } from '../util';
+import { createRule, isDefinitionFile } from '../util';
 import { isTypeImport } from '../util/isTypeImport';
 
 export type MessageIds = 'noShadow' | 'noShadowGlobal';
@@ -568,6 +568,28 @@ export default createRule<Options, MessageIds>({
     }
 
     /**
+     * Checks if the initialization of a variable has the declare modifier in a
+     * definition file.
+     * @param variable The variable to check.
+     * @returns Whether or not the initialization of a variable has the declare
+     * modifier in a definition file.
+     */
+    function isDeclareInDTSFile(variable: TSESLint.Scope.Variable): boolean {
+      const fileName = context.filename;
+      if (!isDefinitionFile(fileName)) {
+        return false;
+      }
+      return variable.defs.some(def => {
+        return (
+          (def.type === DefinitionType.Variable && def.parent.declare) ||
+          (def.type === DefinitionType.ClassName && def.node.declare) ||
+          (def.type === DefinitionType.TSEnumName && def.node.declare) ||
+          (def.type === DefinitionType.TSModuleName && def.node.declare)
+        );
+      });
+    }
+
+    /**
      * Checks the current context for shadowed variables.
      * @param scope Fixme
      */
@@ -602,6 +624,11 @@ export default createRule<Options, MessageIds>({
 
         // ignore configured allowed names
         if (isAllowed(variable)) {
+          continue;
+        }
+
+        // ignore variables with the declare keyword in .d.ts files
+        if (isDeclareInDTSFile(variable)) {
           continue;
         }
 

--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -569,9 +569,6 @@ export default createRule<Options, MessageIds>({
     /**
      * Checks if the initialization of a variable has the declare modifier in a
      * definition file.
-     * @param variable The variable to check.
-     * @returns Whether or not the initialization of a variable has the declare
-     * modifier in a definition file.
      */
     function isDeclareInDTSFile(variable: TSESLint.Scope.Variable): boolean {
       const fileName = context.filename;

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow.test.ts
@@ -931,6 +931,48 @@ function foo<T extends (...args: any[]) => any>(fn: T, args: any[]) {}
         },
       ],
     },
+    {
+      code: `
+declare const has = (environment: 'dev' | 'prod' | 'test') => boolean;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'has',
+          },
+          messageId: 'noShadowGlobal',
+        },
+      ],
+      languageOptions: {
+        globals: {
+          has: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: `
+declare const has: (environment: 'dev' | 'prod' | 'test') => boolean;
+const fn = (has: string) => {};
+      `,
+      errors: [
+        {
+          data: {
+            name: 'has',
+            shadowedColumn: 15,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+      filename: 'foo.d.ts',
+      languageOptions: {
+        globals: {
+          has: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
   ],
   valid: [
     'function foo<T = (arg: any) => any>(arg: T) {}',
@@ -1478,6 +1520,135 @@ type A = 1;
 type A = 1;
       `,
       options: [{ hoist: 'functions' }],
+    },
+    {
+      code: `
+declare const foo1: boolean;
+      `,
+      filename: 'baz.d.ts',
+      languageOptions: {
+        globals: {
+          foo1: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: `
+declare let foo2: boolean;
+      `,
+      filename: 'baz.d.ts',
+      languageOptions: {
+        globals: {
+          foo2: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: `
+declare var foo3: boolean;
+      `,
+      filename: 'baz.d.ts',
+      languageOptions: {
+        globals: {
+          foo3: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: `
+function foo4(name: string): void;
+      `,
+      filename: 'baz.d.ts',
+      languageOptions: {
+        globals: {
+          foo4: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: `
+declare class Foopy1 {
+  name: string;
+}
+      `,
+      filename: 'baz.d.ts',
+      languageOptions: {
+        globals: {
+          Foopy1: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: `
+declare interface Foopy2 {
+  name: string;
+}
+      `,
+      filename: 'baz.d.ts',
+      languageOptions: {
+        globals: {
+          Foopy2: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: `
+declare type Foopy3 = {
+  x: number;
+};
+      `,
+      filename: 'baz.d.ts',
+      languageOptions: {
+        globals: {
+          Foopy3: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: `
+declare enum Foopy4 {
+  x,
+}
+      `,
+      filename: 'baz.d.ts',
+      languageOptions: {
+        globals: {
+          Foopy4: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: `
+declare namespace Foopy5 {}
+      `,
+      filename: 'baz.d.ts',
+      languageOptions: {
+        globals: {
+          Foopy5: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
+    },
+    {
+      code: `
+declare;
+foo5: boolean;
+      `,
+      filename: 'baz.d.ts',
+      languageOptions: {
+        globals: {
+          foo5: false,
+        },
+      },
+      options: [{ builtinGlobals: true }],
     },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2654
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I added an additional guard clause checking if a variable has a `declare` tag and removing it from consideration under no-shadow if it does. The code may look very clunky because the conditional statements were derived through experimentation, so they may not catch all cases. Apologies for the mess, and do let me know how I may improve it.

There's one thing I couldn't figure out how to handle: The test case on `no-shadow.test.ts`, line `953` demonstrates the current behaviour when there is a `declare` keyword variable being shadowed by another in an inner scope. Should we have the error point to the `declare` variable or the global variable? 🧼

