### PR TITLE
chore: fix default value in JSDoc for reportUnusedDisableDirectives

### DIFF
--- a/packages/utils/src/ts-eslint/Config.ts
+++ b/packages/utils/src/ts-eslint/Config.ts
@@ -194,7 +194,7 @@ export namespace FlatConfig {
      * A severity string indicating if and how unused disable and enable
      * directives should be tracked and reported. For legacy compatibility, `true`
      * is equivalent to `"warn"` and `false` is equivalent to `"off"`.
-     * @default "off"
+     * @default "warn"
      */
     reportUnusedDisableDirectives?:
       | boolean


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The default value of the `reportUnusedDisableDirectives` linter option is `'warn'`, not `'off'` (see [ESLint docs](https://eslint.org/docs/latest/use/configure/configuration-files#configuration-objects)). This PR fixes the JSDoc comment of that option to reflect this.
