### PR TITLE
chore: check `VariableDeclaration` syntax error against tsNode

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -985,28 +985,27 @@ export class Converter {
 
       case SyntaxKind.VariableDeclaration: {
         const definite = !!node.exclamationToken;
-        const init = this.convertChild(node.initializer);
-        const id = this.convertBindingNameWithTypeAnnotation(
-          node.name,
-          node.type,
-          node,
-        );
+
         if (definite) {
-          if (init) {
+          if (node.initializer) {
             this.#throwError(
               node,
               'Declarations with initializers cannot also have definite assignment assertions.',
             );
-          } else if (
-            id.type !== AST_NODE_TYPES.Identifier ||
-            !id.typeAnnotation
-          ) {
+          } else if (node.name.kind !== SyntaxKind.Identifier || !node.type) {
             this.#throwError(
               node,
               'Declarations with definite assignment assertions must also have type annotations.',
             );
           }
         }
+
+        const init = this.convertChild(node.initializer);
+        const id = this.convertBindingNameWithTypeAnnotation(
+          node.name,
+          node.type,
+          node,
+        );
         return this.createNode<TSESTree.VariableDeclarator>(node, {
           type: AST_NODE_TYPES.VariableDeclarator,
           definite,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The syntax check should always check against TS node instead of ESTree node before convert, prepare for #11695


`VariableStatement` check also checking against ESTree node, but it's quite complex, will give another try in seperate PR.

<!-- Description of what is changed and how the code change does that. -->
