### PR TITLE
fix(types): add 2026/17 to EcmaVersion

### DIFF
--- a/packages/types/src/parser-options.ts
+++ b/packages/types/src/parser-options.ts
@@ -21,6 +21,7 @@ export type EcmaVersion =
   | 14
   | 15
   | 16
+  | 17
   | 2015
   | 2016
   | 2017
@@ -32,6 +33,7 @@ export type EcmaVersion =
   | 2023
   | 2024
   | 2025
+  | 2026
   | 'latest'
   | undefined;
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/11305 
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I didn't open an issue because it's just for updating a single type for 2026.

I was happening to be manually updating my dependencies and was very confused when I suddenly started getting this error:
```ts
Argument of type 'Config<RulesRecord>' is not assignable to parameter of type 'InfiniteDepthConfigWithExtends'.
  Type 'Config<RulesRecord>' is not assignable to type 'ConfigWithExtends'.
    Types of property 'languageOptions' are incompatible.
      Type 'import("/home/david/Projects/My Price Health/mono/node_modules/eslint/lib/types/index").Linter.LanguageOptions | undefined' is not assignable to type 'import("/home/david/Projects/My Price Health/mono/node_modules/@typescript-eslint/utils/dist/ts-eslint/Config").FlatConfig.LanguageOptions | undefined'.
        Type 'import("/home/david/Projects/My Price Health/mono/node_modules/eslint/lib/types/index").Linter.LanguageOptions' is not assignable to type 'import("/home/david/Projects/My Price Health/mono/node_modules/@typescript-eslint/utils/dist/ts-eslint/Config").FlatConfig.LanguageOptions'.
          Types of property 'ecmaVersion' are incompatible.
            Type 'EcmaVersion | undefined' is not assignable to type 'EcmaVersion'.
              Type '17' is not assignable to type 'EcmaVersion'.
```

This happened because I was writing this:
```ts
export default ts.config(
    [...],
    ...compat.extends("old-config")
    [...]
);
```
[Playground](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBDAznAZlCI4CIYE8wCmiAxlMGDALREA2wAdjFgNwBQokscA3nAGI0AhjADCGMMLgBfVOkxYAArQYwA9MsZRiLVq2IR6iePvCSAvHHoEA7vyGjxwgBQBKNqwIAPTvAAmBFEEAVxp4JAA6fXoUYABzJ1Y4JLgTCRhwrxgCel9EJyxEDAJKCBpfSiiY2KwXVjcgA)  
<sub>Note to future readers: if you enter this playground after this PR has been merged the error will have been fixed because I don't know how to pin dependency version in the TypeScript playground</sub>

And due to `compat.extends` simply returning `Config<RulesRecord>`, the update in [v9.29.0](https://github.com/eslint/eslint/releases/tag/v9.29.0) to add support for 2026 broke this.

I also considered switching form manually defining `export type EcmaVersion = ...` independently to being `export type EcmaVersion = eslint.Linter.EcmaVersion;` as that'd solve the issue in the future but I figured there must be a reason for manually defining `EcmaVersion`. Perhaps peer dependency issues?