### PR TITLE
feat(eslint-plugin): [no-base-to-string] add checkUnknown Option

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
+++ b/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
@@ -99,6 +99,17 @@ let text = `${value}`;
 String(/regex/);
 ```
 
+### `checkUnknown`
+
+{/* insert option description */}
+
+The following patterns are considered incorrect with the options `{ checkUnknown: true }`:
+
+```ts option='{ "checkUnknown": true }' showPlaygroundButton
+declare const x: unknown;
+x.toString();
+```
+
 ## When Not To Use It
 
 If you don't mind a risk of `"[object Object]"` or incorrect type coercions in your values, then you will not need this rule.

--- a/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
+++ b/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
@@ -107,7 +107,7 @@ The following patterns are considered incorrect with the options `{ checkUnknown
 
 ```ts option='{ "checkUnknown": true }' showPlaygroundButton
 declare const x: unknown;
-x.toString();
+String(x);
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -49,9 +49,8 @@ export default createRule<Options, MessageIds>({
         properties: {
           checkUnknown: {
             type: 'boolean',
-            default: false,
             description:
-              'Checks the case where toString is applied to unknown type',
+              'Whether to also check values of type `unknown`',
           },
           ignoredTypeNames: {
             type: 'array',

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -49,8 +49,7 @@ export default createRule<Options, MessageIds>({
         properties: {
           checkUnknown: {
             type: 'boolean',
-            description:
-              'Whether to also check values of type `unknown`',
+            description: 'Whether to also check values of type `unknown`',
           },
           ignoredTypeNames: {
             type: 'array',

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -21,6 +21,7 @@ enum Usefulness {
 export type Options = [
   {
     ignoredTypeNames?: string[];
+    restrictUnknown?: boolean;
   },
 ];
 export type MessageIds = 'baseArrayJoin' | 'baseToString';
@@ -54,6 +55,11 @@ export default createRule<Options, MessageIds>({
               type: 'string',
             },
           },
+          restrictUnknown: {
+            type: 'boolean',
+            default: false,
+            description: 'Restrict applying toString to unknown type',
+          },
         },
       },
     ],
@@ -61,6 +67,7 @@ export default createRule<Options, MessageIds>({
   defaultOptions: [
     {
       ignoredTypeNames: ['Error', 'RegExp', 'URL', 'URLSearchParams'],
+      restrictUnknown: false,
     },
   ],
   create(context, [option]) {

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-base-to-string.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-base-to-string.shot
@@ -60,5 +60,5 @@ String(/regex/);
 Options: { "checkUnknown": true }
 
 declare const x: unknown;
-x.toString();
-~ 'x' may use Object's default stringification format ('[object Object]') when stringified.
+String(x);
+       ~ 'x' may use Object's default stringification format ('[object Object]') when stringified.

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-base-to-string.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-base-to-string.shot
@@ -56,3 +56,9 @@ let value = /regex/;
 value.toString();
 let text = `${value}`;
 String(/regex/);
+
+Options: { "checkUnknown": true }
+
+declare const x: unknown;
+x.toString();
+~ 'x' may use Object's default stringification format ('[object Object]') when stringified.

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -675,6 +675,126 @@ function foo<T>(x: T) {
       ],
     },
     {
+      code: `
+declare const x: any;
+\`\${x})\`;
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'always',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: any;
+x.toString();
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'always',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: any;
+x.toLocaleString();
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'always',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: any;
+'' + x;
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'always',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: any;
+String(x);
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'always',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: any;
+'' += x;
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'always',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
       code: '`${{}})`;',
       errors: [
         {

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -531,6 +531,30 @@ function foo<T>(x: T) {
   String(x);
 }
     `,
+    `
+declare const x: any;
+\`\${x})\`;
+    `,
+    `
+declare const x: any;
+x.toString();
+    `,
+    `
+declare const x: any;
+x.toLocaleString();
+    `,
+    `
+declare const x: any;
+'' + x;
+    `,
+    `
+declare const x: any;
+String(x);
+    `,
+    `
+declare const x: any;
+'' += x;
+    `,
   ],
   invalid: [
     {
@@ -663,126 +687,6 @@ function foo<T>(x: T) {
         {
           data: {
             certainty: 'may',
-            name: 'x',
-          },
-          messageId: 'baseToString',
-        },
-      ],
-      options: [
-        {
-          checkUnknown: true,
-        },
-      ],
-    },
-    {
-      code: `
-declare const x: any;
-\`\${x})\`;
-      `,
-      errors: [
-        {
-          data: {
-            certainty: 'always',
-            name: 'x',
-          },
-          messageId: 'baseToString',
-        },
-      ],
-      options: [
-        {
-          checkUnknown: true,
-        },
-      ],
-    },
-    {
-      code: `
-declare const x: any;
-x.toString();
-      `,
-      errors: [
-        {
-          data: {
-            certainty: 'always',
-            name: 'x',
-          },
-          messageId: 'baseToString',
-        },
-      ],
-      options: [
-        {
-          checkUnknown: true,
-        },
-      ],
-    },
-    {
-      code: `
-declare const x: any;
-x.toLocaleString();
-      `,
-      errors: [
-        {
-          data: {
-            certainty: 'always',
-            name: 'x',
-          },
-          messageId: 'baseToString',
-        },
-      ],
-      options: [
-        {
-          checkUnknown: true,
-        },
-      ],
-    },
-    {
-      code: `
-declare const x: any;
-'' + x;
-      `,
-      errors: [
-        {
-          data: {
-            certainty: 'always',
-            name: 'x',
-          },
-          messageId: 'baseToString',
-        },
-      ],
-      options: [
-        {
-          checkUnknown: true,
-        },
-      ],
-    },
-    {
-      code: `
-declare const x: any;
-String(x);
-      `,
-      errors: [
-        {
-          data: {
-            certainty: 'always',
-            name: 'x',
-          },
-          messageId: 'baseToString',
-        },
-      ],
-      options: [
-        {
-          checkUnknown: true,
-        },
-      ],
-    },
-    {
-      code: `
-declare const x: any;
-'' += x;
-      `,
-      errors: [
-        {
-          data: {
-            certainty: 'always',
             name: 'x',
           },
           messageId: 'baseToString',

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -475,15 +475,6 @@ declare const bb: ExtendedGuildChannel;
 bb.toString();
     `,
     `
-function foo<T>(x: T) {
-  String(x);
-}
-    `,
-    `
-declare const u: unknown;
-String(u);
-    `,
-    `
 type Value = string | Value[];
 declare const v: Value;
 
@@ -511,8 +502,178 @@ String(v);
 declare const v: ('foo' | 'bar')[][];
 String(v);
     `,
+    `
+declare const x: unknown;
+\`\${x})\`;
+      `,
+    `
+declare const x: unknown;
+x.toString();
+      `,
+    `
+declare const x: unknown;
+x.toLocaleString();
+      `,
+    `
+declare const x: unknown;
+'' + x;
+      `,
+    `
+declare const x: unknown;
+String(x);
+      `,
+    `
+      declare const x: unknown;
+      '' += x;
+            `,
+    `
+    function foo<T>(x: T) {
+      String(x);
+    }
+      `,
   ],
   invalid: [
+    {
+      code: `
+declare const x: unknown;
+\`\${x})\`;
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: unknown;
+x.toString();
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: unknown;
+x.toLocaleString();
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: unknown;
+'' + x;
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: unknown;
+String(x);
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+declare const x: unknown;
+'' += x;
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
+    {
+      code: `
+    function foo<T>(x: T) {
+      String(x);
+    }
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'may',
+            name: 'x',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+      options: [
+        {
+          checkUnknown: true,
+        },
+      ],
+    },
     {
       code: '`${{}})`;',
       errors: [

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -505,32 +505,32 @@ String(v);
     `
 declare const x: unknown;
 \`\${x})\`;
-      `,
+    `,
     `
 declare const x: unknown;
 x.toString();
-      `,
+    `,
     `
 declare const x: unknown;
 x.toLocaleString();
-      `,
+    `,
     `
 declare const x: unknown;
 '' + x;
-      `,
+    `,
     `
 declare const x: unknown;
 String(x);
-      `,
+    `,
     `
-      declare const x: unknown;
-      '' += x;
-            `,
+declare const x: unknown;
+'' += x;
+    `,
     `
-    function foo<T>(x: T) {
-      String(x);
-    }
-      `,
+function foo<T>(x: T) {
+  String(x);
+}
+    `,
   ],
   invalid: [
     {
@@ -655,9 +655,9 @@ declare const x: unknown;
     },
     {
       code: `
-    function foo<T>(x: T) {
-      String(x);
-    }
+function foo<T>(x: T) {
+  String(x);
+}
       `,
       errors: [
         {

--- a/packages/eslint-plugin/tests/schema-snapshots/no-base-to-string.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-base-to-string.shot
@@ -6,8 +6,7 @@
     "additionalProperties": false,
     "properties": {
       "checkUnknown": {
-        "default": false,
-        "description": "Checks the case where toString is applied to unknown type",
+        "description": "Whether to also check values of type `unknown`",
         "type": "boolean"
       },
       "ignoredTypeNames": {
@@ -27,7 +26,7 @@
 
 type Options = [
   {
-    /** Checks the case where toString is applied to unknown type */
+    /** Whether to also check values of type `unknown` */
     checkUnknown?: boolean;
     /** Stringified regular expressions of type names to ignore. */
     ignoredTypeNames?: string[];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-base-to-string.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-base-to-string.shot
@@ -5,6 +5,11 @@
   {
     "additionalProperties": false,
     "properties": {
+      "checkUnknown": {
+        "default": false,
+        "description": "Checks the case where toString is applied to unknown type",
+        "type": "boolean"
+      },
       "ignoredTypeNames": {
         "description": "Stringified regular expressions of type names to ignore.",
         "items": {
@@ -22,6 +27,8 @@
 
 type Options = [
   {
+    /** Checks the case where toString is applied to unknown type */
+    checkUnknown?: boolean;
     /** Stringified regular expressions of type names to ignore. */
     ignoredTypeNames?: string[];
   },

--- a/packages/eslint-plugin/vitest.config.mts
+++ b/packages/eslint-plugin/vitest.config.mts
@@ -11,10 +11,7 @@ export default mergeConfig(
     root: import.meta.dirname,
 
     test: {
-      include: [
-        path.join(import.meta.dirname, 'tests/rules/no-base-to-string.test.ts'),
-      ],
-      // dir: path.join(import.meta.dirname, 'tests'),
+      dir: path.join(import.meta.dirname, 'tests'),
       name: packageJson.name.replace('@typescript-eslint/', ''),
       root: import.meta.dirname,
     },

--- a/packages/eslint-plugin/vitest.config.mts
+++ b/packages/eslint-plugin/vitest.config.mts
@@ -11,7 +11,10 @@ export default mergeConfig(
     root: import.meta.dirname,
 
     test: {
-      dir: path.join(import.meta.dirname, 'tests'),
+      include: [
+        path.join(import.meta.dirname, 'tests/rules/no-base-to-string.test.ts'),
+      ],
+      // dir: path.join(import.meta.dirname, 'tests'),
       name: packageJson.name.replace('@typescript-eslint/', ''),
       root: import.meta.dirname,
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10862
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

add checkUnknown option.

One thing I'm curious about is, is it correct to treat generic types as unknown?

```ts
function foo<T>(x: T) {
  String(x);
}
```
