### PR TITLE
fix(eslint-plugin): [prefer-for-of] fix false positive when using erasable type syntax within update expressions

### DIFF
--- a/packages/eslint-plugin/src/util/isAssignee.ts
+++ b/packages/eslint-plugin/src/util/isAssignee.ts
@@ -53,9 +53,12 @@ export function isAssignee(node: TSESTree.Node): boolean {
     return true;
   }
 
-  // a[i]!++, [...a[i]!] = [0], etc.
+  // (a[i] as number)++, [...a[i]!] = [0], etc.
   if (
-    parent.type === AST_NODE_TYPES.TSNonNullExpression &&
+    (parent.type === AST_NODE_TYPES.TSNonNullExpression ||
+      parent.type === AST_NODE_TYPES.TSAsExpression ||
+      parent.type === AST_NODE_TYPES.TSTypeAssertion ||
+      parent.type === AST_NODE_TYPES.TSSatisfiesExpression) &&
     isAssignee(parent)
   ) {
     return true;

--- a/packages/eslint-plugin/src/util/isAssignee.ts
+++ b/packages/eslint-plugin/src/util/isAssignee.ts
@@ -53,5 +53,13 @@ export function isAssignee(node: TSESTree.Node): boolean {
     return true;
   }
 
+  // a[i]!++, [...a[i]!] = [0], etc.
+  if (
+    parent.type === AST_NODE_TYPES.TSNonNullExpression &&
+    isAssignee(parent)
+  ) {
+    return true;
+  }
+
   return false;
 }

--- a/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
@@ -140,12 +140,27 @@ for (let i = 0; i < arr.length; i++) {
     `,
     `
 for (let i = 0; i < arr.length; i++) {
+  arr[i]++;
+}
+    `,
+    `
+for (let i = 0; i < arr.length; i++) {
+  arr[i]!++;
+}
+    `,
+    `
+for (let i = 0; i < arr.length; i++) {
   [arr[i]] = [1];
 }
     `,
     `
 for (let i = 0; i < arr.length; i++) {
   [...arr[i]] = [1];
+}
+    `,
+    `
+for (let i = 0; i < arr.length; i++) {
+  [...arr[i]!] = [1];
 }
     `,
     `

--- a/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-for-of.test.ts
@@ -150,6 +150,36 @@ for (let i = 0; i < arr.length; i++) {
     `,
     `
 for (let i = 0; i < arr.length; i++) {
+  arr[i]!!!++;
+}
+    `,
+    `
+for (let i = 0; i < arr.length; i++) {
+  (arr[i] as number)++;
+}
+    `,
+    `
+for (let i = 0; i < arr.length; i++) {
+  (<number>arr[i])++;
+}
+    `,
+    `
+for (let i = 0; i < arr.length; i++) {
+  (arr[i] as unknown as number)++;
+}
+    `,
+    `
+for (let i = 0; i < arr.length; i++) {
+  (arr[i] satisfies number)++;
+}
+    `,
+    `
+for (let i = 0; i < arr.length; i++) {
+  (arr[i]! satisfies number)++;
+}
+    `,
+    `
+for (let i = 0; i < arr.length; i++) {
   [arr[i]] = [1];
 }
     `,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10977
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Fixed `isAssignee` function to handle erasable type syntax.
