### PR TITLE
feat(utils): add `reportUnusedInlineConfigs` to LinterOptions

### DIFF
--- a/packages/utils/src/ts-eslint/Config.ts
+++ b/packages/utils/src/ts-eslint/Config.ts
@@ -203,6 +203,8 @@ export namespace FlatConfig {
     /**
      * A severity string indicating if and how unused inline directives
      * should be tracked and reported.
+     *
+     * since ESLint 9.19.0
      * @default "off"
      */
     reportUnusedInlineConfigs?:

--- a/packages/utils/src/ts-eslint/Config.ts
+++ b/packages/utils/src/ts-eslint/Config.ts
@@ -200,6 +200,14 @@ export namespace FlatConfig {
       | boolean
       | SharedConfig.Severity
       | SharedConfig.SeverityString;
+    /**
+     * A severity string indicating if and how unused inline directives
+     * should be tracked and reported.
+     * @default "off"
+     */
+    reportUnusedInlineConfigs?:
+      | SharedConfig.Severity
+      | SharedConfig.SeverityString;
   }
 
   export interface LanguageOptions {


### PR DESCRIPTION
Follows https://github.com/eslint/eslint/pull/19201, released in https://github.com/eslint/eslint/releases/tag/v9.19.0. Currently, that flag is not yet usable with `typescriptEslint.config(…)` because of the missing type.

See also https://eslint.org/docs/latest/use/configure/configuration-files#configuration-objects.