### PR TITLE
fix(eslint-plugin): [no-unused-vars] remove trailing newline when removing entire import

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unused-vars.ts
+++ b/packages/eslint-plugin/src/rules/no-unused-vars.ts
@@ -523,6 +523,32 @@ export default createRule<Options, MessageIds>({
       return options;
     })();
 
+    function removeNodeWithTrailingNewline(
+      fixer: TSESLint.RuleFixer,
+      node: TSESTree.Node,
+    ): TSESLint.RuleFix {
+      const sourceCode = context.sourceCode;
+      const { line: startLine } = node.loc.start;
+      const { line: endLine } = node.loc.end;
+      // Expand range: start of first line to start of next line (or EOF)
+      const lineRangeStart = sourceCode.getIndexFromLoc({
+        column: 0,
+        line: startLine,
+      });
+      const lineRangeEnd =
+        endLine < sourceCode.lines.length
+          ? sourceCode.getIndexFromLoc({ column: 0, line: endLine + 1 })
+          : sourceCode.text.length;
+      // If node is the only non-whitespace on its line(s), remove full line(s)
+      if (
+        sourceCode.getText(node) ===
+        sourceCode.text.slice(lineRangeStart, lineRangeEnd).trim()
+      ) {
+        return fixer.removeRange([lineRangeStart, lineRangeEnd]);
+      }
+      return fixer.remove(node);
+    }
+
     function getImportFixer(def: ImportBindingDefinition): {
       fix: TSESLint.ReportFixFunction;
       messageId: MessageIds;
@@ -533,7 +559,7 @@ export default createRule<Options, MessageIds>({
           // just remove entire import declaration
           return {
             messageId: 'removeUnusedImportDeclaration',
-            fix: fixer => fixer.remove(def.node),
+            fix: fixer => removeNodeWithTrailingNewline(fixer, def.node),
           };
 
         case AST_NODE_TYPES.ImportDefaultSpecifier: {
@@ -546,7 +572,7 @@ export default createRule<Options, MessageIds>({
             // declaration
             return {
               messageId: 'removeUnusedImportDeclaration',
-              fix: fixer => fixer.remove(importDecl),
+              fix: fixer => removeNodeWithTrailingNewline(fixer, importDecl),
             };
           }
 
@@ -603,7 +629,7 @@ export default createRule<Options, MessageIds>({
             // declaration
             return {
               messageId: 'removeUnusedImportDeclaration',
-              fix: fixer => fixer.remove(importDecl),
+              fix: fixer => removeNodeWithTrailingNewline(fixer, importDecl),
             };
           }
 
@@ -715,7 +741,7 @@ export default createRule<Options, MessageIds>({
           const importDecl = def.node.parent;
           return {
             messageId: 'removeUnusedImportDeclaration',
-            fix: fixer => fixer.remove(importDecl),
+            fix: fixer => removeNodeWithTrailingNewline(fixer, importDecl),
           };
         }
       }

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-enableAutofixRemoval.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars-enableAutofixRemoval.test.ts
@@ -39,7 +39,6 @@ export {};
           },
         ],
         output: `
-
 export {};
         `,
       },
@@ -66,7 +65,6 @@ export {};
           },
         ],
         output: `
-
 export {};
         `,
       },
@@ -93,7 +91,6 @@ export {};
           },
         ],
         output: `
-
 export {};
         `,
       },
@@ -128,7 +125,6 @@ export {};
           },
         ],
         output: `
-
 export {};
         `,
       },
@@ -271,7 +267,6 @@ export {};
           },
         ],
         output: `
-
 export {};
         `,
       },
@@ -559,6 +554,48 @@ export { Used };
         output: `
 import { Used, } from 'module';
 export { Used };
+        `,
+      },
+      {
+        code: `
+/* this is an important comment */ import assert from 'assert';
+        `,
+        errors: [
+          {
+            line: 2,
+            messageId: 'unusedVar',
+          },
+        ],
+        options: [
+          {
+            enableAutofixRemoval: {
+              imports: true,
+            },
+          },
+        ],
+        output: `
+/* this is an important comment */ 
+        `,
+      },
+      {
+        code: `
+import assert from 'assert'; /* this is an important comment */
+        `,
+        errors: [
+          {
+            line: 2,
+            messageId: 'unusedVar',
+          },
+        ],
+        options: [
+          {
+            enableAutofixRemoval: {
+              imports: true,
+            },
+          },
+        ],
+        output: `
+ /* this is an important comment */
         `,
       },
     ],

--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -61,7 +61,6 @@ export class Foo {}
               },
               messageId: 'removeUnusedImportDeclaration',
               output: `
-
 export class Foo {}
       `,
             },
@@ -124,7 +123,6 @@ console.log(a);
               },
               messageId: 'removeUnusedImportDeclaration',
               output: `
-
 const a: string = 'hello';
 console.log(a);
       `,
@@ -158,7 +156,6 @@ console.log(a);
               messageId: 'removeUnusedImportDeclaration',
               output: `
 import { Nullable } from 'nullable';
-
 const a: Nullable<string> = 'hello';
 console.log(a);
       `,
@@ -197,7 +194,6 @@ new A();
               messageId: 'removeUnusedImportDeclaration',
               output: `
 import { Nullable } from 'nullable';
-
 class A {
   do = (a: Nullable) => {
     console.log(a);
@@ -239,7 +235,6 @@ new A();
               messageId: 'removeUnusedImportDeclaration',
               output: `
 import { Nullable } from 'nullable';
-
 class A {
   do(a: Nullable) {
     console.log(a);
@@ -281,7 +276,6 @@ new A();
               messageId: 'removeUnusedImportDeclaration',
               output: `
 import { Nullable } from 'nullable';
-
 class A {
   do(): Nullable {
     return null;
@@ -320,7 +314,6 @@ export interface A {
               messageId: 'removeUnusedImportDeclaration',
               output: `
 import { Nullable } from 'nullable';
-
 export interface A {
   do(a: Nullable);
 }
@@ -356,7 +349,6 @@ export interface A {
               messageId: 'removeUnusedImportDeclaration',
               output: `
 import { Nullable } from 'nullable';
-
 export interface A {
   other: Nullable;
 }
@@ -391,7 +383,6 @@ foo();
               },
               messageId: 'removeUnusedImportDeclaration',
               output: `
-
 function foo(a: string) {
   console.log(a);
 }
@@ -427,7 +418,6 @@ foo();
               },
               messageId: 'removeUnusedImportDeclaration',
               output: `
-
 function foo(): string | null {
   return null;
 }
@@ -466,7 +456,6 @@ new A();
               messageId: 'removeUnusedImportDeclaration',
               output: `
 import { Nullable } from 'nullable';
-
 import { Another } from 'some';
 class A extends Nullable {
   other: Nullable<Another>;
@@ -506,7 +495,6 @@ new A();
               messageId: 'removeUnusedImportDeclaration',
               output: `
 import { Nullable } from 'nullable';
-
 import { Another } from 'some';
 abstract class A extends Nullable {
   other: Nullable<Another>;
@@ -561,7 +549,6 @@ export interface Bar extends baz.test {}
               },
               messageId: 'removeUnusedImportDeclaration',
               output: `
-
 import baz from 'baz';
 export interface Bar extends baz.test {}
       `,
@@ -593,7 +580,6 @@ export class Bar implements baz.test {}
               },
               messageId: 'removeUnusedImportDeclaration',
               output: `
-
 import baz from 'baz';
 export class Bar implements baz.test {}
       `,
@@ -777,7 +763,6 @@ export const ComponentFoo = () => {
               output: `
 import React from 'react';
 
-
 export const ComponentFoo = () => {
   return <div>Foo Foo</div>;
 };
@@ -820,7 +805,6 @@ export const ComponentFoo = () => {
               },
               messageId: 'removeUnusedImportDeclaration',
               output: `
-
 import { h } from 'some-other-jsx-lib';
 
 export const ComponentFoo = () => {
@@ -866,7 +850,6 @@ export const ComponentFoo = () => {
               },
               messageId: 'removeUnusedImportDeclaration',
               output: `
-
 
 export const ComponentFoo = () => {
   return <div>Foo Foo</div>;
@@ -1116,7 +1099,6 @@ namespace Foo {
   export const foo = 1;
 }
 export namespace Bar {
-${'  '}
 }
       `,
             },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11996
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
The fixer introduced in https://github.com/typescript-eslint/typescript-eslint/pull/11922 leaves blank lines when removing the entire import statement. This PR modifies the fixer to remove trailing new lines when the entire statement is unused.