### PR TITLE
chore: add missing build dependency in website-eslint

### DIFF
--- a/packages/website-eslint/package.json
+++ b/packages/website-eslint/package.json
@@ -55,6 +55,7 @@
       "build": {
         "command": "tsx build.mts",
         "dependsOn": [
+          "^build",
           "types:copy-ast-spec"
         ],
         "cache": true,


### PR DESCRIPTION
~This is a tiny change in the series of #11204
Removed the build process of eslint-plugin-internal, and as a side-effect converted the eslint config file to TS~

Also found a missing build dependency in website-eslint that breaks tasks like `typecheck` (and `website:build`) after a `pnpm clean` run

~It might not save much time, but I guess that bunch of small, quick wins will add up eventually? 🤷~