### PR TITLE
fix(website): acquired types are shown in the editor but not reflected in linting

### DIFF
--- a/packages/website/src/components/linter/bridge.ts
+++ b/packages/website/src/components/linter/bridge.ts
@@ -14,7 +14,9 @@ export function createFileSystem(
   const files = new Map<string, string>();
   files.set(`/.eslintrc`, config.eslintrc);
   files.set(`/tsconfig.json`, config.tsconfig);
-  files.set(`/input${config.fileType}`, config.code);
+  if (config.code !== '') {
+    files.set(`/input${config.fileType}`, config.code);
+  }
 
   const fileWatcherCallbacks = new Map<RegExp, Set<ts.FileWatcherCallback>>();
 
@@ -79,7 +81,9 @@ export function createFileSystem(
     return [...files.keys()].filter(fileName => expPath.test(fileName));
   };
   system.getScriptFileNames = (): string[] => {
-    return [...files.keys()].filter(f => f.endsWith('.ts'));
+    return [...files.keys()]
+      .filter(fileName => !fileName.startsWith('/lib.'))
+      .filter(f => !f.endsWith('/.eslintrc') && !f.endsWith('.json'));
   };
   return system;
 }

--- a/packages/website/src/components/linter/bridge.ts
+++ b/packages/website/src/components/linter/bridge.ts
@@ -78,6 +78,8 @@ export function createFileSystem(
     const expPath = getPathRegExp(path);
     return [...files.keys()].filter(fileName => expPath.test(fileName));
   };
-
+  system.getScriptFileNames = (): string[] => {
+    return [...files.keys()].filter(f => f.endsWith('.ts'));
+  };
   return system;
 }

--- a/packages/website/src/components/linter/createLinter.ts
+++ b/packages/website/src/components/linter/createLinter.ts
@@ -11,6 +11,7 @@ import type {
   LinterOnLint,
   LinterOnParse,
   PlaygroundSystem,
+  RegisterFile,
   WebLinterModule,
 } from './types';
 
@@ -36,6 +37,7 @@ export interface CreateLinter {
   triggerFix(filename: string): Linter.FixReport | undefined;
   triggerLint(filename: string): void;
   updateParserOptions(sourceType?: SourceType): void;
+  registerFile: RegisterFile;
 }
 
 export function createLinter(
@@ -164,6 +166,11 @@ export function createLinter(
     }
   };
 
+  const registerFile = (fileName: string, code: string) => {
+    parser.registerFile(fileName, code);
+    triggerLintAll();
+  };
+
   const triggerLintAll = (): void => {
     system.searchFiles('/input.*').forEach(triggerLint);
   };
@@ -185,6 +192,7 @@ export function createLinter(
     configs: [...configs.keys()],
     onLint: onLint.register,
     onParse: onParse.register,
+    registerFile,
     rules,
     triggerFix,
     triggerLint,

--- a/packages/website/src/components/linter/createParser.ts
+++ b/packages/website/src/components/linter/createParser.ts
@@ -6,6 +6,7 @@ import type * as ts from 'typescript';
 import type {
   ParseSettings,
   PlaygroundSystem,
+  RegisterFile,
   UpdateModel,
   WebLinterModule,
 } from './types';
@@ -20,6 +21,7 @@ export function createParser(
   vfs: typeof tsvfs,
 ): {
   updateConfig: (compilerOptions: ts.CompilerOptions) => void;
+  registerFile: RegisterFile;
 } & Parser.ParserModule {
   const createEnv = (
     compilerOptions: ts.CompilerOptions,
@@ -47,7 +49,6 @@ export function createParser(
       if (system.fileExists(filePath)) {
         compilerHost.updateFile(filePath, code);
       } else {
-        system.writeFile(filePath, code);
         compilerHost.createFile(filePath, code);
       }
 
@@ -105,6 +106,9 @@ export function createParser(
         },
         visitorKeys: utils.visitorKeys,
       };
+    },
+    registerFile(filePath: string, code: string): void {
+      compilerHost.createFile(filePath, code);
     },
     updateConfig(compilerOptions): void {
       compilerHost = createEnv(compilerOptions);

--- a/packages/website/src/components/linter/createParser.ts
+++ b/packages/website/src/components/linter/createParser.ts
@@ -28,7 +28,7 @@ export function createParser(
   ): tsvfs.VirtualTypeScriptEnvironment => {
     return vfs.createVirtualTypeScriptEnvironment(
       system,
-      [...registeredFiles],
+      [...registeredFiles, ...system.getScriptFileNames()],
       window.ts,
       compilerOptions,
     );

--- a/packages/website/src/components/linter/createParser.ts
+++ b/packages/website/src/components/linter/createParser.ts
@@ -21,14 +21,12 @@ export function createParser(
 ): {
   updateConfig: (compilerOptions: ts.CompilerOptions) => void;
 } & Parser.ParserModule {
-  const registeredFiles = new Set<string>();
-
   const createEnv = (
     compilerOptions: ts.CompilerOptions,
   ): tsvfs.VirtualTypeScriptEnvironment => {
     return vfs.createVirtualTypeScriptEnvironment(
       system,
-      [...registeredFiles, ...system.getScriptFileNames()],
+      system.getScriptFileNames(),
       window.ts,
       compilerOptions,
     );
@@ -46,10 +44,10 @@ export function createParser(
       // if text is empty use empty line to avoid error
       const code = text || '\n';
 
-      if (registeredFiles.has(filePath)) {
+      if (system.fileExists(filePath)) {
         compilerHost.updateFile(filePath, code);
       } else {
-        registeredFiles.add(filePath);
+        system.writeFile(filePath, code);
         compilerHost.createFile(filePath, code);
       }
 

--- a/packages/website/src/components/linter/types.ts
+++ b/packages/website/src/components/linter/types.ts
@@ -30,6 +30,7 @@ export interface WebLinterModule {
 export type PlaygroundSystem = {
   removeFile: (fileName: string) => void;
   searchFiles: (path: string) => string[];
+  getScriptFileNames: () => string[];
 } & Required<Pick<ts.System, 'deleteFile' | 'watchFile'>> &
   ts.System;
 

--- a/packages/website/src/components/linter/types.ts
+++ b/packages/website/src/components/linter/types.ts
@@ -40,3 +40,5 @@ export type LinterOnLint = (
 ) => void;
 
 export type LinterOnParse = (fileName: string, model: UpdateModel) => void;
+
+export type RegisterFile = (fileName: string, code: string) => void;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11120 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
I think this issue occurs because of differences in the properties used when creating a ts.Program between Monaco and TypeScript-VFS.

> https://github.com/typescript-eslint/typescript-eslint/blob/e57126a23e3f9b0ec67665d47e37a429d7755753/packages/website/src/components/linter/createParser.ts#L29


The modules like [monaco](https://github.com/microsoft/monaco-editor), [typescript](https://github.com/microsoft/TypeScript), and [typescript-website](https://github.com/microsoft/TypeScript-Website) are scattered, so it’s a bit confusing

**1. create `ts.program` by monace**

**When monaco-editor creating this code will excute**   [link](https://github.com/microsoft/monaco-editor/blob/dd6bdfe8dae1b3c134fa7bc7b176b43fd294916e/src/language/typescript/tsWorker.ts#L35-L41)
`private _languageService = ts.createLanguageService(this);` 


 **createLanguageService in typescript**. [link](https://github.com/microsoft/TypeScript/blob/8c62e08448e0ec76203bd519dd39608dbcb31705/src/services/services.ts#L1725-L1830)
```ts
const rootFileNames = host.getScriptFileNames().slice();
 // some code
const options: CreateProgramOptions = {
  rootNames: rootFileNames,
  options: newSettings,
  host: compilerHost, 
  oldProgram: program,
  projectReferences,
};
program = createProgram(options);
```


And filenames output by `getScriptFileNames` will be added in the code below.
`defaults.addExtraLib(code, path)` in [typescript-website](https://github.com/microsoft/TypeScript-Website/blob/98ce24207d992b2b1a31f5e6b941d946175d48f6/packages/sandbox/src/index.ts#L187) => `defaults.addExtraLib(code, path)` in [monaco](https://github.com/microsoft/monaco-editor/blob/dd6bdfe8dae1b3c134fa7bc7b176b43fd294916e/src/language/typescript/monaco.contribution.ts#L610)

So, when creating a ts.Program, the rootNames array includes some libraries, such as Node or React.

**2. create `ts.program` by TypeScript-VFS.**

> https://github.com/typescript-eslint/typescript-eslint/blob/e57126a23e3f9b0ec67665d47e37a429d7755753/packages/website/src/components/linter/createParser.ts#L24-L31

Unlike case 1 above,We don't pass the name of a node_modules folder in fileNames.

In the sentence above, I modified it so that rootNames are provided when creating the `ts.Program` for both the Editor and Linting

## Testing
1. Click a [link](https://deploy-preview-11198--typescript-eslint.netlify.app/play/#ts=5.8.2&fileType=.tsx&code=FASwtgDg9gTgLgAgN4ICYFMDOBjGIBG6ANAiIgL4IBmMUYCA5AHZQYBccWcDA3MMBhx5CACgYBDBJ0zcSIgJQIAvAD5kwBKThjxmAJ5NsAC1osArpgYldB7AgXK1SDZoTYoTTFAA26AHTeUADmYlRQUAzyfJrkUcCxPEA&eslintrc=N4KABGBECmAeAu0B2ATAzpAXGA2uCUADgDYCuA5gJZKYAC8AnodGgMYBOlh8AtC8dXgB6NPE6tejZj1YALaKwDW0FJHwBdADT5I7UsRZYwoAlHpMWHLr36ChSAPY8AZsQcBDeNXI9C7BwC2lGiG2JAA7u7sSGoQAL4gcUA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false) that already has code pre-filled.
2. Enter code in an empty playground