### PR TITLE
fix(rule-tester): export `TestLanguageOptions`

### DIFF
--- a/packages/rule-tester/src/index.ts
+++ b/packages/rule-tester/src/index.ts
@@ -6,6 +6,7 @@ export type {
   RunTests,
   SuggestionOutput,
   TestCaseError,
+  TestLanguageOptions,
   ValidTestCase,
 } from './types';
 export type {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10866 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Take two! This was previously done in #10892, but I only exported `TestLanguageOptions` from `src/types/index.ts` 🤦‍♂️ 

This change exports it from the `src/index.ts` as well so that it's actually exported from the package.