### PR TITLE
docs: mention ESLint's defineConfig()

### DIFF
--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -54,9 +54,9 @@ This code will enable our [recommended configuration](../users/Shared_Configurat
 <details>
 <summary>Aside on ESLint's `defineConfig()`</summary>
 
-ESLint also provides a `defineConfig()` helper similar to `tseslint.config`.
+ESLint also provides a `defineConfig()` helper similar to `tseslint.config()`.
 However, there is a types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
-For now we recommend using `tseslint.config` for use with typescript-eslint's configs.
+For now we recommend using `tseslint.config()` for use with typescript-eslint's configs.
 
 See [typescript-eslint#10899](https://github.com/typescript-eslint/typescript-eslint/issues/10899) for more details.
 

--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -55,8 +55,8 @@ This code will enable our [recommended configuration](../users/Shared_Configurat
 <summary>Aside on ESLint's `defineConfig()`</summary>
 
 ESLint also provides a `defineConfig()` helper similar to `tseslint.config`.
-However, there is an types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
-For now we recommend using `tseslint.config` for type-safe configs.
+However, there is a types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
+For now we recommend using `tseslint.config` for use with typescript-eslint's configs.
 
 See [typescript-eslint#10899](https://github.com/typescript-eslint/typescript-eslint/issues/10899) for more details.
 

--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -45,18 +45,29 @@ export default tseslint.config(
 
 This code will enable our [recommended configuration](../users/Shared_Configurations.mdx) for linting.
 
+#### Details
+
+- `tseslint.config(...)` is an **_optional_** helper function — see [`typescript-eslint`'s `config(...)`](../packages/TypeScript_ESLint.mdx#config).
+- `'@eslint/js'` / `eslint.configs.recommended` turns on [eslint's recommended config](https://www.npmjs.com/package/@eslint/js).
+- `tseslint.configs.recommended` turns on [our recommended config](../users/Shared_Configurations.mdx#recommended).
+
+<details>
+<summary>Aside on ESLint's `defineConfig()`</summary>
+
+ESLint also provides a `defineConfig()` helper similar to `tseslint.config`.
+However, there is an types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
+For now we recommend using `tseslint.config` for type-safe configs.
+
+See [typescript-eslint#10899](https://github.com/typescript-eslint/typescript-eslint/issues/10899) for more details.
+
+</details>
+
 <details>
 <summary>Aside on file extensions</summary>
 
 The `.mjs` extension makes the file use the [ES modules (ESM)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) format. Node interprets `.js` files in the [CommonJS (CJS)](https://nodejs.org/api/modules.html) format by default, but if you have `"type": "module"` in your `package.json`, you can also use `eslint.config.js`.
 
 </details>
-
-#### Details
-
-- `tseslint.config(...)` is an **_optional_** helper function — see [`typescript-eslint`'s `config(...)`](../packages/TypeScript_ESLint.mdx#config).
-- `'@eslint/js'` / `eslint.configs.recommended` turns on [eslint's recommended config](https://www.npmjs.com/package/@eslint/js).
-- `tseslint.configs.recommended` turns on [our recommended config](../users/Shared_Configurations.mdx#recommended).
 
 ### Step 3: Running ESLint
 

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -47,6 +47,12 @@ export default tseslint.config(
 
 This config file exports a flat config that enables both the [core ESLint recommended config](https://www.npmjs.com/package/@eslint/js) and [our recommended config](../users/Shared_Configurations.mdx#recommended).
 
+:::note
+ESLint also provides a `defineConfig()` helper similar to `tseslint.config`.
+However, there is an types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
+For now we recommend using `tseslint.config` for type-safe configs.
+:::
+
 ### `config(...)`
 
 `tseslint.config(...)` takes in any number of ESLint config objects, each of which may additionally include an `extends` array of configs to extend.

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -31,7 +31,7 @@ npm i typescript-eslint
 
 ## Usage
 
-We recommend getting started by using `tseslint.config` helper function in your ESLint config:
+We recommend getting started by using the `tseslint.config()` helper function in your ESLint config:
 
 ```js title="eslint.config.mjs"
 // @ts-check
@@ -50,7 +50,7 @@ This config file exports a flat config that enables both the [core ESLint recomm
 :::note
 ESLint also provides a `defineConfig()` helper similar to `tseslint.config()`.
 However, there is a types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
-For now we recommend using `tseslint.config` for use with typescript-eslint configs.
+For now we recommend using `tseslint.config()` for use with typescript-eslint configs.
 
 See [typescript-eslint#10899](https://github.com/typescript-eslint/typescript-eslint/issues/10899) for more details.
 
@@ -114,7 +114,7 @@ Otherwise it _will not_ impact your ability to use our tooling.
 
 #### Flat config `extends`
 
-The `tseslint.config` utility function also adds handling for the `extends` property on flat config objects.
+The `tseslint.config()` utility function also adds handling for the `extends` property on flat config objects.
 This allows you to more easily extend shared configs for specific file patterns whilst also overriding rules/options provided by those configs:
 
 ```js

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -49,7 +49,7 @@ This config file exports a flat config that enables both the [core ESLint recomm
 
 :::note
 ESLint also provides a `defineConfig()` helper similar to `tseslint.config`.
-However, there is an types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
+However, there is a types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
 For now we recommend using `tseslint.config` for type-safe configs.
 
 See [typescript-eslint#10899](https://github.com/typescript-eslint/typescript-eslint/issues/10899) for more details.

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -51,6 +51,9 @@ This config file exports a flat config that enables both the [core ESLint recomm
 ESLint also provides a `defineConfig()` helper similar to `tseslint.config`.
 However, there is an types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
 For now we recommend using `tseslint.config` for type-safe configs.
+
+See [typescript-eslint#10899](https://github.com/typescript-eslint/typescript-eslint/issues/10899) for more details.
+
 :::
 
 ### `config(...)`

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -48,7 +48,7 @@ export default tseslint.config(
 This config file exports a flat config that enables both the [core ESLint recommended config](https://www.npmjs.com/package/@eslint/js) and [our recommended config](../users/Shared_Configurations.mdx#recommended).
 
 :::note
-ESLint also provides a `defineConfig()` helper similar to `tseslint.config`.
+ESLint also provides a `defineConfig()` helper similar to `tseslint.config()`.
 However, there is a types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
 For now we recommend using `tseslint.config` for use with typescript-eslint configs.
 

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -50,7 +50,7 @@ This config file exports a flat config that enables both the [core ESLint recomm
 :::note
 ESLint also provides a `defineConfig()` helper similar to `tseslint.config`.
 However, there is a types incompatibility issue that causes type errors to incorrectly be reported when mixing typescript-eslint's configs and `defineConfig()`.
-For now we recommend using `tseslint.config` for type-safe configs.
+For now we recommend using `tseslint.config` for use with typescript-eslint configs.
 
 See [typescript-eslint#10899](https://github.com/typescript-eslint/typescript-eslint/issues/10899) for more details.
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11313
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds an aside under _Quickstart_ explaining the transient `defineConfig()` situation, along with a similar note under the `typescript-eslint` package docs.

I experimented for a bit splitting existing `tseslint.config` code blocks into tabs as suggested by the issue. That felt more confusing to me: that it was almost suggesting writing to files. Explaining the difference would have taken up even more previous docs space.

💖 