### PR TITLE
fix(eslint-plugin): [no-unnecessary-template-expression] ignore enum and enum members

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-template-expression.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-template-expression.mdx
@@ -66,6 +66,7 @@ enum ABC {
   C = 'C',
 }
 type ABCUnion = `${ABC}`;
+type A = `${ABC.A}`;
 
 // Interpolating type parameters is allowed.
 type TextUtil<T extends string> = `${T}`;

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-template-expression.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-template-expression.shot
@@ -59,6 +59,7 @@ enum ABC {
   C = 'C',
 }
 type ABCUnion = \`\${ABC}\`;
+type A = \`\${ABC.A}\`;
 
 // Interpolating type parameters is allowed.
 type TextUtil<T extends string> = \`\${T}\`;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -1191,6 +1191,60 @@ enum Foo {
 type Bar = \`\${Foo.A}\`;
     `,
     `
+enum Enum1 {
+  A = 'A1',
+  B = 'B1',
+}
+
+enum Enum2 {
+  A = 'A2',
+  B = 'B2',
+}
+
+type Union = \`\${Enum1 | Enum2}\`;
+    `,
+    `
+enum Enum1 {
+  A = 'A1',
+  B = 'B1',
+}
+
+enum Enum2 {
+  A = 'A2',
+  B = 'B2',
+}
+
+type Union = \`\${Enum1.A | Enum2.B}\`;
+    `,
+    `
+enum Enum1 {
+  A = 'A1',
+  B = 'B1',
+}
+
+enum Enum2 {
+  A = 'A2',
+  B = 'B2',
+}
+type Enums = Enum1 | Enum2;
+type Union = \`\${Enums}\`;
+    `,
+    `
+enum Enum {
+  A = 'A',
+  B = 'A',
+}
+
+type Intersection = \`\${Enum1.A & string}\`;
+    `,
+    `
+enum Foo {
+  A = 'A',
+  B = 'B',
+}
+type Bar = \`\${Foo.A}\`;
+    `,
+    `
 function foo<T extends string>() {
   const a: \`\${T}\` = 'a';
 }
@@ -1411,31 +1465,6 @@ type Bar = Foo;
         },
       ],
       output: "type FooBar = 'foo' | 'bar';",
-    },
-    {
-      code: `
-enum Foo {
-  A = 'A',
-  B = 'B',
-}
-type Bar = \`\${Foo.A}\`;
-      `,
-      errors: [
-        {
-          column: 13,
-          endColumn: 21,
-          endLine: 6,
-          line: 6,
-          messageId: 'noUnnecessaryTemplateExpression',
-        },
-      ],
-      output: `
-enum Foo {
-  A = 'A',
-  B = 'B',
-}
-type Bar = Foo.A;
-      `,
     },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10769
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This pr allows the use of template literal type expression if any part of the type (union, intersection) has at least one enum member.

<!-- Description of what is changed and how the code change does that. -->
