### PR TITLE
chore: enable erasableSyntaxOnly in tools

### DIFF
--- a/tsconfig.repo-config-files.json
+++ b/tsconfig.repo-config-files.json
@@ -4,7 +4,8 @@
     "outDir": "dist/out-tsc/root/eslint",
     "types": ["@types/node"],
     "allowJs": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true
   },
   "include": [
     "typings",


### PR DESCRIPTION
Is this what you meant @kirkwaiblinger?

we can't enable it at repo level since the ast-types use enums still

## PR Checklist

- [x] Addresses an existing open issue: fixes #10967 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
