### PR TITLE
chore: remove the deprecated `basic` reporter for `vitest`

### DIFF
--- a/vitest.config.base.mts
+++ b/vitest.config.base.mts
@@ -18,7 +18,7 @@ export const vitestBaseConfig = {
     include: ['**/*.test.?(c|m)ts?(x)'],
 
     reporters: process.env.GITHUB_ACTIONS
-      ? [['basic'], ['github-actions']]
+      ? [['default', { summary: false }], ['github-actions']]
       : [['verbose']],
 
     setupFiles: ['console-fail-test/setup'],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #000
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
