### PR TITLE
fix(typescript-estree): skip createIsolatedProgram fallback for projectService

### DIFF
--- a/packages/typescript-estree/src/parser.ts
+++ b/packages/typescript-estree/src/parser.ts
@@ -225,6 +225,12 @@ export function parseAndGenerateServices<
    *
    * In this scenario we cannot rely upon the singleRun AOT compiled programs because the SourceFiles will not contain the source
    * with the latest fixes applied. Therefore we fallback to creating the quickest possible isolated program from the updated source.
+   *
+   * Note: This fallback is only needed for the legacy `project` option which uses AOT compiled programs.
+   * When `projectService` is used, the TypeScript language service always provides up-to-date programs,
+   * so no fallback is necessary. Additionally, external parsers like vue-eslint-parser may call
+   * parseAndGenerateServices() multiple times for the same file in a single lint pass, which would
+   * incorrectly trigger this fallback.
    */
   if (parseSettings.singleRun && tsestreeOptions.filePath) {
     parseAndGenerateServicesCalls[tsestreeOptions.filePath] =
@@ -234,7 +240,8 @@ export function parseAndGenerateServices<
   const { ast, program } =
     parseSettings.singleRun &&
     tsestreeOptions.filePath &&
-    parseAndGenerateServicesCalls[tsestreeOptions.filePath] > 1
+    parseAndGenerateServicesCalls[tsestreeOptions.filePath] > 1 &&
+    !parseSettings.projectService
       ? createIsolatedProgram(parseSettings)
       : getProgramAndAST(parseSettings, hasFullTypeInformation);
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12065
- [x] That issue was marked as [`accepting prs`](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

When using `projectService` with external parsers like `vue-eslint-parser` (v9) in `singleRun` mode (e.g., CI with `CI=true`), the `createIsolatedProgram` fallback is incorrectly triggered, causing `tsconfig.json` compiler options (such as `strictNullChecks`) to be lost.

### Root Cause

`vue-eslint-parser` calls `parseAndGenerateServices()` multiple times for the same file path during a single lint pass — once for the `<script>` block and additional times for template expressions. In `singleRun` mode, the second call increments `parseAndGenerateServicesCalls` above 1, triggering the `createIsolatedProgram` fallback. This fallback does not read `tsconfig.json`, so all compiler options fall back to TypeScript defaults.

### Fix

Skip the `createIsolatedProgram` fallback when `projectService` is in use. This is safe because:

- The fallback exists for the legacy `project` option, which uses AOT-compiled programs that can become stale during `--fix` cycles.
- `projectService` does not use AOT programs — it passes the latest source code to `openClientFile()` on every call, so no fallback is necessary.
- Verified that `projectService` + `singleRun=true` + `--fix` works correctly without the fallback.

### Reproduction

https://github.com/ryo-chin/typescript-eslint-issue-repro

```bash
npm install
CI=true npx eslint --no-cache src/App.vue
# Actual: "This rule requires the `strictNullChecks` compiler option to be turned on"
# Expected: "Unexpected nullish value in conditional"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)