### PR TITLE
fix(ast-spec): narrow ArrowFunctionExpression.generator to false

### DIFF
--- a/packages/ast-spec/src/expression/ArrowFunctionExpression/spec.ts
+++ b/packages/ast-spec/src/expression/ArrowFunctionExpression/spec.ts
@@ -11,7 +11,7 @@ export interface ArrowFunctionExpression extends BaseNode {
   async: boolean;
   body: BlockStatement | Expression;
   expression: boolean;
-  generator: boolean;
+  generator: false;
   id: null;
   params: Parameter[];
   returnType: TSTypeAnnotation | undefined;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #8140
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Narrows it from the general `boolean` to `false` per discussion in the issue.

💖