### PR TITLE
docs: add parserOptions note to Type Checking

### DIFF
--- a/docs/users/Shared_Configurations.mdx
+++ b/docs/users/Shared_Configurations.mdx
@@ -66,14 +66,26 @@ module.exports = {
 
 If your project enables [typed linting](../getting-started/Typed_Linting.mdx), we suggest enabling the [`recommended-type-checked`](#recommended-type-checked) and [`stylistic-type-checked`](#stylistic-type-checked) configurations to start:
 
+> To use type-checking, you also need to configure `languageOptions.parserOptions` as shown in [typed linting docs](../getting-started/Typed_Linting.mdx).
+
 <Tabs groupId="eslint-config">
 <TabItem value="Flat Config">
 
 ```js title="eslint.config.mjs"
 export default tseslint.config(
   eslint.configs.recommended,
+  // Added lines start
   tseslint.configs.recommendedTypeChecked,
   tseslint.configs.stylisticTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  // Added lines end
 );
 ```
 
@@ -84,9 +96,17 @@ export default tseslint.config(
 module.exports = {
   extends: [
     'eslint:recommended',
+    // Added lines start
     'plugin:@typescript-eslint/recommended-type-checked',
     'plugin:@typescript-eslint/stylistic-type-checked',
+    // Added lines end
   ],
+  // Added lines start
+  parserOptions: {
+    projectService: true,
+    tsconfigRootDir: import.meta.dirname,
+  },
+  // Added lines end
 };
 ```
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11514 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
The “Projects With Type Checking” docs were updated to include the missing languageOptions.parserOptions in both Flat and Legacy Config examples. This ensures type-checking works correctly and links users to the Typed Linting guide for more details.