### PR TITLE
chore: fix failing integration tests on deprecation plugin

### DIFF
--- a/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v8/eslint.config.js
+++ b/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v8/eslint.config.js
@@ -52,13 +52,13 @@ function _otherCases() {
     jestPlugin.configs['flat/recommended'],
   );
   tseslint.config(
+    // @ts-expect-error
     compat.config(deprecationPlugin.configs.recommended),
     ...compat.config(jestPlugin.configs.recommended),
   );
   tseslint.config(
     // @ts-expect-error
     deprecationPlugin.configs.recommended,
-    // this should error but doesn't because there are no types exported from the jest plugin
     jestPlugin.configs.recommended,
   );
 }

--- a/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v9/eslint.config.js
+++ b/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v9/eslint.config.js
@@ -52,13 +52,13 @@ function _otherCases() {
     jestPlugin.configs['flat/recommended'],
   );
   tseslint.config(
+    // @ts-expect-error
     compat.config(deprecationPlugin.configs.recommended),
     ...compat.config(jestPlugin.configs.recommended),
   );
   tseslint.config(
     // @ts-expect-error
     deprecationPlugin.configs.recommended,
-    // this should error but doesn't because there are no types exported from the jest plugin
     jestPlugin.configs.recommended,
   );
 }

--- a/packages/integration-tests/tests/__snapshots__/flat-config-types-@types__eslint-v8.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/flat-config-types-@types__eslint-v8.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`flat-config-types-@types__eslint-v8 eslint should work successfully 1`] = `
 [
   {
-    "errorCount": 2,
+    "errorCount": 3,
     "fatalErrorCount": 0,
     "filePath": "<root>/eslint.config.js",
     "fixableErrorCount": 0,
@@ -23,8 +23,19 @@ exports[`flat-config-types-@types__eslint-v8 eslint should work successfully 1`]
       {
         "column": 5,
         "endColumn": 24,
-        "endLine": 59,
-        "line": 59,
+        "endLine": 55,
+        "line": 55,
+        "message": "Include a description after the "@ts-expect-error" directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.",
+        "messageId": "tsDirectiveCommentRequiresDescription",
+        "nodeType": "Line",
+        "ruleId": "@typescript-eslint/ban-ts-comment",
+        "severity": 2,
+      },
+      {
+        "column": 5,
+        "endColumn": 24,
+        "endLine": 60,
+        "line": 60,
         "message": "Include a description after the "@ts-expect-error" directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.",
         "messageId": "tsDirectiveCommentRequiresDescription",
         "nodeType": "Line",
@@ -86,13 +97,13 @@ function _otherCases() {
     jestPlugin.configs['flat/recommended'],
   )
   tseslint.config(
+    // @ts-expect-error
     compat.config(deprecationPlugin.configs.recommended),
     ...compat.config(jestPlugin.configs.recommended),
   )
   tseslint.config(
     // @ts-expect-error
     deprecationPlugin.configs.recommended,
-    // this should error but doesn't because there are no types exported from the jest plugin
     jestPlugin.configs.recommended,
   )
 }

--- a/packages/integration-tests/tests/__snapshots__/flat-config-types-@types__eslint-v9.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/flat-config-types-@types__eslint-v9.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`flat-config-types-@types__eslint-v9 eslint should work successfully 1`] = `
 [
   {
-    "errorCount": 2,
+    "errorCount": 3,
     "fatalErrorCount": 0,
     "filePath": "<root>/eslint.config.js",
     "fixableErrorCount": 0,
@@ -23,8 +23,19 @@ exports[`flat-config-types-@types__eslint-v9 eslint should work successfully 1`]
       {
         "column": 5,
         "endColumn": 24,
-        "endLine": 59,
-        "line": 59,
+        "endLine": 55,
+        "line": 55,
+        "message": "Include a description after the "@ts-expect-error" directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.",
+        "messageId": "tsDirectiveCommentRequiresDescription",
+        "nodeType": "Line",
+        "ruleId": "@typescript-eslint/ban-ts-comment",
+        "severity": 2,
+      },
+      {
+        "column": 5,
+        "endColumn": 24,
+        "endLine": 60,
+        "line": 60,
         "message": "Include a description after the "@ts-expect-error" directive to explain why the @ts-expect-error is necessary. The description must be 3 characters or longer.",
         "messageId": "tsDirectiveCommentRequiresDescription",
         "nodeType": "Line",
@@ -86,13 +97,13 @@ function _otherCases() {
     jestPlugin.configs['flat/recommended'],
   )
   tseslint.config(
+    // @ts-expect-error
     compat.config(deprecationPlugin.configs.recommended),
     ...compat.config(jestPlugin.configs.recommended),
   )
   tseslint.config(
     // @ts-expect-error
     deprecationPlugin.configs.recommended,
-    // this should error but doesn't because there are no types exported from the jest plugin
     jestPlugin.configs.recommended,
   )
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10992
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Fix test failures by marking eslint-plugin-deprecation usage as expecting ts failures

Co-authored-by: @aryaemami59 