### PR TITLE
Remove problematic newline in lint `unboundWithoutThisAnnotation` message

### DIFF
--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -115,7 +115,7 @@ export default createRule<Options, MessageIds>({
     },
     messages: {
       unbound: BASE_MESSAGE,
-      unboundWithoutThisAnnotation: `${BASE_MESSAGE}\nIf your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.`,
+      unboundWithoutThisAnnotation: `${BASE_MESSAGE} If your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.`,
     },
     schema: [
       {

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unbound-method.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unbound-method.shot
@@ -10,14 +10,12 @@ const instance = new MyClass();
 
 // This logs the global scope (`window`/`global`), not the class instance
 const myLog = instance.log;
-              ~~~~~~~~~~~~ Avoid referencing unbound methods which may cause unintentional scoping of `this`.
-                           If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
+              ~~~~~~~~~~~~ Avoid referencing unbound methods which may cause unintentional scoping of `this`. If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
 myLog();
 
 // This log might later be called with an incorrect scope
 const { log } = instance;
-        ~~~ Avoid referencing unbound methods which may cause unintentional scoping of `this`.
-            If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
+        ~~~ Avoid referencing unbound methods which may cause unintentional scoping of `this`. If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
 
 // arith.double may refer to `this` internally
 const arith = {
@@ -26,8 +24,7 @@ const arith = {
   },
 };
 const { double } = arith;
-        ~~~~~~ Avoid referencing unbound methods which may cause unintentional scoping of `this`.
-               If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
+        ~~~~~~ Avoid referencing unbound methods which may cause unintentional scoping of `this`. If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
 
 Correct
 


### PR DESCRIPTION
Newlines in lint issue messages interfere with scripts that count occurrences of errors/warnings with unix coreutils.

This PR *does not* meet the PR checklist but it's very minor and self-evidently useful.

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
