### PR TITLE
feat(utils): deprecate defaultOptions in favor of meta.defaultOptions

### DIFF
--- a/packages/eslint-plugin/tests/schemas.test.ts
+++ b/packages/eslint-plugin/tests/schemas.test.ts
@@ -199,6 +199,8 @@ describe('Rule schemas should validate options correctly', () => {
       expect(
         areOptionsValid(
           rule,
+          // Keep accepting deprecated defaultOptions for backward compatibility.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           overrideValidOptions[ruleName] ?? rule.defaultOptions,
         ),
       ).toBe(true);

--- a/packages/utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/utils/src/eslint-utils/RuleCreator.ts
@@ -27,6 +27,7 @@ export interface RuleCreateAndOptions<
     context: Readonly<RuleContext<MessageIds, Options>>,
     optionsWithDefault: Readonly<Options>,
   ) => RuleListener;
+  /** @deprecated Use meta.defaultOptions instead */
   defaultOptions?: Readonly<Options>;
 }
 
@@ -100,6 +101,8 @@ function createRule<
   PluginDocs = unknown,
 >({
   create,
+  // Keep accepting deprecated defaultOptions for backward compatibility.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   defaultOptions,
   meta,
   name,

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -729,6 +729,7 @@ export interface RuleModule<
   ): ExtendedRuleListener;
 
   /**
+   * @deprecated Use meta.defaultOptions instead
    * Default options the rule will be run with
    */
   defaultOptions?: Options;

--- a/packages/utils/tests/eslint-utils/RuleCreator.test.ts
+++ b/packages/utils/tests/eslint-utils/RuleCreator.test.ts
@@ -87,6 +87,8 @@ describe(ESLintUtils.RuleCreator, () => {
       name: 'with-default-options',
     });
 
+    // Keep accepting deprecated defaultOptions for backward compatibility.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expect(rule.defaultOptions).toEqual([{ option: true }]);
   });
 

--- a/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
@@ -186,6 +186,8 @@ function linkToConfigsForObject(docs: ESLintPluginDocs): string {
 }
 
 function getRuleDefaultOptions(page: RuleDocsPage): string {
+  // Keep accepting deprecated defaultOptions for backward compatibility.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const defaults = JSON.stringify(page.rule.defaultOptions);
   const recommended = page.rule.meta.docs.recommended;
 

--- a/packages/website/plugins/generated-rule-docs/insertions/insertRuleOptions.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertRuleOptions.ts
@@ -33,6 +33,8 @@ export function insertRuleOptions(page: RuleDocsPage): void {
     return;
   }
 
+  // Keep accepting deprecated defaultOptions for backward compatibility.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const defaultOptions = (page.rule.defaultOptions?.[0] ?? {}) as Record<
     string,
     unknown


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #11623
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

- Mark the top-level `defaultOptions` as deprecated and update the resolution logic so existing callers keep working.
- This PR implements the "Deprecating defaultOptions" item mentioned in [the comment](https://github.com/typescript-eslint/typescript-eslint/pull/11956#pullrequestreview-3651381456).

⛄️
