### PR TITLE
fix(type-utils): handle namespaced exports in specifier matching

### DIFF
--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -5,14 +5,17 @@ function findParentModuleDeclaration(
 ): ts.ModuleDeclaration | undefined {
   switch (node.kind) {
     case ts.SyntaxKind.ModuleDeclaration:
+      // "namespace x {...}" should be ignored here
+      if (node.flags & ts.NodeFlags.Namespace) {
+        break;
+      }
       return ts.isStringLiteral((node as ts.ModuleDeclaration).name)
         ? (node as ts.ModuleDeclaration)
         : undefined;
     case ts.SyntaxKind.SourceFile:
       return undefined;
-    default:
-      return findParentModuleDeclaration(node.parent);
   }
+  return findParentModuleDeclaration(node.parent);
 }
 
 function typeDeclaredInDeclareModule(

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -405,6 +405,14 @@ describe('TypeOrValueSpecifier', () => {
           package: 'node:test',
         },
       ],
+      [
+        'import { fail } from "node:assert"; type Test = typeof fail;',
+        {
+          from: 'package',
+          name: 'fail',
+          package: 'assert',
+        },
+      ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       'matches a matching package specifier: %s\n\t%s',
       ([code, typeOrValueSpecifier], { expect }) => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11372
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

As per https://github.com/typescript-eslint/typescript-eslint/issues/11372#issuecomment-3043193221.
