### PR TITLE
chore: enable no-unused-vars import autofix internally

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -160,6 +160,7 @@ export default defineConfig(
         {
           argsIgnorePattern: '^_',
           caughtErrors: 'all',
+          enableAutofixRemoval: { imports: true },
           varsIgnorePattern: '^_',
         },
       ],
@@ -562,7 +563,10 @@ export default defineConfig(
     name: 'ast-spec/source-files',
     rules: {
       // disallow ALL unused vars
-      '@typescript-eslint/no-unused-vars': ['error', { caughtErrors: 'all' }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { caughtErrors: 'all', enableAutofixRemoval: { imports: true } },
+      ],
       '@typescript-eslint/sort-type-constituents': 'error',
 
       'perfectionist/sort-interfaces': [


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

