### PR TITLE
fix(typescript-eslint): tolerate spaces and other path cases in inferred tsconfigRootDir paths

### DIFF
--- a/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
+++ b/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url';
 
 export function getTSConfigRootDirFromStack(stack: string): string | undefined {
   for (const line of stack.split('\n').map(line => line.trim())) {
-    const candidate = /(.+)eslint\.config\.(c|m)?(j|t)s/
+    const candidate = /(.+?)[/\\]+eslint\.config\.(c|m)?(j|t)s/
       .exec(line)?.[1]
       ?.replace(/\s*at\s+(async\s+)?/g, '')
       .replaceAll(/^\S+\s+\(/g, '');


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11398
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This is a bit of a band-aid fix: it makes the original regular expression allow spaces, then manually removes the `at` or `at async` from the line. I think a better long-term strategy would be to go with what @kirkwaiblinger suggested of a more formal error stack trace parser. But I'd really like to get this fixed ASAP.

Note that this mostly only conflicts with #11406 in terms of lines touched. We should be able to merge one after the other with minimal conflict resolution.

💖

Co-authored-by: @kirkwaiblinger 