### PR TITLE
fix(rule-tester): `context.cwd` should always be `process.cwd` in rule tester

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -222,7 +222,6 @@ export class RuleTester extends TestFramework {
       linterForBasePath = (() => {
         const linter = new Linter({
           configType: 'flat',
-          cwd: basePath,
         });
 
         // This nonsense is a workaround for https://github.com/jestjs/jest/issues/14840


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11274
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

According to https://github.com/eslint/eslint/issues/19821#issuecomment-2944904637

> `context.cwd` should, I believe, always be `process.cwd()` when rules are run through RuleTester.
