### PR TITLE
chore(eslint-plugin): refine tests glob for better performance

### DIFF
--- a/packages/eslint-plugin/vitest.config.mts
+++ b/packages/eslint-plugin/vitest.config.mts
@@ -12,6 +12,11 @@ const vitestConfig = mergeConfig(
 
     test: {
       dir: path.join(import.meta.dirname, 'tests'),
+
+      include: process.env.CI
+        ? ['./*.test.?(m)ts', './{eslint-rules,rules,util}/**/*.test.ts']
+        : undefined,
+
       isolate: false,
       name: packageJson.name.replace('@typescript-eslint/', ''),
       root: import.meta.dirname,


### PR DESCRIPTION
Continuing on #11204

As always, some numbers from my machine (M4 Pro, 24GB), saw ~16% improvement:

```
hyperfine "CI=true pnpm vitest" "CI=true FAST=true pnpm vitest"
Benchmark 1: CI=true pnpm vitest
  Time (mean ± σ):     47.981 s ±  4.702 s    [User: 193.125 s, System: 92.273 s]
  Range (min … max):   41.416 s … 55.076 s    10 runs
 
Benchmark 2: CI=true FAST=true pnpm vitest
  Time (mean ± σ):     41.533 s ±  3.643 s    [User: 187.508 s, System: 82.037 s]
  Range (min … max):   34.411 s … 46.507 s    10 runs
 
Summary
  CI=true FAST=true pnpm vitest ran
    1.16 ± 0.15 times faster than CI=true pnpm vitest
```

Inspired by
https://x.com/oriSomething/status/2019743968200679902

Thanks @oriSomething!

EDIT: I'm seeing the improvements only locally, i'm not sure there is a difference in CI 🤔 