### PR TITLE
chore: add missing pnpm cache to workflows

### DIFF
--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -41,6 +41,7 @@ jobs:
         name: Install pnpm
         with:
           run_install: false
+          cache: true
 
       - name: Run nx migrate if @nx/workspace changed and commit the results
         if: ${{ steps.nrwl-workspace-package-check.outputs.was-changed == 'true' }}

--- a/.github/workflows/prettier-update.yml
+++ b/.github/workflows/prettier-update.yml
@@ -37,6 +37,7 @@ jobs:
         name: Install pnpm
         with:
           run_install: false
+          cache: true
 
       - name: Run prettier formatting if prettier was changed and commit the results
         if: ${{ steps.prettier-package-check.outputs.was-changed == 'true' }}


### PR DESCRIPTION
When working on #12130, I mistakenly searched only for pnpm/action-setup that had cache already, and forgot to apply this to other ones as well... this PR fixes that

These 2 workflows don't run _that_ much, so the performance gains are probably negligible, so I'm adding this just as a good measure
