### PR TITLE
fix(eslint-plugin): [consistent-indexed-object-style] skip fixer if interface is a default export

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -163,7 +163,8 @@ export default createRule<Options, MessageIds>({
             node.id,
             `type ${node.id.name}${genericTypes} = `,
             ';',
-            !node.extends.length,
+            !node.extends.length &&
+              node.parent.type !== AST_NODE_TYPES.ExportDefaultDeclaration,
           );
         },
         TSMappedType(node): void {

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -367,6 +367,17 @@ interface B extends A {
       errors: [{ column: 1, line: 2, messageId: 'preferRecord' }],
       output: null,
     },
+
+    // export default interface - no fixer since `export default type` is invalid
+    {
+      code: `
+export default interface Foo {
+  [key: string]: unknown;
+}
+      `,
+      errors: [{ column: 16, line: 2, messageId: 'preferRecord' }],
+      output: null,
+    },
     // Readonly interface with generic parameter
     {
       code: `


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

checkout the playground: https://typescript-eslint.io/play#ts=5.9.2&fileType=.tsx&code=FAUwHgDg9gTgLgAgCYgGYEMCuAbRBLAOzhBgwGMQEBlMgCxCRxKpIDc8KEBvYBPhANoBrEAE8AXAgDOcGIQDmAXUmYCQglADuBANzAAvkA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQAIBcBPABxQGNoBLY-AWhXkoDt8B6MgeyeUuX0Ra1mAE0QAPRMNocARgCtEZOn0JJ0URNGgdokcGAC%2BIA0A&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false

```ts
export default interface SchedulerService {
    [key: string]: unknown;
}
```

has a quick fix to:
```ts
export default type SchedulerService = Record<string, unknown>;
```

But this creates invalid source code, as you cannot have `export default type`


Refs: https://github.com/oxc-project/oxc/issues/17866

Note: I used AI for this PR, but I've reviewed the code it's written and I take responsibility for it's correcness and it's quality