### PR TITLE
fix(eslint-plugin): [no-deprecated] support computed member access

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -393,6 +393,56 @@ export default createRule<Options, MessageIds>({
       });
     }
 
+    function checkMemberExpression(node: TSESTree.MemberExpression): void {
+      if (!node.computed) {
+        return;
+      }
+
+      const propertyType = services.getTypeAtLocation(node.property);
+
+      if (propertyType.isStringLiteral() || propertyType.isLiteral()) {
+        const objectType = services.getTypeAtLocation(node.object);
+
+        let propertyName: string | undefined;
+
+        if (propertyType.isStringLiteral()) {
+          propertyName = propertyType.value;
+        } else if (typeof propertyType.value === 'string') {
+          propertyName = propertyType.value;
+        } else if (typeof propertyType.value === 'number') {
+          propertyName = String(propertyType.value);
+        }
+
+        if (!propertyName) {
+          return;
+        }
+
+        const property = objectType.getProperty(propertyName);
+
+        const reason = getJsDocDeprecation(property);
+        if (reason == null) {
+          return;
+        }
+
+        if (typeMatchesSomeSpecifier(objectType, allow, services.program)) {
+          return;
+        }
+
+        context.report({
+          ...(reason
+            ? {
+                messageId: 'deprecatedWithReason',
+                data: { name: propertyName, reason },
+              }
+            : {
+                messageId: 'deprecated',
+                data: { name: propertyName },
+              }),
+          node: node.property,
+        });
+      }
+    }
+
     return {
       Identifier: checkIdentifier,
       JSXIdentifier(node): void {
@@ -400,6 +450,7 @@ export default createRule<Options, MessageIds>({
           checkIdentifier(node);
         }
       },
+      MemberExpression: checkMemberExpression,
       Super: checkIdentifier,
     };
   },

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -2862,5 +2862,45 @@ class B extends A {
         },
       ],
     },
+    {
+      code: `
+        const a = {
+          /** @deprecated */
+          b: 'string',
+        };
+
+        const c = a['b'];
+      `,
+      errors: [
+        {
+          column: 21,
+          data: { name: 'b' },
+          endColumn: 24,
+          endLine: 7,
+          line: 7,
+          messageId: 'deprecated',
+        },
+      ],
+    },
+    {
+      code: `
+        const a = {
+          /** @deprecated */
+          b: 'string',
+        };
+        const x = 'b';
+        const c = a[x];
+      `,
+      errors: [
+        {
+          column: 21,
+          data: { name: 'b' },
+          endColumn: 22,
+          endLine: 7,
+          line: 7,
+          messageId: 'deprecated',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10837
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The rule now correctly detects deprecated properties when they are accessed using computed member expressions (`obj['prop']`), variables (`const x = 'prop'; obj[x]`).