### PR TITLE
fix(eslint-plugin): [no-deprecated] ignore deprecation on TSImportEqualsDeclaration

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -157,6 +157,10 @@ export default createRule<Options, MessageIds>({
         case AST_NODE_TYPES.TSTypeParameter:
           return true;
 
+        // treat `export import Bar = Foo;` (and `import Foo = require('...')`) as declarations
+        case AST_NODE_TYPES.TSImportEqualsDeclaration:
+          return parent.id === node;
+
         default:
           return false;
       }

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -246,6 +246,14 @@ ruleTester.run('no-deprecated', rule, {
       const { anchor = '' } = x;
     `,
     `
+      namespace Foo {}
+
+      /**
+       * @deprecated
+       */
+      export import Bar = Foo;
+    `,
+    `
       interface Props {
         anchor: 'foo';
       }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11586
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

PR enhances the `no-deprecated` ESLint rule to better handle `TSImportEqualsDeclaration`, specifically cases like `export import Bar = Foo;` 