### PR TITLE
fix: bump ts-api-utils to ^2.0.1

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -68,7 +68,7 @@
     "graphemer": "^1.4.0",
     "ignore": "^5.3.1",
     "natural-compare": "^1.4.0",
-    "ts-api-utils": "^2.0.0"
+    "ts-api-utils": "^2.0.1"
   },
   "devDependencies": {
     "@jest/types": "29.6.3",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -49,7 +49,7 @@
     "@typescript-eslint/typescript-estree": "8.22.0",
     "@typescript-eslint/utils": "8.22.0",
     "debug": "^4.3.4",
-    "ts-api-utils": "^2.0.0"
+    "ts-api-utils": "^2.0.1"
   },
   "peerDependencies": {
     "eslint": "^8.57.0 || ^9.0.0",

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -61,7 +61,7 @@
     "is-glob": "^4.0.3",
     "minimatch": "^9.0.4",
     "semver": "^7.6.0",
-    "ts-api-utils": "^2.0.0"
+    "ts-api-utils": "^2.0.1"
   },
   "devDependencies": {
     "@jest/types": "29.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5763,7 +5763,7 @@ __metadata:
     prettier: ^3.2.5
     rimraf: "*"
     title-case: ^3.0.3
-    ts-api-utils: ^2.0.0
+    ts-api-utils: ^2.0.1
     tsx: "*"
     typescript: "*"
     unist-util-visit: ^5.0.0
@@ -5881,7 +5881,7 @@ __metadata:
     jest: 29.7.0
     prettier: ^3.2.5
     rimraf: "*"
-    ts-api-utils: ^2.0.0
+    ts-api-utils: ^2.0.1
     typescript: "*"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
@@ -5998,7 +5998,7 @@ __metadata:
     rimraf: "*"
     semver: ^7.6.0
     tmp: "*"
-    ts-api-utils: ^2.0.0
+    ts-api-utils: ^2.0.1
     typescript: "*"
   peerDependencies:
     typescript: ">=4.8.4 <5.8.0"
@@ -19310,12 +19310,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "ts-api-utils@npm:2.0.0"
+"ts-api-utils@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "ts-api-utils@npm:2.0.1"
   peerDependencies:
     typescript: ">=4.8.4"
-  checksum: f16f3e4e3308e7ad7ccf0bec3e0cb2e06b46c2d6919c40b6439e37912409c72f14340d231343b2b1b8cc17c2b8b01c5f2418690ea788312db6ca4e72cf2df6d8
+  checksum: ca31f4dc3c0d69691599de2955b41879c27cb91257f2a468bbb444d3f09982a5f717a941fcebd3aaa092b778710647a0be1c2b1dd75cf6c82ceffc3bf4c7d27d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10747
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Consumers can already fix #10747 on their own by running `npm update ts-api-utils` or equivalent. But this forces folks to be on the fixed version.

💖 