### PR TITLE
chore(eslint-plugin): add default excludes to vitest

### DIFF
--- a/packages/eslint-plugin/vitest.config.mts
+++ b/packages/eslint-plugin/vitest.config.mts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import { defineProject, mergeConfig } from 'vitest/config';
+import { defineProject, mergeConfig, configDefaults } from 'vitest/config';
 
 import { vitestBaseConfig } from '../../vitest.config.base.mjs';
 import packageJson from './package.json' with { type: 'json' };
@@ -18,7 +18,7 @@ const vitestConfig = mergeConfig(
 
       // Skip rules tests on Windows CI since they aren't affected by OS.
       exclude: isWindowsCI()
-        ? ['./rules/**/*', './eslint-rules/**/*']
+        ? [...configDefaults.exclude, './rules/**/*', './eslint-rules/**/*']
         : undefined,
     },
   }),


### PR DESCRIPTION
I added this exclude in a previous PR, but suddenly realized that I forgot to add the default excludes, meaning that vitest will try to look for tests inside `node_modules` and such