### PR TITLE
fix(eslint-plugin): [unbound-method] improve wording around `this: void` and binding

### DIFF
--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -100,8 +100,10 @@ const isNotImported = (
   );
 };
 
-const BASE_MESSAGE =
-  'Avoid referencing unbound methods which may cause unintentional scoping of `this`.';
+const BASE_MESSAGE = [
+  `A method that is not declared with \`this: void\` may cause unintentional scoping of \`this\` when separated from its object.`,
+  `Consider using an arrow function or explicitly \`.bind()\`ing the method to avoid calling the method with an unintended \`this\` value. `,
+].join('\n');
 
 export default createRule<Options, MessageIds>({
   name: 'unbound-method',
@@ -115,7 +117,7 @@ export default createRule<Options, MessageIds>({
     },
     messages: {
       unbound: BASE_MESSAGE,
-      unboundWithoutThisAnnotation: `${BASE_MESSAGE}\nIf your function does not access \`this\`, you can annotate it with \`this: void\`, or consider using an arrow function instead.`,
+      unboundWithoutThisAnnotation: `${BASE_MESSAGE}\nIf a function does not access \`this\`, it can be annotated with \`this: void\`.`,
     },
     schema: [
       {

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unbound-method.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unbound-method.shot
@@ -10,14 +10,16 @@ const instance = new MyClass();
 
 // This logs the global scope (`window`/`global`), not the class instance
 const myLog = instance.log;
-              ~~~~~~~~~~~~ Avoid referencing unbound methods which may cause unintentional scoping of `this`.
-                           If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
+              ~~~~~~~~~~~~ A method that is not declared with `this: void` may cause unintentional scoping of `this` when separated from its object.
+                           Consider using an arrow function or explicitly `.bind()`ing the method to avoid calling the method with an unintended `this` value. 
+                           If a function does not access `this`, it can be annotated with `this: void`.
 myLog();
 
 // This log might later be called with an incorrect scope
 const { log } = instance;
-        ~~~ Avoid referencing unbound methods which may cause unintentional scoping of `this`.
-            If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
+        ~~~ A method that is not declared with `this: void` may cause unintentional scoping of `this` when separated from its object.
+            Consider using an arrow function or explicitly `.bind()`ing the method to avoid calling the method with an unintended `this` value. 
+            If a function does not access `this`, it can be annotated with `this: void`.
 
 // arith.double may refer to `this` internally
 const arith = {
@@ -26,8 +28,9 @@ const arith = {
   },
 };
 const { double } = arith;
-        ~~~~~~ Avoid referencing unbound methods which may cause unintentional scoping of `this`.
-               If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
+        ~~~~~~ A method that is not declared with `this: void` may cause unintentional scoping of `this` when separated from its object.
+               Consider using an arrow function or explicitly `.bind()`ing the method to avoid calling the method with an unintended `this` value. 
+               If a function does not access `this`, it can be annotated with `this: void`.
 
 Correct
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10056
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Generally applies the phrasing suggested in https://github.com/typescript-eslint/typescript-eslint/issues/10056#issuecomment-2374507181. I also tweaked the `unboundWithoutThisAnnotation` to speak generally, rather than suggest user action on the specific function.
 
Co-authored-by: @kirkwaiblinger

💖