### PR TITLE
fix(eslint-plugin): [prefer-readonly-parameter-types] ignore tagged primitives

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
@@ -7,6 +7,7 @@ import type { TypeOrValueSpecifier } from '../util';
 import {
   createRule,
   getParserServices,
+  isTypeBrandedLiteral,
   isTypeReadonly,
   readonlynessOptionsDefaults,
   readonlynessOptionsSchema,
@@ -129,7 +130,7 @@ export default createRule<Options, MessageIds>({
             treatMethodsAsReadonly: !!treatMethodsAsReadonly,
           });
 
-          if (!isReadOnly) {
+          if (!isReadOnly && !isTypeBrandedLiteral(type)) {
             context.report({
               node: actualParam,
               messageId: 'shouldBeReadonly',

--- a/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly-parameter-types.test.ts
@@ -320,6 +320,31 @@ function foo(arg: Test) {}
 
       const willNotCrash = (foo: Readonly<WithSymbol>) => {};
     `,
+    `
+type MySpecialString = bigint & {
+  readonly ' __tag': unique symbol;
+};
+function custom1(arg: MySpecialString) {}
+    `,
+    `
+type MySpecialString = number & {
+  readonly ' __tag': unique symbol;
+};
+function custom1(arg: MySpecialString) {}
+    `,
+    `
+type MySpecialString = string & {
+  readonly ' __tag': unique symbol;
+};
+function custom1(arg: MySpecialString) {}
+    `,
+    `
+type MySpecialString = string & {
+  readonly ' __tagA': unique symbol;
+  readonly ' __tagB': unique symbol;
+};
+function custom1(arg: MySpecialString) {}
+    `,
     {
       code: `
         type Callback<T> = (options: T) => void;

--- a/packages/type-utils/src/index.ts
+++ b/packages/type-utils/src/index.ts
@@ -6,6 +6,7 @@ export * from './getDeclaration';
 export * from './getSourceFileOfNode';
 export * from './getTypeName';
 export * from './isSymbolFromDefaultLibrary';
+export * from './isTypeBrandedLiteral';
 export * from './isTypeReadonly';
 export * from './isUnsafeAssignment';
 export * from './predicates';

--- a/packages/type-utils/src/isTypeBrandedLiteral.ts
+++ b/packages/type-utils/src/isTypeBrandedLiteral.ts
@@ -1,0 +1,18 @@
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+function isIntrinsicPrimitiveType(type: ts.Type): boolean {
+  return tsutils.isTypeFlagSet(
+    type,
+    ts.TypeFlags.BigInt | ts.TypeFlags.Number | ts.TypeFlags.String,
+  );
+}
+
+export function isTypeBrandedLiteral(type: ts.Type): boolean {
+  return (
+    type.isIntersection() &&
+    type.types.length === 2 &&
+    type.types.some(isIntrinsicPrimitiveType) &&
+    type.types.some(subType => tsutils.isObjectType(subType))
+  );
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1790
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a special-case exemption for an intersection of a literal and an object, as suggested in https://github.com/typescript-eslint/typescript-eslint/issues/1790#issuecomment-602916305.

💖