### PR TITLE
fix(eslint-plugin): [no-unsafe-function-type] remove fixable property

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-function-type.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-function-type.ts
@@ -12,7 +12,6 @@ export default createRule({
       description: 'Disallow using the unsafe built-in Function type',
       recommended: 'recommended',
     },
-    fixable: 'code',
     messages: {
       bannedFunctionType: [
         'The `Function` type accepts any function-like value.',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10985
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Rule [no-unsafe-function-type](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unsafe-function-type.ts) has an unneeded `fixable : 'code'` property. 

There is no 'fix' or 'suggestion' in rule.

Each `invalid` code tests return a `null` output. That doesn't mean anything, I know, but if I'm right, I should probably remove these outputs. 🤔 
