### PR TITLE
docs(eslint-plugin): [typedef] deprecate the rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/typedef.mdx
+++ b/packages/eslint-plugin/docs/rules/typedef.mdx
@@ -9,6 +9,18 @@ import TabItem from '@theme/TabItem';
 >
 > See **https://typescript-eslint.io/rules/typedef** for documentation.
 
+:::caution
+
+This is an old, deprecated rule.
+It will be removed in a future major version of typescript-eslint.
+
+Requiring type annotations unnecessarily can be cumbersome to maintain and generally reduces code readability.
+TypeScript is often better at inferring types than easily written type annotations would allow.
+
+**Instead of enabling `typedef`, it is generally recommended to use the `--noImplicitAny` and `--strictPropertyInitialization` compiler options to enforce type annotations only when useful.**
+
+:::
+
 TypeScript cannot always infer types for all places in code.
 Some locations require type annotations for their types to be inferred.
 
@@ -29,15 +41,6 @@ class ContainsText {
 ```
 
 > To enforce type definitions existing on call signatures, use [`explicit-function-return-type`](./explicit-function-return-type.mdx), or [`explicit-module-boundary-types`](./explicit-module-boundary-types.mdx).
-
-:::caution
-
-Requiring type annotations unnecessarily can be cumbersome to maintain and generally reduces code readability.
-TypeScript is often better at inferring types than easily written type annotations would allow.
-
-**Instead of enabling `typedef`, it is generally recommended to use the `--noImplicitAny` and `--strictPropertyInitialization` compiler options to enforce type annotations only when useful.**
-
-:::
 
 ## Options
 

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -156,7 +156,6 @@ export = {
     '@typescript-eslint/strict-boolean-expressions': 'error',
     '@typescript-eslint/switch-exhaustiveness-check': 'error',
     '@typescript-eslint/triple-slash-reference': 'error',
-    '@typescript-eslint/typedef': 'error',
     '@typescript-eslint/unbound-method': 'error',
     '@typescript-eslint/unified-signatures': 'error',
     '@typescript-eslint/use-unknown-in-catch-callback-variable': 'error',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -170,7 +170,6 @@ export default (
       '@typescript-eslint/strict-boolean-expressions': 'error',
       '@typescript-eslint/switch-exhaustiveness-check': 'error',
       '@typescript-eslint/triple-slash-reference': 'error',
-      '@typescript-eslint/typedef': 'error',
       '@typescript-eslint/unbound-method': 'error',
       '@typescript-eslint/unified-signatures': 'error',
       '@typescript-eslint/use-unknown-in-catch-callback-variable': 'error',

--- a/packages/eslint-plugin/src/rules/typedef.ts
+++ b/packages/eslint-plugin/src/rules/typedef.ts
@@ -23,6 +23,10 @@ export default createRule<Options, MessageIds>({
   name: 'typedef',
   meta: {
     type: 'suggestion',
+    deprecated: {
+      deprecatedSince: '8.33.0',
+      message: 'This is an old rule that is no longer recommended for use.',
+    },
     docs: {
       description: 'Require type annotations in certain places',
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11187
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

At long last! We haven't recommended this rule in _years_. It's mostly been kept around as a legacy support point. But it's been less and less useful over the years.

Primarily a docs change + addition of `meta.deprecated` to the rule.

Moves the `:::caution` note to be the first added content in the rule's docs file, and adds a note to it that the rule is deprecated.

Note that this does include a behavioral change: the rule is no longer in the `all` configs. Per https://typescript-eslint.io/users/configs#all, the contents of `all` are _not_ considered semver-stable. This is not a breaking change.

💖 