### PR TITLE
fix(eslint-plugin): [prefer-return-this-type] don't report an error when returning a union type that includes a classType.

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-return-this-type.ts
+++ b/packages/eslint-plugin/src/rules/prefer-return-this-type.ts
@@ -1,6 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { isUnionType } from 'ts-api-utils';
 import * as ts from 'typescript';
 
 import { createRule, forEachReturnStatement, getParserServices } from '../util';
@@ -114,6 +115,14 @@ export default createRule({
         if (classType.thisType === type) {
           hasReturnThis = true;
           return;
+        }
+
+        if (
+          isUnionType(type) &&
+          type.types.some(typePart => typePart === classType)
+        ) {
+          hasReturnClassType = true;
+          return true;
         }
 
         return;

--- a/packages/eslint-plugin/tests/rules/prefer-return-this-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-return-this-type.test.ts
@@ -100,6 +100,19 @@ class Foo {
   f?: string;
 }
     `,
+    `
+declare const valueUnion: BaseUnion | string;
+
+class BaseUnion {
+  f(): BaseUnion | string {
+    if (hidden) {
+      return this;
+    }
+
+    return valueUnion;
+  }
+}
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/prefer-return-this-type.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-return-this-type.test.ts
@@ -411,5 +411,41 @@ class Animal<T> {
 }
       `,
     },
+    {
+      code: `
+declare const valueUnion: number | string;
+
+class BaseUnion {
+  f(): BaseUnion | string {
+    if (hidden) {
+      return this;
+    }
+
+    return valueUnion;
+  }
+}
+      `,
+      errors: [
+        {
+          column: 8,
+          endColumn: 17,
+          line: 5,
+          messageId: 'useThisType',
+        },
+      ],
+      output: `
+declare const valueUnion: number | string;
+
+class BaseUnion {
+  f(): this | string {
+    if (hidden) {
+      return this;
+    }
+
+    return valueUnion;
+  }
+}
+      `,
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11225
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
Don't report an error when returning a union type that includes a `classType`.