### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] don't report on unnecessary optional array index access when `noUncheckedIndexedAccess` is enabled

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -357,7 +357,7 @@ export default createRule<Options, MessageId>({
       // Since typescript array index signature types don't represent the
       //  possibility of out-of-bounds access, if we're indexing into an array
       //  just skip the check, to avoid false positives
-      if (isArrayIndexExpression(expression)) {
+      if (!isNoUncheckedIndexedAccess && isArrayIndexExpression(expression)) {
         return;
       }
 
@@ -424,12 +424,13 @@ export default createRule<Options, MessageId>({
         //  possibility of out-of-bounds access, if we're indexing into an array
         //  just skip the check, to avoid false positives
         if (
-          !isArrayIndexExpression(node) &&
-          !(
-            node.type === AST_NODE_TYPES.ChainExpression &&
-            node.expression.type !== AST_NODE_TYPES.TSNonNullExpression &&
-            optionChainContainsOptionArrayIndex(node.expression)
-          )
+          isNoUncheckedIndexedAccess ||
+          (!isArrayIndexExpression(node) &&
+            !(
+              node.type === AST_NODE_TYPES.ChainExpression &&
+              node.expression.type !== AST_NODE_TYPES.TSNonNullExpression &&
+              optionChainContainsOptionArrayIndex(node.expression)
+            ))
         ) {
           messageId = 'neverNullish';
         }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -3369,5 +3369,54 @@ declare const arr2: Array<{ x: { y: { z: object } } }>;
 arr2[42]?.x.y.z;
       `,
     },
+    {
+      code: `
+declare const arr: string[];
+
+if (arr[0]) {
+  arr[0] ?? 'foo';
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          endColumn: 9,
+          endLine: 5,
+          line: 5,
+          messageId: 'neverNullish',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
+    {
+      code: `
+declare const arr: object[];
+
+if (arr[42] && arr[42]) {
+}
+      `,
+      errors: [
+        {
+          column: 16,
+          endColumn: 23,
+          endLine: 4,
+          line: 4,
+          messageId: 'alwaysTruthy',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
+        },
+      },
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10960
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #10960 and disables [the special-casing of optional array index access](https://github.com/typescript-eslint/typescript-eslint/blob/543d36ce9aacdb75e8bf85860984704dfbf8f8ff/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts#L835-L840) when [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess) is enabled. 

This makes the rule report cases like the following:

```ts
declare const test: Array<{ a?: string }>;

// Reported by TypeScript as the object is possibly 'undefined'
test[0].a;

if (test[0]?.a) {
  // Optional chaining isn't necessary here
  test[0].a;    
}

if (test[0]?.a) {
  // Should be reported but doesn't?
  test[0]?.a;
}
```

Note that this also causes the rule to report on unnecessary optional index access that's deeper in the chain (only when `noUncheckedIndexedAccess` is turned on):

```ts
declare const arr2: Array<{ x: { y: { z: object } } }>;

// the following (previously wasn't reported):
arr2[42]?.x?.y?.z;

// is auto-fixed into:
arr2[42]?.x.y.z;
```

I've added a couple of tests to verify the rule handles these cases correctly when `noUncheckedIndexedAccess` is enabled.