### PR TITLE
fix(eslint-plugin): handle statically analyzable computed keys in prefer-readonly

### DIFF
--- a/packages/eslint-plugin/tests/rules/prefer-readonly.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-readonly.test.ts
@@ -732,8 +732,65 @@ class Foo {
         accessor #acc = 3;
       }
     `,
+    `
+      class Test1 {
+        // should not report
+        private prop = 7;
+
+        foo() {
+          this['prop'] = 10;
+        }
+      }
+
+      class Test3 {
+        // should not report
+        private 'prop' = 7;
+
+        foo() {
+          this.prop = 10;
+        }
+      }
+    `,
   ],
   invalid: [
+    {
+      code: `
+        class Test2 {
+          // should report
+          private [Symbol.iterator] = 7;
+        }
+
+        class Test4 {
+          // should report
+          private [1] = 7;
+        }
+      `,
+      errors: [
+        {
+          data: {
+            name: 'Symbol.iterator',
+          },
+          messageId: 'preferReadonly',
+        },
+        {
+          data: {
+            name: '1',
+          },
+          messageId: 'preferReadonly',
+        },
+      ],
+      output: `
+        class Test2 {
+          // should report
+          private readonly [Symbol.iterator] = 7;
+        }
+
+        class Test4 {
+          // should report
+          private readonly [1] = 7;
+        }
+      `,
+    },
     {
       code: `
         class TestIncorrectlyModifiableStatic {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10655 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Problem: prefer-readonly mis-handled quoted/computed private keys and could emit invalid computed-key fixes.
Fix: Added static key handling & computed assignment tracking, fixed fixer placement and updated tests.
