### PR TITLE
fix(eslint-plugin): [no-misused-promises] special-case `.finally` not to report when a promise returning function is provided as an argument

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -1096,6 +1096,13 @@ declare const useCallback: <T extends (...args: unknown[]) => unknown>(
 ) => T;
 useCallback<ReturnsVoid | ReturnsPromiseVoid>(async () => {});
     `,
+    `
+Promise.reject(3).finally(async () => {});
+    `,
+    `
+const f = 'finally';
+Promise.reject(3)[f](async () => {});
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10959
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR addresses #10959 and special-cases the `.finally` handler not to report when a promise returning function is provided as an argument:

```ts
Promise.reject(3).finally(async () => {});
```
