### PR TITLE
docs: fixes bad link to jest docs in unbound-method rule page

### DIFF
--- a/packages/eslint-plugin/docs/rules/unbound-method.mdx
+++ b/packages/eslint-plugin/docs/rules/unbound-method.mdx
@@ -111,4 +111,4 @@ For example, some functions have an additional parameter for specifying the `thi
 This semantic is not easily expressed by TypeScript.
 You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
 
-If you're wanting to use `toBeCalled` and similar matches in `jest` tests, you can disable this rule for your test files in favor of [`eslint-plugin-jest`'s version of this rule](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.mdx).
+If you're wanting to use `toBeCalled` and similar matches in `jest` tests, you can disable this rule for your test files in favor of [`eslint-plugin-jest`'s version of this rule](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md).


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

It is an extremely minor documentation typos. It fixes the bad link to the Jest documentation in the unbound-method rule description page, which had an extra 'x' at the end of it, probably due to a change in file naming in the Jest documentation.