### PR TITLE
test(eslint-plugin): demonstrate no-redundant-type-constituents regression with failing test.

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-redundant-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-type-constituents.test.ts
@@ -269,6 +269,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
       type T = { a: 1 | 2 } | { a: 3 };
       type U = R | T;
     `,
+    `
+      type T = { a: string; b?: T[] };
+      type R = T & { b?: T[] };
+    `,
     'type T = [1, 2] | [1];',
     'type T = [1, 2, 3] | [1, 2, 4];',
     'type T = [] | [1];',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: proves #11787
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hey folks, I understand I'm deviating from the format substantially, but I figured the easiest reproduction case for this regression: https://github.com/typescript-eslint/typescript-eslint/issues/11787 would be demonstrated in the project tests themselves. I'm more than happy for this to be closed quickly and taken over independently, just trying to be as helpful as I can be!
