### PR TITLE
docs: fix typos in no-unsafe-argument examples

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-argument.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-argument.mdx
@@ -45,10 +45,10 @@ foo('a', ...tuple2, anyTyped);
 
 declare function bar(arg1: string, arg2: number, ...rest: string[]): void;
 const x = [1, 2] as [number, ...number[]];
-foo('a', ...x, anyTyped);
+bar('a', ...x, anyTyped);
 
 declare function baz(arg1: Set<string>, arg2: Map<string, string>): void;
-foo(new Set<any>(), new Map<any, string>());
+baz(new Set<any>(), new Map<any, string>());
 ```
 
 </TabItem>
@@ -67,7 +67,7 @@ const array: string[] = ['a'];
 bar('a', 1, ...array);
 
 declare function baz(arg1: Set<string>, arg2: Map<string, string>): void;
-foo(new Set<string>(), new Map<string, string>());
+baz(new Set<string>(), new Map<string, string>());
 ```
 
 </TabItem>

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unsafe-argument.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unsafe-argument.shot
@@ -26,10 +26,13 @@ foo('a', ...tuple2, anyTyped);
 
 declare function bar(arg1: string, arg2: number, ...rest: string[]): void;
 const x = [1, 2] as [number, ...number[]];
-foo('a', ...x, anyTyped);
+bar('a', ...x, anyTyped);
+               ~~~~~~~~ Unsafe argument of type \`any\` assigned to a parameter of type \`string\`.
 
 declare function baz(arg1: Set<string>, arg2: Map<string, string>): void;
-foo(new Set<any>(), new Map<any, string>());
+baz(new Set<any>(), new Map<any, string>());
+    ~~~~~~~~~~~~~~ Unsafe argument of type \`Set<any>\` assigned to a parameter of type \`Set<string>\`.
+                    ~~~~~~~~~~~~~~~~~~~~~~ Unsafe argument of type \`Map<any, string>\` assigned to a parameter of type \`Map<string, string>\`.
 "
 `;
 
@@ -48,7 +51,7 @@ const array: string[] = ['a'];
 bar('a', 1, ...array);
 
 declare function baz(arg1: Set<string>, arg2: Map<string, string>): void;
-foo(new Set<string>(), new Map<string, string>());
+baz(new Set<string>(), new Map<string, string>());
 "
 `;
 


### PR DESCRIPTION
Some lines in example code are incorrect.

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
