### PR TITLE
fix(utils): correct `calculateConfigForFile` return type

### DIFF
--- a/packages/utils/src/ts-eslint/eslint/FlatESLint.ts
+++ b/packages/utils/src/ts-eslint/eslint/FlatESLint.ts
@@ -6,7 +6,7 @@ import type * as Shared from './ESLintShared';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare class FlatESLintBase extends Shared.ESLintBase<
-  FlatConfig.ConfigArray,
+  FlatConfig.Config | FlatConfig.ConfigArray,
   FlatESLint.ESLintOptions
 > {
   static readonly configType: 'flat';
@@ -18,7 +18,7 @@ declare class FlatESLintBase extends Shared.ESLintBase<
    * @param filePath The path of the file to retrieve a config object for.
    * @returns A configuration object for the file or `undefined` if there is no configuration data for the object.
    */
-  calculateConfigForFile(filePath: string): Promise<FlatConfig.ConfigArray>;
+  calculateConfigForFile(filePath: string): Promise<FlatConfig.Config>;
 
   /**
    * Finds the config file being used by this instance based on the options


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11444
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Changes:
- Extend `FlatESLintBase` generic with `FlatConfig.Config`
- Update `calculateConfigForFile` to return `FlatConfig.Config`

### Notes:
The comment for `calculateConfigForFile` in `FlatESLintBase` mentions it may return `undefined` if no config is available, which differs from the base `SharedESLintBase`, which does not mention `undefined`.

I've preserved the comment and focused solely on aligning the return type with `FlatConfig.Config`. If you'd like this potential discrepancy explored or clarified further, I'm happy to look into it and follow up with additional typing or doc updates in this PR or a separate one.