### PR TITLE
docs(eslint-plugin): add FAQ about JSDoc link usage with no-unused-vars

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unused-vars.mdx
@@ -121,7 +121,7 @@ If you find yourself writing runtime values only for types, consider refactoring
 
 ### Why are variables reported as unused despite being referenced by @link in JSDoc?
 
-JSDoc references are not supported by typeScript-eslint.
+JSDoc references are not supported by typescript-eslint.
 You can use a rule such as [`jsdoc/no-undefined-types`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/no-undefined-types.md) to resolve variables as used in JSDoc comments.
 
 ```ts


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11210
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Added an FAQ about JSDoc not being supported by `no-unused-vars` with a reference to [jsdoc/no-undefined-types](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/no-undefined-types.md) as an alternative recommendation.