### PR TITLE
docs: fix broken parserOptions.project link

### DIFF
--- a/docs/troubleshooting/typed-linting/index.mdx
+++ b/docs/troubleshooting/typed-linting/index.mdx
@@ -260,7 +260,7 @@ This error may appear from the combination of two things:
 
 - The ESLint configuration for the source file specifies at least one TSConfig file in `parserOptions.project`
 - None of those TSConfig files includes the source file being linted
-  - Note that files with the same name and different extension may not be recognized by TypeScript: see [`parserOptions.project` docs](https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/parser#parseroptionsproject)
+  - Note that files with the same name and different extension may not be recognized by TypeScript: see [`parserOptions.project` docs](../../packages/parser/#project)
 
 When TSConfig files are specified for parsing a source file, `@typescript-eslint/parser` will use the first TSConfig that is able to include that source file (per [aka.ms/tsconfig#include](https://www.typescriptlang.org/tsconfig#include)) to generate type information.
 However, if no specified TSConfig includes the source file, the parser won't be able to generate type information.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fix a broken link

The old link https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/parser#parseroptionsproject has no content.
