### PR TITLE
chore: migrate to nx-cloud-id

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,6 +1,5 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "nxCloudAccessToken": "YjIzMmMxMWItMjhiMS00NWY2LTk1NWYtYWU3YWQ0YjE4YjBlfHJlYWQ=",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",
@@ -84,5 +83,6 @@
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/vitest.config.mts"
     ]
-  }
+  },
+  "nxCloudId": "60b38765e74d975e3faae5ad"
 }


### PR DESCRIPTION
We were using legacy settings for Nx Cloud. I have updated both our account and configuration to the more secure and reliable setup.