### PR TITLE
fix(eslint-plugin): [no-useless-default-assignment] require strictNullChecks (#11966)

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-useless-default-assignment.mdx
+++ b/packages/eslint-plugin/docs/rules/no-useless-default-assignment.mdx
@@ -48,6 +48,16 @@ const [foo = ''] = [undefined];
 </TabItem>
 </Tabs>
 
+## Options
+
+### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
+
+{/* insert option description */}
+
+If this is set to `false`, then the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.
+
+Without `strictNullChecks`, TypeScript essentially erases `undefined` and `null` from the types. This means when this rule inspects the types from a variable, **it will not be able to tell that the variable might be `null` or `undefined`**, which essentially makes this rule useless.
+
 ## When Not To Use It
 
 If you use default values defensively against runtime values that bypass type checking, or for documentation purposes, you may want to disable this rule.

--- a/packages/eslint-plugin/tests/docs.test.mts
+++ b/packages/eslint-plugin/tests/docs.test.mts
@@ -184,6 +184,7 @@ describe('Validating rule docs', () => {
     'no-misused-promises',
     'no-type-alias',
     'no-unnecessary-condition',
+    'no-useless-default-assignment',
     'no-unnecessary-type-assertion',
     'parameter-properties',
     'prefer-nullish-coalescing',

--- a/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-useless-default-assignment.test.ts
@@ -1,3 +1,5 @@
+import * as path from 'node:path';
+
 import rule from '../../src/rules/no-useless-default-assignment';
 import { createRuleTesterWithTypes, getFixturesRootDir } from '../RuleTester';
 
@@ -232,6 +234,18 @@ ruleTester.run('no-useless-default-assignment', rule, {
     `
       const { a = 'default' } =
         Math.random() > 0.5 ? (Math.random() > 0.5 ? { a: 'Hello' } : {}) : {};
+    `,
+    // Optional parameter with meaningful default value
+    `
+      function findPosts({
+        category,
+        maxResults = 100,
+      }: {
+        category: string;
+        maxResults?: number;
+      }): Promise<string[]> {
+        return Promise.resolve([category, String(maxResults)]);
+      }
     `,
   ],
   invalid: [
@@ -549,6 +563,96 @@ ruleTester.run('no-useless-default-assignment', rule, {
         function f(
           /* comment */ x? /* comment 2 */ : /* comment 3 */ SomeType,
         ) {}
+      `,
+    },
+    // noStrictNullCheck tests
+    {
+      code: `
+        function Bar({ foo = '' }: { foo: string }) {
+          return foo;
+        }
+      `,
+      errors: [
+        {
+          column: 1,
+          line: 0,
+          messageId: 'noStrictNullCheck',
+        },
+        {
+          column: 30,
+          data: { type: 'property' },
+          endColumn: 32,
+          line: 2,
+          messageId: 'uselessDefaultAssignment',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          tsconfigRootDir: path.join(rootDir, 'unstrict'),
+        },
+      },
+      output: `
+        function Bar({ foo }: { foo: string }) {
+          return foo;
+        }
+      `,
+    },
+    {
+      code: `
+        function foo(a = undefined) {}
+      `,
+      errors: [
+        {
+          column: 1,
+          line: 0,
+          messageId: 'noStrictNullCheck',
+        },
+        {
+          column: 26,
+          data: { type: 'parameter' },
+          endColumn: 35,
+          line: 2,
+          messageId: 'uselessUndefined',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          tsconfigRootDir: path.join(rootDir, 'unstrict'),
+        },
+      },
+      output: `
+        function foo(a) {}
+      `,
+    },
+    {
+      code: `
+        function Bar({ foo = '' }: { foo: string }) {
+          return foo;
+        }
+      `,
+      errors: [
+        {
+          column: 30,
+          data: { type: 'property' },
+          endColumn: 32,
+          line: 2,
+          messageId: 'uselessDefaultAssignment',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          tsconfigRootDir: path.join(rootDir, 'unstrict'),
+        },
+      },
+      options: [
+        {
+          allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: true,
+        },
+      ],
+      output: `
+        function Bar({ foo }: { foo: string }) {
+          return foo;
+        }
       `,
     },
   ],

--- a/packages/eslint-plugin/tests/schema-snapshots/no-useless-default-assignment.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/no-useless-default-assignment.shot
@@ -1,10 +1,25 @@
 
 # SCHEMA:
 
-[]
+[
+  {
+    "additionalProperties": false,
+    "properties": {
+      "allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing": {
+        "description": "Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`.",
+        "type": "boolean"
+      }
+    },
+    "type": "object"
+  }
+]
 
 
 # TYPES:
 
-/** No options declared */
-type Options = [];
+type Options = [
+  {
+    /** Unless this is set to `true`, the rule will error on every file whose `tsconfig.json` does _not_ have the `strictNullChecks` compiler option (or `strict`) set to `true`. */
+    allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing?: boolean;
+  },
+];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11966
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR adds a strictNullChecks compiler option check to the no-useless-default-assignment rule.                                                  
Without strictNullChecks enabled, TypeScript treats all types as potentially null or undefined, which can cause the rule to produce false positives.

For example: `function Bar({ foo = '' }: { foo: string }) {}`     
- With strictNullChecks: `true`: foo is strictly string, so the default value is correctly flagged as useless.
- With strictNullChecks: `false`: foo could be string | null | undefined, so the default value might actually be needed.

### Changes
1. Added noStrictNullCheck message to warn users when strictNullChecks is not enabled.
2. Added allowRuleToRunWithoutStrictNullChecksIKnow WhatIAmDoing option (consistent with other rules like no-unnecessary-condition, prefer-nullish-coalescing, etc.) to allow users to bypass this check if they understand the implications.
3. Added corresponding test cases for the new behavior.

💖