### PR TITLE
fix(eslint-plugin): support arbitrary extensions in definition files

### DIFF
--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -25,6 +25,11 @@ export function isDefinitionFile(fileName: string): boolean {
       return true;
     }
   }
+
+  if (lowerFileName.includes('.d.') && lowerFileName.endsWith('.ts')) {
+    return true;
+  }
+
   return false;
 }
 

--- a/packages/eslint-plugin/src/util/misc.ts
+++ b/packages/eslint-plugin/src/util/misc.ts
@@ -26,11 +26,7 @@ export function isDefinitionFile(fileName: string): boolean {
     }
   }
 
-  if (lowerFileName.includes('.d.') && lowerFileName.endsWith('.ts')) {
-    return true;
-  }
-
-  return false;
+  return /\.d\.(ts|cts|mts|.*\.ts)$/.test(lowerFileName);
 }
 
 /**

--- a/packages/eslint-plugin/tests/util/misc.test.ts
+++ b/packages/eslint-plugin/tests/util/misc.test.ts
@@ -1,5 +1,26 @@
 import * as misc from '../../src/util/misc';
 
+describe('isDefinitionFile', () => {
+  it('returns true for standard definition files', () => {
+    expect(misc.isDefinitionFile('index.d.ts')).toBe(true);
+    expect(misc.isDefinitionFile('module.d.cts')).toBe(true);
+    expect(misc.isDefinitionFile('package.d.mts')).toBe(true);
+  });
+
+  it('returns true for arbitrary extension definition files', () => {
+    expect(misc.isDefinitionFile('vite-env.d.ts')).toBe(true);
+    expect(misc.isDefinitionFile('styled-components.d.ts')).toBe(true);
+    expect(misc.isDefinitionFile('mdx.d.ts')).toBe(true);
+  });
+
+  it('returns false for non definition files', () => {
+    expect(misc.isDefinitionFile('index.ts')).toBe(false);
+    expect(misc.isDefinitionFile('app.tsx')).toBe(false);
+    expect(misc.isDefinitionFile('styles.css.ts')).toBe(false);
+    expect(misc.isDefinitionFile('vite.config.ts')).toBe(false);
+  });
+});
+
 describe('formatWordList', () => {
   it('can format with no words', () => {
     expect(misc.formatWordList([])).toBe('');

--- a/packages/eslint-plugin/tests/util/misc.test.ts
+++ b/packages/eslint-plugin/tests/util/misc.test.ts
@@ -8,9 +8,9 @@ describe('isDefinitionFile', () => {
   });
 
   it('returns true for arbitrary extension definition files', () => {
-    expect(misc.isDefinitionFile('vite-env.d.ts')).toBe(true);
-    expect(misc.isDefinitionFile('styled-components.d.ts')).toBe(true);
-    expect(misc.isDefinitionFile('mdx.d.ts')).toBe(true);
+    expect(misc.isDefinitionFile('styles.d.css.ts')).toBe(true);
+    expect(misc.isDefinitionFile('component.d.vue.ts')).toBe(true);
+    expect(misc.isDefinitionFile('env.d.node.ts')).toBe(true);
   });
 
   it('returns false for non definition files', () => {

--- a/packages/eslint-plugin/tests/util/misc.test.ts
+++ b/packages/eslint-plugin/tests/util/misc.test.ts
@@ -1,24 +1,26 @@
 import * as misc from '../../src/util/misc';
 
 describe('isDefinitionFile', () => {
-  it('returns true for standard definition files', () => {
-    expect(misc.isDefinitionFile('index.d.ts')).toBe(true);
-    expect(misc.isDefinitionFile('module.d.cts')).toBe(true);
-    expect(misc.isDefinitionFile('package.d.mts')).toBe(true);
-  });
+  it.each([['index.d.ts'], ['module.d.cts'], ['package.d.mts']])(
+    'returns true for standard definition file: %s',
+    filename => {
+      expect(misc.isDefinitionFile(filename)).toBe(true);
+    },
+  );
 
-  it('returns true for arbitrary extension definition files', () => {
-    expect(misc.isDefinitionFile('styles.d.css.ts')).toBe(true);
-    expect(misc.isDefinitionFile('component.d.vue.ts')).toBe(true);
-    expect(misc.isDefinitionFile('env.d.node.ts')).toBe(true);
-  });
+  it.each([['styles.d.css.ts'], ['component.d.vue.ts'], ['env.d.node.ts']])(
+    'returns true for arbitrary extension definition file: %s',
+    filename => {
+      expect(misc.isDefinitionFile(filename)).toBe(true);
+    },
+  );
 
-  it('returns false for non definition files', () => {
-    expect(misc.isDefinitionFile('index.ts')).toBe(false);
-    expect(misc.isDefinitionFile('app.tsx')).toBe(false);
-    expect(misc.isDefinitionFile('styles.css.ts')).toBe(false);
-    expect(misc.isDefinitionFile('vite.config.ts')).toBe(false);
-  });
+  it.each([['index.ts'], ['app.tsx'], ['styles.css.ts'], ['vite.config.ts']])(
+    'returns false for non definition file: %s',
+    filename => {
+      expect(misc.isDefinitionFile(filename)).toBe(false);
+    },
+  );
 });
 
 describe('formatWordList', () => {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10911 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR #10911 adds support for TypeScript's `allowArbitraryExtensions` feature in the `isDefinitionFile` utility.
