### PR TITLE
chore(typescript-estree): use class property to define `TSError.name` instead of `Object.defineProperty()`

### DIFF
--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -638,6 +638,8 @@ export function convertTokens(ast: ts.SourceFile): TSESTree.Token[] {
 }
 
 export class TSError extends Error {
+  override name = 'TSError';
+
   constructor(
     message: string,
     public readonly fileName: string,
@@ -655,11 +657,6 @@ export class TSError extends Error {
     },
   ) {
     super(message);
-    Object.defineProperty(this, 'name', {
-      configurable: true,
-      enumerable: false,
-      value: new.target.name,
-    });
   }
 
   // For old version of ESLint https://github.com/typescript-eslint/typescript-eslint/pull/6556#discussion_r1123237311


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
