### PR TITLE
docs: note that tsconfigRootDir also applies to projectService

### DIFF
--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -283,7 +283,7 @@ If this setting is specified, you must only lint files that are included in the 
 
 For an option that allows linting files outside of your TSConfig file(s), see [`projectService`](#projectservice).
 
-### Usage with `projectService`
+#### Usage with `projectService`
 
 Enabling both `project` and `projectService` at the same time will cause an error:
 
@@ -433,7 +433,7 @@ For example, by default it will ensure that a glob like `./**/tsconfig.json` wil
 
 > Default: the directory of the ESLint config file.
 
-This option allows you to provide the root directory for relative TSConfig paths specified in the `project` option above.
+This option allows you to provide the root directory for relative TSConfig paths specified in the [`project`](#project) and [`projectService`](#projectservice) options.
 Doing so ensures running ESLint from a directory other than the root will still be able to find your TSConfig.
 
 `tsconfigRootDir` uses the call stack to determine the closest `eslint.config.*` ESLint config file.
@@ -442,6 +442,7 @@ Manually specifying `tsconfigRootDir` to the directory of your ESLint config fil
 
 ```js
 parserOptions: {
+  projectService: true,
   tsconfigRootDir: import.meta.dirname,
   // or, in CommonJS, __dirname
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10826
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Explicitly mentions and links to `projectService`, to make it clear that `tsconfigRootDir` _does_ apply to both `project` and `projectService`.

💖