### PR TITLE
fix(eslint-plugin): [no-base-to-string] check if superclass is ignored

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -278,7 +278,7 @@ export default createRule<Options, MessageIds>({
       ) {
         return Usefulness.Always;
       }
-      
+
       if (isIgnoredTypeOrBase(type)) {
         return Usefulness.Always;
       }

--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -224,15 +224,9 @@ export default createRule<Options, MessageIds>({
     function isIgnoredTypeOrBase(
       type: ts.Type,
       seen = new Set<ts.Type>(),
-      cache = new Map<ts.Type, boolean>(),
     ): boolean {
       if (seen.has(type)) {
         return false;
-      }
-
-      const cached = cache.get(type);
-      if (cached != null) {
-        return cached;
       }
 
       seen.add(type);
@@ -243,10 +237,9 @@ export default createRule<Options, MessageIds>({
       if (!result && hasBaseTypes(type)) {
         result = checker
           .getBaseTypes(type)
-          .some(base => isIgnoredTypeOrBase(base, seen, cache));
+          .some(base => isIgnoredTypeOrBase(base, seen));
       }
 
-      cache.set(type, result);
       return result;
     }
 

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -337,14 +337,23 @@ whiskers.toString();
     },
     {
   code: `
+interface MyError extends Error {}
+
+declare const error: MyError;
+error.toString();
+  `,
+    },
+    {
+      code: `
 class UnknownBase {}
 class CustomError extends UnknownBase {}
 
 declare const err: CustomError;
 err.toString();
-  `,
+      `,
       options: [{ ignoredTypeNames: ['UnknownBase'] }],
     },
+
     `
 function String(value) {
   return value;

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -324,6 +324,27 @@ error.toString();
       `,
       options: [{ ignoredTypeNames: ['MyError'] }],
     },
+    {
+      code: `
+interface Animal {}
+interface Serializable {}
+interface Cat extends Animal, Serializable {}
+
+declare const whiskers: Cat;
+whiskers.toString();
+      `,
+      options: [{ ignoredTypeNames: ['Animal'] }],
+    },
+    {
+  code: `
+class UnknownBase {}
+class CustomError extends UnknownBase {}
+
+declare const err: CustomError;
+err.toString();
+  `,
+      options: [{ ignoredTypeNames: ['UnknownBase'] }],
+    },
     `
 function String(value) {
   return value;
@@ -2262,6 +2283,23 @@ v.join();
             name: 'v',
           },
           messageId: 'baseArrayJoin',
+        },
+      ],
+    },
+    {
+      code: `
+interface Dog extends Animal {}
+
+declare const labrador: Dog;
+labrador.toString();
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'will',
+            name: 'labrador',
+          },
+          messageId: 'baseToString',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -353,7 +353,18 @@ err.toString();
       `,
       options: [{ ignoredTypeNames: ['UnknownBase'] }],
     },
+    {
+      code: `
+interface Animal {}
+interface Dog extends Animal {}
+interface Cat extends Animal {}
 
+declare const dog: Dog;
+declare const cat: Cat;
+cat.toString();
+      `,
+      options: [{ ignoredTypeNames: ['Animal'] }],
+    },
     `
 function String(value) {
   return value;
@@ -2307,6 +2318,24 @@ labrador.toString();
           data: {
             certainty: 'will',
             name: 'labrador',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+    },
+    {
+      code: `
+interface A extends B {}
+interface B extends A {}
+
+declare const a: A;
+a.toString();
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'will',
+            name: 'a',
           },
           messageId: 'baseToString',
         },

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -2341,5 +2341,25 @@ a.toString();
         },
       ],
     },
+    {
+      code: `
+        interface Base {}
+        interface Left extends Base {}
+        interface Right extends Base {}
+        interface Diamond extends Left, Right {}
+
+        declare const d: Diamond;
+        d.toString();
+      `,
+      errors: [
+        {
+          data: {
+            certainty: 'will',
+            name: 'd',
+          },
+          messageId: 'baseToString',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -336,12 +336,12 @@ whiskers.toString();
       options: [{ ignoredTypeNames: ['Animal'] }],
     },
     {
-  code: `
+      code: `
 interface MyError extends Error {}
 
 declare const error: MyError;
 error.toString();
-  `,
+      `,
     },
     {
       code: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11520
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Added isIgnoredTypeOrBase to ensure that a type’s superclass or extended interfaces are properly checked against the ignored types list.
