### PR TITLE
docs: use `T[]` instead of `[T, ...T[]]` in rule options

### DIFF
--- a/packages/eslint-plugin/tests/schema-snapshots/no-deprecated.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-deprecated.shot
@@ -114,16 +114,16 @@ type Options = [
     allow?: (
       | {
           from: 'file';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           path?: string;
         }
       | {
           from: 'lib';
-          name: [string, ...string[]] | string;
+          name: string | string[];
         }
       | {
           from: 'package';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           package: string;
         }
       | string

--- a/packages/eslint-plugin/tests/schema-snapshots/no-floating-promises.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-floating-promises.shot
@@ -221,16 +221,16 @@ type Options = [
     allowForKnownSafeCalls?: (
       | {
           from: 'file';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           path?: string;
         }
       | {
           from: 'lib';
-          name: [string, ...string[]] | string;
+          name: string | string[];
         }
       | {
           from: 'package';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           package: string;
         }
       | string
@@ -239,16 +239,16 @@ type Options = [
     allowForKnownSafePromises?: (
       | {
           from: 'file';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           path?: string;
         }
       | {
           from: 'lib';
-          name: [string, ...string[]] | string;
+          name: string | string[];
         }
       | {
           from: 'package';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           package: string;
         }
       | string

--- a/packages/eslint-plugin/tests/schema-snapshots/no-invalid-void-type.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-invalid-void-type.shot
@@ -45,6 +45,6 @@ type Options = [
      */
     | boolean
       /** Allowlist of types that may accept `void` as a generic type parameter. */
-      | [string, ...string[]];
+      | string[];
   },
 ];

--- a/packages/eslint-plugin/tests/schema-snapshots/no-misused-spread.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-misused-spread.shot
@@ -114,16 +114,16 @@ type Options = [
     allow?: (
       | {
           from: 'file';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           path?: string;
         }
       | {
           from: 'lib';
-          name: [string, ...string[]] | string;
+          name: string | string[];
         }
       | {
           from: 'package';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           package: string;
         }
       | string

--- a/packages/eslint-plugin/tests/schema-snapshots/no-restricted-imports.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-restricted-imports.shot
@@ -197,13 +197,13 @@ type Options =
         patterns?:
           | {
               allowImportNamePattern?: string;
-              allowImportNames?: [string, ...string[]];
+              allowImportNames?: string[];
               /** Whether to allow type-only imports for a path. */
               allowTypeImports?: boolean;
               caseSensitive?: boolean;
-              group?: [string, ...string[]];
+              group?: string[];
               importNamePattern?: string;
-              importNames?: [string, ...string[]];
+              importNames?: string[];
               message?: string;
               regex?: string;
             }[]

--- a/packages/eslint-plugin/tests/schema-snapshots/only-throw-error.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/only-throw-error.shot
@@ -122,16 +122,16 @@ type Options = [
     allow?: (
       | {
           from: 'file';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           path?: string;
         }
       | {
           from: 'lib';
-          name: [string, ...string[]] | string;
+          name: string | string[];
         }
       | {
           from: 'package';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           package: string;
         }
       | string

--- a/packages/eslint-plugin/tests/schema-snapshots/prefer-readonly-parameter-types.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/prefer-readonly-parameter-types.shot
@@ -126,16 +126,16 @@ type Options = [
     allow?: (
       | {
           from: 'file';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           path?: string;
         }
       | {
           from: 'lib';
-          name: [string, ...string[]] | string;
+          name: string | string[];
         }
       | {
           from: 'package';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           package: string;
         }
       | string

--- a/packages/eslint-plugin/tests/schema-snapshots/restrict-template-expressions.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/restrict-template-expressions.shot
@@ -142,16 +142,16 @@ type Options = [
     allow?: (
       | {
           from: 'file';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           path?: string;
         }
       | {
           from: 'lib';
-          name: [string, ...string[]] | string;
+          name: string | string[];
         }
       | {
           from: 'package';
-          name: [string, ...string[]] | string;
+          name: string | string[];
           package: string;
         }
       | string


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11117 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Update rule-schema-to-typescript-types to remove support for `minItems`/`maxItems` in array type generation
