### PR TITLE
docs: replace link to deprecated rule

### DIFF
--- a/docs/troubleshooting/typed-linting/Performance.mdx
+++ b/docs/troubleshooting/typed-linting/Performance.mdx
@@ -258,7 +258,7 @@ We recommend you do not use the following rules, as TypeScript provides the same
 - `import/namespace`
 - `import/default`
 - `import/no-named-as-default-member`
-- `import/no-unresolved` (as long as you are using [`import` over `require`](/rules/no-var-requires/))
+- `import/no-unresolved` (as long as you are using [`import` over `require`](/rules/no-require-imports))
 
 The following rules do not have equivalent checks in TypeScript, so we recommend that you only run them at CI/push time, to lessen the local performance burden.
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Replaces a link to the deprecated `no-var-requires` rule by the recommended `no-require-imports` rule.