### PR TITLE
fix(eslint-plugin): [unified-signatures] handle same-named type parameters in different overloads

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -324,6 +324,10 @@ export default createRule<Options, MessageIds>({
       const sig1 = a.params;
       const sig2 = b.params;
 
+      // Extract type parameters for normalization
+      const aTypeParams = a.typeParameters?.params;
+      const bTypeParams = b.typeParameters?.params;
+
       const minLength = Math.min(sig1.length, sig2.length);
       const longer = sig1.length < sig2.length ? sig2 : sig1;
       const shorter = sig1.length < sig2.length ? sig1 : sig2;
@@ -361,7 +365,14 @@ export default createRule<Options, MessageIds>({
           ? sig2i.parameter.typeAnnotation
           : sig2i.typeAnnotation;
 
-        if (!typesAreEqual(typeAnnotation1, typeAnnotation2)) {
+        if (
+          !typesAreEqualWithTypeParams(
+            typeAnnotation1,
+            typeAnnotation2,
+            aTypeParams,
+            bTypeParams,
+          )
+        ) {
           return undefined;
         }
       }
@@ -484,6 +495,86 @@ export default createRule<Options, MessageIds>({
       b: TSESTree.TSTypeParameter,
     ): boolean {
       return constraintsAreEqual(a.constraint, b.constraint);
+    }
+
+    /**
+     * Creates a mapping from type parameter names to their normalized positional names.
+     * Example: <T, U> and <R, S> both map to { T/R: "_0", U/S: "_1" }
+     */
+    function buildTypeParameterMap(
+      typeParams: readonly TSESTree.TSTypeParameter[] | undefined,
+    ): Map<string, string> {
+      const map = new Map<string, string>();
+      if (!typeParams) {
+        return map;
+      }
+
+      for (let i = 0; i < typeParams.length; i++) {
+        map.set(typeParams[i].name.name, `_${i}`);
+      }
+
+      return map;
+    }
+
+    /**
+     * Normalizes a type annotation by replacing type parameter names with positional identifiers.
+     * This allows comparing types that reference different type parameter names but same positions.
+     * Example: "T" with map {T: "_0"} becomes "_0"
+     *          "Array<T>" with map {T: "_0"} becomes "Array<_0>"
+     */
+    function normalizeTypeAnnotation(
+      typeAnnotation: TSESTree.TSTypeAnnotation | undefined,
+      typeParamMap: Map<string, string>,
+    ): string | undefined {
+      if (!typeAnnotation || typeParamMap.size === 0) {
+        return typeAnnotation
+          ? context.sourceCode.getText(typeAnnotation.typeAnnotation)
+          : undefined;
+      }
+
+      // Get the source text
+      let text = context.sourceCode.getText(typeAnnotation.typeAnnotation);
+
+      // Replace type parameter names with normalized versions
+      // Sort by length descending to avoid partial replacements (e.g., "T" before "Type")
+      const sortedEntries = Array.from(typeParamMap.entries()).sort(
+        (a, b) => b[0].length - a[0].length,
+      );
+
+      for (const [name, normalized] of sortedEntries) {
+        // Use word boundaries to avoid replacing parts of other identifiers
+        // e.g., don't replace "T" in "Type"
+        const regex = new RegExp(`\\b${name}\\b`, 'g');
+        text = text.replace(regex, normalized);
+      }
+
+      return text;
+    }
+
+    /**
+     * Compares two type annotations, normalizing type parameter references.
+     * Used when comparing signatures with potentially different type parameter names.
+     */
+    function typesAreEqualWithTypeParams(
+      a: TSESTree.TSTypeAnnotation | undefined,
+      b: TSESTree.TSTypeAnnotation | undefined,
+      aTypeParams: readonly TSESTree.TSTypeParameter[] | undefined,
+      bTypeParams: readonly TSESTree.TSTypeParameter[] | undefined,
+    ): boolean {
+      // Fast path: if no type parameters, use existing comparison
+      if (!aTypeParams && !bTypeParams) {
+        return typesAreEqual(a, b);
+      }
+
+      // Build normalization maps
+      const aMap = buildTypeParameterMap(aTypeParams);
+      const bMap = buildTypeParameterMap(bTypeParams);
+
+      // Normalize and compare
+      const aNormalized = normalizeTypeAnnotation(a, aMap);
+      const bNormalized = normalizeTypeAnnotation(b, bMap);
+
+      return aNormalized === bNormalized;
     }
 
     function typesAreEqual(

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -483,10 +483,7 @@ export default createRule<Options, MessageIds>({
       a: TSESTree.TSTypeParameter,
       b: TSESTree.TSTypeParameter,
     ): boolean {
-      return (
-        a.name.name === b.name.name &&
-        constraintsAreEqual(a.constraint, b.constraint)
-      );
+      return constraintsAreEqual(a.constraint, b.constraint);
     }
 
     function typesAreEqual(
@@ -506,7 +503,12 @@ export default createRule<Options, MessageIds>({
       a: TSESTree.TypeNode | undefined,
       b: TSESTree.TypeNode | undefined,
     ): boolean {
-      return a === b || (a != null && a.type === b?.type);
+      return (
+        a === b ||
+        (a != null &&
+          b != null &&
+          context.sourceCode.getText(a) === context.sourceCode.getText(b))
+      );
     }
 
     /* Returns the first index where `a` and `b` differ. */

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -537,7 +537,7 @@ export default createRule<Options, MessageIds>({
 
       // Replace type parameter names with normalized versions
       // Sort by length descending to avoid partial replacements (e.g., "T" before "Type")
-      const sortedEntries = Array.from(typeParamMap.entries()).sort(
+      const sortedEntries = [...typeParamMap.entries()].sort(
         (a, b) => b[0].length - a[0].length,
       );
 

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1290,12 +1290,12 @@ function c<T extends string>(s: T, param?: string): string {
       `,
       errors: [
         {
-          column: 31,
+          column: 36,
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
           },
-          line: 6,
+          line: 4,
           messageId: 'omittingSingleParameter',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -408,6 +408,28 @@ function f(this: void, a: boolean): void;
 function f(this: {}, a: boolean): void;
 function f(this: void | {}, a: boolean): void {}
     `,
+    // Different type parameter constraints - function a
+    `
+type A = 1 | 2;
+type B = 3 | 4;
+
+function a<T extends A>(s: T, param: string): string;
+function a<R extends B>(s: R): string;
+function a<T extends A | B>(s: T, param?: string): string {
+  return 'aaa';
+}
+    `,
+    // Different type parameter constraints - function b (same name)
+    `
+type A = 1 | 2;
+type B = 3 | 4;
+
+function b<T extends A>(s: T, param: string): string;
+function b<T extends B>(s: T): string;
+function b<T extends A | B>(s: T, param?: string): string {
+  return 'aaa';
+}
+    `,
   ],
   invalid: [
     {
@@ -1253,6 +1275,29 @@ function f(this: string | number, a: boolean): void {}
           },
           line: 3,
           messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      code: `
+type A = 1 | 2;
+type B = 3 | 4;
+
+function c<T extends string>(s: T, param: string): string;
+function c<R extends string>(s: R): string;
+function c<T extends string>(s: T, param?: string): string {
+  return 'aaa';
+}
+      `,
+      errors: [
+        {
+          column: 31,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          line: 6,
+          messageId: 'omittingSingleParameter',
         },
       ],
     },

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -430,6 +430,33 @@ function b<T extends A | B>(s: T, param?: string): string {
   return 'aaa';
 }
     `,
+    // Asymmetric type parameters - one has type params, other doesn't
+    `
+function d<T>(x: T): void;
+function d(x: number): void;
+function d<T>(x: T | number): void {}
+    `,
+    // Multiple type parameters with different constraints
+    `
+function e<T extends string, U extends number>(x: T, y: U): void;
+function e<R extends boolean, S extends symbol>(x: R, y: S): void;
+function e<T extends string | boolean, U extends number | symbol>(
+  x: T,
+  y: U,
+): void {}
+    `,
+    // Multi-character type parameter names
+    `
+function g<Type extends string>(x: Type): void;
+function g<Element extends number>(x: Element): void;
+function g<Type extends string | number>(x: Type): void {}
+    `,
+    // Complex nested generics
+    `
+function h<T extends string>(x: Array<T>): void;
+function h<R extends number>(x: Array<R>): void;
+function h<T extends string | number>(x: Array<T>): void {}
+    `,
   ],
   invalid: [
     {
@@ -1296,6 +1323,42 @@ function c<T extends string>(s: T, param?: string): string {
               'These overloads can be combined into one signature',
           },
           line: 4,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      code: `
+function i<T extends string, U extends number>(x: T, y: U, z: string): void;
+function i<R extends string, S extends number>(x: R, y: S): void;
+function i<T extends string, U extends number>(x: T, y: U, z?: string): void {}
+      `,
+      errors: [
+        {
+          column: 60,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      code: `
+function j<T extends string>(x: T[], y: string): void;
+function j<R extends string>(x: R[]): void;
+function j<T extends string>(x: T[], y?: string): void {}
+      `,
+      errors: [
+        {
+          column: 38,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          line: 2,
           messageId: 'omittingSingleParameter',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1363,5 +1363,43 @@ function j<T extends string>(x: T[], y?: string): void {}
         },
       ],
     },
+    {
+      // Same-constrained type parameters with optional parameter
+      code: `
+function f<T>(a: number): void;
+function f<U>(a: number, b?: string): void;
+function f<T>(a: number, b?: string): void {}
+      `,
+      errors: [
+        {
+          column: 26,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          line: 3,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // Same-constrained type parameters with rest parameter
+      code: `
+function g<T>(a: string): void;
+function g<U>(a: string, ...b: number[]): void;
+function g<T>(a: string, ...b: number[]): void {}
+      `,
+      errors: [
+        {
+          column: 26,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          line: 3,
+          messageId: 'omittingRestParameter',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1282,7 +1282,6 @@ function f(this: string | number, a: boolean): void {}
       code: `
 type A = 1 | 2;
 type B = 3 | 4;
-
 function c<T extends string>(s: T, param: string): string;
 function c<R extends string>(s: R): string;
 function c<T extends string>(s: T, param?: string): string {


### PR DESCRIPTION

## PR Checklist

- [v] Addresses an existing open issue: fixes [#12143](https://github.com/typescript-eslint/typescript-eslint/issues/12143)
- [v] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [v] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Updated the rule to distinguish between type parameters with the same name if they are declared in different function overloads. This prevents false positives where distinct signatures were incorrectly flagged as unifiable.