### PR TITLE
fix: normalize tsconfigRootDir to handle trailing path separators in project: true

### DIFF
--- a/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
+++ b/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
@@ -38,9 +38,12 @@ export function getProjectConfigFiles(
   log('Looking for tsconfig.json at or above file: %s', parseSettings.filePath);
   let directory = path.dirname(parseSettings.filePath);
   const checkedDirectories = [directory];
-  
+
   // Normalize tsconfigRootDir once to avoid repeated regex operations in the loop
-  const normalizedTsconfigRootDirLength = Math.max(1, parseSettings.tsconfigRootDir.replace(/[/\\]+$/, '').length);
+  const normalizedTsconfigRootDirLength = Math.max(
+    1,
+    parseSettings.tsconfigRootDir.replace(/[/\\]+$/, '').length,
+  );
 
   do {
     log('Checking tsconfig.json path: %s', directory);

--- a/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
+++ b/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
@@ -38,6 +38,9 @@ export function getProjectConfigFiles(
   log('Looking for tsconfig.json at or above file: %s', parseSettings.filePath);
   let directory = path.dirname(parseSettings.filePath);
   const checkedDirectories = [directory];
+  
+  // Normalize tsconfigRootDir once to avoid repeated regex operations in the loop
+  const normalizedTsconfigRootDirLength = Math.max(1, parseSettings.tsconfigRootDir.replace(/[/\\]+$/, '').length);
 
   do {
     log('Checking tsconfig.json path: %s', directory);
@@ -57,7 +60,7 @@ export function getProjectConfigFiles(
     checkedDirectories.push(directory);
   } while (
     directory.length > 1 &&
-    directory.length >= Math.max(1, parseSettings.tsconfigRootDir.replace(/[/\\]+$/, '').length)
+    directory.length >= normalizedTsconfigRootDirLength
   );
 
   throw new Error(

--- a/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
+++ b/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
@@ -57,7 +57,7 @@ export function getProjectConfigFiles(
     checkedDirectories.push(directory);
   } while (
     directory.length > 1 &&
-    directory.length >= path.normalize(parseSettings.tsconfigRootDir).replace(/[/\\]$/, '').length
+    directory.length >= Math.max(1, parseSettings.tsconfigRootDir.replace(/[/\\]+$/, '').length)
   );
 
   throw new Error(

--- a/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
+++ b/packages/typescript-estree/src/parseSettings/getProjectConfigFiles.ts
@@ -57,7 +57,7 @@ export function getProjectConfigFiles(
     checkedDirectories.push(directory);
   } while (
     directory.length > 1 &&
-    directory.length >= parseSettings.tsconfigRootDir.length
+    directory.length >= path.normalize(parseSettings.tsconfigRootDir).replace(/[/\\]$/, '').length
   );
 
   throw new Error(

--- a/packages/typescript-estree/tests/lib/getProjectConfigFiles.test.ts
+++ b/packages/typescript-estree/tests/lib/getProjectConfigFiles.test.ts
@@ -178,5 +178,20 @@ describe(getProjectConfigFiles, () => {
         `[Error: project was set to \`true\` but couldn't find any tsconfig.json relative to './repos/repo/packages/package/file.ts' within '/'.]`,
       );
     });
+
+    it('works correctly with trailing path separator in tsconfigRootDir', () => {
+      mockExistsSync.mockImplementation(
+        filePath => filePath === path.normalize('repos/repo/tsconfig.json'),
+      );
+
+      const actual = getProjectConfigFiles(
+        { ...parseSettings, tsconfigRootDir: './repos/repo/' },
+        true,
+      );
+
+      expect(actual).toStrictEqual([
+        path.normalize('repos/repo/tsconfig.json'),
+      ]);
+    });
   });
 });


### PR DESCRIPTION
[…project: true](fix: normalize tsconfigRootDir to handle trailing path separators in project: true)

Fixes #11413

When using project: true, the search for tsconfig.json files would stop prematurely if 	sconfigRootDir contained a trailing path separator. This was due to an incorrect length comparison that included the trailing separator character.

The fix normalizes the tsconfigRootDir path and removes trailing separators before comparing lengths, ensuring consistent behavior regardless of whether the path ends with '/' or '\'.

Changes:
- Modified getProjectConfigFiles to normalize tsconfigRootDir path
- Added test case to verify fix works with trailing separators
- Maintains backward compatibility with existing functionality

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
