### PR TITLE
chore: shard lint tasks in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        lint-task: ['deduplicate', 'lint', 'typecheck', 'knip']
+        lint-task: ['deduplicate', 'typecheck', 'knip']
     env:
       NX_CI_EXECUTION_ENV: 'ubuntu-latest'
     steps:
@@ -132,8 +132,54 @@ jobs:
 
       - name: Run Check
         run: pnpm ${{ matrix.lint-task }}
-        env:
-          ESLINT_USE_FLAT_CONFIG: true
+
+  # Note -- intentionally use the same name as lint_with_build just so everything looks uniform in the checks section
+  lint_with_build_eslint:
+    name: Lint with build
+    environment: ${{ (github.repository == 'typescript-eslint/typescript-eslint' && github.ref == 'refs/heads/main') && 'main' || '' }} # Have to specify per job
+    # because we lint with our own tooling, we need to build
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - shard: 1
+            projects:
+              - eslint-plugin
+
+          - shard: 2
+            projects:
+              - ast-spec
+              - utils
+              - scope-manager
+              - eslint-plugin-internal
+
+          - shard: 3
+            projects:
+              - typescript-estree
+              - types
+              - website
+              - rule-tester
+              - visitor-keys
+
+          - shard: 4
+            projects:
+              - parser
+              - type-utils
+              - rule-schema-to-typescript-types
+              - typescript-eslint
+              - repo
+              - website-eslint
+              - integration-tests
+    env:
+      NX_CI_EXECUTION_ENV: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare-install
+        with:
+          node-version: ${{ env.PRIMARY_NODE_VERSION }}
+      - uses: ./.github/actions/prepare-build
+      - run: pnpm lint --projects=${{ join(matrix.projects, ',') }}
 
   stylelint:
     name: Stylelint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,18 +143,21 @@ jobs:
     strategy:
       matrix:
         include:
-          - shard: 1
+          - shard: '1/4'
+            args: '--concurrency=auto'
             projects:
               - eslint-plugin
 
-          - shard: 2
+          - shard: '2/4'
+            args: ''
             projects:
               - ast-spec
               - utils
               - scope-manager
               - eslint-plugin-internal
 
-          - shard: 3
+          - shard: '3/4'
+            args: ''
             projects:
               - typescript-estree
               - types
@@ -162,7 +165,8 @@ jobs:
               - rule-tester
               - visitor-keys
 
-          - shard: 4
+          - shard: '4/4'
+            args: ''
             projects:
               - parser
               - type-utils
@@ -179,7 +183,7 @@ jobs:
         with:
           node-version: ${{ env.PRIMARY_NODE_VERSION }}
       - uses: ./.github/actions/prepare-build
-      - run: pnpm lint --projects=${{ join(matrix.projects, ',') }}
+      - run: pnpm lint --projects=${{ join(matrix.projects, ',') }} {{ matarix.args }}
 
   stylelint:
     name: Stylelint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
         with:
           node-version: ${{ env.PRIMARY_NODE_VERSION }}
       - uses: ./.github/actions/prepare-build
-      - run: pnpm lint --projects=${{ join(matrix.projects, ',') }} {{ matarix.args }}
+      - run: pnpm lint --projects=${{ join(matrix.projects, ',') }} ${{ matrix.args }}
 
   stylelint:
     name: Stylelint


### PR DESCRIPTION
Trying lint sharding as per https://github.com/typescript-eslint/typescript-eslint/issues/11204#issuecomment-4072062334

Used cursor to help me calculate (based on local timings) the sharding distribution, ~let's see what the spreading will look like~ seems like it's pretty even (~55s each, and eslint-plugin is ~1m20s)

eslint-plugin was obviously the longest, so it has its own shard, and I added concurrency to make it slightly faster

I gotta admit that it's not the most maintainable approach, but I didn't find a way to shard automatically (https://github.com/eslint/eslint/issues/16726, https://github.com/nrwl/nx/issues/15040)

______

The total duration is [5m9s](https://github.com/typescript-eslint/typescript-eslint/actions/runs/23215183525?pr=12137) compared to [5m56s](https://github.com/typescript-eslint/typescript-eslint/actions/runs/23176640116), [5m38s](https://github.com/typescript-eslint/typescript-eslint/actions/runs/23176313976?pr=12029), [5m22s](https://github.com/typescript-eslint/typescript-eslint/actions/runs/23176145416) of random runs

So it's slightly faster (ranges between 4%-15% improvemet), but is it worth it? idk... wdyt?