### PR TITLE
fix(typescript-estree): fix span start for decorated `AssignmentPattern` function parameter

### DIFF
--- a/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/fixture.ts
+++ b/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/fixture.ts
@@ -1,0 +1,5 @@
+function decorator() {}
+
+class A {
+  foo(@decorator d = 1) {}
+}

--- a/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,198 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter AssignmentPattern decorated-assignment-pattern-parameter TSESTree - AST 1`] = `
+Program {
+  type: "Program",
+  body: [
+    FunctionDeclaration {
+      type: "FunctionDeclaration",
+      async: false,
+      body: BlockStatement {
+        type: "BlockStatement",
+        body: [],
+
+        range: [21, 23],
+        loc: {
+          start: { column: 21, line: 1 },
+          end: { column: 23, line: 1 },
+        },
+      },
+      declare: false,
+      expression: false,
+      generator: false,
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "decorator",
+        optional: false,
+
+        range: [9, 18],
+        loc: {
+          start: { column: 9, line: 1 },
+          end: { column: 18, line: 1 },
+        },
+      },
+      params: [],
+
+      range: [0, 23],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 23, line: 1 },
+      },
+    },
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          MethodDefinition {
+            type: "MethodDefinition",
+            computed: false,
+            decorators: [],
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "foo",
+              optional: false,
+
+              range: [37, 40],
+              loc: {
+                start: { column: 2, line: 4 },
+                end: { column: 5, line: 4 },
+              },
+            },
+            kind: "method",
+            optional: false,
+            override: false,
+            static: false,
+            value: FunctionExpression {
+              type: "FunctionExpression",
+              async: false,
+              body: BlockStatement {
+                type: "BlockStatement",
+                body: [],
+
+                range: [59, 61],
+                loc: {
+                  start: { column: 24, line: 4 },
+                  end: { column: 26, line: 4 },
+                },
+              },
+              declare: false,
+              expression: false,
+              generator: false,
+              id: null,
+              params: [
+                AssignmentPattern {
+                  type: "AssignmentPattern",
+                  decorators: [
+                    Decorator {
+                      type: "Decorator",
+                      expression: Identifier {
+                        type: "Identifier",
+                        decorators: [],
+                        name: "decorator",
+                        optional: false,
+
+                        range: [42, 51],
+                        loc: {
+                          start: { column: 7, line: 4 },
+                          end: { column: 16, line: 4 },
+                        },
+                      },
+
+                      range: [41, 51],
+                      loc: {
+                        start: { column: 6, line: 4 },
+                        end: { column: 16, line: 4 },
+                      },
+                    },
+                  ],
+                  left: Identifier {
+                    type: "Identifier",
+                    decorators: [],
+                    name: "d",
+                    optional: false,
+
+                    range: [52, 53],
+                    loc: {
+                      start: { column: 17, line: 4 },
+                      end: { column: 18, line: 4 },
+                    },
+                  },
+                  optional: false,
+                  right: Literal {
+                    type: "Literal",
+                    raw: "1",
+                    value: 1,
+
+                    range: [56, 57],
+                    loc: {
+                      start: { column: 21, line: 4 },
+                      end: { column: 22, line: 4 },
+                    },
+                  },
+
+                  range: [41, 57],
+                  loc: {
+                    start: { column: 6, line: 4 },
+                    end: { column: 22, line: 4 },
+                  },
+                },
+              ],
+
+              range: [40, 61],
+              loc: {
+                start: { column: 5, line: 4 },
+                end: { column: 26, line: 4 },
+              },
+            },
+
+            range: [37, 61],
+            loc: {
+              start: { column: 2, line: 4 },
+              end: { column: 26, line: 4 },
+            },
+          },
+        ],
+
+        range: [33, 63],
+        loc: {
+          start: { column: 8, line: 3 },
+          end: { column: 1, line: 5 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "A",
+        optional: false,
+
+        range: [31, 32],
+        loc: {
+          start: { column: 6, line: 3 },
+          end: { column: 7, line: 3 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [25, 63],
+      loc: {
+        start: { column: 0, line: 3 },
+        end: { column: 1, line: 5 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 64],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 6 },
+  },
+}
+`;

--- a/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/1-TSESTree-AST.shot
@@ -134,9 +134,9 @@ Program {
                     },
                   },
 
-                  range: [41, 57],
+                  range: [52, 57],
                   loc: {
-                    start: { column: 6, line: 4 },
+                    start: { column: 17, line: 4 },
                     end: { column: 22, line: 4 },
                   },
                 },

--- a/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,206 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter AssignmentPattern decorated-assignment-pattern-parameter TSESTree - Tokens 1`] = `
+[
+  Keyword {
+    type: "Keyword",
+    value: "function",
+
+    range: [0, 8],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "decorator",
+
+    range: [9, 18],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 18, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [18, 19],
+    loc: {
+      start: { column: 18, line: 1 },
+      end: { column: 19, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [21, 22],
+    loc: {
+      start: { column: 21, line: 1 },
+      end: { column: 22, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [22, 23],
+    loc: {
+      start: { column: 22, line: 1 },
+      end: { column: 23, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [25, 30],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 5, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "A",
+
+    range: [31, 32],
+    loc: {
+      start: { column: 6, line: 3 },
+      end: { column: 7, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [33, 34],
+    loc: {
+      start: { column: 8, line: 3 },
+      end: { column: 9, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "foo",
+
+    range: [37, 40],
+    loc: {
+      start: { column: 2, line: 4 },
+      end: { column: 5, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [40, 41],
+    loc: {
+      start: { column: 5, line: 4 },
+      end: { column: 6, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "@",
+
+    range: [41, 42],
+    loc: {
+      start: { column: 6, line: 4 },
+      end: { column: 7, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "decorator",
+
+    range: [42, 51],
+    loc: {
+      start: { column: 7, line: 4 },
+      end: { column: 16, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "d",
+
+    range: [52, 53],
+    loc: {
+      start: { column: 17, line: 4 },
+      end: { column: 18, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=",
+
+    range: [54, 55],
+    loc: {
+      start: { column: 19, line: 4 },
+      end: { column: 20, line: 4 },
+    },
+  },
+  Numeric {
+    type: "Numeric",
+    value: "1",
+
+    range: [56, 57],
+    loc: {
+      start: { column: 21, line: 4 },
+      end: { column: 22, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [57, 58],
+    loc: {
+      start: { column: 22, line: 4 },
+      end: { column: 23, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [59, 60],
+    loc: {
+      start: { column: 24, line: 4 },
+      end: { column: 25, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [60, 61],
+    loc: {
+      start: { column: 25, line: 4 },
+      end: { column: 26, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [62, 63],
+    loc: {
+      start: { column: 0, line: 5 },
+      end: { column: 1, line: 5 },
+    },
+  },
+]
+`;

--- a/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/3-Babel-AST.shot
@@ -1,0 +1,178 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter AssignmentPattern decorated-assignment-pattern-parameter Babel - AST 1`] = `
+Program {
+  type: "Program",
+  body: [
+    FunctionDeclaration {
+      type: "FunctionDeclaration",
+      async: false,
+      body: BlockStatement {
+        type: "BlockStatement",
+        body: [],
+
+        range: [21, 23],
+        loc: {
+          start: { column: 21, line: 1 },
+          end: { column: 23, line: 1 },
+        },
+      },
+      expression: false,
+      generator: false,
+      id: Identifier {
+        type: "Identifier",
+        name: "decorator",
+
+        range: [9, 18],
+        loc: {
+          start: { column: 9, line: 1 },
+          end: { column: 18, line: 1 },
+        },
+      },
+      params: [],
+
+      range: [0, 23],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 23, line: 1 },
+      },
+    },
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          MethodDefinition {
+            type: "MethodDefinition",
+            computed: false,
+            key: Identifier {
+              type: "Identifier",
+              name: "foo",
+
+              range: [37, 40],
+              loc: {
+                start: { column: 2, line: 4 },
+                end: { column: 5, line: 4 },
+              },
+            },
+            kind: "method",
+            static: false,
+            value: FunctionExpression {
+              type: "FunctionExpression",
+              async: false,
+              body: BlockStatement {
+                type: "BlockStatement",
+                body: [],
+
+                range: [59, 61],
+                loc: {
+                  start: { column: 24, line: 4 },
+                  end: { column: 26, line: 4 },
+                },
+              },
+              expression: false,
+              generator: false,
+              id: null,
+              params: [
+                AssignmentPattern {
+                  type: "AssignmentPattern",
+                  decorators: [
+                    Decorator {
+                      type: "Decorator",
+                      expression: Identifier {
+                        type: "Identifier",
+                        name: "decorator",
+
+                        range: [42, 51],
+                        loc: {
+                          start: { column: 7, line: 4 },
+                          end: { column: 16, line: 4 },
+                        },
+                      },
+
+                      range: [41, 51],
+                      loc: {
+                        start: { column: 6, line: 4 },
+                        end: { column: 16, line: 4 },
+                      },
+                    },
+                  ],
+                  left: Identifier {
+                    type: "Identifier",
+                    name: "d",
+
+                    range: [52, 53],
+                    loc: {
+                      start: { column: 17, line: 4 },
+                      end: { column: 18, line: 4 },
+                    },
+                  },
+                  right: Literal {
+                    type: "Literal",
+                    raw: "1",
+                    value: 1,
+
+                    range: [56, 57],
+                    loc: {
+                      start: { column: 21, line: 4 },
+                      end: { column: 22, line: 4 },
+                    },
+                  },
+
+                  range: [52, 57],
+                  loc: {
+                    start: { column: 17, line: 4 },
+                    end: { column: 22, line: 4 },
+                  },
+                },
+              ],
+
+              range: [40, 61],
+              loc: {
+                start: { column: 5, line: 4 },
+                end: { column: 26, line: 4 },
+              },
+            },
+
+            range: [37, 61],
+            loc: {
+              start: { column: 2, line: 4 },
+              end: { column: 26, line: 4 },
+            },
+          },
+        ],
+
+        range: [33, 63],
+        loc: {
+          start: { column: 8, line: 3 },
+          end: { column: 1, line: 5 },
+        },
+      },
+      id: Identifier {
+        type: "Identifier",
+        name: "A",
+
+        range: [31, 32],
+        loc: {
+          start: { column: 6, line: 3 },
+          end: { column: 7, line: 3 },
+        },
+      },
+      superClass: null,
+
+      range: [25, 63],
+      loc: {
+        start: { column: 0, line: 3 },
+        end: { column: 1, line: 5 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 64],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 6 },
+  },
+}
+`;

--- a/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,206 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter AssignmentPattern decorated-assignment-pattern-parameter Babel - Tokens 1`] = `
+[
+  Keyword {
+    type: "Keyword",
+    value: "function",
+
+    range: [0, 8],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "decorator",
+
+    range: [9, 18],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 18, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [18, 19],
+    loc: {
+      start: { column: 18, line: 1 },
+      end: { column: 19, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [21, 22],
+    loc: {
+      start: { column: 21, line: 1 },
+      end: { column: 22, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [22, 23],
+    loc: {
+      start: { column: 22, line: 1 },
+      end: { column: 23, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [25, 30],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 5, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "A",
+
+    range: [31, 32],
+    loc: {
+      start: { column: 6, line: 3 },
+      end: { column: 7, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [33, 34],
+    loc: {
+      start: { column: 8, line: 3 },
+      end: { column: 9, line: 3 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "foo",
+
+    range: [37, 40],
+    loc: {
+      start: { column: 2, line: 4 },
+      end: { column: 5, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [40, 41],
+    loc: {
+      start: { column: 5, line: 4 },
+      end: { column: 6, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "@",
+
+    range: [41, 42],
+    loc: {
+      start: { column: 6, line: 4 },
+      end: { column: 7, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "decorator",
+
+    range: [42, 51],
+    loc: {
+      start: { column: 7, line: 4 },
+      end: { column: 16, line: 4 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "d",
+
+    range: [52, 53],
+    loc: {
+      start: { column: 17, line: 4 },
+      end: { column: 18, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "=",
+
+    range: [54, 55],
+    loc: {
+      start: { column: 19, line: 4 },
+      end: { column: 20, line: 4 },
+    },
+  },
+  Numeric {
+    type: "Numeric",
+    value: "1",
+
+    range: [56, 57],
+    loc: {
+      start: { column: 21, line: 4 },
+      end: { column: 22, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [57, 58],
+    loc: {
+      start: { column: 22, line: 4 },
+      end: { column: 23, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [59, 60],
+    loc: {
+      start: { column: 24, line: 4 },
+      end: { column: 25, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [60, 61],
+    loc: {
+      start: { column: 25, line: 4 },
+      end: { column: 26, line: 4 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [62, 63],
+    loc: {
+      start: { column: 0, line: 5 },
+      end: { column: 1, line: 5 },
+    },
+  },
+]
+`;

--- a/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/5-AST-Alignment-AST.shot
+++ b/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/5-AST-Alignment-AST.shot
@@ -1,0 +1,204 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter AssignmentPattern decorated-assignment-pattern-parameter AST Alignment - AST 1`] = `
+"Snapshot Diff:
+- TSESTree
++ Babel
+
+  Program {
+    type: 'Program',
+    body: Array [
+      FunctionDeclaration {
+        type: 'FunctionDeclaration',
+        async: false,
+        body: BlockStatement {
+          type: 'BlockStatement',
+          body: Array [],
+
+          range: [21, 23],
+          loc: {
+            start: { column: 21, line: 1 },
+            end: { column: 23, line: 1 },
+          },
+        },
+-       declare: false,
+        expression: false,
+        generator: false,
+        id: Identifier {
+          type: 'Identifier',
+-         decorators: Array [],
+          name: 'decorator',
+-         optional: false,
+
+          range: [9, 18],
+          loc: {
+            start: { column: 9, line: 1 },
+            end: { column: 18, line: 1 },
+          },
+        },
+        params: Array [],
+
+        range: [0, 23],
+        loc: {
+          start: { column: 0, line: 1 },
+          end: { column: 23, line: 1 },
+        },
+      },
+      ClassDeclaration {
+        type: 'ClassDeclaration',
+-       abstract: false,
+        body: ClassBody {
+          type: 'ClassBody',
+          body: Array [
+            MethodDefinition {
+              type: 'MethodDefinition',
+              computed: false,
+-             decorators: Array [],
+              key: Identifier {
+                type: 'Identifier',
+-               decorators: Array [],
+                name: 'foo',
+-               optional: false,
+
+                range: [37, 40],
+                loc: {
+                  start: { column: 2, line: 4 },
+                  end: { column: 5, line: 4 },
+                },
+              },
+              kind: 'method',
+-             optional: false,
+-             override: false,
+              static: false,
+              value: FunctionExpression {
+                type: 'FunctionExpression',
+                async: false,
+                body: BlockStatement {
+                  type: 'BlockStatement',
+                  body: Array [],
+
+                  range: [59, 61],
+                  loc: {
+                    start: { column: 24, line: 4 },
+                    end: { column: 26, line: 4 },
+                  },
+                },
+-               declare: false,
+                expression: false,
+                generator: false,
+                id: null,
+                params: Array [
+                  AssignmentPattern {
+                    type: 'AssignmentPattern',
+                    decorators: Array [
+                      Decorator {
+                        type: 'Decorator',
+                        expression: Identifier {
+                          type: 'Identifier',
+-                         decorators: Array [],
+                          name: 'decorator',
+-                         optional: false,
+
+                          range: [42, 51],
+                          loc: {
+                            start: { column: 7, line: 4 },
+                            end: { column: 16, line: 4 },
+                          },
+                        },
+
+                        range: [41, 51],
+                        loc: {
+                          start: { column: 6, line: 4 },
+                          end: { column: 16, line: 4 },
+                        },
+                      },
+                    ],
+                    left: Identifier {
+                      type: 'Identifier',
+-                     decorators: Array [],
+                      name: 'd',
+-                     optional: false,
+
+                      range: [52, 53],
+                      loc: {
+                        start: { column: 17, line: 4 },
+                        end: { column: 18, line: 4 },
+                      },
+                    },
+-                   optional: false,
+                    right: Literal {
+                      type: 'Literal',
+                      raw: '1',
+                      value: 1,
+
+                      range: [56, 57],
+                      loc: {
+                        start: { column: 21, line: 4 },
+                        end: { column: 22, line: 4 },
+                      },
+                    },
+
+-                   range: [41, 57],
++                   range: [52, 57],
+                    loc: {
+-                     start: { column: 6, line: 4 },
++                     start: { column: 17, line: 4 },
+                      end: { column: 22, line: 4 },
+                    },
+                  },
+                ],
+
+                range: [40, 61],
+                loc: {
+                  start: { column: 5, line: 4 },
+                  end: { column: 26, line: 4 },
+                },
+              },
+
+              range: [37, 61],
+              loc: {
+                start: { column: 2, line: 4 },
+                end: { column: 26, line: 4 },
+              },
+            },
+          ],
+
+          range: [33, 63],
+          loc: {
+            start: { column: 8, line: 3 },
+            end: { column: 1, line: 5 },
+          },
+        },
+-       declare: false,
+-       decorators: Array [],
+        id: Identifier {
+          type: 'Identifier',
+-         decorators: Array [],
+          name: 'A',
+-         optional: false,
+
+          range: [31, 32],
+          loc: {
+            start: { column: 6, line: 3 },
+            end: { column: 7, line: 3 },
+          },
+        },
+-       implements: Array [],
+        superClass: null,
+
+        range: [25, 63],
+        loc: {
+          start: { column: 0, line: 3 },
+          end: { column: 1, line: 5 },
+        },
+      },
+    ],
+    sourceType: 'script',
+
+    range: [0, 64],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 0, line: 6 },
+    },
+  }"
+`;

--- a/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/5-AST-Alignment-AST.shot
+++ b/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/5-AST-Alignment-AST.shot
@@ -138,11 +138,9 @@ exports[`AST Fixtures parameter AssignmentPattern decorated-assignment-pattern-p
                       },
                     },
 
--                   range: [41, 57],
-+                   range: [52, 57],
+                    range: [52, 57],
                     loc: {
--                     start: { column: 6, line: 4 },
-+                     start: { column: 17, line: 4 },
+                      start: { column: 17, line: 4 },
                       end: { column: 22, line: 4 },
                     },
                   },

--- a/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/6-AST-Alignment-Tokens.shot
+++ b/packages/ast-spec/src/parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/snapshots/6-AST-Alignment-Tokens.shot
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AST Fixtures parameter AssignmentPattern decorated-assignment-pattern-parameter AST Alignment - Token 1`] = `
+"Snapshot Diff:
+Compared values have no visual difference."
+`;

--- a/packages/ast-spec/tests/fixtures-with-differences-ast.shot
+++ b/packages/ast-spec/tests/fixtures-with-differences-ast.shot
@@ -488,6 +488,7 @@ exports[`AST Fixtures List fixtures with AST differences 1`] = `
   "legacy-fixtures/types/fixtures/typeof/fixture.ts",
   "legacy-fixtures/types/fixtures/union-intersection/fixture.ts",
   "legacy-fixtures/types/fixtures/union-type/fixture.ts",
+  "parameter/AssignmentPattern/fixtures/decorated-assignment-pattern-parameter/fixture.ts",
   "special/Decorator/fixtures/decorator-class-member-super-with-parens/fixture.ts",
   "special/Decorator/fixtures/decorator-class-member-super-without-parens/fixture.ts",
   "special/ExportSpecifier/fixtures/literal-specifier/fixture.ts",

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1955,6 +1955,7 @@ export class Converter {
           parameter = this.convertChild(node.name) as TSESTree.BindingName;
           result = this.createNode<TSESTree.AssignmentPattern>(node, {
             type: AST_NODE_TYPES.AssignmentPattern,
+            range: [node.name.getStart(this.ast), node.initializer.end],
             decorators: [],
             left: parameter,
             optional: false,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10937
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10937 and adjusts the range for decorated `AssignmentPattern` function parameter to match other binding patterns.

I've added a test for this since the change didn't cause any tests to fail (and so this was probably missing a test).