### PR TITLE
fix(eslint-plugin): [no-non-null-assertion] wrong suggestion on left-hand side of an assignment

### DIFF
--- a/packages/eslint-plugin/src/rules/no-non-null-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-non-null-assertion.ts
@@ -4,6 +4,7 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import {
   createRule,
+  isAssignee,
   isNonNullAssertionPunctuator,
   nullThrows,
   NullThrowsReasons,
@@ -53,7 +54,8 @@ export default createRule<[], MessageIds>({
 
         if (
           node.parent.type === AST_NODE_TYPES.MemberExpression &&
-          node.parent.object === node
+          node.parent.object === node &&
+          !isAssignee(node.parent)
         ) {
           if (!node.parent.optional) {
             if (node.parent.computed) {

--- a/packages/eslint-plugin/tests/rules/no-non-null-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-non-null-assertion.test.ts
@@ -387,5 +387,39 @@ x?.
         },
       ],
     },
+    {
+      code: noFormat`
+document.querySelector("input")!.files = new FileList();
+`,
+      errors: [
+        {
+          column: 1,
+          endColumn: 33,
+          line: 2,
+          messageId: 'noNonNull',
+        },
+      ],
+    },
+    {
+      code: noFormat`
+hoge.files = document.querySelector("input")!.files
+`,
+      errors: [
+        {
+          column: 14,
+          endColumn: 46,
+          line: 2,
+          messageId: 'noNonNull',
+          suggestions: [
+            {
+              messageId: 'suggestOptionalChain',
+              output: `
+hoge.files = document.querySelector("input")?.files
+`,
+            },
+          ],
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #11473 
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Avoid suggestions for non-null assertions in assignee positions to prevent invalid auto-fixes.

🐛
