### PR TITLE
chore: make copy-ast-spec non cacheable

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -70,7 +70,7 @@
         ]
       },
       "copy-ast-spec": {
-        "cache": true,
+        "cache": false,
         "command": "tsx tools/copy-ast-spec.mts",
         "dependsOn": [
           "ast-spec:build"


### PR DESCRIPTION
The `types:copy-ast-spec` task could hit the remote cache when the `ast-spec` build outputs were changing. This change ensures that is now impossible by making it so that `copy-ast-spec` will always run. It's a very cheap operation anyway.