### PR TITLE
feat(eslint-plugin): [no-unnecessary-type-assertion] add option to ignore string const assertions

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.mdx
@@ -73,6 +73,16 @@ function foo(x: number | undefined): number {
 
 ## Options
 
+### `ignoreStringConstAssertion`
+
+{/* insert option description */}
+
+With `@typescript-eslint/no-unnecessary-type-assertion: ["error", { ignoreStringConstAssertion: true }]`, the following is **correct** code:
+
+```ts option='{ "ignoreStringConstAssertion": true }' showPlaygroundButton
+const foo = `foo` as const;
+```
+
 ### `typesToIgnore`
 
 {/* insert option description */}

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.mdx
@@ -69,15 +69,17 @@ function foo(x: number | undefined): number {
 
 ## Options
 
-### `checkLiteralConstAssertion`
+### `checkLiteralConstAssertions`
 
 {/* insert option description */}
 
-With `@typescript-eslint/no-unnecessary-type-assertion: ["error", { checkLiteralConstAssertion: true }]`, the following is **incorrect** code:
+With `@typescript-eslint/no-unnecessary-type-assertion: ["error", { checkLiteralConstAssertions: true }]`, the following is **incorrect** code:
 
-```ts option='{ "checkLiteralConstAssertion": true }' showPlaygroundButton
+```ts option='{ "checkLiteralConstAssertions": true }' showPlaygroundButton
 const foo = 'foo' as const;
 ```
+
+See [#8721 False positives for "as const" assertions (issue comment)](https://github.com/typescript-eslint/typescript-eslint/issues/8721#issuecomment-2145291966) for more information on this option.
 
 ### `typesToIgnore`
 

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.mdx
@@ -38,10 +38,6 @@ const foo = (3 + 5) as Foo;
 ```
 
 ```ts
-const foo = 'foo' as const;
-```
-
-```ts
 function foo(x: number): number {
   return x!; // unnecessary non-null
 }
@@ -73,14 +69,14 @@ function foo(x: number | undefined): number {
 
 ## Options
 
-### `ignoreStringConstAssertion`
+### `checkLiteralConstAssertion`
 
 {/* insert option description */}
 
-With `@typescript-eslint/no-unnecessary-type-assertion: ["error", { ignoreStringConstAssertion: true }]`, the following is **correct** code:
+With `@typescript-eslint/no-unnecessary-type-assertion: ["error", { checkLiteralConstAssertion: true }]`, the following is **incorrect** code:
 
-```ts option='{ "ignoreStringConstAssertion": true }' showPlaygroundButton
-const foo = `foo` as const;
+```ts option='{ "checkLiteralConstAssertion": true }' showPlaygroundButton
+const foo = 'foo' as const;
 ```
 
 ### `typesToIgnore`

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -223,12 +223,7 @@ export default createRule<Options, MessageIds>({
     }
 
     function isTypeLiteral(type: ts.Type) {
-      return (
-        type.isLiteral() ||
-        tsutils.isBooleanLiteralType(type) ||
-        type.flags === ts.TypeFlags.Undefined ||
-        type.flags === ts.TypeFlags.Null
-      );
+      return type.isLiteral() || tsutils.isBooleanLiteralType(type);
     }
 
     return {
@@ -244,8 +239,6 @@ export default createRule<Options, MessageIds>({
         }
 
         const castType = services.getTypeAtLocation(node);
-        const uncastType = services.getTypeAtLocation(node.expression);
-        const typeIsUnchanged = isTypeUnchanged(uncastType, castType);
         const castTypeIsLiteral = isTypeLiteral(castType);
         const typeAnnotationIsConstAssertion = isConstAssertion(
           node.typeAnnotation,
@@ -259,6 +252,8 @@ export default createRule<Options, MessageIds>({
           return;
         }
 
+        const uncastType = services.getTypeAtLocation(node.expression);
+        const typeIsUnchanged = isTypeUnchanged(uncastType, castType);
         const wouldSameTypeBeInferred = castTypeIsLiteral
           ? isImplicitlyNarrowedLiteralDeclaration(node)
           : !typeAnnotationIsConstAssertion;

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -21,6 +21,7 @@ import {
 
 export type Options = [
   {
+    ignoreStringConstAssertion?: boolean;
     typesToIgnore?: string[];
   },
 ];
@@ -48,6 +49,10 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         additionalProperties: false,
         properties: {
+          ignoreStringConstAssertion: {
+            type: 'boolean',
+            description: 'Whether to ignore string const assertions.',
+          },
           typesToIgnore: {
             type: 'array',
             description: 'A list of type names to ignore.',
@@ -232,6 +237,14 @@ export default createRule<Options, MessageIds>({
         const castType = services.getTypeAtLocation(node);
         const uncastType = services.getTypeAtLocation(node.expression);
         const typeIsUnchanged = isTypeUnchanged(uncastType, castType);
+
+        if (
+          options.ignoreStringConstAssertion &&
+          uncastType.isStringLiteral() &&
+          isConstAssertion(node.typeAnnotation)
+        ) {
+          return;
+        }
 
         const wouldSameTypeBeInferred = castType.isLiteral()
           ? isImplicitlyNarrowedLiteralDeclaration(node)

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -21,7 +21,7 @@ import {
 
 export type Options = [
   {
-    ignoreStringConstAssertion?: boolean;
+    checkLiteralConstAssertion?: boolean;
     typesToIgnore?: string[];
   },
 ];
@@ -49,9 +49,9 @@ export default createRule<Options, MessageIds>({
         type: 'object',
         additionalProperties: false,
         properties: {
-          ignoreStringConstAssertion: {
+          checkLiteralConstAssertion: {
             type: 'boolean',
-            description: 'Whether to ignore string const assertions.',
+            description: 'Whether to check literal const assertions.',
           },
           typesToIgnore: {
             type: 'array',
@@ -239,8 +239,8 @@ export default createRule<Options, MessageIds>({
         const typeIsUnchanged = isTypeUnchanged(uncastType, castType);
 
         if (
-          options.ignoreStringConstAssertion &&
-          uncastType.isStringLiteral() &&
+          !options.checkLiteralConstAssertion &&
+          node.expression.type === AST_NODE_TYPES.Literal &&
           isConstAssertion(node.typeAnnotation)
         ) {
           return;

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -222,6 +222,16 @@ export default createRule<Options, MessageIds>({
       return false;
     }
 
+    function isTypeLiteral(type: ts.Type) {
+      // type.isLiteral() only covers numbers/bigints and strings, hence the rest of the conditions.
+      return (
+        type.isLiteral() ||
+        tsutils.isBooleanLiteralType(type) ||
+        type.flags === ts.TypeFlags.Undefined ||
+        type.flags === ts.TypeFlags.Null
+      );
+    }
+
     return {
       'TSAsExpression, TSTypeAssertion'(
         node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
@@ -240,13 +250,13 @@ export default createRule<Options, MessageIds>({
 
         if (
           !options.checkLiteralConstAssertion &&
-          node.expression.type === AST_NODE_TYPES.Literal &&
-          isConstAssertion(node.typeAnnotation)
+          isConstAssertion(node.typeAnnotation) &&
+          isTypeLiteral(castType)
         ) {
           return;
         }
 
-        const wouldSameTypeBeInferred = castType.isLiteral()
+        const wouldSameTypeBeInferred = isTypeLiteral(castType)
           ? isImplicitlyNarrowedLiteralDeclaration(node)
           : !isConstAssertion(node.typeAnnotation);
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-type-assertion.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-type-assertion.shot
@@ -23,11 +23,6 @@ const foo = (3 + 5) as Foo;
 
 Incorrect
 
-const foo = 'foo' as const;
-            ~~~~~~~~~~~~~~ This assertion is unnecessary since it does not change the type of the expression.
-
-Incorrect
-
 function foo(x: number): number {
   return x!; // unnecessary non-null
          ~~ This assertion is unnecessary since it does not change the type of the expression.
@@ -51,9 +46,10 @@ function foo(x: number | undefined): number {
   return x!;
 }
 
-Options: { "ignoreStringConstAssertion": true }
+Options: { "checkLiteralConstAssertion": true }
 
-const foo = `foo` as const;
+const foo = 'foo' as const;
+            ~~~~~~~~~~~~~~ This assertion is unnecessary since it does not change the type of the expression.
 
 Options: { "typesToIgnore": ["Foo"] }
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-type-assertion.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-type-assertion.shot
@@ -51,6 +51,10 @@ function foo(x: number | undefined): number {
   return x!;
 }
 
+Options: { "ignoreStringConstAssertion": true }
+
+const foo = `foo` as const;
+
 Options: { "typesToIgnore": ["Foo"] }
 
 type Foo = 3;

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-type-assertion.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-type-assertion.shot
@@ -46,7 +46,7 @@ function foo(x: number | undefined): number {
   return x!;
 }
 
-Options: { "checkLiteralConstAssertion": true }
+Options: { "checkLiteralConstAssertions": true }
 
 const foo = 'foo' as const;
             ~~~~~~~~~~~~~~ This assertion is unnecessary since it does not change the type of the expression.

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -1322,6 +1322,42 @@ foo(baz);
       `,
     },
     {
+      code: 'const a = null as const;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = null;',
+    },
+    {
+      code: 'const a = <const>null;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = null;',
+    },
+    {
+      code: 'const a = undefined as const;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = undefined;',
+    },
+    {
+      code: 'const a = <const>undefined;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = undefined;',
+    },
+    {
+      code: 'const a = true as const;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = true;',
+    },
+    {
+      code: 'const a = <const>true;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = true;',
+    },
+    {
       code: 'const a = 1 as const;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
       options: [{ checkLiteralConstAssertion: true }],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -429,6 +429,32 @@ declare function foo<T extends unknown>(bar: T): T;
 const baz: unknown = {};
 foo(baz!);
     `,
+    {
+      code: 'const a = `a` as const;',
+    },
+    {
+      code: "const a = 'a' as const;",
+    },
+    {
+      code: "const a = <const>'a';",
+    },
+    {
+      code: `
+class T {
+  readonly a = 'a' as const;
+}
+      `,
+    },
+    {
+      code: `
+enum T {
+  Value1,
+  Value2,
+}
+declare const a: T.Value1;
+const b = a as const;
+      `,
+    },
   ],
 
   invalid: [
@@ -1320,30 +1346,6 @@ function foo(bar: unknown) {}
 const baz: unknown = {};
 foo(baz);
       `,
-    },
-    {
-      code: 'const a = null as const;',
-      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertions: true }],
-      output: 'const a = null;',
-    },
-    {
-      code: 'const a = <const>null;',
-      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertions: true }],
-      output: 'const a = null;',
-    },
-    {
-      code: 'const a = undefined as const;',
-      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertions: true }],
-      output: 'const a = undefined;',
-    },
-    {
-      code: 'const a = <const>undefined;',
-      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertions: true }],
-      output: 'const a = undefined;',
     },
     {
       code: 'const a = true as const;',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -429,37 +429,9 @@ declare function foo<T extends unknown>(bar: T): T;
 const baz: unknown = {};
 foo(baz!);
     `,
-    {
-      code: 'const a = `a` as const;',
-      options: [{ ignoreStringConstAssertion: true }],
-    },
-    {
-      code: "const a = 'a' as const;",
-      options: [{ ignoreStringConstAssertion: true }],
-    },
-    {
-      code: "const a = <const>'a';",
-      options: [{ ignoreStringConstAssertion: true }],
-    },
   ],
 
   invalid: [
-    // https://github.com/typescript-eslint/typescript-eslint/issues/8737
-    {
-      code: 'const a = `a` as const;',
-      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      output: 'const a = `a`;',
-    },
-    {
-      code: "const a = 'a' as const;",
-      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      output: "const a = 'a';",
-    },
-    {
-      code: "const a = <const>'a';",
-      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      output: "const a = 'a';",
-    },
     {
       code: 'const foo = <3>3;',
       errors: [{ column: 13, line: 1, messageId: 'unnecessaryAssertion' }],
@@ -1222,24 +1194,6 @@ var x = 1;
     {
       code: `
 class T {
-  readonly a = 'a' as const;
-}
-      `,
-      errors: [
-        {
-          line: 3,
-          messageId: 'unnecessaryAssertion',
-        },
-      ],
-      output: `
-class T {
-  readonly a = 'a';
-}
-      `,
-    },
-    {
-      code: `
-class T {
   readonly a = 3 as 3;
 }
       `,
@@ -1337,31 +1291,6 @@ const b = a;
     },
     {
       code: `
-enum T {
-  Value1,
-  Value2,
-}
-
-declare const a: T.Value1;
-const b = a as const;
-      `,
-      errors: [
-        {
-          messageId: 'unnecessaryAssertion',
-        },
-      ],
-      output: `
-enum T {
-  Value1,
-  Value2,
-}
-
-declare const a: T.Value1;
-const b = a;
-      `,
-    },
-    {
-      code: `
 const foo: unknown = {};
 const bar: unknown = foo!;
       `,
@@ -1390,6 +1319,94 @@ foo(baz!);
 function foo(bar: unknown) {}
 const baz: unknown = {};
 foo(baz);
+      `,
+    },
+    {
+      code: 'const a = 1 as const;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = 1;',
+    },
+    {
+      code: 'const a = <const>1;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = 1;',
+    },
+    {
+      code: 'const a = 1n as const;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = 1n;',
+    },
+    {
+      code: 'const a = <const>1n;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = 1n;',
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/8737
+    {
+      code: 'const a = `a` as const;',
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: 'const a = `a`;',
+    },
+    {
+      code: "const a = 'a' as const;",
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: "const a = 'a';",
+    },
+    {
+      code: "const a = <const>'a';",
+      errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: "const a = 'a';",
+    },
+    {
+      code: `
+class T {
+  readonly a = 'a' as const;
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: `
+class T {
+  readonly a = 'a';
+}
+      `,
+    },
+    {
+      code: `
+enum T {
+  Value1,
+  Value2,
+}
+
+declare const a: T.Value1;
+const b = a as const;
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      options: [{ checkLiteralConstAssertion: true }],
+      output: `
+enum T {
+  Value1,
+  Value2,
+}
+
+declare const a: T.Value1;
+const b = a;
       `,
     },
   ],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -429,6 +429,18 @@ declare function foo<T extends unknown>(bar: T): T;
 const baz: unknown = {};
 foo(baz!);
     `,
+    {
+      code: 'const a = `a` as const;',
+      options: [{ ignoreStringConstAssertion: true }],
+    },
+    {
+      code: "const a = 'a' as const;",
+      options: [{ ignoreStringConstAssertion: true }],
+    },
+    {
+      code: "const a = <const>'a';",
+      options: [{ ignoreStringConstAssertion: true }],
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -1324,80 +1324,80 @@ foo(baz);
     {
       code: 'const a = null as const;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = null;',
     },
     {
       code: 'const a = <const>null;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = null;',
     },
     {
       code: 'const a = undefined as const;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = undefined;',
     },
     {
       code: 'const a = <const>undefined;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = undefined;',
     },
     {
       code: 'const a = true as const;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = true;',
     },
     {
       code: 'const a = <const>true;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = true;',
     },
     {
       code: 'const a = 1 as const;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = 1;',
     },
     {
       code: 'const a = <const>1;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = 1;',
     },
     {
       code: 'const a = 1n as const;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = 1n;',
     },
     {
       code: 'const a = <const>1n;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = 1n;',
     },
     // https://github.com/typescript-eslint/typescript-eslint/issues/8737
     {
       code: 'const a = `a` as const;',
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: 'const a = `a`;',
     },
     {
       code: "const a = 'a' as const;",
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: "const a = 'a';",
     },
     {
       code: "const a = <const>'a';",
       errors: [{ line: 1, messageId: 'unnecessaryAssertion' }],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: "const a = 'a';",
     },
     {
@@ -1412,7 +1412,7 @@ class T {
           messageId: 'unnecessaryAssertion',
         },
       ],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: `
 class T {
   readonly a = 'a';
@@ -1434,7 +1434,7 @@ const b = a as const;
           messageId: 'unnecessaryAssertion',
         },
       ],
-      options: [{ checkLiteralConstAssertion: true }],
+      options: [{ checkLiteralConstAssertions: true }],
       output: `
 enum T {
   Value1,

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-type-assertion.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-type-assertion.shot
@@ -5,8 +5,8 @@
   {
     "additionalProperties": false,
     "properties": {
-      "ignoreStringConstAssertion": {
-        "description": "Whether to ignore string const assertions.",
+      "checkLiteralConstAssertion": {
+        "description": "Whether to check literal const assertions.",
         "type": "boolean"
       },
       "typesToIgnore": {
@@ -26,8 +26,8 @@
 
 type Options = [
   {
-    /** Whether to ignore string const assertions. */
-    ignoreStringConstAssertion?: boolean;
+    /** Whether to check literal const assertions. */
+    checkLiteralConstAssertion?: boolean;
     /** A list of type names to ignore. */
     typesToIgnore?: string[];
   },

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-type-assertion.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-type-assertion.shot
@@ -5,7 +5,7 @@
   {
     "additionalProperties": false,
     "properties": {
-      "checkLiteralConstAssertion": {
+      "checkLiteralConstAssertions": {
         "description": "Whether to check literal const assertions.",
         "type": "boolean"
       },
@@ -27,7 +27,7 @@
 type Options = [
   {
     /** Whether to check literal const assertions. */
-    checkLiteralConstAssertion?: boolean;
+    checkLiteralConstAssertions?: boolean;
     /** A list of type names to ignore. */
     typesToIgnore?: string[];
   },

--- a/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-type-assertion.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-unnecessary-type-assertion.shot
@@ -5,6 +5,10 @@
   {
     "additionalProperties": false,
     "properties": {
+      "ignoreStringConstAssertion": {
+        "description": "Whether to ignore string const assertions.",
+        "type": "boolean"
+      },
       "typesToIgnore": {
         "description": "A list of type names to ignore.",
         "items": {
@@ -22,6 +26,8 @@
 
 type Options = [
   {
+    /** Whether to ignore string const assertions. */
+    ignoreStringConstAssertion?: boolean;
     /** A list of type names to ignore. */
     typesToIgnore?: string[];
   },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8721
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Add new ignoreStringConstAssertion that ignores const assertions on string literals to as it is a common use case to force typescript to not widen type to string