### PR TITLE
docs: use plain text for project name, not code, in homepage

### DIFF
--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -71,8 +71,7 @@ const features: FeatureItem[] = [
         <div className="col col--offset-2 col--8">
           <p>
             <strong>
-              <code>typescript-eslint</code> enables ESLint to run on TypeScript
-              code.
+              typescript-eslint enables ESLint to run on TypeScript code.
             </strong>{' '}
             It brings in the best of both tools to help you write the best
             JavaScript or TypeScript code you possibly can.
@@ -87,7 +86,7 @@ const features: FeatureItem[] = [
           </p>
         </div>
         <div className="col col--offset-2 col--8">
-          <code>typescript-eslint</code>:
+          typescript-eslint:
           <ul>
             <li>allows ESLint to parse TypeScript syntax</li>
             <li>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10562
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I couldn't find any other places that use `<code>typescript-eslint</code>` or refer to the project as <code>\`typescript-eslint`</code>.

💖 