### PR TITLE
fix(typescript-eslint): handle `file://` urls in stack trace when inferring `tsconfigRootDir`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -46,6 +46,7 @@
     "\\(#.+?\\)"
   ],
   "words": [
+    "AFAICT",
     "Airbnb",
     "Airbnb's",
     "allowdefaultproject",

--- a/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
+++ b/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
@@ -33,7 +33,7 @@ export function getTSConfigRootDirFromStack(): string | undefined {
     }
 
     // ESM seem to return a file URL, so we'll convert it to a file path.
-    // This isn't terribly documented in the v8 API docs, but it seems to be the case.
+    // AFAICT this isn't documented in the v8 API docs, but it seems to be the case.
     // See https://github.com/typescript-eslint/typescript-eslint/issues/11429
     const stackFrameFilePath = stackFrameFilePathOrUrl.startsWith('file://')
       ? fileURLToPath(stackFrameFilePathOrUrl)

--- a/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
+++ b/packages/typescript-eslint/src/getTSConfigRootDirFromStack.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Infers the `tsconfigRootDir` from the current call stack, using the V8 API.
@@ -26,10 +27,17 @@ export function getTSConfigRootDirFromStack(): string | undefined {
   }
 
   for (const callSite of getStack()) {
-    const stackFrameFilePath = callSite.getFileName();
-    if (!stackFrameFilePath) {
+    const stackFrameFilePathOrUrl = callSite.getFileName();
+    if (!stackFrameFilePathOrUrl) {
       continue;
     }
+
+    // ESM seem to return a file URL, so we'll convert it to a file path.
+    // This isn't terribly documented in the v8 API docs, but it seems to be the case.
+    // See https://github.com/typescript-eslint/typescript-eslint/issues/11429
+    const stackFrameFilePath = stackFrameFilePathOrUrl.startsWith('file://')
+      ? fileURLToPath(stackFrameFilePathOrUrl)
+      : stackFrameFilePathOrUrl;
 
     const parsedPath = path.parse(stackFrameFilePath);
     if (/^eslint\.config\.(c|m)?(j|t)s$/.test(parsedPath.base)) {

--- a/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
+++ b/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
@@ -19,7 +19,7 @@ describe(getTSConfigRootDirFromStack, () => {
             getFileName() {
               return !isWindows
                 ? 'file:///a/b/eslint.config.mts'
-                : 'file:F:\\a\\b\\eslint.config.mts';
+                : 'file:///F:/a/b/eslint.config.mts';
             },
           },
         ];

--- a/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
+++ b/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
@@ -3,6 +3,8 @@ import * as normalFolder from './path-test-fixtures/tsconfigRootDirInference-nor
 import * as notEslintConfig from './path-test-fixtures/tsconfigRootDirInference-not-eslint-config/not-an-eslint.config.cjs';
 import * as folderThatHasASpace from './path-test-fixtures/tsconfigRootDirInference-space/folder that has a space/eslint.config.cjs';
 
+const isWindows = process.platform === 'win32';
+
 describe(getTSConfigRootDirFromStack, () => {
   it('does stack analysis right for normal folder', () => {
     expect(normalFolder.get()).toBe(normalFolder.dirname());
@@ -15,7 +17,9 @@ describe(getTSConfigRootDirFromStack, () => {
         target.stack = [
           {
             getFileName() {
-              return 'file:///a/b/eslint.config.mts';
+              return !isWindows
+                ? 'file:///a/b/eslint.config.mts'
+                : 'file:F:\\a\\b\\eslint.config.mts';
             },
           },
         ];
@@ -24,7 +28,7 @@ describe(getTSConfigRootDirFromStack, () => {
 
     const inferredTsconfigRootDir = getTSConfigRootDirFromStack();
 
-    expect(inferredTsconfigRootDir).toBe('/a/b');
+    expect(inferredTsconfigRootDir).toBe(!isWindows ? '/a/b' : 'F:\\a\\b');
   });
 
   it('does stack analysis right for folder that has a space', () => {

--- a/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
+++ b/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
@@ -8,6 +8,25 @@ describe(getTSConfigRootDirFromStack, () => {
     expect(normalFolder.get()).toBe(normalFolder.dirname());
   });
 
+  it('does stack analysis right for a file that gives a file:// URL as its name', () => {
+    vi.spyOn(Error, 'captureStackTrace').mockImplementationOnce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (target: any, _constructorOpt) => {
+        target.stack = [
+          {
+            getFileName() {
+              return 'file:///a/b/eslint.config.mts';
+            },
+          },
+        ];
+      },
+    );
+
+    const inferredTsconfigRootDir = getTSConfigRootDirFromStack();
+
+    expect(inferredTsconfigRootDir).toBe('/a/b');
+  });
+
   it('does stack analysis right for folder that has a space', () => {
     expect(folderThatHasASpace.get()).toBe(folderThatHasASpace.dirname());
   });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11429
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I haven't written an automated test for this, since... it's not super clear how without mocking the v8 stack trace API (which seems really yucky) or writing a full integration test (tedious).

But it's very easy to clone down the repo in https://github.com/typescript-eslint/typescript-eslint/issues/11429, `yarn link`, and observe the bug being fixed. 

Maybe more comprehensive automated testing of the `tsconfigRootDir` can be a follow-on if we want to invest in that effort?