### PR TITLE
fix(typescript-estree): forbid class property with name `constructor`

### DIFF
--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/fixture.ts
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  accessor '\u{63}onstructor'
+}

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > AccessorProperty > _error_ > key-constructor-string-escaped > TSESTree - Error`]
+TSError
+  1 | class Foo {
+> 2 |   accessor '\u{63}onstructor'
+    |            ^^^^^^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
+  3 | }
+  4 |

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > AccessorProperty > _error_ > key-constructor-string-escaped > Babel - Error`]
+BabelError
+  1 | class Foo {
+> 2 |   accessor '\u{63}onstructor'
+    |            ^ Classes may not have a field named 'constructor'. (2:11)
+  3 | }
+  4 |
+  

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > AccessorProperty > _error_ > key-constructor-string-escaped > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string/fixture.ts
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  accessor 'constructor'
+}

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > AccessorProperty > _error_ > key-constructor-string > TSESTree - Error`]
+TSError
+  1 | class Foo {
+> 2 |   accessor 'constructor'
+    |            ^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
+  3 | }
+  4 |

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string/snapshots/2-Babel-Error.shot
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > AccessorProperty > _error_ > key-constructor-string > Babel - Error`]
+BabelError
+  1 | class Foo {
+> 2 |   accessor 'constructor'
+    |            ^ Classes may not have a field named 'constructor'. (2:11)
+  3 | }
+  4 |
+  

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > AccessorProperty > _error_ > key-constructor-string > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/fixture.ts
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/fixture.ts
@@ -1,3 +1,3 @@
 class Foo {
-  accessor [constructor]
+  accessor [constructor];
 }

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/fixture.ts
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  accessor [constructor]
+}

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,79 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          AccessorProperty {
+            type: "AccessorProperty",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "constructor",
+              optional: false,
+
+              range: [24, 35],
+              loc: {
+                start: { column: 12, line: 2 },
+                end: { column: 23, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [14, 36],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 24, line: 2 },
+            },
+          },
+        ],
+
+        range: [10, 38],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 38],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 39],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
@@ -31,15 +31,15 @@ Program {
             static: false,
             value: null,
 
-            range: [14, 36],
+            range: [14, 37],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 24, line: 2 },
+              end: { column: 25, line: 2 },
             },
           },
         ],
 
-        range: [10, 38],
+        range: [10, 39],
         loc: {
           start: { column: 10, line: 1 },
           end: { column: 1, line: 3 },
@@ -62,7 +62,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 38],
+      range: [0, 39],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -71,7 +71,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 39],
+  range: [0, 40],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,82 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "accessor",
+
+    range: [14, 22],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 10, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [23, 24],
+    loc: {
+      start: { column: 11, line: 2 },
+      end: { column: 12, line: 2 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "constructor",
+
+    range: [24, 35],
+    loc: {
+      start: { column: 12, line: 2 },
+      end: { column: 23, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [35, 36],
+    loc: {
+      start: { column: 23, line: 2 },
+      end: { column: 24, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [37, 38],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
@@ -71,9 +71,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [36, 37],
+    loc: {
+      start: { column: 24, line: 2 },
+      end: { column: 25, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [37, 38],
+    range: [38, 39],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
@@ -1,0 +1,79 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          AccessorProperty {
+            type: "AccessorProperty",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "constructor",
+              optional: false,
+
+              range: [24, 35],
+              loc: {
+                start: { column: 12, line: 2 },
+                end: { column: 23, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [14, 36],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 24, line: 2 },
+            },
+          },
+        ],
+
+        range: [10, 38],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 38],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 39],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
@@ -31,15 +31,15 @@ Program {
             static: false,
             value: null,
 
-            range: [14, 36],
+            range: [14, 37],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 24, line: 2 },
+              end: { column: 25, line: 2 },
             },
           },
         ],
 
-        range: [10, 38],
+        range: [10, 39],
         loc: {
           start: { column: 10, line: 1 },
           end: { column: 1, line: 3 },
@@ -62,7 +62,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 38],
+      range: [0, 39],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -71,7 +71,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 39],
+  range: [0, 40],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,82 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "accessor",
+
+    range: [14, 22],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 10, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [23, 24],
+    loc: {
+      start: { column: 11, line: 2 },
+      end: { column: 12, line: 2 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "constructor",
+
+    range: [24, 35],
+    loc: {
+      start: { column: 12, line: 2 },
+      end: { column: 23, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [35, 36],
+    loc: {
+      start: { column: 23, line: 2 },
+      end: { column: 24, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [37, 38],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
@@ -71,9 +71,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [36, 37],
+    loc: {
+      start: { column: 24, line: 2 },
+      end: { column: 25, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [37, 38],
+    range: [38, 39],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/fixture.ts
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  accessor ['constructor']
+}

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/fixture.ts
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/fixture.ts
@@ -1,3 +1,3 @@
 class Foo {
-  accessor ['constructor']
+  accessor ['constructor'];
 }

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
@@ -30,15 +30,15 @@ Program {
             static: false,
             value: null,
 
-            range: [14, 38],
+            range: [14, 39],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 26, line: 2 },
+              end: { column: 27, line: 2 },
             },
           },
         ],
 
-        range: [10, 40],
+        range: [10, 41],
         loc: {
           start: { column: 10, line: 1 },
           end: { column: 1, line: 3 },
@@ -61,7 +61,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 40],
+      range: [0, 41],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -70,7 +70,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 41],
+  range: [0, 42],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,78 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          AccessorProperty {
+            type: "AccessorProperty",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Literal {
+              type: "Literal",
+              raw: "'constructor'",
+              value: "constructor",
+
+              range: [24, 37],
+              loc: {
+                start: { column: 12, line: 2 },
+                end: { column: 25, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [14, 38],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 26, line: 2 },
+            },
+          },
+        ],
+
+        range: [10, 40],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 40],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 41],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
@@ -71,9 +71,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [38, 39],
+    loc: {
+      start: { column: 26, line: 2 },
+      end: { column: 27, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [39, 40],
+    range: [40, 41],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,82 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "accessor",
+
+    range: [14, 22],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 10, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [23, 24],
+    loc: {
+      start: { column: 11, line: 2 },
+      end: { column: 12, line: 2 },
+    },
+  },
+  String {
+    type: "String",
+    value: "'constructor'",
+
+    range: [24, 37],
+    loc: {
+      start: { column: 12, line: 2 },
+      end: { column: 25, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [37, 38],
+    loc: {
+      start: { column: 25, line: 2 },
+      end: { column: 26, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [39, 40],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
@@ -30,15 +30,15 @@ Program {
             static: false,
             value: null,
 
-            range: [14, 38],
+            range: [14, 39],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 26, line: 2 },
+              end: { column: 27, line: 2 },
             },
           },
         ],
 
-        range: [10, 40],
+        range: [10, 41],
         loc: {
           start: { column: 10, line: 1 },
           end: { column: 1, line: 3 },
@@ -61,7 +61,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 40],
+      range: [0, 41],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -70,7 +70,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 41],
+  range: [0, 42],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
@@ -1,0 +1,78 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          AccessorProperty {
+            type: "AccessorProperty",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Literal {
+              type: "Literal",
+              raw: "'constructor'",
+              value: "constructor",
+
+              range: [24, 37],
+              loc: {
+                start: { column: 12, line: 2 },
+                end: { column: 25, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [14, 38],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 26, line: 2 },
+            },
+          },
+        ],
+
+        range: [10, 40],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 40],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 41],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
@@ -71,9 +71,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [38, 39],
+    loc: {
+      start: { column: 26, line: 2 },
+      end: { column: 27, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [39, 40],
+    range: [40, 41],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,82 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "accessor",
+
+    range: [14, 22],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 10, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [23, 24],
+    loc: {
+      start: { column: 11, line: 2 },
+      end: { column: 12, line: 2 },
+    },
+  },
+  String {
+    type: "String",
+    value: "'constructor'",
+
+    range: [24, 37],
+    loc: {
+      start: { column: 12, line: 2 },
+      end: { column: 25, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [37, 38],
+    loc: {
+      start: { column: 25, line: 2 },
+      end: { column: 26, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [39, 40],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-identifier/fixture.ts
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-identifier/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  constructor
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-identifier > TSESTree - Error`]
+TSError
+  1 | class Foo {
+  2 |   constructor
+> 3 | }
+    | ^ '(' expected.
+  4 |

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/2-Babel-Error.shot
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-identifier > Babel - Error`]
+BabelError
+  1 | class Foo {
+> 2 |   constructor
+    |   ^ Classes may not have a field named 'constructor'. (2:2)
+  3 | }
+  4 |
+  

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-identifier > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/fixture.ts
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  '\u{63}onstructor'
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-string-escaped > TSESTree - Error`]
+TSError
+  1 | class Foo {
+> 2 |   '\u{63}onstructor'
+    |   ^^^^^^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
+  3 | }
+  4 |

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-string-escaped > Babel - Error`]
+BabelError
+  1 | class Foo {
+> 2 |   '\u{63}onstructor'
+    |   ^ Classes may not have a field named 'constructor'. (2:2)
+  3 | }
+  4 |
+  

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-string-escaped > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string/fixture.ts
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  'constructor'
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-string > TSESTree - Error`]
+TSError
+  1 | class Foo {
+> 2 |   'constructor'
+    |   ^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
+  3 | }
+  4 |

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/2-Babel-Error.shot
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-string > Babel - Error`]
+BabelError
+  1 | class Foo {
+> 2 |   'constructor'
+    |   ^ Classes may not have a field named 'constructor'. (2:2)
+  3 | }
+  4 |
+  

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-string > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/fixture.ts
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/fixture.ts
@@ -1,3 +1,3 @@
 class Foo {
-  [constructor]
+  [constructor];
 }

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/fixture.ts
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  [constructor]
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,79 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          PropertyDefinition {
+            type: "PropertyDefinition",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "constructor",
+              optional: false,
+
+              range: [15, 26],
+              loc: {
+                start: { column: 3, line: 2 },
+                end: { column: 14, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [14, 27],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 15, line: 2 },
+            },
+          },
+        ],
+
+        range: [10, 29],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 29],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 30],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
@@ -31,15 +31,15 @@ Program {
             static: false,
             value: null,
 
-            range: [14, 27],
+            range: [14, 28],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 15, line: 2 },
+              end: { column: 16, line: 2 },
             },
           },
         ],
 
-        range: [10, 29],
+        range: [10, 30],
         loc: {
           start: { column: 10, line: 1 },
           end: { column: 1, line: 3 },
@@ -62,7 +62,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 29],
+      range: [0, 30],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -71,7 +71,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 30],
+  range: [0, 31],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,72 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [14, 15],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 3, line: 2 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "constructor",
+
+    range: [15, 26],
+    loc: {
+      start: { column: 3, line: 2 },
+      end: { column: 14, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [26, 27],
+    loc: {
+      start: { column: 14, line: 2 },
+      end: { column: 15, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [28, 29],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
@@ -61,9 +61,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [27, 28],
+    loc: {
+      start: { column: 15, line: 2 },
+      end: { column: 16, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [28, 29],
+    range: [29, 30],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
@@ -1,0 +1,79 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          PropertyDefinition {
+            type: "PropertyDefinition",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "constructor",
+              optional: false,
+
+              range: [15, 26],
+              loc: {
+                start: { column: 3, line: 2 },
+                end: { column: 14, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [14, 27],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 15, line: 2 },
+            },
+          },
+        ],
+
+        range: [10, 29],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 29],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 30],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
@@ -31,15 +31,15 @@ Program {
             static: false,
             value: null,
 
-            range: [14, 27],
+            range: [14, 28],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 15, line: 2 },
+              end: { column: 16, line: 2 },
             },
           },
         ],
 
-        range: [10, 29],
+        range: [10, 30],
         loc: {
           start: { column: 10, line: 1 },
           end: { column: 1, line: 3 },
@@ -62,7 +62,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 29],
+      range: [0, 30],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -71,7 +71,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 30],
+  range: [0, 31],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,72 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [14, 15],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 3, line: 2 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "constructor",
+
+    range: [15, 26],
+    loc: {
+      start: { column: 3, line: 2 },
+      end: { column: 14, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [26, 27],
+    loc: {
+      start: { column: 14, line: 2 },
+      end: { column: 15, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [28, 29],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
@@ -61,9 +61,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [27, 28],
+    loc: {
+      start: { column: 15, line: 2 },
+      end: { column: 16, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [28, 29],
+    range: [29, 30],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/fixture.ts
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  ['constructor']
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/fixture.ts
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/fixture.ts
@@ -1,3 +1,3 @@
 class Foo {
-  ['constructor']
+  ['constructor'];
 }

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,78 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          PropertyDefinition {
+            type: "PropertyDefinition",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Literal {
+              type: "Literal",
+              raw: "'constructor'",
+              value: "constructor",
+
+              range: [15, 28],
+              loc: {
+                start: { column: 3, line: 2 },
+                end: { column: 16, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [14, 29],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 17, line: 2 },
+            },
+          },
+        ],
+
+        range: [10, 31],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 31],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 32],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
@@ -30,15 +30,15 @@ Program {
             static: false,
             value: null,
 
-            range: [14, 29],
+            range: [14, 30],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 17, line: 2 },
+              end: { column: 18, line: 2 },
             },
           },
         ],
 
-        range: [10, 31],
+        range: [10, 32],
         loc: {
           start: { column: 10, line: 1 },
           end: { column: 1, line: 3 },
@@ -61,7 +61,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 31],
+      range: [0, 32],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -70,7 +70,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 32],
+  range: [0, 33],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,72 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [14, 15],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 3, line: 2 },
+    },
+  },
+  String {
+    type: "String",
+    value: "'constructor'",
+
+    range: [15, 28],
+    loc: {
+      start: { column: 3, line: 2 },
+      end: { column: 16, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [28, 29],
+    loc: {
+      start: { column: 16, line: 2 },
+      end: { column: 17, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [30, 31],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
@@ -61,9 +61,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [29, 30],
+    loc: {
+      start: { column: 17, line: 2 },
+      end: { column: 18, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [30, 31],
+    range: [31, 32],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
@@ -1,0 +1,78 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          PropertyDefinition {
+            type: "PropertyDefinition",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Literal {
+              type: "Literal",
+              raw: "'constructor'",
+              value: "constructor",
+
+              range: [15, 28],
+              loc: {
+                start: { column: 3, line: 2 },
+                end: { column: 16, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [14, 29],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 17, line: 2 },
+            },
+          },
+        ],
+
+        range: [10, 31],
+        loc: {
+          start: { column: 10, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 31],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 32],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
@@ -30,15 +30,15 @@ Program {
             static: false,
             value: null,
 
-            range: [14, 29],
+            range: [14, 30],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 17, line: 2 },
+              end: { column: 18, line: 2 },
             },
           },
         ],
 
-        range: [10, 31],
+        range: [10, 32],
         loc: {
           start: { column: 10, line: 1 },
           end: { column: 1, line: 3 },
@@ -61,7 +61,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 31],
+      range: [0, 32],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -70,7 +70,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 32],
+  range: [0, 33],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,72 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [10, 11],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 11, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [14, 15],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 3, line: 2 },
+    },
+  },
+  String {
+    type: "String",
+    value: "'constructor'",
+
+    range: [15, 28],
+    loc: {
+      start: { column: 3, line: 2 },
+      end: { column: 16, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [28, 29],
+    loc: {
+      start: { column: 16, line: 2 },
+      end: { column: 17, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [30, 31],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
@@ -61,9 +61,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [29, 30],
+    loc: {
+      start: { column: 17, line: 2 },
+      end: { column: 18, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [30, 31],
+    range: [31, 32],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/fixture.ts
@@ -1,0 +1,3 @@
+abstract class Foo {
+  accessor '\u{63}onstructor'
+}

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractAccessorProperty > _error_ > key-constructor-string-escaped > TSESTree - Error`]
+TSError
+  1 | abstract class Foo {
+> 2 |   accessor '\u{63}onstructor'
+    |            ^^^^^^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
+  3 | }
+  4 |

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractAccessorProperty > _error_ > key-constructor-string-escaped > Babel - Error`]
+BabelError
+  1 | abstract class Foo {
+> 2 |   accessor '\u{63}onstructor'
+    |            ^ Classes may not have a field named 'constructor'. (2:11)
+  3 | }
+  4 |
+  

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractAccessorProperty > _error_ > key-constructor-string-escaped > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string/fixture.ts
@@ -1,0 +1,3 @@
+abstract class Foo {
+  accessor 'constructor'
+}

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractAccessorProperty > _error_ > key-constructor-string > TSESTree - Error`]
+TSError
+  1 | abstract class Foo {
+> 2 |   accessor 'constructor'
+    |            ^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
+  3 | }
+  4 |

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string/snapshots/2-Babel-Error.shot
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractAccessorProperty > _error_ > key-constructor-string > Babel - Error`]
+BabelError
+  1 | abstract class Foo {
+> 2 |   accessor 'constructor'
+    |            ^ Classes may not have a field named 'constructor'. (2:11)
+  3 | }
+  4 |
+  

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractAccessorProperty > _error_ > key-constructor-string > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/fixture.ts
@@ -1,0 +1,3 @@
+abstract class Foo {
+  accessor [constructor]
+}

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/fixture.ts
@@ -1,3 +1,3 @@
 abstract class Foo {
-  accessor [constructor]
+  accessor [constructor];
 }

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
@@ -31,15 +31,15 @@ Program {
             static: false,
             value: null,
 
-            range: [23, 45],
+            range: [23, 46],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 24, line: 2 },
+              end: { column: 25, line: 2 },
             },
           },
         ],
 
-        range: [19, 47],
+        range: [19, 48],
         loc: {
           start: { column: 19, line: 1 },
           end: { column: 1, line: 3 },
@@ -62,7 +62,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 47],
+      range: [0, 48],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -71,7 +71,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 48],
+  range: [0, 49],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,79 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: true,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          AccessorProperty {
+            type: "AccessorProperty",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "constructor",
+              optional: false,
+
+              range: [33, 44],
+              loc: {
+                start: { column: 12, line: 2 },
+                end: { column: 23, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [23, 45],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 24, line: 2 },
+            },
+          },
+        ],
+
+        range: [19, 47],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [15, 18],
+        loc: {
+          start: { column: 15, line: 1 },
+          end: { column: 18, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 47],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 48],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,92 @@
+[
+  Identifier {
+    type: "Identifier",
+    value: "abstract",
+
+    range: [0, 8],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [9, 14],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 14, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [15, 18],
+    loc: {
+      start: { column: 15, line: 1 },
+      end: { column: 18, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "accessor",
+
+    range: [23, 31],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 10, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [32, 33],
+    loc: {
+      start: { column: 11, line: 2 },
+      end: { column: 12, line: 2 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "constructor",
+
+    range: [33, 44],
+    loc: {
+      start: { column: 12, line: 2 },
+      end: { column: 23, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [44, 45],
+    loc: {
+      start: { column: 23, line: 2 },
+      end: { column: 24, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [46, 47],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
@@ -81,9 +81,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [45, 46],
+    loc: {
+      start: { column: 24, line: 2 },
+      end: { column: 25, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [46, 47],
+    range: [47, 48],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
@@ -31,15 +31,15 @@ Program {
             static: false,
             value: null,
 
-            range: [23, 45],
+            range: [23, 46],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 24, line: 2 },
+              end: { column: 25, line: 2 },
             },
           },
         ],
 
-        range: [19, 47],
+        range: [19, 48],
         loc: {
           start: { column: 19, line: 1 },
           end: { column: 1, line: 3 },
@@ -62,7 +62,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 47],
+      range: [0, 48],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -71,7 +71,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 48],
+  range: [0, 49],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
@@ -1,0 +1,79 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: true,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          AccessorProperty {
+            type: "AccessorProperty",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "constructor",
+              optional: false,
+
+              range: [33, 44],
+              loc: {
+                start: { column: 12, line: 2 },
+                end: { column: 23, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [23, 45],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 24, line: 2 },
+            },
+          },
+        ],
+
+        range: [19, 47],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [15, 18],
+        loc: {
+          start: { column: 15, line: 1 },
+          end: { column: 18, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 47],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 48],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,92 @@
+[
+  Identifier {
+    type: "Identifier",
+    value: "abstract",
+
+    range: [0, 8],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [9, 14],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 14, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [15, 18],
+    loc: {
+      start: { column: 15, line: 1 },
+      end: { column: 18, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "accessor",
+
+    range: [23, 31],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 10, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [32, 33],
+    loc: {
+      start: { column: 11, line: 2 },
+      end: { column: 12, line: 2 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "constructor",
+
+    range: [33, 44],
+    loc: {
+      start: { column: 12, line: 2 },
+      end: { column: 23, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [44, 45],
+    loc: {
+      start: { column: 23, line: 2 },
+      end: { column: 24, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [46, 47],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
@@ -81,9 +81,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [45, 46],
+    loc: {
+      start: { column: 24, line: 2 },
+      end: { column: 25, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [46, 47],
+    range: [47, 48],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/fixture.ts
@@ -1,0 +1,3 @@
+abstract class Foo {
+  accessor ['constructor']
+}

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/fixture.ts
@@ -1,3 +1,3 @@
 abstract class Foo {
-  accessor ['constructor']
+  accessor ['constructor'];
 }

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
@@ -30,15 +30,15 @@ Program {
             static: false,
             value: null,
 
-            range: [23, 47],
+            range: [23, 48],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 26, line: 2 },
+              end: { column: 27, line: 2 },
             },
           },
         ],
 
-        range: [19, 49],
+        range: [19, 50],
         loc: {
           start: { column: 19, line: 1 },
           end: { column: 1, line: 3 },
@@ -61,7 +61,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 49],
+      range: [0, 50],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -70,7 +70,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 50],
+  range: [0, 51],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,78 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: true,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          AccessorProperty {
+            type: "AccessorProperty",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Literal {
+              type: "Literal",
+              raw: "'constructor'",
+              value: "constructor",
+
+              range: [33, 46],
+              loc: {
+                start: { column: 12, line: 2 },
+                end: { column: 25, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [23, 47],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 26, line: 2 },
+            },
+          },
+        ],
+
+        range: [19, 49],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [15, 18],
+        loc: {
+          start: { column: 15, line: 1 },
+          end: { column: 18, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 49],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 50],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,92 @@
+[
+  Identifier {
+    type: "Identifier",
+    value: "abstract",
+
+    range: [0, 8],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [9, 14],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 14, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [15, 18],
+    loc: {
+      start: { column: 15, line: 1 },
+      end: { column: 18, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "accessor",
+
+    range: [23, 31],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 10, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [32, 33],
+    loc: {
+      start: { column: 11, line: 2 },
+      end: { column: 12, line: 2 },
+    },
+  },
+  String {
+    type: "String",
+    value: "'constructor'",
+
+    range: [33, 46],
+    loc: {
+      start: { column: 12, line: 2 },
+      end: { column: 25, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [46, 47],
+    loc: {
+      start: { column: 25, line: 2 },
+      end: { column: 26, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [48, 49],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
@@ -81,9 +81,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [47, 48],
+    loc: {
+      start: { column: 26, line: 2 },
+      end: { column: 27, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [48, 49],
+    range: [49, 50],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
@@ -30,15 +30,15 @@ Program {
             static: false,
             value: null,
 
-            range: [23, 47],
+            range: [23, 48],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 26, line: 2 },
+              end: { column: 27, line: 2 },
             },
           },
         ],
 
-        range: [19, 49],
+        range: [19, 50],
         loc: {
           start: { column: 19, line: 1 },
           end: { column: 1, line: 3 },
@@ -61,7 +61,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 49],
+      range: [0, 50],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -70,7 +70,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 50],
+  range: [0, 51],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
@@ -1,0 +1,78 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: true,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          AccessorProperty {
+            type: "AccessorProperty",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Literal {
+              type: "Literal",
+              raw: "'constructor'",
+              value: "constructor",
+
+              range: [33, 46],
+              loc: {
+                start: { column: 12, line: 2 },
+                end: { column: 25, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [23, 47],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 26, line: 2 },
+            },
+          },
+        ],
+
+        range: [19, 49],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [15, 18],
+        loc: {
+          start: { column: 15, line: 1 },
+          end: { column: 18, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 49],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 50],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,92 @@
+[
+  Identifier {
+    type: "Identifier",
+    value: "abstract",
+
+    range: [0, 8],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [9, 14],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 14, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [15, 18],
+    loc: {
+      start: { column: 15, line: 1 },
+      end: { column: 18, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "accessor",
+
+    range: [23, 31],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 10, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [32, 33],
+    loc: {
+      start: { column: 11, line: 2 },
+      end: { column: 12, line: 2 },
+    },
+  },
+  String {
+    type: "String",
+    value: "'constructor'",
+
+    range: [33, 46],
+    loc: {
+      start: { column: 12, line: 2 },
+      end: { column: 25, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [46, 47],
+    loc: {
+      start: { column: 25, line: 2 },
+      end: { column: 26, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [48, 49],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
@@ -81,9 +81,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [47, 48],
+    loc: {
+      start: { column: 26, line: 2 },
+      end: { column: 27, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [48, 49],
+    range: [49, 50],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-identifier/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-identifier/fixture.ts
@@ -1,0 +1,3 @@
+abstract class Foo {
+  constructor
+}

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-identifier > TSESTree - Error`]
+TSError
+  1 | abstract class Foo {
+  2 |   constructor
+> 3 | }
+    | ^ '(' expected.
+  4 |

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/2-Babel-Error.shot
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-identifier > Babel - Error`]
+BabelError
+  1 | abstract class Foo {
+> 2 |   constructor
+    |   ^ Classes may not have a field named 'constructor'. (2:2)
+  3 | }
+  4 |
+  

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-identifier/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-identifier > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/fixture.ts
@@ -1,0 +1,3 @@
+abstract class Foo {
+  '\u{63}onstructor'
+}

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-string-escaped > TSESTree - Error`]
+TSError
+  1 | abstract class Foo {
+> 2 |   '\u{63}onstructor'
+    |   ^^^^^^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
+  3 | }
+  4 |

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-string-escaped > Babel - Error`]
+BabelError
+  1 | abstract class Foo {
+> 2 |   '\u{63}onstructor'
+    |   ^ Classes may not have a field named 'constructor'. (2:2)
+  3 | }
+  4 |
+  

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-string-escaped > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string/fixture.ts
@@ -1,0 +1,3 @@
+abstract class Foo {
+  'constructor'
+}

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-string > TSESTree - Error`]
+TSError
+  1 | abstract class Foo {
+> 2 |   'constructor'
+    |   ^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
+  3 | }
+  4 |

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/2-Babel-Error.shot
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-string > Babel - Error`]
+BabelError
+  1 | abstract class Foo {
+> 2 |   'constructor'
+    |   ^ Classes may not have a field named 'constructor'. (2:2)
+  3 | }
+  4 |
+  

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-string > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/fixture.ts
@@ -1,3 +1,3 @@
 abstract class Foo {
-  [constructor]
+  [constructor];
 }

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/fixture.ts
@@ -1,0 +1,3 @@
+abstract class Foo {
+  [constructor]
+}

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
@@ -31,15 +31,15 @@ Program {
             static: false,
             value: null,
 
-            range: [23, 36],
+            range: [23, 37],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 15, line: 2 },
+              end: { column: 16, line: 2 },
             },
           },
         ],
 
-        range: [19, 38],
+        range: [19, 39],
         loc: {
           start: { column: 19, line: 1 },
           end: { column: 1, line: 3 },
@@ -62,7 +62,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 38],
+      range: [0, 39],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -71,7 +71,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 39],
+  range: [0, 40],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,79 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: true,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          PropertyDefinition {
+            type: "PropertyDefinition",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "constructor",
+              optional: false,
+
+              range: [24, 35],
+              loc: {
+                start: { column: 3, line: 2 },
+                end: { column: 14, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [23, 36],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 15, line: 2 },
+            },
+          },
+        ],
+
+        range: [19, 38],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [15, 18],
+        loc: {
+          start: { column: 15, line: 1 },
+          end: { column: 18, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 38],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 39],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,82 @@
+[
+  Identifier {
+    type: "Identifier",
+    value: "abstract",
+
+    range: [0, 8],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [9, 14],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 14, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [15, 18],
+    loc: {
+      start: { column: 15, line: 1 },
+      end: { column: 18, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [23, 24],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 3, line: 2 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "constructor",
+
+    range: [24, 35],
+    loc: {
+      start: { column: 3, line: 2 },
+      end: { column: 14, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [35, 36],
+    loc: {
+      start: { column: 14, line: 2 },
+      end: { column: 15, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [37, 38],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/2-TSESTree-Tokens.shot
@@ -71,9 +71,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [36, 37],
+    loc: {
+      start: { column: 15, line: 2 },
+      end: { column: 16, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [37, 38],
+    range: [38, 39],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
@@ -31,15 +31,15 @@ Program {
             static: false,
             value: null,
 
-            range: [23, 36],
+            range: [23, 37],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 15, line: 2 },
+              end: { column: 16, line: 2 },
             },
           },
         ],
 
-        range: [19, 38],
+        range: [19, 39],
         loc: {
           start: { column: 19, line: 1 },
           end: { column: 1, line: 3 },
@@ -62,7 +62,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 38],
+      range: [0, 39],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -71,7 +71,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 39],
+  range: [0, 40],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/3-Babel-AST.shot
@@ -1,0 +1,79 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: true,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          PropertyDefinition {
+            type: "PropertyDefinition",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Identifier {
+              type: "Identifier",
+              decorators: [],
+              name: "constructor",
+              optional: false,
+
+              range: [24, 35],
+              loc: {
+                start: { column: 3, line: 2 },
+                end: { column: 14, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [23, 36],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 15, line: 2 },
+            },
+          },
+        ],
+
+        range: [19, 38],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [15, 18],
+        loc: {
+          start: { column: 15, line: 1 },
+          end: { column: 18, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 38],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 39],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,82 @@
+[
+  Identifier {
+    type: "Identifier",
+    value: "abstract",
+
+    range: [0, 8],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [9, 14],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 14, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [15, 18],
+    loc: {
+      start: { column: 15, line: 1 },
+      end: { column: 18, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [23, 24],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 3, line: 2 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "constructor",
+
+    range: [24, 35],
+    loc: {
+      start: { column: 3, line: 2 },
+      end: { column: 14, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [35, 36],
+    loc: {
+      start: { column: 14, line: 2 },
+      end: { column: 15, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [37, 38],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-identifier-computed/snapshots/4-Babel-Tokens.shot
@@ -71,9 +71,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [36, 37],
+    loc: {
+      start: { column: 15, line: 2 },
+      end: { column: 16, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [37, 38],
+    range: [38, 39],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/fixture.ts
@@ -1,3 +1,3 @@
 abstract class Foo {
-  ['constructor']
+  ['constructor'];
 }

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/fixture.ts
@@ -1,0 +1,3 @@
+abstract class Foo {
+  ['constructor']
+}

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
@@ -30,15 +30,15 @@ Program {
             static: false,
             value: null,
 
-            range: [23, 38],
+            range: [23, 39],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 17, line: 2 },
+              end: { column: 18, line: 2 },
             },
           },
         ],
 
-        range: [19, 40],
+        range: [19, 41],
         loc: {
           start: { column: 19, line: 1 },
           end: { column: 1, line: 3 },
@@ -61,7 +61,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 40],
+      range: [0, 41],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -70,7 +70,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 41],
+  range: [0, 42],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,78 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: true,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          PropertyDefinition {
+            type: "PropertyDefinition",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Literal {
+              type: "Literal",
+              raw: "'constructor'",
+              value: "constructor",
+
+              range: [24, 37],
+              loc: {
+                start: { column: 3, line: 2 },
+                end: { column: 16, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [23, 38],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 17, line: 2 },
+            },
+          },
+        ],
+
+        range: [19, 40],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [15, 18],
+        loc: {
+          start: { column: 15, line: 1 },
+          end: { column: 18, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 40],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 41],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,82 @@
+[
+  Identifier {
+    type: "Identifier",
+    value: "abstract",
+
+    range: [0, 8],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [9, 14],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 14, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [15, 18],
+    loc: {
+      start: { column: 15, line: 1 },
+      end: { column: 18, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [23, 24],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 3, line: 2 },
+    },
+  },
+  String {
+    type: "String",
+    value: "'constructor'",
+
+    range: [24, 37],
+    loc: {
+      start: { column: 3, line: 2 },
+      end: { column: 16, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [37, 38],
+    loc: {
+      start: { column: 16, line: 2 },
+      end: { column: 17, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [39, 40],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/2-TSESTree-Tokens.shot
@@ -71,9 +71,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [38, 39],
+    loc: {
+      start: { column: 17, line: 2 },
+      end: { column: 18, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [39, 40],
+    range: [40, 41],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
@@ -30,15 +30,15 @@ Program {
             static: false,
             value: null,
 
-            range: [23, 38],
+            range: [23, 39],
             loc: {
               start: { column: 2, line: 2 },
-              end: { column: 17, line: 2 },
+              end: { column: 18, line: 2 },
             },
           },
         ],
 
-        range: [19, 40],
+        range: [19, 41],
         loc: {
           start: { column: 19, line: 1 },
           end: { column: 1, line: 3 },
@@ -61,7 +61,7 @@ Program {
       implements: [],
       superClass: null,
 
-      range: [0, 40],
+      range: [0, 41],
       loc: {
         start: { column: 0, line: 1 },
         end: { column: 1, line: 3 },
@@ -70,7 +70,7 @@ Program {
   ],
   sourceType: "script",
 
-  range: [0, 41],
+  range: [0, 42],
   loc: {
     start: { column: 0, line: 1 },
     end: { column: 0, line: 4 },

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/3-Babel-AST.shot
@@ -1,0 +1,78 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: true,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [
+          PropertyDefinition {
+            type: "PropertyDefinition",
+            computed: true,
+            declare: false,
+            decorators: [],
+            definite: false,
+            key: Literal {
+              type: "Literal",
+              raw: "'constructor'",
+              value: "constructor",
+
+              range: [24, 37],
+              loc: {
+                start: { column: 3, line: 2 },
+                end: { column: 16, line: 2 },
+              },
+            },
+            optional: false,
+            override: false,
+            readonly: false,
+            static: false,
+            value: null,
+
+            range: [23, 38],
+            loc: {
+              start: { column: 2, line: 2 },
+              end: { column: 17, line: 2 },
+            },
+          },
+        ],
+
+        range: [19, 40],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 1, line: 3 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [15, 18],
+        loc: {
+          start: { column: 15, line: 1 },
+          end: { column: 18, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: null,
+
+      range: [0, 40],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 1, line: 3 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 41],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 4 },
+  },
+}

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,82 @@
+[
+  Identifier {
+    type: "Identifier",
+    value: "abstract",
+
+    range: [0, 8],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 8, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [9, 14],
+    loc: {
+      start: { column: 9, line: 1 },
+      end: { column: 14, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [15, 18],
+    loc: {
+      start: { column: 15, line: 1 },
+      end: { column: 18, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [19, 20],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 20, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "[",
+
+    range: [23, 24],
+    loc: {
+      start: { column: 2, line: 2 },
+      end: { column: 3, line: 2 },
+    },
+  },
+  String {
+    type: "String",
+    value: "'constructor'",
+
+    range: [24, 37],
+    loc: {
+      start: { column: 3, line: 2 },
+      end: { column: 16, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "]",
+
+    range: [37, 38],
+    loc: {
+      start: { column: 16, line: 2 },
+      end: { column: 17, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [39, 40],
+    loc: {
+      start: { column: 0, line: 3 },
+      end: { column: 1, line: 3 },
+    },
+  },
+]

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/key-constructor-string-computed/snapshots/4-Babel-Tokens.shot
@@ -71,9 +71,19 @@
   },
   Punctuator {
     type: "Punctuator",
+    value: ";",
+
+    range: [38, 39],
+    loc: {
+      start: { column: 17, line: 2 },
+      end: { column: 18, line: 2 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
     value: "}",
 
-    range: [39, 40],
+    range: [40, 41],
     loc: {
       start: { column: 0, line: 3 },
       end: { column: 1, line: 3 },

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1524,6 +1524,16 @@ export class Converter {
           );
         }
 
+        if (
+          node.name.kind === SyntaxKind.StringLiteral &&
+          node.name.text === 'constructor'
+        ) {
+          this.#throwError(
+            node.name,
+            "Classes may not have a field named 'constructor'.",
+          );
+        }
+
         const isAccessor = hasModifier(SyntaxKind.AccessorKeyword, node);
         const type = (() => {
           if (isAccessor) {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11584
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
