### PR TITLE
fix(eslint-plugin): [prefer-optional-chain] include mixed "nullish comparison style" chains in checks

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -129,10 +129,7 @@ const analyzeAndChainOperand: OperandAnalyzer = (
   chain,
 ) => {
   switch (operand.comparisonType) {
-    case NullishComparisonType.Boolean: {
-      return [operand];
-    }
-
+    case NullishComparisonType.Boolean:
     case NullishComparisonType.NotEqualNullOrUndefined:
       return [operand];
 
@@ -148,7 +145,8 @@ const analyzeAndChainOperand: OperandAnalyzer = (
         return [operand, nextOperand];
       }
       if (
-        includesType(
+        nextOperand &&
+        !includesType(
           parserServices,
           operand.comparedName,
           ts.TypeFlags.Undefined,
@@ -157,10 +155,9 @@ const analyzeAndChainOperand: OperandAnalyzer = (
         // we know the next operand is not an `undefined` check and that this
         // operand includes `undefined` - which means that making this an
         // optional chain would change the runtime behavior of the expression
-        return null;
+        return [operand];
       }
-
-      return [operand];
+      return null;
     }
 
     case NullishComparisonType.NotStrictEqualUndefined: {
@@ -676,7 +673,10 @@ export function analyzeChain(
                 parserServices,
               )
             ) {
-              subChain.push(operand);
+              subChain.push({
+                ...operand,
+                comparisonType: ComparisonType.NotStrictEqual,
+              });
             }
           }
         }

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
@@ -197,53 +197,55 @@ export function gatherLogicalOperands(
           continue;
         }
 
-        switch (operand.operator) {
-          case '!=':
-          case '==':
-            if (
-              comparedValue === ComparisonValueType.Null ||
-              comparedValue === ComparisonValueType.Undefined
-            ) {
-              // x == null, x == undefined
-              result.push({
-                comparedName: comparedExpression,
-                comparisonType: operand.operator.startsWith('!')
-                  ? NullishComparisonType.NotEqualNullOrUndefined
-                  : NullishComparisonType.EqualNullOrUndefined,
-                isYoda,
-                node: operand,
-                type: OperandValidity.Valid,
-              });
-              continue;
-            }
-
-          case '!==':
-          case '===': {
-            const comparedName = comparedExpression;
-            switch (comparedValue) {
-              case ComparisonValueType.Null:
+        if (operand.operator.startsWith('!') !== (node.operator === '||')) {
+          switch (operand.operator) {
+            case '!=':
+            case '==':
+              if (
+                comparedValue === ComparisonValueType.Null ||
+                comparedValue === ComparisonValueType.Undefined
+              ) {
+                // x == null, x == undefined
                 result.push({
-                  comparedName,
+                  comparedName: comparedExpression,
                   comparisonType: operand.operator.startsWith('!')
-                    ? NullishComparisonType.NotStrictEqualNull
-                    : NullishComparisonType.StrictEqualNull,
+                    ? NullishComparisonType.NotEqualNullOrUndefined
+                    : NullishComparisonType.EqualNullOrUndefined,
                   isYoda,
                   node: operand,
                   type: OperandValidity.Valid,
                 });
                 continue;
+              }
 
-              case ComparisonValueType.Undefined:
-                result.push({
-                  comparedName,
-                  comparisonType: operand.operator.startsWith('!')
-                    ? NullishComparisonType.NotStrictEqualUndefined
-                    : NullishComparisonType.StrictEqualUndefined,
-                  isYoda,
-                  node: operand,
-                  type: OperandValidity.Valid,
-                });
-                continue;
+            case '!==':
+            case '===': {
+              const comparedName = comparedExpression;
+              switch (comparedValue) {
+                case ComparisonValueType.Null:
+                  result.push({
+                    comparedName,
+                    comparisonType: operand.operator.startsWith('!')
+                      ? NullishComparisonType.NotStrictEqualNull
+                      : NullishComparisonType.StrictEqualNull,
+                    isYoda,
+                    node: operand,
+                    type: OperandValidity.Valid,
+                  });
+                  continue;
+
+                case ComparisonValueType.Undefined:
+                  result.push({
+                    comparedName,
+                    comparisonType: operand.operator.startsWith('!')
+                      ? NullishComparisonType.NotStrictEqualUndefined
+                      : NullishComparisonType.StrictEqualUndefined,
+                    isYoda,
+                    node: operand,
+                    type: OperandValidity.Valid,
+                  });
+                  continue;
+              }
             }
           }
         }

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/gatherLogicalOperands.ts
@@ -25,6 +25,7 @@ const enum ComparisonValueType {
 }
 export const enum OperandValidity {
   Valid = 'Valid',
+  Last = 'Last',
   Invalid = 'Invalid',
 }
 export const enum NullishComparisonType {
@@ -48,17 +49,31 @@ export const enum NullishComparisonType {
   /** `x` */
   Boolean = 'Boolean', // eslint-disable-line @typescript-eslint/internal/prefer-ast-types-enum
 }
+export const enum ComparisonType {
+  NotEqual = 'NotEqual',
+  Equal = 'Equal',
+  NotStrictEqual = 'NotStrictEqual',
+  StrictEqual = 'StrictEqual',
+}
 export interface ValidOperand {
   comparedName: TSESTree.Node;
-  comparisonType: NullishComparisonType;
+  comparisonType: NullishComparisonType | ComparisonType;
   isYoda: boolean;
   node: TSESTree.Expression;
   type: OperandValidity.Valid;
 }
+export interface LastChainOperand {
+  comparedName: TSESTree.Node;
+  comparisonType: ComparisonType;
+  comparisonValue: TSESTree.Node;
+  isYoda: boolean;
+  node: TSESTree.BinaryExpression;
+  type: OperandValidity.Last;
+}
 export interface InvalidOperand {
   type: OperandValidity.Invalid;
 }
-type Operand = InvalidOperand | ValidOperand;
+type Operand = InvalidOperand | ValidOperand | LastChainOperand;
 
 const NULLISH_FLAGS = ts.TypeFlags.Null | ts.TypeFlags.Undefined;
 function isValidFalseBooleanCheckType(
@@ -201,9 +216,6 @@ export function gatherLogicalOperands(
               });
               continue;
             }
-            // x == something :(
-            result.push({ type: OperandValidity.Invalid });
-            continue;
 
           case '!==':
           case '===': {
@@ -232,11 +244,51 @@ export function gatherLogicalOperands(
                   type: OperandValidity.Valid,
                 });
                 continue;
+            }
+          }
+        }
 
-              default:
-                // x === something :(
-                result.push({ type: OperandValidity.Invalid });
-                continue;
+        // x == something :(
+        // x === something :(
+        // x != something :(
+        // x !== something :(
+        const binaryComparisonChain = getBinaryComparisonChain(operand);
+        if (binaryComparisonChain) {
+          const { comparedName, comparedValue, isYoda } = binaryComparisonChain;
+
+          switch (operand.operator) {
+            case '==':
+            case '===': {
+              const comparisonType =
+                operand.operator === '=='
+                  ? ComparisonType.Equal
+                  : ComparisonType.StrictEqual;
+              result.push({
+                isYoda,
+                comparedName,
+                comparisonType: comparisonType,
+                type: OperandValidity.Last,
+                node: operand,
+                comparisonValue: comparedValue,
+              });
+              continue;
+            }
+
+            case '!=':
+            case '!==': {
+              const comparisonType =
+                operand.operator === '!='
+                  ? ComparisonType.NotEqual
+                  : ComparisonType.NotStrictEqual;
+              result.push({
+                isYoda,
+                comparedName,
+                comparisonType: comparisonType,
+                type: OperandValidity.Last,
+                node: operand,
+                comparisonValue: comparedValue,
+              });
+              continue;
             }
           }
         }
@@ -372,6 +424,33 @@ export function gatherLogicalOperands(
         return null;
     }
 
+    return null;
+  }
+
+  function getBinaryComparisonChain(node: TSESTree.BinaryExpression) {
+    const { left, right } = node;
+    let isYoda = false;
+    const isLeftMemberExpression =
+      left.type === AST_NODE_TYPES.MemberExpression;
+    const isRightMemberExpression =
+      right.type === AST_NODE_TYPES.MemberExpression;
+    if (isLeftMemberExpression && !isRightMemberExpression) {
+      const [comparedName, comparedValue] = [left, right];
+      return {
+        isYoda,
+        comparedName,
+        comparedValue,
+      };
+    } else if (!isLeftMemberExpression && isRightMemberExpression) {
+      const [comparedName, comparedValue] = [right, left];
+
+      isYoda = true;
+      return {
+        isYoda,
+        comparedName,
+        comparedValue,
+      };
+    }
     return null;
   }
 }

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain.ts
@@ -138,6 +138,17 @@ export default createRule<
               currentChain,
             );
             currentChain = [];
+          } else if (operand.type === OperandValidity.Last) {
+            analyzeChain(
+              context,
+              parserServices,
+              options,
+              node,
+              node.operator,
+              currentChain,
+              operand,
+            );
+            currentChain = [];
           } else {
             currentChain.push(operand);
           }

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -771,6 +771,60 @@ describe('chain ending with comparison', () => {
         declare const x: 0n | { a: string };
         x && x.a;
       `,
+      '!foo || foo.bar != x',
+      '!foo || foo.bar != null',
+      '!foo || foo.bar != undefined',
+      '!foo || foo.bar === 0',
+      '!foo || foo.bar === 1',
+      '!foo || foo.bar === "123"',
+      '!foo || foo.bar === {}',
+      '!foo || foo.bar === false',
+      '!foo || foo.bar === true',
+      '!foo || foo.bar === null',
+      '!foo || foo.bar === x',
+      '!foo || foo.bar !== x',
+      '!foo || foo.bar !== undefined',
+      'foo == null || foo.bar != x',
+      'foo == null || foo.bar != null',
+      'foo == null || foo.bar != undefined',
+      'foo == null || foo.bar === 0',
+      'foo == null || foo.bar === 1',
+      'foo == null || foo.bar === "123"',
+      'foo == null || foo.bar === {}',
+      'foo == null || foo.bar === false',
+      'foo == null || foo.bar === true',
+      'foo == null || foo.bar === null',
+      'foo == null || foo.bar === x',
+      'foo == null || foo.bar !== x',
+      'foo == null || foo.bar !== undefined',
+      'foo || foo.bar != 0;',
+      'foo || foo.bar != 1;',
+      'foo || foo.bar != "123";',
+      'foo || foo.bar != {};',
+      'foo || foo.bar != false;',
+      'foo || foo.bar != true;',
+      'foo || foo.bar === undefined;',
+      'foo || foo.bar !== 0;',
+      'foo || foo.bar !== 1;',
+      'foo || foo.bar !== "123";',
+      'foo || foo.bar !== {};',
+      'foo || foo.bar !== false;',
+      'foo || foo.bar !== true;',
+      'foo || foo.bar !== null;',
+      'foo != null || foo.bar != 0;',
+      'foo != null || foo.bar != 1;',
+      'foo != null || foo.bar != "123";',
+      'foo != null || foo.bar != {};',
+      'foo != null || foo.bar != false;',
+      'foo != null || foo.bar != true;',
+      'foo != null || foo.bar === undefined;',
+      'foo != null || foo.bar !== 0;',
+      'foo != null || foo.bar !== 1;',
+      'foo != null || foo.bar !== "123";',
+      'foo != null || foo.bar !== {};',
+      'foo != null || foo.bar !== false;',
+      'foo != null || foo.bar !== true;',
+      'foo != null || foo.bar !== null;',
     ],
     invalid: [
       {
@@ -1219,6 +1273,432 @@ describe('chain ending with comparison', () => {
         output: `
             declare const foo: { bar: number } | 0;
             foo?.bar == x;
+          `,
+      },
+      {
+        code: `!foo || foo.bar != 0`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != 0`,
+      },
+      {
+        code: `!foo || foo.bar != 1`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != 1`,
+      },
+      {
+        code: `!foo || foo.bar != "123"`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != "123"`,
+      },
+      {
+        code: `!foo || foo.bar != {}`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != {}`,
+      },
+      {
+        code: `!foo || foo.bar != false`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != false`,
+      },
+      {
+        code: `!foo || foo.bar != true`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != true`,
+      },
+      {
+        code: `!foo || foo.bar === undefined`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === undefined`,
+      },
+      {
+        code: `!foo || foo.bar !== 0`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== 0`,
+      },
+      {
+        code: `!foo || foo.bar !== 1`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== 1`,
+      },
+      {
+        code: `!foo || foo.bar !== "123"`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== "123"`,
+      },
+      {
+        code: `!foo || foo.bar !== {}`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== {}`,
+      },
+      {
+        code: `!foo || foo.bar !== false`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== false`,
+      },
+      {
+        code: `!foo || foo.bar !== true`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== true`,
+      },
+      {
+        code: `!foo || foo.bar !== null`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== null`,
+      },
+      {
+        code: `foo == null || foo.bar != 0`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != 0`,
+      },
+      {
+        code: `foo == null || foo.bar != 1`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != 1`,
+      },
+      {
+        code: `foo == null || foo.bar != "123"`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != "123"`,
+      },
+      {
+        code: `foo == null || foo.bar != {}`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != {}`,
+      },
+      {
+        code: `foo == null || foo.bar != false`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != false`,
+      },
+      {
+        code: `foo == null || foo.bar != true`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar != true`,
+      },
+      {
+        code: `foo == null || foo.bar === undefined`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === undefined`,
+      },
+      {
+        code: `foo == null || foo.bar !== 0`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== 0`,
+      },
+      {
+        code: `foo == null || foo.bar !== 1`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== 1`,
+      },
+      {
+        code: `foo == null || foo.bar !== "123"`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== "123"`,
+      },
+      {
+        code: `foo == null || foo.bar !== {}`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== {}`,
+      },
+      {
+        code: `foo == null || foo.bar !== false`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== false`,
+      },
+      {
+        code: `foo == null || foo.bar !== true`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== true`,
+      },
+      {
+        code: `foo == null || foo.bar !== null`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== null`,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar == x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar == null;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == null;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar == undefined;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == undefined;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar === x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar === x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar === undefined;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar === undefined;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar !== 0;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== 0;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar !== 1;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== 1;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar !== "123";
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== "123";
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar !== {};
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== {};
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar !== false;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== false;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar !== true;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== true;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar !== null;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== null;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            !foo || foo.bar !== x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar == x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar == null;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == null;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar == undefined;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == undefined;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar === x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar === x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar === undefined;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar === undefined;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar !== 0;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== 0;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar !== 1;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== 1;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar !== "123";
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== "123";
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar !== {};
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== {};
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar !== false;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== false;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar !== true;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== true;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar !== null;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== null;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo == null || foo.bar !== x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== x;
           `,
       },
     ],

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -3088,6 +3088,7 @@ describe('base cases', () => {
           // with the `| null | undefined` type - `=== null` doesn't cover the
           // `undefined` case - so optional chaining is not a valid conversion
           valid: BaseCases({
+            skipIds: [20, 26],
             mutateCode: c => c.replaceAll('||', '=== null ||'),
             mutateOutput: identity,
             operator: '||',
@@ -3105,7 +3106,30 @@ describe('base cases', () => {
             mutateOutput: c => c.replace(/;$/, ' === null;'),
             operator: '||',
             useSuggestionFixer: true,
-          }),
+          }).concat([
+            {
+              code: `
+                declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+                foo.bar === null || foo.bar() === null || foo.bar().baz === null || foo.bar().baz.buzz === null || foo.bar().baz.buzz();
+              `,
+              errors: [{ messageId: 'preferOptionalChain' }],
+              output: `
+                declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+                foo.bar?.() === null || foo.bar().baz === null || foo.bar().baz.buzz === null || foo.bar().baz.buzz();
+              `,
+            },
+            {
+              code: `
+                declare const foo: {bar: () => ({baz: number} | null | undefined)};
+                foo.bar === null || foo.bar?.() === null || foo.bar?.().baz;
+              `,
+              errors: [{ messageId: 'preferOptionalChain' }],
+              output: `
+                declare const foo: {bar: () => ({baz: number} | null | undefined)};
+                foo.bar?.() === null || foo.bar?.().baz;
+              `,
+            },
+          ]),
         });
       });
 
@@ -3130,6 +3154,7 @@ describe('base cases', () => {
           // with the `| null | undefined` type - `=== undefined` doesn't cover the
           // `null` case - so optional chaining is not a valid conversion
           valid: BaseCases({
+            skipIds: [20, 26],
             mutateCode: c => c.replaceAll('||', '=== undefined ||'),
             mutateOutput: identity,
             operator: '||',
@@ -3146,7 +3171,30 @@ describe('base cases', () => {
             mutateDeclaration: c => c.replaceAll('| null', ''),
             mutateOutput: c => c.replace(/;$/, ' === undefined;'),
             operator: '||',
-          }),
+          }).concat([
+            {
+              code: `
+                declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+                foo.bar === undefined || foo.bar() === undefined || foo.bar().baz === undefined || foo.bar().baz.buzz === undefined || foo.bar().baz.buzz();
+              `,
+              errors: [{ messageId: 'preferOptionalChain' }],
+              output: `
+                declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+                foo.bar?.() === undefined || foo.bar().baz === undefined || foo.bar().baz.buzz === undefined || foo.bar().baz.buzz();
+              `,
+            },
+            {
+              code: `
+                declare const foo: {bar: () => ({baz: number} | null | undefined)};
+                foo.bar === undefined || foo.bar?.() === undefined || foo.bar?.().baz;
+              `,
+              errors: [{ messageId: 'preferOptionalChain' }],
+              output: `
+                declare const foo: {bar: () => ({baz: number} | null | undefined)};
+                foo.bar?.() === undefined || foo.bar?.().baz;
+              `,
+            },
+          ]),
         });
       });
 

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -1203,8 +1203,7 @@ describe('hand-crafted cases', () => {
       {
         code: 'foo && foo.bar != null && foo.bar.baz !== undefined && foo.bar.baz.buzz;',
         errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
-        output:
-          'foo?.bar != null && foo.bar.baz !== undefined && foo.bar.baz.buzz;',
+        output: 'foo?.bar?.baz !== undefined && foo.bar.baz.buzz;',
       },
       {
         code: `
@@ -1215,8 +1214,7 @@ describe('hand-crafted cases', () => {
         `,
         errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
         output: `
-          foo.bar?.baz != null &&
-            foo.bar.baz.qux !== undefined &&
+          foo.bar?.baz?.qux !== undefined &&
             foo.bar.baz.qux.buzz;
         `,
       },

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -755,6 +755,22 @@ describe('chain ending with comparison', () => {
       'foo == null && foo.bar === true;',
       'foo == null && foo.bar === null;',
       'foo == null && foo.bar !== undefined;',
+      `
+        declare const x: false | { a: string };
+        x && x.a == x;
+      `,
+      `
+        declare const x: '' | { a: string };
+        x && x.a == x;
+      `,
+      `
+        declare const x: 0 | { a: string };
+        x && x.a == x;
+      `,
+      `
+        declare const x: 0n | { a: string };
+        x && x.a;
+      `,
     ],
     invalid: [
       {
@@ -1181,6 +1197,28 @@ describe('chain ending with comparison', () => {
         output: `
             declare const foo: { bar: number };
             foo?.bar !== x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number } | 1;
+            foo && foo.bar == x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number } | 1;
+            foo?.bar == x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number } | 0;
+            foo != null && foo.bar == x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number } | 0;
+            foo?.bar == x;
           `,
       },
     ],

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -698,6 +698,495 @@ describe('|| {}', () => {
   });
 });
 
+describe('chain ending with comparison', () => {
+  ruleTester.run('prefer-optional-chain', rule, {
+    valid: [
+      'foo && foo.bar == x',
+      'foo && foo.bar == null',
+      'foo && foo.bar == undefined',
+      'foo && foo.bar === x',
+      'foo && foo.bar === undefined',
+      'foo && foo.bar !== 0',
+      'foo && foo.bar !== 1',
+      'foo && foo.bar !== "123"',
+      'foo && foo.bar !== {}',
+      'foo && foo.bar !== false',
+      'foo && foo.bar !== true',
+      'foo && foo.bar !== null',
+      'foo && foo.bar !== x',
+      'foo != null && foo.bar == x',
+      'foo != null && foo.bar == null',
+      'foo != null && foo.bar == undefined',
+      'foo != null && foo.bar === x',
+      'foo != null && foo.bar === undefined',
+      'foo != null && foo.bar !== 0',
+      'foo != null && foo.bar !== 1',
+      'foo != null && foo.bar !== "123"',
+      'foo != null && foo.bar !== {}',
+      'foo != null && foo.bar !== false',
+      'foo != null && foo.bar !== true',
+      'foo != null && foo.bar !== null',
+      'foo != null && foo.bar !== x',
+      '!foo && foo.bar == 0;',
+      '!foo && foo.bar == 1;',
+      '!foo && foo.bar == "123";',
+      '!foo && foo.bar == {};',
+      '!foo && foo.bar == false;',
+      '!foo && foo.bar == true;',
+      '!foo && foo.bar === 0;',
+      '!foo && foo.bar === 1;',
+      '!foo && foo.bar === "123";',
+      '!foo && foo.bar === {};',
+      '!foo && foo.bar === false;',
+      '!foo && foo.bar === true;',
+      '!foo && foo.bar === null;',
+      '!foo && foo.bar !== undefined;',
+      'foo == null && foo.bar == 0;',
+      'foo == null && foo.bar == 1;',
+      'foo == null && foo.bar == "123";',
+      'foo == null && foo.bar == {};',
+      'foo == null && foo.bar == false;',
+      'foo == null && foo.bar == true;',
+      'foo == null && foo.bar === 0;',
+      'foo == null && foo.bar === 1;',
+      'foo == null && foo.bar === "123";',
+      'foo == null && foo.bar === {};',
+      'foo == null && foo.bar === false;',
+      'foo == null && foo.bar === true;',
+      'foo == null && foo.bar === null;',
+      'foo == null && foo.bar !== undefined;',
+    ],
+    invalid: [
+      {
+        code: `foo && foo.bar == 0;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == 0;`,
+      },
+      {
+        code: `foo && foo.bar == 1;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == 1;`,
+      },
+      {
+        code: `foo && foo.bar == "123";`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == "123";`,
+      },
+      {
+        code: `foo && foo.bar == {};`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == {};`,
+      },
+      {
+        code: `foo && foo.bar == false;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == false;`,
+      },
+      {
+        code: `foo && foo.bar == true;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == true;`,
+      },
+      {
+        code: `foo && foo.bar === 0;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === 0;`,
+      },
+      {
+        code: `foo && foo.bar === 1;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === 1;`,
+      },
+      {
+        code: `foo && foo.bar === "123";`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === "123";`,
+      },
+      {
+        code: `foo && foo.bar === {};`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === {};`,
+      },
+      {
+        code: `foo && foo.bar === false;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === false;`,
+      },
+      {
+        code: `foo && foo.bar === true;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === true;`,
+      },
+      {
+        code: `foo && foo.bar === null;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === null;`,
+      },
+      {
+        code: `foo && foo.bar !== undefined;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== undefined;`,
+      },
+      {
+        code: `foo != null && foo.bar == 0;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == 0;`,
+      },
+      {
+        code: `foo != null && foo.bar == 1;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == 1;`,
+      },
+      {
+        code: `foo != null && foo.bar == "123";`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == "123";`,
+      },
+      {
+        code: `foo != null && foo.bar == {};`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == {};`,
+      },
+      {
+        code: `foo != null && foo.bar == false;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == false;`,
+      },
+      {
+        code: `foo != null && foo.bar == true;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar == true;`,
+      },
+      {
+        code: `foo != null && foo.bar === 0;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === 0;`,
+      },
+      {
+        code: `foo != null && foo.bar === 1;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === 1;`,
+      },
+      {
+        code: `foo != null && foo.bar === "123";`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === "123";`,
+      },
+      {
+        code: `foo != null && foo.bar === {};`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === {};`,
+      },
+      {
+        code: `foo != null && foo.bar === false;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === false;`,
+      },
+      {
+        code: `foo != null && foo.bar === true;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === true;`,
+      },
+      {
+        code: `foo != null && foo.bar === null;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar === null;`,
+      },
+      {
+        code: `foo != null && foo.bar !== undefined;`,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `foo?.bar !== undefined;`,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar == x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar == null;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == null;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar == undefined;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == undefined;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar === x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar === x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar === undefined;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar === undefined;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar !== 0;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== 0;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar !== 1;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== 1;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar !== "123";
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== "123";
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar !== {};
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== {};
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar !== false;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== false;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar !== true;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== true;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar !== null;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== null;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo && foo.bar !== x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar == x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar == null;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == null;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar == undefined;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar == undefined;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar === x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar === x;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar === undefined;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar === undefined;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar !== 0;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== 0;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar !== 1;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== 1;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar !== "123";
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== "123";
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar !== {};
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== {};
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar !== false;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== false;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar !== true;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== true;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar !== null;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== null;
+          `,
+      },
+      {
+        code: `
+            declare const foo: { bar: number };
+            foo != null && foo.bar !== x;
+          `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+            declare const foo: { bar: number };
+            foo?.bar !== x;
+          `,
+      },
+    ],
+  });
+});
+
 describe('hand-crafted cases', () => {
   ruleTester.run('prefer-optional-chain', rule, {
     invalid: [

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -1446,51 +1446,9 @@ describe('hand-crafted cases', () => {
         output: '!foo.bar!.baz?.paz;',
       },
       {
-        code: `
-          declare const foo: { bar: string } | null;
-          foo !== null && foo.bar !== null;
-        `,
-        errors: [
-          {
-            messageId: 'preferOptionalChain',
-            suggestions: [
-              {
-                messageId: 'optionalChainSuggest',
-                output: `
-          declare const foo: { bar: string } | null;
-          foo?.bar !== null;
-        `,
-              },
-            ],
-          },
-        ],
-        output: null,
-      },
-      {
         code: 'foo != null && foo.bar != null;',
         errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
         output: 'foo?.bar != null;',
-      },
-      {
-        code: `
-          declare const foo: { bar: string | null } | null;
-          foo != null && foo.bar !== null;
-        `,
-        errors: [
-          {
-            messageId: 'preferOptionalChain',
-            suggestions: [
-              {
-                messageId: 'optionalChainSuggest',
-                output: `
-          declare const foo: { bar: string | null } | null;
-          foo?.bar !== null;
-        `,
-              },
-            ],
-          },
-        ],
-        output: null,
       },
       {
         code: `
@@ -2298,6 +2256,14 @@ const baz = foo?.bar;
       '(x || y) != null && (x || y).foo;',
       // TODO - should we handle this?
       '(await foo) && (await foo).bar;',
+      `
+        declare const foo: { bar: string } | null;
+        foo !== null && foo.bar !== null;
+      `,
+      `
+        declare const foo: { bar: string | null } | null;
+        foo != null && foo.bar !== null;
+      `,
       {
         code: `
           declare const x: string;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #7170
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This is still a work in progress, but I have one unclear point. I have a question and was hoping you could help.
I want to make sure the categories are clearly defined: `suggestion`, `error`, and `valid`.
I’m especially unsure about suggestion — could you explain that part?

### Valid
Cases where converting to optional chaining may change the behavior -- especially with truthy and falsy values. In such cases we do not report at all.
Example from [issue 7654](https://github.com/typescript-eslint/typescript-eslint/issues/7654)
```
const data: Data | null = getData();

// Checking both that `data` is truthy AND that `data.value` is not null (because 0 is valid)
if (data && data.value !== null) {
  console.log("Number: " + data.value);
} else {
  console.log("Invalid data.");
}
```

### Error
Conversion to optional chaining either produces the same result as before, or introduces an option value.
```
foo != null && foo.bar
foo?.bar
```
### Suggestion 
Optional chaining introduces an additional undefined type, which changes the result type but preserves the same truthy/falsy behavior.
```
declare const foo: { bar: number } | null | undefined;
foo != undefined && foo.bar;         => false | number
foo?.bar                                           => undefined | number
```
Currently, even when the type changes, especially truthy and false some cases report as a suggestion.
examples 
```
declare const foo : { bar : number | null } | null

foo == null || foo.bar === null    => true when foo is null
foo?.bar === null                         => false when foo is null
```
[repro](https://typescript-eslint.io/play/#ts=5.2.2&fileType=.tsx&code=LAKAJgpgxgNghgJwgAigewHYGcAuyBmaaAXMgN7IBGipGArgLaUQLIA%2By9MMyAvu5zrcA3KFABLfMgAUhNMgC8Cwd3Yc5AOmqslyrjACU5UMgJFhyAPSWz89BhxxxGFTFC8JU2UQD8WxIpKrkZkJrYW1racaHj2js6u7kA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6Y6RAM0WloHsalfkwCG8WmQAWo5uii9o-aJHBgAviHVA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)
I think we should fix these cases not to be reported as suggestions.

Am I understanding this correctly and approaching it the right way?
If not, please clarify how it should continue to be reported as a suggestion.