### PR TITLE
docs(eslint-plugin): [no-unsafe-return] added Limitations note

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-return.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-return.mdx
@@ -114,9 +114,16 @@ function foo2(): unknown[] {
 
 `@typescript-eslint/no-unsafe-return` only checks for unsafely returning `any`, `any[]`, and (specifically in `async` functions) `Promise<any>`.
 It will not detect `any` in type parameters for generic constructs.
-If you want to enforce safety around those `any`s, see the related `no-unsafe-*` rules for checking usage.
 
-For `Promise<any>` in particular, see also [`@typescript-eslint/promise-function-async`](https://typescript-eslint.io/rules/promise-function-async) to enforce functions that return `Promise`s are marked as `async` -- and thus can have `Promise<any>` detection run by this rule.
+```ts
+function createUnsafeMap() {
+  // Caught by other rules, but not by @typescript-eslint/no-unsafe-return
+  return new Map<string, any>();
+}
+```
+
+If you want to enforce safety around those `any`s, see the [Related To](#related-to) rules for checking usage.
+For `Promise<any>` in particular, see also [`@typescript-eslint/promise-function-async`](https://typescript-eslint.io/rules/promise-function-async) to enforce functions that return `Promise`s are marked as `async` - and thus can have `Promise<any>` detection run by this rule.
 
 ## When Not To Use It
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11354
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a `## Limitations` section that briefly summarizes the discussion in https://github.com/typescript-eslint/typescript-eslint/issues/11354#issuecomment-3014400590 onward.

I'm not sure how I feel about our rule docs content injection logic putting `Options` _after_ `Limitations`...

💖