### PR TITLE
fix(types): export TSESTree namespace as type-only

### DIFF
--- a/packages/types/src/ts-estree.ts
+++ b/packages/types/src/ts-estree.ts
@@ -253,4 +253,4 @@ declare module './generated/ast-spec' {
   }
 }
 
-export * as TSESTree from './generated/ast-spec';
+export type * as TSESTree from './generated/ast-spec';


### PR DESCRIPTION
Fixes #11310 

## PR Checklist

- [x] Addresses an existing open issue: https://github.com/typescript-eslint/typescript-eslint/issues/11310
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
  - This PR was short enough that I created it in advance of the issue being triaged
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The `TSESTree` namespace is a collection of types related to the flavor/variant of estree that typescript-eslint uses. It is particularly useful when writing code that interacts with `@typescript-eslint/parser`. All of the definitions in this namespace are types, and the namespaces doesn't actually have a value/runtime equivalent, so this export should be defined as type-only.
