### PR TITLE
docs: use `defineConfig` in "How to use"

### DIFF
--- a/packages/website/plugins/generated-rule-docs/insertions/insertBaseRuleReferences.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertBaseRuleReferences.ts
@@ -39,7 +39,7 @@ export function insertBaseRuleReferences(page: RuleDocsPage): string {
               lang: 'js',
               meta: 'title="eslint.config.mjs"',
               type: 'code',
-              value: `export default tseslint.config({
+              value: `export default defineConfig({
   rules: ${getRulesString(extendsBaseRuleName, page.file.stem, true)}
 });`,
             },

--- a/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
@@ -85,7 +85,7 @@ export async function insertNewRuleReferences(
               lang: 'js',
               meta: 'title="eslint.config.mjs"',
               type: 'code',
-              value: `export default tseslint.config(${eslintConfig});`,
+              value: `export default defineConfig(${eslintConfig});`,
             },
           ],
           name: 'TabItem',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12107 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fixes the generated text to use `defineConfig` instead of `tseslint.config()`