### PR TITLE
docs: rename "directive comments" to "comment directives"

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-ts-comment.mdx
+++ b/packages/eslint-plugin/docs/rules/ban-ts-comment.mdx
@@ -9,11 +9,11 @@ import TabItem from '@theme/TabItem';
 >
 > See **https://typescript-eslint.io/rules/ban-ts-comment** for documentation.
 
-TypeScript provides several directive comments that can be used to alter how it processes files.
+TypeScript provides several comment directives that can be used to alter how it processes files.
 Using these to suppress TypeScript compiler errors reduces the effectiveness of TypeScript overall.
 Instead, it's generally better to correct the types of code, to make directives unnecessary.
 
-The directive comments supported by TypeScript are:
+The comment directives supported by TypeScript are:
 
 ```ts
 // @ts-expect-error
@@ -22,7 +22,7 @@ The directive comments supported by TypeScript are:
 // @ts-check
 ```
 
-This rule lets you set which directive comments you want to allow in your codebase.
+This rule lets you set which comment directives you want to allow in your codebase.
 
 ## Options
 

--- a/packages/eslint-plugin/src/util/astUtils.ts
+++ b/packages/eslint-plugin/src/util/astUtils.ts
@@ -11,9 +11,9 @@ export * from '@typescript-eslint/utils/ast-utils';
 // https://github.com/eslint/eslint/blob/145aec1ab9052fbca96a44d04927c595951b1536/lib/rules/utils/ast-utils.js#L1751-L1779
 // Could be export { getNameLocationInGlobalDirectiveComment } from 'eslint/lib/rules/utils/ast-utils'
 /**
- * Get the `loc` object of a given name in a `/*globals` directive comment.
+ * Get the `loc` object of a given name in a `/*globals` comment directive.
  * @param sourceCode The source code to convert index to loc.
- * @param comment The `/*globals` directive comment which include the name.
+ * @param comment The `/*globals` comment directive which include the name.
  * @param name The name to find.
  * @returns The `loc` object.
  */

--- a/packages/scope-manager/src/variable/ESLintScopeVariable.ts
+++ b/packages/scope-manager/src/variable/ESLintScopeVariable.ts
@@ -17,21 +17,21 @@ export class ESLintScopeVariable extends VariableBase {
 
   /**
    * Written to by ESLint.
-   * This property is undefined if there are no globals directive comments.
-   * The array of globals directive comments which defined this global variable in the source code file.
+   * This property is undefined if there are no globals comment directives.
+   * The array of globals comment directives which defined this global variable in the source code file.
    */
   public eslintExplicitGlobal?: boolean;
 
   /**
    * Written to by ESLint.
-   * The configured value in config files. This can be different from `variable.writeable` if there are globals directive comments.
+   * The configured value in config files. This can be different from `variable.writeable` if there are globals comment directives.
    */
   public eslintImplicitGlobalSetting?: 'readonly' | 'writable';
 
   /**
    * Written to by ESLint.
    * If this key exists, it is a global variable added by ESLint.
-   * If `true`, this global variable was defined by a globals directive comment in the source code file.
+   * If `true`, this global variable was defined by a globals comment directive in the source code file.
    */
   public eslintExplicitGlobalComments?: TSESTree.Comment[];
 }

--- a/packages/utils/src/ts-eslint/Config.ts
+++ b/packages/utils/src/ts-eslint/Config.ts
@@ -79,7 +79,7 @@ export namespace ClassicConfig {
      */
     globals?: GlobalsConfig;
     /**
-     * The flag that disables directive comments.
+     * The flag that disables comment directives.
      */
     noInlineConfig?: boolean;
     /**

--- a/packages/utils/src/ts-eslint/eslint/ESLintShared.ts
+++ b/packages/utils/src/ts-eslint/eslint/ESLintShared.ts
@@ -104,7 +104,7 @@ export declare class ESLintBase<
 }
 export interface ESLintOptions<Config extends Linter.ConfigType> {
   /**
-   * If false is present, ESLint suppresses directive comments in source code.
+   * If false is present, ESLint suppresses comment directives in source code.
    * If this option is false, it overrides the noInlineConfig setting in your configurations.
    * @default true
    */


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR only renames "directive comments" into "comment directives" in documentation.

The wording is rather similar, indeed. It seems to me that "comment directives" is the preferred naming in the ecosystem:

- when support for the `// @ts-expect-error` was added to TypeScript, several internal types use the "comment directives" naming: https://github.com/microsoft/TypeScript/pull/36014
- the Learning TypeScript book has a whole chapter named Comment Directives (but not Directive Comments): https://www.learningtypescript.com/articles/comment-directives

