### PR TITLE
fix(typescript-estree): align constructor literal with eslint

### DIFF
--- a/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor-string-literal/fixture.ts
+++ b/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor-string-literal/fixture.ts
@@ -1,0 +1,4 @@
+class Foo {
+  // prettier-ignore
+  "constructor"() {}
+}

--- a/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor-string-literal/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor-string-literal/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,100 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          MethodDefinition {
+            type: "MethodDefinition",
+            computed: false,
+            decorators: [],
+            key: Literal {
+              type: "Literal",
+              raw: ""constructor"",
+              value: "constructor",
+
+              range: [35, 48],
+              loc: {
+                start: { column: 2, line: 3 },
+                end: { column: 15, line: 3 },
+              },
+            },
+            kind: "constructor",
+            optional: false,
+            override: false,
+            static: false,
+            value: FunctionExpression {
+              type: "FunctionExpression",
+              async: false,
+              body: BlockStatement {
+                type: "BlockStatement",
+                body: [],
+
+                range: [51, 53],
+                loc: {
+                  start: { column: 18, line: 3 },
+                  end: { column: 20, line: 3 },
+                },
+              },
+              declare: false,
+              expression: false,
+              generator: false,
+              id: null,
+              params: [],
+
+              range: [48, 53],
+              loc: {
+                start: { column: 15, line: 3 },
+                end: { column: 20, line: 3 },
+              },
+            },
+
+            range: [35, 53],
+            loc: {
+              start: { column: 2, line: 3 },
+              end: { column: 20, line: 3 },
+            },
+          },
+        ],
+
+        range: [10, 55],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 4 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 55],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 4 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 56],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 5 },
+  },
+}

--- a/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor-string-literal/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor-string-literal/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,92 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  String {
+    type: "String",
+    value: ""constructor"",
+
+    range: [35, 48],
+    loc: {
+      start: { column: 2, line: 3 },
+      end: { column: 15, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [48, 49],
+    loc: {
+      start: { column: 15, line: 3 },
+      end: { column: 16, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [49, 50],
+    loc: {
+      start: { column: 16, line: 3 },
+      end: { column: 17, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [51, 52],
+    loc: {
+      start: { column: 18, line: 3 },
+      end: { column: 19, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [52, 53],
+    loc: {
+      start: { column: 19, line: 3 },
+      end: { column: 20, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [54, 55],
+    loc: {
+      start: { column: 0, line: 4 },
+      end: { column: 1, line: 4 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor-string-literal/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor-string-literal/snapshots/3-Babel-AST.shot
@@ -1,0 +1,100 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          MethodDefinition {
+            type: "MethodDefinition",
+            computed: false,
+            decorators: [],
+            key: Literal {
+              type: "Literal",
+              raw: ""constructor"",
+              value: "constructor",
+
+              range: [35, 48],
+              loc: {
+                start: { column: 2, line: 3 },
+                end: { column: 15, line: 3 },
+              },
+            },
+            kind: "constructor",
+            optional: false,
+            override: false,
+            static: false,
+            value: FunctionExpression {
+              type: "FunctionExpression",
+              async: false,
+              body: BlockStatement {
+                type: "BlockStatement",
+                body: [],
+
+                range: [51, 53],
+                loc: {
+                  start: { column: 18, line: 3 },
+                  end: { column: 20, line: 3 },
+                },
+              },
+              declare: false,
+              expression: false,
+              generator: false,
+              id: null,
+              params: [],
+
+              range: [48, 53],
+              loc: {
+                start: { column: 15, line: 3 },
+                end: { column: 20, line: 3 },
+              },
+            },
+
+            range: [35, 53],
+            loc: {
+              start: { column: 2, line: 3 },
+              end: { column: 20, line: 3 },
+            },
+          },
+        ],
+
+        range: [10, 55],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 4 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 55],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 4 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 56],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 5 },
+  },
+}

--- a/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor-string-literal/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor-string-literal/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,92 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  String {
+    type: "String",
+    value: ""constructor"",
+
+    range: [35, 48],
+    loc: {
+      start: { column: 2, line: 3 },
+      end: { column: 15, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [48, 49],
+    loc: {
+      start: { column: 15, line: 3 },
+      end: { column: 16, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [49, 50],
+    loc: {
+      start: { column: 16, line: 3 },
+      end: { column: 17, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [51, 52],
+    loc: {
+      start: { column: 18, line: 3 },
+      end: { column: 19, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [52, 53],
+    loc: {
+      start: { column: 19, line: 3 },
+      end: { column: 20, line: 3 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [54, 55],
+    loc: {
+      start: { column: 0, line: 4 },
+      end: { column: 1, line: 4 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor/fixture.ts
+++ b/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  constructor() {}
+}

--- a/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,101 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          MethodDefinition {
+            type: "MethodDefinition",
+            computed: false,
+            decorators: [],
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "constructor",
+              optional: false,
+
+              range: [14, 25],
+              loc: {
+                start: { column: 2, line: 2 },
+                end: { column: 13, line: 2 },
+              },
+            },
+            kind: "constructor",
+            optional: false,
+            override: false,
+            static: false,
+            value: FunctionExpression {
+              type: "FunctionExpression",
+              async: false,
+              body: BlockStatement {
+                type: "BlockStatement",
+                body: [],
+
+                range: [28, 30],
+                loc: {
+                  start: { column: 16, line: 2 },
+                  end: { column: 18, line: 2 },
+                },
+              },
+              declare: false,
+              expression: false,
+              generator: false,
+              id: null,
+              params: [],
+
+              range: [25, 30],
+              loc: {
+                start: { column: 13, line: 2 },
+                end: { column: 18, line: 2 },
+              },
+            },
+
+            range: [14, 30],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 18, line: 2 },
+            },
+          },
+        ],
+
+        range: [10, 32],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 32],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 33],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,92 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "constructor",
+
+    range: [14, 25],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 13, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [25, 26],
+    loc: {
+      start: { column: 13, line: 2 },
+      end: { column: 14, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [26, 27],
+    loc: {
+      start: { column: 14, line: 2 },
+      end: { column: 15, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [28, 29],
+    loc: {
+      start: { column: 16, line: 2 },
+      end: { column: 17, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [29, 30],
+    loc: {
+      start: { column: 17, line: 2 },
+      end: { column: 18, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [31, 32],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor/snapshots/3-Babel-AST.shot
@@ -1,0 +1,101 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          MethodDefinition {
+            type: "MethodDefinition",
+            computed: false,
+            decorators: [],
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "constructor",
+              optional: false,
+
+              range: [14, 25],
+              loc: {
+                start: { column: 2, line: 2 },
+                end: { column: 13, line: 2 },
+              },
+            },
+            kind: "constructor",
+            optional: false,
+            override: false,
+            static: false,
+            value: FunctionExpression {
+              type: "FunctionExpression",
+              async: false,
+              body: BlockStatement {
+                type: "BlockStatement",
+                body: [],
+
+                range: [28, 30],
+                loc: {
+                  start: { column: 16, line: 2 },
+                  end: { column: 18, line: 2 },
+                },
+              },
+              declare: false,
+              expression: false,
+              generator: false,
+              id: null,
+              params: [],
+
+              range: [25, 30],
+              loc: {
+                start: { column: 13, line: 2 },
+                end: { column: 18, line: 2 },
+              },
+            },
+
+            range: [14, 30],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 18, line: 2 },
+            },
+          },
+        ],
+
+        range: [10, 32],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 32],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 33],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/MethodDefinition/fixtures/constructor/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,92 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "constructor",
+
+    range: [14, 25],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 13, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [25, 26],
+    loc: {
+      start: { column: 13, line: 2 },
+      end: { column: 14, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [26, 27],
+    loc: {
+      start: { column: 14, line: 2 },
+      end: { column: 15, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [28, 29],
+    loc: {
+      start: { column: 16, line: 2 },
+      end: { column: 17, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [29, 30],
+    loc: {
+      start: { column: 17, line: 2 },
+      end: { column: 18, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [31, 32],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1695,14 +1695,24 @@ export class Converter {
           this.fixParentLocation(constructor, constructor.typeParameters.range);
         }
 
-        const constructorKey = this.createNode<TSESTree.Identifier>(node, {
-          type: AST_NODE_TYPES.Identifier,
-          range: [constructorToken.getStart(this.ast), constructorToken.end],
-          decorators: [],
-          name: 'constructor',
-          optional: false,
-          typeAnnotation: undefined,
-        });
+        const constructorKey =
+          constructorToken.kind === SyntaxKind.StringLiteral
+            ? this.createNode<TSESTree.StringLiteral>(constructorToken, {
+                type: AST_NODE_TYPES.Literal,
+                raw: constructorToken.getText(),
+                value: 'constructor',
+              })
+            : this.createNode<TSESTree.Identifier>(node, {
+                type: AST_NODE_TYPES.Identifier,
+                range: [
+                  constructorToken.getStart(this.ast),
+                  constructorToken.end,
+                ],
+                decorators: [],
+                name: 'constructor',
+                optional: false,
+                typeAnnotation: undefined,
+              });
 
         const isStatic = hasModifier(SyntaxKind.StaticKeyword, node);
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11084
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

cases:
```ts
// Literal
class A {
  "constructor"() { }
}

// Identifier
class B {
  constructor() { }
}
```

💖
<!-- Description of what is changed and how the code change does that. -->
