### PR TITLE
chore: fix project service links

### DIFF
--- a/docs/getting-started/Typed_Linting.mdx
+++ b/docs/getting-started/Typed_Linting.mdx
@@ -82,7 +82,7 @@ module.exports = {
 In more detail:
 
 - `plugin:@typescript-eslint/recommended-type-checked` is a [shared configuration](../users/Shared_Configurations.mdx). It contains recommended rules that additionally require type information.
-- `parserOptions.projectService: true` indicates to ask TypeScript's type checking service for each source file's type information (see [Parser > `projectService`](../packages/Parser.mdx#projectService)).
+- `parserOptions.projectService: true` indicates to ask TypeScript's type checking service for each source file's type information (see [Parser > `projectService`](../packages/Parser.mdx#projectservice)).
 - `parserOptions.tsconfigRootDir` tells our parser the absolute path of your project's root directory (see [Parser > `tsconfigRootDir`](../packages/Parser.mdx#tsconfigrootdir)).
 
 </TabItem>
@@ -163,5 +163,5 @@ If you're having problems with typed linting, please see our [Troubleshooting FA
 
 For details on the parser options that enable typed linting, see:
 
-- [Parser > `projectService`](../packages/Parser.mdx#projectService): our recommended option, with settings to customize TypeScript project information
-- [Parser > `project`](../packages/Parser.mdx#projectService): an older option that can be used as an alternative
+- [Parser > `projectService`](../packages/Parser.mdx#projectservice): our recommended option, with settings to customize TypeScript project information
+- [Parser > `project`](../packages/Parser.mdx#project): an older option that can be used as an alternative

--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -282,7 +282,7 @@ If this setting is specified, you must only lint files that are included in the 
 }
 ```
 
-For an option that allows linting files outside of your TSConfig file(s), see [`projectService`](#projectService).
+For an option that allows linting files outside of your TSConfig file(s), see [`projectService`](#projectservice).
 
 <HiddenHeading id="experimental_useprojectservice" />
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- Fixes the links at https://typescript-eslint.io/getting-started/typed-linting#troubleshooting. 

- Fixes the link to the project service section at the `project` section: https://typescript-eslint.io/packages/parser#project
