### PR TITLE
chore: update test fixtures to avoid spellcheck error

### DIFF
--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/fixture.ts
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/fixture.ts
@@ -1,3 +1,3 @@
 class Foo {
-  accessor '\u{63}onstructor'
+  accessor 'construct\u{6f}r'
 }

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
@@ -3,7 +3,7 @@
 exports[`AST Fixtures > element > AccessorProperty > _error_ > key-constructor-string-escaped > TSESTree - Error`]
 TSError
   1 | class Foo {
-> 2 |   accessor '\u{63}onstructor'
+> 2 |   accessor 'construct\u{6f}r'
     |            ^^^^^^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
   3 | }
   4 |

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -7,4 +7,4 @@ BabelError
     |            ^ Classes may not have a field named 'constructor'. (2:11)
   3 | }
   4 |
-
+  

--- a/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/AccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -3,8 +3,8 @@
 exports[`AST Fixtures > element > AccessorProperty > _error_ > key-constructor-string-escaped > Babel - Error`]
 BabelError
   1 | class Foo {
-> 2 |   accessor '\u{63}onstructor'
+> 2 |   accessor 'construct\u{6f}r'
     |            ^ Classes may not have a field named 'constructor'. (2:11)
   3 | }
   4 |
-  
+

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/fixture.ts
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/fixture.ts
@@ -1,3 +1,3 @@
 class Foo {
-  '\u{63}onstructor'
+  'construct\u{6f}r'
 }

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
@@ -3,7 +3,7 @@
 exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-string-escaped > TSESTree - Error`]
 TSError
   1 | class Foo {
-> 2 |   '\u{63}onstructor'
+> 2 |   'construct\u{6f}r'
     |   ^^^^^^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
   3 | }
   4 |

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -3,8 +3,8 @@
 exports[`AST Fixtures > element > PropertyDefinition > _error_ > key-constructor-string-escaped > Babel - Error`]
 BabelError
   1 | class Foo {
-> 2 |   '\u{63}onstructor'
+> 2 |   'construct\u{6f}r'
     |   ^ Classes may not have a field named 'constructor'. (2:2)
   3 | }
   4 |
-  
+

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -7,4 +7,4 @@ BabelError
     |   ^ Classes may not have a field named 'constructor'. (2:2)
   3 | }
   4 |
-
+  

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/fixture.ts
@@ -1,3 +1,3 @@
 abstract class Foo {
-  accessor '\u{63}onstructor'
+  accessor 'construct\u{6f}r'
 }

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
@@ -3,7 +3,7 @@
 exports[`AST Fixtures > element > TSAbstractAccessorProperty > _error_ > key-constructor-string-escaped > TSESTree - Error`]
 TSError
   1 | abstract class Foo {
-> 2 |   accessor '\u{63}onstructor'
+> 2 |   accessor 'construct\u{6f}r'
     |            ^^^^^^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
   3 | }
   4 |

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -7,4 +7,4 @@ BabelError
     |            ^ Classes may not have a field named 'constructor'. (2:11)
   3 | }
   4 |
-
+  

--- a/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractAccessorProperty/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -3,8 +3,8 @@
 exports[`AST Fixtures > element > TSAbstractAccessorProperty > _error_ > key-constructor-string-escaped > Babel - Error`]
 BabelError
   1 | abstract class Foo {
-> 2 |   accessor '\u{63}onstructor'
+> 2 |   accessor 'construct\u{6f}r'
     |            ^ Classes may not have a field named 'constructor'. (2:11)
   3 | }
   4 |
-  
+

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/fixture.ts
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/fixture.ts
@@ -1,3 +1,3 @@
 abstract class Foo {
-  '\u{63}onstructor'
+  'construct\u{6f}r'
 }

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/1-TSESTree-Error.shot
@@ -3,7 +3,7 @@
 exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-string-escaped > TSESTree - Error`]
 TSError
   1 | abstract class Foo {
-> 2 |   '\u{63}onstructor'
+> 2 |   'construct\u{6f}r'
     |   ^^^^^^^^^^^^^^^^^^ Classes may not have a field named 'constructor'.
   3 | }
   4 |

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -7,4 +7,4 @@ BabelError
     |   ^ Classes may not have a field named 'constructor'. (2:2)
   3 | }
   4 |
-
+  

--- a/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/TSAbstractPropertyDefinition/fixtures/_error_/key-constructor-string-escaped/snapshots/2-Babel-Error.shot
@@ -3,8 +3,8 @@
 exports[`AST Fixtures > element > TSAbstractPropertyDefinition > _error_ > key-constructor-string-escaped > Babel - Error`]
 BabelError
   1 | abstract class Foo {
-> 2 |   '\u{63}onstructor'
+> 2 |   'construct\u{6f}r'
     |   ^ Classes may not have a field named 'constructor'. (2:2)
   3 | }
   4 |
-  
+


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

When I [update @​typescript-eslint/typescript-estree](https://github.com/prettier/prettier/pull/17931) with changes from #​11590 in Prettier, I found that CSpell reports on original fixtures, use  `'construct\u{6f}r'` instead of `'\u{63}onstructor'` fixed it.
