### PR TITLE
chore(website): lint for missing `g` flag

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -322,6 +322,7 @@ export default defineConfig(
       'jsdoc/tag-lines': 'off',
 
       'regexp/no-dupe-disjunctions': 'error',
+      'regexp/no-missing-g-flag': 'error',
       'regexp/no-useless-character-class': 'error',
       'regexp/no-useless-flag': 'error',
       'regexp/no-useless-lazy': 'error',

--- a/packages/website/src/components/editor/createProvideTwoslashInlay.ts
+++ b/packages/website/src/components/editor/createProvideTwoslashInlay.ts
@@ -9,7 +9,7 @@ import type { SandboxInstance } from './useSandboxServices';
 
 function findTwoshashQueries(code: string): RegExpExecArray[] {
   // RegExp that matches '^<spaces>//?<spaces>$'
-  const twoslashQueryRegex = /^(\s*\/\/\s*\^\?)\s*$/m;
+  const twoslashQueryRegex = /^(\s*\/\/\s*\^\?)\s*$/gm;
   return [...code.matchAll(twoslashQueryRegex)];
 }
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

While looking into other website issues, I noticed that @kirkwaiblinger's work in #11558 introduced a runtime error, because it removed a `g` flag from a regular expression that is passed to `String#matchAll`, which does require a `g` flag.

This PR fixes this issue, as well as enabling `regexp/no-missing-g-flag` (which did successfully identify this issue) to prevent this from occurring again.