### PR TITLE
fix(eslint-plugin): [no-unnecessary-template-expression] allow interpolating type parameter in type context

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-template-expression.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-template-expression.mdx
@@ -67,6 +67,9 @@ enum ABC {
 }
 type ABCUnion = `${ABC}`;
 
+// Interpolating type parameters is allowed.
+type TextUtil<T extends string> = `${T}`;
+
 const stringWithNumber = `1 + 1 = 2`;
 
 const stringWithBoolean = `true is true`;

--- a/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
@@ -451,13 +451,14 @@ export default createRule<[], MessageId>({
           isTrivialInterpolation(node) &&
           !hasCommentsBetweenQuasi(node.quasis[0], node.quasis[1])
         ) {
-          const { constraintType } = getConstraintInfo(
+          const { constraintType, isTypeParameter } = getConstraintInfo(
             checker,
             services.getTypeAtLocation(node.types[0]),
           );
 
           if (
             constraintType &&
+            !isTypeParameter &&
             isUnderlyingTypeString(constraintType) &&
             !isEnumType(constraintType)
           ) {

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-template-expression.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-template-expression.shot
@@ -60,6 +60,9 @@ enum ABC {
 }
 type ABCUnion = \`\${ABC}\`;
 
+// Interpolating type parameters is allowed.
+type TextUtil<T extends string> = \`\${T}\`;
+
 const stringWithNumber = \`1 + 1 = 2\`;
 
 const stringWithBoolean = \`true is true\`;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -1190,6 +1190,11 @@ enum Foo {
 }
 type Bar = \`\${Foo.A}\`;
     `,
+    `
+function foo<T extends string>() {
+  const a: \`\${T}\` = 'a';
+}
+    `,
   ],
 
   invalid: [
@@ -1429,27 +1434,6 @@ enum Foo {
   B = 'B',
 }
 type Bar = Foo.A;
-      `,
-    },
-    {
-      code: `
-function foo<T extends string>() {
-  const a: \`\${T}\` = 'a';
-}
-      `,
-      errors: [
-        {
-          column: 13,
-          endColumn: 17,
-          endLine: 3,
-          line: 3,
-          messageId: 'noUnnecessaryTemplateExpression',
-        },
-      ],
-      output: `
-function foo<T extends string>() {
-  const a: T = 'a';
-}
       `,
     },
   ],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -1195,6 +1195,7 @@ function foo<T extends string>() {
   const a: \`\${T}\` = 'a';
 }
     `,
+    'type T<A extends string> = `${A}`;',
   ],
 
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10738
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

It addresses https://github.com/typescript-eslint/typescript-eslint/issues/10738.
Just as we allowed interpolation to convert an enum to a union, make it allow for the type parameter also.

<!-- Description of what is changed and how the code change does that. -->
