### PR TITLE
feat(eslint-plugin): add prefer-record-type-annotation rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/prefer-record-type-annotation.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-record-type-annotation.mdx
@@ -1,0 +1,170 @@
+---
+description: 'Enforce explicit Record<K, V> type annotations for object literals.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/prefer-record-type-annotation** for documentation.
+
+This rule enforces explicit `Record<K, V>` type annotations for object literals that could benefit from them. It helps improve type safety and code clarity by making the intended structure of objects explicit.
+
+## Rule Details
+
+When you have object literals with multiple properties of the same type, it can be beneficial to explicitly type them as `Record<K, V>` to:
+
+1. **Improve type safety** - TypeScript can better catch errors when the structure is explicit
+2. **Enhance readability** - Other developers immediately understand the intended structure
+3. **Enable better IntelliSense** - IDEs can provide better autocomplete and suggestions
+4. **Facilitate refactoring** - Changes to the value type are easier to make consistently
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+const statusMessages = {
+  success: "Operation completed",
+  error: "An error occurred",
+  pending: "Operation pending",
+};
+
+const userScores = {
+  alice: 100,
+  bob: 95,
+  charlie: 87,
+};
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+const statusMessages: Record<'success' | 'error' | 'pending', string> = {
+  success: "Operation completed",
+  error: "An error occurred",
+  pending: "Operation pending",
+};
+
+const userScores: Record<'alice' | 'bob' | 'charlie', number> = {
+  alice: 100,
+  bob: 95,
+  charlie: 87,
+};
+```
+
+</TabItem>
+</Tabs>
+
+## Configuration
+
+This rule has no configurable options. It triggers for object literals that have consistent value types.
+
+## When Not To Use It
+
+You might want to disable this rule if:
+
+- You prefer to rely on TypeScript's type inference for object literals
+- Your team has a different style preference for object typing
+- You're working with dynamic objects where explicit typing would be overly restrictive
+- You have many small objects that don't benefit from explicit Record typing
+
+## Examples
+
+### Basic Usage
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+// Even small objects trigger the rule
+const environment = {
+  dev: "development",
+  prod: "production",
+};
+
+// String values
+const statusMessages = {
+  success: "Operation completed successfully",
+  error: "An error occurred",
+  pending: "Operation is pending",
+};
+
+// Number values
+const httpStatusCodes = {
+  ok: 200,
+  notFound: 404,
+  serverError: 500,
+};
+
+// Boolean values
+const featureFlags = {
+  newDesign: true,
+  betaFeatures: false,
+  analytics: true,
+};
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+// Even small objects need explicit typing
+const environment: Record<'dev' | 'prod', string> = {
+  dev: "development",
+  prod: "production",
+};
+
+// String values
+const statusMessages: Record<'success' | 'error' | 'pending', string> = {
+  success: "Operation completed successfully",
+  error: "An error occurred",
+  pending: "Operation is pending",
+};
+
+// Number values
+const httpStatusCodes: Record<'ok' | 'notFound' | 'serverError', number> = {
+  ok: 200,
+  notFound: 404,
+  serverError: 500,
+};
+
+// Boolean values
+const featureFlags: Record<'newDesign' | 'betaFeatures' | 'analytics', boolean> = {
+  newDesign: true,
+  betaFeatures: false,
+  analytics: true,
+};
+```
+
+</TabItem>
+</Tabs>
+
+### Cases That Won't Trigger The Rule
+
+```ts
+// Already has explicit type annotation
+const typed: Record<string, string> = { a: "1", b: "2", c: "3" };
+
+// Mixed value types
+const mixed = { str: "hello", num: 42, bool: true };
+
+// Complex properties (computed keys, methods)
+const complex = {
+  a: "1",
+  b: "2",
+  c: "3",
+  ['computed']: "4",
+  method() { return "value"; }
+};
+
+// Non-literal values
+const variable = "test";
+const dynamic = { a: variable, b: variable, c: variable };
+```
+
+## Related Rules
+
+- [`consistent-indexed-object-style`](https://typescript-eslint.io/rules/consistent-indexed-object-style) - Enforces consistent usage of Record vs index signatures
+- [`typedef`](https://typescript-eslint.io/rules/typedef) - Requires type annotations in various places

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -111,6 +111,7 @@ import preferOptionalChain from './prefer-optional-chain';
 import preferPromiseRejectErrors from './prefer-promise-reject-errors';
 import preferReadonly from './prefer-readonly';
 import preferReadonlyParameterTypes from './prefer-readonly-parameter-types';
+import preferRecordTypeAnnotation from './prefer-record-type-annotation';
 import preferReduceTypeParameter from './prefer-reduce-type-parameter';
 import preferRegexpExec from './prefer-regexp-exec';
 import preferReturnThisType from './prefer-return-this-type';
@@ -245,6 +246,7 @@ const rules = {
   'prefer-promise-reject-errors': preferPromiseRejectErrors,
   'prefer-readonly': preferReadonly,
   'prefer-readonly-parameter-types': preferReadonlyParameterTypes,
+  'prefer-record-type-annotation': preferRecordTypeAnnotation,
   'prefer-reduce-type-parameter': preferReduceTypeParameter,
   'prefer-regexp-exec': preferRegexpExec,
   'prefer-return-this-type': preferReturnThisType,

--- a/packages/eslint-plugin/src/rules/prefer-record-type-annotation.ts
+++ b/packages/eslint-plugin/src/rules/prefer-record-type-annotation.ts
@@ -1,0 +1,210 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import { createRule } from '../util';
+
+export type MessageIds = 'preferRecordAnnotation';
+
+export default createRule<[], MessageIds>({
+  name: 'prefer-record-type-annotation',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Enforce explicit Record<K, V> type annotations for object literals',
+      recommended: 'stylistic',
+    },
+    fixable: 'code',
+    messages: {
+      preferRecordAnnotation:
+        'Object literal should have explicit Record<{{keyType}}, {{valueType}}> type annotation.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+
+    /**
+     * Determines if all values in an object expression have compatible types
+     * Returns the unified type name if compatible, null otherwise
+     */
+    function getUnifiedValueType(
+      properties: TSESTree.ObjectExpressionProperty[],
+    ): string | null {
+      if (properties.length === 0) {
+        return null;
+      }
+
+      // For now, we'll focus on literals and simple cases
+      let unifiedType: string | null = null;
+
+      for (const property of properties) {
+        if (
+          property.type !== AST_NODE_TYPES.Property ||
+          property.computed ||
+          property.method ||
+          property.kind !== 'init'
+        ) {
+          return null; // Skip complex properties
+        }
+
+        const valueType = inferValueType(property.value);
+        if (valueType === null) {
+          return null; // Can't determine type
+        }
+
+        if (unifiedType === null) {
+          unifiedType = valueType;
+        } else if (unifiedType !== valueType) {
+          // For mixed types, we could use union types, but for simplicity
+          // let's just handle cases where all values have the same type
+          if (
+            (unifiedType === 'string' && valueType === 'string') ||
+            (unifiedType === 'number' && valueType === 'number') ||
+            (unifiedType === 'boolean' && valueType === 'boolean')
+          ) {
+            continue;
+          }
+          return null;
+        }
+      }
+
+      return unifiedType;
+    }
+
+    /**
+     * Infer the TypeScript type from a value expression
+     */
+    function inferValueType(value: TSESTree.Expression): string | null {
+      switch (value.type) {
+        case AST_NODE_TYPES.Literal:
+          if (typeof value.value === 'string') return 'string';
+          if (typeof value.value === 'number') return 'number';
+          if (typeof value.value === 'boolean') return 'boolean';
+          if (value.value === null) return 'null';
+          break;
+        case AST_NODE_TYPES.TemplateLiteral:
+          return 'string';
+        case AST_NODE_TYPES.UnaryExpression:
+          if (value.operator === '-' && value.argument.type === AST_NODE_TYPES.Literal) {
+            return 'number';
+          }
+          break;
+        case AST_NODE_TYPES.Identifier:
+          // Could be a variable, but we can't easily determine its type
+          // For now, skip these cases
+          return null;
+        case AST_NODE_TYPES.ArrayExpression:
+          return 'any[]'; // Could be more specific, but this is a start
+        case AST_NODE_TYPES.ObjectExpression:
+          return 'object';
+      }
+      return null;
+    }
+
+    /**
+     * Generate Record type annotation text
+     */
+    function generateRecordType(
+      keys: string[],
+      valueType: string,
+    ): string {
+      const keyUnion = keys.map(key => `'${key}'`).join(' | ');
+      return `Record<${keyUnion}, ${valueType}>`;
+    }
+
+    /**
+     * Extract property keys from object expression
+     */
+    function extractPropertyKeys(
+      properties: TSESTree.ObjectExpressionProperty[],
+    ): string[] | null {
+      const keys: string[] = [];
+
+      for (const property of properties) {
+        if (
+          property.type !== AST_NODE_TYPES.Property ||
+          property.computed ||
+          property.method ||
+          property.kind !== 'init'
+        ) {
+          return null; // Skip complex properties
+        }
+
+        if (property.key.type === AST_NODE_TYPES.Identifier) {
+          keys.push(property.key.name);
+        } else if (
+          property.key.type === AST_NODE_TYPES.Literal &&
+          typeof property.key.value === 'string'
+        ) {
+          keys.push(property.key.value);
+        } else {
+          return null; // Can't handle computed or complex keys
+        }
+      }
+
+      return keys;
+    }
+
+    return {
+      VariableDeclarator(node): void {
+        // Skip if already has type annotation
+        if (node.id.typeAnnotation) {
+          return;
+        }
+
+        // Only handle simple identifier declarations
+        if (node.id.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+
+        // Only handle object expression initializers
+        if (!node.init || node.init.type !== AST_NODE_TYPES.ObjectExpression) {
+          return;
+        }
+
+        const objectExpression = node.init;
+        const properties = objectExpression.properties;
+
+        // Only handle simple properties (not spread, methods, etc.)
+        const simpleProperties = properties.filter(
+          (prop): prop is TSESTree.Property =>
+            prop.type === AST_NODE_TYPES.Property &&
+            !prop.computed &&
+            !prop.method &&
+            prop.kind === 'init',
+        );
+
+        if (simpleProperties.length !== properties.length) {
+          return; // Has complex properties, skip
+        }
+
+        const keys = extractPropertyKeys(simpleProperties);
+        if (!keys) {
+          return;
+        }
+
+        const valueType = getUnifiedValueType(simpleProperties);
+        if (!valueType) {
+          return;
+        }
+
+        const keyType = keys.map(key => `'${key}'`).join(' | ');
+        const recordType = generateRecordType(keys, valueType);
+
+        context.report({
+          node: node.id,
+          messageId: 'preferRecordAnnotation',
+          data: {
+            keyType,
+            valueType,
+          },
+          fix: (fixer): TSESLint.RuleFix => {
+            return fixer.insertTextAfter(node.id, `: ${recordType}`);
+          },
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/tests/rules/prefer-record-type-annotation.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-record-type-annotation.test.ts
@@ -1,0 +1,202 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import rule from '../../src/rules/prefer-record-type-annotation';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-record-type-annotation', rule, {
+  valid: [
+    // Already has type annotation
+    'const obj: Record<string, string> = { a: "1", b: "2", c: "3" };',
+
+
+
+    // Mixed value types (not supported)
+    'const obj = { a: "string", b: 42, c: true };',
+
+    // Complex properties (computed, methods, etc.)
+    `const obj = {
+      a: "1",
+      b: "2",
+      c: "3",
+      ['computed']: "4"
+    };`,
+
+    // Object with methods
+    `const obj = {
+      a: "1",
+      b: "2",
+      c: "3",
+      method() { return "4"; }
+    };`,
+
+    // Not a variable declaration
+    `function test() {
+      return { a: "1", b: "2", c: "3" };
+    }`,
+
+    // Destructuring assignment
+    'const { a, b, c } = { a: "1", b: "2", c: "3" };',
+
+    // Array assignment
+    'const arr = ["a", "b", "c"];',
+
+    // Non-object assignment
+    'const str = "hello";',
+
+
+
+    // Values that can't be typed (variables)
+    `const value = "test";
+     const obj = { a: value, b: value, c: value };`,
+  ],
+  invalid: [
+    // 2 properties should now trigger
+    {
+      code: 'const config = { dev: "development", prod: "production" };',
+      errors: [
+        {
+          messageId: 'preferRecordAnnotation',
+          data: {
+            keyType: "'dev' | 'prod'",
+            valueType: 'string',
+          },
+        },
+      ],
+      output: "const config: Record<'dev' | 'prod', string> = { dev: \"development\", prod: \"production\" };",
+    },
+
+    // Basic case - 3 string properties
+    {
+      code: 'const statusMessages = { success: "OK", error: "Failed", pending: "Loading" };',
+      errors: [
+        {
+          messageId: 'preferRecordAnnotation',
+          data: {
+            keyType: "'success' | 'error' | 'pending'",
+            valueType: 'string',
+          },
+        },
+      ],
+      output: "const statusMessages: Record<'success' | 'error' | 'pending', string> = { success: \"OK\", error: \"Failed\", pending: \"Loading\" };",
+    },
+
+    // String properties with longer values
+    {
+      code: `const apiEndpoints = {
+        users: "https://api.example.com/v1/users",
+        posts: "https://api.example.com/v1/posts",
+        comments: "https://api.example.com/v1/comments",
+      };`,
+      errors: [
+        {
+          messageId: 'preferRecordAnnotation',
+        },
+      ],
+      output: `const apiEndpoints: Record<'users' | 'posts' | 'comments', string> = {
+        users: "https://api.example.com/v1/users",
+        posts: "https://api.example.com/v1/posts",
+        comments: "https://api.example.com/v1/comments",
+      };`,
+    },
+
+    // Number properties
+    {
+      code: 'const scores = { alice: 100, bob: 95, charlie: 87 };',
+      errors: [
+        {
+          messageId: 'preferRecordAnnotation',
+          data: {
+            keyType: "'alice' | 'bob' | 'charlie'",
+            valueType: 'number',
+          },
+        },
+      ],
+      output: "const scores: Record<'alice' | 'bob' | 'charlie', number> = { alice: 100, bob: 95, charlie: 87 };",
+    },
+
+    // Boolean properties
+    {
+      code: 'const flags = { debugMode: true, testMode: false, prodMode: true };',
+      errors: [
+        {
+          messageId: 'preferRecordAnnotation',
+          data: {
+            keyType: "'debugMode' | 'testMode' | 'prodMode'",
+            valueType: 'boolean',
+          },
+        },
+      ],
+      output: "const flags: Record<'debugMode' | 'testMode' | 'prodMode', boolean> = { debugMode: true, testMode: false, prodMode: true };",
+    },
+
+    // Template literal values
+    {
+      code: 'const messages = { greeting: `Hello world`, farewell: `Goodbye`, welcome: `Welcome` };',
+      errors: [
+        {
+          messageId: 'preferRecordAnnotation',
+          data: {
+            keyType: "'greeting' | 'farewell' | 'welcome'",
+            valueType: 'string',
+          },
+        },
+      ],
+      output: "const messages: Record<'greeting' | 'farewell' | 'welcome', string> = { greeting: `Hello world`, farewell: `Goodbye`, welcome: `Welcome` };",
+    },
+
+    // Negative numbers
+    {
+      code: 'const temperatures = { freezing: -32, cold: -10, hot: 100 };',
+      errors: [
+        {
+          messageId: 'preferRecordAnnotation',
+        },
+      ],
+      output: "const temperatures: Record<'freezing' | 'cold' | 'hot', number> = { freezing: -32, cold: -10, hot: 100 };",
+    },
+
+    // String keys (quoted)
+    {
+      code: `const obj = { "key-1": "value1", "key-2": "value2", "key-3": "value3" };`,
+      errors: [
+        {
+          messageId: 'preferRecordAnnotation',
+        },
+      ],
+      output: `const obj: Record<'key-1' | 'key-2' | 'key-3', string> = { "key-1": "value1", "key-2": "value2", "key-3": "value3" };`,
+    },
+
+
+
+    // Object arrays
+    {
+      code: 'const data = { items: [], values: [], results: [] };',
+      errors: [
+        {
+          messageId: 'preferRecordAnnotation',
+          data: {
+            keyType: "'items' | 'values' | 'results'",
+            valueType: 'any[]',
+          },
+        },
+      ],
+      output: "const data: Record<'items' | 'values' | 'results', any[]> = { items: [], values: [], results: [] };",
+    },
+
+    // Nested objects
+    {
+      code: 'const configs = { dev: {}, staging: {}, prod: {} };',
+      errors: [
+        {
+          messageId: 'preferRecordAnnotation',
+          data: {
+            keyType: "'dev' | 'staging' | 'prod'",
+            valueType: 'object',
+          },
+        },
+      ],
+      output: "const configs: Record<'dev' | 'staging' | 'prod', object> = { dev: {}, staging: {}, prod: {} };",
+    },
+  ],
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/typescript-eslint/typescript-eslint/issues/11410
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The `prefer-record-type-annotation` rule enforces explicit `Record<K, V>` type annotations for object literals that have consistent value types (like all strings, numbers, or booleans), transforming implicit typing like `const config = { dev: "development", prod: "production" }` into explicit typing like `const config: Record<'dev' | 'prod', string> = { dev: "development", prod: "production" }`. This is useful because explicit Record typing improves type safety by making the intended object structure clear to both TypeScript and developers, enables better IDE support with enhanced autocomplete and refactoring capabilities, makes code more self-documenting by immediately conveying that all values should be of the same type, and helps catch type errors earlier when the object structure is modified - particularly valuable for configuration objects, lookup tables, and mapping objects where consistency is important but might not be obvious from the variable name alone.
