### PR TITLE
docs(eslint-plugin): [no-base-to-string] remove incorrect ignoredTypeNames description of regular expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -60,8 +60,7 @@ export default createRule<Options, MessageIds>({
           },
           ignoredTypeNames: {
             type: 'array',
-            description:
-              'Stringified regular expressions of type names to ignore.',
+            description: 'Stringified type names to ignore.',
             items: {
               type: 'string',
             },

--- a/packages/eslint-plugin/tests/schema-snapshots/no-base-to-string.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-base-to-string.shot
@@ -10,7 +10,7 @@
         "type": "boolean"
       },
       "ignoredTypeNames": {
-        "description": "Stringified regular expressions of type names to ignore.",
+        "description": "Stringified type names to ignore.",
         "items": {
           "type": "string"
         },
@@ -28,7 +28,7 @@ type Options = [
   {
     /** Whether to also check values of type `unknown` */
     checkUnknown?: boolean;
-    /** Stringified regular expressions of type names to ignore. */
+    /** Stringified type names to ignore. */
     ignoredTypeNames?: string[];
   },
 ];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11420
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

💖