### PR TITLE
docs: import @eslint/js as js instead of eslint

### DIFF
--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -34,12 +34,12 @@ Next, create an `eslint.config.mjs` config file in the root of your project, and
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommended,
 );
 ```
@@ -49,7 +49,7 @@ This code will enable our [recommended configuration](../users/Shared_Configurat
 #### Details
 
 - `defineConfig(...)` is an optional helper function built in to current versions of ESLint. See [the ESLint configuration docs](https://eslint.org/docs/latest/use/configure/configuration-files) for more detail.
-- `'@eslint/js'` / `eslint.configs.recommended` turns on [eslint's recommended config](https://www.npmjs.com/package/@eslint/js).
+- `'@eslint/js'` / `js.configs.recommended` turns on [eslint's recommended config](https://www.npmjs.com/package/@eslint/js).
 - `tseslint.configs.recommended` turns on [our recommended config](../users/Shared_Configurations.mdx#recommended).
 
 <details>
@@ -102,7 +102,7 @@ We recommend you consider enabling the following two configs:
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   // Remove this line
   tseslint.configs.recommended,
   // Add this line

--- a/docs/getting-started/Typed_Linting.mdx
+++ b/docs/getting-started/Typed_Linting.mdx
@@ -19,16 +19,16 @@ To enable typed linting, there are two small changes you need to make to your co
 2. Add `languageOptions.parserOptions` to tell our parser how to find the TSConfig for each source file.
 
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   // Remove this line
-  tseslint.configs.recommended,
+  tsjs.configs.recommended,
   // Added lines start
-  tseslint.configs.recommendedTypeChecked,
+  tsjs.configs.recommendedTypeChecked,
   {
     languageOptions: {
       parserOptions: {
@@ -42,7 +42,7 @@ export default defineConfig(
 
 In more detail:
 
-- `tseslint.configs.recommendedTypeChecked` is a [shared configuration](../users/Shared_Configurations.mdx). It contains recommended rules that additionally require type information.
+- `tsjs.configs.recommendedTypeChecked` is a [shared configuration](../users/Shared_Configurations.mdx). It contains recommended rules that additionally require type information.
 - `parserOptions.projectService: true` indicates to ask TypeScript's type checking service for each source file's type information (see [Parser > Project Service](../packages/Parser.mdx#projectservice)).
 - `parserOptions.tsconfigRootDir` tells our parser the absolute path of your project's root directory (see [Parser > tsconfigRootDir](../packages/Parser.mdx#tsconfigrootdir)).
 
@@ -100,14 +100,14 @@ If you enabled the [`strict` shared config](../users/Shared_Configurations.mdx#s
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   // Removed lines start
-  tseslint.configs.strict,
-  tseslint.configs.stylistic,
+  tsjs.configs.strict,
+  tsjs.configs.stylistic,
   // Removed lines end
   // Added lines start
-  tseslint.configs.strictTypeChecked,
-  tseslint.configs.stylisticTypeChecked,
+  tsjs.configs.strictTypeChecked,
+  tsjs.configs.stylisticTypeChecked,
   // Added lines end
   // ...
 );

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -37,13 +37,13 @@ We recommend getting started by using the default ESLint setup with our shared c
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
-  tseslint.configs.recommended,
+  js.configs.recommended,
+  tsjs.configs.recommended,
 );
 ```
 
@@ -72,12 +72,12 @@ Additionally, if you provide invalid values, it can trigger informative TypeScri
 ```ts title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
-  tseslint.configs.recommended,
+  js.configs.recommended,
+  tsjs.configs.recommended,
   {
     /*... */
   },
@@ -91,13 +91,13 @@ export default tseslint.config(
 ```ts title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 /** @type {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigFile} */
 export default [
-  eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  js.configs.recommended,
+  ...tsjs.configs.recommended,
   {
     /*... */
   },
@@ -123,8 +123,8 @@ This allows you to more easily extend shared configs for specific file patterns 
 export default tseslint.config({
   files: ['**/*.ts'],
   extends: [
-    eslint.configs.recommended,
-    tseslint.configs.recommended,
+    js.configs.recommended,
+    tsjs.configs.recommended,
   ],
   rules: {
     '@typescript-eslint/array-type': 'error',
@@ -136,8 +136,8 @@ export default tseslint.config({
 
 export default [
   ...[
-    eslint.configs.recommended,
-    ...tseslint.configs.recommended,
+    js.configs.recommended,
+    ...tsjs.configs.recommended,
   ].map(conf => ({
     ...conf,
     files: ['**/*.ts'],
@@ -159,7 +159,7 @@ For example, in codebases with type-aware linting, a config object like the foll
 ```js
 export default tseslint.config({
   files: ['**/*.js'],
-  extends: [tseslint.configs.disableTypeChecked],
+  extends: [tsjs.configs.disableTypeChecked],
   rules: {
     // turn off other type-aware rules
     'other-plugin/typed-rule': 'off',
@@ -255,7 +255,7 @@ You can declare our plugin and parser in your config via this package, for examp
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import jestPlugin from 'eslint-plugin-jest';
 import tseslint from 'typescript-eslint';
@@ -300,7 +300,7 @@ This config:
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import jestPlugin from 'eslint-plugin-jest';
 import tseslint from 'typescript-eslint';
@@ -310,7 +310,7 @@ export default defineConfig(
     // config with just ignores is the replacement for `.eslintignore`
     ignores: ['**/build/**', '**/dist/**', 'src/some/file/to/ignore.ts'],
   },
-  eslint.configs.recommended,
+  js.configs.recommended,
   {
     plugins: {
       '@typescript-eslint': tseslint.plugin,
@@ -330,7 +330,7 @@ export default defineConfig(
   {
     // disable type-aware linting on JS files
     files: ['**/*.js'],
-    extends: [tseslint.configs.disableTypeChecked],
+    extends: [tsjs.configs.disableTypeChecked],
   },
   {
     // enable jest rules on test files

--- a/docs/troubleshooting/faqs/General.mdx
+++ b/docs/troubleshooting/faqs/General.mdx
@@ -241,12 +241,12 @@ For example, the following config enables only the recommended config's type-che
 
 {/* prettier-ignore */}
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  tseslint.configs.recommendedTypeCheckedOnly,
+  tsjs.configs.recommendedTypeCheckedOnly,
   {
     languageOptions: {
       parserOptions: {

--- a/docs/troubleshooting/typed-linting/Performance.mdx
+++ b/docs/troubleshooting/typed-linting/Performance.mdx
@@ -177,12 +177,12 @@ Instead of globs that use `**` to recursively check all folders, prefer paths th
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
-  tseslint.configs.recommendedRequiringTypeChecking,
+  js.configs.recommended,
+  tsjs.configs.recommendedRequiringTypeChecking,
   {
     languageOptions: {
       parserOptions: {

--- a/docs/users/Shared_Configurations.mdx
+++ b/docs/users/Shared_Configurations.mdx
@@ -20,13 +20,13 @@ See [Getting Started > Quickstart](../getting-started/Quickstart.mdx) first to s
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
-  tseslint.configs.recommended,
+  js.configs.recommended,
+  tsjs.configs.recommended,
 );
 ```
 
@@ -39,9 +39,9 @@ If your project does not enable [typed linting](../getting-started/Typed_Linting
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
-  tseslint.configs.recommended,
-  tseslint.configs.stylistic,
+  js.configs.recommended,
+  tsjs.configs.recommended,
+  tsjs.configs.stylistic,
 );
 ```
 
@@ -76,10 +76,10 @@ To use type-checking, you also need to configure `languageOptions.parserOptions`
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   // Added lines start
-  tseslint.configs.recommendedTypeChecked,
-  tseslint.configs.stylisticTypeChecked,
+  tsjs.configs.recommendedTypeChecked,
+  tsjs.configs.stylisticTypeChecked,
   // Added lines end
   // Other configuration...
 );
@@ -139,7 +139,7 @@ These rules are those whose reports are almost always for a bad practice and/or 
 {/* prettier-ignore */}
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  tseslint.configs.recommended,
+  tsjs.configs.recommended,
 );
 ```
 
@@ -168,7 +168,7 @@ Rules newly added in this configuration are similarly useful to those in `recomm
 {/* prettier-ignore */}
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  tseslint.configs.recommendedTypeChecked,
+  tsjs.configs.recommendedTypeChecked,
 );
 ```
 
@@ -197,7 +197,7 @@ Rules added in `strict` are more opinionated than recommended rules and might no
 {/* prettier-ignore */}
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  tseslint.configs.strict,
+  tsjs.configs.strict,
 );
 ```
 
@@ -236,7 +236,7 @@ Rules newly added in this configuration are similarly useful (and opinionated) t
 {/* prettier-ignore */}
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  tseslint.configs.strictTypeChecked,
+  tsjs.configs.strictTypeChecked,
 );
 ```
 
@@ -275,7 +275,7 @@ These rules are generally opinionated about enforcing simpler code patterns.
 {/* prettier-ignore */}
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  tseslint.configs.stylistic,
+  tsjs.configs.stylistic,
 );
 ```
 
@@ -307,7 +307,7 @@ Rules newly added in this configuration are similarly opinionated to those in `s
 {/* prettier-ignore */}
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  tseslint.configs.stylisticTypeChecked,
+  tsjs.configs.stylisticTypeChecked,
 );
 ```
 
@@ -374,8 +374,8 @@ If you use type-aware rules from other plugins, you will need to manually disabl
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
-  tseslint.configs.recommendedTypeChecked,
+  js.configs.recommended,
+  tsjs.configs.recommendedTypeChecked,
   {
     languageOptions: {
       parserOptions: {
@@ -386,7 +386,7 @@ export default defineConfig(
   // Added lines start
   {
     files: ['**/*.js'],
-    extends: [tseslint.configs.disableTypeChecked],
+    extends: [tsjs.configs.disableTypeChecked],
   },
   // Added lines end
 );
@@ -437,8 +437,8 @@ Additionally, it enables rules that promote using the more modern constructs Typ
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
-  tseslint.configs.eslintRecommended,
+  js.configs.recommended,
+  tsjs.configs.eslintRecommended,
 );
 ```
 

--- a/docs/users/What_About_Formatting.mdx
+++ b/docs/users/What_About_Formatting.mdx
@@ -49,15 +49,15 @@ Using this config by adding it to the end of your `extends`:
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import someOtherConfig from 'eslint-config-other-configuration-that-enables-formatting-rules';
 import prettierConfig from 'eslint-config-prettier';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
-  tseslint.configs.recommended,
+  js.configs.recommended,
+  tsjs.configs.recommended,
   someOtherConfig,
   // Add this line
   prettierConfig,

--- a/packages/typescript-eslint/src/config-helper.ts
+++ b/packages/typescript-eslint/src/config-helper.ts
@@ -33,8 +33,8 @@ export interface ConfigWithExtends extends TSESLint.FlatConfig.Config {
    * export default tseslint.config({
    *   files: ['** /*.ts'],
    *   extends: [
-   *     eslint.configs.recommended,
-   *     tseslint.configs.recommended,
+   *     js.configs.recommended,
+   *     tsjs.configs.recommended,
    *   ],
    *   rules: {
    *     '@typescript-eslint/array-type': 'error',
@@ -46,10 +46,10 @@ export interface ConfigWithExtends extends TSESLint.FlatConfig.Config {
    *
    * export default [
    *   {
-   *     ...eslint.configs.recommended,
+   *     ...js.configs.recommended,
    *     files: ['** /*.ts'],
    *   },
-   *   ...tseslint.configs.recommended.map(conf => ({
+   *   ...tsjs.configs.recommended.map(conf => ({
    *     ...conf,
    *     files: ['** /*.ts'],
    *   })),
@@ -75,12 +75,12 @@ export type ConfigArray = TSESLint.FlatConfig.ConfigArray;
  * ```js
  * // @ts-check
  *
- * import eslint from '@eslint/js';
+ * import js from '@eslint/js';
  * import tseslint from 'typescript-eslint';
  *
  * export default tseslint.config(
- *   eslint.configs.recommended,
- *   tseslint.configs.recommended,
+ *   js.configs.recommended,
+ *   tsjs.configs.recommended,
  *   {
  *     rules: {
  *       '@typescript-eslint/array-type': 'error',

--- a/packages/website/blog/2024-02-12-announcing-typescript-eslint-v7.md
+++ b/packages/website/blog/2024-02-12-announcing-typescript-eslint-v7.md
@@ -51,12 +51,12 @@ The simplest of this new tooling would be the following which will enable the ES
 ```js title="eslint.config.js"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
-  ...tseslint.configs.recommended,
+  js.configs.recommended,
+  ...tsjs.configs.recommended,
 );
 ```
 

--- a/packages/website/blog/2024-05-27-announcing-typescript-eslint-v8-beta.mdx
+++ b/packages/website/blog/2024-05-27-announcing-typescript-eslint-v8-beta.mdx
@@ -85,12 +85,12 @@ It's been experimentally available since v6.1.0 under the name `EXPERIMENTAL_use
 You can use the new project service in your configuration instead of the previous `parserOptions.project`:
 
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
-  ...tseslint.configs.recommendedTypeChecked,
+  js.configs.recommended,
+  ...tsjs.configs.recommendedTypeChecked,
   {
     languageOptions: {
       parserOptions: {
@@ -115,12 +115,12 @@ Typed linting for out-of-project files can be done by specifying two properties 
 - `defaultProject`: path to a TypeScript configuration file to use for the slower default project
 
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
-  ...tseslint.configs.recommendedTypeChecked,
+  js.configs.recommended,
+  ...tsjs.configs.recommendedTypeChecked,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/website/blog/2024-07-31-announcing-typescript-eslint-v8.md
+++ b/packages/website/blog/2024-07-31-announcing-typescript-eslint-v8.md
@@ -73,12 +73,12 @@ It's been experimentally available since v6.1.0 under the name `EXPERIMENTAL_use
 You can use the new project service in your configuration instead of the previous `parserOptions.project`:
 
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
-  ...tseslint.configs.recommendedTypeChecked,
+  js.configs.recommended,
+  ...tsjs.configs.recommendedTypeChecked,
   {
     languageOptions: {
       parserOptions: {
@@ -103,12 +103,12 @@ Typed linting for out-of-project files can be done by specifying two properties 
 - `defaultProject`: path to a TypeScript configuration file to use for the slower default project
 
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
-  ...tseslint.configs.recommendedTypeChecked,
+  js.configs.recommended,
+  ...tsjs.configs.recommendedTypeChecked,
   {
     languageOptions: {
       parserOptions: {


### PR DESCRIPTION
## Description

Updates documentation to use `import js from '@eslint/js'` instead of `import eslint from '@eslint/js'` to align with ESLint's official documentation conventions.

Fixes #12099

## Changes

- Changed all occurrences of `import eslint from '@eslint/js'` to `import js from '@eslint/js'`
- Updated all references from `eslint.configs.*` to `js.configs.*`
- Affected 11 files across docs, blog posts, and source code comments

## Checklist

- [x] Changes are limited to documentation updates
- [x] All code examples have been updated consistently
- [x] The changes align with ESLint's official documentation style

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This is a documentation-only change that doesn't affect the actual API or functionality.
