### PR TITLE
chore: allow releases without changes

### DIFF
--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -20,6 +20,12 @@ const options = await yargs(process.argv.slice(2))
       'Whether to perform a dry-run of the release process, defaults to true',
     type: 'boolean',
   })
+  .option('forceReleaseWithoutChanges', {
+    default: false,
+    description:
+      'Whether to do a release regardless of if there have been changes',
+    type: 'boolean',
+  })
   .option('verbose', {
     default: false,
     description: 'Whether or not to enable verbose logging, defaults to false',
@@ -55,7 +61,7 @@ await releaseChangelog({
 
 // An explicit null value here means that no changes were detected across any package
 // eslint-disable-next-line eqeqeq, @typescript-eslint/internal/eqeq-nullish
-if (workspaceVersion === null) {
+if (!option.forceReleaseWithoutChanges && workspaceVersion === null) {
   console.log(
     '⏭️ No changes detected across any package, skipping publish step altogether',
   );

--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -61,7 +61,7 @@ await releaseChangelog({
 
 // An explicit null value here means that no changes were detected across any package
 // eslint-disable-next-line eqeqeq, @typescript-eslint/internal/eqeq-nullish
-if (!option.forceReleaseWithoutChanges && workspaceVersion === null) {
+if (!options.forceReleaseWithoutChanges && workspaceVersion === null) {
   console.log(
     '⏭️ No changes detected across any package, skipping publish step altogether',
   );


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## Overview

<!-- Description of what is changed and how the code change does that. -->
Adds a flag that will allow us to do manual releases that bypass this check.
For example right now the [v8.27.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.27.0) release didn't go to npm due to a token issue -- but all of the GH stuff was done. This will allow us to rectify this situation in future with a few clicks!