### PR TITLE
fix(eslint-plugin): [consistent-generic-constructors] check `accessor` class properties 

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-generic-constructors.ts
+++ b/packages/eslint-plugin/src/rules/consistent-generic-constructors.ts
@@ -34,20 +34,26 @@ export default createRule<Options, MessageIds>({
   defaultOptions: ['constructor'],
   create(context, [mode]) {
     return {
-      'VariableDeclarator,PropertyDefinition,:matches(FunctionDeclaration,FunctionExpression) > AssignmentPattern'(
+      'VariableDeclarator,PropertyDefinition,AccessorProperty,:matches(FunctionDeclaration,FunctionExpression) > AssignmentPattern'(
         node:
+          | TSESTree.AccessorProperty
           | TSESTree.AssignmentPattern
           | TSESTree.PropertyDefinition
           | TSESTree.VariableDeclarator,
       ): void {
         function getLHSRHS(): [
-          TSESTree.BindingName | TSESTree.PropertyDefinition,
+          (
+            | TSESTree.AccessorProperty
+            | TSESTree.BindingName
+            | TSESTree.PropertyDefinition
+          ),
           TSESTree.Expression | null,
         ] {
           switch (node.type) {
             case AST_NODE_TYPES.VariableDeclarator:
               return [node.id, node.init];
             case AST_NODE_TYPES.PropertyDefinition:
+            case AST_NODE_TYPES.AccessorProperty:
               return [node, node.value];
             case AST_NODE_TYPES.AssignmentPattern:
               return [node.left, node.right];
@@ -88,7 +94,10 @@ export default createRule<Options, MessageIds>({
                 function getIDToAttachAnnotation():
                   | TSESTree.Node
                   | TSESTree.Token {
-                  if (node.type !== AST_NODE_TYPES.PropertyDefinition) {
+                  if (
+                    node.type !== AST_NODE_TYPES.PropertyDefinition &&
+                    node.type !== AST_NODE_TYPES.AccessorProperty
+                  ) {
                     return lhsName;
                   }
                   if (!node.computed) {

--- a/packages/eslint-plugin/tests/rules/consistent-generic-constructors.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-generic-constructors.test.ts
@@ -286,12 +286,12 @@ class Foo {
   accessor a = new Foo<string>();
 }
       `,
-      options: ['type-annotation'],
       errors: [
         {
           messageId: 'preferTypeAnnotation',
         },
       ],
+      options: ['type-annotation'],
       output: `
 class Foo {
   accessor a: Foo<string> = new Foo();

--- a/packages/eslint-plugin/tests/rules/consistent-generic-constructors.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-generic-constructors.test.ts
@@ -283,6 +283,24 @@ class Foo {
     {
       code: `
 class Foo {
+  accessor a = new Foo<string>();
+}
+      `,
+      options: ['type-annotation'],
+      errors: [
+        {
+          messageId: 'preferTypeAnnotation',
+        },
+      ],
+      output: `
+class Foo {
+  accessor a: Foo<string> = new Foo();
+}
+      `,
+    },
+    {
+      code: `
+class Foo {
   accessor [a]: Foo<string> = new Foo();
 }
       `,

--- a/packages/eslint-plugin/tests/rules/consistent-generic-constructors.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-generic-constructors.test.ts
@@ -24,6 +24,11 @@ class Foo {
 }
     `,
     `
+class Foo {
+  accessor a = new Foo<string>();
+}
+    `,
+    `
 function foo(a: Foo = new Foo<string>()) {}
     `,
     `
@@ -85,6 +90,14 @@ const a = function (a: Foo = new Foo<string>()) {};
       code: `
 class Foo {
   a: Foo<string> = new Foo();
+}
+      `,
+      options: ['type-annotation'],
+    },
+    {
+      code: `
+class Foo {
+  accessor a: Foo<string> = new Foo();
 }
       `,
       options: ['type-annotation'],
@@ -247,6 +260,40 @@ class Foo {
       output: `
 class Foo {
   [a] = new Foo<string>();
+}
+      `,
+    },
+    {
+      code: `
+class Foo {
+  accessor a: Foo<string> = new Foo();
+}
+      `,
+      errors: [
+        {
+          messageId: 'preferConstructor',
+        },
+      ],
+      output: `
+class Foo {
+  accessor a = new Foo<string>();
+}
+      `,
+    },
+    {
+      code: `
+class Foo {
+  accessor [a]: Foo<string> = new Foo();
+}
+      `,
+      errors: [
+        {
+          messageId: 'preferConstructor',
+        },
+      ],
+      output: `
+class Foo {
+  accessor [a] = new Foo<string>();
 }
       `,
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10786
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10786 and adjusts the rule to check `accessor` class properties.
