### PR TITLE
fix(eslint-plugin): fix crash and false positives in `no-useless-default-assignment`

### DIFF
--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -118,6 +118,10 @@ export default createRule<[], MessageId>({
             }
 
             const signatures = contextualType.getCallSignatures();
+            if (signatures.length === 0) {
+              return;
+            }
+
             const params = signatures[0].getParameters();
             if (paramIndex < params.length) {
               const paramSymbol = params[paramIndex];

--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -103,10 +103,9 @@ export default createRule<[], MessageId>({
           return;
         }
 
-        const parent = node.parent;
         const type =
-          parent.type === AST_NODE_TYPES.Property ||
-          parent.type === AST_NODE_TYPES.ArrayPattern
+          node.parent.type === AST_NODE_TYPES.Property ||
+          node.parent.type === AST_NODE_TYPES.ArrayPattern
             ? 'property'
             : 'parameter';
         reportUselessDefault(node, type, 'uselessUndefined');

--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -74,35 +74,11 @@ export default createRule<[], MessageId>({
       return arrayType.getNumberIndexType() ?? null;
     }
 
-    function isInsideFunctionParameter(node: TSESTree.Node): boolean {
-      let current: TSESTree.Node | undefined = node.parent;
-      while (current) {
-        if (isFunction(current)) {
-          return true;
-        }
-        if (
-          current.type !== AST_NODE_TYPES.Property &&
-          current.type !== AST_NODE_TYPES.ArrayPattern &&
-          current.type !== AST_NODE_TYPES.ObjectPattern &&
-          current.type !== AST_NODE_TYPES.AssignmentPattern &&
-          current.type !== AST_NODE_TYPES.RestElement
-        ) {
-          return false;
-        }
-        current = current.parent;
-      }
-      return false;
-    }
-
     function checkAssignmentPattern(node: TSESTree.AssignmentPattern): void {
       if (
         node.right.type === AST_NODE_TYPES.Identifier &&
         node.right.name === 'undefined'
       ) {
-        if (isInsideFunctionParameter(node)) {
-          return;
-        }
-
         const type =
           node.parent.type === AST_NODE_TYPES.Property ||
           node.parent.type === AST_NODE_TYPES.ArrayPattern

--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -178,8 +178,11 @@ export default createRule<[], MessageId>({
         }
 
         const tupleArgs = checker.getTypeArguments(sourceType);
+        if (elementIndex < 0 || elementIndex >= tupleArgs.length) {
+          return;
+        }
         const elementType = tupleArgs[elementIndex];
-        if (elementType && !canBeUndefined(elementType)) {
+        if (!canBeUndefined(elementType)) {
           reportUselessDefault(node, 'property', 'uselessDefaultAssignment');
         }
       }

--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -179,12 +179,8 @@ export default createRule<[], MessageId>({
         }
 
         const tupleArgs = checker.getTypeArguments(sourceType);
-        if (elementIndex < 0 || elementIndex >= tupleArgs.length) {
-          return;
-        }
-
         const elementType = tupleArgs[elementIndex];
-        if (!canBeUndefined(elementType)) {
+        if (elementType && !canBeUndefined(elementType)) {
           reportUselessDefault(node, 'property', 'uselessDefaultAssignment');
         }
       }

--- a/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-useless-default-assignment.ts
@@ -147,13 +147,12 @@ export default createRule<[], MessageId>({
           return;
         }
 
-        const elementIndex = parent.elements.indexOf(node);
-
         if (!checker.isTupleType(sourceType)) {
           return;
         }
 
         const tupleArgs = checker.getTypeArguments(sourceType);
+        const elementIndex = parent.elements.indexOf(node);
         if (elementIndex < 0 || elementIndex >= tupleArgs.length) {
           return;
         }

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -1,6 +1,7 @@
 import rule from '../../src/rules/no-useless-default-assignment';
-import { createRuleTesterWithTypes } from '../RuleTester';
+import { createRuleTesterWithTypes, getFixturesRootDir } from '../RuleTester';
 
+const rootDir = getFixturesRootDir();
 const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('no-useless-default-assignment', rule, {
@@ -144,6 +145,45 @@ ruleTester.run('no-useless-default-assignment', rule, {
       for ([[a = 1]] of []) {
       }
     `,
+    {
+      code: `
+        declare const g: Array<string>;
+        const [foo = ''] = g;
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: rootDir,
+        },
+      },
+    },
+    {
+      code: `
+        declare const g: Record<string, string>;
+        const { foo = '' } = g;
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: rootDir,
+        },
+      },
+    },
+    {
+      code: `
+        declare const h: { [key: string]: string };
+        const { bar = '' } = h;
+      `,
+      languageOptions: {
+        parserOptions: {
+          project: './tsconfig.noUncheckedIndexedAccess.json',
+          projectService: false,
+          tsconfigRootDir: rootDir,
+        },
+      },
+    },
     `
       declare const g: Array<string>;
       const [foo = ''] = g;

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -190,6 +190,10 @@ ruleTester.run('no-useless-default-assignment', rule, {
     `
       function foo({ a = undefined }) {}
     `,
+    `
+      declare const tuple: [string];
+      const [a, b = 'default'] = tuple;
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -184,6 +184,16 @@ ruleTester.run('no-useless-default-assignment', rule, {
         },
       },
     },
+    // https://github.com/typescript-eslint/typescript-eslint/pull/11720#issuecomment-3657141976
+    `
+      type Merge = boolean | ((incoming: string[]) => void);
+
+      const policy: { merge: Merge } = {
+        merge: (incoming: string[] = []) => {
+          incoming;
+        },
+      };
+    `,
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -431,7 +431,23 @@ ruleTester.run('no-useless-default-assignment', rule, {
         };
       `,
     },
-
+    {
+      code: `
+        function foo(a = undefined) {}
+      `,
+      errors: [
+        {
+          column: 26,
+          data: { type: 'parameter' },
+          endColumn: 35,
+          line: 2,
+          messageId: 'uselessUndefined',
+        },
+      ],
+      output: `
+        function foo(a) {}
+      `,
+    },
     {
       code: `
         const { a = undefined } = {};
@@ -464,6 +480,23 @@ ruleTester.run('no-useless-default-assignment', rule, {
       ],
       output: `
         const [a] = [];
+      `,
+    },
+    {
+      code: `
+        function foo({ a = undefined }) {}
+      `,
+      errors: [
+        {
+          column: 28,
+          data: { type: 'property' },
+          endColumn: 37,
+          line: 2,
+          messageId: 'uselessUndefined',
+        },
+      ],
+      output: `
+        function foo({ a }) {}
       `,
     },
   ],

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -156,7 +156,7 @@ ruleTester.run('no-useless-default-assignment', rule, {
       declare const h: { [key: string]: string };
       const { bar = '' } = h;
     `,
-    // https://github.com/typescript-eslint/typescript-eslint/pull/11720#issuecomment-3657141976
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11849
     `
       type Merge = boolean | ((incoming: string[]) => void);
 

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -1,7 +1,6 @@
 import rule from '../../src/rules/no-useless-default-assignment';
-import { createRuleTesterWithTypes, getFixturesRootDir } from '../RuleTester';
+import { createRuleTesterWithTypes } from '../RuleTester';
 
-const rootDir = getFixturesRootDir();
 const ruleTester = createRuleTesterWithTypes();
 
 ruleTester.run('no-useless-default-assignment', rule, {
@@ -145,45 +144,18 @@ ruleTester.run('no-useless-default-assignment', rule, {
       for ([[a = 1]] of []) {
       }
     `,
-    {
-      code: `
-        declare const g: Array<string>;
-        const [foo = ''] = g;
-      `,
-      languageOptions: {
-        parserOptions: {
-          project: './tsconfig.noUncheckedIndexedAccess.json',
-          projectService: false,
-          tsconfigRootDir: rootDir,
-        },
-      },
-    },
-    {
-      code: `
-        declare const g: Record<string, string>;
-        const { foo = '' } = g;
-      `,
-      languageOptions: {
-        parserOptions: {
-          project: './tsconfig.noUncheckedIndexedAccess.json',
-          projectService: false,
-          tsconfigRootDir: rootDir,
-        },
-      },
-    },
-    {
-      code: `
-        declare const h: { [key: string]: string };
-        const { bar = '' } = h;
-      `,
-      languageOptions: {
-        parserOptions: {
-          project: './tsconfig.noUncheckedIndexedAccess.json',
-          projectService: false,
-          tsconfigRootDir: rootDir,
-        },
-      },
-    },
+    `
+      declare const g: Array<string>;
+      const [foo = ''] = g;
+    `,
+    `
+      declare const g: Record<string, string>;
+      const { foo = '' } = g;
+    `,
+    `
+      declare const h: { [key: string]: string };
+      const { bar = '' } = h;
+    `,
     // https://github.com/typescript-eslint/typescript-eslint/pull/11720#issuecomment-3657141976
     `
       type Merge = boolean | ((incoming: string[]) => void);
@@ -193,6 +165,30 @@ ruleTester.run('no-useless-default-assignment', rule, {
           incoming;
         },
       };
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11846
+    `
+      const [a, b = ''] = 'somestr'.split('.');
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11846
+    `
+      declare const params: string[];
+      const [c = '123'] = params;
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11846
+    `
+      declare function useCallback<T>(callback: T);
+      useCallback((value: number[] = []) => {});
+    `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11847
+    `
+      function myFunction(p: number | undefined = undefined) {}
+    `,
+    `
+      function foo(a = undefined) {}
+    `,
+    `
+      function foo({ a = undefined }) {}
     `,
   ],
   invalid: [
@@ -401,23 +397,7 @@ ruleTester.run('no-useless-default-assignment', rule, {
         };
       `,
     },
-    {
-      code: `
-        function foo(a = undefined) {}
-      `,
-      errors: [
-        {
-          column: 26,
-          data: { type: 'parameter' },
-          endColumn: 35,
-          line: 2,
-          messageId: 'uselessUndefined',
-        },
-      ],
-      output: `
-        function foo(a) {}
-      `,
-    },
+
     {
       code: `
         const { a = undefined } = {};
@@ -450,80 +430,6 @@ ruleTester.run('no-useless-default-assignment', rule, {
       ],
       output: `
         const [a] = [];
-      `,
-    },
-    {
-      code: `
-        function foo({ a = undefined }) {}
-      `,
-      errors: [
-        {
-          column: 28,
-          data: { type: 'property' },
-          endColumn: 37,
-          line: 2,
-          messageId: 'uselessUndefined',
-        },
-      ],
-      output: `
-        function foo({ a }) {}
-      `,
-    },
-    {
-      code: `
-        declare const g: Record<string, string>;
-        const { hello = '' } = g;
-      `,
-      errors: [
-        {
-          column: 25,
-          data: { type: 'property' },
-          endColumn: 27,
-          line: 3,
-          messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
-        declare const g: Record<string, string>;
-        const { hello } = g;
-      `,
-    },
-    {
-      code: `
-        declare const h: { [key: string]: string };
-        const { world = '' } = h;
-      `,
-      errors: [
-        {
-          column: 25,
-          data: { type: 'property' },
-          endColumn: 27,
-          line: 3,
-          messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
-        declare const h: { [key: string]: string };
-        const { world } = h;
-      `,
-    },
-    {
-      code: `
-        declare const g: Array<string>;
-        const [foo = ''] = g;
-      `,
-      errors: [
-        {
-          column: 22,
-          data: { type: 'property' },
-          endColumn: 24,
-          line: 3,
-          messageId: 'uselessDefaultAssignment',
-        },
-      ],
-      output: `
-        declare const g: Array<string>;
-        const [foo] = g;
       `,
     },
   ],

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -180,16 +180,6 @@ ruleTester.run('no-useless-default-assignment', rule, {
       declare function useCallback<T>(callback: T);
       useCallback((value: number[] = []) => {});
     `,
-    // https://github.com/typescript-eslint/typescript-eslint/issues/11847
-    `
-      function myFunction(p: number | undefined = undefined) {}
-    `,
-    `
-      function foo(a = undefined) {}
-    `,
-    `
-      function foo({ a = undefined }) {}
-    `,
     `
       declare const tuple: [string];
       const [a, b = 'default'] = tuple;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11846; fixes #11849
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The rule now treats types as if `isNoUncheckedIndexedAccess` is enabled to not report false positives and suggest unsafe fixes. This required me to move some test cases from the "invalid" section to the "valid" section. Also added reproduction test cases for every issue this PR fixes.

Fixes #11846 (3 false positives)
Fixes #11849 (1 crash)
