### PR TITLE
fix(eslint-plugin): [no-misused-promises] expand union type to retrieve target property

### DIFF
--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -502,10 +502,10 @@ export default createRule<Options, MessageId>({
         if (objType == null) {
           return;
         }
-        const propertySymbol = checker.getPropertyOfType(
-          objType,
-          tsNode.name.text,
-        );
+        const propertySymbol = tsutils
+          .unionConstituents(objType)
+          .map(t => checker.getPropertyOfType(t, tsNode.name.getText()))
+          .find(p => p);
         if (propertySymbol == null) {
           return;
         }

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -2653,5 +2653,22 @@ const obj: O = {
         },
       ],
     },
+    {
+      code: `
+type A = { f: () => void } | undefined;
+const a: A = {
+  async f() {},
+};
+      `,
+      errors: [
+        {
+          column: 3,
+          endColumn: 10,
+          endLine: 4,
+          line: 4,
+          messageId: 'voidReturnProperty',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11699
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
For union type, `getPropertyOfType(type, name)` can’t get property that exist only in one constituent. We need to manually expand the union and check each constituent, and `unionConstituents` helper is a good choice for this and also works with non-union type.

💖

<!-- Description of what is changed and how the code change does that. -->
