### PR TITLE
fix(eslint-plugin): fix mistake with eslintrc config generation

### DIFF
--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -8,7 +8,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
-  extends: ['./configs/base', './configs/eslint-recommended'],
+  extends: ['./configs/eslintrc/base', './configs/eslintrc/eslint-recommended'],
   rules: {
     '@typescript-eslint/adjacent-overload-signatures': 'error',
     '@typescript-eslint/array-type': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/recommended-type-checked-only.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/recommended-type-checked-only.ts
@@ -8,7 +8,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
-  extends: ['./configs/base', './configs/eslint-recommended'],
+  extends: ['./configs/eslintrc/base', './configs/eslintrc/eslint-recommended'],
   rules: {
     '@typescript-eslint/await-thenable': 'error',
     '@typescript-eslint/no-array-delete': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/recommended-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/recommended-type-checked.ts
@@ -8,7 +8,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
-  extends: ['./configs/base', './configs/eslint-recommended'],
+  extends: ['./configs/eslintrc/base', './configs/eslintrc/eslint-recommended'],
   rules: {
     '@typescript-eslint/await-thenable': 'error',
     '@typescript-eslint/ban-ts-comment': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/recommended.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/recommended.ts
@@ -8,7 +8,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
-  extends: ['./configs/base', './configs/eslint-recommended'],
+  extends: ['./configs/eslintrc/base', './configs/eslintrc/eslint-recommended'],
   rules: {
     '@typescript-eslint/ban-ts-comment': 'error',
     'no-array-constructor': 'off',

--- a/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked-only.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked-only.ts
@@ -8,7 +8,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
-  extends: ['./configs/base', './configs/eslint-recommended'],
+  extends: ['./configs/eslintrc/base', './configs/eslintrc/eslint-recommended'],
   rules: {
     '@typescript-eslint/await-thenable': 'error',
     '@typescript-eslint/no-array-delete': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked.ts
@@ -8,7 +8,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
-  extends: ['./configs/base', './configs/eslint-recommended'],
+  extends: ['./configs/eslintrc/base', './configs/eslintrc/eslint-recommended'],
   rules: {
     '@typescript-eslint/await-thenable': 'error',
     '@typescript-eslint/ban-ts-comment': [

--- a/packages/eslint-plugin/src/configs/eslintrc/strict.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/strict.ts
@@ -8,7 +8,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
-  extends: ['./configs/base', './configs/eslint-recommended'],
+  extends: ['./configs/eslintrc/base', './configs/eslintrc/eslint-recommended'],
   rules: {
     '@typescript-eslint/ban-ts-comment': [
       'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/stylistic-type-checked-only.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/stylistic-type-checked-only.ts
@@ -8,7 +8,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
-  extends: ['./configs/base', './configs/eslint-recommended'],
+  extends: ['./configs/eslintrc/base', './configs/eslintrc/eslint-recommended'],
   rules: {
     'dot-notation': 'off',
     '@typescript-eslint/dot-notation': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/stylistic-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/stylistic-type-checked.ts
@@ -8,7 +8,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
-  extends: ['./configs/base', './configs/eslint-recommended'],
+  extends: ['./configs/eslintrc/base', './configs/eslintrc/eslint-recommended'],
   rules: {
     '@typescript-eslint/adjacent-overload-signatures': 'error',
     '@typescript-eslint/array-type': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/stylistic.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/stylistic.ts
@@ -8,7 +8,7 @@
 import type { ClassicConfig } from '@typescript-eslint/utils/ts-eslint';
 
 export = {
-  extends: ['./configs/base', './configs/eslint-recommended'],
+  extends: ['./configs/eslintrc/base', './configs/eslintrc/eslint-recommended'],
   rules: {
     '@typescript-eslint/adjacent-overload-signatures': 'error',
     '@typescript-eslint/array-type': 'error',

--- a/tools/scripts/generate-configs.mts
+++ b/tools/scripts/generate-configs.mts
@@ -36,12 +36,12 @@ const EXTENDS_MODULES = [
   {
     moduleRelativePath: './base',
     name: 'baseConfig',
-    packageRelativePath: './configs/base',
+    packageRelativePath: './configs/eslintrc/base',
   },
   {
     moduleRelativePath: './eslint-recommended',
     name: 'eslintRecommendedConfig',
-    packageRelativePath: './configs/eslint-recommended',
+    packageRelativePath: './configs/eslintrc/eslint-recommended',
   },
 ] as const;
 const CLASSIC_EXTENDS: readonly string[] = EXTENDS_MODULES.map(


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11071
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

To repro: Create a minimal _eslintrc_ setup using `"extends": ["plugin:@typescript-eslint/recommended"]`, and execute `ESLINT_USE_FLAT_CONFIG=false eslint .`.

Tested, and this fixes the issue for me locally. Can follow up with an integration test or something if we want.