### PR TITLE
fix(typescript-eslint): address trailing path sep bug in `tsconfigRootDir` inference

### DIFF
--- a/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
+++ b/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
@@ -2,7 +2,10 @@ import { fileURLToPath } from 'node:url';
 
 export function getTSConfigRootDirFromStack(stack: string): string | undefined {
   for (const line of stack.split('\n').map(line => line.trim())) {
-    const candidate = /(\S+)eslint\.config\.(c|m)?(j|t)s/.exec(line)?.[1];
+    const candidate = /(\S+?)[/\\]+eslint\.config\.(c|m)?(j|t)s/.exec(
+      line,
+    )?.[1];
+
     if (!candidate) {
       continue;
     }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11398 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Arcane regex tweaks to extract trailing path separators from the `tsconfigRootDir`.