### PR TITLE
feat(typescript-eslint): export util types (close #10848)

### DIFF
--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -22,6 +22,7 @@ This package exports the following:
 | `configs`             | [Shared ESLint (flat) configs](../users/Shared_Configurations.mdx)                                |
 | `parser`              | A re-export of [`@typescript-eslint/parser`](./Parser.mdx)                                        |
 | `plugin`              | A re-export of [`@typescript-eslint/eslint-plugin`](./ESLint_Plugin.mdx)                          |
+| `FlatConfig`          | A re-export of the type from [`@typescript-eslint/utils`](./Utils.mdx)                            |
 
 ## Installation
 

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -16,7 +16,7 @@ import type {
 import { config } from './config-helper';
 import { getTSConfigRootDirFromStack } from './getTSConfigRootDirFromStack';
 
-export type { TSESLint } from '@typescript-eslint/utils';
+export type { FlatConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export const parser: CompatibleParser =
   rawPlugin.parser as CompatibleParser satisfies FlatConfig.Parser;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10848
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This adds export for a namespace `TSLint` which contain types used in tslint.

The main reason is that as the documentation suggests using tslint stricter types: https://typescript-eslint.io/getting-started#step-2-configuration, people may need to implicitly mark codes to these types in their own flag config, as auto-infer may contain "loose types" (e.g.: `string` instead of `'a' | 'b'`) that triggers ts errors.

For examples,see #10848
