### PR TITLE
fix(eslint-plugin): [no-unsafe-assignment] report on an `any` value assigned as an initializer of an `accessor` property

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-assignment.ts
@@ -337,6 +337,16 @@ export default createRule({
     }
 
     return {
+      'AccessorProperty[value != null]'(
+        node: { value: NonNullable<unknown> } & TSESTree.AccessorProperty,
+      ): void {
+        checkAssignment(
+          node.key,
+          node.value,
+          node,
+          getComparisonType(node.typeAnnotation),
+        );
+      },
       'AssignmentExpression[operator = "="], AssignmentPattern'(
         node: TSESTree.AssignmentExpression | TSESTree.AssignmentPattern,
       ): void {

--- a/packages/eslint-plugin/tests/rules/no-unsafe-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-assignment.test.ts
@@ -94,6 +94,11 @@ class Foo {
   private a = 1;
 }
     `,
+    `
+class Foo {
+  accessor a = 1;
+}
+    `,
     'const x: Set<string> = new Set();',
     'const x: Set<string> = new Set<string>();',
     'const [x] = [1];',

--- a/packages/eslint-plugin/tests/rules/no-unsafe-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-assignment.test.ts
@@ -203,6 +203,14 @@ class Foo {
     },
     {
       code: `
+class Foo {
+  accessor a = 1 as any;
+}
+      `,
+      errors: [{ messageId: 'anyAssignment' }],
+    },
+    {
+      code: `
 const [x] = spooky;
       `,
       errors: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10784
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10784 and adds checks for `accessor` properties.
