### PR TITLE
feat(eslint-plugin): [no-unnecessary-condition] detect unnecessary `Array.isArray` calls

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -580,31 +580,6 @@ export default createRule<Options, MessageId>({
       checkNode(node.test);
     }
 
-    function isArrayIsArrayCall(node: TSESTree.CallExpression): boolean {
-      if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
-        return false;
-      }
-
-      const { computed, object, property } = node.callee;
-
-      if (!isIdentifier(object) || object.name !== 'Array') {
-        return false;
-      }
-
-      if (computed) {
-        return (
-          node.callee.property.type === AST_NODE_TYPES.Literal &&
-          node.callee.property.value === 'isArray'
-        );
-      }
-
-      return (
-        isIdentifier(property) &&
-        property.name === 'isArray' &&
-        !node.callee.optional
-      );
-    }
-
     function checkCallExpression(node: TSESTree.CallExpression): void {
       if (checkTypePredicates) {
         const truthinessAssertedArgument = findTruthinessAssertedArgument(
@@ -624,15 +599,12 @@ export default createRule<Options, MessageId>({
             services,
             typeGuardAssertedArgument.argument,
           );
-          const isArrayCheck = isArrayIsArrayCall(node);
-          const typesMatch = isArrayCheck
-            ? checker.isTypeAssignableTo(
-                typeOfArgument,
-                typeGuardAssertedArgument.type,
-              )
-            : typeOfArgument === typeGuardAssertedArgument.type;
-
-          if (typesMatch) {
+          if (
+            checker.isTypeAssignableTo(
+              typeOfArgument,
+              typeGuardAssertedArgument.type,
+            )
+          ) {
             context.report({
               node: typeGuardAssertedArgument.argument,
               messageId: 'typeGuardAlreadyIsType',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1138,6 +1138,55 @@ isString('falafel');
       `,
       options: [{ checkTypePredicates: true }],
     },
+
+    {
+      code: `
+const items: number[] | null = [1, 2, 3];
+if (Array.isArray(items)) {
+  console.log('items is an array');
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+const items: number[] | string = [1, 2, 3];
+if (Array.isArray(items)) {
+  console.log('items is an array');
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+const items: unknown = [1, 2, 3];
+if (Array.isArray(items)) {
+  console.log('items is an array');
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+function process(value: string | number[]) {
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+  return value.length;
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+const items: number[] = [1, 2, 3];
+if (Array.isArray(items)) {
+  console.log('items is an array');
+}
+      `,
+      options: [{ checkTypePredicates: false }],
+    },
+
     `
 type A = { [name in Lowercase<string>]?: A };
 declare const a: A;
@@ -3513,6 +3562,68 @@ isString('fa' + 'lafel');
       errors: [
         {
           line: 4,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+const items: number[] = [1, 2, 3];
+if (Array.isArray(items)) {
+  console.log('items is an array');
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+const items: string[] = ['a', 'b'];
+Array.isArray(items);
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+const matrix: number[][] = [
+  [1, 2],
+  [3, 4],
+];
+if (Array.isArray(matrix)) {
+  console.log('matrix is an array');
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+function processArray(arr: readonly string[]) {
+  if (Array.isArray(arr)) {
+    return arr.length;
+  }
+}
+      `,
+      errors: [
+        {
+          line: 3,
           messageId: 'typeGuardAlreadyIsType',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1123,10 +1123,26 @@ isString(a);
       options: [{ checkTypePredicates: false }],
     },
     {
+      // Technically, this has type 'falafel' and not string.
+      code: `
+declare function assertString(x: unknown): asserts x is string;
+assertString('falafel');
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // Technically, this has type 'falafel' and not string.
+      code: `
+declare function isString(x: unknown): x is string;
+isString('falafel');
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
       code: `
 declare const items: number[] | null;
 if (Array.isArray(items)) {
-  console.log('items is an array');
+  console.log(items.length);
 }
       `,
       options: [{ checkTypePredicates: true }],
@@ -1135,7 +1151,7 @@ if (Array.isArray(items)) {
       code: `
 declare const items: number[] | string;
 if (Array.isArray(items)) {
-  console.log('items is an array');
+  console.log(items.length);
 }
       `,
       options: [{ checkTypePredicates: true }],
@@ -1144,18 +1160,26 @@ if (Array.isArray(items)) {
       code: `
 declare const items: unknown;
 if (Array.isArray(items)) {
-  console.log('items is an array');
+  console.log(items.length);
 }
       `,
       options: [{ checkTypePredicates: true }],
     },
     {
       code: `
-function process(value: string | number[]) {
-  if (Array.isArray(value)) {
-    return value.length;
-  }
-  return value.length;
+declare const items: any;
+if (Array.isArray(items)) {
+  console.log(items.length);
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+declare const MaybeArray: typeof Array | undefined;
+declare const items: number[];
+if (MaybeArray?.isArray(items)) {
+  console.log(items.length);
 }
       `,
       options: [{ checkTypePredicates: true }],
@@ -1163,13 +1187,22 @@ function process(value: string | number[]) {
     {
       code: `
 declare const items: number[];
-if (Array.isArray(items)) {
-  console.log('items is an array');
+if (Array['isArray'](items)) {
+  console.log(items.length);
 }
       `,
-      options: [{ checkTypePredicates: false }],
+      options: [{ checkTypePredicates: true }],
     },
-
+    {
+      code: `
+function process<T>(value: T) {
+  if (Array.isArray(value)) {
+    console.log(value.length);
+  }
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
     `
 type A = { [name in Lowercase<string>]?: A };
 declare const a: A;
@@ -3554,7 +3587,7 @@ isString('fa' + 'lafel');
       code: `
 declare const items: number[];
 if (Array.isArray(items)) {
-  console.log('items is an array');
+  console.log(items.length);
 }
       `,
       errors: [
@@ -3580,9 +3613,9 @@ Array.isArray(items);
     },
     {
       code: `
-declare const matrix: number[][];
-if (Array.isArray(matrix)) {
-  console.log('matrix is an array');
+const tuple: [string, number] = ['a', 1];
+if (Array.isArray(tuple)) {
+  console.log(tuple[0]);
 }
       `,
       errors: [
@@ -3595,32 +3628,20 @@ if (Array.isArray(matrix)) {
     },
     {
       code: `
-declare function isString(x: unknown): x is string;
-isString('falafel');
+declare const items: string[] | number[];
+if (Array.isArray(items)) {
+  console.log(items.length);
+}
       `,
       errors: [
         {
-          column: 10,
           line: 3,
           messageId: 'typeGuardAlreadyIsType',
         },
       ],
       options: [{ checkTypePredicates: true }],
     },
-    {
-      code: `
-declare function assertString(x: unknown): asserts x is string;
-assertString('falafel');
-      `,
-      errors: [
-        {
-          column: 14,
-          line: 3,
-          messageId: 'typeGuardAlreadyIsType',
-        },
-      ],
-      options: [{ checkTypePredicates: true }],
-    },
+
     // "branded" types
     unnecessaryConditionTest('"" & {}', 'alwaysFalsy'),
     unnecessaryConditionTest('"" & { __brand: string }', 'alwaysFalsy'),

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1141,7 +1141,7 @@ isString('falafel');
 
     {
       code: `
-const items: number[] | null = [1, 2, 3];
+declare const items: number[] | null;
 if (Array.isArray(items)) {
   console.log('items is an array');
 }
@@ -1150,7 +1150,7 @@ if (Array.isArray(items)) {
     },
     {
       code: `
-const items: number[] | string = [1, 2, 3];
+declare const items: number[] | string;
 if (Array.isArray(items)) {
   console.log('items is an array');
 }
@@ -1159,7 +1159,7 @@ if (Array.isArray(items)) {
     },
     {
       code: `
-const items: unknown = [1, 2, 3];
+declare const items: unknown;
 if (Array.isArray(items)) {
   console.log('items is an array');
 }
@@ -1179,7 +1179,7 @@ function process(value: string | number[]) {
     },
     {
       code: `
-const items: number[] = [1, 2, 3];
+declare const items: number[];
 if (Array.isArray(items)) {
   console.log('items is an array');
 }
@@ -3569,7 +3569,7 @@ isString('fa' + 'lafel');
     },
     {
       code: `
-const items: number[] = [1, 2, 3];
+declare const items: number[];
 if (Array.isArray(items)) {
   console.log('items is an array');
 }
@@ -3584,7 +3584,7 @@ if (Array.isArray(items)) {
     },
     {
       code: `
-const items: string[] = ['a', 'b'];
+declare const items: string[];
 Array.isArray(items);
       `,
       errors: [
@@ -3597,28 +3597,9 @@ Array.isArray(items);
     },
     {
       code: `
-const matrix: number[][] = [
-  [1, 2],
-  [3, 4],
-];
+declare const matrix: number[][];
 if (Array.isArray(matrix)) {
   console.log('matrix is an array');
-}
-      `,
-      errors: [
-        {
-          line: 3,
-          messageId: 'typeGuardAlreadyIsType',
-        },
-      ],
-      options: [{ checkTypePredicates: true }],
-    },
-    {
-      code: `
-function processArray(arr: readonly string[]) {
-  if (Array.isArray(arr)) {
-    return arr.length;
-  }
 }
       `,
       errors: [

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1123,23 +1123,6 @@ isString(a);
       options: [{ checkTypePredicates: false }],
     },
     {
-      // Technically, this has type 'falafel' and not string.
-      code: `
-declare function assertString(x: unknown): asserts x is string;
-assertString('falafel');
-      `,
-      options: [{ checkTypePredicates: true }],
-    },
-    {
-      // Technically, this has type 'falafel' and not string.
-      code: `
-declare function isString(x: unknown): x is string;
-isString('falafel');
-      `,
-      options: [{ checkTypePredicates: true }],
-    },
-
-    {
       code: `
 declare const items: number[] | null;
 if (Array.isArray(items)) {
@@ -3610,7 +3593,34 @@ if (Array.isArray(matrix)) {
       ],
       options: [{ checkTypePredicates: true }],
     },
-
+    {
+      code: `
+declare function isString(x: unknown): x is string;
+isString('falafel');
+      `,
+      errors: [
+        {
+          column: 10,
+          line: 3,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      code: `
+declare function assertString(x: unknown): asserts x is string;
+assertString('falafel');
+      `,
+      errors: [
+        {
+          column: 14,
+          line: 3,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
     // "branded" types
     unnecessaryConditionTest('"" & {}', 'alwaysFalsy'),
     unnecessaryConditionTest('"" & { __brand: string }', 'alwaysFalsy'),

--- a/packages/rule-tester/src/utils/flat-config-schema.ts
+++ b/packages/rule-tester/src/utils/flat-config-schema.ts
@@ -423,7 +423,7 @@ const processorSchema: ObjectPropertySchema<Processor.LooseProcessorModule> = {
   },
 };
 
-type ConfigRules = Record<string, SharedConfig.RuleLevelAndOptions>;
+type ConfigRules = Record<string, SharedConfig.RuleEntry>;
 
 const rulesSchema = {
   merge(first: ConfigRules = {}, second: ConfigRules = {}): ConfigRules {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11716
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds detection of redundant Array.isArray() calls when checkTypePredicates is enabled.

Reports error when the argument is already typed as an array (including readonly arrays).
