### PR TITLE
docs: move Kirk Waiblinger from Committers to Maintainers

### DIFF
--- a/docs/maintenance/Team.mdx
+++ b/docs/maintenance/Team.mdx
@@ -46,6 +46,11 @@ Its members are volunteer open source developers dedicated to making the TypeScr
       name: 'Josh Goldberg',
       username: 'joshuakgoldberg',
     },
+    {
+      description: 'Dotting my "j"s and crossing my "z"s.',
+      name: 'Kirk Waiblinger',
+      username: 'kirkwaiblinger',
+    },
   ]}
   description="Leaders stewarding the direction of the project."
   explanation="In addition to committer tasks, maintainers work on the processes behind the project, relationships with neighboring ecosystem projects, and manage regular releases."
@@ -75,11 +80,6 @@ Its members are volunteer open source developers dedicated to making the TypeScr
       description: '...',
       name: 'auvred',
       username: 'auvred',
-    },
-    {
-      description: 'Dotting my "j"s and crossing my "z"s.',
-      name: 'Kirk Waiblinger',
-      username: 'kirkwaiblinger',
     },
     {
       description: 'Hello World!',


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Summary

- Moves Kirk Waiblinger's entry from the Committers section to the Maintainers section on the team page (`docs/maintenance/Team.mdx`)

## Test plan

- [x] Verify the website builds successfully
- [ ] Check the team page renders correctly with Kirk listed under Maintainers