### PR TITLE
chore: de-duplicate lint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -406,6 +406,7 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
+  // jest-specific config
   {
     files: [
       'packages/*/tests/**/*.test.{ts,tsx,cts,mts}',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,9 +29,11 @@ const restrictNamedDeclarations = {
   selector: 'ExportNamedDeclaration[declaration=null][source=null]',
 };
 
-const vitestFiles = [
-  'packages/eslint-plugin-internal/tests/**/*.test.{ts,tsx,cts,mts}',
-];
+const vitestPackages = ['eslint-plugin-internal'];
+
+const vitestFiles = vitestPackages.map(
+  name => `packages/${name}/tests/**/*.test.{ts,tsx,cts,mts}`,
+);
 
 export default tseslint.config(
   // register all of the plugins up-front
@@ -392,7 +394,6 @@ export default tseslint.config(
       'packages/integration-tests/tools/integration-test-base.ts',
       'packages/integration-tests/tools/pack-packages.ts',
     ],
-    ignores: vitestFiles,
     rules: {
       '@typescript-eslint/no-empty-function': [
         'error',
@@ -403,6 +404,18 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
+    },
+  },
+  {
+    files: [
+      'packages/*/tests/**/*.test.{ts,tsx,cts,mts}',
+      'packages/*/tests/**/test.{ts,tsx,cts,mts}',
+      'packages/parser/tests/**/*.{ts,tsx,cts,mts}',
+      'packages/integration-tests/tools/integration-test-base.ts',
+      'packages/integration-tests/tools/pack-packages.ts',
+    ],
+    ignores: vitestFiles,
+    rules: {
       'jest/no-alias-methods': 'error',
       'jest/no-deprecated-functions': 'error',
       'jest/no-disabled-tests': 'error',
@@ -423,15 +436,6 @@ export default tseslint.config(
   {
     files: vitestFiles,
     rules: {
-      '@typescript-eslint/no-empty-function': [
-        'error',
-        { allow: ['arrowFunctions'] },
-      ],
-      '@typescript-eslint/no-non-null-assertion': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/no-unsafe-return': 'off',
       'vitest/no-alias-methods': 'error',
       'vitest/no-disabled-tests': 'error',
       'vitest/no-focused-tests': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -433,7 +433,7 @@ export default tseslint.config(
       'jest/valid-expect': 'error',
     },
   },
-  // test file specific configuration
+  // vitest-specific configuration
   {
     files: vitestFiles,
     rules: {


### PR DESCRIPTION
This just simplifies the lint config slightly by doing the following:

- Separate vitest and jest rules from regular rules, so we can declare the regular rules once for both
- Change `vitestFiles` to be computed in preparation for us moving more packages to vitest (so we don't end up with a bunch of _very similar_ globs)

## PR Checklist

- [x] Addresses an existing open issue: #7112
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
