### PR TITLE
docs: give release time in UTC and local time

### DIFF
--- a/docs/users/Releases.mdx
+++ b/docs/users/Releases.mdx
@@ -22,7 +22,7 @@ export function LocalTimeOfRelease() {
     'Friday',
     'Saturday',
   ];
-  if (date.getDay() !== 1) {
+  if (date.getDay() !== date.getUTCDay()) {
     return `${dayNames[date.getDay()]}s at ${formatted}`;
   }
   return formatted;

--- a/docs/users/Releases.mdx
+++ b/docs/users/Releases.mdx
@@ -5,7 +5,7 @@ title: Releases
 ---
 
 export function LocalTimeOfRelease() {
-  // An arbitrary Wednesday at 17:00 UTC.
+  // An arbitrary Monday at 17:00 UTC.
   const date = new Date('1970-01-05T17:00Z');
   const formatted = date.toLocaleTimeString('en-US', {
     hour: 'numeric',

--- a/docs/users/Releases.mdx
+++ b/docs/users/Releases.mdx
@@ -13,7 +13,7 @@ title: Releases
   />
 </a>
 
-We release a latest version every Monday at 1pm US Eastern time using the latest commit to `main` at that time. This release is performed automatically by a Github action located in a private repository. This release goes to the standard `latest` tag on npm.
+We release a latest version every Monday at 17:00 UTC using the latest commit to `main` at that time. This release is performed automatically by a Github action located in a private repository. This release goes to the standard `latest` tag on npm.
 
 See [Versioning](./Versioning.mdx) for how the version number is calculated.
 

--- a/docs/users/Releases.mdx
+++ b/docs/users/Releases.mdx
@@ -9,20 +9,11 @@ export function LocalTimeOfRelease() {
   const now = new Date();
   // your time zone minus UTC time
   const offset = -now.getTimezoneOffset();
-  const formatter = new Intl.DateTimeFormat(undefined, {
+  const formatted = date.toLocaleTimeString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
     timeZoneName: 'short',
   });
-  const parts = formatter.formatToParts(date);
-  const formatted = parts
-    .map(part => {
-      if (part.type === 'dayPeriod') {
-        return part.value.toLowerCase();
-      }
-      return part.value;
-    })
-    .join('');
   if (offset >= (24 - 17) * 60) {
     return 'Tuesdays at ' + formatted;
   }

--- a/docs/users/Releases.mdx
+++ b/docs/users/Releases.mdx
@@ -4,13 +4,17 @@ sidebar_label: Releases
 title: Releases
 ---
 
+import useIsBrowser from '@docusaurus/useIsBrowser';
+
 export function LocalTimeOfRelease() {
+  const isBrowser = useIsBrowser();
   // An arbitrary Monday at 17:00 UTC.
   const date = new Date('1970-01-05T17:00Z');
   const formatted = date.toLocaleTimeString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
     timeZoneName: 'short',
+    timeZone: isBrowser ? undefined : 'UTC',
   });
   // Specify the day of week if it's not a Monday.
   const dayNames = [

--- a/docs/users/Releases.mdx
+++ b/docs/users/Releases.mdx
@@ -5,20 +5,25 @@ title: Releases
 ---
 
 export function LocalTimeOfRelease() {
-  const date = new Date('1970-01-01T17:00Z');
-  const now = new Date();
-  // your time zone minus UTC time
-  const offset = -now.getTimezoneOffset();
+  // An arbitrary Wednesday at 17:00 UTC.
+  const date = new Date('1970-01-05T17:00Z');
   const formatted = date.toLocaleTimeString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
     timeZoneName: 'short',
   });
-  if (offset >= (24 - 17) * 60) {
-    return 'Tuesdays at ' + formatted;
-  }
-  if (offset < -17 * 60) {
-    return 'Sundays at ' + formatted;
+  // Specify the day of week if it's not a Monday.
+  const dayNames = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ];
+  if (date.getDay() !== 1) {
+    return `${dayNames[date.getDay()]}s at ${formatted}`;
   }
   return formatted;
 }

--- a/docs/users/Releases.mdx
+++ b/docs/users/Releases.mdx
@@ -4,6 +4,34 @@ sidebar_label: Releases
 title: Releases
 ---
 
+export function LocalTimeOfRelease() {
+  const date = new Date('1970-01-01T17:00Z');
+  const now = new Date();
+  // your time zone minus UTC time
+  const offset = -now.getTimezoneOffset();
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });
+  const parts = formatter.formatToParts(date);
+  const formatted = parts
+    .map(part => {
+      if (part.type === 'dayPeriod') {
+        return part.value.toLowerCase();
+      }
+      return part.value;
+    })
+    .join('');
+  if (offset >= (24 - 17) * 60) {
+    return 'Tuesdays at ' + formatted;
+  }
+  if (offset < -17 * 60) {
+    return 'Sundays at ' + formatted;
+  }
+  return formatted;
+}
+
 ## Latest
 
 <a href="https://www.npmjs.com/package/@typescript-eslint/parser">
@@ -13,7 +41,7 @@ title: Releases
   />
 </a>
 
-We release a latest version every Monday at 17:00 UTC using the latest commit to `main` at that time. This release is performed automatically by a Github action located in a private repository. This release goes to the standard `latest` tag on npm.
+We release a latest version every Monday at 17:00 UTC (<LocalTimeOfRelease />) using the latest commit to `main` at that time. This release is performed automatically by a Github action located in a private repository. This release goes to the standard `latest` tag on npm.
 
 See [Versioning](./Versioning.mdx) for how the version number is calculated.
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

We on the maintenance team are spread around the world, so are our users, and our release automations don't respect DST, so let's just use UTC and call it a day?