### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] false positive on non-null assertion after an implicitly-any variable gets initialised inside conditional block

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -118,9 +118,11 @@ export default createRule<Options, MessageIds>({
         if (
           // is it `const x!: number`
           declaration.initializer == null &&
-          declaration.exclamationToken == null &&
-          declaration.type != null
+          declaration.exclamationToken == null
         ) {
+          if (declaration.type == null) {
+            return true;
+          }
           // check if the defined variable type has changed since assignment
           const declarationType = checker.getTypeFromTypeNode(declaration.type);
           const type = getConstrainedTypeAtLocation(services, node);

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -429,6 +429,13 @@ declare function foo<T extends unknown>(bar: T): T;
 const baz: unknown = {};
 foo(baz!);
     `,
+    `
+let x;
+if (Math.random() > -1) {
+  x = 2;
+}
+x!;
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
> [!CAUTION]
> Currently blocked by https://github.com/typescript-eslint/typescript-eslint/issues/10334 / https://github.com/microsoft/TypeScript/issues/60514. See https://github.com/typescript-eslint/typescript-eslint/pull/11082#discussion_r2047412747

***

## PR Checklist

- [x] Addresses an existing open issue: fixes #11054 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
I have updated it so that [isPossiblyUsedBeforeAssigned](https://github.com/typescript-eslint/typescript-eslint/blob/23c5aa725ede26fbb88ac77cb950181ac2fca4d7/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts#L68-L149) returns `true` when the variable is not explicitly typed at the time of declaration
