### PR TITLE
fix(eslint-plugin): [no-array-constructor] remove optional chaining exemption

### DIFF
--- a/packages/eslint-plugin/src/rules/no-array-constructor.ts
+++ b/packages/eslint-plugin/src/rules/no-array-constructor.ts
@@ -36,26 +36,18 @@ export default createRule({
         return '';
       }
 
-      let firstToken = sourceCode.getTokenAfter(node.callee);
-
-      // if(firstToken == null){
-      //   return ""
-      // }
+      let firstToken: TSESTree.Expression | TSESTree.Token | null = node.callee;
 
       do {
-        if (firstToken == null) {
+        firstToken = sourceCode.getTokenAfter(firstToken);
+        if (!firstToken || firstToken === lastToken) {
           return '';
         }
-        const fisrtTokenCandidate = sourceCode.getTokenAfter(firstToken);
-
-        if (fisrtTokenCandidate == null || fisrtTokenCandidate === lastToken) {
-          return '';
-        }
-        firstToken = fisrtTokenCandidate;
       } while (!isOpeningParenToken(firstToken));
 
       return sourceCode.text.slice(firstToken.range[1], lastToken.range[0]);
     }
+
     /**
      * Disallow construction of dense arrays using the Array constructor
      * @param node node to evaluate

--- a/packages/eslint-plugin/src/rules/no-array-constructor.ts
+++ b/packages/eslint-plugin/src/rules/no-array-constructor.ts
@@ -2,7 +2,7 @@ import type { TSESTree } from '@typescript-eslint/utils';
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
-import { createRule, isOptionalCallExpression } from '../util';
+import { createRule } from '../util';
 
 export default createRule({
   name: 'no-array-constructor',
@@ -32,8 +32,7 @@ export default createRule({
         node.arguments.length !== 1 &&
         node.callee.type === AST_NODE_TYPES.Identifier &&
         node.callee.name === 'Array' &&
-        !node.typeArguments &&
-        !isOptionalCallExpression(node)
+        !node.typeArguments
       ) {
         context.report({
           node,
@@ -43,7 +42,10 @@ export default createRule({
               return fixer.replaceText(node, '[]');
             }
             const fullText = context.sourceCode.getText(node);
-            const preambleLength = node.callee.range[1] - node.range[0];
+            const preambleLength =
+              node.parent.type === AST_NODE_TYPES.ChainExpression
+                ? node.callee.range[1] + 2 - node.range[0]
+                : node.callee.range[1] - node.range[0];
 
             return fixer.replaceText(
               node,

--- a/packages/eslint-plugin/tests/rules/no-array-constructor.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-array-constructor.test.ts
@@ -33,8 +33,6 @@ ruleTester.run('no-array-constructor', rule, {
     'Array.foo?.();',
     'Array?.<Foo>(1, 2, 3);',
     'Array?.<Foo>();',
-    'Array?.(0, 1, 2);',
-    'Array?.(x, y);',
   ],
 
   invalid: [
@@ -50,6 +48,16 @@ ruleTester.run('no-array-constructor', rule, {
     },
     {
       code: 'Array();',
+      errors: [
+        {
+          messageId,
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+      output: '[];',
+    },
+    {
+      code: 'Array?.();',
       errors: [
         {
           messageId,
@@ -79,6 +87,16 @@ ruleTester.run('no-array-constructor', rule, {
       output: '[x, y];',
     },
     {
+      code: 'Array?.(x, y);',
+      errors: [
+        {
+          messageId,
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+      output: '[x, y];',
+    },
+    {
       code: 'new Array(0, 1, 2);',
       errors: [
         {
@@ -90,6 +108,16 @@ ruleTester.run('no-array-constructor', rule, {
     },
     {
       code: 'Array(0, 1, 2);',
+      errors: [
+        {
+          messageId,
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+      output: '[0, 1, 2];',
+    },
+    {
+      code: 'Array?.(0, 1, 2);',
       errors: [
         {
           messageId,

--- a/packages/eslint-plugin/tests/rules/no-array-constructor.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-array-constructor.test.ts
@@ -67,6 +67,16 @@ ruleTester.run('no-array-constructor', rule, {
       output: '[];',
     },
     {
+      code: '/* a */ /* b */ Array /* c */ /* d */ /* e */ /* f */?.(); /* g */ /* h */',
+      errors: [
+        {
+          messageId,
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+      output: '/* a */ /* b */ []; /* g */ /* h */',
+    },
+    {
       code: 'new Array(x, y);',
       errors: [
         {
@@ -97,6 +107,16 @@ ruleTester.run('no-array-constructor', rule, {
       output: '[x, y];',
     },
     {
+      code: '/* a */ /* b */ Array /* c */ /* d */ /* e */ /* f */?.(x, y); /* g */ /* h */',
+      errors: [
+        {
+          messageId,
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+      output: '/* a */ /* b */ [x, y]; /* g */ /* h */',
+    },
+    {
       code: 'new Array(0, 1, 2);',
       errors: [
         {
@@ -125,6 +145,28 @@ ruleTester.run('no-array-constructor', rule, {
         },
       ],
       output: '[0, 1, 2];',
+    },
+    {
+      code: `
+/* a */ /* b */ Array /* c */ /* d */ /* e */ /* f */?.(
+  0,
+  1,
+  2,
+); /* g */ /* h */
+      `,
+      errors: [
+        {
+          messageId,
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+      output: `
+/* a */ /* b */ [
+  0,
+  1,
+  2,
+]; /* g */ /* h */
+      `,
     },
     {
       code: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10933
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

remove optional chaining logic and change test case
