### PR TITLE
chore: fix more vitest config CI failures

### DIFF
--- a/packages/ast-spec/tsconfig.spec.json
+++ b/packages/ast-spec/tsconfig.spec.json
@@ -7,7 +7,7 @@
     "types": ["node", "vitest/globals", "vitest/importMeta"]
   },
   "include": [
-    "vitest.config.mts",
+    "vitest.config.*",
     "package.json",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",

--- a/packages/eslint-plugin/tsconfig.spec.json
+++ b/packages/eslint-plugin/tsconfig.spec.json
@@ -7,7 +7,7 @@
     "types": ["node", "vitest/globals", "vitest/importMeta"]
   },
   "include": [
-    "vitest.config.mts",
+    "vitest.config.*",
     "package.json",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",

--- a/packages/integration-tests/tsconfig.spec.json
+++ b/packages/integration-tests/tsconfig.spec.json
@@ -7,7 +7,7 @@
     "types": ["node", "vitest/globals", "vitest/importMeta"]
   },
   "include": [
-    "vitest.config.mts",
+    "vitest.config.*",
     "package.json",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",

--- a/packages/rule-schema-to-typescript-types/tsconfig.spec.json
+++ b/packages/rule-schema-to-typescript-types/tsconfig.spec.json
@@ -5,7 +5,7 @@
     "resolveJsonModule": true,
     "types": ["vitest/globals", "vitest/importMeta"]
   },
-  "include": ["vitest.config.mts", "package.json", "tests"],
+  "include": ["vitest.config.*", "package.json", "tests"],
   "exclude": ["**/fixtures/**"],
   "references": [
     {

--- a/packages/rule-tester/tsconfig.spec.json
+++ b/packages/rule-tester/tsconfig.spec.json
@@ -7,7 +7,7 @@
     "types": ["node", "vitest/globals", "vitest/importMeta"]
   },
   "include": [
-    "vitest.config.mts",
+    "vitest.config.*",
     "package.json",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",

--- a/packages/scope-manager/tsconfig.spec.json
+++ b/packages/scope-manager/tsconfig.spec.json
@@ -7,7 +7,7 @@
     "types": ["node", "vitest/globals", "vitest/importMeta"]
   },
   "include": [
-    "vitest.config.mts",
+    "vitest.config.*",
     "package.json",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",

--- a/packages/type-utils/tsconfig.spec.json
+++ b/packages/type-utils/tsconfig.spec.json
@@ -7,7 +7,7 @@
     "types": ["node", "vitest/globals", "vitest/importMeta"]
   },
   "include": [
-    "vitest.config.mts",
+    "vitest.config.*",
     "package.json",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",

--- a/packages/types/tsconfig.spec.json
+++ b/packages/types/tsconfig.spec.json
@@ -5,7 +5,7 @@
     "resolveJsonModule": true,
     "types": ["vitest/globals", "vitest/importMeta"]
   },
-  "include": ["vitest.config.mts", "package.json", "tests"],
+  "include": ["vitest.config.*", "package.json", "tests"],
   "exclude": ["**/fixtures/**"],
   "references": [
     {

--- a/packages/typescript-estree/tsconfig.spec.json
+++ b/packages/typescript-estree/tsconfig.spec.json
@@ -7,7 +7,7 @@
     "types": ["node", "vitest/globals", "vitest/importMeta"]
   },
   "include": [
-    "vitest.config.mts",
+    "vitest.config.*",
     "package.json",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

same fix as https://github.com/typescript-eslint/typescript-eslint/pull/11067 for same problem again in CI? (I have no idea why this fixes the failure)

(failure on main: https://cloud.nx.app/runs/jK7P2iHuD6/task/types%3Atypecheck)

```
vitest.config.mts(4,34): error TS6305: 
Output file '/home/runner/work/typescript-eslint/typescript-eslint/dist/out-tsc/root/vitest/vitest.config.base.d.mts' 
has not been built from source file '/home/runner/work/typescript-eslint/typescript-eslint/vitest.config.base.mts'.
```