### PR TITLE
fix(typescript-eslint): infer tsconfigRootDir with v8 API

### DIFF
--- a/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
+++ b/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
@@ -2,27 +2,27 @@ import path from 'node:path';
 
 /**
  * Infers the `tsconfigRootDir` from the current call stack, using the V8 API.
- * This appears to be available in current Deno and Bun as well.
+ *
+ * See https://v8.dev/docs/stack-trace-api
+ *
+ * This API is implemented in Deno and Bun as well.
  */
 export function getTSConfigRootDirFromStack(): string | undefined {
   function getStack(): NodeJS.CallSite[] {
     const stackTraceLimit = Error.stackTraceLimit;
     Error.stackTraceLimit = Infinity;
-    try {
-      const prepareStackTrace = Error.prepareStackTrace;
-      Error.prepareStackTrace = (_, structuredStackTrace) =>
-        structuredStackTrace;
-      try {
-        const dummyObject: { stack?: NodeJS.CallSite[] } = {};
-        Error.captureStackTrace(dummyObject, getTSConfigRootDirFromStack);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- stack is set by captureStackTrace
-        return dummyObject.stack!;
-      } finally {
-        Error.prepareStackTrace = prepareStackTrace;
-      }
-    } finally {
-      Error.stackTraceLimit = stackTraceLimit;
-    }
+    const prepareStackTrace = Error.prepareStackTrace;
+    Error.prepareStackTrace = (_, structuredStackTrace) => structuredStackTrace;
+
+    const dummyObject: { stack?: NodeJS.CallSite[] } = {};
+    Error.captureStackTrace(dummyObject, getTSConfigRootDirFromStack);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- stack is set by captureStackTrace
+    const rv = dummyObject.stack!;
+
+    Error.prepareStackTrace = prepareStackTrace;
+    Error.stackTraceLimit = stackTraceLimit;
+
+    return rv;
   }
 
   for (const callSite of getStack()) {

--- a/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
+++ b/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
 
-export function getTSConfigRootDirFromV8Api(): string | undefined {
+/**
+ * Infers the `tsconfigRootDir` from the current call stack, using the V8 API.
+ * This appears to be available in current Deno and Bun as well.
+ */
+export function getTSConfigRootDirFromStack(): string | undefined {
   function getStack(): NodeJS.CallSite[] {
     const stackTraceLimit = Error.stackTraceLimit;
     Error.stackTraceLimit = Infinity;
@@ -10,7 +14,7 @@ export function getTSConfigRootDirFromV8Api(): string | undefined {
         structuredStackTrace;
       try {
         const dummyObject: { stack?: NodeJS.CallSite[] } = {};
-        Error.captureStackTrace(dummyObject, getTSConfigRootDirFromV8Api);
+        Error.captureStackTrace(dummyObject, getTSConfigRootDirFromStack);
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- stack is set by captureStackTrace
         return dummyObject.stack!;
       } finally {

--- a/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
+++ b/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
@@ -32,8 +32,6 @@ export function getTSConfigRootDirFromStack(): string | undefined {
     }
 
     const parsedPath = path.parse(stackFrameFilePath);
-
-    // Check if the file name matches the ESLint config pattern
     if (/^eslint\.config\.(c|m)?(j|t)s$/.test(parsedPath.base)) {
       return parsedPath.dir;
     }

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -6,7 +6,7 @@ import rawPlugin from '@typescript-eslint/eslint-plugin/use-at-your-own-risk/raw
 import { addCandidateTSConfigRootDir } from '@typescript-eslint/typescript-estree';
 
 import { config } from './config-helper';
-import { getTSConfigRootDirFromV8Api } from './getTSConfigRootDirFromStack';
+import { getTSConfigRootDirFromStack } from './getTSConfigRootDirFromStack';
 
 export const parser: TSESLint.FlatConfig.Parser = rawPlugin.parser;
 
@@ -135,7 +135,7 @@ function createConfigsGetters<T extends object>(values: T): T {
         {
           enumerable: true,
           get: () => {
-            const candidateRootDir = getTSConfigRootDirFromV8Api();
+            const candidateRootDir = getTSConfigRootDirFromStack();
             if (candidateRootDir) {
               addCandidateTSConfigRootDir(candidateRootDir);
             }

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -6,7 +6,7 @@ import rawPlugin from '@typescript-eslint/eslint-plugin/use-at-your-own-risk/raw
 import { addCandidateTSConfigRootDir } from '@typescript-eslint/typescript-estree';
 
 import { config } from './config-helper';
-import { getTSConfigRootDirFromStack } from './getTSConfigRootDirFromStack';
+import { getTSConfigRootDirFromV8Api } from './getTSConfigRootDirFromStack';
 
 export const parser: TSESLint.FlatConfig.Parser = rawPlugin.parser;
 
@@ -135,10 +135,7 @@ function createConfigsGetters<T extends object>(values: T): T {
         {
           enumerable: true,
           get: () => {
-            const candidateRootDir = getTSConfigRootDirFromStack(
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              new Error().stack!,
-            );
+            const candidateRootDir = getTSConfigRootDirFromV8Api();
             if (candidateRootDir) {
               addCandidateTSConfigRootDir(candidateRootDir);
             }

--- a/packages/typescript-eslint/tests/configs.test.ts
+++ b/packages/typescript-eslint/tests/configs.test.ts
@@ -10,8 +10,8 @@ import tseslint from '../src/index.js';
 
 vi.mock('@typescript-eslint/typescript-estree', async () => ({
   ...(await vi.importActual('@typescript-eslint/typescript-estree')),
-  get addCandidateTSConfigRootDir() {
-    return mockAddCandidateTSConfigRootDir;
+  get getTSConfigRootDirFromV8Api() {
+    return mockGetTSConfigRootDirFromV8Api;
   },
 }));
 
@@ -401,12 +401,12 @@ describe('stylistic-type-checked-only.ts', () => {
   );
 });
 
-const mockAddCandidateTSConfigRootDir = vi.fn();
+const mockGetTSConfigRootDirFromV8Api = vi.fn();
 
 describe('Candidate tsconfigRootDirs', () => {
   beforeEach(() => {
     clearCandidateTSConfigRootDirs();
-    mockAddCandidateTSConfigRootDir.mockClear();
+    mockGetTSConfigRootDirFromV8Api.mockClear();
   });
 
   describe.each(Object.keys(tseslint.configs))('%s', configKey => {
@@ -416,7 +416,7 @@ describe('Candidate tsconfigRootDirs', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       tseslint.configs[configKey as keyof typeof tseslint.configs];
 
-      expect(mockAddCandidateTSConfigRootDir).not.toHaveBeenCalled();
+      expect(mockGetTSConfigRootDirFromV8Api).not.toHaveBeenCalled();
     });
 
     it('populates a candidate tsconfigRootDir when accessed and one can be inferred from the stack', () => {
@@ -427,7 +427,7 @@ describe('Candidate tsconfigRootDirs', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       tseslint.configs[configKey as keyof typeof tseslint.configs];
 
-      expect(mockAddCandidateTSConfigRootDir).toHaveBeenCalledWith(
+      expect(mockGetTSConfigRootDirFromV8Api).toHaveBeenCalledWith(
         tsconfigRootDir,
       );
     });

--- a/packages/typescript-eslint/tests/configs.test.ts
+++ b/packages/typescript-eslint/tests/configs.test.ts
@@ -10,8 +10,8 @@ import tseslint from '../src/index.js';
 
 vi.mock('@typescript-eslint/typescript-estree', async () => ({
   ...(await vi.importActual('@typescript-eslint/typescript-estree')),
-  get getTSConfigRootDirFromV8Api() {
-    return mockGetTSConfigRootDirFromV8Api;
+  get addCandidateTSConfigRootDir() {
+    return mockAddCandidateTSConfigRootDir;
   },
 }));
 
@@ -401,12 +401,12 @@ describe('stylistic-type-checked-only.ts', () => {
   );
 });
 
-const mockGetTSConfigRootDirFromV8Api = vi.fn();
+const mockAddCandidateTSConfigRootDir = vi.fn();
 
 describe('Candidate tsconfigRootDirs', () => {
   beforeEach(() => {
     clearCandidateTSConfigRootDirs();
-    mockGetTSConfigRootDirFromV8Api.mockClear();
+    mockAddCandidateTSConfigRootDir.mockClear();
   });
 
   describe.each(Object.keys(tseslint.configs))('%s', configKey => {
@@ -416,7 +416,7 @@ describe('Candidate tsconfigRootDirs', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       tseslint.configs[configKey as keyof typeof tseslint.configs];
 
-      expect(mockGetTSConfigRootDirFromV8Api).not.toHaveBeenCalled();
+      expect(mockAddCandidateTSConfigRootDir).not.toHaveBeenCalled();
     });
 
     it('populates a candidate tsconfigRootDir when accessed and one can be inferred from the stack', () => {
@@ -427,7 +427,7 @@ describe('Candidate tsconfigRootDirs', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       tseslint.configs[configKey as keyof typeof tseslint.configs];
 
-      expect(mockGetTSConfigRootDirFromV8Api).toHaveBeenCalledWith(
+      expect(mockAddCandidateTSConfigRootDir).toHaveBeenCalledWith(
         tsconfigRootDir,
       );
     });

--- a/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
+++ b/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
@@ -1,9 +1,9 @@
-import { getTSConfigRootDirFromV8Api } from '../src/getTSConfigRootDirFromStack';
+import { getTSConfigRootDirFromStack } from '../src/getTSConfigRootDirFromStack';
 import * as normalFolder from './path-test-fixtures/tsconfigRootDirInference-normal/normal-folder/eslint.config.cjs';
 import * as notEslintConfig from './path-test-fixtures/tsconfigRootDirInference-not-eslint-config/not-an-eslint.config.cjs';
 import * as folderThatHasASpace from './path-test-fixtures/tsconfigRootDirInference-space/folder that has a space/eslint.config.cjs';
 
-describe(getTSConfigRootDirFromV8Api, () => {
+describe(getTSConfigRootDirFromStack, () => {
   it('does stack analysis right for normal folder', () => {
     expect(normalFolder.get()).toBe(normalFolder.dirname());
   });

--- a/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
+++ b/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
@@ -15,4 +15,14 @@ describe(getTSConfigRootDirFromStack, () => {
   it("doesn't get tricked by a file that is not an ESLint config", () => {
     expect(notEslintConfig.get()).toBeUndefined();
   });
+
+  it('should work in the presence of a messed up strack trace string', () => {
+    const prepareStackTrace = Error.prepareStackTrace;
+    const dummyFunction = () => {};
+    Error.prepareStackTrace = dummyFunction;
+    expect(new Error().stack).toBeUndefined();
+    expect(normalFolder.get()).toBe(normalFolder.dirname());
+    expect(Error.prepareStackTrace).toBe(dummyFunction);
+    Error.prepareStackTrace = prepareStackTrace;
+  });
 });

--- a/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
+++ b/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
@@ -1,54 +1,18 @@
-import path from 'node:path';
+import { getTSConfigRootDirFromV8Api } from '../src/getTSConfigRootDirFromStack';
+import * as normalFolder from './path-test-fixtures/tsconfigRootDirInference-normal/normal-folder/eslint.config.cjs';
+import * as notEslintConfig from './path-test-fixtures/tsconfigRootDirInference-not-eslint-config/not-an-eslint.config.cjs';
+import * as folderThatHasASpace from './path-test-fixtures/tsconfigRootDirInference-space/folder that has a space/eslint.config.cjs';
 
-import { getTSConfigRootDirFromStack } from '../src/getTSConfigRootDirFromStack';
-
-const isWindows = process.platform === 'win32';
-
-describe(getTSConfigRootDirFromStack, () => {
-  it('returns undefined when no file path seems to be an ESLint config', () => {
-    const actual = getTSConfigRootDirFromStack(
-      [
-        `Error`,
-        ' at file:///other.config.js',
-        ' at ModuleJob.run',
-        'at async NodeHfs.walk(...)',
-      ].join('\n'),
-    );
-
-    expect(actual).toBeUndefined();
+describe(getTSConfigRootDirFromV8Api, () => {
+  it('does stack analysis right for normal folder', () => {
+    expect(normalFolder.get()).toBe(normalFolder.dirname());
   });
 
-  it.runIf(!isWindows)(
-    'returns a Posix config file path when a file:// path to an ESLint config is in the stack',
-    () => {
-      const actual = getTSConfigRootDirFromStack(
-        [
-          `Error`,
-          ' at file:///path/to/file/eslint.config.js',
-          ' at ModuleJob.run',
-          'at async NodeHfs.walk(...)',
-        ].join('\n'),
-      );
+  it('does stack analysis right for folder that has a space', () => {
+    expect(folderThatHasASpace.get()).toBe(folderThatHasASpace.dirname());
+  });
 
-      expect(actual).toBe('/path/to/file/');
-    },
-  );
-
-  it.each(['cjs', 'cts', 'js', 'mjs', 'mts', 'ts'])(
-    'returns the path to the config file when its extension is %s',
-    extension => {
-      const expected = isWindows ? 'C:\\path\\to\\file\\' : '/path/to/file/';
-
-      const actual = getTSConfigRootDirFromStack(
-        [
-          `Error`,
-          ` at ${path.join(expected, `eslint.config.${extension}`)}`,
-          ' at ModuleJob.run',
-          'at async NodeHfs.walk(...)',
-        ].join('\n'),
-      );
-
-      expect(actual).toBe(expected);
-    },
-  );
+  it("doesn't get tricked by a file that is not an ESLint config", () => {
+    expect(notEslintConfig.get()).toBeUndefined();
+  });
 });

--- a/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-normal/normal-folder/eslint.config.cts
+++ b/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-normal/normal-folder/eslint.config.cts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { getTSConfigRootDirFromV8Api } from './../../../../src/getTSConfigRootDirFromStack';
+import { getTSConfigRootDirFromStack } from './../../../../src/getTSConfigRootDirFromStack';
 
 export function get() {
-  return getTSConfigRootDirFromV8Api();
+  return getTSConfigRootDirFromStack();
 }
 
 export function dirname() {

--- a/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-normal/normal-folder/eslint.config.cts
+++ b/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-normal/normal-folder/eslint.config.cts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { getTSConfigRootDirFromV8Api } from './../../../../src/getTSConfigRootDirFromStack';
+
+export function get() {
+  return getTSConfigRootDirFromV8Api();
+}
+
+export function dirname() {
+  return __dirname;
+}

--- a/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-not-eslint-config/not-an-eslint.config.cts
+++ b/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-not-eslint-config/not-an-eslint.config.cts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { getTSConfigRootDirFromV8Api } from '../../../src/getTSConfigRootDirFromStack';
+
+export function get() {
+  return getTSConfigRootDirFromV8Api();
+}
+
+export function dirname() {
+  return __dirname;
+}

--- a/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-not-eslint-config/not-an-eslint.config.cts
+++ b/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-not-eslint-config/not-an-eslint.config.cts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { getTSConfigRootDirFromV8Api } from '../../../src/getTSConfigRootDirFromStack';
+import { getTSConfigRootDirFromStack } from '../../../src/getTSConfigRootDirFromStack';
 
 export function get() {
-  return getTSConfigRootDirFromV8Api();
+  return getTSConfigRootDirFromStack();
 }
 
 export function dirname() {

--- a/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-space/folder that has a space/eslint.config.cts
+++ b/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-space/folder that has a space/eslint.config.cts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { getTSConfigRootDirFromV8Api } from '../../../../src/getTSConfigRootDirFromStack';
+
+export function get() {
+  return getTSConfigRootDirFromV8Api();
+}
+
+export function dirname() {
+  return __dirname;
+}

--- a/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-space/folder that has a space/eslint.config.cts
+++ b/packages/typescript-eslint/tests/path-test-fixtures/tsconfigRootDirInference-space/folder that has a space/eslint.config.cts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { getTSConfigRootDirFromV8Api } from '../../../../src/getTSConfigRootDirFromStack';
+import { getTSConfigRootDirFromStack } from '../../../../src/getTSConfigRootDirFromStack';
 
 export function get() {
-  return getTSConfigRootDirFromV8Api();
+  return getTSConfigRootDirFromStack();
 }
 
 export function dirname() {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: 
   - fixes #11398 
   - fixes #11407 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Alternative option or followup to https://github.com/typescript-eslint/typescript-eslint/pull/11408

See discord discussion around this: https://discord.com/channels/1026804805894672454/1395485881334366361

https://v8.dev/docs/stack-trace-api#customizing-stack-traces