### PR TITLE
docs(eslint-plugin): [Quickstart] fix example config

### DIFF
--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -39,7 +39,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   eslint.configs.recommended,
-  tseslint.configs.recommended,
+  ...tseslint.configs.recommended,
 );
 ```
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Either the example config is wrong, or the type of the config helper is wrong :

In the quickstart, the example config uses `tseslint.configs.recommended`, but using this will raise the type error `Argument type TSESLint.FlatConfig.ConfigArray is not assignable to parameter type ConfigWithExtends . Type Config[] is not assignable to type ConfigWithExtends`.

The doc of the `tseslint.config` function uses `...tseslint. configs. recommended` which indeed solves the type error.

The same problem can be seen here : https://typescript-eslint.io/users/what-about-formatting/#suggested-usage---prettier
