### PR TITLE
feat(eslint-plugin): [only-throw-error] support yield/await expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/only-throw-error.ts
+++ b/packages/eslint-plugin/src/rules/only-throw-error.ts
@@ -143,13 +143,6 @@ export default createRule<Options, MessageIds>({
     }
 
     function checkThrowArgument(node: TSESTree.Node): void {
-      if (
-        node.type === AST_NODE_TYPES.AwaitExpression ||
-        node.type === AST_NODE_TYPES.YieldExpression
-      ) {
-        return;
-      }
-
       if (options.allowRethrowing && isRethrownError(node)) {
         return;
       }

--- a/packages/eslint-plugin/tests/rules/only-throw-error.test.ts
+++ b/packages/eslint-plugin/tests/rules/only-throw-error.test.ts
@@ -257,7 +257,7 @@ async function foo() {
     },
     {
       code: `
-function *foo(): Generator<number, void, Error> {
+function* foo(): Generator<number, void, Error> {
   throw yield 303;
 }
       `,

--- a/packages/eslint-plugin/tests/rules/only-throw-error.test.ts
+++ b/packages/eslint-plugin/tests/rules/only-throw-error.test.ts
@@ -243,6 +243,30 @@ Promise.reject('foo').catch(e => {
         },
       ],
     },
+    {
+      code: `
+async function foo() {
+  throw await Promise.resolve(new Error('error'));
+}
+      `,
+      options: [
+        {
+          allowThrowingAny: false,
+        },
+      ],
+    },
+    {
+      code: `
+function *foo(): Generator<number, void, Error> {
+  throw yield 303;
+}
+      `,
+      options: [
+        {
+          allowThrowingAny: false,
+        },
+      ],
+    },
   ],
   invalid: [
     {
@@ -742,6 +766,40 @@ Promise.reject('foo').then(e => {
           allowRethrowing: true,
           allowThrowingAny: false,
           allowThrowingUnknown: false,
+        },
+      ],
+    },
+    {
+      code: `
+async function foo() {
+  throw await bar;
+}
+      `,
+      errors: [
+        {
+          messageId: 'object',
+        },
+      ],
+      options: [
+        {
+          allowThrowingAny: false,
+        },
+      ],
+    },
+    {
+      code: `
+async function foo() {
+  throw await Promise.resolve<number>(303);
+}
+      `,
+      errors: [
+        {
+          messageId: 'object',
+        },
+      ],
+      options: [
+        {
+          allowThrowingAny: false,
         },
       ],
     },


### PR DESCRIPTION
It seems we can actually support yield and await as the type checker will already resolve the yielded/awaited type.

When yielding, it is possible a generator can be typed such that the `yield` resolves to an `Error`.

## PR Checklist

- [x] Addresses an existing open issue: fixes #11418
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
