### PR TITLE
docs: always use files in config examples

### DIFF
--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -41,6 +41,9 @@ import tseslint from 'typescript-eslint';
 export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -109,6 +112,9 @@ export default defineConfig(
   tseslint.configs.strict,
   // Add this line
   tseslint.configs.stylistic,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 

--- a/docs/getting-started/Typed_Linting.mdx
+++ b/docs/getting-started/Typed_Linting.mdx
@@ -30,6 +30,7 @@ export default defineConfig(
   // Added lines start
   tseslint.configs.recommendedTypeChecked,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         projectService: true,
@@ -109,7 +110,9 @@ export default defineConfig(
   tseslint.configs.strictTypeChecked,
   tseslint.configs.stylisticTypeChecked,
   // Added lines end
-  // ...
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -44,6 +44,9 @@ import tseslint from 'typescript-eslint';
 export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -261,6 +264,7 @@ import jestPlugin from 'eslint-plugin-jest';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig({
+  files: ['**/*.ts', '**/*.tsx'],
   plugins: {
     // highlight-next-line
     '@typescript-eslint': tseslint.plugin,
@@ -312,6 +316,7 @@ export default defineConfig(
   },
   eslint.configs.recommended,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     plugins: {
       '@typescript-eslint': tseslint.plugin,
       jest: jestPlugin,

--- a/docs/troubleshooting/faqs/ESLint.mdx
+++ b/docs/troubleshooting/faqs/ESLint.mdx
@@ -59,6 +59,9 @@ export default defineConfig(
       'no-undef': 'off',
     },
   },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+  },
 );
 ```
 

--- a/docs/troubleshooting/faqs/Frameworks.mdx
+++ b/docs/troubleshooting/faqs/Frameworks.mdx
@@ -22,6 +22,7 @@ See [Changes to `extraFileExtensions` with `projectService`](../typed-linting/Pe
 export default defineConfig(
   // ... the rest of your config ...
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         // Add this line
@@ -67,6 +68,7 @@ import vueParser from 'vue-eslint-parser';
 export default defineConfig(
   // ... the rest of your config ...
   {
+    files: ['**/*.vue'],
     languageOptions: {
       // Remove this line
       parser: tseslint.parser,

--- a/docs/troubleshooting/faqs/General.mdx
+++ b/docs/troubleshooting/faqs/General.mdx
@@ -39,6 +39,7 @@ Some examples
 export default defineConfig(
   // ... the rest of your config ...
   {
+    files: ['**/*.ts', '**/*.tsx'],
     rules: {
       // turns a rule on with no configuration (i.e. uses the default configuration)
       '@typescript-eslint/array-type': 'error',
@@ -248,6 +249,7 @@ import tseslint from 'typescript-eslint';
 export default defineConfig(
   tseslint.configs.recommendedTypeCheckedOnly,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         projectService: true,

--- a/docs/troubleshooting/typed-linting/Monorepos.mdx
+++ b/docs/troubleshooting/typed-linting/Monorepos.mdx
@@ -60,6 +60,7 @@ export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         // Remove this line
@@ -110,6 +111,7 @@ export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         // Remove this line

--- a/docs/troubleshooting/typed-linting/Performance.mdx
+++ b/docs/troubleshooting/typed-linting/Performance.mdx
@@ -184,6 +184,7 @@ export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommendedRequiringTypeChecking,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         // Remove this line

--- a/docs/troubleshooting/typed-linting/index.mdx
+++ b/docs/troubleshooting/typed-linting/index.mdx
@@ -39,6 +39,9 @@ export default defineConfig(
     files: ['**/*.js'],
     extends: [tseslint.configs.disableTypeChecked],
   },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -75,6 +78,7 @@ export default defineConfig(
   tseslint.configs.recommendedTypeChecked,
   tseslint.configs.stylisticTypeChecked,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         projectService: true,
@@ -298,6 +302,7 @@ For example, if you use a specific `tsconfig.eslint.json` for linting, you'd spe
 
 ```js title="eslint.config.mjs"
 export default defineConfig({
+  files: ['**/*.ts', '**/*.tsx'],
   // ...
   languageOptions: {
     parserOptions: {

--- a/docs/users/Shared_Configurations.mdx
+++ b/docs/users/Shared_Configurations.mdx
@@ -27,6 +27,9 @@ import tseslint from 'typescript-eslint';
 export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -42,6 +45,9 @@ export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommended,
   tseslint.configs.stylistic,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -81,7 +87,9 @@ export default defineConfig(
   tseslint.configs.recommendedTypeChecked,
   tseslint.configs.stylisticTypeChecked,
   // Added lines end
-  // Other configuration...
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -140,6 +148,9 @@ These rules are those whose reports are almost always for a bad practice and/or 
 ```js title="eslint.config.mjs"
 export default defineConfig(
   tseslint.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -169,6 +180,9 @@ Rules newly added in this configuration are similarly useful to those in `recomm
 ```js title="eslint.config.mjs"
 export default defineConfig(
   tseslint.configs.recommendedTypeChecked,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -198,6 +212,9 @@ Rules added in `strict` are more opinionated than recommended rules and might no
 ```js title="eslint.config.mjs"
 export default defineConfig(
   tseslint.configs.strict,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -237,6 +254,9 @@ Rules newly added in this configuration are similarly useful (and opinionated) t
 ```js title="eslint.config.mjs"
 export default defineConfig(
   tseslint.configs.strictTypeChecked,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -276,6 +296,9 @@ These rules are generally opinionated about enforcing simpler code patterns.
 ```js title="eslint.config.mjs"
 export default defineConfig(
   tseslint.configs.stylistic,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -308,6 +331,9 @@ Rules newly added in this configuration are similarly opinionated to those in `s
 ```js title="eslint.config.mjs"
 export default defineConfig(
   tseslint.configs.stylisticTypeChecked,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 
@@ -377,6 +403,7 @@ export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         projectService: true,
@@ -439,6 +466,9 @@ Additionally, it enables rules that promote using the more modern constructs Typ
 export default defineConfig(
   eslint.configs.recommended,
   tseslint.configs.eslintRecommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 

--- a/docs/users/What_About_Formatting.mdx
+++ b/docs/users/What_About_Formatting.mdx
@@ -61,6 +61,9 @@ export default defineConfig(
   someOtherConfig,
   // Add this line
   prettierConfig,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+  },
 );
 ```
 


### PR DESCRIPTION
## Summary

Following ESLint's new guidance to always include a `files` property in config examples (https://github.com/eslint/eslint/pull/20158), this PR updates all documentation examples to include `files` in config objects.

## Changes

Updated the following documentation files to include `files: ['**/*.ts', '**/*.tsx']` or similar appropriate patterns:

- `docs/getting-started/Quickstart.mdx` - Updated quickstart examples
- `docs/getting-started/Typed_Linting.mdx` - Updated typed linting examples  
- `docs/packages/TypeScript_ESLint.mdx` - Updated package usage examples
- `docs/troubleshooting/faqs/ESLint.mdx` - Updated ESLint FAQ examples
- `docs/troubleshooting/faqs/Frameworks.mdx` - Updated framework-specific examples (Vue)
- `docs/troubleshooting/faqs/General.mdx` - Updated general FAQ examples
- `docs/troubleshooting/typed-linting/Monorepos.mdx` - Updated monorepo configuration examples
- `docs/troubleshooting/typed-linting/Performance.mdx` - Updated performance troubleshooting examples
- `docs/troubleshooting/typed-linting/index.mdx` - Updated typed linting troubleshooting examples
- `docs/users/Shared_Configurations.mdx` - Updated all shared config examples
- `docs/users/What_About_Formatting.mdx` - Updated formatting configuration examples

## Why

ESLint now recommends always including a `files` property in configuration examples to make it explicit which files the configuration applies to. This helps users understand the scope of their configurations and prevents accidental application of rules to unintended files.

Fixes #12092