### PR TITLE
test(eslint-plugin): skip rules tests in windows ci

### DIFF
--- a/packages/eslint-plugin/vitest.config.mts
+++ b/packages/eslint-plugin/vitest.config.mts
@@ -4,10 +4,6 @@ import { defineProject, mergeConfig } from 'vitest/config';
 import { vitestBaseConfig } from '../../vitest.config.base.mjs';
 import packageJson from './package.json' with { type: 'json' };
 
-console.log('isWindowsCI', isWindowsCI());
-console.log('process.platform', process.platform);
-console.log('process.env.CI', process.env.CI);
-
 const vitestConfig = mergeConfig(
   vitestBaseConfig,
 


### PR DESCRIPTION
Coming from https://github.com/typescript-eslint/typescript-eslint/issues/11204#issuecomment-3717214684

I'm wondering whether it's 100% safe.
We don't have any rule that somehow interacts with things like the filesystem, for example?