### PR TITLE
chore: enable exactOptionalPropertyTypes internally

### DIFF
--- a/docs/packages/Scope_Manager.mdx
+++ b/docs/packages/Scope_Manager.mdx
@@ -23,27 +23,27 @@ interface AnalyzeOptions {
   /**
    * Known visitor keys.
    */
-  childVisitorKeys?: Record<string, string[]> | null;
+  childVisitorKeys?: Record<string, string[]> | null | undefined;
 
   /**
    * Whether the whole script is executed under node.js environment.
    * When enabled, the scope manager adds a function scope immediately following the global scope.
    * Defaults to `false`.
    */
-  globalReturn?: boolean;
+  globalReturn?: boolean | undefined;
 
   /**
    * Implied strict mode.
    * Defaults to `false`.
    */
-  impliedStrict?: boolean;
+  impliedStrict?: boolean | undefined;
 
   /**
    * The identifier that's used for JSX Element creation (after transpilation).
    * This should not be a member expression - just the root identifier (i.e. use "React" instead of "React.createElement").
    * Defaults to `"React"`.
    */
-  jsxPragma?: string;
+  jsxPragma?: string | undefined;
 
   /**
    * The identifier that's used for JSX fragment elements (after transpilation).
@@ -51,7 +51,7 @@ interface AnalyzeOptions {
    * This should not be a member expression - just the root identifier (i.e. use "h" instead of "h.Fragment").
    * Defaults to `null`.
    */
-  jsxFragmentName?: string | null;
+  jsxFragmentName?: string | null | undefined;
 
   /**
    * The lib used by the project.
@@ -60,18 +60,18 @@ interface AnalyzeOptions {
    *
    * Defaults to ['esnext'].
    */
-  lib?: Lib[];
+  lib?: Lib[] | undefined;
 
   /**
    * The source type of the script.
    */
-  sourceType?: 'script' | 'module';
+  sourceType?: 'script' | 'module' | undefined;
 
   /**
    * Emit design-type metadata for decorated declarations in source.
    * Defaults to `false`.
    */
-  emitDecoratorMetadata?: boolean;
+  emitDecoratorMetadata?: boolean | undefined;
 }
 ```
 

--- a/docs/packages/TypeScript_ESTree.mdx
+++ b/docs/packages/TypeScript_ESTree.mdx
@@ -37,23 +37,23 @@ interface ParseOptions {
    * Specify the `sourceType`.
    * For more details, see https://github.com/typescript-eslint/typescript-eslint/pull/9121
    */
-  sourceType?: SourceType;
+  sourceType?: SourceType | undefined;
 
   /**
    * Prevents the parser from throwing an error if it receives an invalid AST from TypeScript.
    * This case only usually occurs when attempting to lint invalid code.
    */
-  allowInvalidAST?: boolean;
+  allowInvalidAST?: boolean | undefined;
 
   /**
    * create a top-level comments array containing all comments
    */
-  comment?: boolean;
+  comment?: boolean | undefined;
 
   /**
    * Whether deprecated AST properties should skip calling console.warn on accesses.
    */
-  suppressDeprecatedPropertyWarnings?: boolean;
+  suppressDeprecatedPropertyWarnings?: boolean | undefined;
 
   /**
    * An array of modules to turn explicit debugging on for.
@@ -65,18 +65,21 @@ interface ParseOptions {
    * - true === ['typescript-eslint']
    * - false === []
    */
-  debugLevel?: boolean | ('typescript-eslint' | 'eslint' | 'typescript')[];
+  debugLevel?:
+    | boolean
+    | ('typescript-eslint' | 'eslint' | 'typescript')[]
+    | undefined;
 
   /**
    * Cause the parser to error if it encounters an unknown AST node type (useful for testing).
    * This case only usually occurs when TypeScript releases new features.
    */
-  errorOnUnknownASTType?: boolean;
+  errorOnUnknownASTType?: boolean | undefined;
 
   /**
    * Absolute (or relative to `cwd`) path to the file being parsed.
    */
-  filePath?: string;
+  filePath?: string | undefined;
 
   /**
    * If you are using TypeScript version >=5.3 then this option can be used as a performance optimization.
@@ -88,7 +91,7 @@ interface ParseOptions {
    *
    * If you do not rely on JSDoc tags from the TypeScript AST, then you can safely set this to `'none'` to improve performance.
    */
-  jsDocParsingMode?: JSDocParsingMode;
+  jsDocParsingMode?: JSDocParsingMode | undefined;
 
   /**
    * Enable parsing of JSX.
@@ -99,33 +102,33 @@ interface ParseOptions {
    *
    * For the exact behavior, see https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/parser#parseroptionsecmafeaturesjsx
    */
-  jsx?: boolean;
+  jsx?: boolean | undefined;
 
   /**
    * Controls whether the `loc` information to each node.
    * The `loc` property is an object which contains the exact line/column the node starts/ends on.
    * This is similar to the `range` property, except it is line/column relative.
    */
-  loc?: boolean;
+  loc?: boolean | undefined;
 
   /*
    * Allows overriding of function used for logging.
    * When value is `false`, no logging will occur.
    * When value is not provided, `console.log()` will be used.
    */
-  loggerFn?: Function | false;
+  loggerFn?: Function | false | undefined;
 
   /**
    * Controls whether the `range` property is included on AST nodes.
    * The `range` property is a [number, number] which indicates the start/end index of the node in the file contents.
    * This is similar to the `loc` property, except this is the absolute index.
    */
-  range?: boolean;
+  range?: boolean | undefined;
 
   /**
    * Set to true to create a top-level array containing all tokens from the file.
    */
-  tokens?: boolean;
+  tokens?: boolean | undefined;
 }
 
 const PARSE_DEFAULT_OPTIONS: ParseOptions = {

--- a/packages/eslint-plugin/src/rules/class-literal-property-style.ts
+++ b/packages/eslint-plugin/src/rules/class-literal-property-style.ts
@@ -19,7 +19,7 @@ export type MessageIds =
   | 'preferGetterStyleSuggestion';
 
 interface NodeWithModifiers {
-  accessibility?: TSESTree.Accessibility;
+  accessibility?: TSESTree.Accessibility | undefined;
   static: boolean;
 }
 

--- a/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
+++ b/packages/eslint-plugin/src/rules/prefer-readonly-parameter-types.ts
@@ -15,7 +15,7 @@ import {
 
 export type Options = [
   {
-    allow?: TypeOrValueSpecifier[];
+    allow?: TypeOrValueSpecifier[] | undefined;
     checkParameterProperties?: boolean;
     ignoreInferredTypes?: boolean;
     treatMethodsAsReadonly?: boolean;

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -538,7 +538,7 @@ export default createRule<Options, MessageIds>({
     interface Scope {
       overloads: Map<string, OverloadNode[]>;
       parent?: ScopeNode;
-      typeParameters?: TSESTree.TSTypeParameterDeclaration;
+      typeParameters?: TSESTree.TSTypeParameterDeclaration | undefined;
     }
 
     const scopes: Scope[] = [];

--- a/packages/project-service/src/createProjectService.ts
+++ b/packages/project-service/src/createProjectService.ts
@@ -179,13 +179,13 @@ export function createProjectService({
 
   const service = new tsserver.server.ProjectService({
     cancellationToken: { isCancellationRequested: (): boolean => false },
-    eventHandler: logTsserverEvent.enabled
-      ? (e): void => {
-          logTsserverEvent(e);
-        }
-      : undefined,
+    ...(logTsserverEvent.enabled && {
+      eventHandler: (e): void => {
+        logTsserverEvent(e);
+      },
+    }),
     host: system,
-    jsDocParsingMode,
+    ...(jsDocParsingMode && { jsDocParsingMode }),
     logger,
     session: undefined,
     useInferredProjectPerProjectRoot: false,

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -199,7 +199,7 @@ export class RuleTester extends TestFramework {
   }
 
   #getLinterForFilename(filename: string | undefined): Linter {
-    let basePath: string | undefined =
+    let basePath =
       this.#testerConfig.languageOptions.parserOptions?.tsconfigRootDir;
     // For an absolute path (`/foo.ts`), or a path that steps
     // up (`../foo.ts`), resolve the path relative to the base
@@ -605,7 +605,7 @@ export class RuleTester extends TestFramework {
     afterAST: TSESTree.Program;
     beforeAST: TSESTree.Program;
     config: RuleTesterConfig;
-    filename?: string;
+    filename?: string | undefined;
     messages: Linter.LintMessage[];
     outputs: string[];
   } {

--- a/packages/scope-manager/src/ScopeManager.ts
+++ b/packages/scope-manager/src/ScopeManager.ts
@@ -27,9 +27,9 @@ import { ClassFieldInitializerScope } from './scope/ClassFieldInitializerScope';
 import { ClassStaticBlockScope } from './scope/ClassStaticBlockScope';
 
 interface ScopeManagerOptions {
-  globalReturn?: boolean;
-  impliedStrict?: boolean;
-  sourceType?: SourceType;
+  globalReturn?: boolean | undefined;
+  impliedStrict?: boolean | undefined;
+  sourceType?: SourceType | undefined;
 }
 
 /**

--- a/packages/scope-manager/src/analyze.ts
+++ b/packages/scope-manager/src/analyze.ts
@@ -15,27 +15,27 @@ export interface AnalyzeOptions {
   /**
    * Known visitor keys.
    */
-  childVisitorKeys?: ReferencerOptions['childVisitorKeys'];
+  childVisitorKeys?: ReferencerOptions['childVisitorKeys'] | undefined;
 
   /**
    * Whether the whole script is executed under node.js environment.
    * When enabled, the scope manager adds a function scope immediately following the global scope.
    * Defaults to `false`.
    */
-  globalReturn?: boolean;
+  globalReturn?: boolean | undefined;
 
   /**
    * Implied strict mode.
    * Defaults to `false`.
    */
-  impliedStrict?: boolean;
+  impliedStrict?: boolean | undefined;
 
   /**
    * The identifier that's used for JSX Element creation (after transpilation).
    * This should not be a member expression - just the root identifier (i.e. use "React" instead of "React.createElement").
    * Defaults to `"React"`.
    */
-  jsxPragma?: string | null;
+  jsxPragma?: string | null | undefined;
 
   /**
    * The identifier that's used for JSX fragment elements (after transpilation).
@@ -43,7 +43,7 @@ export interface AnalyzeOptions {
    * This should not be a member expression - just the root identifier (i.e. use "h" instead of "h.Fragment").
    * Defaults to `null`.
    */
-  jsxFragmentName?: string | null;
+  jsxFragmentName?: string | null | undefined;
 
   /**
    * The lib used by the project.
@@ -52,12 +52,12 @@ export interface AnalyzeOptions {
    *
    * https://www.typescriptlang.org/tsconfig#lib
    */
-  lib?: Lib[];
+  lib?: Lib[] | undefined;
 
   /**
    * The source type of the script.
    */
-  sourceType?: SourceType;
+  sourceType?: SourceType | undefined;
 
   // TODO - remove this in v10
   /**
@@ -66,7 +66,7 @@ export interface AnalyzeOptions {
   emitDecoratorMetadata?: boolean;
 }
 
-const DEFAULT_OPTIONS: Required<AnalyzeOptions> = {
+const DEFAULT_OPTIONS = {
   childVisitorKeys: visitorKeys,
   emitDecoratorMetadata: false,
   globalReturn: false,
@@ -75,7 +75,7 @@ const DEFAULT_OPTIONS: Required<AnalyzeOptions> = {
   jsxPragma: 'React',
   lib: ['es2018'],
   sourceType: 'script',
-};
+} satisfies Required<AnalyzeOptions>;
 
 /**
  * Takes an AST and returns the analyzed scopes.
@@ -84,7 +84,7 @@ export function analyze(
   tree: TSESTree.Program,
   providedOptions?: AnalyzeOptions,
 ): ScopeManager {
-  const options: Required<AnalyzeOptions> = {
+  const options = {
     childVisitorKeys:
       providedOptions?.childVisitorKeys ?? DEFAULT_OPTIONS.childVisitorKeys,
     emitDecoratorMetadata: false,

--- a/packages/scope-manager/src/referencer/Reference.ts
+++ b/packages/scope-manager/src/referencer/Reference.ts
@@ -90,11 +90,11 @@ export class Reference {
     this.#flag = flag;
 
     if (this.isWrite()) {
-      this.writeExpr = writeExpr;
-      this.init = init;
+      this.writeExpr = writeExpr ?? null;
+      this.init = init ?? false;
     }
 
-    this.maybeImplicitGlobal = maybeImplicitGlobal;
+    this.maybeImplicitGlobal = maybeImplicitGlobal ?? null;
     this.#referenceType = referenceType;
   }
 

--- a/packages/scope-manager/src/referencer/VisitorBase.ts
+++ b/packages/scope-manager/src/referencer/VisitorBase.ts
@@ -4,7 +4,7 @@ import type { VisitorKeys } from '@typescript-eslint/visitor-keys';
 import { visitorKeys } from '@typescript-eslint/visitor-keys';
 
 export interface VisitorOptions {
-  childVisitorKeys?: VisitorKeys | null;
+  childVisitorKeys?: VisitorKeys | null | undefined;
   visitChildrenEvenIfSelectorExists?: boolean;
 }
 

--- a/packages/type-utils/src/isTypeReadonly.ts
+++ b/packages/type-utils/src/isTypeReadonly.ts
@@ -22,8 +22,8 @@ const enum Readonlyness {
 }
 
 export interface ReadonlynessOptions {
-  readonly allow?: TypeOrValueSpecifier[];
-  readonly treatMethodsAsReadonly?: boolean;
+  readonly allow?: TypeOrValueSpecifier[] | undefined;
+  readonly treatMethodsAsReadonly?: boolean | undefined;
 }
 
 export const readonlynessOptionsSchema = {
@@ -37,10 +37,10 @@ export const readonlynessOptionsSchema = {
   type: 'object',
 } satisfies JSONSchema4;
 
-export const readonlynessOptionsDefaults: ReadonlynessOptions = {
+export const readonlynessOptionsDefaults = {
   allow: [],
   treatMethodsAsReadonly: false,
-};
+} satisfies ReadonlynessOptions;
 
 function hasSymbol(node: ts.Node): node is { symbol: ts.Symbol } & ts.Node {
   return Object.hasOwn(node, 'symbol');

--- a/packages/typescript-estree/src/create-program/createIsolatedProgram.ts
+++ b/packages/typescript-estree/src/create-program/createIsolatedProgram.ts
@@ -68,7 +68,7 @@ export function createIsolatedProgram(
     [parseSettings.filePath],
     {
       jsDocParsingMode: parseSettings.jsDocParsingMode,
-      jsx: parseSettings.jsx ? ts.JsxEmit.Preserve : undefined,
+      ...(parseSettings.jsx && { jsx: ts.JsxEmit.Preserve }),
       noResolve: true,
       target: ts.ScriptTarget.Latest,
       ...createDefaultCompilerOptionsFromExtra(parseSettings),

--- a/packages/typescript-estree/src/create-program/createSourceFile.ts
+++ b/packages/typescript-estree/src/create-program/createSourceFile.ts
@@ -26,7 +26,10 @@ export function createSourceFile(parseSettings: ParseSettings): ts.SourceFile {
         {
           jsDocParsingMode: parseSettings.jsDocParsingMode,
           languageVersion: ts.ScriptTarget.Latest,
-          setExternalModuleIndicator: parseSettings.setExternalModuleIndicator,
+          ...(parseSettings.setExternalModuleIndicator && {
+            setExternalModuleIndicator:
+              parseSettings.setExternalModuleIndicator,
+          }),
         },
         /* setParentNodes */ true,
         getScriptKind(parseSettings.filePath, parseSettings.jsx),

--- a/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
+++ b/packages/typescript-estree/src/create-program/getWatchProgramsForProjects.ts
@@ -341,7 +341,9 @@ function createWatchProgram(
 
   // Since we don't want to asynchronously update program we want to disable timeout methods
   // So any changes in the program will be delayed and updated when getProgram is called on watch
+  // @ts-expect-error -- TypeScript's types don't play well with exactOptionalPropertyTypes.
   watchCompilerHost.setTimeout = undefined;
+  // @ts-expect-error -- TypeScript's types don't play well with exactOptionalPropertyTypes.
   watchCompilerHost.clearTimeout = undefined;
   return ts.createWatchProgram(watchCompilerHost);
 }

--- a/packages/typescript-estree/src/node-utils.ts
+++ b/packages/typescript-estree/src/node-utils.ts
@@ -438,7 +438,7 @@ export function isComputedProperty(
  * @param node ts.Node to be checked
  */
 export function isOptional(node: {
-  questionToken?: ts.QuestionToken;
+  questionToken?: ts.QuestionToken | undefined;
 }): boolean {
   return !!node.questionToken;
 }

--- a/packages/typescript-estree/src/parseSettings/createParseSettings.ts
+++ b/packages/typescript-estree/src/parseSettings/createParseSettings.ts
@@ -158,14 +158,14 @@ export function createParseSettings(
             tsconfigRootDir,
           })
         : undefined,
-    setExternalModuleIndicator:
-      tsestreeOptions.sourceType === 'module' ||
+    ...((tsestreeOptions.sourceType === 'module' ||
       (tsestreeOptions.sourceType == null && extension === ts.Extension.Mjs) ||
-      (tsestreeOptions.sourceType == null && extension === ts.Extension.Mts)
-        ? (file): void => {
-            file.externalModuleIndicator = true;
-          }
-        : undefined,
+      tsestreeOptions.sourceType == null) &&
+      extension === ts.Extension.Mts && {
+        setExternalModuleIndicator: (file): void => {
+          file.externalModuleIndicator = true;
+        },
+      }),
     singleRun,
     suppressDeprecatedPropertyWarnings:
       tsestreeOptions.suppressDeprecatedPropertyWarnings ??

--- a/packages/typescript-estree/src/parser-options.ts
+++ b/packages/typescript-estree/src/parser-options.ts
@@ -18,18 +18,18 @@ interface ParseOptions {
    * Specify the `sourceType`.
    * For more details, see https://github.com/typescript-eslint/typescript-eslint/pull/9121
    */
-  sourceType?: SourceType;
+  sourceType?: SourceType | undefined;
 
   /**
    * Prevents the parser from throwing an error if it receives an invalid AST from TypeScript.
    * This case only usually occurs when attempting to lint invalid code.
    */
-  allowInvalidAST?: boolean;
+  allowInvalidAST?: boolean | undefined;
 
   /**
    * create a top-level comments array containing all comments
    */
-  comment?: boolean;
+  comment?: boolean | undefined;
 
   /**
    * An array of modules to turn explicit debugging on for.
@@ -41,18 +41,18 @@ interface ParseOptions {
    * - true === ['typescript-eslint']
    * - false === []
    */
-  debugLevel?: DebugLevel;
+  debugLevel?: DebugLevel | undefined;
 
   /**
    * Cause the parser to error if it encounters an unknown AST node type (useful for testing).
    * This case only usually occurs when TypeScript releases new features.
    */
-  errorOnUnknownASTType?: boolean;
+  errorOnUnknownASTType?: boolean | undefined;
 
   /**
    * Absolute (or relative to `cwd`) path to the file being parsed.
    */
-  filePath?: string;
+  filePath?: string | undefined;
 
   /**
    * If you are using TypeScript version >=5.3 then this option can be used as a performance optimization.
@@ -64,7 +64,7 @@ interface ParseOptions {
    *
    * If you do not rely on JSDoc tags from the TypeScript AST, then you can safely set this to `'none'` to improve performance.
    */
-  jsDocParsingMode?: JSDocParsingMode;
+  jsDocParsingMode?: JSDocParsingMode | undefined;
 
   /**
    * Enable parsing of JSX.
@@ -75,38 +75,38 @@ interface ParseOptions {
    *
    * For the exact behavior, see https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/parser#parseroptionsecmafeaturesjsx
    */
-  jsx?: boolean;
+  jsx?: boolean | undefined;
 
   /**
    * Controls whether the `loc` information to each node.
    * The `loc` property is an object which contains the exact line/column the node starts/ends on.
    * This is similar to the `range` property, except it is line/column relative.
    */
-  loc?: boolean;
+  loc?: boolean | undefined;
 
   /*
    * Allows overriding of function used for logging.
    * When value is `false`, no logging will occur.
    * When value is not provided, `console.log()` will be used.
    */
-  loggerFn?: ((message: string) => void) | false;
+  loggerFn?: ((message: string) => void) | false | undefined;
 
   /**
    * Controls whether the `range` property is included on AST nodes.
    * The `range` property is a [number, number] which indicates the start/end index of the node in the file contents.
    * This is similar to the `loc` property, except this is the absolute index.
    */
-  range?: boolean;
+  range?: boolean | undefined;
 
   /**
    * Set to true to create a top-level array containing all tokens from the file.
    */
-  tokens?: boolean;
+  tokens?: boolean | undefined;
 
   /**
    * Whether deprecated AST properties should skip calling console.warn on accesses.
    */
-  suppressDeprecatedPropertyWarnings?: boolean;
+  suppressDeprecatedPropertyWarnings?: boolean | undefined;
 }
 
 interface ParseAndGenerateServicesOptions extends ParseOptions {

--- a/packages/typescript-estree/src/simple-traverse.ts
+++ b/packages/typescript-estree/src/simple-traverse.ts
@@ -24,10 +24,10 @@ function getVisitorKeysForNode(
 type SimpleTraverseOptions = Readonly<
   | {
       enter: (node: TSESTree.Node, parent: TSESTree.Node | undefined) => void;
-      visitorKeys?: Readonly<VisitorKeys>;
+      visitorKeys?: Readonly<VisitorKeys> | undefined;
     }
   | {
-      visitorKeys?: Readonly<VisitorKeys>;
+      visitorKeys?: Readonly<VisitorKeys> | undefined;
       visitors: Record<
         string,
         (node: TSESTree.Node, parent: TSESTree.Node | undefined) => void
@@ -54,7 +54,8 @@ class SimpleTraverser {
     }
 
     if (this.setParentPointers) {
-      node.parent = parent;
+      // @ts-expect-error -- TSESTree.Node's parent is a very long, difficult-to-satisfy union
+      node.parent = parent as typeof node.parent;
     }
 
     if ('enter' in this.selectors) {

--- a/packages/utils/src/eslint-utils/RuleCreator.ts
+++ b/packages/utils/src/eslint-utils/RuleCreator.ts
@@ -111,9 +111,9 @@ function createRule<
   Options,
   PluginDocs
 > {
+  const internalDefaultOptions = (defaultOptions ?? []) as Readonly<Options>;
   const resolvedDefaultOptions = (meta.defaultOptions ??
-    defaultOptions ??
-    []) as Readonly<Options>;
+    internalDefaultOptions) as Readonly<Options>;
   return {
     create(context: Readonly<RuleContext<MessageIds, Options>>): RuleListener {
       const optionsWithDefault = applyDefault(
@@ -122,9 +122,9 @@ function createRule<
       );
       return create(context, optionsWithDefault);
     },
-    defaultOptions,
+    defaultOptions: internalDefaultOptions,
     meta,
-    name,
+    ...(name != null && { name }),
   };
 }
 

--- a/packages/utils/src/ts-eslint/Linter.ts
+++ b/packages/utils/src/ts-eslint/Linter.ts
@@ -118,12 +118,12 @@ namespace Linter {
      * Which config format to use.
      * @default 'flat'
      */
-    configType?: ConfigTypeSpecifier;
+    configType?: ConfigTypeSpecifier | undefined;
 
     /**
      * path to a directory that should be considered as the current working directory.
      */
-    cwd?: string;
+    cwd?: string | undefined;
   }
 
   export type ConfigTypeSpecifier = 'eslintrc' | 'flat';

--- a/packages/utils/src/ts-eslint/Rule.ts
+++ b/packages/utils/src/ts-eslint/Rule.ts
@@ -106,11 +106,11 @@ export interface RuleMetaData<
   /**
    * The fixer category. Omit if there is no fixer
    */
-  fixable?: 'code' | 'whitespace';
+  fixable?: 'code' | 'whitespace' | undefined;
   /**
    * Specifies whether rules can return suggestions. Omit if there is no suggestions
    */
-  hasSuggestions?: boolean;
+  hasSuggestions?: boolean | undefined;
   /**
    * A map of messages which the rule can report.
    * The key is the messageId, and the string is the parameterised error string.
@@ -207,11 +207,11 @@ interface ReportDescriptorBase<MessageIds extends string> {
   /**
    * The parameters for the message string associated with `messageId`.
    */
-  readonly data?: ReportDescriptorMessageData;
+  readonly data?: ReportDescriptorMessageData | undefined;
   /**
    * The fixer function.
    */
-  readonly fix?: ReportFixFunction | null;
+  readonly fix?: ReportFixFunction | null | undefined;
   /**
    * The messageId which is being reported.
    */
@@ -226,7 +226,10 @@ interface ReportDescriptorWithSuggestion<
   /**
    * 6.7's Suggestions API
    */
-  readonly suggest?: Readonly<ReportSuggestionArray<MessageIds>> | null;
+  readonly suggest?:
+    | Readonly<ReportSuggestionArray<MessageIds>>
+    | null
+    | undefined;
 }
 
 interface ReportDescriptorNodeOptionalLoc {
@@ -235,7 +238,8 @@ interface ReportDescriptorNodeOptionalLoc {
    */
   readonly loc?:
     | Readonly<TSESTree.Position>
-    | Readonly<TSESTree.SourceLocation>;
+    | Readonly<TSESTree.SourceLocation>
+    | undefined;
   /**
    * The Node or AST Token which the report is being attached to
    */

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "emitDeclarationOnly": true,
     "emitDecoratorMetadata": false,
     "esModuleInterop": true,
+    "exactOptionalPropertyTypes": true,
     "experimentalDecorators": false,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": false,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6307
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I tried to keep this to as few changes as possible. When there was a new type error:

* If it was part of our exported public API types: change internal logic to adhere to the existing type
* If it was part of an external API such as ESLint's: make our types more permissive

💖