### PR TITLE
feat(website): Show tsconfig parsing errors in tab

### DIFF
--- a/packages/website/src/components/ErrorsViewer.tsx
+++ b/packages/website/src/components/ErrorsViewer.tsx
@@ -133,6 +133,8 @@ export function ErrorViewer({
 export function ErrorsViewer({ value }: ErrorsViewerProps): React.JSX.Element {
   const [isLocked, setIsLocked] = useState(false);
 
+  console.log(value);
+
   useEffect(() => {
     setIsLocked(false);
   }, [value]);

--- a/packages/website/src/components/Playground.tsx
+++ b/packages/website/src/components/Playground.tsx
@@ -39,7 +39,7 @@ function Playground(): React.JSX.Element {
   const [tsVersions, setTSVersion] = useState<readonly string[]>([]);
   const [selectedRange, setSelectedRange] = useState<SelectedRange>();
   const [position, setPosition] = useState<number>();
-  const [activeTab, setTab] = useState<TabType>('code');
+  const [activeTab, setTab] = useState<TabType>('tsconfig');
   const [esQueryError, setEsQueryError] = useState<Error>();
   const [visualEslintRc, setVisualEslintRc] = useState(false);
   const [visualTSConfig, setVisualTSConfig] = useState(false);
@@ -63,6 +63,7 @@ function Playground(): React.JSX.Element {
     [],
   );
 
+  console.log(markers);
   const ActiveVisualEditor =
     !isLoading &&
     {

--- a/packages/website/src/components/editor/LoadedEditor.tsx
+++ b/packages/website/src/components/editor/LoadedEditor.tsx
@@ -83,7 +83,11 @@ export const LoadedEditor: React.FC<LoadedEditorProps> = ({
     const markers = monaco.editor.getModelMarkers({
       resource: model.uri,
     });
-    onMarkersChange(parseMarkers(markers, codeActions, editor));
+
+    const test = parseMarkers(markers, codeActions, editor);
+
+    console.log(test);
+    // onMarkersChange(parseMarkers(markers, codeActions, editor));
   }, [codeActions, onMarkersChange, editor, monaco.editor]);
 
   useEffect(() => {

--- a/packages/website/src/components/editor/useSandboxServices.ts
+++ b/packages/website/src/components/editor/useSandboxServices.ts
@@ -116,6 +116,7 @@ export const useSandboxServices = (
           system,
           lintUtils,
           sandboxInstance.tsvfs,
+          props.onMarkersChange,
         );
 
         onLoaded(

--- a/packages/website/src/components/linter/createLinter.ts
+++ b/packages/website/src/components/linter/createLinter.ts
@@ -19,7 +19,7 @@ import { createEventsBinder } from '../lib/createEventsBinder';
 import { parseESLintRC, parseTSConfig } from '../lib/parseConfig';
 import { defaultEslintConfig, PARSER_NAME } from './config';
 import { createParser } from './createParser';
-
+import { ErrorGroup } from '../../../../website/src/components/types';
 export interface CreateLinter {
   configs: string[];
   onLint(cb: LinterOnLint): () => void;
@@ -42,6 +42,7 @@ export function createLinter(
   system: PlaygroundSystem,
   webLinterModule: WebLinterModule,
   vfs: typeof tsvfs,
+  onMarkersChange: (value: ErrorGroup[]) => void,
 ): CreateLinter {
   const rules: CreateLinter['rules'] = new Map();
   const configs = new Map(Object.entries(webLinterModule.configs));
@@ -160,7 +161,31 @@ export function createLinter(
       console.log('[Editor] Updating', fileName, compilerOptions);
       parser.updateConfig(compilerOptions);
     } catch (e) {
-      console.error(e);
+      const errors = {
+        group: 'Typescript',
+        items: e.message
+          .trim()
+          .split('\n')
+          .map((message: string) => {
+            return {
+              fixer: undefined,
+              location: '',
+              message,
+              severity: 8,
+              suggestions: [],
+            };
+          }),
+        uri: undefined,
+      };
+
+      console.log(onMarkersChange);
+      console.log(errors);
+
+      onMarkersChange([errors]);
+
+      // const marker =
+
+      // console.error("asdf",e);
     }
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20455,7 +20455,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.8.2#~builtin<compat/typescript>":
   version: 5.8.2
-  resolution: "typescript@patch:typescript@npm%3A5.8.2#~builtin<compat/typescript>::version=5.8.2&hash=b45daf"
+  resolution: "typescript@patch:typescript@npm%3A5.8.2#~builtin<compat/typescript>::version=5.8.2&hash=f3b441"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8580
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

WIP. 
I'm trying to manage tsconfig errors with different markers and statuses.

Because I couldn't integrate tsconfig errors into markers since markers change depending on editor changes, and I thought it was wrong to apply tsconfig where markers are created.