### PR TITLE
chore: fix integration test failure with eslint stylistic plugin deprecation warning

### DIFF
--- a/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v9/eslint.config.js
+++ b/packages/integration-tests/fixtures/flat-config-types-@types__eslint-v9/eslint.config.js
@@ -31,7 +31,7 @@ export default tseslint.config(
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
-  stylisticPlugin.configs['recommended-flat'],
+  stylisticPlugin.configs.recommended,
 );
 
 // wrapped in a function so they aren't executed at lint time
@@ -48,7 +48,7 @@ function _otherCases() {
   tseslint.config(
     eslint.configs.recommended,
     ...tseslint.configs.recommended,
-    stylisticPlugin.configs['recommended-flat'],
+    stylisticPlugin.configs.recommended,
     vitestPlugin.configs.recommended,
   );
   tseslint.config(

--- a/packages/integration-tests/tests/__snapshots__/flat-config-types-@types__eslint-v9.test.ts.snap
+++ b/packages/integration-tests/tests/__snapshots__/flat-config-types-@types__eslint-v9.test.ts.snap
@@ -76,7 +76,7 @@ export default tseslint.config(
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
-  stylisticPlugin.configs['recommended-flat'],
+  stylisticPlugin.configs.recommended,
 )
 
 // wrapped in a function so they aren't executed at lint time
@@ -93,7 +93,7 @@ function _otherCases() {
   tseslint.config(
     eslint.configs.recommended,
     ...tseslint.configs.recommended,
-    stylisticPlugin.configs['recommended-flat'],
+    stylisticPlugin.configs.recommended,
     vitestPlugin.configs.recommended,
   )
   tseslint.config(


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Integration tests have been failing lately, due to a deprecation warning with `stylistic.configs['recommended-flat']` ([example](https://cloud.nx.app/runs/JDM1jutRpo?utm_source=pull-request&utm_medium=comment)). Maybe this is related to their recent [v5 release](https://github.com/eslint-stylistic/eslint-stylistic/releases/tag/v5.0.0)? Unsure 🤷‍♂️.