### PR TITLE
fix(eslint-plugin): decode unicode escapes in identifier tokens

### DIFF
--- a/packages/typescript-estree/tests/lib/node-utils.test.ts
+++ b/packages/typescript-estree/tests/lib/node-utils.test.ts
@@ -1,4 +1,7 @@
-import { unescapeStringLiteralText } from '../../src/node-utils';
+import {
+  unescapeStringLiteralText,
+  unescapeUnicodeIdentifier,
+} from '../../src/node-utils';
 
 describe(unescapeStringLiteralText, () => {
   it('should not modify content', () => {
@@ -40,5 +43,32 @@ describe(unescapeStringLiteralText, () => {
         'a\n&lt;&gt;&quot;&apos;&amp;&copy;&#8710;&rx;&#128514;&#0;&#1;',
       ),
     ).toBe(`a\n<>"'&©∆&rx;😂\u0000\u0001`);
+  });
+});
+
+describe('unescapeUnicodeIdentifier', () => {
+  it('should decode simple \\uXXXX escape', () => {
+    expect(unescapeUnicodeIdentifier('\\u0061')).toBe('a');
+    expect(unescapeUnicodeIdentifier('\\u0042')).toBe('B');
+  });
+
+  it('should decode \\u{X} escape', () => {
+    expect(unescapeUnicodeIdentifier('\\u{61}')).toBe('a');
+    expect(unescapeUnicodeIdentifier('\\u{1F602}')).toBe('😂');
+  });
+
+  it('should decode multiple escapes in one string', () => {
+    expect(unescapeUnicodeIdentifier('\\u0061\\u0062')).toBe('ab');
+    expect(unescapeUnicodeIdentifier('\\u{61}\\u{62}')).toBe('ab');
+  });
+
+  it('should leave non-escape text unchanged', () => {
+    expect(unescapeUnicodeIdentifier('foo')).toBe('foo');
+    expect(unescapeUnicodeIdentifier('a\\u0062c')).toBe('abc');
+  });
+
+  it('should not decode invalid escapes', () => {
+    expect(unescapeUnicodeIdentifier('\\u00ZZ')).toBe('\\u00ZZ');
+    expect(unescapeUnicodeIdentifier('\\u{ZZ}')).toBe('\\u{ZZ}');
   });
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11036 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
<img width="1366" alt="Screenshot 2025-04-29 at 17 20 16" src="https://github.com/user-attachments/assets/590004fe-845a-454e-a771-0d6625825e8a" />
<img width="1369" alt="Screenshot 2025-04-29 at 17 21 03" src="https://github.com/user-attachments/assets/800710f1-f1cd-4660-b97d-d91eb2e41cb6" />



<!-- Description of what is changed and how the code change does that. -->
