### PR TITLE
fix(scope-manager): prevent misidentification of `"use strict"` directives

### DIFF
--- a/packages/scope-manager/src/scope/ScopeBase.ts
+++ b/packages/scope-manager/src/scope/ScopeBase.ts
@@ -86,22 +86,14 @@ function isStrictScope(
 
   // Search 'use strict' directive.
   for (const stmt of body.body) {
-    if (stmt.type !== AST_NODE_TYPES.ExpressionStatement) {
+    if (
+      stmt.type !== AST_NODE_TYPES.ExpressionStatement ||
+      stmt.directive == null
+    ) {
       break;
     }
 
     if (stmt.directive === 'use strict') {
-      return true;
-    }
-
-    const expr = stmt.expression;
-    if (expr.type !== AST_NODE_TYPES.Literal) {
-      break;
-    }
-    if (expr.raw === '"use strict"' || expr.raw === "'use strict'") {
-      return true;
-    }
-    if (expr.value === 'use strict') {
       return true;
     }
   }

--- a/packages/scope-manager/tests/eslint-scope/use-strict-directive.test.ts
+++ b/packages/scope-manager/tests/eslint-scope/use-strict-directive.test.ts
@@ -1,0 +1,191 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/types';
+
+import { ScopeType } from '../../src/index.js';
+import { parseAndAnalyze } from '../test-utils/index.js';
+
+describe('"use strict" directives', () => {
+  describe('top level', () => {
+    it('"use strict" at top level makes the global scope strict', () => {
+      const { scopeManager } = parseAndAnalyze('"use strict";', 'script');
+
+      expect(scopeManager.scopes).toHaveLength(1);
+
+      const globalScope = scopeManager.scopes[0];
+      assert.isScopeOfType(globalScope, ScopeType.global);
+      expect(globalScope.isStrict).toBe(true);
+
+      const statement = globalScope.block.body[0];
+      assert.isNodeOfType(statement, AST_NODE_TYPES.ExpressionStatement);
+      expect(statement.directive).toBe('use strict');
+    });
+
+    it('"use strict" at top level makes child scopes strict', () => {
+      const { scopeManager } = parseAndAnalyze(
+        `
+          "use strict";
+          {
+            let x;
+          }
+          function f() {}
+        `,
+        'script',
+      );
+
+      expect(scopeManager.scopes).toHaveLength(3);
+
+      const globalScope = scopeManager.scopes[0];
+      assert.isScopeOfType(globalScope, ScopeType.global);
+      expect(globalScope.isStrict).toBe(true);
+
+      const blockScope = scopeManager.scopes[1];
+      assert.isScopeOfType(blockScope, ScopeType.block);
+      expect(blockScope.isStrict).toBe(true);
+
+      const functionScope = scopeManager.scopes[2];
+      assert.isScopeOfType(functionScope, ScopeType.function);
+      assert.isNodeOfType(
+        functionScope.block,
+        AST_NODE_TYPES.FunctionDeclaration,
+      );
+      expect(functionScope.isStrict).toBe(true);
+    });
+
+    it('`ExpressionStatement`s without `directive` property are not directives', () => {
+      const { scopeManager } = parseAndAnalyze('("use strict");', 'script');
+
+      expect(scopeManager.scopes).toHaveLength(1);
+
+      const globalScope = scopeManager.scopes[0];
+      assert.isScopeOfType(globalScope, ScopeType.global);
+      expect(globalScope.isStrict).toBe(false);
+
+      const statement = globalScope.block.body[0];
+      assert.isNodeOfType(statement, AST_NODE_TYPES.ExpressionStatement);
+      expect(statement.directive).toBeUndefined();
+    });
+
+    it('other directives at top level do not make the global scope strict', () => {
+      const { scopeManager } = parseAndAnalyze('"use server";', 'script');
+
+      expect(scopeManager.scopes).toHaveLength(1);
+
+      const globalScope = scopeManager.scopes[0];
+      assert.isScopeOfType(globalScope, ScopeType.global);
+      expect(globalScope.isStrict).toBe(false);
+    });
+  });
+
+  describe('function', () => {
+    it('"use strict" in a function makes that function scope strict', () => {
+      const { scopeManager } = parseAndAnalyze(
+        'function f() { "use strict"; }',
+        'script',
+      );
+
+      expect(scopeManager.scopes).toHaveLength(2);
+
+      const globalScope = scopeManager.scopes[0];
+      assert.isScopeOfType(globalScope, ScopeType.global);
+      expect(globalScope.isStrict).toBe(false);
+
+      const functionScope = scopeManager.scopes[1];
+      assert.isScopeOfType(functionScope, ScopeType.function);
+      assert.isNodeOfType(
+        functionScope.block,
+        AST_NODE_TYPES.FunctionDeclaration,
+      );
+      expect(functionScope.isStrict).toBe(true);
+
+      const statement = functionScope.block.body.body[0];
+      assert.isNodeOfType(statement, AST_NODE_TYPES.ExpressionStatement);
+      expect(statement.directive).toBe('use strict');
+    });
+
+    it('"use strict" in a function makes child scopes strict', () => {
+      const { scopeManager } = parseAndAnalyze(
+        `
+        function f() {
+          "use strict";
+          {
+            let x;
+          }
+          function g() {}
+        }
+      `,
+        'script',
+      );
+
+      expect(scopeManager.scopes).toHaveLength(4);
+
+      const globalScope = scopeManager.scopes[0];
+      assert.isScopeOfType(globalScope, ScopeType.global);
+      expect(globalScope.isStrict).toBe(false);
+
+      const outerFunctionScope = scopeManager.scopes[1];
+      assert.isScopeOfType(outerFunctionScope, ScopeType.function);
+      assert.isNodeOfType(
+        outerFunctionScope.block,
+        AST_NODE_TYPES.FunctionDeclaration,
+      );
+      expect(outerFunctionScope.isStrict).toBe(true);
+
+      const blockScope = scopeManager.scopes[2];
+      assert.isScopeOfType(blockScope, ScopeType.block);
+      expect(blockScope.isStrict).toBe(true);
+
+      const innerFunctionScope = scopeManager.scopes[3];
+      assert.isScopeOfType(innerFunctionScope, ScopeType.function);
+      assert.isNodeOfType(
+        innerFunctionScope.block,
+        AST_NODE_TYPES.FunctionDeclaration,
+      );
+      expect(innerFunctionScope.isStrict).toBe(true);
+    });
+
+    it('`ExpressionStatement`s without `directive` property are not directives', () => {
+      const { scopeManager } = parseAndAnalyze(
+        'function f() { ("use strict"); }',
+        'script',
+      );
+
+      expect(scopeManager.scopes).toHaveLength(2);
+
+      const globalScope = scopeManager.scopes[0];
+      assert.isScopeOfType(globalScope, ScopeType.global);
+      expect(globalScope.isStrict).toBe(false);
+
+      const functionScope = scopeManager.scopes[1];
+      assert.isScopeOfType(functionScope, ScopeType.function);
+      assert.isNodeOfType(
+        functionScope.block,
+        AST_NODE_TYPES.FunctionDeclaration,
+      );
+      expect(functionScope.isStrict).toBe(false);
+
+      const statement = functionScope.block.body.body[0];
+      assert.isNodeOfType(statement, AST_NODE_TYPES.ExpressionStatement);
+      expect(statement.directive).toBeUndefined();
+    });
+
+    it('other directives do not make the function scope strict', () => {
+      const { scopeManager } = parseAndAnalyze(
+        'function f() { "use server"; }',
+        'script',
+      );
+
+      expect(scopeManager.scopes).toHaveLength(2);
+
+      const globalScope = scopeManager.scopes[0];
+      assert.isScopeOfType(globalScope, ScopeType.global);
+      expect(globalScope.isStrict).toBe(false);
+
+      const functionScope = scopeManager.scopes[1];
+      assert.isScopeOfType(functionScope, ScopeType.function);
+      assert.isNodeOfType(
+        functionScope.block,
+        AST_NODE_TYPES.FunctionDeclaration,
+      );
+      expect(functionScope.isStrict).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11993
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fixes #11993.

Previously, `ExpressionStatement`s without a `directive` property were incorrectly treated as directives. For example this function incorrectly had `isStrict: true`:

```js
// script
function f() {
  ("use strict");
}
```

Fix this by only treating `ExpressionStatement`s as directives if they have a `directive` property.

I may have gone overboard with the tests, but I couldn't find any existing tests for `"use strict"` directives at top level or in functions (only arrow functions), so I thought may as well add tests for these at the same time.