### PR TITLE
chore: remove redundant tsconfig reference

### DIFF
--- a/tsconfig.repo-config-files.json
+++ b/tsconfig.repo-config-files.json
@@ -16,9 +16,6 @@
   ],
   "references": [
     {
-      "path": "./packages/typescript-eslint/tsconfig.build.json"
-    },
-    {
       "path": "./tsconfig.spec.json"
     }
   ]


### PR DESCRIPTION
Continuing on #11204 again

When working on #12001, I noticed that we have a seemingly redundant reference to `packages/typescript-eslint`

It causes the `repo:typecheck` to also check some of the packages themselves, rather than just the root files, resulting in slightly (but probably negligible) slower run and duplicated errors.

To see the issue, checkout `main`, add a type error in one of the referenced packages (i.e. `eslint-package`), and run `yarn nx run-many --target typecheck`.
You should see the same error twice

