### PR TITLE
docs(parser): fix default value of disallowAutomaticSingleRunInference

### DIFF
--- a/docs/packages/Parser.mdx
+++ b/docs/packages/Parser.mdx
@@ -63,7 +63,7 @@ interface ParserOptions {
 
 ### `disallowAutomaticSingleRunInference`
 
-> Default: `process.env.TSESTREE_SINGLE_RUN` or `true`.
+> Default: `process.env.TSESTREE_SINGLE_RUN` or `false`.
 
 Whether to stop using common heuristics to infer whether ESLint is being used as part of a single run (as opposed to `--fix` mode or in a persistent session such as an editor extension).
 In other words, typescript-eslint is faster by default, and this option disables an automatic performance optimization.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12063
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The documentation for `disallowAutomaticSingleRunInference` states the default value is `true`, but it is actually `false`.

- The JSDoc in `packages/typescript-estree/src/parser-options.ts` explicitly states: "Otherwise, the default value is `false`."
- The implementation in `inferSingleRun.ts` uses `!options.disallowAutomaticSingleRunInference`, confirming `undefined` (unset) means inference is enabled — i.e., the option defaults to `false`.

This PR fixes the one-word error in `docs/packages/Parser.mdx`.