### PR TITLE
fix: fix behavior of `config-helper.ts` when base config contains only meta keys

### DIFF
--- a/packages/typescript-eslint/src/config-helper.ts
+++ b/packages/typescript-eslint/src/config-helper.ts
@@ -138,7 +138,11 @@ export function config(
           ...(name && { name }),
         };
       }),
-      config,
+      ...(Object.keys(config).every(key =>
+        ['name', 'files', 'ignores'].includes(key),
+      )
+        ? []
+        : [config]),
     ];
   });
 }

--- a/packages/typescript-eslint/tests/config-helper.test.ts
+++ b/packages/typescript-eslint/tests/config-helper.test.ts
@@ -247,4 +247,44 @@ describe('config helper', () => {
       { rules: { rule: 'error' } },
     ]);
   });
+
+  it('does not create global ignores in extends', () => {
+    expect(
+      plugin.config({
+        extends: [{ rules: { rule1: 'error' } }, { rules: { rule2: 'error' } }],
+        ignores: ['ignored'],
+      }),
+    ).toEqual([
+      { rules: { rule1: 'error' }, ignores: ['ignored'] },
+      { rules: { rule2: 'error' }, ignores: ['ignored'] },
+      // Should not create global ignores
+      // { ignores: ['ignored'] },
+    ]);
+  });
+
+  it('does not create extraneous config in extends', () => {
+    expect(
+      plugin.config({
+        extends: [{ rules: { rule1: 'error' } }, { rules: { rule2: 'error' } }],
+        files: ['file'],
+        ignores: ['ignored'],
+        name: 'my-config',
+      }),
+    ).toEqual([
+      {
+        rules: { rule1: 'error' },
+        files: ['file'],
+        ignores: ['ignored'],
+        name: 'my-config',
+      },
+      {
+        rules: { rule2: 'error' },
+        files: ['file'],
+        ignores: ['ignored'],
+        name: 'my-config',
+      },
+      // Should not create configuration object with no keys
+      // { name: "my-config", files: ["file"], ignores: ["ignored"] },
+    ]);
+  });
 });


### PR DESCRIPTION
- `config-helper.ts` only adds base config to config array if it contains keys other than `files`, `ignores`, `names`.
- Fixes bug where config helper would create global ignores when extending with base config of `ignores`
- Fixes bug where config helper creates extraneous config when extending with base config of only `files`, `ignores`, `names`

## PR Checklist

- [x] Addresses an existing open issue: fixes #10754
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Checks if base config only contains the keys `files`, `ignores`, or `names`. If so, do not add it to the config array by itself, and only use it for extending. Otherwise, add it to the config array.