### PR TITLE
chore(eslint-plugin): use correct type for return type of `createValidator`

### DIFF
--- a/packages/eslint-plugin/src/rules/naming-convention-utils/validator.ts
+++ b/packages/eslint-plugin/src/rules/naming-convention-utils/validator.ts
@@ -4,7 +4,7 @@ import type * as ts from 'typescript';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import type { SelectorsString } from './enums';
-import type { Context, NormalizedSelector } from './types';
+import type { Context, NormalizedSelector, ValidatorFunction } from './types';
 
 import { getParserServices } from '../../util';
 import {
@@ -26,9 +26,7 @@ export function createValidator(
   type: SelectorsString,
   context: Context,
   allConfigs: NormalizedSelector[],
-): (
-  node: TSESTree.Identifier | TSESTree.Literal | TSESTree.PrivateIdentifier,
-) => void {
+): ValidatorFunction {
   // make sure the "highest priority" configs are checked first
   const selectorType = Selectors[type];
   const configs = allConfigs
@@ -72,10 +70,7 @@ export function createValidator(
       return b.selector - a.selector;
     });
 
-  return (
-    node: TSESTree.Identifier | TSESTree.Literal | TSESTree.PrivateIdentifier,
-    modifiers: Set<Modifiers> = new Set<Modifiers>(),
-  ): void => {
+  return (node, modifiers = new Set<Modifiers>()): void => {
     const originalName =
       node.type === AST_NODE_TYPES.Identifier ||
       node.type === AST_NODE_TYPES.PrivateIdentifier


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

While working on #11720, I noticed that the return type of the function is typed as a callback with one parameter, but is actually returning a callback with two parameters. It's now using the correct type and simultaneously with five lines less code.