### PR TITLE
Revert "feat(eslint-plugin): expose rule name via RuleModule interface"

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-eslint.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-eslint.test.ts
@@ -40,7 +40,6 @@ ruleTester.defineRule('use-every-a', {
     schema: [],
     type: 'problem',
   },
-  name: 'use-every-a',
 });
 
 /**

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -32,7 +32,6 @@ ruleTester.defineRule('collect-unused-vars', {
     schema: [],
     type: 'problem',
   },
-  name: 'collect-unused-vars',
 });
 
 ruleTester.run('no-unused-vars', rule, {

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -94,7 +94,6 @@ const NOOP_RULE: RuleModule<'error'> = {
     schema: [],
     type: 'problem',
   },
-  name: 'rule',
 };
 
 function windowsToPosixPath(p: string): string {
@@ -1109,7 +1108,6 @@ describe('RuleTester - hooks', () => {
       schema: [],
       type: 'problem',
     },
-    name: 'rule',
   };
 
   const ruleTester = new RuleTester();
@@ -1333,7 +1331,6 @@ describe('RuleTester - multipass fixer', () => {
         schema: [],
         type: 'problem',
       },
-      name: 'rule',
     };
 
     it('passes with no output', () => {
@@ -1419,7 +1416,6 @@ describe('RuleTester - multipass fixer', () => {
         schema: [],
         type: 'problem',
       },
-      name: 'rule',
     };
 
     it('passes with correct string output', () => {
@@ -1542,7 +1538,6 @@ describe('RuleTester - multipass fixer', () => {
         schema: [],
         type: 'problem',
       },
-      name: 'rule',
     };
 
     it('passes with correct array output', () => {
@@ -1649,7 +1644,6 @@ describe('RuleTester - run types', () => {
       ],
       type: 'suggestion',
     },
-    name: 'rule',
   };
 
   describe('infer from `rule` parameter', () => {

--- a/packages/rule-tester/tests/filename.test.ts
+++ b/packages/rule-tester/tests/filename.test.ts
@@ -19,7 +19,6 @@ const rule = ESLintUtils.RuleCreator.withoutDocs({
     type: 'problem',
     hasSuggestions: true,
   },
-  name: 'rule',
   defaultOptions: [],
   create: context => ({
     Program(node): void {

--- a/packages/utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/utils/src/eslint-utils/RuleCreator.ts
@@ -36,7 +36,6 @@ export interface RuleWithMeta<
   Docs = unknown,
 > extends RuleCreateAndOptions<Options, MessageIds> {
   meta: RuleMetaData<MessageIds, Docs, Options>;
-  name: string;
 }
 
 export interface RuleWithMetaAndName<
@@ -77,7 +76,6 @@ export function RuleCreator<PluginDocs = unknown>(
           url: urlCreator(name),
         },
       },
-      name,
       ...rule,
     });
   };
@@ -91,7 +89,6 @@ function createRule<
   create,
   defaultOptions,
   meta,
-  name,
 }: Readonly<RuleWithMeta<Options, MessageIds, PluginDocs>>): RuleModule<
   MessageIds,
   Options,
@@ -104,7 +101,6 @@ function createRule<
     },
     defaultOptions,
     meta,
-    name,
   };
 }
 

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -735,11 +735,6 @@ export interface RuleModule<
    * Metadata about the rule
    */
   meta: RuleMetaData<MessageIds, Docs, Options>;
-
-  /**
-   * Rule name
-   */
-  name: string;
 }
 
 export type AnyRuleModule = RuleModule<string, readonly unknown[]>;


### PR DESCRIPTION
Reverts typescript-eslint/typescript-eslint#11616

I'd like to get the change back in, but it's non-trivial to work around #11662.