### PR TITLE
chore: remove eslint vscode extension flat config experimental flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,6 @@
       "typescript",
       "typescriptreact"
   ],
-  // required to make the extension pickup the flat config
-  "eslint.experimental.useFlatConfig": true,
 
   // When enabled, will trim trailing whitespace when saving a file.
   "files.trimTrailingWhitespace": true,


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Flat config is no longer experimental, of course. Also we get this in the eslint output: 

```
ESLint version 9.22.0 supports flat config without experimental opt-in. 
The 'eslint.experimental.useFlatConfig' setting can be removed.
```