### PR TITLE
fix(eslint-plugin): [await-thenable] should not report passing values to promise aggregators which may be a promise in an array literal

### DIFF
--- a/packages/eslint-plugin/src/rules/await-thenable.ts
+++ b/packages/eslint-plugin/src/rules/await-thenable.ts
@@ -111,7 +111,7 @@ export default createRule<[], MessageId>({
             const type = getConstrainedTypeAtLocation(services, element);
             const tsNode = services.esTreeNodeToTSNodeMap.get(element);
 
-            if (containsNonAwaitableType(type, tsNode, checker)) {
+            if (isAlwaysNonAwaitableType(type, tsNode, checker)) {
               context.report({
                 node: element,
                 messageId: 'invalidPromiseAggregatorInput',
@@ -279,6 +279,19 @@ function getValueTypesOfArrayLike(
   }
 
   return null;
+}
+
+function isAlwaysNonAwaitableType(
+  type: ts.Type,
+  node: ts.Node,
+  checker: ts.TypeChecker,
+): boolean {
+  return tsutils
+    .unionConstituents(type)
+    .every(
+      typeArgumentPart =>
+        needsToBeAwaited(checker, node, typeArgumentPart) === Awaitable.Never,
+    );
 }
 
 function containsNonAwaitableType(

--- a/packages/eslint-plugin/tests/rules/await-thenable.test.ts
+++ b/packages/eslint-plugin/tests/rules/await-thenable.test.ts
@@ -686,6 +686,18 @@ Promise.all([
 ]);
       `,
     },
+    {
+      code: `
+declare const maybePromise: Promise<number> | number;
+
+Promise.all([
+  maybePromise,
+  Promise.resolve(1),
+  Promise.resolve(2),
+  Promise.resolve(3),
+]);
+      `,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11609
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR addresses #11609 and adjusts `await-thenable` to allow passing values which may be promises to promise aggregator methods, specifically in an array literal:

```ts
declare const maybePromise: Promise<number> | number;

Promise.all([
  maybePromise,
  Promise.resolve(1),
  Promise.resolve(2),
  Promise.resolve(3),
]);
```

Note that this special cases array literals, and the code below will still be reported:

```ts
declare const maybePromise: Promise<number> | number;

const arr = [
  maybePromise,
  Promise.resolve(1),
  Promise.resolve(2),
  Promise.resolve(3),
];

// Unexpected iterable of non-Promise (non-"Thenable") values passed to promise aggregator. 
Promise.all(arr);
```
