### PR TITLE
fix(eslint-plugin): [no-extraneous-class] handle index signatures

### DIFF
--- a/packages/eslint-plugin/src/rules/no-extraneous-class.ts
+++ b/packages/eslint-plugin/src/rules/no-extraneous-class.ts
@@ -126,6 +126,7 @@ export default createRule<Options, MessageIds>({
                 prop.type === AST_NODE_TYPES.MethodDefinition ||
                 prop.type === AST_NODE_TYPES.AccessorProperty) &&
                 !prop.static) ||
+              prop.type === AST_NODE_TYPES.TSIndexSignature ||
               prop.type === AST_NODE_TYPES.TSAbstractPropertyDefinition ||
               prop.type === AST_NODE_TYPES.TSAbstractMethodDefinition || // `static abstract` methods and properties are currently not supported. See: https://github.com/microsoft/TypeScript/issues/34516
               prop.type === AST_NODE_TYPES.TSAbstractAccessorProperty

--- a/packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts
@@ -111,6 +111,11 @@ class Foo {
 }
     `,
     `
+class Foo {
+  [key: string]: string;
+}
+    `,
+    `
 abstract class Foo {
   accessor prop: string;
 }


### PR DESCRIPTION
 ## PR Checklist

  - [x] Addresses an existing open issue: fixes #12061
  - [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
  - [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

  ## Overview

  Fixes a false positive in `@typescript-eslint/no-extraneous-class` for classes that only declare an index
  signature.

  The rule previously treated `TSIndexSignature` as if it didn't count as an instance member, which left the class
  categorized as "only static" and reported `Unexpected class with only static properties.`

  This change treats `TSIndexSignature` as a non-static class member and adds a regression test covering:

  ```ts
  class Foo {
    [key: string]: string;
  }