### PR TITLE
feat(eslint-plugin): add a default-off option to autofix remove unused imports

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -1734,6 +1734,122 @@ export {};
       ],
       filename: 'foo.d.ts',
     },
+    {
+      code: `
+import * as Unused from 'foo';
+import * as Used from 'bar';
+export { Used };
+      `,
+      errors: [
+        {
+          column: 13,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'Unused',
+          },
+          line: 2,
+          messageId: 'unusedVar',
+        },
+      ],
+      options: [{ enableAutofixRemoval: { imports: true } }],
+      output: `
+import * as Used from 'bar';
+export { Used };
+      `,
+    },
+    {
+      code: `
+import Unused1 from 'foo';
+import Unused2, { Used } from 'bar';
+export { Used };
+      `,
+      errors: [
+        {
+          column: 8,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'Unused1',
+          },
+          line: 2,
+          messageId: 'unusedVar',
+        },
+        {
+          column: 8,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'Unused2',
+          },
+          line: 3,
+          messageId: 'unusedVar',
+        },
+      ],
+      options: [{ enableAutofixRemoval: { imports: true } }],
+      output: `
+import { Used } from 'bar';
+export { Used };
+      `,
+    },
+    {
+      code: `
+import { Unused1 } from 'foo';
+import Used1, { Unused2 } from 'bar';
+import { Used2, Unused3 } from 'baz';
+import Used3, { Unused4, Used4 } from 'foobar';
+export { Used1, Used2, Used3, Used4 };
+      `,
+      errors: [
+        {
+          column: 10,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'Unused1',
+          },
+          line: 2,
+          messageId: 'unusedVar',
+        },
+        {
+          column: 17,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'Unused2',
+          },
+          line: 3,
+          messageId: 'unusedVar',
+        },
+        {
+          column: 17,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'Unused3',
+          },
+          line: 4,
+          messageId: 'unusedVar',
+        },
+        {
+          column: 17,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'Unused4',
+          },
+          line: 5,
+          messageId: 'unusedVar',
+        },
+      ],
+      options: [{ enableAutofixRemoval: { imports: true } }],
+      output: `
+import Used1 from 'bar';
+import { Used2 } from 'baz';
+import Used3, { Used4 } from 'foobar';
+export { Used1, Used2, Used3, Used4 };
+      `,
+    },
   ],
 
   valid: [
@@ -2939,39 +3055,6 @@ export namespace Foo {
 declare module 'foo' {
   export import Bar = Something.Bar;
   const foo: 1234;
-}
-      `,
-      filename: 'foo.d.ts',
-    },
-    {
-      code: `
-export import Bar = Something.Bar;
-const foo: 1234;
-      `,
-      filename: 'foo.d.ts',
-    },
-    {
-      code: `
-declare module 'foo' {
-  export import Bar = Something.Bar;
-  const foo: 1234;
-  export const bar: string;
-  export namespace NS {
-    const baz: 1234;
-  }
-}
-      `,
-      filename: 'foo.d.ts',
-    },
-    {
-      code: `
-export namespace Foo {
-  export import Bar = Something.Bar;
-  const foo: 1234;
-  export const bar: string;
-  export namespace NS {
-    const baz: 1234;
-  }
 }
       `,
       filename: 'foo.d.ts',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11223
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
**DRAFT**
- When add option `enableAutofixRemoval: { imports: true } `, auto fix and remove unused import statement
- Add test case in issue
- More test cases are needed. First of all, since it is my first contribution, it is very difficult, so I will think about it after uploading the PR. I can check the comments quickly.
- There may be something wrong with the comma handling. First, pass the test case.