### PR TITLE
feat(rule-tester): remove workaround for jest circular structure error

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -219,31 +219,11 @@ export class RuleTester extends TestFramework {
 
     let linterForBasePath = this.#lintersByBasePath.get(basePath);
     if (!linterForBasePath) {
-      linterForBasePath = (() => {
-        const linter = new Linter({
-          configType: 'flat',
-          cwd: basePath,
-        });
+      linterForBasePath = new Linter({
+        configType: 'flat',
+        cwd: basePath,
+      });
 
-        // This nonsense is a workaround for https://github.com/jestjs/jest/issues/14840
-        // see also https://github.com/typescript-eslint/typescript-eslint/issues/8942
-        //
-        // For some reason rethrowing exceptions skirts around the circular JSON error.
-        const oldVerify = linter.verify.bind(linter);
-        linter.verify = (
-          ...args: Parameters<Linter['verify']>
-        ): ReturnType<Linter['verify']> => {
-          try {
-            return oldVerify(...args);
-          } catch (error) {
-            throw new Error('Caught an error while linting', {
-              cause: error,
-            });
-          }
-        };
-
-        return linter;
-      })();
       this.#lintersByBasePath.set(basePath, linterForBasePath);
     }
     return linterForBasePath;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11079 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Anyone experiencing issues due to this change should be able to just upgrade to jest 30 🚀 