### PR TITLE
fix(eslint-plugin): [no-deprecated] don't report on deprecated `accessor` property declaration

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -121,6 +121,7 @@ export default createRule<Options, MessageIds>({
 
         case AST_NODE_TYPES.MethodDefinition:
         case AST_NODE_TYPES.PropertyDefinition:
+        case AST_NODE_TYPES.AccessorProperty:
           return parent.key === node;
 
         case AST_NODE_TYPES.Property:

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -64,10 +64,27 @@ ruleTester.run('no-deprecated', rule, {
       new A().b;
     `,
     `
+      class A {
+        accessor b: 1;
+        /** @deprecated */ accessor c: 2;
+      }
+
+      new A().b;
+    `,
+    `
       declare class A {
         /** @deprecated */
         static b: string;
         static c: string;
+      }
+
+      A.c;
+    `,
+    `
+      declare class A {
+        /** @deprecated */
+        static accessor b: string;
+        static accessor c: string;
       }
 
       A.c;
@@ -2753,6 +2770,94 @@ class B extends A {
           endColumn: 56,
           endLine: 19,
           line: 19,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        declare class A {
+          /** @deprecated */
+          accessor b: () => string;
+        }
+
+        declare const a: A;
+
+        a.b;
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { name: 'b' },
+          endColumn: 12,
+          endLine: 9,
+          line: 9,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        declare class A {
+          /** @deprecated */
+          accessor b: () => string;
+        }
+
+        declare const a: A;
+
+        a.b();
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { name: 'b' },
+          endColumn: 12,
+          endLine: 9,
+          line: 9,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        class A {
+          /** @deprecated */
+          accessor b = (): string => {
+            return '';
+          };
+        }
+
+        declare const a: A;
+
+        a.b();
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { name: 'b' },
+          endColumn: 12,
+          endLine: 11,
+          line: 11,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        declare class A {
+          /** @deprecated */
+          static accessor b: () => string;
+        }
+
+        A.b();
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { name: 'b' },
+          endColumn: 12,
+          endLine: 7,
+          line: 7,
           messageId: 'deprecated',
         },
       ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10811
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10811 and adds handling of `accessor` properties.

I've added a couple of tests to check `accessor` properties generally work (not just the false-positive of declaring them). Please let me know if this shouldn't be included.
