### PR TITLE
chore: slightly improve `convertComments`

### DIFF
--- a/packages/typescript-estree/src/convert-comments.ts
+++ b/packages/typescript-estree/src/convert-comments.ts
@@ -34,14 +34,14 @@ export function convertComments(
       const textEnd =
         comment.kind === ts.SyntaxKind.SingleLineCommentTrivia
           ? // single line comments end at the end
-            range[1] - textStart
+            range[1]
           : // multiline comments end 2 characters early
-            range[1] - textStart - 2;
+            range[1] - 2;
       comments.push({
         type,
         loc,
         range,
-        value: code.slice(textStart, textStart + textEnd),
+        value: code.slice(textStart, textEnd),
       });
     },
     ast,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

The `textEnd` is actually the length of the value text of the comment, but `textEnd` is what we needed.
