### PR TITLE
chore(website): add data/ directory to Nx outputs

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -116,7 +116,8 @@
         },
         "cache": true,
         "outputs": [
-          "{projectRoot}/build"
+          "{projectRoot}/build",
+          "{projectRoot}/data"
         ]
       },
       "lint": {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12030
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds the website's `data/` directory to its build outputs. This should capture both `data/recent-blog-posts.json` and `data/sponsors.json`.

💖