### PR TITLE
feat(eslint-plugin): expose rule name via RuleModule interface

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-eslint.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-eslint.test.ts
@@ -40,6 +40,7 @@ ruleTester.defineRule('use-every-a', {
     schema: [],
     type: 'problem',
   },
+  name: 'rule',
 });
 
 /**

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-eslint.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-eslint.test.ts
@@ -40,7 +40,7 @@ ruleTester.defineRule('use-every-a', {
     schema: [],
     type: 'problem',
   },
-  name: 'rule',
+  name: 'use-every-a',
 });
 
 /**

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -32,6 +32,7 @@ ruleTester.defineRule('collect-unused-vars', {
     schema: [],
     type: 'problem',
   },
+  name: 'rule',
 });
 
 ruleTester.run('no-unused-vars', rule, {

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -32,7 +32,7 @@ ruleTester.defineRule('collect-unused-vars', {
     schema: [],
     type: 'problem',
   },
-  name: 'rule',
+  name: 'collect-unused-vars',
 });
 
 ruleTester.run('no-unused-vars', rule, {

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -94,6 +94,7 @@ const NOOP_RULE: RuleModule<'error'> = {
     schema: [],
     type: 'problem',
   },
+  name: 'rule',
 };
 
 function windowsToPosixPath(p: string): string {
@@ -1108,6 +1109,7 @@ describe('RuleTester - hooks', () => {
       schema: [],
       type: 'problem',
     },
+    name: 'rule',
   };
 
   const ruleTester = new RuleTester();
@@ -1331,6 +1333,7 @@ describe('RuleTester - multipass fixer', () => {
         schema: [],
         type: 'problem',
       },
+      name: 'rule',
     };
 
     it('passes with no output', () => {
@@ -1416,6 +1419,7 @@ describe('RuleTester - multipass fixer', () => {
         schema: [],
         type: 'problem',
       },
+      name: 'rule',
     };
 
     it('passes with correct string output', () => {
@@ -1538,6 +1542,7 @@ describe('RuleTester - multipass fixer', () => {
         schema: [],
         type: 'problem',
       },
+      name: 'rule',
     };
 
     it('passes with correct array output', () => {
@@ -1644,6 +1649,7 @@ describe('RuleTester - run types', () => {
       ],
       type: 'suggestion',
     },
+    name: 'rule',
   };
 
   describe('infer from `rule` parameter', () => {

--- a/packages/rule-tester/tests/filename.test.ts
+++ b/packages/rule-tester/tests/filename.test.ts
@@ -19,6 +19,7 @@ const rule = ESLintUtils.RuleCreator.withoutDocs({
     type: 'problem',
     hasSuggestions: true,
   },
+  name: 'rule',
   defaultOptions: [],
   create: context => ({
     Program(node): void {

--- a/packages/utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/utils/src/eslint-utils/RuleCreator.ts
@@ -30,6 +30,7 @@ export interface RuleCreateAndOptions<
   defaultOptions: Readonly<Options>;
 }
 
+/** @deprecated use `'RuleWithMetaAndName'` */
 export interface RuleWithMeta<
   Options extends readonly unknown[],
   MessageIds extends string,
@@ -76,6 +77,7 @@ export function RuleCreator<PluginDocs = unknown>(
           url: urlCreator(name),
         },
       },
+      name,
       ...rule,
     });
   };
@@ -89,7 +91,8 @@ function createRule<
   create,
   defaultOptions,
   meta,
-}: Readonly<RuleWithMeta<Options, MessageIds, PluginDocs>>): RuleModule<
+  name,
+}: Readonly<RuleWithMetaAndName<Options, MessageIds, PluginDocs>>): RuleModule<
   MessageIds,
   Options,
   PluginDocs
@@ -101,6 +104,7 @@ function createRule<
     },
     defaultOptions,
     meta,
+    name,
   };
 }
 
@@ -114,7 +118,7 @@ RuleCreator.withoutDocs = function withoutDocs<
   Options extends readonly unknown[],
   MessageIds extends string,
 >(
-  args: Readonly<RuleWithMeta<Options, MessageIds>>,
+  args: Readonly<RuleWithMetaAndName<Options, MessageIds>>,
 ): RuleModule<MessageIds, Options> {
   return createRule(args);
 };

--- a/packages/utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/utils/src/eslint-utils/RuleCreator.ts
@@ -30,13 +30,13 @@ export interface RuleCreateAndOptions<
   defaultOptions: Readonly<Options>;
 }
 
-/** @deprecated use `'RuleWithMetaAndName'` */
 export interface RuleWithMeta<
   Options extends readonly unknown[],
   MessageIds extends string,
   Docs = unknown,
 > extends RuleCreateAndOptions<Options, MessageIds> {
   meta: RuleMetaData<MessageIds, Docs, Options>;
+  name: string;
 }
 
 export interface RuleWithMetaAndName<
@@ -92,7 +92,7 @@ function createRule<
   defaultOptions,
   meta,
   name,
-}: Readonly<RuleWithMetaAndName<Options, MessageIds, PluginDocs>>): RuleModule<
+}: Readonly<RuleWithMeta<Options, MessageIds, PluginDocs>>): RuleModule<
   MessageIds,
   Options,
   PluginDocs
@@ -118,7 +118,7 @@ RuleCreator.withoutDocs = function withoutDocs<
   Options extends readonly unknown[],
   MessageIds extends string,
 >(
-  args: Readonly<RuleWithMetaAndName<Options, MessageIds>>,
+  args: Readonly<RuleWithMeta<Options, MessageIds>>,
 ): RuleModule<MessageIds, Options> {
   return createRule(args);
 };

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -735,6 +735,10 @@ export interface RuleModule<
    * Metadata about the rule
    */
   meta: RuleMetaData<MessageIds, Docs, Options>;
+  /**
+   * Rule name
+   */
+  name: string;
 }
 
 export type AnyRuleModule = RuleModule<string, readonly unknown[]>;

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -735,6 +735,7 @@ export interface RuleModule<
    * Metadata about the rule
    */
   meta: RuleMetaData<MessageIds, Docs, Options>;
+
   /**
    * Rule name
    */


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11608
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR introduces an `name` property to the `RuleModule` interface.

🚀