### PR TITLE
fix: disable generating declaration maps

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
     "allowSyntheticDefaultImports": true,
     "composite": true,
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": false,
     "emitDeclarationOnly": true,
     "emitDecoratorMetadata": false,
     "esModuleInterop": true,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11613
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Disables generating `.d.ts.map` files when building packages.

NOTE: The issue isn't marked accepting prs, but the fix is really simple so I thought to submit it for now.
