### PR TITLE
fix(eslint-plugin): [prefer-nullish-coalescing] ignoreBooleanCoercion should not apply to top-level ternary expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -301,7 +301,11 @@ export default createRule<Options, MessageIds>({
 
       if (
         ignoreBooleanCoercion === true &&
-        isBooleanConstructorContext(node, context)
+        isBooleanConstructorContext(node, context) &&
+        !(
+          node.type === AST_NODE_TYPES.ConditionalExpression &&
+          node.parent.type === AST_NODE_TYPES.CallExpression
+        )
       ) {
         return false;
       }

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -1253,32 +1253,6 @@ const test = Boolean(((a = b), b || c));
     },
     {
       code: `
-let a: string | true | undefined;
-let b: string | boolean | undefined;
-
-const x = Boolean(a ? a : b);
-      `,
-      options: [
-        {
-          ignoreBooleanCoercion: true,
-        },
-      ],
-    },
-    {
-      code: `
-let a: string | boolean | undefined;
-let b: string | boolean | undefined;
-
-const test = Boolean(!a ? b : a);
-      `,
-      options: [
-        {
-          ignoreBooleanCoercion: true,
-        },
-      ],
-    },
-    {
-      code: `
 let a: string | boolean | undefined;
 let b: string | boolean | undefined;
 let c: string | boolean | undefined;
@@ -5073,6 +5047,64 @@ let a: string | true | undefined;
 let b: string | boolean | undefined;
 
 const x = Boolean(1 + (a ?? b));
+      `,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          ignoreBooleanCoercion: true,
+        },
+      ],
+    },
+    {
+      code: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+const x = Boolean(a ? a : b);
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverTernary',
+          suggestions: [
+            {
+              messageId: 'suggestNullish',
+              output: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+const x = Boolean(a ?? b);
+      `,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          ignoreBooleanCoercion: true,
+        },
+      ],
+    },
+    {
+      code: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+
+const test = Boolean(!a ? b : a);
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverTernary',
+          suggestions: [
+            {
+              messageId: 'suggestNullish',
+              output: `
+let a: string | boolean | undefined;
+let b: string | boolean | undefined;
+
+const test = Boolean(a ?? b);
       `,
             },
           ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11581
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
Report this case when ignoreBooleanCoercion is true:
```
declare const a: string | true | undefined;
declare const b: string | boolean | undefined;
const x = Boolean(a ? a : b);
```
but do not report this case:
```
declare const a: string | true | undefined;
declare const b: string | boolean | undefined;
declare const c: string | boolean | undefined;
const x = Boolean(c || (a ? a : b));
```