### PR TITLE
fix(eslint-plugin): [explicit-member-accessibility] check `accessor` class properties for missing accessibility modifier

### DIFF
--- a/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
+++ b/packages/eslint-plugin/src/rules/explicit-member-accessibility.ts
@@ -196,8 +196,10 @@ export default createRule<Options, MessageIds>({
      */
     function findPublicKeyword(
       node:
+        | TSESTree.AccessorProperty
         | TSESTree.MethodDefinition
         | TSESTree.PropertyDefinition
+        | TSESTree.TSAbstractAccessorProperty
         | TSESTree.TSAbstractMethodDefinition
         | TSESTree.TSAbstractPropertyDefinition
         | TSESTree.TSParameterProperty,
@@ -238,8 +240,10 @@ export default createRule<Options, MessageIds>({
      */
     function getMissingAccessibilitySuggestions(
       node:
+        | TSESTree.AccessorProperty
         | TSESTree.MethodDefinition
         | TSESTree.PropertyDefinition
+        | TSESTree.TSAbstractAccessorProperty
         | TSESTree.TSAbstractMethodDefinition
         | TSESTree.TSAbstractPropertyDefinition
         | TSESTree.TSParameterProperty,
@@ -284,7 +288,9 @@ export default createRule<Options, MessageIds>({
      */
     function checkPropertyAccessibilityModifier(
       propertyDefinition:
+        | TSESTree.AccessorProperty
         | TSESTree.PropertyDefinition
+        | TSESTree.TSAbstractAccessorProperty
         | TSESTree.TSAbstractPropertyDefinition,
     ): void {
       if (propertyDefinition.key.type === AST_NODE_TYPES.PrivateIdentifier) {
@@ -389,7 +395,7 @@ export default createRule<Options, MessageIds>({
     return {
       'MethodDefinition, TSAbstractMethodDefinition':
         checkMethodAccessibilityModifier,
-      'PropertyDefinition, TSAbstractPropertyDefinition':
+      'PropertyDefinition, TSAbstractPropertyDefinition, AccessorProperty, TSAbstractAccessorProperty':
         checkPropertyAccessibilityModifier,
       TSParameterProperty: checkParameterPropertyAccessibilityModifier,
     };

--- a/packages/eslint-plugin/src/util/getMemberHeadLoc.ts
+++ b/packages/eslint-plugin/src/util/getMemberHeadLoc.ts
@@ -30,8 +30,10 @@ import {
 export function getMemberHeadLoc(
   sourceCode: Readonly<TSESLint.SourceCode>,
   node:
+    | TSESTree.AccessorProperty
     | TSESTree.MethodDefinition
     | TSESTree.PropertyDefinition
+    | TSESTree.TSAbstractAccessorProperty
     | TSESTree.TSAbstractMethodDefinition
     | TSESTree.TSAbstractPropertyDefinition,
 ): TSESTree.SourceLocation {

--- a/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
@@ -1975,7 +1975,6 @@ class SomeClass {
         },
       ],
       options: [{ accessibility: 'explicit' }],
-      output: null,
     },
     {
       code: `
@@ -2022,7 +2021,6 @@ abstract class SomeClass {
         },
       ],
       options: [{ accessibility: 'explicit' }],
-      output: null,
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
@@ -308,7 +308,6 @@ class Test {
       `,
       options: [{ accessibility: 'no-public' }],
     },
-    // private members
     {
       code: `
 class Test {
@@ -317,6 +316,20 @@ class Test {
 }
       `,
       options: [{ accessibility: 'explicit' }],
+    },
+    {
+      code: `
+class Test {
+  private accessor foo = 1;
+}
+      `,
+    },
+    {
+      code: `
+abstract class Test {
+  private abstract accessor foo: number;
+}
+      `,
     },
   ],
   invalid: [

--- a/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-member-accessibility.test.ts
@@ -1919,6 +1919,100 @@ abstract class SomeClass {
     },
     {
       code: `
+class SomeClass {
+  accessor foo = 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          endColumn: 15,
+          endLine: 3,
+          line: 3,
+          messageId: 'missingAccessibility',
+          suggestions: [
+            {
+              data: { type: 'public' },
+              messageId: 'addExplicitAccessibility',
+              output: `
+class SomeClass {
+  public accessor foo = 1;
+}
+      `,
+            },
+            {
+              data: { type: 'private' },
+              messageId: 'addExplicitAccessibility',
+              output: `
+class SomeClass {
+  private accessor foo = 1;
+}
+      `,
+            },
+            {
+              data: { type: 'protected' },
+              messageId: 'addExplicitAccessibility',
+              output: `
+class SomeClass {
+  protected accessor foo = 1;
+}
+      `,
+            },
+          ],
+        },
+      ],
+      options: [{ accessibility: 'explicit' }],
+      output: null,
+    },
+    {
+      code: `
+abstract class SomeClass {
+  abstract accessor foo: string;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          endColumn: 24,
+          endLine: 3,
+          line: 3,
+          messageId: 'missingAccessibility',
+          suggestions: [
+            {
+              data: { type: 'public' },
+              messageId: 'addExplicitAccessibility',
+              output: `
+abstract class SomeClass {
+  public abstract accessor foo: string;
+}
+      `,
+            },
+            {
+              data: { type: 'private' },
+              messageId: 'addExplicitAccessibility',
+              output: `
+abstract class SomeClass {
+  private abstract accessor foo: string;
+}
+      `,
+            },
+            {
+              data: { type: 'protected' },
+              messageId: 'addExplicitAccessibility',
+              output: `
+abstract class SomeClass {
+  protected abstract accessor foo: string;
+}
+      `,
+            },
+          ],
+        },
+      ],
+      options: [{ accessibility: 'explicit' }],
+      output: null,
+    },
+    {
+      code: `
 class DecoratedClass {
   constructor(@foo @bar() readonly arg: string) {}
   @foo @bar() x: string;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10803
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10803 and adds checks for `accessor` properties.