### PR TITLE
feat(project-service): allow passing `Partial<ts.server.ServerHost>` to project service

### DIFF
--- a/packages/project-service/src/createProjectService.ts
+++ b/packages/project-service/src/createProjectService.ts
@@ -75,6 +75,13 @@ export interface CreateProjectServiceSettings {
    * Root directory for the tsconfig.json file, if not the current directory.
    */
   tsconfigRootDir?: string;
+
+  /**
+   * Custom project service host.
+   *
+   * @default `ts.sys` with stub watchers
+   */
+  host?: Partial<ts.server.ServerHost>;
 }
 
 /**
@@ -91,6 +98,7 @@ export interface CreateProjectServiceSettings {
  * ```
  */
 export function createProjectService({
+  host,
   jsDocParsingMode,
   options: optionsRaw = {},
   tsconfigRootDir,
@@ -129,6 +137,7 @@ export function createProjectService({
         module: undefined,
       }),
     }),
+    ...host,
   };
 
   const logger: ts.server.Logger = {

--- a/packages/project-service/tests/createProjectService.test.ts
+++ b/packages/project-service/tests/createProjectService.test.ts
@@ -274,4 +274,30 @@ describe(createProjectService, () => {
       },
     });
   });
+
+  it('uses watchFile from custom host', () => {
+    const watchFile = (): ts.FileWatcher => ({
+      close() {
+        void 0;
+      },
+    });
+    const { service } = createProjectService({
+      host: {
+        watchFile,
+      },
+    });
+
+    expect(service.host.watchFile).toEqual(watchFile);
+  });
+
+  it('uses readFile from custom host', () => {
+    const readFile = (): string | undefined => undefined;
+    const { service } = createProjectService({
+      host: {
+        readFile,
+      },
+    });
+
+    expect(service.host.readFile).toEqual(readFile);
+  });
 });


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #11915
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I decided to go with `Partial<ts.server.ServerHost>` instead of `ts.server.ServerHost | ts.System`, since it allows users to provide individual methods.
