### PR TITLE
fix(ast-spec): cleanup `TSLiteralType`

### DIFF
--- a/packages/ast-spec/src/expression/UnaryExpression/spec.ts
+++ b/packages/ast-spec/src/expression/UnaryExpression/spec.ts
@@ -1,7 +1,31 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { UnaryExpressionBase } from '../../base/UnaryExpressionBase';
 
-export interface UnaryExpression extends UnaryExpressionBase {
+interface UnaryExpressionSpecific<T extends string>
+  extends UnaryExpressionBase {
   type: AST_NODE_TYPES.UnaryExpression;
-  operator: '!' | '+' | '-' | 'delete' | 'typeof' | 'void' | '~';
+  operator: T;
 }
+
+export type UnaryExpressionNot = UnaryExpressionSpecific<'!'>;
+
+export type UnaryExpressionPlus = UnaryExpressionSpecific<'+'>;
+
+export type UnaryExpressionMinus = UnaryExpressionSpecific<'-'>;
+
+export type UnaryExpressionDelete = UnaryExpressionSpecific<'delete'>;
+
+export type UnaryExpressionTypeof = UnaryExpressionSpecific<'typeof'>;
+
+export type UnaryExpressionVoid = UnaryExpressionSpecific<'void'>;
+
+export type UnaryExpressionBitwiseNot = UnaryExpressionSpecific<'~'>;
+
+export type UnaryExpression =
+  | UnaryExpressionBitwiseNot
+  | UnaryExpressionDelete
+  | UnaryExpressionMinus
+  | UnaryExpressionNot
+  | UnaryExpressionPlus
+  | UnaryExpressionTypeof
+  | UnaryExpressionVoid;

--- a/packages/ast-spec/src/type/TSLiteralType/spec.ts
+++ b/packages/ast-spec/src/type/TSLiteralType/spec.ts
@@ -2,12 +2,16 @@ import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
 import type { NullLiteral } from '../../expression/literal/NullLiteral/spec';
 import type { RegExpLiteral } from '../../expression/literal/RegExpLiteral/spec';
-import type { UnaryExpression } from '../../expression/UnaryExpression/spec';
+import type {
+  UnaryExpressionMinus,
+  UnaryExpressionPlus,
+} from '../../expression/UnaryExpression/spec';
 import type { LiteralExpression } from '../../unions/LiteralExpression';
 
 export interface TSLiteralType extends BaseNode {
   type: AST_NODE_TYPES.TSLiteralType;
   literal:
     | Exclude<LiteralExpression, NullLiteral | RegExpLiteral>
-    | (UnaryExpression & { operator: '+' | '-' });
+    | UnaryExpressionMinus
+    | UnaryExpressionPlus;
 }

--- a/packages/ast-spec/src/type/TSLiteralType/spec.ts
+++ b/packages/ast-spec/src/type/TSLiteralType/spec.ts
@@ -1,10 +1,13 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
+import type { NullLiteral } from '../../expression/literal/NullLiteral/spec';
+import type { RegExpLiteral } from '../../expression/literal/RegExpLiteral/spec';
 import type { UnaryExpression } from '../../expression/UnaryExpression/spec';
-import type { UpdateExpression } from '../../expression/UpdateExpression/spec';
 import type { LiteralExpression } from '../../unions/LiteralExpression';
 
 export interface TSLiteralType extends BaseNode {
   type: AST_NODE_TYPES.TSLiteralType;
-  literal: LiteralExpression | UnaryExpression | UpdateExpression;
+  literal:
+    | Exclude<LiteralExpression, NullLiteral | RegExpLiteral>
+    | (UnaryExpression & { operator: '+' | '-' });
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11587
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

From @bradzacher's proposal in #11587:

- Remove `UpdateExpression` from the type
- Refine the `Literal` union to just the valid literals
- Refine the `UnaryExpression` to just the valid operators
