### PR TITLE
feat(eslint-plugin): disable core rule no-with in eslint-recommended

### DIFF
--- a/packages/eslint-plugin/TSLINT_RULE_ALTERNATIVES.md
+++ b/packages/eslint-plugin/TSLINT_RULE_ALTERNATIVES.md
@@ -259,7 +259,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 | `no-unnecessary-override`             | 🛑  | N/A                                                                    |
 | `no-unnecessary-semicolons`           | 🌟  | [`no-extra-semi`][no-extra-semi] or [Prettier]                         |
 | `no-useless-files`                    | 🛑  | N/A                                                                    |
-| `no-with-statement`                   | 🌟  | [`no-with`][no-with]                                                   |
+| `no-with-statement`                   | 🛑  | `with` statements are not allowed by Typescript compiler               |
 | `promise-must-complete`               | 🛑  | N/A                                                                    |
 | `underscore-consistent-invocation`    | 🔌  | [`lodash/chaining`]                                                    |
 | `use-named-parameter`                 | 🛑  | N/A                                                                    |
@@ -588,7 +588,6 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 [no-octal]: https://eslint.org/docs/rules/no-octal
 [no-octal-escape]: https://eslint.org/docs/rules/no-octal-escape
 [no-extra-semi]: https://eslint.org/docs/rules/no-extra-semi
-[no-with]: https://eslint.org/docs/rules/no-with
 [no-warning-comments]: https://eslint.org/docs/rules/no-warning-comments
 
 <!-- @typescript-eslint/eslint-plugin -->

--- a/packages/eslint-plugin/TSLINT_RULE_ALTERNATIVES.md
+++ b/packages/eslint-plugin/TSLINT_RULE_ALTERNATIVES.md
@@ -259,7 +259,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 | `no-unnecessary-override`             | 🛑  | N/A                                                                    |
 | `no-unnecessary-semicolons`           | 🌟  | [`no-extra-semi`][no-extra-semi] or [Prettier]                         |
 | `no-useless-files`                    | 🛑  | N/A                                                                    |
-| `no-with-statement`                   | 🛑  | `with` statements are not allowed by TypeScript compiler               |
+| `no-with-statement`                   | 🌟  | [`no-with`][no-with] <sup>[6]</sup>                                    |
 | `promise-must-complete`               | 🛑  | N/A                                                                    |
 | `underscore-consistent-invocation`    | 🔌  | [`lodash/chaining`]                                                    |
 | `use-named-parameter`                 | 🛑  | N/A                                                                    |
@@ -270,6 +270,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 <sup>[3]</sup> Recommended config: `["error", "declaration", { "allowArrowFunctions": true }]`<br>
 <sup>[4]</sup> Recommended config: `["error", { "terms": ["BUG", "HACK", "FIXME", "LATER", "LATER2", "TODO"], "location": "anywhere" }]`<br>
 <sup>[5]</sup> Does not check class fields.
+<sup>[6]</sup> But note that `with` statements are not allowed by the TypeScript compiler
 
 ### Security
 
@@ -588,6 +589,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 [no-octal]: https://eslint.org/docs/rules/no-octal
 [no-octal-escape]: https://eslint.org/docs/rules/no-octal-escape
 [no-extra-semi]: https://eslint.org/docs/rules/no-extra-semi
+[no-with]: https://eslint.org/docs/rules/no-with
 [no-warning-comments]: https://eslint.org/docs/rules/no-warning-comments
 
 <!-- @typescript-eslint/eslint-plugin -->

--- a/packages/eslint-plugin/TSLINT_RULE_ALTERNATIVES.md
+++ b/packages/eslint-plugin/TSLINT_RULE_ALTERNATIVES.md
@@ -259,7 +259,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 | `no-unnecessary-override`             | 🛑  | N/A                                                                    |
 | `no-unnecessary-semicolons`           | 🌟  | [`no-extra-semi`][no-extra-semi] or [Prettier]                         |
 | `no-useless-files`                    | 🛑  | N/A                                                                    |
-| `no-with-statement`                   | 🛑  | `with` statements are not allowed by Typescript compiler               |
+| `no-with-statement`                   | 🛑  | `with` statements are not allowed by TypeScript compiler               |
 | `promise-must-complete`               | 🛑  | N/A                                                                    |
 | `underscore-consistent-invocation`    | 🔌  | [`lodash/chaining`]                                                    |
 | `use-named-parameter`                 | 🛑  | N/A                                                                    |

--- a/packages/eslint-plugin/TSLINT_RULE_ALTERNATIVES.md
+++ b/packages/eslint-plugin/TSLINT_RULE_ALTERNATIVES.md
@@ -270,7 +270,7 @@ Relevant plugins: [`chai-expect-keywords`](https://github.com/gavinaiken/eslint-
 <sup>[3]</sup> Recommended config: `["error", "declaration", { "allowArrowFunctions": true }]`<br>
 <sup>[4]</sup> Recommended config: `["error", { "terms": ["BUG", "HACK", "FIXME", "LATER", "LATER2", "TODO"], "location": "anywhere" }]`<br>
 <sup>[5]</sup> Does not check class fields.
-<sup>[6]</sup> But note that `with` statements are not allowed by the TypeScript compiler
+<sup>[6]</sup> `with` statements are not allowed by the TypeScript compiler
 
 ### Security
 

--- a/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
+++ b/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
@@ -43,6 +43,7 @@ const config = (
     'prefer-const': 'error', // ts provides better types with const
     'prefer-rest-params': 'error', // ts provides better types with rest args over arguments
     'prefer-spread': 'error', // ts transpiles spread to apply, so no need for manual apply
+    'no-with': 'off', // ts(1101) & ts(2410)
   },
 });
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10526
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Original tickets suggests removing references to `no-with`, since `with` statements are already not allowed by Typescript compiler.
This is the only mention I could find.