### PR TITLE
feat(eslint-plugin): [explicit-module-boundary-types] add an option to ignore overload implementations

### DIFF
--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
@@ -260,16 +260,16 @@ export const foo: FooType = bar => {};
 </TabItem>
 </Tabs>
 
-### `allowImplicitReturnTypeForOverloadImplementations`
+### `allowOverloadFunctions`
 
 {/* insert option description */}
 
-Examples of code for this rule with `{ allowImplicitReturnTypeForOverloadImplementations: false }`:
+Examples of code for this rule with `{ allowOverloadFunctions: false }`:
 
 <Tabs>
 <TabItem value="❌ Incorrect">
 
-```ts option='{ "allowImplicitReturnTypeForOverloadImplementations": false }'
+```ts option='{ "allowOverloadFunctions": false }'
 export function test(a: string): string;
 export function test(a: number): number;
 export function test(a: unknown) {
@@ -280,7 +280,7 @@ export function test(a: unknown) {
 </TabItem>
 <TabItem value="✅ Correct">
 
-```ts option='{ "allowImplicitReturnTypeForOverloadImplementations": true }'
+```ts option='{ "allowOverloadFunctions": true }'
 export function test(a: string): string;
 export function test(a: number): number;
 export function test(a: unknown) {

--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
@@ -260,6 +260,37 @@ export const foo: FooType = bar => {};
 </TabItem>
 </Tabs>
 
+### `allowImplicitReturnTypeForOverloadImplementations`
+
+{/* insert option description */}
+
+Examples of code for this rule with `{ allowImplicitReturnTypeForOverloadImplementations: false }`:
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts option='{ "allowImplicitReturnTypeForOverloadImplementations": false }'
+export function test(a: string): string;
+export function test(a: number): number;
+export function test(a: unknown) {
+  return a;
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts option='{ "allowImplicitReturnTypeForOverloadImplementations": true }'
+export function test(a: string): string;
+export function test(a: number): number;
+export function test(a: unknown) {
+  return a;
+}
+```
+
+</TabItem>
+</Tabs>
+
 ## When Not To Use It
 
 If your project is not used by downstream consumers that are sensitive to API types, you can disable this rule.

--- a/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
+++ b/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.mdx
@@ -264,32 +264,15 @@ export const foo: FooType = bar => {};
 
 {/* insert option description */}
 
-Examples of code for this rule with `{ allowOverloadFunctions: false }`:
+Examples of correct code when `allowOverloadFunctions` is set to `true`:
 
-<Tabs>
-<TabItem value="❌ Incorrect">
-
-```ts option='{ "allowOverloadFunctions": false }'
+```ts option='{ "allowOverloadFunctions": true }' showPlaygroundButton
 export function test(a: string): string;
 export function test(a: number): number;
 export function test(a: unknown) {
   return a;
 }
 ```
-
-</TabItem>
-<TabItem value="✅ Correct">
-
-```ts option='{ "allowOverloadFunctions": true }'
-export function test(a: string): string;
-export function test(a: number): number;
-export function test(a: unknown) {
-  return a;
-}
-```
-
-</TabItem>
-</Tabs>
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -30,7 +30,7 @@ export type Options = [
     allowedNames?: string[];
     allowHigherOrderFunctions?: boolean;
     allowTypedFunctionExpressions?: boolean;
-    allowImplicitReturnTypeForOverloadImplementations?: boolean;
+    allowOverloadFunctions?: boolean;
   },
 ];
 export type MessageIds =
@@ -88,10 +88,10 @@ export default createRule<Options, MessageIds>({
               'You must still type the parameters of the function.',
             ].join('\n'),
           },
-          allowImplicitReturnTypeForOverloadImplementations: {
+          allowOverloadFunctions: {
             type: 'boolean',
             description:
-              'Whether to ignore missing return type annotations on functions with overload signatures.',
+              'Whether to ignore return type annotations on functions with overload signatures.',
           },
           allowTypedFunctionExpressions: {
             type: 'boolean',
@@ -108,7 +108,7 @@ export default createRule<Options, MessageIds>({
       allowDirectConstAssertionInArrowFunctions: true,
       allowedNames: [],
       allowHigherOrderFunctions: true,
-      allowImplicitReturnTypeForOverloadImplementations: false,
+      allowOverloadFunctions: false,
       allowTypedFunctionExpressions: true,
     },
   ],
@@ -469,7 +469,7 @@ export default createRule<Options, MessageIds>({
       }
 
       if (
-        options.allowImplicitReturnTypeForOverloadImplementations &&
+        options.allowOverloadFunctions &&
         node.parent.type === AST_NODE_TYPES.MethodDefinition &&
         hasOverloadSignatures(node.parent, context)
       ) {
@@ -506,7 +506,7 @@ export default createRule<Options, MessageIds>({
       }
 
       if (
-        options.allowImplicitReturnTypeForOverloadImplementations &&
+        options.allowOverloadFunctions &&
         hasOverloadSignatures(node, context)
       ) {
         return;

--- a/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
+++ b/packages/eslint-plugin/src/rules/explicit-module-boundary-types.ts
@@ -9,7 +9,12 @@ import type {
   FunctionNode,
 } from '../util/explicitReturnTypeUtils';
 
-import { createRule, isFunction, isStaticMemberAccessOfValue } from '../util';
+import {
+  createRule,
+  hasOverloadSignatures,
+  isFunction,
+  isStaticMemberAccessOfValue,
+} from '../util';
 import {
   ancestorHasReturnType,
   checkFunctionExpressionReturnType,
@@ -25,6 +30,7 @@ export type Options = [
     allowedNames?: string[];
     allowHigherOrderFunctions?: boolean;
     allowTypedFunctionExpressions?: boolean;
+    allowImplicitReturnTypeForOverloadImplementations?: boolean;
   },
 ];
 export type MessageIds =
@@ -82,6 +88,11 @@ export default createRule<Options, MessageIds>({
               'You must still type the parameters of the function.',
             ].join('\n'),
           },
+          allowImplicitReturnTypeForOverloadImplementations: {
+            type: 'boolean',
+            description:
+              'Whether to ignore missing return type annotations on functions with overload signatures.',
+          },
           allowTypedFunctionExpressions: {
             type: 'boolean',
             description:
@@ -97,6 +108,7 @@ export default createRule<Options, MessageIds>({
       allowDirectConstAssertionInArrowFunctions: true,
       allowedNames: [],
       allowHigherOrderFunctions: true,
+      allowImplicitReturnTypeForOverloadImplementations: false,
       allowTypedFunctionExpressions: true,
     },
   ],
@@ -456,6 +468,14 @@ export default createRule<Options, MessageIds>({
         return;
       }
 
+      if (
+        options.allowImplicitReturnTypeForOverloadImplementations &&
+        node.parent.type === AST_NODE_TYPES.MethodDefinition &&
+        hasOverloadSignatures(node.parent, context)
+      ) {
+        return;
+      }
+
       checkFunctionExpressionReturnType(
         { node, returns },
         options,
@@ -482,6 +502,13 @@ export default createRule<Options, MessageIds>({
       checkedFunctions.add(node);
 
       if (isAllowedName(node) || ancestorHasReturnType(node)) {
+        return;
+      }
+
+      if (
+        options.allowImplicitReturnTypeForOverloadImplementations &&
+        hasOverloadSignatures(node, context)
+      ) {
         return;
       }
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-module-boundary-types.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-module-boundary-types.shot
@@ -192,3 +192,28 @@ type FooType = (bar: string) => void;
 export const foo: FooType = bar => {};
 "
 `;
+
+exports[`Validating rule docs explicit-module-boundary-types.mdx code examples ESLint output 11`] = `
+"Incorrect
+Options: { "allowOverloadFunctions": false }
+
+export function test(a: string): string;
+export function test(a: number): number;
+export function test(a: unknown) {
+       ~~~~~~~~~~~~~ Missing return type on function.
+  return a;
+}
+"
+`;
+
+exports[`Validating rule docs explicit-module-boundary-types.mdx code examples ESLint output 12`] = `
+"Correct
+Options: { "allowOverloadFunctions": true }
+
+export function test(a: string): string;
+export function test(a: number): number;
+export function test(a: unknown) {
+  return a;
+}
+"
+`;

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-module-boundary-types.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/explicit-module-boundary-types.shot
@@ -194,21 +194,7 @@ export const foo: FooType = bar => {};
 `;
 
 exports[`Validating rule docs explicit-module-boundary-types.mdx code examples ESLint output 11`] = `
-"Incorrect
-Options: { "allowOverloadFunctions": false }
-
-export function test(a: string): string;
-export function test(a: number): number;
-export function test(a: unknown) {
-       ~~~~~~~~~~~~~ Missing return type on function.
-  return a;
-}
-"
-`;
-
-exports[`Validating rule docs explicit-module-boundary-types.mdx code examples ESLint output 12`] = `
-"Correct
-Options: { "allowOverloadFunctions": true }
+"Options: { "allowOverloadFunctions": true }
 
 export function test(a: string): string;
 export function test(a: number): number;

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -2135,5 +2135,75 @@ export const foo = {
         },
       ],
     },
+    {
+      code: `
+export function test(a: string): string;
+export function test(a: number): number;
+export function test(a: unknown) {
+  return a;
+}
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 21,
+          line: 4,
+          messageId: 'missingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+export default function test(a: string): string;
+export default function test(a: number): number;
+export default function test(a: unknown) {
+  return a;
+}
+      `,
+      errors: [
+        {
+          column: 16,
+          endColumn: 29,
+          line: 4,
+          messageId: 'missingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+export default function (a: string): string;
+export default function (a: number): number;
+export default function (a: unknown) {
+  return a;
+}
+      `,
+      errors: [
+        {
+          column: 16,
+          endColumn: 25,
+          line: 4,
+          messageId: 'missingReturnType',
+        },
+      ],
+    },
+    {
+      code: `
+export class Test {
+  test(a: string): string;
+  test(a: number): number;
+  test(a: unknown) {
+    return a;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          endColumn: 7,
+          line: 5,
+          messageId: 'missingReturnType',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -831,7 +831,7 @@ export function test(a: unknown) {
       `,
       options: [
         {
-          allowImplicitReturnTypeForOverloadImplementations: true,
+          allowOverloadFunctions: true,
         },
       ],
     },
@@ -845,7 +845,7 @@ export default function test(a: unknown) {
       `,
       options: [
         {
-          allowImplicitReturnTypeForOverloadImplementations: true,
+          allowOverloadFunctions: true,
         },
       ],
     },
@@ -859,7 +859,7 @@ export default function (a: unknown) {
       `,
       options: [
         {
-          allowImplicitReturnTypeForOverloadImplementations: true,
+          allowOverloadFunctions: true,
         },
       ],
     },
@@ -875,7 +875,7 @@ export class Test {
       `,
       options: [
         {
-          allowImplicitReturnTypeForOverloadImplementations: true,
+          allowOverloadFunctions: true,
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/explicit-module-boundary-types.test.ts
@@ -821,6 +821,64 @@ export const a: Foo = {
   f: (x: boolean) => x,
 };
     `,
+    {
+      code: `
+export function test(a: string): string;
+export function test(a: number): number;
+export function test(a: unknown) {
+  return a;
+}
+      `,
+      options: [
+        {
+          allowImplicitReturnTypeForOverloadImplementations: true,
+        },
+      ],
+    },
+    {
+      code: `
+export default function test(a: string): string;
+export default function test(a: number): number;
+export default function test(a: unknown) {
+  return a;
+}
+      `,
+      options: [
+        {
+          allowImplicitReturnTypeForOverloadImplementations: true,
+        },
+      ],
+    },
+    {
+      code: `
+export default function (a: string): string;
+export default function (a: number): number;
+export default function (a: unknown) {
+  return a;
+}
+      `,
+      options: [
+        {
+          allowImplicitReturnTypeForOverloadImplementations: true,
+        },
+      ],
+    },
+    {
+      code: `
+export class Test {
+  test(a: string): string;
+  test(a: number): number;
+  test(a: unknown) {
+    return a;
+  }
+}
+      `,
+      options: [
+        {
+          allowImplicitReturnTypeForOverloadImplementations: true,
+        },
+      ],
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/schema-snapshots/explicit-module-boundary-types.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/explicit-module-boundary-types.shot
@@ -27,6 +27,10 @@ exports[`Rule schemas should be convertible to TS types for documentation purpos
         "description": "Whether to ignore return type annotations on functions immediately returning another function expression.\\nYou must still type the parameters of the function.",
         "type": "boolean"
       },
+      "allowOverloadFunctions": {
+        "description": "Whether to ignore return type annotations on functions with overload signatures.",
+        "type": "boolean"
+      },
       "allowTypedFunctionExpressions": {
         "description": "Whether to ignore type annotations on the variable of a function expression.",
         "type": "boolean"
@@ -53,6 +57,8 @@ type Options = [
      * You must still type the parameters of the function.
      */
     allowHigherOrderFunctions?: boolean;
+    /** Whether to ignore return type annotations on functions with overload signatures. */
+    allowOverloadFunctions?: boolean;
     /** Whether to ignore type annotations on the variable of a function expression. */
     allowTypedFunctionExpressions?: boolean;
     /** An array of function/method names that will not have their arguments or return values checked. */


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #4586
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #4586 and add an option to ignore overload implementations:

```ts
export function test(a: string): string;
export function test(a: number): number;
export function test(a: unknown) {
  return a;
}
```

---

Some thoughts:

Would it make sense to apply the same option to `explicit-function-return-type` too?

It seems both rules share several options (e.g. `allowHigherOrderFunctions`, `allowDirectConstAssertionInArrowFunctions`, `allowTypedFunctionExpressions`) and also have [common code for handling these options](https://github.com/typescript-eslint/typescript-eslint/blob/c910ac1553e517ebc534d3271e84b51e4ac23f5d/packages/eslint-plugin/src/util/explicitReturnTypeUtils.ts).

I think the motivation for having this option in `explicit-function-return-type` is the same for `explicit-module-boundary-types`.