### PR TITLE
fix(typescript-estree): If the template literal is tagged and the text has an invalid escape, `cooked` will be `null`

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -93,6 +93,7 @@ export class Converter {
   private allowPattern = false;
   private readonly ast: ts.SourceFile;
   private readonly esTreeNodeToTSNodeMap = new WeakMap();
+  private isInTaggedTemplate = false;
   private readonly options: ConverterOptions;
   private readonly tsNodeToESTreeNodeMap = new WeakMap();
 
@@ -1917,19 +1918,25 @@ export class Converter {
         return result;
       }
 
-      case SyntaxKind.TaggedTemplateExpression:
-        return this.createNode<TSESTree.TaggedTemplateExpression>(node, {
-          type: AST_NODE_TYPES.TaggedTemplateExpression,
-          quasi: this.convertChild(node.template),
-          tag: this.convertChild(node.tag),
-          typeArguments:
-            node.typeArguments &&
-            this.convertTypeArgumentsToTypeParameterInstantiation(
-              node.typeArguments,
-              node,
-            ),
-        });
-
+      case SyntaxKind.TaggedTemplateExpression: {
+        this.isInTaggedTemplate = true;
+        const result = this.createNode<TSESTree.TaggedTemplateExpression>(
+          node,
+          {
+            type: AST_NODE_TYPES.TaggedTemplateExpression,
+            quasi: this.convertChild(node.template),
+            tag: this.convertChild(node.tag),
+            typeArguments:
+              node.typeArguments &&
+              this.convertTypeArgumentsToTypeParameterInstantiation(
+                node.typeArguments,
+                node,
+              ),
+          },
+        );
+        this.isInTaggedTemplate = false;
+        return result;
+      }
       case SyntaxKind.TemplateHead:
       case SyntaxKind.TemplateMiddle:
       case SyntaxKind.TemplateTail: {

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -926,4 +926,58 @@ describe(parser.parseAndGenerateServices, () => {
       });
     },
   );
+
+  describe('template literal cooked values', () => {
+    const getTemplateElement = (
+      code: string,
+    ): parser.TSESTree.TemplateElement | null => {
+      const result = parser.parse(code, {
+        comment: true,
+        loc: true,
+        range: true,
+        tokens: true,
+      });
+
+      const taggedTemplate = result.body.find(
+        b => b.type === parser.AST_NODE_TYPES.ExpressionStatement,
+      );
+      const expression = taggedTemplate?.expression;
+      if (expression?.type !== parser.AST_NODE_TYPES.TaggedTemplateExpression) {
+        return null;
+      }
+      return expression.quasi.quasis[0];
+    };
+
+    it('should set cooked to null for invalid escape sequences in tagged template literals', () => {
+      const code = 'String.raw`\\uXXXX`';
+      const templateElement = getTemplateElement(code);
+
+      expect(templateElement?.value.cooked).toBeNull();
+      expect(templateElement?.value.raw).toBe('\\uXXXX');
+    });
+
+    it('should set cooked to null for other invalid escape sequences', () => {
+      const code = 'String.raw`\\unicode and \\u{55}`';
+      const templateElement = getTemplateElement(code);
+
+      expect(templateElement?.value.cooked).toBeNull();
+      expect(templateElement?.value.raw).toBe('\\unicode and \\u{55}');
+    });
+
+    it('should set cooked to parsed value for valid escape sequences', () => {
+      const code = 'String.raw`\\n\\t\\u0041`';
+      const templateElement = getTemplateElement(code);
+
+      expect(templateElement?.value.cooked).toBe('\n\tA');
+      expect(templateElement?.value.raw).toBe('\\n\\t\\u0041');
+    });
+
+    it('should handle mixed valid and invalid escape sequences', () => {
+      const code = 'String.raw`\\n\\uXXXX\\t`';
+      const templateElement = getTemplateElement(code);
+
+      expect(templateElement?.value.cooked).toBeNull();
+      expect(templateElement?.value.raw).toBe('\\n\\uXXXX\\t');
+    });
+  });
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11353 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
- Add a flag `isInTaggedTemplate` indicating whether template literal is tagged
- Function to validate escape
- Add test case