### PR TITLE
fix(eslint-plugin-internal): check formatting in suggestion output fields

### DIFF
--- a/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
+++ b/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
@@ -520,8 +520,33 @@ export default createRule<Options, MessageIds>({
           continue;
         }
 
-        if (prop.key.name === 'code') {
+        if (prop.key.name === 'code' || prop.key.name === 'output') {
           checkExpression(prop.value, isErrorTest);
+        }
+
+        if (
+          prop.key.name === 'errors' &&
+          prop.value.type === AST_NODE_TYPES.ArrayExpression
+        ) {
+          for (const errorElement of prop.value.elements) {
+            if (errorElement?.type === AST_NODE_TYPES.ObjectExpression) {
+              for (const errorProp of errorElement.properties) {
+                if (
+                  errorProp.type === AST_NODE_TYPES.Property &&
+                  !errorProp.computed &&
+                  errorProp.key.type === AST_NODE_TYPES.Identifier &&
+                  errorProp.key.name === 'suggestions' &&
+                  errorProp.value.type === AST_NODE_TYPES.ArrayExpression
+                ) {
+                  for (const suggestion of errorProp.value.elements) {
+                    if (suggestion?.type === AST_NODE_TYPES.ObjectExpression) {
+                      checkInvalidTest(suggestion, isErrorTest);
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes the `@typescript-eslint/internal/plugin-test-formatting` rule to also check formatting of `output` fields within `errors[].suggestions[]` arrays in test cases.

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Previously, the rule only checked `code` field at the top level of test objects, but ignored `output` fields inside suggestion objects. This led to inconsistent formatting in test files where suggestion outputs could contain improperly formatted code.

Before:

```js
suggestions: [
  {
    messageId: 'suggestNullish',
    output: "bad formatting here", // ❌ Not checked
  },
]
```

After

```js
suggestions: [
  {
    messageId: 'suggestNullish', 
    output: "properly formatted code", // ✅ Now checked and auto-fixed
  },
]
```