### PR TITLE
fix(eslint-plugin): [no-misused-promises] don't report on `static` `accessor` properties

### DIFF
--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -987,7 +987,8 @@ function getMemberIfExists(
 function isStaticMember(node: TSESTree.Node): boolean {
   return (
     (node.type === AST_NODE_TYPES.MethodDefinition ||
-      node.type === AST_NODE_TYPES.PropertyDefinition) &&
+      node.type === AST_NODE_TYPES.PropertyDefinition ||
+      node.type === AST_NODE_TYPES.AccessorProperty) &&
     node.static
   );
 }

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -467,6 +467,36 @@ class Bar extends Foo {
 }
     `,
     `
+class Foo {
+  public doThing = (): void => {};
+}
+
+class Bar extends Foo {
+  public static accessor doThing = async (): Promise<void> => {};
+}
+    `,
+    `
+class Foo {
+  public accessor doThing = (): void => {};
+}
+
+class Bar extends Foo {
+  public static accessor doThing = (): void => {};
+}
+    `,
+    {
+      code: `
+class Foo {
+  [key: string]: void;
+}
+
+class Bar extends Foo {
+  [key: string]: Promise<void>;
+}
+      `,
+      options: [{ checksVoidReturn: { inheritedMethods: true } }],
+    },
+    `
 function restTuple(...args: []): void;
 function restTuple(...args: [string]): void;
 function restTuple(..._args: string[]): void {}
@@ -2024,6 +2054,46 @@ abstract class MyAbstractClassImplementsMyInterface implements MyInterface {
       errors: [
         {
           data: { heritageTypeName: 'MyInterface' },
+          line: 7,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+class MyClass {
+  accessor setThing = (): void => {
+    return;
+  };
+}
+
+class MySubclassExtendsMyClass extends MyClass {
+  accessor setThing = async (): Promise<void> => {
+    await Promise.resolve();
+  };
+}
+      `,
+      errors: [
+        {
+          data: { heritageTypeName: 'MyClass' },
+          line: 9,
+          messageId: 'voidReturnInheritedMethod',
+        },
+      ],
+    },
+    {
+      code: `
+abstract class MyClass {
+  abstract accessor setThing: () => void;
+}
+
+abstract class MySubclassExtendsMyClass extends MyClass {
+  abstract accessor setThing: () => Promise<void>;
+}
+      `,
+      errors: [
+        {
+          data: { heritageTypeName: 'MyClass' },
           line: 7,
           messageId: 'voidReturnInheritedMethod',
         },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10812
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10812 and adds logic to handle `static` `accessor` properties.

I've added a couple of tests to check `accessor` properties generally work, regardless of being `static`. Please let me know if this shouldn't be included.
