### PR TITLE
feat(unified-signatures): support ignoring overload signatures with different JSDoc comments

### DIFF
--- a/packages/eslint-plugin/docs/rules/unified-signatures.mdx
+++ b/packages/eslint-plugin/docs/rules/unified-signatures.mdx
@@ -78,6 +78,50 @@ function f(b: string): void;
 </TabItem>
 </Tabs>
 
+### `ignoreOverloadsWithDifferentJSDoc`
+
+{/* insert option description */}
+
+Examples of code for this rule with `ignoreOverloadsWithDifferentJSDoc`:
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts option='{ "ignoreOverloadsWithDifferentJSDoc": true }'
+declare function f(x: string): void;
+declare function f(x: boolean): void;
+/**
+ * @deprecate
+ */
+declare function f(x: number): void;
+/**
+ * @deprecate
+ */
+declare function f(x: null): void;
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts option='{ "ignoreOverloadsWithDifferentJSDoc": true }'
+declare function f(x: string): void;
+/**
+ * This signature does something else.
+ */
+declare function f(x: boolean): void;
+/**
+ * @async
+ */
+declare function f(x: number): void;
+/**
+ * @deprecate
+ */
+declare function f(x: null): void;
+```
+
+</TabItem>
+</Tabs>
+
 ## When Not To Use It
 
 This is purely a stylistic rule to help with readability of function signature overloads.

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unified-signatures.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unified-signatures.shot
@@ -60,3 +60,42 @@ function f(a: number): void;
 function f(b: string): void;
 "
 `;
+
+exports[`Validating rule docs unified-signatures.mdx code examples ESLint output 8`] = `
+"Incorrect
+Options: { "ignoreOverloadsWithDifferentJSDoc": true }
+
+declare function f(x: string): void;
+declare function f(x: boolean): void;
+                   ~~~~~~~~~~ This overload and the one on line 1 can be combined into one signature taking \`string | boolean\`.
+/**
+ * @deprecate
+ */
+declare function f(x: number): void;
+/**
+ * @deprecate
+ */
+declare function f(x: null): void;
+                   ~~~~~~~ This overload and the one on line 6 can be combined into one signature taking \`number | null\`.
+"
+`;
+
+exports[`Validating rule docs unified-signatures.mdx code examples ESLint output 9`] = `
+"Correct
+Options: { "ignoreOverloadsWithDifferentJSDoc": true }
+
+declare function f(x: string): void;
+/**
+ * This signature does something else.
+ */
+declare function f(x: boolean): void;
+/**
+ * @async
+ */
+declare function f(x: number): void;
+/**
+ * @deprecate
+ */
+declare function f(x: null): void;
+"
+`;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -220,6 +220,145 @@ class C {
       `,
       options: [{ ignoreDifferentlyNamedParameters: true }],
     },
+    {
+      code: `
+/** @deprecated */
+declare function f(x: number): unknown;
+declare function f(x: boolean): unknown;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+declare function f(x: number): unknown;
+/** @deprecated */
+declare function f(x: boolean): unknown;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+declare function f(x: number): unknown;
+/** @deprecated */ declare function f(x: boolean): unknown;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+declare function f(x: string): void;
+/**
+ * @async
+ */
+declare function f(x: boolean): void;
+/**
+ * @deprecate
+ */
+declare function f(x: number): void;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+/**
+ * @deprecate
+ */
+declare function f(x: string): void;
+/**
+ * @async
+ */
+declare function f(x: boolean): void;
+declare function f(x: number): void;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+/**
+ * This signature does something.
+ */
+declare function f(x: number): void;
+
+/**
+ * This signature does something else.
+ */
+declare function f(x: string): void;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+/** @deprecated */
+export function f(x: number): unknown;
+export function f(x: boolean): unknown;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+export function f(x: number): unknown;
+/** @deprecated */
+export function f(x: boolean): unknown;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+export function f(x: string): void;
+/**
+ * @async
+ */
+export function f(x: boolean): void;
+/**
+ * @deprecate
+ */
+export function f(x: number): void;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+/**
+ * @deprecate
+ */
+export function f(x: string): void;
+/**
+ * @async
+ */
+export function f(x: boolean): void;
+export function f(x: number): void;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+/**
+ * This signature does something.
+ */
+export function f(x: number): void;
+
+/**
+ * This signature does something else.
+ */
+export function f(x: string): void;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+/**
+ * This signature does something.
+ */
+
+// some other comment
+export function f(x: number): void;
+
+/**
+ * This signature does something else.
+ */
+export function f(x: string): void;
+      `,
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
   ],
   invalid: [
     {
@@ -770,6 +909,231 @@ export default function (foo: number, bar?: string): string[];
           messageId: 'omittingSingleParameter',
         },
       ],
+    },
+    {
+      code: `
+/**
+ * @deprecate
+ */
+declare function f(x: string): void;
+declare function f(x: number): void;
+declare function f(x: boolean): void;
+      `,
+      errors: [
+        {
+          column: 20,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 6 can be combined into one signature',
+            type1: 'number',
+            type2: 'boolean',
+          },
+          line: 7,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+/**
+ * @deprecate
+ */
+declare function f(x: string): void;
+/**
+ * @deprecate
+ */
+declare function f(x: number): void;
+declare function f(x: boolean): void;
+      `,
+      errors: [
+        {
+          column: 20,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 5 can be combined into one signature',
+            type1: 'string',
+            type2: 'number',
+          },
+          line: 9,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+declare function f(x: string): void;
+/**
+ * @deprecate
+ */
+declare function f(x: number): void;
+/**
+ * @deprecate
+ */
+declare function f(x: boolean): void;
+      `,
+      errors: [
+        {
+          column: 20,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 6 can be combined into one signature',
+            type1: 'number',
+            type2: 'boolean',
+          },
+          line: 10,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+export function f(x: string): void;
+/**
+ * @deprecate
+ */
+export function f(x: number): void;
+/**
+ * @deprecate
+ */
+export function f(x: boolean): void;
+      `,
+      errors: [
+        {
+          column: 19,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 6 can be combined into one signature',
+            type1: 'number',
+            type2: 'boolean',
+          },
+          line: 10,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+/**
+ * This signature does something.
+ */
+
+/**
+ * This signature does something else.
+ */
+function f(x: number): void;
+
+/**
+ * This signature does something else.
+ */
+function f(x: string): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: 'string',
+          },
+          line: 14,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    // invalid jsdoc comments
+    {
+      code: `
+/* @deprecated */
+declare function f(x: number): unknown;
+declare function f(x: boolean): unknown;
+      `,
+      errors: [
+        {
+          column: 20,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: 'boolean',
+          },
+          line: 4,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+/*
+ * This signature does something.
+ */
+declare function f(x: number): unknown;
+declare function f(x: boolean): unknown;
+      `,
+      errors: [
+        {
+          column: 20,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: 'boolean',
+          },
+          line: 6,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+/**
+ * This signature does something.
+ **/
+declare function f(x: number): unknown;
+declare function f(x: boolean): unknown;
+      `,
+      errors: [
+        {
+          column: 20,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: 'boolean',
+          },
+          line: 6,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
+    },
+    {
+      code: `
+// just a comment
+declare function f(x: number): unknown;
+declare function f(x: boolean): unknown;
+      `,
+      errors: [
+        {
+          column: 20,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: 'boolean',
+          },
+          line: 4,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreOverloadsWithDifferentJSDoc: true }],
     },
   ],
 });

--- a/packages/eslint-plugin/tests/schema-snapshots/unified-signatures.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/unified-signatures.shot
@@ -11,6 +11,10 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
       "ignoreDifferentlyNamedParameters": {
         "description": "Whether two parameters with different names at the same index should be considered different even if their types are the same.",
         "type": "boolean"
+      },
+      "ignoreOverloadsWithDifferentJSDoc": {
+        "description": "Whether two overloads with different JSDoc comments should be considered different even if their parameter and return types are the same.",
+        "type": "boolean"
       }
     },
     "type": "object"
@@ -24,6 +28,8 @@ type Options = [
   {
     /** Whether two parameters with different names at the same index should be considered different even if their types are the same. */
     ignoreDifferentlyNamedParameters?: boolean;
+    /** Whether two overloads with different JSDoc comments should be considered different even if their parameter and return types are the same. */
+    ignoreOverloadsWithDifferentJSDoc?: boolean;
   },
 ];
 "


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10520
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR attempts to tackle #10520 and adds the `ignoreOverloadsWithDifferentJSDoc` option. When enabled, the following is considered valid:

```ts
/**
 * This signature does something.
 */
declare function f(x: number): void;

/**
 * This signature does something else.
 */
declare function f(x: string): void;
```

Some thoughts/notes:

- I've only considered JSDoc comments that annotate a function signature, not ones that annotate its params (or return type annotation, see below), so the following is reported, even though it has similar issues with unifying two signatures with different jsdoc comments:

  ```ts
  declare function f(x: {
    /** @deprecated */
    a: boolean;
  }): void;
  declare function f(x: { a: number }): void;
  ```
  
  This is tricky, as the following overloads, for example, can be unified (and should be reported):

  ```ts
  declare function f(x: {
    /** @deprecated */
    a: boolean;
  }): void;
  declare function f(x: { b: number }): void;
  ```
  
  I'm a bit unsure if this should be checked or not, as it wasn't described on the issue. I'd love to hear opinions on this, and would be happy to add this check for this (although this seems somewhat complex 🙈).
  
- I didn't add any checks to an annotated return type, as return type annotations are checked [by comparing the source code text](https://github.com/typescript-eslint/typescript-eslint/blob/bcdf56017a1c9d66d701d2104651ae9d9cf035dd/packages/eslint-plugin/src/rules/unified-signatures.ts#L441-L452).
  
  So the following signatures already count as unique ([playground link](https://typescript-eslint.io/play/#ts=5.7.3&fileType=.tsx&code=CYUwxgNghgTiAEAzArgOzAFwJYHtVIAoAPALngCMccIQpUBKMgbwCh54B6AKi-gAFQABzhgoGEMHhcObeFDKVqtVAG4WAXzWhIsBCnTY8hUvFTIAtuRAxG8Vu3mmLVmGs0sgA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6WJygM0sQBNaySgHMmAQ3yxoKdFETRoAe2iRwYAL4h1QA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)):
  
  ```ts
  declare function f(x: boolean): {
    /** @deprecated */
    a: boolean;
  };
  declare function f(x: number): {
    a: number;
  };
  ```
  
  ---
  
  Unrelated to the change in the PR: Although this does have some false positives, as the following should be reported but doesn't:
  
  ```ts
  declare function f(x: boolean): {
    a: number;
  };
  declare function f(x: number): { a: number };
   ```

  This also includes random, non-jsdoc comments, spaces, line-breaks, etc ([playground link](https://typescript-eslint.io/play/#ts=5.7.3&showAST=es&fileType=.tsx&code=PTAEFp1ATBLAzeBTATkgdgF1AZwA4CGAxrOgOYA0oANqUuAEZoEDWOVRA9gLbcabtQSTEVDdWSUJgAWklAFdqk9J2xo8nFNkgAoHSFDrNmJNFBcUaIpmoBPHdCRFqBNKHjz012J3TuAFAAeAFygDJycSgToAJShAN6gBKHo8twMqKAAvgDcDk4ubh5emD5%2B8EEpaRkocaCJyaCp6Zm5egY40pyKZhmGSBpapmHy2NCcSDjoAOSY%2Bc6uksXevqBklWERUbEJSVUtKNl5jgtFnit%2B6yFN1ah18TqgezcHOm36YJBJ1DicoADusBkoDwKE4eBwUmkBDGEyms1A0IAbpIZJIcAQ%2BKBNI5DroPv1BiYzBYrDZ7CdCktzqVVtINuFIkhovdns0ajkwqEcJgUKQyEd5lT3DSyoiNuy7rtGpKUJyGNzefzBQTOt1qL05ANjMMGKMYHCZnNKYsRSUxSwGVtmTt6lzcEryJyZbdDm0TWdzatLddZayXQd5Yq%2BeRBUA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6WJygM0sQBNaySgHMmAQ3yxoKdFETRoAe2iRwYAL4h1QA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)). Should I open a separate issue on this?