### PR TITLE
fix(typescript-estree): switch back to use `ts.getModifiers()`

### DIFF
--- a/packages/typescript-estree/src/check-modifiers.ts
+++ b/packages/typescript-estree/src/check-modifiers.ts
@@ -393,7 +393,7 @@ export function checkModifiers(node: ts.Node): void {
   // `ts.getModifiers()` can't access invalid modifiers on object properties
   // Eg: `({declare a: 1})`
   // See https://github.com/typescript-eslint/typescript-eslint/pull/11931#discussion_r2678961730
-  // @eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- incorrect type
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- incorrect type
   if (node.parent?.kind === SyntaxKind.ObjectLiteralExpression) {
     // @ts-expect-error intentional to access deprecated `node.modifiers`
     for (const modifier of (node.modifiers as ts.Modifier[] | undefined) ??


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12027
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Switch back to use `ts.getModifiers()` as requested in https://github.com/typescript-eslint/typescript-eslint/pull/11931#discussion_r2666662391

Make an exception for `object` properties, check `node.modifiers` directly since `ts.getModifiers()` can't access them. https://github.com/typescript-eslint/typescript-eslint/pull/11931#discussion_r2678961730
