### PR TITLE
fix(eslint-plugin): revert "[no-redundant-type-constituents] use assignability checking for redundancy checks"

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -193,7 +193,7 @@ export default createRule<[], MessageIds>({
     }
 
     function checkUnsafeArguments(
-      args: TSESTree.CallExpressionArgument[],
+      args: TSESTree.CallExpressionArgument[] | TSESTree.Expression[],
       callee: TSESTree.Expression,
       node:
         | TSESTree.CallExpression

--- a/packages/eslint-plugin/src/rules/related-getter-setter-pairs.ts
+++ b/packages/eslint-plugin/src/rules/related-getter-setter-pairs.ts
@@ -11,7 +11,9 @@ type GetMethod = {
   returnType: TSESTree.TSTypeAnnotation;
 } & Method;
 
-type GetMethodRaw = GetMethod;
+type GetMethodRaw = {
+  returnType: TSESTree.TSTypeAnnotation | undefined;
+} & GetMethod;
 
 type SetMethod = { kind: 'set'; params: [TSESTree.Node] } & Method;
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-redundant-type-constituents.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-redundant-type-constituents.shot
@@ -22,11 +22,11 @@ type IntersectionNever = string | never;
                                   ~~~~~ 'never' is overridden by other types in this union type.
 
 type IntersectionBooleanLiteral = boolean & false;
-                                  ~~~~~~~ boolean is overridden by false in this intersection type.
+                                  ~~~~~~~ boolean is overridden by the false in this intersection type.
 type IntersectionNumberLiteral = number & 1;
-                                 ~~~~~~ number is overridden by 1 in this intersection type.
+                                 ~~~~~~ number is overridden by the 1 in this intersection type.
 type IntersectionStringLiteral = string & 'foo';
-                                 ~~~~~~ string is overridden by "foo" in this intersection type.
+                                 ~~~~~~ string is overridden by the "foo" in this intersection type.
 
 Correct
 

--- a/packages/eslint-plugin/tests/rules/no-redundant-type-constituents.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-redundant-type-constituents.test.ts
@@ -156,132 +156,8 @@ ruleTester.run('no-redundant-type-constituents', rule, {
       type U = T & string;
     `,
     "declare function fn(): never | 'foo';",
-    "declare function fn(): (never | 'foo') | 123;",
-    "declare function fn(): ((never | 4) | 'foo') | 123;",
-    'type Foo = { a: string } | { a: number };',
-    "type Foo = { a: string } | { a: 'b' | 'c' | 0 };",
-    "type Foo = { a: 'b' | 'c' | 0 } | ({ a: 1 } | { a: 'a' });",
-    'type Foo = { a: 1 } | { a: 1; b: 1 };',
-    'type Foo = { a: 1 } | ({ a: 1 } & { b: 1 });',
-    'type Foo = ({ a: 1 } & { b: 1 }) | { a: 1 };',
-    'type Foo = { a: 1 } & { b: number };',
-    'type Foo = { a: 1; b: 1 } & ({ a: 1; b: 1; c: 1 } | { a: 1 });',
-    'type Foo = ({ a: 1; b: 1; c: 1 } | { a: 1 }) & { a: 1; b: 1 };',
-    `
-      type Foo =
-        | (({ a: 1 } | { b: 1 }) & { a: 1 })
-        | (({ a: 1 } | { c: 1 }) & { a: 1 });
-    `,
-    'type Foo = { a: 1 } | { a: { a: 1 } };',
-    'type T = { [key: string]: 1 } | { a: 1 };',
-    'type T = Partial<{ a: 1; b: 1 }> | { a: 1 };',
-    "type T = Omit<{ a: 1; b: 1 }, 'a'> | { a: number; b: number };",
-    'type T = { a?: 1; b?: 1 } & { a: 1 };',
-    "type F<T> = Omit<T, 'a'> & { a: 1 };",
-    "type F<T> = Omit<T, 'a'> & { a?: 1 };",
-    "type F<T> = Omit<T, 'c'> & { a?: 1; b?: 1 };",
-    "type F<T> = Omit<T, 'c'> & { a?: 1; b: 1 };",
-    'type T = { a: { b: 1 } } & { a: { b: { c: 1 } } };',
-    `
-      interface A {
-        a: 1;
-      }
-      interface B extends A {
-        b: 1;
-      }
-      type C = A | B;
-    `,
-    'type T = { a: { b: 1 }; c: { d: 1 } } | { a: { b: 1 }; c: { d: 1; a: 1 } };',
-    'type T = Record<string, number> & { a: 1 };',
-    'type T = { [key: string]: 1 } & { a: 1 };',
-    `
-      type T = { [key: string]: 1 };
-      type U = T & { a: 1 };
-    `,
-    `
-      type T = { a: 1; b: 1 };
-      type U<K extends string> = Omit<T, K> & Required<T>;
-      type K = U<'a'>;
-      type R = K | { a: 1 };
-    `,
-    "type T = (() => string) | (() => '123');",
-    "type T = (() => string) & (() => '123');",
-    'type T = (() => { a: 1; b: 1 }) & (() => { a: 1 });',
-    'type T = (() => { a: 1; b: 1 }) | (() => { a: 1 });',
-    `
-      class A {
-        a: string;
-      }
-      class B {
-        a: '132';
-      }
-      type T = A | B;
-    `,
-    `
-      class A {
-        a: string;
-      }
-      class B {
-        a: '132';
-      }
-      type T = A & B;
-    `,
-    `
-      interface A {
-        a: 1;
-        m(): string;
-      }
-      interface B {
-        a: 1;
-        m(): '123';
-      }
-      type T = A & B;
-    `,
-    "type T = { a: { b: () => string } } | { a: { b: () => '123' } };",
-    "type T = { a: { b: () => string } } & { a: { b: () => '123' } };",
-    "type T = (() => '123') & (() => string);",
-    "type T = (() => '123') | (() => string);",
-    'type T = { a: 1 | { a: 1; b: 1 } } | { a: 1 | { b: 1 } };',
-    'type T = { a: 1 | 3 | (() => void) } | { a: 1 | 3 | 5 };',
-    'type T = { a: 1 | 3 | { c: 1 } } & { a: 1 | { b: 1 } };',
-    'type T = { a: 1 | 3 | { b: 1; c: 1 } } & { a: 1 | { b: 1 } };',
-    'type T = { a: 1 | 3 | { c: 1 } | (() => void) } & { a: 1 | { b: 1 } };',
-    "type T = { a: '1' | { b: 1 } } & { a: 1 | { b: 1 } };",
-    'type T = { a: { c: 1 } | { b: 1 } } & { a: { b: 1 } };',
-    'type T = { a: { c: 1 } | { a?: 1; b: 1 } } & { a: { b: 1 } | { a?: 1; b: 1 } };',
-    'type T = { a: { d: number } | { b: number } } & { a: { b: 1 } | { d: 1 } };',
-    `
-      type Node = {
-        value: string;
-        next?: Node;
-      };
-      type T = Node & { next: Node };
-    `,
-    `
-      type Node = {
-        value: string;
-        next: Node;
-      };
-      type T = Node | { next: Node };
-    `,
-    `
-      type R = { a: 1 } | { a: 4 };
-      type T = { a: 1 | 2 } | { a: 3 };
-      type U = R | T;
-    `,
-    'type T = [1, 2] | [1];',
-    'type T = [1, 2, 3] | [1, 2, 4];',
-    'type T = [] | [1];',
-    'type T = Array<number> | Array<string>;',
-    'type T = Array<number> | string[];',
-    'type T = [1, 2, 3] | [1, 2, 3, 4];',
-    'type T = [{ a: 1 }] | [{ a: 1; b: 1 }];',
-    'type T = [{ a: number }] | [{ a: 1; b: 1 }];',
-    'type T = [1, 2] & [1];',
-    'type T = Array<string> & [1];',
-    'type T = Array<number> & Array<string>;',
-    'type T = Array<number> & string[];',
   ],
+
   invalid: [
     {
       code: 'type T = number | any;',
@@ -444,11 +320,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 19,
           data: {
-            container: 'union',
-            nonRedundantType: 'number',
-            redundantType: '0',
+            literal: '0',
+            primitive: 'number',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -458,11 +333,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 20,
           data: {
-            container: 'union',
-            nonRedundantType: 'number',
-            redundantType: '0 | 1',
+            literal: '0 | 1',
+            primitive: 'number',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -472,11 +346,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 11,
           data: {
-            container: 'union',
-            nonRedundantType: 'number',
-            redundantType: '0 | 0',
+            literal: '0 | 0',
+            primitive: 'number',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -489,11 +362,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 19,
           data: {
-            container: 'union',
-            nonRedundantType: 'number',
-            redundantType: '2 | B',
+            literal: '2 | 0 | 1',
+            primitive: 'number',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -503,11 +375,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 11,
           data: {
-            container: 'union',
-            nonRedundantType: 'number',
-            redundantType: '0 | 1 | 2',
+            literal: '0 | 1 | 2',
+            primitive: 'number',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -517,11 +388,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 11,
           data: {
-            container: 'union',
-            nonRedundantType: 'number',
-            redundantType: '0 | 1',
+            literal: '0 | 1',
+            primitive: 'number',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -531,11 +401,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 11,
           data: {
-            container: 'union',
-            nonRedundantType: 'number',
-            redundantType: '0 | 0 | 1',
+            literal: '0 | 0 | 1',
+            primitive: 'number',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -545,11 +414,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 11,
           data: {
-            container: 'union',
-            nonRedundantType: 'number',
-            redundantType: '2 | 3',
+            literal: '2 | 3',
+            primitive: 'number',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -559,11 +427,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 10,
           data: {
-            container: 'union',
-            nonRedundantType: 'string',
-            redundantType: '""',
+            literal: '""',
+            primitive: 'string',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -576,11 +443,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 18,
           data: {
-            container: 'union',
-            nonRedundantType: 'string',
-            redundantType: '"b"',
+            literal: '"b"',
+            primitive: 'string',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -590,11 +456,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 10,
           data: {
-            container: 'union',
-            nonRedundantType: 'string',
-            redundantType: '`a${number}c`',
+            literal: 'template literal type',
+            primitive: 'string',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -607,11 +472,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 18,
           data: {
-            container: 'union',
-            nonRedundantType: 'string',
-            redundantType: '`a${number}c`',
+            literal: 'template literal type',
+            primitive: 'string',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -621,11 +485,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 10,
           data: {
-            container: 'union',
-            nonRedundantType: 'string',
-            redundantType: '`${number}`',
+            literal: 'template literal type',
+            primitive: 'string',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -635,11 +498,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 10,
           data: {
-            container: 'union',
-            nonRedundantType: 'bigint',
-            redundantType: '0n',
+            literal: '0n',
+            primitive: 'bigint',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -649,11 +511,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 10,
           data: {
-            container: 'union',
-            nonRedundantType: 'bigint',
-            redundantType: '-1n',
+            literal: '-1n',
+            primitive: 'bigint',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -663,11 +524,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 11,
           data: {
-            container: 'union',
-            nonRedundantType: 'bigint',
-            redundantType: '-1n | 1n',
+            literal: '-1n | 1n',
+            primitive: 'bigint',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -680,11 +540,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 22,
           data: {
-            container: 'union',
-            nonRedundantType: 'boolean',
-            redundantType: 'false',
+            literal: 'false',
+            primitive: 'boolean',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -694,11 +553,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 10,
           data: {
-            container: 'union',
-            nonRedundantType: 'boolean',
-            redundantType: 'false',
+            literal: 'false',
+            primitive: 'boolean',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -708,11 +566,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 10,
           data: {
-            container: 'union',
-            nonRedundantType: 'boolean',
-            redundantType: 'true',
+            literal: 'true',
+            primitive: 'boolean',
           },
-          messageId: 'typeOverridden',
+          messageId: 'literalOverridden',
         },
       ],
     },
@@ -722,11 +579,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 18,
           data: {
-            container: 'intersection',
-            nonRedundantType: 'false',
-            redundantType: 'boolean',
+            literal: 'false',
+            primitive: 'boolean',
           },
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },
@@ -739,11 +595,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 22,
           data: {
-            container: 'intersection',
-            nonRedundantType: 'false',
-            redundantType: 'boolean',
+            literal: 'false',
+            primitive: 'boolean',
           },
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },
@@ -756,11 +611,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 22,
           data: {
-            container: 'intersection',
-            nonRedundantType: 'true',
-            redundantType: 'boolean',
+            literal: 'true',
+            primitive: 'boolean',
           },
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },
@@ -770,11 +624,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 17,
           data: {
-            container: 'intersection',
-            nonRedundantType: 'true',
-            redundantType: 'boolean',
+            literal: 'true',
+            primitive: 'boolean',
           },
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },
@@ -891,11 +744,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 10,
           data: {
-            container: 'intersection',
-            nonRedundantType: '0',
-            redundantType: 'number',
+            literal: '0',
+            primitive: 'number',
           },
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },
@@ -905,11 +757,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 15,
           data: {
-            container: 'intersection',
-            nonRedundantType: '""',
-            redundantType: 'string',
+            literal: '""',
+            primitive: 'string',
           },
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },
@@ -922,11 +773,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 22,
           data: {
-            container: 'intersection',
-            nonRedundantType: '0n',
-            redundantType: 'bigint',
+            literal: '0n',
+            primitive: 'bigint',
           },
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },
@@ -936,11 +786,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 15,
           data: {
-            container: 'intersection',
-            nonRedundantType: '0n',
-            redundantType: 'bigint',
+            literal: '0n',
+            primitive: 'bigint',
           },
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },
@@ -950,11 +799,10 @@ ruleTester.run('no-redundant-type-constituents', rule, {
         {
           column: 16,
           data: {
-            container: 'intersection',
-            nonRedundantType: '-1n',
-            redundantType: 'bigint',
+            literal: '-1n',
+            primitive: 'bigint',
           },
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },
@@ -965,13 +813,12 @@ ruleTester.run('no-redundant-type-constituents', rule, {
       `,
       errors: [
         {
-          column: 22,
+          column: 18,
           data: {
-            container: 'intersection',
-            nonRedundantType: 'T',
-            redundantType: 'string',
+            literal: '"a" | "b"',
+            primitive: 'string',
           },
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },
@@ -983,1318 +830,20 @@ ruleTester.run('no-redundant-type-constituents', rule, {
       `,
       errors: [
         {
-          column: 26,
+          column: 18,
           data: {
-            container: 'intersection',
-            nonRedundantType: 'T',
-            redundantType: 'string',
+            literal: '1 | 2',
+            primitive: 'number',
           },
-          endColumn: 32,
-          line: 4,
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
-        {
-          column: 35,
-          data: {
-            container: 'intersection',
-            nonRedundantType: 'S',
-            redundantType: 'number',
-          },
-          endColumn: 41,
-          line: 4,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 } | any;',
-      errors: [
-        {
-          column: 21,
-          data: {
-            container: 'union',
-            typeName: 'any',
-          },
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: `
-        type B = { a: 1 };
-        type T = B | any;
-      `,
-      errors: [
         {
           column: 22,
           data: {
-            container: 'union',
-            typeName: 'any',
+            literal: '"a" | "b"',
+            primitive: 'string',
           },
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: 'type T = any | { a: 1 };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            typeName: 'any',
-          },
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: `
-        type B = any;
-        type T = B | { a: 1 };
-      `,
-      errors: [
-        {
-          column: 18,
-          data: {
-            container: 'union',
-            typeName: 'any',
-          },
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 } | never;',
-      errors: [
-        {
-          column: 21,
-          data: {
-            container: 'union',
-            typeName: 'never',
-          },
-          messageId: 'overridden',
-        },
-      ],
-    },
-    {
-      code: `
-        type B = { a: 1 };
-        type T = B | never;
-      `,
-      errors: [
-        {
-          column: 22,
-          data: {
-            container: 'union',
-            typeName: 'never',
-          },
-          messageId: 'overridden',
-        },
-      ],
-    },
-    {
-      code: `
-        type B = never;
-        type T = B | { a: 1 };
-      `,
-      errors: [
-        {
-          column: 18,
-          data: {
-            container: 'union',
-            typeName: 'never',
-          },
-          messageId: 'overridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = never | { a: 1 };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            typeName: 'never',
-          },
-          messageId: 'overridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 } | unknown;',
-      errors: [
-        {
-          column: 21,
-          data: {
-            container: 'union',
-            typeName: 'unknown',
-          },
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: 'type T = unknown | { a: 1 };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            typeName: 'unknown',
-          },
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: 'type ErrorTypes = NotKnown | { a: 1 };',
-      errors: [
-        {
-          column: 19,
-          data: {
-            container: 'union',
-            typeName: 'NotKnown',
-          },
-          messageId: 'errorTypeOverrides',
-        },
-      ],
-    },
-    {
-      code: 'type Foo = { a: 1 | 2 } | ({ a: 1 } & { a: 1 | 3 });',
-      errors: [
-        {
-          column: 28,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: 1 | 2; }',
-            redundantType: '{ a: 1; } & { a: 1 | 3; }',
-          },
-          endColumn: 51,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 39,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; }',
-            redundantType: '{ a: 1 | 3; }',
-          },
-          endColumn: 51,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type Foo = { a: 1 | 2 } | ({ a: 1 } | ({ a: 2 } & { a: 1 | 2 }));',
-      errors: [
-        {
-          column: 28,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: 1 | 2; }',
-            redundantType: '{ a: 1; } | ({ a: 2; } & { a: 1 | 2; })',
-          },
-          endColumn: 64,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 51,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 2; }',
-            redundantType: '{ a: 1 | 2; }',
-          },
-          endColumn: 63,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type Foo = { a: 1 } | ({ a: 3 } | ({ a: 1 | 2 } & { a: number }));',
-      errors: [
-        {
-          column: 12,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: 1 | 2; } & { a: number; }',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 20,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 51,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1 | 2; }',
-            redundantType: '{ a: number; }',
-          },
-          endColumn: 64,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-type R = { a: 1 | 2 } & { a: number };
-type T = R | { a: 1 };
-      `,
-      errors: [
-        {
-          column: 25,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1 | 2; }',
-            redundantType: '{ a: number; }',
-          },
-          endColumn: 38,
-          line: 2,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 14,
-          data: {
-            container: 'union',
-            nonRedundantType: 'R',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 22,
-          line: 3,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-type R = ({ a: 1; b: 2; c: 1 } & { a: 1; b: 2 }) | { a: 2; b: 1 };
-type P = R & { a: number; b: number };
-      `,
-      errors: [
-        {
-          column: 34,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; b: 2; c: 1; }',
-            redundantType: '{ a: 1; b: 2; }',
-          },
-          endColumn: 48,
-          line: 2,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 14,
-          data: {
-            container: 'intersection',
-            nonRedundantType: 'R',
-            redundantType: '{ a: number; b: number; }',
-          },
-          endColumn: 38,
-          line: 3,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-type R = { a: 1 | 2 } & { a: number };
-type T = R | { a: 1 };
-type U = T | { a: 2 };
-      `,
-      errors: [
-        {
-          column: 25,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1 | 2; }',
-            redundantType: '{ a: number; }',
-          },
-          endColumn: 38,
-          line: 2,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 14,
-          data: {
-            container: 'union',
-            nonRedundantType: 'R',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 22,
-          line: 3,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 14,
-          data: {
-            container: 'union',
-            nonRedundantType: 'T',
-            redundantType: '{ a: 2; }',
-          },
-          endColumn: 22,
-          line: 4,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: false } & { a: boolean };',
-      errors: [
-        {
-          column: 25,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: false; }',
-            redundantType: '{ a: boolean; }',
-          },
-          endColumn: 39,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-type B = { a: false };
-type T = B & { a: boolean };
-      `,
-      errors: [
-        {
-          column: 14,
-          data: {
-            container: 'intersection',
-            nonRedundantType: 'B',
-            redundantType: '{ a: boolean; }',
-          },
-          endColumn: 28,
-          line: 3,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: true } & { a: boolean };',
-      errors: [
-        {
-          column: 24,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: true; }',
-            redundantType: '{ a: boolean; }',
-          },
-          endColumn: 38,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: number } & any;',
-      errors: [
-        {
-          column: 26,
-          data: {
-            container: 'intersection',
-            typeName: 'any',
-          },
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: 'type T = any & { a: number };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            typeName: 'any',
-          },
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: 'type ErrorTypes = NotKnown & { a: 0 };',
-      errors: [
-        {
-          column: 19,
-          data: {
-            container: 'intersection',
-            typeName: 'NotKnown',
-          },
-          messageId: 'errorTypeOverrides',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: number } & never;',
-      errors: [
-        {
-          column: 26,
-          data: {
-            container: 'intersection',
-            typeName: 'never',
-          },
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: `
-        type B = never;
-        type T = B & { a: number };
-      `,
-      errors: [
-        {
-          column: 18,
-          data: {
-            container: 'intersection',
-            typeName: 'never',
-          },
-          line: 3,
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: 'type T = never & { a: number };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            typeName: 'never',
-          },
-          messageId: 'overrides',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: number } & unknown;',
-      errors: [
-        {
-          column: 26,
-          data: {
-            container: 'intersection',
-            typeName: 'unknown',
-          },
-          messageId: 'overridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = unknown & { a: number };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            typeName: 'unknown',
-          },
-          messageId: 'overridden',
-        },
-      ],
-    },
-    {
-      code: `
-type T = { a: 1 } | { a: 2 };
-type U = T & { a: number };
-      `,
-      errors: [
-        {
-          column: 14,
-          data: {
-            container: 'intersection',
-            nonRedundantType: 'T',
-            redundantType: '{ a: number; }',
-          },
-          endColumn: 27,
-          line: 3,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-type S = { a: 1 } | { a: 2 };
-type T = { a: 'a' } | { a: 'b' };
-type U = S & T & { a: string } & { a: number };
-      `,
-      errors: [
-        {
-          column: 18,
-          data: {
-            container: 'intersection',
-            nonRedundantType: 'T',
-            redundantType: '{ a: string; }',
-          },
-          endColumn: 31,
-          line: 4,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 34,
-          data: {
-            container: 'intersection',
-            nonRedundantType: 'S',
-            redundantType: '{ a: number; }',
-          },
-          endColumn: 47,
-          line: 4,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 | 2 } & { a: number } & { a: 1 };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; }',
-            redundantType: '{ a: 1 | 2; }',
-          },
-          endColumn: 22,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 25,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1 | 2; }',
-            redundantType: '{ a: number; }',
-          },
-          endColumn: 38,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 25,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; }',
-            redundantType: '{ a: number; }',
-          },
-          endColumn: 38,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type Foo = ({ a: number } & { b: number }) & { a: 1; b: 1 };',
-      errors: [
-        {
-          column: 13,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; b: 1; }',
-            redundantType: '{ a: number; } & { b: number; }',
-          },
-          endColumn: 42,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type Foo = ({ a: number } & { b: number }) & { a: 1 } & { b: 1 };',
-      errors: [
-        {
-          column: 13,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; }',
-            redundantType: '{ a: number; }',
-          },
-          endColumn: 42,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 13,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ b: 1; }',
-            redundantType: '{ b: number; }',
-          },
-          endColumn: 42,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type Foo = { a: 1; b: 1 } | ({ a: number } & ({ b: 1 } | { d: 1 }));',
-      errors: [
-        {
-          column: 12,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: number; } & ({ b: 1; } | { d: 1; })',
-            redundantType: '{ a: 1; b: 1; }',
-          },
-          endColumn: 26,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type F = { a: 1 } & ({ a: 1; b: 1 } | { a: 1 });',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; b: 1; } | { a: 1; }',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 18,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type F = ({ a: 1; b: 1 } | { a: 1 }) & { a: 1 };',
-      errors: [
-        {
-          column: 40,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; b: 1; } | { a: 1; }',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 48,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type F = { a: 1; b: 1 } & ({ a: 1 } | { b: 1 });',
-      errors: [
-        {
-          column: 28,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; b: 1; }',
-            redundantType: '{ a: 1; } | { b: 1; }',
-          },
-          endColumn: 47,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type F = { a: 1 } & { a: 1; b: 1 };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; b: 1; }',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 18,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-type R = { a: 1; b: 2 } | { a: 2; b: 1 };
-type T = { a: number } | { b: number };
-type U = R & T;
-      `,
-      errors: [
-        {
-          column: 14,
-          data: {
-            container: 'intersection',
-            nonRedundantType: 'R',
-            redundantType: 'T',
-          },
-          endColumn: 15,
-          line: 4,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-type T = { a: 1; b: 1 };
-type U<K extends string> = Omit<T, K> & Required<T>;
-type K = U<'a'>;
-type R = K & { a: 1 };
-      `,
-      errors: [
-        {
-          column: 14,
-          data: {
-            container: 'intersection',
-            nonRedundantType: 'K',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 22,
-          line: 5,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-interface T {
-  a: 1;
-}
-type U = T | { a: number };
-      `,
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: number; }',
-            redundantType: 'T',
-          },
-          endColumn: 11,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-type T = { a: '1'; b: '2' };
-type U<Type> = {
-  [Property in keyof Type]: 0;
-};
-type F = U<T> | { a: number; b: number };
-      `,
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: number; b: number; }',
-            redundantType: 'U<T>',
-          },
-          endColumn: 14,
-          line: 6,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-type T = { a: '1'; b: '2' };
-type U<Type> = {
-  [Property in keyof Type]: 0;
-};
-type F = U<T> & { a: number; b: number };
-      `,
-      errors: [
-        {
-          column: 17,
-          data: {
-            container: 'intersection',
-            nonRedundantType: 'U<T>',
-            redundantType: '{ a: number; b: number; }',
-          },
-          endColumn: 41,
-          line: 6,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = Partial<{ a: 1 }> | { a: 1 };',
-      errors: [
-        {
-          column: 30,
-          data: {
-            container: 'union',
-            nonRedundantType: 'Partial<{ a: 1; }>',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 38,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = Partial<{ a: 1 }> & { a: 1 };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; }',
-            redundantType: 'Partial<{ a: 1; }>',
-          },
-          endColumn: 27,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a?: 1 } & { a: 1; b?: 1 };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; b?: 1 | undefined; }',
-            redundantType: '{ a?: 1 | undefined; }',
-          },
-          endColumn: 19,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 } & { a: 1; b?: 1 };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; b?: 1 | undefined; }',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 18,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: { b: 1 } } & { a: { b: 1; c?: 1 } };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: { b: 1; c?: 1 | undefined; }; }',
-            redundantType: '{ a: { b: 1; }; }',
-          },
-          endColumn: 25,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-interface A {
-  a: 1;
-}
-interface B extends A {
-  b: 1;
-}
-type C = A & B;
-      `,
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: 'B',
-            redundantType: 'A',
-          },
-          endColumn: 11,
-          line: 8,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 } | { a: number } | { a: number };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: number; }',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 18,
-          messageId: 'typeOverridden',
-        },
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: number; }',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 18,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: "declare function fn(): (never | 'foo') & string;",
-      errors: [
-        {
-          column: 25,
-          data: {
-            container: 'union',
-            typeName: 'never',
-          },
-          endColumn: 30,
-          messageId: 'overridden',
-        },
-        {
-          column: 42,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '"foo"',
-            redundantType: 'string',
-          },
-          endColumn: 48,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 } | ({ a: 1 } & ({ a: 1 } | { b: 1 }));',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: 1; } & ({ a: 1; } | { b: 1; })',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 18,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1; b: 1 } | ({ a: 1 } & ({ b: number } | { b: number }));',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: 1; } & ({ b: number; } | { b: number; })',
-            redundantType: '{ a: 1; b: 1; }',
-          },
-          endColumn: 24,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = ({ a: 1 } & ({ a: 1 } | { b: 1 })) | { a: 1 };',
-      errors: [
-        {
-          column: 47,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: 1; } & ({ a: 1; } | { b: 1; })',
-            redundantType: '{ a: 1; }',
-          },
-          endColumn: 55,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 | 3 } | { a: 1 | 3 | 5 };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: 1 | 3 | 5; }',
-            redundantType: '{ a: 1 | 3; }',
-          },
-          endColumn: 22,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 | 3 | { b: 1 } } | { a: 1 | 3 | 5 | { b: 1 | 2 } };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: 1 | 3 | 5 | { b: 1 | 2; }; }',
-            redundantType: '{ a: 1 | 3 | { b: 1; }; }',
-          },
-          endColumn: 33,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 | 3 } & { a: 1 | 3 | 5 };',
-      errors: [
-        {
-          column: 25,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1 | 3; }',
-            redundantType: '{ a: 1 | 3 | 5; }',
-          },
-          endColumn: 41,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 | { a?: 1; b: 1 } } & { a: 1 | { b: 1 } };',
-      errors: [
-        {
-          column: 39,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1 | { a?: 1 | undefined; b: 1; }; }',
-            redundantType: '{ a: 1 | { b: 1; }; }',
-          },
-          endColumn: 58,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 | 3 | { b: 1 } } & { a: 1 | { b: 1 } };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1 | { b: 1; }; }',
-            redundantType: '{ a: 1 | 3 | { b: 1; }; }',
-          },
-          endColumn: 33,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = { a: 1 | 3 | { b: 1 } } & { a: 1 | { b: 1; c: 1 } };',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1 | { b: 1; c: 1; }; }',
-            redundantType: '{ a: 1 | 3 | { b: 1; }; }',
-          },
-          endColumn: 33,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: `
-        type R = { a: 1 } | { a: 2 };
-        type T = { a: 1 | 2 } | { a: 3 };
-        type U = R | T;
-      `,
-      errors: [
-        {
-          column: 18,
-          data: {
-            container: 'union',
-            nonRedundantType: 'T',
-            redundantType: 'R',
-          },
-          endColumn: 19,
-          line: 4,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = [] | number[];',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'union',
-            nonRedundantType: 'number[]',
-            redundantType: '[]',
-          },
-          endColumn: 12,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = Array<number> | [1, 2, 3, 4];',
-      errors: [
-        {
-          column: 26,
-          data: {
-            container: 'union',
-            nonRedundantType: 'number[]',
-            redundantType: '[1, 2, 3, 4]',
-          },
-          endColumn: 38,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = Array<number> | Array<1>;',
-      errors: [
-        {
-          column: 26,
-          data: {
-            container: 'union',
-            nonRedundantType: 'number[]',
-            redundantType: '1[]',
-          },
-          endColumn: 34,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = [{ a: number }] | [{ a: 1 }];',
-      errors: [
-        {
-          column: 28,
-          data: {
-            container: 'union',
-            nonRedundantType: '[{ a: number; }]',
-            redundantType: '[{ a: 1; }]',
-          },
-          endColumn: 38,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = Array<{ a: number }> | Array<{ a: 1 }>;',
-      errors: [
-        {
-          column: 33,
-          data: {
-            container: 'union',
-            nonRedundantType: '{ a: number; }[]',
-            redundantType: '{ a: 1; }[]',
-          },
-          endColumn: 48,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = [] & number[];',
-      errors: [
-        {
-          column: 15,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '[]',
-            redundantType: 'number[]',
-          },
-          endColumn: 23,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = [1, 2, 3, 4] & Array<number>;',
-      errors: [
-        {
-          column: 25,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '[1, 2, 3, 4]',
-            redundantType: 'number[]',
-          },
-          endColumn: 38,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = Array<number> & Array<1>;',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '1[]',
-            redundantType: 'number[]',
-          },
-          endColumn: 23,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = [{ a: number }] & [{ a: 1 }];',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '[{ a: 1; }]',
-            redundantType: '[{ a: number; }]',
-          },
-          endColumn: 25,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = Array<{ a: number }> & Array<{ a: 1 }>;',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; }[]',
-            redundantType: '{ a: number; }[]',
-          },
-          endColumn: 30,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = Array<{ a: number }> & Array<{ a: 1; b: 1 }>;',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '{ a: 1; b: 1; }[]',
-            redundantType: '{ a: number; }[]',
-          },
-          endColumn: 30,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = [{ a: 1 }] & [{ a: 1; b?: 1 }];',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '[{ a: 1; b?: 1 | undefined; }]',
-            redundantType: '[{ a: 1; }]',
-          },
-          endColumn: 20,
-          messageId: 'typeOverridden',
-        },
-      ],
-    },
-    {
-      code: 'type T = [{ a: number }] & [{ a: 1; b: 1 }];',
-      errors: [
-        {
-          column: 10,
-          data: {
-            container: 'intersection',
-            nonRedundantType: '[{ a: 1; b: 1; }]',
-            redundantType: '[{ a: number; }]',
-          },
-          endColumn: 25,
-          messageId: 'typeOverridden',
+          messageId: 'primitiveOverridden',
         },
       ],
     },

--- a/packages/scope-manager/tests/test-utils/serializers/TSESTreeNode.ts
+++ b/packages/scope-manager/tests/test-utils/serializers/TSESTreeNode.ts
@@ -17,10 +17,7 @@ const EXCLUDED_KEYS = new Set([
 
 const generator = createIdGenerator();
 type Node = { type: AST_NODE_TYPES } & Record<string, unknown>;
-type Identifier = { name: string; type: AST_NODE_TYPES.Identifier } & Record<
-  string,
-  unknown
->;
+type Identifier = { name: string; type: AST_NODE_TYPES.Identifier } & Node;
 const SEEN_NODES = new Map<Node, number>();
 
 export const serializer: NewPlugin = {

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -7,7 +7,7 @@ import type {
 } from '@typescript-eslint/types';
 import type * as ts from 'typescript';
 
-import type { TSESTree, TSESTreeToTSNode, TSToken } from './ts-estree';
+import type { TSESTree, TSESTreeToTSNode, TSNode, TSToken } from './ts-estree';
 
 //////////////////////////////////////////////////////////
 // MAKE SURE THIS IS KEPT IN SYNC WITH THE WEBSITE DOCS //
@@ -242,7 +242,7 @@ export interface ParserServicesBase {
 }
 export interface ParserServicesNodeMaps {
   esTreeNodeToTSNodeMap: ParserWeakMapESTreeToTSNode;
-  tsNodeToESTreeNodeMap: ParserWeakMap<TSToken, TSESTree.Node>;
+  tsNodeToESTreeNodeMap: ParserWeakMap<TSNode | TSToken, TSESTree.Node>;
 }
 export interface ParserServicesWithTypeInformation
   extends ParserServicesNodeMaps,

--- a/packages/typescript-estree/src/semantic-or-syntactic-errors.ts
+++ b/packages/typescript-estree/src/semantic-or-syntactic-errors.ts
@@ -1,4 +1,9 @@
-import type { Diagnostic, Program, SourceFile } from 'typescript';
+import type {
+  Diagnostic,
+  DiagnosticWithLocation,
+  Program,
+  SourceFile,
+} from 'typescript';
 
 import { flattenDiagnosticMessageText, sys } from 'typescript';
 
@@ -54,8 +59,8 @@ export function getFirstSemanticOrSyntacticError(
 }
 
 function allowlistSupportedDiagnostics(
-  diagnostics: readonly Diagnostic[],
-): readonly Diagnostic[] {
+  diagnostics: readonly (Diagnostic | DiagnosticWithLocation)[],
+): readonly (Diagnostic | DiagnosticWithLocation)[] {
   return diagnostics.filter(diagnostic => {
     switch (diagnostic.code) {
       case 1013: // "A rest parameter or binding pattern may not have a trailing comma."

--- a/packages/utils/src/ts-eslint/Config.ts
+++ b/packages/utils/src/ts-eslint/Config.ts
@@ -147,7 +147,7 @@ export namespace FlatConfig {
   export type Settings = SharedConfigurationSettings;
   export type Severity = SharedConfig.Severity;
   export type SeverityString = SharedConfig.SeverityString;
-  export type SourceType = ParserOptionsTypes.SourceType;
+  export type SourceType = 'commonjs' | ParserOptionsTypes.SourceType;
 
   export interface SharedConfigs {
     [key: string]: Config | ConfigArray;
@@ -219,7 +219,7 @@ export namespace FlatConfig {
      * Set to `"latest"` for the most recent supported version.
      * @default "latest"
      */
-    ecmaVersion?: EcmaVersion;
+    ecmaVersion?: EcmaVersion | undefined;
     /**
      * An object specifying additional objects that should be added to the global scope during linting.
      */

--- a/packages/website/src/components/ast/DataRenderer.tsx
+++ b/packages/website/src/components/ast/DataRenderer.tsx
@@ -30,7 +30,8 @@ export interface JsonRenderProps<T> {
   readonly value: T;
 }
 
-export interface ExpandableRenderProps extends JsonRenderProps<object> {
+export interface ExpandableRenderProps
+  extends JsonRenderProps<object | unknown[]> {
   readonly closeBracket: string;
   readonly data: [string, unknown][];
   readonly openBracket: string;

--- a/packages/website/src/components/hooks/useHashState.ts
+++ b/packages/website/src/components/hooks/useHashState.ts
@@ -75,7 +75,7 @@ const parseStateFromUrl = (
       );
     }
 
-    let esQuery: ConfigModel['esQuery'];
+    let esQuery: ConfigModel['esQuery'] | undefined;
     if (searchParams.has('esQuery')) {
       esQuery = JSON.parse(
         readQueryParam(searchParams.get('esQuery'), ''),


### PR DESCRIPTION
Reverts typescript-eslint/typescript-eslint#10744.

* Fixes #11787
* Fixes #11790
* Fixes #11800
* Fixes #11810
* Fixes #11811 
