### PR TITLE
test(eslint-plugin): [consistent-type-exports] add more shadowed imports tests

### DIFF
--- a/packages/eslint-plugin/tests/fixtures/consistent-type-exports/index.ts
+++ b/packages/eslint-plugin/tests/fixtures/consistent-type-exports/index.ts
@@ -1,6 +1,5 @@
 export type Type1 = 1;
 export type Type2 = 1;
-export type Type3 = { foo: string };
 export const value1 = 2;
 export const value2 = 2;
 

--- a/packages/eslint-plugin/tests/fixtures/consistent-type-exports/reexport-1.ts
+++ b/packages/eslint-plugin/tests/fixtures/consistent-type-exports/reexport-1.ts
@@ -1,0 +1,1 @@
+export type A = 1;

--- a/packages/eslint-plugin/tests/fixtures/consistent-type-exports/reexport-2-named.ts
+++ b/packages/eslint-plugin/tests/fixtures/consistent-type-exports/reexport-2-named.ts
@@ -1,0 +1,3 @@
+import { A } from './reexport-1';
+const A = 1;
+export { A };

--- a/packages/eslint-plugin/tests/fixtures/consistent-type-exports/reexport-2-namespace.ts
+++ b/packages/eslint-plugin/tests/fixtures/consistent-type-exports/reexport-2-namespace.ts
@@ -1,0 +1,5 @@
+import { A } from './reexport-1';
+namespace A {
+  export const b = 2;
+}
+export { A };

--- a/packages/eslint-plugin/tests/rules/consistent-type-exports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-exports.test.ts
@@ -68,9 +68,18 @@ const Type1 = 1;
 export { Type1 };
     `,
     `
-import { Type3 } from './consistent-type-exports';
-const Type3 = { foo: 'bar' };
-export { Type3 };
+export { A } from './consistent-type-exports/reexport-2-named';
+    `,
+    `
+import { A } from './consistent-type-exports/reexport-2-named';
+export { A };
+    `,
+    `
+export { A } from './consistent-type-exports/reexport-2-namespace';
+    `,
+    `
+import { A } from './consistent-type-exports/reexport-2-namespace';
+export { A };
     `,
   ],
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11761
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR fixes the consistent-type-exports rule to correctly handle cases where imported types are shadowed by local value definitions.

I noticed @ntdiary mentioned working on this in the issue comments. I've submitted my approach here - maintainers, please feel free to compare both solutions and choose the one that works best, or we can collaborate to combine the best aspects of each!
