### PR TITLE
fix(typescript-estree): replace fast-glob with builtin globSync

### DIFF
--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -57,7 +57,6 @@
     "@typescript-eslint/types": "8.41.0",
     "@typescript-eslint/visitor-keys": "8.41.0",
     "debug": "^4.3.4",
-    "fast-glob": "^3.3.2",
     "is-glob": "^4.0.3",
     "minimatch": "^9.0.4",
     "semver": "^7.6.0",

--- a/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
+++ b/packages/typescript-estree/src/parseSettings/resolveProjectList.ts
@@ -1,6 +1,6 @@
 import debug from 'debug';
-import { globSync } from 'node:fs';
 import isGlob from 'is-glob';
+import { globSync } from 'node:fs';
 
 import type { CanonicalPath } from '../create-program/shared';
 import type { TSESTreeOptions } from '../parser-options';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6070,7 +6070,6 @@ __metadata:
     "@vitest/coverage-v8": ^3.1.3
     debug: ^4.3.4
     eslint: "*"
-    fast-glob: ^3.3.2
     glob: "*"
     is-glob: ^4.0.3
     minimatch: ^9.0.4
@@ -10446,7 +10445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
+"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.3":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10533
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22) [^1]
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR removes dependence on `fast-glob` by switching to the built-in `fs.globSync` function included as of Node v22, which is current active LTS and minimum used by typescript-eslint.

[^1]: There has been a lot of discussion in the issue, and it hasn't been fully accepted, so I'm creating it as a draft. 