### PR TITLE
feat(tsconfig-utils): more informative error on parsing failures

### DIFF
--- a/packages/tsconfig-utils/src/getParsedConfigFile.ts
+++ b/packages/tsconfig-utils/src/getParsedConfigFile.ts
@@ -43,7 +43,12 @@ export function getParsedConfigFile(
   );
 
   if (parsed?.errors.length) {
-    throw new Error(formatDiagnostics(parsed.errors));
+    throw new Error(
+      [
+        "Unable to parse the specified 'tsconfig' file. Ensure it's correct and has valid syntax.",
+        formatDiagnostics(parsed.errors),
+      ].join('\n\n'),
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10511
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Prepends @ronami's proposed note in front of the formatted diagnostics. There are no logic changes. 

I validated locally that this error is what you get now:

```plaintext
 $ npx eslint src/index.ts

/Users/josh/repos/create-typescript-app/src/index.ts
  0:0  error  Parsing error: Unable to parse the specified 'tsconfig' file. Ensure it's correct and has valid syntax.

tsconfig.json(1,1): error TS1136: Property assignment expected
```

💖 