### PR TITLE
docs(eslint-plugin): [strict-boolean-expressions] mention @eslint-react/no-leaked-conditional-rendering

### DIFF
--- a/packages/eslint-plugin/docs/rules/strict-boolean-expressions.mdx
+++ b/packages/eslint-plugin/docs/rules/strict-boolean-expressions.mdx
@@ -181,4 +181,5 @@ If you prefer more succinct checks over more precise boolean logic, this rule mi
 
 ## Related To
 
-- [no-unnecessary-condition](./no-unnecessary-condition.mdx) - Similar rule which reports always-truthy and always-falsy values in conditions
+- [`@typescript-eslint/no-unnecessary-condition`](./no-unnecessary-condition.mdx): Similar rule which reports always-truthy and always-falsy values in conditions
+- [`@eslint-react/no-leaked-conditional-rendering`](https://www.eslint-react.xyz/docs/rules/no-leaked-conditional-rendering): additionally reports JSX values that "leak" in React's conditional rendering


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10705
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I believe this is the only actively-maintained JSX-area plugin rule that uses type information to be fully accurate? Someone please shout if there's >=1 I missed.

💖