### PR TITLE
feat(rule-tester): export `TestLanguageOptions`

### DIFF
--- a/packages/rule-tester/src/types/index.ts
+++ b/packages/rule-tester/src/types/index.ts
@@ -35,4 +35,4 @@ export type {
   TestCaseError,
 } from './InvalidTestCase';
 export type { RuleTesterConfig } from './RuleTesterConfig';
-export type { ValidTestCase } from './ValidTestCase';
+export type { TestLanguageOptions, ValidTestCase } from './ValidTestCase';


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10866 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

`TestLanguageOptions` is now exported from the `rule-tester` package, allowing that type to be used directly instead of accessing it via `ValidTestCase['languageOptions']`