### PR TITLE
fix(website): fix typo

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-declaration-merging.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-declaration-merging.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 TypeScript's "declaration merging" supports merging separate declarations with the same name.
 
 Declaration merging between classes and interfaces is unsafe.
-The TypeScript compiler doesn't check whether properties are initialized, which can cause lead to TypeScript not detecting code that will cause runtime errors.
+The TypeScript compiler doesn't check whether properties are initialized, which can lead to TypeScript not detecting code that will cause runtime errors.
 
 ```ts
 interface Foo {


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR fixes a simple typo on https://typescript-eslint.io/rules/no-unsafe-declaration-merging.
