### PR TITLE
fix(eslint-plugin): prevent invalid fix when comparison value contains optional chain

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -56,6 +56,28 @@ function includesType(
   return false;
 }
 
+function containsOptionalChain(node: TSESTree.Node): boolean {
+  switch (node.type) {
+    case AST_NODE_TYPES.ChainExpression:
+      return true;
+    case AST_NODE_TYPES.MemberExpression:
+      return node.optional || containsOptionalChain(node.object);
+    case AST_NODE_TYPES.CallExpression:
+      return node.optional || containsOptionalChain(node.callee);
+    case AST_NODE_TYPES.BinaryExpression:
+    case AST_NODE_TYPES.LogicalExpression:
+      return (
+        containsOptionalChain(node.left) || containsOptionalChain(node.right)
+      );
+    case AST_NODE_TYPES.UnaryExpression:
+      return containsOptionalChain(node.argument);
+    case AST_NODE_TYPES.TSNonNullExpression:
+      return containsOptionalChain(node.expression);
+    default:
+      return false;
+  }
+}
+
 function isValidAndLastChainOperand(
   ComparisonValueType: TSESTree.Node,
   comparisonType: ComparisonType,
@@ -778,8 +800,17 @@ export function analyzeChain(
 
     const { comparedName, comparisonValue, isSubset, isYoda } =
       resolveOperandSubset(lastOperand, lastChainOperand);
+
+    // If the comparison value contains an optional chain, converting the left side
+    // to optional chain would change semantics. For example:
+    // foo && foo.bar === foos[0]?.bar
+    // If converted to: foo?.bar === foos[0]?.bar
+    // When foo is null and foos[0] is undefined:
+    // Before: false (short-circuits on foo)
+    // After: undefined === undefined → true (semantic change)
     if (
       isSubset &&
+      !containsOptionalChain(comparisonValue) &&
       isValidLastChainOperand(
         comparisonValue,
         lastChainOperand.comparisonType,

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -3740,3 +3740,54 @@ describe('base cases', () => {
     });
   });
 });
+
+// https://github.com/typescript-eslint/typescript-eslint/issues/11917
+describe('issue 11917 - should not fix when comparison value contains optional chain', () => {
+  ruleTester.run('prefer-optional-chain', rule, {
+    invalid: [
+      // Should still work when comparison value has NO optional chain
+      {
+        code: `
+          interface Foo {
+            bar: number;
+          }
+          declare const foo: Foo | null;
+          declare const foos: Foo[];
+          foo && foo.bar === foos[0].bar;
+        `,
+        errors: [{ messageId: 'preferOptionalChain' }],
+        output: `
+          interface Foo {
+            bar: number;
+          }
+          declare const foo: Foo | null;
+          declare const foos: Foo[];
+          foo?.bar === foos[0].bar;
+        `,
+      },
+    ],
+    valid: [
+      // No error when comparison value has optional chain
+      {
+        code: `
+          interface Foo {
+            bar: number;
+          }
+          declare const foo: Foo | null;
+          declare const foos: Foo[];
+          foo && foo.bar === foos[0]?.bar;
+        `,
+      },
+      {
+        code: `
+          interface Foo {
+            bar: number;
+          }
+          declare const foo: Foo | null;
+          declare const obj: { prop?: Foo };
+          foo && foo.bar === obj.prop?.bar;
+        `,
+      },
+    ],
+  });
+});


### PR DESCRIPTION
## Description

Fixes #11917

When the comparison value in a binary expression contains an optional chain, converting the left side to optional chain changes the semantics.

### Example

**Before fix:**
```ts
foo && foo.bar === foos[0]?.bar
```
- If `foo` is null: short-circuits to `false`

**After incorrect fix:**
```ts
foo?.bar === foos[0]?.bar
```
- If `foo` is null and `foos[0]` is undefined: `undefined === undefined` → `true` ❌

This is a semantic change that breaks the original logic.

## Solution

Added a `containsOptionalChain()` helper function that recursively checks if an expression contains any optional chain operators. The fix is now prevented when the comparison value contains optional chaining.

## Changes

- Added `containsOptionalChain()` function to detect optional chains in expressions
- Modified the validation logic in `analyzeChain()` to check for optional chains before allowing the fix
- Added test cases to verify the fix works correctly

## Testing

- ✅ All existing tests pass
- ✅ New test cases added for the issue
- ✅ Lint and format checks pass

🦞