### PR TITLE
fix(type-utils): Add missing 'types' dependency to 'type-utils'

### DIFF
--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -44,6 +44,7 @@
     "typecheck": "yarn run -BT nx typecheck"
   },
   "dependencies": {
+    "@typescript-eslint/types": "8.36.0",
     "@typescript-eslint/typescript-estree": "8.36.0",
     "@typescript-eslint/utils": "8.36.0",
     "debug": "^4.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6116,6 +6116,7 @@ __metadata:
   resolution: "@typescript-eslint/type-utils@workspace:packages/type-utils"
   dependencies:
     "@typescript-eslint/parser": 8.36.0
+    "@typescript-eslint/types": 8.36.0
     "@typescript-eslint/typescript-estree": 8.36.0
     "@typescript-eslint/utils": 8.36.0
     "@vitest/coverage-v8": ^3.1.3


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #11382
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview


https://github.com/typescript-eslint/typescript-eslint/pull/10670 added an import from `@typescript-eslint/types` to  `@typescript-eslint/type-utils`. However, the former is not present in the latters dependencies so strict pacakge managers (e.g. yarn pnp) will throw an error.

This PR adds the dependency.