### PR TITLE
fix(eslint-plugin): [consistent-indexed-object-style] adjust auto-fixer to generate valid syntax for `TSMappedType` with no type annotation

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -226,9 +226,9 @@ export default createRule<Options, MessageIds>({
             ...(canFix && {
               fix: (fixer): ReturnType<ReportFixFunction> => {
                 const keyType = context.sourceCode.getText(constraint);
-                const valueType = context.sourceCode.getText(
-                  node.typeAnnotation,
-                );
+                const valueType = node.typeAnnotation
+                  ? context.sourceCode.getText(node.typeAnnotation)
+                  : 'any';
 
                 let recordText = `Record<${keyType}, ${valueType}>`;
 

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -904,5 +904,17 @@ interface Bar {
 }
       `,
     },
+
+    {
+      code: `
+type Bar = {
+  [k in string];
+};
+      `,
+      errors: [{ column: 12, line: 2, messageId: 'preferRecord' }],
+      output: `
+type Bar = Record<string, any>;
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -907,13 +907,13 @@ interface Bar {
 
     {
       code: `
-type Bar = {
+type Foo = {
   [k in string];
 };
       `,
       errors: [{ column: 12, line: 2, messageId: 'preferRecord' }],
       output: `
-type Bar = Record<string, any>;
+type Foo = Record<string, any>;
       `,
     },
   ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11179
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR addresses #11179 and adjusts the auto-fixer to fix the following:

```ts
type Bar = {
  [k in string];
};
```

Into:

```ts
type Bar = Record<string, any>;
```
