### PR TITLE
fix: resolve type error in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -362,11 +362,6 @@ export default tseslint.config(
 
   // test file specific configuration
   {
-    files: [
-      'packages/*/tests/**/*.?(m|c)ts?(x)',
-      'packages/integration-tests/tools/**/*.ts',
-    ],
-
     extends: [
       // @ts-expect-error -- uses `string` instead of `off` | `readonly` | `writable` for the globals setting.
       vitestPlugin.configs.env,
@@ -397,6 +392,11 @@ export default tseslint.config(
         },
         settings: { vitest: { typecheck: true } },
       },
+    ],
+
+    files: [
+      'packages/*/tests/**/*.?(m|c)ts?(x)',
+      'packages/integration-tests/tools/**/*.ts',
     ],
   },
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Another CI problem, since the PR (https://github.com/typescript-eslint/typescript-eslint/pull/11484) was up to date and did pass its CI checks (cc @JamesHenry)