### PR TITLE
chore: fix `generate-website-dts` script

### DIFF
--- a/packages/website/src/vendor/sandbox.d.ts
+++ b/packages/website/src/vendor/sandbox.d.ts
@@ -10,7 +10,7 @@
 
 import type * as ts from 'typescript';
 import type * as MonacoEditor from 'monaco-editor';
-import type TypeScriptWorker = MonacoEditor.languages.typescript.TypeScriptWorker;
+type TypeScriptWorker = MonacoEditor.languages.typescript.TypeScriptWorker;
 import type lzstring from 'lz-string';
 import type * as tsvfs from './typescript-vfs';
 type CompilerOptions = MonacoEditor.languages.typescript.CompilerOptions;

--- a/packages/website/tools/generate-website-dts.mts
+++ b/packages/website/tools/generate-website-dts.mts
@@ -70,7 +70,7 @@ function processFiles(text: string): string {
   // replace the import of the worker with the type
   result = result.replace(
     /import\s*\{\s*TypeScriptWorker\s*}\s*from\s*['"].\/tsWorker['"];/,
-    'import TypeScriptWorker = MonacoEditor.languages.typescript.TypeScriptWorker;',
+    'type TypeScriptWorker = MonacoEditor.languages.typescript.TypeScriptWorker;',
   );
   // replace all imports with import type
   result = result.replaceAll(/^import\s+(?!type)/gm, 'import type ');


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

```
import type TypeScriptWorker = MonacoEditor.languages.typescript.TypeScriptWorker;
```

is invalid now, https://github.com/typescript-eslint/typescript-eslint/pull/11936

Unreleased Prettier is now unable to format it.
