### PR TITLE
fix(eslint-plugin): [prefer-return-this-type] check `accessor` properties with a function initializer

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-return-this-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-return-this-type.ts
@@ -148,24 +148,27 @@ export default createRule({
       }
     }
 
+    function checkProperty(
+      node: TSESTree.AccessorProperty | TSESTree.PropertyDefinition,
+    ): void {
+      if (
+        !(
+          node.value?.type === AST_NODE_TYPES.FunctionExpression ||
+          node.value?.type === AST_NODE_TYPES.ArrowFunctionExpression
+        )
+      ) {
+        return;
+      }
+
+      checkFunction(node.value, node.parent.parent as ClassLikeDeclaration);
+    }
+
     return {
+      'ClassBody > AccessorProperty': checkProperty,
       'ClassBody > MethodDefinition'(node: TSESTree.MethodDefinition): void {
         checkFunction(node.value, node.parent.parent as ClassLikeDeclaration);
       },
-      'ClassBody > PropertyDefinition'(
-        node: TSESTree.PropertyDefinition,
-      ): void {
-        if (
-          !(
-            node.value?.type === AST_NODE_TYPES.FunctionExpression ||
-            node.value?.type === AST_NODE_TYPES.ArrowFunctionExpression
-          )
-        ) {
-          return;
-        }
-
-        checkFunction(node.value, node.parent.parent as ClassLikeDeclaration);
-      },
+      'ClassBody > PropertyDefinition': checkProperty,
     };
   },
 });

--- a/packages/eslint-plugin/src/rules/prefer-return-this-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-return-this-type.ts
@@ -160,13 +160,13 @@ export default createRule({
         return;
       }
 
-      checkFunction(node.value, node.parent.parent as ClassLikeDeclaration);
+      checkFunction(node.value, node.parent.parent);
     }
 
     return {
       'ClassBody > AccessorProperty': checkProperty,
       'ClassBody > MethodDefinition'(node: TSESTree.MethodDefinition): void {
-        checkFunction(node.value, node.parent.parent as ClassLikeDeclaration);
+        checkFunction(node.value, node.parent.parent);
       },
       'ClassBody > PropertyDefinition': checkProperty,
     };

--- a/packages/eslint-plugin/tests/rules/prefer-return-this-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-return-this-type.test.ts
@@ -81,6 +81,25 @@ class Derived extends Base {
   }
 }
     `,
+    `
+class Foo {
+  accessor f = () => {
+    return this;
+  };
+}
+    `,
+    `
+class Foo {
+  accessor f = (): this => {
+    return this;
+  };
+}
+    `,
+    `
+class Foo {
+  f?: string;
+}
+    `,
   ],
   invalid: [
     {
@@ -103,6 +122,29 @@ class Foo {
   f(): this {
     return this;
   }
+}
+      `,
+    },
+    {
+      code: `
+class Foo {
+  f = function (): Foo {
+    return this;
+  };
+}
+      `,
+      errors: [
+        {
+          column: 20,
+          line: 3,
+          messageId: 'useThisType',
+        },
+      ],
+      output: `
+class Foo {
+  f = function (): this {
+    return this;
+  };
 }
       `,
     },

--- a/packages/eslint-plugin/tests/rules/prefer-return-this-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-return-this-type.test.ts
@@ -201,6 +201,48 @@ class Foo {
     {
       code: `
 class Foo {
+  accessor f = (): Foo => {
+    return this;
+  };
+}
+      `,
+      errors: [
+        {
+          column: 20,
+          line: 3,
+          messageId: 'useThisType',
+        },
+      ],
+      output: `
+class Foo {
+  accessor f = (): this => {
+    return this;
+  };
+}
+      `,
+    },
+    {
+      code: `
+class Foo {
+  accessor f = (): Foo => this;
+}
+      `,
+      errors: [
+        {
+          column: 20,
+          line: 3,
+          messageId: 'useThisType',
+        },
+      ],
+      output: `
+class Foo {
+  accessor f = (): this => this;
+}
+      `,
+    },
+    {
+      code: `
+class Foo {
   f1(): Foo | undefined {
     return this;
   }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10791
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10791 and adds checks for `accessor` properties.