### PR TITLE
fix(typescript-estree): match filenames starting with a period when using glob in allowDefaultProject

### DIFF
--- a/packages/typescript-estree/src/useProgramFromProjectService.ts
+++ b/packages/typescript-estree/src/useProgramFromProjectService.ts
@@ -1,4 +1,4 @@
-import type { ProjectServiceAndMetadata as ProjectServiceAndMetadata } from '@typescript-eslint/project-service';
+import type { ProjectServiceAndMetadata } from '@typescript-eslint/project-service';
 
 import debug from 'debug';
 import { minimatch } from 'minimatch';
@@ -316,5 +316,7 @@ function filePathMatchedBy(
   filePath: string,
   allowDefaultProject: string[] | undefined,
 ): boolean {
-  return !!allowDefaultProject?.some(pattern => minimatch(filePath, pattern));
+  return !!allowDefaultProject?.some(pattern =>
+    minimatch(filePath, pattern, { dot: true }),
+  );
 }

--- a/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
@@ -625,7 +625,7 @@ If you absolutely need more files included, set parserOptions.projectService.max
     );
   });
 
-  it('matchs filenames starting with a period', () => {
+  it('matches filenames starting with a period', () => {
     const { service } = createMockProjectService();
 
     const filePath = `.prettierrc.js`;

--- a/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
+++ b/packages/typescript-estree/tests/lib/useProgramFromProjectService.test.ts
@@ -624,4 +624,31 @@ If you absolutely need more files included, set parserOptions.projectService.max
       )}\`) is non-standard. It should be added to your existing \`parserOptions.extraFileExtensions\`.`,
     );
   });
+
+  it('matchs filenames starting with a period', () => {
+    const { service } = createMockProjectService();
+
+    const filePath = `.prettierrc.js`;
+
+    const program = { getSourceFile: vi.fn() };
+
+    mockGetProgram.mockReturnValueOnce(program);
+
+    service.openClientFile.mockReturnValueOnce({
+      configFileName: 'tsconfig.json',
+    });
+    mockCreateProjectProgram.mockReturnValueOnce(program);
+
+    const actual = useProgramFromProjectService(
+      createProjectServiceSettings({
+        allowDefaultProject: ['*.js'],
+        service,
+      }),
+      { ...mockParseSettings, filePath },
+      false,
+      new Set(),
+    );
+
+    expect(actual).toBe(program);
+  });
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11494
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Use minimatch dot option to take file starting with a dot into account when configuring allowDefaultProject using globs