### PR TITLE
docs(eslint-plugin): [no-useless-default-assignment] fix misformatted link

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-useless-default-assignment.mdx
+++ b/packages/eslint-plugin/docs/rules/no-useless-default-assignment.mdx
@@ -52,5 +52,5 @@ const [foo = ''] = [undefined];
 
 If you use default values defensively against runtime values that bypass type checking, or for documentation purposes, you may want to disable this rule.
 
-In a few niche situations (e.g. [express.js error handler functions](https://expressjs.com/en/guide/error-handling.html)), the runtime [`.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length of a function) may be important to you.
+In a few niche situations (e.g. [express.js error handler functions](https://expressjs.com/en/guide/error-handling.html)), the runtime [`.length`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length) of a function may be important to you.
 In these rare cases, you may need to disable the fixes produced by this rule, which can affect function's `.length` value.


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The documentation for the "no-useless-default-assignment" rule contains a formatting typo (misplaced parenthesis) which prevents a link from being rendered correctly. This change just fixes the link.

🙃