### PR TITLE
docs(website): update reference to PR title validation workflow

### DIFF
--- a/docs/contributing/Pull_Requests.mdx
+++ b/docs/contributing/Pull_Requests.mdx
@@ -74,7 +74,7 @@ Within the body of your PR, make sure you reference the issue that you have work
 
 Must be one of the following:
 
-{/* Keep this synchronized with /.github/workflows/semantic-pr-titles.yml */}
+{/* Keep this synchronized with /.github/workflows/pr-title-validation.yml */}
 
 - `docs` - if you only change documentation, and not shipped code
 - `feat` - for any new functionality additions


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: Minor documentation fix
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hello! This is my first time contributing to the `typescript-eslint` repository, so I hope I've followed the team's guidelines.

This PR contains a minor documentation fix, so I didn't open an issue:

<img width="694" height="67" alt="like to the typescript contribute guidlines" src="https://github.com/user-attachments/assets/21bb32ec-7478-4b5b-88bf-dce1f3381f2e" />

---

In this PR, I've updated the reference to the PR title validation workflow in `Pull_Requests.mdx`.

https://github.com/typescript-eslint/typescript-eslint/tree/main/.github/workflows

<img width="1545" height="473" alt="github workflows folder description" src="https://github.com/user-attachments/assets/da87edbd-8e50-40c5-8b39-adb2b923b880" />

It seems the current workflow no longer includes `semantic-pr-titles.yml` and has been replaced by `pr-title-validation.yml`.

---

😄 
