### PR TITLE
feat(eslint-plugin): [no-unused-private-class-members] new extension rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unused-private-class-members.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unused-private-class-members.mdx
@@ -1,0 +1,82 @@
+---
+description: 'Disallow unused private class members.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-unused-private-class-members** for documentation.
+
+This rule extends the base [`eslint/no-unused-private-class-members`](https://eslint.org/docs/rules/no-unused-private-class-members) rule.
+It adds support for members declared with TypeScript's `private` keyword.
+
+## Options
+
+This rule has no options.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+class A {
+  private foo = 123;
+}
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```tsx
+class A {
+  private foo = 123;
+
+  constructor() {
+    console.log(this.foo);
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+## Limitations
+
+This rule does not detect the following cases:
+
+(1) Nested classes using private members of the outer class:
+
+```ts
+class Foo {
+  private prop = 123;
+
+  method(a: Foo) {
+    return class {
+      // ✅ Detected as a usage
+      prop = this.prop;
+
+      // ❌ NOT detected as a usage
+      innerProp = a.prop;
+    };
+  }
+}
+```
+
+(2) Usages of the private member outside of the class:
+
+```ts
+class Foo {
+  private prop = 123;
+}
+
+const instance = new Foo();
+// ❌ NOT detected as a usage
+console.log(foo['prop']);
+```
+
+## When Not To Use It
+
+If you don't want to be notified about unused private class members, you can safely turn this rule off.

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -111,6 +111,8 @@ export = {
     '@typescript-eslint/no-unsafe-unary-minus': 'error',
     'no-unused-expressions': 'off',
     '@typescript-eslint/no-unused-expressions': 'error',
+    'no-unused-private-class-members': 'off',
+    '@typescript-eslint/no-unused-private-class-members': 'error',
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
     'no-use-before-define': 'off',

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -87,6 +87,7 @@ import noUnsafeReturn from './no-unsafe-return';
 import noUnsafeTypeAssertion from './no-unsafe-type-assertion';
 import noUnsafeUnaryMinus from './no-unsafe-unary-minus';
 import noUnusedExpressions from './no-unused-expressions';
+import noUnusedPrivateClassMembers from './no-unused-private-class-members';
 import noUnusedVars from './no-unused-vars';
 import noUseBeforeDefine from './no-use-before-define';
 import noUselessConstructor from './no-useless-constructor';
@@ -220,6 +221,7 @@ const rules = {
   'no-unsafe-type-assertion': noUnsafeTypeAssertion,
   'no-unsafe-unary-minus': noUnsafeUnaryMinus,
   'no-unused-expressions': noUnusedExpressions,
+  'no-unused-private-class-members': noUnusedPrivateClassMembers,
   'no-unused-vars': noUnusedVars,
   'no-use-before-define': noUseBeforeDefine,
   'no-useless-constructor': noUselessConstructor,

--- a/packages/eslint-plugin/src/rules/no-unused-private-class-members.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-private-class-members.ts
@@ -1,0 +1,266 @@
+// The following code is adapted from the code in eslint/eslint.
+// Source: https://github.com/eslint/eslint/blob/522d8a32f326c52886c531f43cf6a1ff15af8286/lib/rules/no-unused-private-class-members.js
+// License: https://github.com/eslint/eslint/blob/522d8a32f326c52886c531f43cf6a1ff15af8286/LICENSE
+
+import type { TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import { createRule } from '../util';
+
+type Options = [];
+export type MessageIds = 'unusedPrivateClassMember';
+
+interface PrivateMember {
+  declaredNode:
+    | TSESTree.MethodDefinitionComputedName
+    | TSESTree.MethodDefinitionNonComputedName
+    | TSESTree.PropertyDefinitionComputedName
+    | TSESTree.PropertyDefinitionNonComputedName;
+  isAccessor: boolean;
+}
+
+export default createRule<Options, MessageIds>({
+  name: 'no-unused-private-class-members',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow unused private class members',
+      extendsBaseRule: true,
+      requiresTypeChecking: false,
+    },
+
+    messages: {
+      unusedPrivateClassMember:
+        "'{{classMemberName}}' is defined but never used.",
+    },
+
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const trackedClassMembers: Map<string, PrivateMember>[] = [];
+
+    /**
+     * The core ESLint rule tracks methods by adding an extra property of
+     * "isUsed" to the method, which is a bug according to Joshua Goldberg.
+     * Instead, in our extended rule, we create a separate data structure to
+     * track whether a method is being used.
+     */
+    const trackedClassMembersUsed = new Set<
+      | TSESTree.MethodDefinitionComputedName
+      | TSESTree.MethodDefinitionNonComputedName
+      | TSESTree.PropertyDefinitionComputedName
+      | TSESTree.PropertyDefinitionNonComputedName
+    >();
+
+    /**
+     * Check whether the current node is in a write only assignment.
+     * @param node Node referring to a private identifier
+     * @returns Whether the node is in a write only assignment
+     * @private
+     */
+    function isWriteOnlyAssignment(
+      node: TSESTree.Identifier | TSESTree.PrivateIdentifier,
+    ): boolean {
+      const parentStatement = node.parent.parent;
+      if (parentStatement == null) {
+        return false;
+      }
+
+      const isAssignmentExpression =
+        parentStatement.type === AST_NODE_TYPES.AssignmentExpression;
+
+      if (
+        !isAssignmentExpression &&
+        parentStatement.type !== AST_NODE_TYPES.ForInStatement &&
+        parentStatement.type !== AST_NODE_TYPES.ForOfStatement &&
+        parentStatement.type !== AST_NODE_TYPES.AssignmentPattern
+      ) {
+        return false;
+      }
+
+      // It is a write-only usage, since we still allow usages on the right for
+      // reads.
+      if (parentStatement.left !== node.parent) {
+        return false;
+      }
+
+      // For any other operator (such as '+=') we still consider it a read
+      // operation.
+      if (isAssignmentExpression && parentStatement.operator !== '=') {
+        // However, if the read operation is "discarded" in an empty statement,
+        // then we consider it write only.
+        return (
+          parentStatement.parent.type === AST_NODE_TYPES.ExpressionStatement
+        );
+      }
+
+      return true;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    function processPrivateIdentifier(
+      node: TSESTree.Identifier | TSESTree.PrivateIdentifier,
+    ): void {
+      const classBody = trackedClassMembers.find(classProperties =>
+        classProperties.has(node.name),
+      );
+
+      // Can't happen, as it is a parser error to have a missing class body, but
+      // let's code defensively here.
+      if (classBody == null) {
+        return;
+      }
+
+      // In case any other usage was already detected, we can short circuit the
+      // logic here.
+      const memberDefinition = classBody.get(node.name);
+      if (memberDefinition == null) {
+        return;
+      }
+      if (trackedClassMembersUsed.has(memberDefinition.declaredNode)) {
+        return;
+      }
+
+      // The definition of the class member itself
+      if (
+        node.parent.type === AST_NODE_TYPES.PropertyDefinition ||
+        node.parent.type === AST_NODE_TYPES.MethodDefinition
+      ) {
+        return;
+      }
+
+      // Any usage of an accessor is considered a read, as the getter/setter can
+      // have side-effects in its definition.
+      if (memberDefinition.isAccessor) {
+        trackedClassMembersUsed.add(memberDefinition.declaredNode);
+        return;
+      }
+
+      // Any assignments to this member, except for assignments that also read
+      if (isWriteOnlyAssignment(node)) {
+        return;
+      }
+
+      const wrappingExpressionType = node.parent.parent?.type;
+      const parentOfWrappingExpressionType = node.parent.parent?.parent?.type;
+
+      // A statement which only increments (`this.#x++;`)
+      if (
+        wrappingExpressionType === AST_NODE_TYPES.UpdateExpression &&
+        parentOfWrappingExpressionType === AST_NODE_TYPES.ExpressionStatement
+      ) {
+        return;
+      }
+
+      /*
+       * ({ x: this.#usedInDestructuring } = bar);
+       *
+       * But should treat the following as a read:
+       * ({ [this.#x]: a } = foo);
+       */
+      if (
+        wrappingExpressionType === AST_NODE_TYPES.Property &&
+        parentOfWrappingExpressionType === AST_NODE_TYPES.ObjectPattern &&
+        node.parent.parent?.value === node.parent
+      ) {
+        return;
+      }
+
+      // [...this.#unusedInRestPattern] = bar;
+      if (wrappingExpressionType === AST_NODE_TYPES.RestElement) {
+        return;
+      }
+
+      // [this.#unusedInAssignmentPattern] = bar;
+      if (wrappingExpressionType === AST_NODE_TYPES.ArrayPattern) {
+        return;
+      }
+
+      // We can't delete the memberDefinition, as we need to keep track of which
+      // member we are marking as used. In the case of nested classes, we only
+      // mark the first member we encounter as used. If you were to delete the
+      // member, then any subsequent usage could incorrectly mark the member of
+      // an encapsulating parent class as used, which is incorrect.
+      trackedClassMembersUsed.add(memberDefinition.declaredNode);
+    }
+
+    return {
+      // Collect all declared members/methods up front and assume they are all
+      // unused.
+      ClassBody(classBodyNode): void {
+        const privateMembers = new Map<string, PrivateMember>();
+
+        trackedClassMembers.unshift(privateMembers);
+        for (const bodyMember of classBodyNode.body) {
+          if (
+            (bodyMember.type === AST_NODE_TYPES.PropertyDefinition ||
+              bodyMember.type === AST_NODE_TYPES.MethodDefinition) &&
+            (bodyMember.key.type === AST_NODE_TYPES.PrivateIdentifier ||
+              (bodyMember.key.type === AST_NODE_TYPES.Identifier &&
+                bodyMember.accessibility === 'private'))
+          ) {
+            privateMembers.set(bodyMember.key.name, {
+              declaredNode: bodyMember,
+              isAccessor:
+                bodyMember.type === AST_NODE_TYPES.MethodDefinition &&
+                (bodyMember.kind === 'set' || bodyMember.kind === 'get'),
+            });
+          }
+        }
+      },
+
+      // Process all usages of the private identifier and remove a member from
+      // `declaredAndUnusedPrivateMembers` if we deem it used.
+      PrivateIdentifier(node): void {
+        processPrivateIdentifier(node);
+      },
+
+      // Process all usages of the identifier and remove a member from
+      // `declaredAndUnusedPrivateMembers` if we deem it used.
+      MemberExpression(node): void {
+        if (
+          !node.computed &&
+          node.object.type === AST_NODE_TYPES.ThisExpression &&
+          node.property.type === AST_NODE_TYPES.Identifier
+        ) {
+          processPrivateIdentifier(node.property);
+        }
+      },
+
+      // Post-process the class members and report any remaining members. Since
+      // private members can only be accessed in the current class context, we
+      // can safely assume that all usages are within the current class body.
+      'ClassBody:exit'(): void {
+        const unusedPrivateMembers = trackedClassMembers.shift();
+        if (unusedPrivateMembers == null) {
+          return;
+        }
+
+        for (const [
+          classMemberName,
+          { declaredNode },
+        ] of unusedPrivateMembers.entries()) {
+          if (trackedClassMembersUsed.has(declaredNode)) {
+            continue;
+          }
+          context.report({
+            loc: declaredNode.key.loc,
+            node: declaredNode,
+            messageId: 'unusedPrivateClassMember',
+            data: {
+              classMemberName:
+                declaredNode.key.type === AST_NODE_TYPES.PrivateIdentifier
+                  ? `#${classMemberName}`
+                  : classMemberName,
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unused-private-class-members.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unused-private-class-members.shot
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Validating rule docs no-unused-private-class-members.mdx code examples ESLint output 1`] = `
+"Incorrect
+
+class A {
+  private foo = 123;
+          ~~~ 'foo' is defined but never used.
+}
+"
+`;
+
+exports[`Validating rule docs no-unused-private-class-members.mdx code examples ESLint output 2`] = `
+"Correct
+
+class A {
+  private foo = 123;
+
+  constructor() {
+    console.log(this.foo);
+  }
+}
+"
+`;

--- a/packages/eslint-plugin/tests/rules/no-unused-private-class-members.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-private-class-members.test.ts
@@ -1,0 +1,520 @@
+// The following tests are adapted from the tests in eslint.
+// Original Code: https://github.com/eslint/eslint/blob/522d8a32f326c52886c531f43cf6a1ff15af8286/tests/lib/rules/no-unused-private-class-members.js
+// License      : https://github.com/eslint/eslint/blob/522d8a32f326c52886c531f43cf6a1ff15af8286/LICENSE
+
+import type { TestCaseError } from '@typescript-eslint/rule-tester';
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import type { MessageIds } from '../../src/rules/no-unused-private-class-members';
+
+import rule from '../../src/rules/no-unused-private-class-members';
+
+const ruleTester = new RuleTester();
+
+/** Returns an expected error for defined-but-not-used private class member. */
+function definedError(
+  classMemberName: string,
+  addHashTag = true,
+): TestCaseError<MessageIds> {
+  return {
+    data: {
+      classMemberName: addHashTag ? `#${classMemberName}` : classMemberName,
+    },
+    messageId: 'unusedPrivateClassMember',
+  };
+}
+
+ruleTester.run('no-unused-private-class-members', rule, {
+  valid: [
+    'class Foo {}',
+    `
+class Foo {
+  publicMember = 42;
+}
+    `,
+    `
+class Foo {
+  public publicMember = 42;
+}
+    `,
+    `
+class Foo {
+  protected publicMember = 42;
+}
+    `,
+    `
+class C {
+  #usedInInnerClass;
+
+  method(a) {
+    return class {
+      foo = a.#usedInInnerClass;
+    };
+  }
+}
+    `,
+
+    ...[
+      `
+class Foo {
+  @# = 42;
+  method() {
+    return this.#;
+  }
+}
+      `,
+      `
+class Foo {
+  @# = 42;
+  anotherMember = this.#;
+}
+      `,
+      `
+class Foo {
+  @# = 42;
+  foo() {
+    anotherMember = this.#;
+  }
+}
+      `,
+      `
+class C {
+  @#;
+
+  foo() {
+    bar((this.# += 1));
+  }
+}
+      `,
+      `
+class Foo {
+  @# = 42;
+  method() {
+    return someGlobalMethod(this.#);
+  }
+}
+      `,
+      `
+class C {
+  @#;
+
+  foo() {
+    return class {};
+  }
+
+  bar() {
+    return this.#;
+  }
+}
+      `,
+      `
+class Foo {
+  @#;
+  method() {
+    for (const bar in this.#) {
+    }
+  }
+}
+      `,
+      `
+class Foo {
+  @#;
+  method() {
+    for (const bar of this.#) {
+    }
+  }
+}
+      `,
+      `
+class Foo {
+  @#;
+  method() {
+    [bar = 1] = this.#;
+  }
+}
+      `,
+      `
+class Foo {
+  @#;
+  method() {
+    [bar] = this.#;
+  }
+}
+      `,
+      `
+class C {
+  @#;
+
+  method() {
+    ({ [this.#]: a } = foo);
+  }
+}
+      `,
+      `
+class C {
+  @set #(value) {
+    doSomething(value);
+  }
+  @get #() {
+    return something();
+  }
+  method() {
+    this.# += 1;
+  }
+}
+      `,
+      `
+class Foo {
+  @set #(value) {}
+
+  method(a) {
+    [this.#] = a;
+  }
+}
+      `,
+      `
+class C {
+  @get #() {
+    return something();
+  }
+  @set #(value) {
+    doSomething(value);
+  }
+  method() {
+    this.# += 1;
+  }
+}
+      `,
+
+      //--------------------------------------------------------------------------
+      // Method definitions
+      //--------------------------------------------------------------------------
+      `
+class Foo {
+  @#() {
+    return 42;
+  }
+  anotherMethod() {
+    return this.#();
+  }
+}
+      `,
+      `
+class C {
+  @set #(value) {
+    doSomething(value);
+  }
+
+  foo() {
+    this.# = 1;
+  }
+}
+      `,
+    ].flatMap(code => [
+      code.replaceAll('#', '#privateMember').replaceAll('@', ''),
+      code.replaceAll('#', 'privateMember').replaceAll('@', 'private '),
+    ]),
+  ],
+  invalid: [
+    {
+      code: `
+class C {
+  #unusedInOuterClass;
+
+  foo() {
+    return class {
+      #unusedInOuterClass;
+
+      bar() {
+        return this.#unusedInOuterClass;
+      }
+    };
+  }
+}
+      `,
+      errors: [definedError('unusedInOuterClass')],
+    },
+    {
+      code: `
+class C {
+  #unusedOnlyInSecondNestedClass;
+
+  foo() {
+    return class {
+      #unusedOnlyInSecondNestedClass;
+
+      bar() {
+        return this.#unusedOnlyInSecondNestedClass;
+      }
+    };
+  }
+
+  baz() {
+    return this.#unusedOnlyInSecondNestedClass;
+  }
+
+  bar() {
+    return class {
+      #unusedOnlyInSecondNestedClass;
+    };
+  }
+}
+      `,
+      errors: [definedError('unusedOnlyInSecondNestedClass')],
+    },
+    {
+      code: `
+class C {
+  #usedOnlyInTheSecondInnerClass;
+
+  method(a) {
+    return class {
+      #usedOnlyInTheSecondInnerClass;
+
+      method2(b) {
+        foo = b.#usedOnlyInTheSecondInnerClass;
+      }
+
+      method3(b) {
+        foo = b.#usedOnlyInTheSecondInnerClass;
+      }
+    };
+  }
+}
+      `,
+      errors: [
+        {
+          ...definedError('usedOnlyInTheSecondInnerClass'),
+          line: 3,
+        },
+      ],
+    },
+
+    // intentionally not handled cases
+    {
+      code: `
+class C {
+  private usedInInnerClass;
+
+  method(a: C) {
+    return class {
+      foo = a.usedInInnerClass;
+    };
+  }
+}
+      `,
+      errors: [definedError('usedInInnerClass', false)],
+    },
+    {
+      code: `
+class C {
+  private usedOutsideClass;
+}
+
+const instance = new C();
+console.log(instance.usedOutsideClass);
+      `,
+      errors: [definedError('usedOutsideClass', false)],
+    },
+
+    ...[
+      {
+        code: `
+class Foo {
+  @# = 5;
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class First {}
+class Second {
+  @# = 5;
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class First {
+  @# = 5;
+}
+class Second {}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class First {
+  @# = 5;
+  @#2 = 5;
+}
+      `,
+        errors: [definedError('#', false), definedError('#2', false)],
+      },
+      {
+        code: `
+class Foo {
+  @# = 5;
+  method() {
+    this.# = 42;
+  }
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class Foo {
+  @# = 5;
+  method() {
+    this.# += 42;
+  }
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class C {
+  @#;
+
+  foo() {
+    this.#++;
+  }
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+
+      //--------------------------------------------------------------------------
+      // Unused method definitions
+      //--------------------------------------------------------------------------
+      {
+        code: `
+class Foo {
+  @#() {}
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class Foo {
+  @#() {}
+  @#Used() {
+    return 42;
+  }
+  publicMethod() {
+    return this.#Used();
+  }
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class Foo {
+  @set #(value) {}
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class Foo {
+  @#;
+  method() {
+    for (this.# in bar) {
+    }
+  }
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class Foo {
+  @#;
+  method() {
+    for (this.# of bar) {
+    }
+  }
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class Foo {
+  @#;
+  method() {
+    ({ x: this.# } = bar);
+  }
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class Foo {
+  @#;
+  method() {
+    [...this.#] = bar;
+  }
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class Foo {
+  @#;
+  method() {
+    [this.# = 1] = bar;
+  }
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+      {
+        code: `
+class Foo {
+  @#;
+  method() {
+    [this.#] = bar;
+  }
+}
+      `,
+        errors: [definedError('#', false)],
+      },
+    ].flatMap(({ code, errors }) => [
+      {
+        code: code.replaceAll('#', '#privateMember').replaceAll('@', ''),
+        errors: errors.map(error => ({
+          ...error,
+          data: {
+            classMemberName: (error.data?.classMemberName as string).replaceAll(
+              '#',
+              '#privateMember',
+            ),
+          },
+        })),
+      },
+      {
+        code: code.replaceAll('#', 'privateMember').replaceAll('@', 'private '),
+        errors: errors.map(error => ({
+          ...error,
+          data: {
+            classMemberName: (error.data?.classMemberName as string).replaceAll(
+              '#',
+              'privateMember',
+            ),
+          },
+        })),
+      },
+    ]),
+  ],
+});

--- a/packages/typescript-eslint/src/configs/all.ts
+++ b/packages/typescript-eslint/src/configs/all.ts
@@ -125,6 +125,8 @@ export default (
       '@typescript-eslint/no-unsafe-unary-minus': 'error',
       'no-unused-expressions': 'off',
       '@typescript-eslint/no-unused-expressions': 'error',
+      'no-unused-private-class-members': 'off',
+      '@typescript-eslint/no-unused-private-class-members': 'error',
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': 'error',
       'no-use-before-define': 'off',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/4571
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR implements an extension rule for `no-unused-private-class-members` that introduces support for `private` members.