### PR TITLE
fix(website): did not find a source file error if url hash doesn't contain fileType

### DIFF
--- a/packages/website/src/components/linter/createParser.ts
+++ b/packages/website/src/components/linter/createParser.ts
@@ -46,7 +46,7 @@ export function createParser(
       // if text is empty use empty line to avoid error
       const code = text || '\n';
 
-      if (system.fileExists(filePath)) {
+      if (compilerHost.getSourceFile(filePath)) {
         compilerHost.updateFile(filePath, code);
       } else {
         compilerHost.createFile(filePath, code);


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11342
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
Sorry, I didn’t consider that case either. @JoshuaKGoldberg 

When `fileType` doesn't exist in the URL hash, the following hook is executed:
> https://github.com/typescript-eslint/typescript-eslint/blob/db32b8a82d58eddb29be207a5f4476644973abbf/packages/website/src/components/editor/LoadedEditor.tsx#L93-L110


As a result, `system.write` is called.

After that, this code runs.
> https://github.com/typescript-eslint/typescript-eslint/blob/db32b8a82d58eddb29be207a5f4476644973abbf/packages/website/src/components/linter/createParser.ts#L49-L51


At this point, `system` has the file, but `compilerHost` does not.

At the result "cannot find source file" error occur in [typescript-website](https://github.com/microsoft/TypeScript-Website/blob/1019cfc8f96ded4729e8ccd342742534a9826a9d/packages/typescript-vfs/src/index.ts#L83-L87)
```
 updateFile: (fileName, content, optPrevTextSpan) => {
      const prevSourceFile = languageService.getProgram()!.getSourceFile(fileName)
      if (!prevSourceFile) {
        throw new Error("Did not find a source file for " + fileName)
      }
```
