### PR TITLE
fix(eslint-plugin): [explicit-module-boundary-types] check `accessor` class properties with a function initializer

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -270,7 +270,8 @@ export default createRule<Options, MessageIds>({
         node.type === AST_NODE_TYPES.MethodDefinition ||
         node.type === AST_NODE_TYPES.TSAbstractMethodDefinition ||
         (node.type === AST_NODE_TYPES.Property && node.method) ||
-        node.type === AST_NODE_TYPES.PropertyDefinition
+        node.type === AST_NODE_TYPES.PropertyDefinition ||
+        node.type === AST_NODE_TYPES.AccessorProperty
       ) {
         return isStaticMemberAccessOfValue(
           node,
@@ -369,6 +370,7 @@ export default createRule<Options, MessageIds>({
           return;
 
         case AST_NODE_TYPES.PropertyDefinition:
+        case AST_NODE_TYPES.AccessorProperty:
         case AST_NODE_TYPES.MethodDefinition:
         case AST_NODE_TYPES.TSAbstractMethodDefinition:
           if (

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -239,6 +239,7 @@ export function isParenlessArrowFunction(
 }
 
 export type NodeWithKey =
+  | TSESTree.AccessorProperty
   | TSESTree.MemberExpression
   | TSESTree.MethodDefinition
   | TSESTree.Property

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -601,6 +601,15 @@ export default { Foo };
     },
     {
       code: `
+export class Foo {
+  accessor bar = (): void => {
+    return;
+  };
+}
+      `,
+    },
+    {
+      code: `
 export function foo(): (n: number) => string {
   return n => String(n);
 }

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -1689,6 +1689,52 @@ export default Foo;
     {
       code: `
 class Foo {
+  accessor bool = arg => {
+    return arg;
+  };
+}
+export default Foo;
+      `,
+      errors: [
+        {
+          data: {
+            name: 'arg',
+          },
+          line: 3,
+          messageId: 'missingArgType',
+        },
+        {
+          line: 3,
+          messageId: 'missingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  accessor bool = function (arg) {
+    return arg;
+  };
+}
+export default Foo;
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'missingReturnType',
+        },
+        {
+          data: {
+            name: 'arg',
+          },
+          line: 3,
+          messageId: 'missingArgType',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
   bool = function (arg) {
     return arg;
   };


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10802
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10802 and adds checks for `accessor` properties.