### PR TITLE
docs: change `code` in `aside nav ul`s to baseline vertical alignment

### DIFF
--- a/packages/website/src/css/custom.css
+++ b/packages/website/src/css/custom.css
@@ -212,6 +212,10 @@ h6 {
   vertical-align: baseline;
 }
 
+aside nav ul code {
+  vertical-align: baseline;
+}
+
 td > p:last-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- ~[ ] Addresses an existing open issue: fixes #000~ Quick fix, forgive me 🙏 
- ~[ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~
- ~[ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken~

## Overview

This has been bugging me:

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="318" height="112" alt="Screenshot of 'Avoiding anys with Linting and TypeScript' in the nav bar, where 'any's is monospace font and lower by 2px" src="https://github.com/user-attachments/assets/2f52449e-e357-4ea3-8f11-bf8ebf56a39c" />
</td>
<td>
<img width="318" height="112" alt="Screenshot of 'Avoiding anys with Linting and TypeScript' in the nav bar, where 'any's is monospace font and not lower than other text" src="https://github.com/user-attachments/assets/d1221846-28b7-4c42-8864-1b1272b7d196" />
</td>
</tr>
</tbody>
</table>

Split out of #11873.

💖