### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] fix false positive with template literal types

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -63,6 +63,13 @@ function toStaticValue(
   if (type.flags === ts.TypeFlags.Null) {
     return { value: null };
   }
+
+  // Template literal types like `a${string}` represent multiple possible values,
+  // not a single static value, so comparisons with them are necessary conditions.
+  if (tsutils.isTypeFlagSet(type, ts.TypeFlags.TemplateLiteral)) {
+    return undefined;
+  }
+
   if (type.isLiteral()) {
     return { value: getValueOfLiteralType(type) };
   }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -77,6 +77,32 @@ declare const bigInt: 0n | 1n;
 if (bigInt) {
 }
     `,
+
+    `
+function test(t: \`a\${string}\`) {
+  if (t === 'ab') {
+  }
+}
+    `,
+    `
+type T = \`\${string}-\${number}\`;
+declare const t: T;
+if (t === 'hello-42') {
+}
+    `,
+    `
+type T = \`a\${string}\` | \`b\${string}\`;
+declare const t: T;
+if (t === 'abc') {
+}
+    `,
+    `
+type T = \`prefix\${string}\`;
+declare const t: T;
+const lit = 'prefixValue';
+if (t === lit) {
+}
+    `,
     necessaryConditionTest('false | 5'), // Truthy literal and falsy literal
     necessaryConditionTest('boolean | "foo"'), // boolean and truthy literal
     necessaryConditionTest('0 | boolean'), // boolean and falsy literal


### PR DESCRIPTION


## PR Checklist

- [v] Addresses an existing open issue: fixes []
- [v] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [v] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview
The current rule produces a false positive when comparing a template literal type with a string literal, as it fails to account for potential pattern matches. To resolve this, I have updated the logic to relax the check when a template literal type is involved in the comparison.
