### PR TITLE
fix: resolves 'TypeError: typeParameters.params is not iterable' and 'TypeError: Cannot read properties of undefined (reading 'name')'

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -388,7 +388,7 @@ export default createRule<Options, MessageIds>({
     function getIsTypeParameter(
       typeParameters?: TSESTree.TSTypeParameterDeclaration,
     ): IsTypeParameter {
-      if (!typeParameters || !typeParameters.params) {
+      if (!typeParameters?.params) {
         return (() => false) as IsTypeParameter;
       }
 
@@ -396,7 +396,7 @@ export default createRule<Options, MessageIds>({
       for (const t of typeParameters.params) {
         // sometimes type parameters don't have names e.g. Promise<{foo: number}>
         if (t.name == null) {
-            continue;
+          continue;
         }
         set.add(t.name.name);
       }


### PR DESCRIPTION
The first change fixed:

```
> ramblefeed-workspace@0.1.0 lint
> eslint --max-warnings 65

Oops! Something went wrong! :(

ESLint: 9.39.0

TypeError: typeParameters.params is not iterable
Occurred while linting /Users/scott/src/activescott/ramblefeed/packages/web-app/app/lib/components/note-card.tsx:15
Rule: "@typescript-eslint/unified-signatures"
    at getIsTypeParameter (/Users/scott/src/activescott/ramblefeed/node_modules/@typescript-eslint/eslint-plugin/dist/rules/unified-signatures.js:242:44)
    at checkOverloads (/Users/scott/src/activescott/ramblefeed/node_modules/@typescript-eslint/eslint-plugin/dist/rules/unified-signatures.js:99:37)
    at checkScope (/Users/scott/src/activescott/ramblefeed/node_modules/@typescript-eslint/eslint-plugin/dist/rules/unified-signatures.js:344:30)
    at ruleErrorHandler (/Users/scott/src/activescott/ramblefeed/node_modules/eslint/lib/linter/linter.js:1173:33)
    at /Users/scott/src/activescott/ramblefeed/node_modules/eslint/lib/linter/source-code-visitor.js:76:46
    at Array.forEach (<anonymous>)
    at SourceCodeVisitor.callSync (/Users/scott/src/activescott/ramblefeed/node_modules/eslint/lib/linter/source-code-visitor.js:76:30)
    at /Users/scott/src/activescott/ramblefeed/node_modules/eslint/lib/linter/source-code-traverser.js:306:18
    at Array.forEach (<anonymous>)
    at SourceCodeTraverser.traverseSync (/Users/scott/src/activescott/ramblefeed/node_modules/eslint/lib/linter/source-code-traverser.js:305:10)
```

The second change just below there then fixed the following error and lint then was able to run successfully. I'm not sure the cause of the first one the second one was surprisingly straightforward, but a little too surprising. Maybe the first fix allowed the second error to manifest?

```
> ramblefeed-workspace@0.1.0 lint
> eslint --max-warnings 65

Oops! Something went wrong! :(

ESLint: 9.39.0

TypeError: Cannot read properties of undefined (reading 'name')
Occurred while linting /Users/scott/src/activescott/ramblefeed/packages/web-app/app/lib/repositories/note.ts:689
Rule: "@typescript-eslint/unified-signatures"
    at getIsTypeParameter (/Users/scott/src/activescott/ramblefeed/node_modules/@typescript-eslint/eslint-plugin/dist/rules/unified-signatures.js:243:32)
    at checkOverloads (/Users/scott/src/activescott/ramblefeed/node_modules/@typescript-eslint/eslint-plugin/dist/rules/unified-signatures.js:99:37)
    at checkScope (/Users/scott/src/activescott/ramblefeed/node_modules/@typescript-eslint/eslint-plugin/dist/rules/unified-signatures.js:344:30)
    at ruleErrorHandler (/Users/scott/src/activescott/ramblefeed/node_modules/eslint/lib/linter/linter.js:1173:33)
    at /Users/scott/src/activescott/ramblefeed/node_modules/eslint/lib/linter/source-code-visitor.js:76:46
    at Array.forEach (<anonymous>)
    at SourceCodeVisitor.callSync (/Users/scott/src/activescott/ramblefeed/node_modules/eslint/lib/linter/source-code-visitor.js:76:30)
    at /Users/scott/src/activescott/ramblefeed/node_modules/eslint/lib/linter/source-code-traverser.js:306:18
    at Array.forEach (<anonymous>)
    at SourceCodeTraverser.traverseSync (/Users/scott/src/activescott/ramblefeed/node_modules/eslint/lib/linter/source-code-traverser.js:305:10)
```

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
