### PR TITLE
chore(visitor-keys): bump `eslint-visitor-keys` dependency

### DIFF
--- a/packages/visitor-keys/package.json
+++ b/packages/visitor-keys/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@typescript-eslint/types": "8.34.0",
-    "eslint-visitor-keys": "^4.2.0"
+    "eslint-visitor-keys": "^4.2.1"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5713,7 +5713,7 @@ __metadata:
   dependencies:
     "@typescript-eslint/types": 8.34.0
     "@vitest/coverage-v8": ^3.1.3
-    eslint-visitor-keys: ^4.2.0
+    eslint-visitor-keys: ^4.2.1
     rimraf: "*"
     typescript: "*"
     vitest: ^3.1.3
@@ -9564,6 +9564,13 @@ __metadata:
   version: 4.2.0
   resolution: "eslint-visitor-keys@npm:4.2.0"
   checksum: 779c604672b570bb4da84cef32f6abb085ac78379779c1122d7879eade8bb38ae715645324597cf23232d03cef06032c9844d25c73625bc282a5bfd30247e5b5
+  languageName: node
+  linkType: hard
+
+"eslint-visitor-keys@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "eslint-visitor-keys@npm:4.2.1"
+  checksum: 3a77e3f99a49109f6fb2c5b7784bc78f9743b834d238cdba4d66c602c6b52f19ed7bcd0a5c5dbbeae3a8689fd785e76c001799f53d2228b278282cf9f699fff5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11293
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fix #11293 by bumping dependency of `eslint-visitor-keys` to v4.2.1.

As mentioned in #11293, as far as I can see, this is the only substantive change made in v4.2.1, so I think it should be possible to bump `eslint-visitor-keys` dependency in isolation, without breaking anything else.

No-one has had a chance to respond on #11293 yet, so I'm jumping the gun by submitting a PR. However, judging by #11279, I assume this will be considered a bug, and I thought a PR would help verify that this fix doesn't break anything.

If I'm out of line, please feel free to close this!