### PR TITLE
chore: remove vestiges of Jest internally

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,4 @@
 * text=auto eol=lf
 
-# force github to treat out custom jest snapshot extension as normal jest snapshots
-*.shot linguist-language=Jest-Snapshot
 *.shot linguist-generated
 packages/scope-manager/src/lib/**/* linguist-generated

--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -2,7 +2,7 @@
 # `nx migrate` when renovate opens a PR to change the version of @nx/workspace.
 #
 # You will therefore also notice that in the renovate configuration, we ignore any packages which
-# Nx will manage for us as part of `nx migrate` such as the remaining @nx/* packages and jest.
+# Nx will manage for us as part of `nx migrate` such as the remaining @nx/* packages.
 
 name: Nx Migrate
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
       "editorconfig.editorconfig",
       "esbenp.prettier-vscode",
       "streetsidesoftware.code-spell-checker",
-      "tlent.jest-snapshot-language-support",
       "mrmlnc.vscode-json5",
       "vitest.explorer"
   ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,18 +20,4 @@
   "javascript.preferences.quoteStyle": "single",
   "typescript.preferences.quoteStyle": "single",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-
-  // make the .shot files from jest-specific-snapshot act like normal snapshots
-  "files.associations": {
-    "*.shot": "jest-snapshot"
-  },
-  "vsicons.associations.files": [
-    {
-        "icon": "jest_snapshot",
-        "extensions": [
-            ".shot",
-        ],
-        "extends": "jest_snapshot"
-    },
-  ],
 }

--- a/packages/scope-manager/tests/eslint-scope/README.md
+++ b/packages/scope-manager/tests/eslint-scope/README.md
@@ -6,7 +6,6 @@ The intention is to help us ensure we do not regress functionality compared to t
 They have been modified to:
 
 - be written in TypeScript
-- work with jest
 - work with our folder structure
 - adhere to our formatting and linting style
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11068
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Removed mentions of Jest mentioned in [#11078 (review)](https://github.com/typescript-eslint/typescript-eslint/pull/11078#pullrequestreview-2781298096) along with some other places I could find.