### PR TITLE
chore: fix website lint task to rely on build

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -113,7 +113,10 @@
         }
       },
       "lint": {
-        "command": "eslint"
+        "command": "eslint",
+        "dependsOn": [
+          "build"
+        ]
       },
       "start": {
         "command": "docusaurus start",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11376
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Sets the website's `build` task as a dependency for its `lint` task.

💖 