### PR TITLE
fix(eslint-plugin): [no-unsafe-enum-comparison] support unions of literals

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-enum-comparison.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-enum-comparison.ts
@@ -23,25 +23,33 @@ function typeViolates(leftTypeParts: ts.Type[], rightType: ts.Type): boolean {
 }
 
 function isNumberLike(type: ts.Type): boolean {
-  const typeParts = tsutils.intersectionConstituents(type);
-
-  return typeParts.some(typePart => {
-    return tsutils.isTypeFlagSet(
-      typePart,
-      ts.TypeFlags.Number | ts.TypeFlags.NumberLike,
+  return tsutils
+    .unionConstituents(type)
+    .every(unionPart =>
+      tsutils
+        .intersectionConstituents(unionPart)
+        .some(intersectionPart =>
+          tsutils.isTypeFlagSet(
+            intersectionPart,
+            ts.TypeFlags.Number | ts.TypeFlags.NumberLike,
+          ),
+        ),
     );
-  });
 }
 
 function isStringLike(type: ts.Type): boolean {
-  const typeParts = tsutils.intersectionConstituents(type);
-
-  return typeParts.some(typePart => {
-    return tsutils.isTypeFlagSet(
-      typePart,
-      ts.TypeFlags.String | ts.TypeFlags.StringLike,
+  return tsutils
+    .unionConstituents(type)
+    .every(unionPart =>
+      tsutils
+        .intersectionConstituents(unionPart)
+        .some(intersectionPart =>
+          tsutils.isTypeFlagSet(
+            intersectionPart,
+            ts.TypeFlags.String | ts.TypeFlags.StringLike,
+          ),
+        ),
     );
-  });
 }
 
 /**

--- a/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
@@ -1184,12 +1184,12 @@ switch (numberUnion) {
       `,
       errors: [
         {
-          messageId: 'mismatchedCase',
           line: 12,
+          messageId: 'mismatchedCase',
         },
         {
-          messageId: 'mismatchedCase',
           line: 13,
+          messageId: 'mismatchedCase',
         },
       ],
     },
@@ -1212,12 +1212,12 @@ switch (stringUnion) {
       `,
       errors: [
         {
-          messageId: 'mismatchedCase',
           line: 12,
+          messageId: 'mismatchedCase',
         },
         {
-          messageId: 'mismatchedCase',
           line: 13,
+          messageId: 'mismatchedCase',
         },
       ],
     },
@@ -1236,8 +1236,8 @@ stringUnion === stringEnum;
       `,
       errors: [
         {
-          messageId: 'mismatchedCondition',
           line: 11,
+          messageId: 'mismatchedCondition',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
@@ -1165,5 +1165,81 @@ ruleTester.run('no-unsafe-enum-comparison', rule, {
       `,
       errors: [{ messageId: 'mismatchedCondition' }],
     },
+    {
+      code: `
+enum NUMBER_ENUM {
+  First = 0,
+  Second = 1,
+}
+
+type NumberUnion = 0 | 1;
+
+declare const numberUnion: NumberUnion;
+
+switch (numberUnion) {
+  case NUMBER_ENUM.First:
+  case NUMBER_ENUM.Second:
+    break;
+}
+      `,
+      errors: [
+        {
+          messageId: 'mismatchedCase',
+          line: 12,
+        },
+        {
+          messageId: 'mismatchedCase',
+          line: 13,
+        },
+      ],
+    },
+    {
+      code: `
+enum STRING_ENUM {
+  First = 'one',
+  Second = 'two',
+}
+
+type StringUnion = 'one' | 'two';
+
+declare const stringUnion: StringUnion;
+
+switch (stringUnion) {
+  case STRING_ENUM.First:
+  case STRING_ENUM.Second:
+    break;
+}
+      `,
+      errors: [
+        {
+          messageId: 'mismatchedCase',
+          line: 12,
+        },
+        {
+          messageId: 'mismatchedCase',
+          line: 13,
+        },
+      ],
+    },
+    {
+      code: `
+declare const stringUnion: 'foo' | 'bar';
+
+enum StringEnum {
+  FOO = 'foo',
+  BAR = 'bar',
+}
+
+declare const stringEnum: StringEnum;
+
+stringUnion === stringEnum;
+      `,
+      errors: [
+        {
+          messageId: 'mismatchedCondition',
+          line: 11,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11596 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The problem was not about which type was the switch argument and which was the case, and more so about the fact that the rule didn't consider unions of number literals to be numbers (and ditto for strings).