### PR TITLE
fix(eslint-plugin): [restrict-plus-operands] report adding bigints to strings when `allowNumberAndString` is `false`

### DIFF
--- a/packages/eslint-plugin/docs/rules/restrict-plus-operands.mdx
+++ b/packages/eslint-plugin/docs/rules/restrict-plus-operands.mdx
@@ -171,6 +171,7 @@ let fn = (a: number, b: never) => a + b;
 ```ts option='{ "allowNumberAndString": true }'
 let fn = (a: number, b: string) => a + b;
 let fn = (a: number, b: number | string) => a + b;
+let fn = (a: bigint, b: string) => a + b;
 ```
 
 </TabItem>

--- a/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
+++ b/packages/eslint-plugin/src/rules/restrict-plus-operands.ts
@@ -218,7 +218,10 @@ export default createRule<Options, MessageIds>({
         if (
           !allowNumberAndString &&
           isTypeFlagSetInUnion(baseType, ts.TypeFlags.StringLike) &&
-          isTypeFlagSetInUnion(otherType, ts.TypeFlags.NumberLike)
+          isTypeFlagSetInUnion(
+            otherType,
+            ts.TypeFlags.NumberLike | ts.TypeFlags.BigIntLike,
+          )
         ) {
           return context.report({
             node,

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/restrict-plus-operands.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/restrict-plus-operands.shot
@@ -101,6 +101,7 @@ Options: { "allowNumberAndString": true }
 
 let fn = (a: number, b: string) => a + b;
 let fn = (a: number, b: number | string) => a + b;
+let fn = (a: bigint, b: string) => a + b;
 "
 `;
 

--- a/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-plus-operands.test.ts
@@ -371,6 +371,10 @@ const f = (a: string | number, b: string | number) => a + b;
         },
       ],
     },
+    {
+      code: "let foo = '1' + 1n;",
+      options: [{ allowNumberAndString: true }],
+    },
   ],
   invalid: [
     {
@@ -1769,6 +1773,23 @@ const f = (a: any, b: unknown) => a + b;
           allowRegExp: true,
         },
       ],
+    },
+    {
+      code: "let foo = '1' + 1n;",
+      errors: [
+        {
+          column: 11,
+          data: {
+            left: 'string',
+            right: 'bigint',
+            stringLike:
+              'string, allowing a string + any of: `any`, `boolean`, `null`, `RegExp`, `undefined`',
+          },
+          line: 1,
+          messageId: 'mismatched',
+        },
+      ],
+      options: [{ allowNumberAndString: false }],
     },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10715
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

If `allowNumberAndString` is set to `false`, `restrict-plus-operands` now reports when a `bigint` and a `string` are added, instead of just reporting for `number` and `string`. This is inline with the docs for `allowNumberAndString`:
> Whether to allow bigint/number typed values and string typed values to be added together.

## Example

`eslintrc`:
```json
{
  "rules": {
    "@typescript-eslint/restrict-plus-operands": [
      "error",
      {
          "allowNumberAndString": false
      }
    ]
  }
}
```
Code snippet:
```ts
let fnBigint = (a: bigint, b: string) => a + b;
```

> [!WARNING]
> Operands of '+' operations must be a number or string, allowing a string + any of: `any`, `boolean`, `null`, `RegExp`, `undefined`. Got `bigint` + `string`.