### PR TITLE
fix: exclude docs/ directory from eslint-plugin package

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -5,7 +5,6 @@
   "files": [
     "dist",
     "!*.tsbuildinfo",
-    "docs",
     "index.d.ts",
     "raw-plugin.d.ts",
     "rules.d.ts",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -9,7 +9,7 @@
     "raw-plugin.d.ts",
     "rules.d.ts",
     "package.json",
-    "README.md",
+    "./README.md",
     "LICENSE"
   ],
   "type": "commonjs",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11234
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR excludes `docs/` directory from the published `@typescript-eslint/eslint-plugin` package.

I converted from `README.md` to `./README.md` in [`files`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files) of `package.json`.  This is because [docs/rules/README.md](https://github.com/roottool/typescript-eslint/blob/db9e2c553e306880b7de7bb27e216f4c26a5ec9f/packages/eslint-plugin/docs/rules/README.md) is included in the eslint-plugin package after `docs/` directory is excluded. I checked it with [`yarn pack --dry-run`](https://v3.yarnpkg.com/cli/pack).

As an aside, I think that `README.md`  in `files` can be deleted. `README` is always included in this `files` config.

> Certain files are always included, regardless of settings:
> 
> - `package.json`
> - `README`
> - `LICENSE` / `LICENCE`
> - The file in the "main" field
> - The file(s) in the "bin" field
> 
> [files - package.json | npm Docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files)