### PR TITLE
fix(rule-tester): Add missing `parser` dependency

### DIFF
--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -49,6 +49,7 @@
   },
   "//": "NOTE - AJV is out-of-date, but it's intentionally synced with ESLint - https://github.com/eslint/eslint/blob/ad9dd6a933fd098a0d99c6a9aa059850535c23ee/package.json#L70",
   "dependencies": {
+    "@typescript-eslint/parser": "8.25.0",
     "@typescript-eslint/typescript-estree": "8.25.0",
     "@typescript-eslint/utils": "8.25.0",
     "ajv": "^6.12.6",
@@ -63,7 +64,6 @@
     "@jest/types": "29.6.3",
     "@types/json-stable-stringify-without-jsonify": "^1.0.2",
     "@types/lodash.merge": "4.6.9",
-    "@typescript-eslint/parser": "8.25.0",
     "chai": "^4.4.1",
     "eslint-visitor-keys": "^4.2.0",
     "espree": "^10.3.0",


### PR DESCRIPTION

## PR Checklist

- [x] Fixes https://github.com/typescript-eslint/typescript-eslint/issues/10908
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Refer to the related issue:https://github.com/typescript-eslint/typescript-eslint/issues/10908
