### PR TITLE
chore(eslint-plugin): correct TODO comment on the wrong line

### DIFF
--- a/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
+++ b/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts
@@ -28,12 +28,12 @@ const config = (
     'no-func-assign': 'off', // ts(2630)
     'no-import-assign': 'off', // ts(2632) & ts(2540)
     'no-new-native-nonconstructor': 'off', // ts(7009)
-     // "no-new-symbol" was deprecated in ESLint 9.0.0 and will be removed in
-     // ESLint v11.0.0. See:
-     // https://eslint.org/docs/latest/rules/no-new-symbol
-     // We need to keep the rule disabled until TSESLint drops support for
-     // ESlint 8. See:
-     // https://github.com/typescript-eslint/typescript-eslint/pull/8895
+    // "no-new-symbol" was deprecated in ESLint 9.0.0 and will be removed in
+    // ESLint v11.0.0. See:
+    // https://eslint.org/docs/latest/rules/no-new-symbol
+    // We need to keep the rule disabled until TSESLint drops support for
+    // ESlint 8. See:
+    // https://github.com/typescript-eslint/typescript-eslint/pull/8895
     'no-new-symbol': 'off', // ts(7009)
     'no-obj-calls': 'off', // ts(2349)
     'no-redeclare': 'off', // ts(2451)


### PR DESCRIPTION
I noticed that the TODO comment in this file was actually in the wrong spot, implying that "no-new-native-nonconstructor" was the deprecated rule instead of "no-new-symbol".

I moved the comment, and then expanded it to make it more descriptive.