### PR TITLE
chore: remove unused scripts

### DIFF
--- a/packages/eslint-plugin/project.json
+++ b/packages/eslint-plugin/project.json
@@ -7,6 +7,12 @@
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"]
+    },
+    "generate-breaking-changes": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "generate:breaking-changes"
+      }
     }
   }
 }

--- a/packages/rule-schema-to-typescript-types/package.json
+++ b/packages/rule-schema-to-typescript-types/package.json
@@ -26,8 +26,6 @@
   "scripts": {
     "build": "tsc -b tsconfig.build.json",
     "format": "prettier --write \"./**/*.{ts,mts,cts,tsx,js,mjs,cjs,jsx,json,md,css}\" --ignore-path ../../.prettierignore",
-    "generate-contributors": "tsx ./src/generate-contributors.ts",
-    "generate-sponsors": "tsx ./src/generate-sponsors.ts",
     "lint": "npx nx lint",
     "postinstall-script": "tsx ./src/postinstall.ts",
     "check-types": "npx nx typecheck"


### PR DESCRIPTION
Removes a couple of unused/broken scripts from
`rule-schema-to-typescript-types`.

Also adds a missing nx target such that `generate-breaking-changes` works again.

## PR Checklist

- [x] Addresses an existing open issue: relates to #10885 
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22) (**fully aware this issue isn't marked as accepting PRs yet, but this is clearly broken and has to happen for that issue to be tackleable**)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken