### PR TITLE
[WIP] feat(eslint-plugin): [no-unsafe-enum-assignment] create rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unsafe-enum-assignment.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-enum-assignment.mdx
@@ -1,0 +1,75 @@
+---
+description: 'Disallow assigning non-enum values to enum typed locations.'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+> 🛑 This file is source code, not the primary documentation location! 🛑
+>
+> See **https://typescript-eslint.io/rules/no-unsafe-enum-assignment** for documentation.
+
+TypeScript allows some assignments of literal values into enum-typed locations that are convenient but easy to misuse.
+That includes assigning plain `number` values into numeric enums and plain `string` values into string enums.
+
+Those assignments make enums behave more like bags of primitive values than named constants.
+That weakens refactoring safety and makes it easier to accidentally depend on enum implementation details.
+
+This rule reports assignments, arguments, returns, JSX props, and assertions where an enum-typed location receives a non-enum value of the same primitive kind.
+
+## Examples
+
+<Tabs>
+<TabItem value="❌ Incorrect">
+
+```ts
+enum Fruit {
+  Apple,
+}
+
+const fruit: Fruit = 0;
+
+function takesFruit(value: Fruit) {}
+takesFruit(0);
+
+function getFruit(): Fruit {
+  return 0;
+}
+
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+const vegetable = 'asparagus' as const;
+```
+
+</TabItem>
+<TabItem value="✅ Correct">
+
+```ts
+enum Fruit {
+  Apple,
+}
+
+const fruit: Fruit = Fruit.Apple;
+
+function takesFruit(value: Fruit) {}
+takesFruit(Fruit.Apple);
+
+function getFruit(): Fruit {
+  return Fruit.Apple;
+}
+
+enum Vegetable {
+  Asparagus = 'asparagus',
+}
+
+const vegetable: Vegetable = Vegetable.Asparagus;
+```
+
+</TabItem>
+</Tabs>
+
+## When Not To Use It
+
+If your codebase intentionally treats enums as interchangeable with their underlying primitive values, this rule may be too strict.

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -104,6 +104,7 @@ export = {
     '@typescript-eslint/no-unsafe-assignment': 'error',
     '@typescript-eslint/no-unsafe-call': 'error',
     '@typescript-eslint/no-unsafe-declaration-merging': 'error',
+    '@typescript-eslint/no-unsafe-enum-assignment': 'error',
     '@typescript-eslint/no-unsafe-enum-comparison': 'error',
     '@typescript-eslint/no-unsafe-function-type': 'error',
     '@typescript-eslint/no-unsafe-member-access': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/disable-type-checked.ts
@@ -39,6 +39,7 @@ export = {
     '@typescript-eslint/no-unsafe-argument': 'off',
     '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unsafe-call': 'off',
+    '@typescript-eslint/no-unsafe-enum-assignment': 'off',
     '@typescript-eslint/no-unsafe-enum-comparison': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',

--- a/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked-only.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked-only.ts
@@ -35,6 +35,7 @@ export = {
     '@typescript-eslint/no-unsafe-argument': 'error',
     '@typescript-eslint/no-unsafe-assignment': 'error',
     '@typescript-eslint/no-unsafe-call': 'error',
+    '@typescript-eslint/no-unsafe-enum-assignment': 'error',
     '@typescript-eslint/no-unsafe-enum-comparison': 'error',
     '@typescript-eslint/no-unsafe-member-access': 'error',
     '@typescript-eslint/no-unsafe-return': 'error',

--- a/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/strict-type-checked.ts
@@ -57,6 +57,7 @@ export = {
     '@typescript-eslint/no-unsafe-assignment': 'error',
     '@typescript-eslint/no-unsafe-call': 'error',
     '@typescript-eslint/no-unsafe-declaration-merging': 'error',
+    '@typescript-eslint/no-unsafe-enum-assignment': 'error',
     '@typescript-eslint/no-unsafe-enum-comparison': 'error',
     '@typescript-eslint/no-unsafe-function-type': 'error',
     '@typescript-eslint/no-unsafe-member-access': 'error',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -118,6 +118,7 @@ export default (
       '@typescript-eslint/no-unsafe-assignment': 'error',
       '@typescript-eslint/no-unsafe-call': 'error',
       '@typescript-eslint/no-unsafe-declaration-merging': 'error',
+      '@typescript-eslint/no-unsafe-enum-assignment': 'error',
       '@typescript-eslint/no-unsafe-enum-comparison': 'error',
       '@typescript-eslint/no-unsafe-function-type': 'error',
       '@typescript-eslint/no-unsafe-member-access': 'error',

--- a/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/flat/disable-type-checked.ts
@@ -46,6 +46,7 @@ export default (
     '@typescript-eslint/no-unsafe-argument': 'off',
     '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unsafe-call': 'off',
+    '@typescript-eslint/no-unsafe-enum-assignment': 'off',
     '@typescript-eslint/no-unsafe-enum-comparison': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',

--- a/packages/eslint-plugin/src/configs/flat/strict-type-checked-only.ts
+++ b/packages/eslint-plugin/src/configs/flat/strict-type-checked-only.ts
@@ -48,6 +48,7 @@ export default (
       '@typescript-eslint/no-unsafe-argument': 'error',
       '@typescript-eslint/no-unsafe-assignment': 'error',
       '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-unsafe-enum-assignment': 'error',
       '@typescript-eslint/no-unsafe-enum-comparison': 'error',
       '@typescript-eslint/no-unsafe-member-access': 'error',
       '@typescript-eslint/no-unsafe-return': 'error',

--- a/packages/eslint-plugin/src/configs/flat/strict-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/flat/strict-type-checked.ts
@@ -70,6 +70,7 @@ export default (
       '@typescript-eslint/no-unsafe-assignment': 'error',
       '@typescript-eslint/no-unsafe-call': 'error',
       '@typescript-eslint/no-unsafe-declaration-merging': 'error',
+      '@typescript-eslint/no-unsafe-enum-assignment': 'error',
       '@typescript-eslint/no-unsafe-enum-comparison': 'error',
       '@typescript-eslint/no-unsafe-function-type': 'error',
       '@typescript-eslint/no-unsafe-member-access': 'error',

--- a/packages/eslint-plugin/src/rules/enum-utils/shared.ts
+++ b/packages/eslint-plugin/src/rules/enum-utils/shared.ts
@@ -57,6 +57,184 @@ export function getEnumTypes(
 }
 
 /**
+ * @returns Whether two types compare unsafely because an enum value is being
+ * compared against a non-enum value of the same primitive kind.
+ */
+export function isMismatchedEnumComparisonTypes(
+  typeChecker: ts.TypeChecker,
+  leftType: ts.Type,
+  rightType: ts.Type,
+): boolean {
+  // Allow comparisons that don't have anything to do with enums:
+  //
+  // ```ts
+  // 1 === 2;
+  // ```
+  const leftEnumTypes = getEnumTypes(typeChecker, leftType);
+  const rightEnumTypes = new Set(getEnumTypes(typeChecker, rightType));
+  if (leftEnumTypes.length === 0 && rightEnumTypes.size === 0) {
+    return false;
+  }
+
+  // Allow comparisons that share an enum type:
+  //
+  // ```ts
+  // Fruit.Apple === Fruit.Banana;
+  // ```
+  for (const leftEnumType of leftEnumTypes) {
+    if (rightEnumTypes.has(leftEnumType)) {
+      return false;
+    }
+  }
+
+  // We need to split the type into the union type parts in order to find
+  // valid enum comparisons like:
+  //
+  // ```ts
+  // declare const something: Fruit | Vegetable;
+  // something === Fruit.Apple;
+  // ```
+  const leftTypeParts = tsutils.unionConstituents(leftType);
+  const rightTypeParts = tsutils.unionConstituents(rightType);
+
+  // If a type exists in both sides, we consider this comparison safe:
+  //
+  // ```ts
+  // declare const fruit: Fruit.Apple | 0;
+  // fruit === 0;
+  // ```
+  for (const leftTypePart of leftTypeParts) {
+    if (rightTypeParts.includes(leftTypePart)) {
+      return false;
+    }
+  }
+
+  return (
+    typeViolates(leftTypeParts, rightType) ||
+    typeViolates(rightTypeParts, leftType)
+  );
+}
+
+/**
+ * @returns Whether assigning a sender type to a receiver type is unsafe because
+ * the receiver expects an enum value but the sender only provides non-enum
+ * values of the same primitive kind.
+ */
+export function isMismatchedEnumAssignmentTypes(
+  typeChecker: ts.TypeChecker,
+  senderType: ts.Type,
+  receiverType: ts.Type,
+): boolean {
+  const receiverEnumTypes = getEnumTypes(typeChecker, receiverType);
+  if (receiverEnumTypes.length === 0) {
+    return false;
+  }
+
+  const receiverTypeParts = tsutils.unionConstituents(receiverType);
+  const receiverNonEnumParts = receiverTypeParts.filter(
+    receiverTypePart =>
+      getEnumTypes(typeChecker, receiverTypePart).length === 0,
+  );
+  const receiverEnumValueTypes = new Set(
+    receiverTypeParts.map(getEnumValueType),
+  );
+
+  for (const senderTypePart of tsutils.unionConstituents(senderType)) {
+    if (hasSharedEnumType(typeChecker, senderTypePart, receiverEnumTypes)) {
+      continue;
+    }
+
+    if (
+      receiverNonEnumParts.some(receiverTypePart =>
+        typeChecker.isTypeAssignableTo(senderTypePart, receiverTypePart),
+      )
+    ) {
+      continue;
+    }
+
+    if (
+      (receiverEnumValueTypes.has(ts.TypeFlags.Number) &&
+        isNumberLike(senderTypePart)) ||
+      (receiverEnumValueTypes.has(ts.TypeFlags.String) &&
+        isStringLike(senderTypePart))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * @returns Whether the right type is an unsafe comparison against any left type.
+ */
+function typeViolates(leftTypeParts: ts.Type[], rightType: ts.Type): boolean {
+  const leftEnumValueTypes = new Set(leftTypeParts.map(getEnumValueType));
+
+  return (
+    (leftEnumValueTypes.has(ts.TypeFlags.Number) && isNumberLike(rightType)) ||
+    (leftEnumValueTypes.has(ts.TypeFlags.String) && isStringLike(rightType))
+  );
+}
+
+function hasSharedEnumType(
+  typeChecker: ts.TypeChecker,
+  type: ts.Type,
+  expectedEnumTypes: readonly ts.Type[],
+): boolean {
+  const typeEnumTypes = new Set(getEnumTypes(typeChecker, type));
+
+  for (const expectedEnumType of expectedEnumTypes) {
+    if (typeEnumTypes.has(expectedEnumType)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isNumberLike(type: ts.Type): boolean {
+  return tsutils
+    .unionConstituents(type)
+    .every(unionPart =>
+      tsutils
+        .intersectionConstituents(unionPart)
+        .some(intersectionPart =>
+          tsutils.isTypeFlagSet(
+            intersectionPart,
+            ts.TypeFlags.Number | ts.TypeFlags.NumberLike,
+          ),
+        ),
+    );
+}
+
+function isStringLike(type: ts.Type): boolean {
+  return tsutils
+    .unionConstituents(type)
+    .every(unionPart =>
+      tsutils
+        .intersectionConstituents(unionPart)
+        .some(intersectionPart =>
+          tsutils.isTypeFlagSet(
+            intersectionPart,
+            ts.TypeFlags.String | ts.TypeFlags.StringLike,
+          ),
+        ),
+    );
+}
+
+/**
+ * @returns What type a type's enum value is (number or string), if either.
+ */
+function getEnumValueType(type: ts.Type): ts.TypeFlags | undefined {
+  return tsutils.isTypeFlagSet(type, ts.TypeFlags.EnumLike)
+    ? tsutils.isTypeFlagSet(type, ts.TypeFlags.NumberLiteral)
+      ? ts.TypeFlags.Number
+      : ts.TypeFlags.String
+    : undefined;
+}
+
+/**
  * Returns the enum key that matches the given literal node, or null if none
  * match. For example:
  * ```ts

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -81,6 +81,7 @@ import noUnsafeArgument from './no-unsafe-argument';
 import noUnsafeAssignment from './no-unsafe-assignment';
 import noUnsafeCall from './no-unsafe-call';
 import noUnsafeDeclarationMerging from './no-unsafe-declaration-merging';
+import noUnsafeEnumAssignment from './no-unsafe-enum-assignment';
 import noUnsafeEnumComparison from './no-unsafe-enum-comparison';
 import noUnsafeFunctionType from './no-unsafe-function-type';
 import noUnsafeMemberAccess from './no-unsafe-member-access';
@@ -218,6 +219,7 @@ const rules = {
   'no-unsafe-assignment': noUnsafeAssignment,
   'no-unsafe-call': noUnsafeCall,
   'no-unsafe-declaration-merging': noUnsafeDeclarationMerging,
+  'no-unsafe-enum-assignment': noUnsafeEnumAssignment,
   'no-unsafe-enum-comparison': noUnsafeEnumComparison,
   'no-unsafe-function-type': noUnsafeFunctionType,
   'no-unsafe-member-access': noUnsafeMemberAccess,

--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -6,8 +6,8 @@ import * as ts from 'typescript';
 
 import {
   createRule,
+  FunctionSignature,
   getParserServices,
-  isRestParameterDeclaration,
   isTypeAnyArrayType,
   isTypeAnyType,
   isUnsafeAssignment,
@@ -19,127 +19,6 @@ export type MessageIds =
   | 'unsafeArraySpread'
   | 'unsafeSpread'
   | 'unsafeTupleSpread';
-
-const enum RestTypeKind {
-  Array,
-  Tuple,
-  Other,
-}
-type RestType =
-  | {
-      index: number;
-      kind: RestTypeKind.Array;
-      type: ts.Type;
-    }
-  | {
-      index: number;
-      kind: RestTypeKind.Other;
-      type: ts.Type;
-    }
-  | {
-      index: number;
-      kind: RestTypeKind.Tuple;
-      typeArguments: readonly ts.Type[];
-    };
-
-class FunctionSignature {
-  private hasConsumedArguments = false;
-
-  private parameterTypeIndex = 0;
-
-  private constructor(
-    private paramTypes: ts.Type[],
-    private restType: RestType | null,
-  ) {}
-
-  public static create(
-    checker: ts.TypeChecker,
-    tsNode: ts.CallLikeExpression,
-  ): FunctionSignature | null {
-    const signature = checker.getResolvedSignature(tsNode);
-    if (!signature) {
-      return null;
-    }
-
-    const paramTypes: ts.Type[] = [];
-    let restType: RestType | null = null;
-
-    const parameters = signature.getParameters();
-    for (let i = 0; i < parameters.length; i += 1) {
-      const param = parameters[i];
-      const type = checker.getTypeOfSymbolAtLocation(param, tsNode);
-
-      const decl = param.getDeclarations()?.[0];
-      if (decl && isRestParameterDeclaration(decl)) {
-        // is a rest param
-        if (checker.isArrayType(type)) {
-          restType = {
-            type: checker.getTypeArguments(type)[0],
-            index: i,
-            kind: RestTypeKind.Array,
-          };
-        } else if (checker.isTupleType(type)) {
-          restType = {
-            index: i,
-            kind: RestTypeKind.Tuple,
-            typeArguments: checker.getTypeArguments(type),
-          };
-        } else {
-          restType = {
-            type,
-            index: i,
-            kind: RestTypeKind.Other,
-          };
-        }
-        break;
-      }
-
-      paramTypes.push(type);
-    }
-
-    return new this(paramTypes, restType);
-  }
-
-  public consumeRemainingArguments(): void {
-    this.hasConsumedArguments = true;
-  }
-
-  public getNextParameterType(): ts.Type | null {
-    const index = this.parameterTypeIndex;
-    this.parameterTypeIndex += 1;
-
-    if (index >= this.paramTypes.length || this.hasConsumedArguments) {
-      if (this.restType == null) {
-        return null;
-      }
-
-      switch (this.restType.kind) {
-        case RestTypeKind.Tuple: {
-          const typeArguments = this.restType.typeArguments;
-          if (this.hasConsumedArguments) {
-            // all types consumed by a rest - just assume it's the last type
-            // there is one edge case where this is wrong, but we ignore it because
-            // it's rare and really complicated to handle
-            // eg: function foo(...a: [number, ...string[], number])
-            return typeArguments[typeArguments.length - 1];
-          }
-
-          const typeIndex = index - this.restType.index;
-          if (typeIndex >= typeArguments.length) {
-            return typeArguments[typeArguments.length - 1];
-          }
-
-          return typeArguments[typeIndex];
-        }
-
-        case RestTypeKind.Array:
-        case RestTypeKind.Other:
-          return this.restType.type;
-      }
-    }
-    return this.paramTypes[index];
-  }
-}
 
 export default createRule<[], MessageIds>({
   name: 'no-unsafe-argument',

--- a/packages/eslint-plugin/src/rules/no-unsafe-enum-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-enum-assignment.ts
@@ -1,0 +1,988 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
+
+import {
+  createRule,
+  FunctionSignature,
+  getContextualType,
+  getParserServices,
+  getStaticMemberAccessValue,
+  MakeRequired,
+} from '../util';
+import { getParentFunctionNode } from '../util/getParentFunctionNode';
+import {
+  getEnumTypes,
+  isMismatchedEnumAssignmentTypes,
+} from './enum-utils/shared';
+
+const bitwiseBinaryOperators = new Set(['&', '<<', '>>', '>>>', '^', '|']);
+
+export default createRule({
+  name: 'no-unsafe-enum-assignment',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow assigning non-enum values to enum typed locations',
+      recommended: 'strict',
+      requiresTypeChecking: true,
+    },
+    messages: {
+      unsafeEnumAccess:
+        'The computed key used here does not have a shared enum type with the expected enum {{enumNames}}.',
+      unsafeEnumArgument:
+        'The argument passed here does not have a shared enum type with the expected enum {{enumNames}}.',
+      unsafeEnumAssertion:
+        'The value asserted here does not have a shared enum type with the expected enum {{enumNames}}.',
+      unsafeEnumAssignment:
+        'The value assigned here does not have a shared enum type with the expected enum {{enumNames}}.',
+      unsafeEnumReturn:
+        'The value returned here does not have a shared enum type with the expected enum {{enumNames}}.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const services = getParserServices(context);
+    const checker = services.program.getTypeChecker();
+    const suppressedNestedReportRoots = new WeakSet<TSESTree.Node>();
+
+    function hasSharedEnumType(
+      type: ts.Type,
+      expectedEnumTypes: readonly ts.Type[],
+    ) {
+      const typeEnumTypes = new Set(getEnumTypes(checker, type));
+
+      for (const expectedEnumType of expectedEnumTypes) {
+        if (typeEnumTypes.has(expectedEnumType)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    function getTsExpression(node: TSESTree.Expression): ts.Expression {
+      return services.esTreeNodeToTSNodeMap.get(node) as ts.Expression;
+    }
+
+    function getContextualTypeForExpression(node: TSESTree.Expression) {
+      return getContextualType(checker, getTsExpression(node));
+    }
+
+    function isTypeReference(type: ts.Type): type is ts.TypeReference {
+      return 'target' in type;
+    }
+
+    function getTypeArguments(type: ts.Type): readonly ts.Type[] {
+      if (!isTypeReference(type)) {
+        return [];
+      }
+
+      return checker.getTypeArguments(type);
+    }
+
+    function isSafeEnumBitwiseExpression(
+      expression: TSESTree.Expression,
+      receiverType: ts.Type,
+    ) {
+      const receiverEnumTypes = getEnumTypes(checker, receiverType);
+      if (receiverEnumTypes.length === 0) {
+        return false;
+      }
+
+      function unwrapTsExpression(node: ts.Expression) {
+        if (ts.isParenthesizedExpression(node)) {
+          return unwrapTsExpression(node.expression);
+        }
+
+        if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)) {
+          return unwrapTsExpression(node.expression);
+        }
+
+        return node;
+      }
+
+      function isBitwiseOperand(node: ts.Expression): boolean {
+        const unwrappedNode = unwrapTsExpression(node);
+        if (ts.isBinaryExpression(unwrappedNode)) {
+          const operator = ts.tokenToString(unwrappedNode.operatorToken.kind);
+          if (!operator || !bitwiseBinaryOperators.has(operator)) {
+            return false;
+          }
+
+          return (
+            isBitwiseOperand(unwrappedNode.left) &&
+            isBitwiseOperand(unwrappedNode.right)
+          );
+        }
+
+        return hasSharedEnumType(
+          checker.getTypeAtLocation(unwrappedNode),
+          receiverEnumTypes,
+        );
+      }
+
+      const unwrappedExpression = unwrapTsExpression(
+        getTsExpression(expression),
+      );
+      if (!ts.isBinaryExpression(unwrappedExpression)) {
+        return false;
+      }
+
+      const operator = ts.tokenToString(unwrappedExpression.operatorToken.kind);
+      if (!operator || !bitwiseBinaryOperators.has(operator)) {
+        return false;
+      }
+
+      return (
+        isBitwiseOperand(unwrappedExpression.left) &&
+        isBitwiseOperand(unwrappedExpression.right)
+      );
+    }
+
+    function getImplementedMemberTypes(
+      node: TSESTree.AccessorProperty | TSESTree.PropertyDefinition,
+    ) {
+      const memberName = getStaticMemberAccessValue(node, context);
+      if (typeof memberName !== 'string') {
+        return [];
+      }
+
+      const tsMemberNode = services.esTreeNodeToTSNodeMap.get(node);
+      const classNode = tsMemberNode.parent;
+
+      const implementedTypes = [];
+      for (const heritageClause of classNode.heritageClauses ?? []) {
+        for (const heritageType of heritageClause.types) {
+          const implementedType = checker.getTypeAtLocation(heritageType);
+          const memberSymbol = implementedType.getProperty(memberName);
+          if (!memberSymbol) {
+            continue;
+          }
+
+          implementedTypes.push(checker.getTypeOfSymbol(memberSymbol));
+        }
+      }
+
+      return implementedTypes;
+    }
+
+    function hasSuppressedNestedReportAncestor(node: TSESTree.Node) {
+      let current: TSESTree.Node | undefined = node;
+
+      while (current) {
+        if (suppressedNestedReportRoots.has(current)) {
+          return true;
+        }
+
+        current = current.parent;
+      }
+
+      return false;
+    }
+
+    function formatEnumNames(enumNames: readonly string[]) {
+      return enumNames.map(enumName => `'${enumName}'`).join(', ');
+    }
+
+    function getExpectedEnumNames(type: ts.Type) {
+      const visited = new Set<ts.Type>();
+      const enumNames = new Set<string>();
+
+      function visit(currentType: ts.Type) {
+        const constrainedType = getConstraintType(currentType);
+
+        for (const enumType of getEnumTypes(checker, constrainedType)) {
+          enumNames.add(checker.typeToString(enumType));
+        }
+
+        if (visited.has(constrainedType)) {
+          return;
+        }
+        visited.add(constrainedType);
+
+        for (const typeArgument of getTypeArguments(constrainedType)) {
+          visit(typeArgument);
+        }
+
+        const indexType = checker.getIndexTypeOfType(
+          constrainedType,
+          ts.IndexKind.Number,
+        );
+        if (indexType) {
+          visit(indexType);
+        }
+
+        for (const property of constrainedType.getProperties()) {
+          visit(checker.getTypeOfSymbol(property));
+        }
+      }
+
+      visit(type);
+
+      return [...enumNames].sort();
+    }
+
+    function getReportDataForTypes(types: readonly ts.Type[]) {
+      const enumNames = new Set<string>();
+
+      for (const type of types) {
+        for (const enumName of getExpectedEnumNames(type)) {
+          enumNames.add(enumName);
+        }
+      }
+
+      return {
+        enumNames: formatEnumNames([...enumNames].sort()),
+      };
+    }
+
+    function reportWithSuppressedNestedRoots(
+      nodeToSuppress: TSESTree.Node,
+      reportingNode: TSESTree.Node,
+      messageId:
+        | 'unsafeEnumAccess'
+        | 'unsafeEnumArgument'
+        | 'unsafeEnumAssertion'
+        | 'unsafeEnumAssignment'
+        | 'unsafeEnumReturn',
+      receiverTypes: readonly ts.Type[],
+    ) {
+      suppressedNestedReportRoots.add(nodeToSuppress);
+      context.report({
+        node: reportingNode,
+        messageId,
+        data: getReportDataForTypes(receiverTypes),
+      });
+    }
+
+    function checkImplementedMemberAssignment(
+      node: TSESTree.AccessorProperty | TSESTree.PropertyDefinition,
+      valueNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node,
+    ) {
+      const implementedMemberTypes = getImplementedMemberTypes(node);
+      if (implementedMemberTypes.length === 0) {
+        return false;
+      }
+
+      const senderType = services.getTypeAtLocation(valueNode);
+
+      for (const receiverType of implementedMemberTypes) {
+        if (
+          !hasDeepEnumAssignmentMismatch(senderType, receiverType) ||
+          isSafeEnumBitwiseExpression(valueNode, receiverType)
+        ) {
+          return false;
+        }
+      }
+
+      reportWithSuppressedNestedRoots(
+        valueNode,
+        reportingNode,
+        'unsafeEnumAssignment',
+        implementedMemberTypes,
+      );
+
+      return true;
+    }
+
+    function checkAssignmentWithReceiverType(
+      receiverType: ts.Type,
+      senderNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node,
+    ) {
+      const senderType = services.getTypeAtLocation(senderNode);
+
+      if (senderNode.type === AST_NODE_TYPES.ObjectExpression) {
+        return false;
+      }
+
+      if (senderNode.type === AST_NODE_TYPES.ArrayExpression) {
+        const constrainedReceiverType = getConstraintType(receiverType);
+
+        if (
+          !isTypeParameterType(receiverType) &&
+          (checker.isArrayType(constrainedReceiverType) ||
+            checker.isTupleType(constrainedReceiverType))
+        ) {
+          return false;
+        }
+      }
+
+      if (hasDeepEnumAssignmentMismatch(senderType, receiverType)) {
+        if (isSafeEnumBitwiseExpression(senderNode, receiverType)) {
+          return false;
+        }
+
+        reportWithSuppressedNestedRoots(
+          senderNode,
+          reportingNode,
+          'unsafeEnumAssignment',
+          [receiverType],
+        );
+        return true;
+      }
+
+      return false;
+    }
+
+    function checkAssignment(
+      receiverNode: TSESTree.Node,
+      senderNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node,
+    ) {
+      return checkAssignmentWithReceiverType(
+        services.getTypeAtLocation(receiverNode),
+        senderNode,
+        reportingNode,
+      );
+    }
+
+    function checkContextualAssignment(
+      receiverNode: TSESTree.Node,
+      senderNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node,
+      contextualReceiverNode: TSESTree.Expression,
+    ) {
+      return checkAssignmentWithReceiverType(
+        getContextualTypeForExpression(contextualReceiverNode) ??
+          services.getTypeAtLocation(receiverNode),
+        senderNode,
+        reportingNode,
+      );
+    }
+
+    function getConstraintType(type: ts.Type) {
+      return checker.getBaseConstraintOfType(type) ?? type;
+    }
+
+    function isTypeParameterType(type: ts.Type) {
+      return tsutils.isTypeFlagSet(type, ts.TypeFlags.TypeParameter);
+    }
+
+    function getEffectiveArgumentReceiverType(
+      _argument: TSESTree.Expression,
+      parameterType: ts.Type,
+    ) {
+      return parameterType;
+    }
+
+    function hasDeepEnumAssignmentMismatch(
+      senderType: ts.Type,
+      receiverType: ts.Type,
+      visited = new Set<string>(),
+    ) {
+      const constrainedSenderType = getConstraintType(senderType);
+      const constrainedReceiverType = getConstraintType(receiverType);
+
+      const key = `${checker.typeToString(constrainedSenderType)}=>${checker.typeToString(constrainedReceiverType)}`;
+      if (visited.has(key)) {
+        return false;
+      }
+      visited.add(key);
+
+      if (
+        isMismatchedEnumAssignmentTypes(
+          checker,
+          constrainedSenderType,
+          constrainedReceiverType,
+        )
+      ) {
+        return true;
+      }
+
+      const senderTypeArguments = getTypeArguments(constrainedSenderType);
+      const receiverTypeArguments = getTypeArguments(constrainedReceiverType);
+      if (
+        senderTypeArguments.length > 0 &&
+        senderTypeArguments.length === receiverTypeArguments.length
+      ) {
+        for (let index = 0; index < receiverTypeArguments.length; index += 1) {
+          if (
+            hasDeepEnumAssignmentMismatch(
+              senderTypeArguments[index],
+              receiverTypeArguments[index],
+              visited,
+            )
+          ) {
+            return true;
+          }
+        }
+      }
+
+      const receiverElementType = checker.getIndexTypeOfType(
+        constrainedReceiverType,
+        ts.IndexKind.Number,
+      );
+      if (
+        receiverElementType &&
+        checker.isTupleType(constrainedSenderType) &&
+        checker
+          .getTypeArguments(constrainedSenderType)
+          .some(elementType =>
+            hasDeepEnumAssignmentMismatch(
+              elementType,
+              receiverElementType,
+              visited,
+            ),
+          )
+      ) {
+        return true;
+      }
+
+      for (const receiverProperty of constrainedReceiverType.getProperties()) {
+        const senderProperty = constrainedSenderType.getProperty(
+          receiverProperty.name,
+        );
+        if (!senderProperty) {
+          continue;
+        }
+
+        if (
+          hasDeepEnumAssignmentMismatch(
+            checker.getTypeOfSymbol(senderProperty),
+            checker.getTypeOfSymbol(receiverProperty),
+            visited,
+          )
+        ) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    function checkArrayDestructurePattern(
+      receiverNode: TSESTree.ArrayPattern,
+      senderNode: TSESTree.Expression,
+    ) {
+      const receiverType = services.getTypeAtLocation(receiverNode);
+      if (
+        !checker.isTupleType(receiverType) &&
+        !checker.isArrayType(receiverType)
+      ) {
+        return false;
+      }
+
+      const senderType = services.getTypeAtLocation(senderNode);
+      const senderElementTypes = checker.isTupleType(senderType)
+        ? checker.getTypeArguments(senderType)
+        : [];
+      const receiverElementTypes = checker.isTupleType(receiverType)
+        ? checker.getTypeArguments(receiverType)
+        : [];
+      const receiverArrayElementType = checker.getIndexTypeOfType(
+        receiverType,
+        ts.IndexKind.Number,
+      );
+
+      let foundMismatch = false;
+      for (let index = 0; index < receiverNode.elements.length; index += 1) {
+        const receiverElement = receiverNode.elements[index];
+        if (
+          !receiverElement ||
+          receiverElement.type === AST_NODE_TYPES.RestElement
+        ) {
+          continue;
+        }
+
+        const receiverElementType =
+          receiverElementTypes[index] ?? receiverArrayElementType;
+
+        const senderElementType =
+          senderElementTypes[index] ??
+          checker.getIndexTypeOfType(senderType, ts.IndexKind.Number);
+
+        if (
+          !hasDeepEnumAssignmentMismatch(senderElementType, receiverElementType)
+        ) {
+          continue;
+        }
+
+        context.report({
+          node: receiverElement,
+          messageId: 'unsafeEnumAssignment',
+          data: getReportDataForTypes([receiverElementType]),
+        });
+        foundMismatch = true;
+      }
+
+      return foundMismatch;
+    }
+
+    function checkObjectDestructurePattern(
+      receiverNode: TSESTree.ObjectPattern,
+      senderNode: TSESTree.Expression,
+    ) {
+      const receiverType = services.getTypeAtLocation(receiverNode);
+      const senderType = services.getTypeAtLocation(senderNode);
+
+      let foundMismatch = false;
+      for (const property of receiverNode.properties) {
+        if (
+          property.type !== AST_NODE_TYPES.Property ||
+          property.value.type === AST_NODE_TYPES.AssignmentPattern
+        ) {
+          continue;
+        }
+
+        const key = getStaticMemberAccessValue(property, context);
+        if (typeof key !== 'string') {
+          continue;
+        }
+
+        const senderProperty = senderType.getProperty(key);
+        const receiverProperty = receiverType.getProperty(key);
+        if (!senderProperty || !receiverProperty) {
+          continue;
+        }
+
+        const senderPropertyType = checker.getTypeOfSymbol(senderProperty);
+        const receiverPropertyType = checker.getTypeOfSymbol(receiverProperty);
+
+        if (
+          !hasDeepEnumAssignmentMismatch(
+            senderPropertyType,
+            receiverPropertyType,
+          )
+        ) {
+          continue;
+        }
+
+        context.report({
+          node: property.value,
+          messageId: 'unsafeEnumAssignment',
+          data: getReportDataForTypes([receiverPropertyType]),
+        });
+        foundMismatch = true;
+      }
+
+      return foundMismatch;
+    }
+
+    function checkArguments(
+      args: TSESTree.CallExpressionArgument[] | TSESTree.Expression[],
+      node:
+        | TSESTree.CallExpression
+        | TSESTree.NewExpression
+        | TSESTree.TaggedTemplateExpression,
+    ) {
+      if (args.length === 0) {
+        return;
+      }
+
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const signature = FunctionSignature.create(checker, tsNode, {
+        useDeclaredParameterTypes: true,
+      })!;
+
+      if (node.type === AST_NODE_TYPES.TaggedTemplateExpression) {
+        signature.getNextParameterType();
+      }
+
+      for (const argument of args) {
+        if (argument.type === AST_NODE_TYPES.SpreadElement) {
+          const spreadArgType = services.getTypeAtLocation(argument.argument);
+          if (checker.isTupleType(spreadArgType)) {
+            const spreadTypeArguments = checker.getTypeArguments(spreadArgType);
+            for (const tupleType of spreadTypeArguments) {
+              const parameterType = signature.getNextParameterType();
+              if (parameterType == null) {
+                continue;
+              }
+
+              if (hasDeepEnumAssignmentMismatch(tupleType, parameterType)) {
+                reportWithSuppressedNestedRoots(
+                  argument,
+                  argument,
+                  'unsafeEnumArgument',
+                  [parameterType],
+                );
+              }
+            }
+
+            if (spreadArgType.target.combinedFlags & ts.ElementFlags.Variable) {
+              signature.consumeRemainingArguments();
+            }
+          }
+
+          continue;
+        }
+
+        const parameterType = signature.getNextParameterType();
+        if (parameterType == null) {
+          continue;
+        }
+
+        if (argument.type === AST_NODE_TYPES.ArrayExpression) {
+          const constrainedParameterType = getConstraintType(parameterType);
+
+          if (
+            !isTypeParameterType(parameterType) &&
+            (checker.isArrayType(constrainedParameterType) ||
+              checker.isTupleType(constrainedParameterType))
+          ) {
+            continue;
+          }
+        }
+
+        const receiverType = getEffectiveArgumentReceiverType(
+          argument,
+          parameterType,
+        );
+
+        const argumentType = services.getTypeAtLocation(argument);
+        if (
+          hasDeepEnumAssignmentMismatch(argumentType, receiverType) &&
+          !isSafeEnumBitwiseExpression(argument, receiverType)
+        ) {
+          reportWithSuppressedNestedRoots(
+            argument,
+            argument,
+            'unsafeEnumArgument',
+            [receiverType],
+          );
+        }
+      }
+    }
+
+    function checkAssigningVariable(
+      node: TSESTree.Node,
+      assignee: TSESTree.Node,
+      value: TSESTree.Expression,
+    ) {
+      switch (assignee.type) {
+        case AST_NODE_TYPES.ArrayPattern:
+          checkArrayDestructurePattern(assignee, value);
+          return;
+        case AST_NODE_TYPES.ObjectPattern:
+          checkObjectDestructurePattern(assignee, value);
+          return;
+        default:
+          checkAssignment(assignee, value, node);
+          return;
+      }
+    }
+
+    function checkReturn(
+      returnNode: TSESTree.Expression,
+      reportingNode: TSESTree.Node = returnNode,
+    ) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const functionNode = getParentFunctionNode(returnNode)!;
+
+      const functionTsNode = services.esTreeNodeToTSNodeMap.get(functionNode);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const signature = checker.getSignatureFromDeclaration(functionTsNode)!;
+
+      const returnNodeType = services.getTypeAtLocation(returnNode);
+      const senderType = functionNode.async
+        ? checker.getAwaitedType(returnNodeType)
+        : returnNodeType;
+      if (!senderType) {
+        return;
+      }
+
+      const signatureReturnType = signature.getReturnType();
+      const receiverType = functionNode.async
+        ? checker.getAwaitedType(signatureReturnType)
+        : signatureReturnType;
+      if (!receiverType) {
+        return;
+      }
+
+      if (
+        hasDeepEnumAssignmentMismatch(senderType, receiverType) &&
+        !isSafeEnumBitwiseExpression(returnNode, receiverType)
+      ) {
+        reportWithSuppressedNestedRoots(
+          returnNode,
+          reportingNode,
+          'unsafeEnumReturn',
+          [receiverType],
+        );
+      }
+    }
+
+    function checkTypeAssertion(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+    ) {
+      const expressionType = services.getTypeAtLocation(node.expression);
+      const assertedType = services.getTypeAtLocation(node.typeAnnotation);
+
+      if (
+        hasDeepEnumAssignmentMismatch(expressionType, assertedType) &&
+        !isSafeEnumBitwiseExpression(node.expression, assertedType)
+      ) {
+        reportWithSuppressedNestedRoots(node, node, 'unsafeEnumAssertion', [
+          assertedType,
+        ]);
+      }
+    }
+
+    function addMappedKeyConstraintTypesFromDeclarations(
+      declaration: ts.Declaration,
+    ): ts.Type[] {
+      if (
+        !ts.isParameter(declaration) &&
+        !ts.isPropertyDeclaration(declaration) &&
+        !ts.isPropertySignature(declaration) &&
+        !ts.isVariableDeclaration(declaration)
+      ) {
+        return [];
+      }
+
+      if (!declaration.type) {
+        return [];
+      }
+
+      if (ts.isMappedTypeNode(declaration.type)) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const constraint = declaration.type.typeParameter.constraint!;
+        return [checker.getTypeFromTypeNode(constraint)];
+      }
+
+      if (ts.isTypeLiteralNode(declaration.type)) {
+        const receiverTypes: ts.Type[] = [];
+        for (const member of declaration.type.members) {
+          if (
+            ts.isPropertySignature(member) &&
+            ts.isComputedPropertyName(member.name)
+          ) {
+            receiverTypes.push(
+              checker.getTypeAtLocation(member.name.expression),
+            );
+          }
+        }
+
+        return receiverTypes;
+      }
+
+      return [];
+    }
+
+    function isObjectPatternDestructureSource(
+      objectExpression: TSESTree.ObjectExpression,
+    ) {
+      const objectExpressionParent = objectExpression.parent;
+
+      return (
+        (objectExpressionParent.type === AST_NODE_TYPES.VariableDeclarator &&
+          objectExpressionParent.id.type === AST_NODE_TYPES.ObjectPattern &&
+          objectExpressionParent.init === objectExpression) ||
+        (objectExpressionParent.type === AST_NODE_TYPES.AssignmentExpression &&
+          objectExpressionParent.left.type === AST_NODE_TYPES.ObjectPattern &&
+          objectExpressionParent.right === objectExpression) ||
+        (objectExpressionParent.type === AST_NODE_TYPES.AssignmentPattern &&
+          objectExpressionParent.left.type === AST_NODE_TYPES.ObjectPattern &&
+          objectExpressionParent.right === objectExpression)
+      );
+    }
+
+    function isArrayPatternDestructureSource(node: TSESTree.ArrayExpression) {
+      const parent = node.parent;
+
+      return (
+        (parent.type === AST_NODE_TYPES.VariableDeclarator &&
+          parent.id.type === AST_NODE_TYPES.ArrayPattern &&
+          parent.init === node) ||
+        (parent.type === AST_NODE_TYPES.AssignmentExpression &&
+          parent.left.type === AST_NODE_TYPES.ArrayPattern &&
+          parent.right === node) ||
+        (parent.type === AST_NODE_TYPES.AssignmentPattern &&
+          parent.left.type === AST_NODE_TYPES.ArrayPattern &&
+          parent.right === node)
+      );
+    }
+
+    return {
+      ':not(ObjectPattern) > Property'(
+        node: TSESTree.Property & {
+          parent: TSESTree.ObjectExpression;
+          value: TSESTree.Expression;
+        },
+      ) {
+        if (
+          hasSuppressedNestedReportAncestor(node) ||
+          isObjectPatternDestructureSource(node.parent)
+        ) {
+          return;
+        }
+
+        checkContextualAssignment(
+          node.computed ? node.value : node.key,
+          node.value,
+          node,
+          node.computed ? node.value : node.key,
+        );
+      },
+      'AccessorProperty[value != null]'(
+        node: { value: NonNullable<unknown> } & TSESTree.AccessorProperty,
+      ) {
+        if (checkImplementedMemberAssignment(node, node.value, node)) {
+          return;
+        }
+
+        checkAssignment(node, node.value, node);
+      },
+      ArrayExpression(node) {
+        if (
+          hasSuppressedNestedReportAncestor(node) ||
+          isArrayPatternDestructureSource(node)
+        ) {
+          return;
+        }
+
+        const contextualType = getContextualTypeForExpression(node);
+        const constrainedContextualType = contextualType
+          ? getConstraintType(contextualType)
+          : undefined;
+        if (
+          !constrainedContextualType ||
+          (!checker.isArrayType(constrainedContextualType) &&
+            !checker.isTupleType(constrainedContextualType))
+        ) {
+          return;
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const arrayElementType = checker.getIndexTypeOfType(
+          constrainedContextualType,
+          ts.IndexKind.Number,
+        )!;
+        if (getEnumTypes(checker, arrayElementType).length === 0) {
+          return;
+        }
+
+        for (const element of node.elements.filter(
+          arrayElement =>
+            arrayElement != null &&
+            arrayElement.type !== AST_NODE_TYPES.SpreadElement,
+        )) {
+          const elementType = services.getTypeAtLocation(element);
+          if (
+            isMismatchedEnumAssignmentTypes(
+              checker,
+              elementType,
+              arrayElementType,
+            )
+          ) {
+            context.report({
+              node: element,
+              messageId: 'unsafeEnumAssignment',
+              data: getReportDataForTypes([arrayElementType]),
+            });
+          }
+        }
+      },
+      ArrowFunctionExpression(node) {
+        if (node.body.type !== AST_NODE_TYPES.BlockStatement) {
+          checkReturn(node.body, node.body);
+        }
+      },
+      'AssignmentExpression[operator = "="], AssignmentPattern'(
+        node: TSESTree.AssignmentExpression | TSESTree.AssignmentPattern,
+      ) {
+        checkAssigningVariable(node, node.left, node.right);
+      },
+      'CallExpression, NewExpression'(
+        node: TSESTree.CallExpression | TSESTree.NewExpression,
+      ) {
+        checkArguments(node.arguments, node);
+      },
+      'JSXAttribute[value != null]'(
+        node: MakeRequired<TSESTree.JSXAttribute, 'value'>,
+      ) {
+        if (
+          node.value.type !== AST_NODE_TYPES.JSXExpressionContainer ||
+          node.value.expression.type === AST_NODE_TYPES.JSXEmptyExpression
+        ) {
+          return;
+        }
+
+        const receiverType = getContextualTypeForExpression(
+          node.value.expression,
+        );
+        if (!receiverType) {
+          return;
+        }
+        const senderType = services.getTypeAtLocation(node.value.expression);
+
+        if (
+          hasDeepEnumAssignmentMismatch(senderType, receiverType) &&
+          !isSafeEnumBitwiseExpression(node.value.expression, receiverType)
+        ) {
+          reportWithSuppressedNestedRoots(
+            node.value.expression,
+            node.value.expression,
+            'unsafeEnumAssignment',
+            [receiverType],
+          );
+        }
+      },
+      'MemberExpression[computed = true]'(
+        node: TSESTree.MemberExpression & { property: TSESTree.Expression },
+      ) {
+        const receiverTypes = [
+          getContextualTypeForExpression(node.property),
+        ].filter(type => type != null);
+
+        const memberTsNode = services.esTreeNodeToTSNodeMap.get(node);
+        for (const declaration of checker.getSymbolAtLocation(
+          memberTsNode.expression,
+        )?.declarations ?? []) {
+          receiverTypes.push(
+            ...addMappedKeyConstraintTypesFromDeclarations(declaration),
+          );
+        }
+
+        if (receiverTypes.length === 0) {
+          return;
+        }
+
+        const senderType = services.getTypeAtLocation(node.property);
+
+        for (const receiverType of receiverTypes) {
+          if (!hasDeepEnumAssignmentMismatch(senderType, receiverType)) {
+            return;
+          }
+        }
+
+        context.report({
+          node: node.property,
+          messageId: 'unsafeEnumAccess',
+          data: getReportDataForTypes(receiverTypes),
+        });
+      },
+      'PropertyDefinition[value != null]'(
+        node: TSESTree.PropertyDefinition & { value: NonNullable<unknown> },
+      ) {
+        if (!checkImplementedMemberAssignment(node, node.value, node)) {
+          checkAssignment(node, node.value, node);
+        }
+      },
+      ReturnStatement(node) {
+        if (node.argument) {
+          checkReturn(node.argument, node);
+        }
+      },
+      TaggedTemplateExpression(node: TSESTree.TaggedTemplateExpression) {
+        checkArguments(node.quasi.expressions, node);
+      },
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+      'VariableDeclarator[init != null]'(
+        node: TSESTree.VariableDeclarator & {
+          init: NonNullable<TSESTree.VariableDeclarator['init']>;
+        },
+      ) {
+        checkAssigningVariable(node, node.id, node.init);
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/no-unsafe-enum-comparison.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-enum-comparison.ts
@@ -1,67 +1,11 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 
-import * as tsutils from 'ts-api-utils';
-import * as ts from 'typescript';
-
 import { createRule, getParserServices, getStaticValue } from '../util';
 import {
   getEnumKeyForLiteral,
   getEnumLiterals,
-  getEnumTypes,
+  isMismatchedEnumComparisonTypes,
 } from './enum-utils/shared';
-
-/**
- * @returns Whether the right type is an unsafe comparison against any left type.
- */
-function typeViolates(leftTypeParts: ts.Type[], rightType: ts.Type): boolean {
-  const leftEnumValueTypes = new Set(leftTypeParts.map(getEnumValueType));
-
-  return (
-    (leftEnumValueTypes.has(ts.TypeFlags.Number) && isNumberLike(rightType)) ||
-    (leftEnumValueTypes.has(ts.TypeFlags.String) && isStringLike(rightType))
-  );
-}
-
-function isNumberLike(type: ts.Type): boolean {
-  return tsutils
-    .unionConstituents(type)
-    .every(unionPart =>
-      tsutils
-        .intersectionConstituents(unionPart)
-        .some(intersectionPart =>
-          tsutils.isTypeFlagSet(
-            intersectionPart,
-            ts.TypeFlags.Number | ts.TypeFlags.NumberLike,
-          ),
-        ),
-    );
-}
-
-function isStringLike(type: ts.Type): boolean {
-  return tsutils
-    .unionConstituents(type)
-    .every(unionPart =>
-      tsutils
-        .intersectionConstituents(unionPart)
-        .some(intersectionPart =>
-          tsutils.isTypeFlagSet(
-            intersectionPart,
-            ts.TypeFlags.String | ts.TypeFlags.StringLike,
-          ),
-        ),
-    );
-}
-
-/**
- * @returns What type a type's enum value is (number or string), if either.
- */
-function getEnumValueType(type: ts.Type): ts.TypeFlags | undefined {
-  return tsutils.isTypeFlagSet(type, ts.TypeFlags.EnumLike)
-    ? tsutils.isTypeFlagSet(type, ts.TypeFlags.NumberLiteral)
-      ? ts.TypeFlags.Number
-      : ts.TypeFlags.String
-    : undefined;
-}
 
 export default createRule({
   name: 'no-unsafe-enum-comparison',
@@ -87,60 +31,6 @@ export default createRule({
     const parserServices = getParserServices(context);
     const typeChecker = parserServices.program.getTypeChecker();
 
-    function isMismatchedComparison(
-      leftType: ts.Type,
-      rightType: ts.Type,
-    ): boolean {
-      // Allow comparisons that don't have anything to do with enums:
-      //
-      // ```ts
-      // 1 === 2;
-      // ```
-      const leftEnumTypes = getEnumTypes(typeChecker, leftType);
-      const rightEnumTypes = new Set(getEnumTypes(typeChecker, rightType));
-      if (leftEnumTypes.length === 0 && rightEnumTypes.size === 0) {
-        return false;
-      }
-
-      // Allow comparisons that share an enum type:
-      //
-      // ```ts
-      // Fruit.Apple === Fruit.Banana;
-      // ```
-      for (const leftEnumType of leftEnumTypes) {
-        if (rightEnumTypes.has(leftEnumType)) {
-          return false;
-        }
-      }
-
-      // We need to split the type into the union type parts in order to find
-      // valid enum comparisons like:
-      //
-      // ```ts
-      // declare const something: Fruit | Vegetable;
-      // something === Fruit.Apple;
-      // ```
-      const leftTypeParts = tsutils.unionConstituents(leftType);
-      const rightTypeParts = tsutils.unionConstituents(rightType);
-
-      // If a type exists in both sides, we consider this comparison safe:
-      //
-      // ```ts
-      // declare const fruit: Fruit.Apple | 0;
-      // fruit === 0;
-      // ```
-      for (const leftTypePart of leftTypeParts) {
-        if (rightTypeParts.includes(leftTypePart)) {
-          return false;
-        }
-      }
-
-      return (
-        typeViolates(leftTypeParts, rightType) ||
-        typeViolates(rightTypeParts, leftType)
-      );
-    }
-
     return {
       'BinaryExpression[operator=/^[<>!=]?={0,2}$/]'(
         node: TSESTree.BinaryExpression,
@@ -148,7 +38,7 @@ export default createRule({
         const leftType = parserServices.getTypeAtLocation(node.left);
         const rightType = parserServices.getTypeAtLocation(node.right);
 
-        if (isMismatchedComparison(leftType, rightType)) {
+        if (isMismatchedEnumComparisonTypes(typeChecker, leftType, rightType)) {
           context.report({
             node,
             messageId: 'mismatchedCondition',
@@ -204,7 +94,7 @@ export default createRule({
         const leftType = parserServices.getTypeAtLocation(parent.discriminant);
         const rightType = parserServices.getTypeAtLocation(node.test);
 
-        if (isMismatchedComparison(leftType, rightType)) {
+        if (isMismatchedEnumComparisonTypes(typeChecker, leftType, rightType)) {
           context.report({
             node,
             messageId: 'mismatchedCase',

--- a/packages/eslint-plugin/src/util/FunctionSignature.ts
+++ b/packages/eslint-plugin/src/util/FunctionSignature.ts
@@ -1,0 +1,124 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+import * as ts from 'typescript';
+
+import { isRestParameterDeclaration } from './misc';
+
+const { nullThrows } = ESLintUtils;
+
+const enum RestTypeKind {
+  Array,
+  Tuple,
+}
+
+type RestType =
+  | {
+      index: number;
+      kind: RestTypeKind.Array;
+      type: ts.Type;
+    }
+  | {
+      index: number;
+      kind: RestTypeKind.Tuple;
+      typeArguments: readonly ts.Type[];
+    };
+
+export class FunctionSignature {
+  private hasConsumedArguments = false;
+
+  private parameterTypeIndex = 0;
+
+  private constructor(
+    private readonly paramTypes: ts.Type[],
+    private readonly restType: RestType | null,
+  ) {}
+
+  public static create(
+    checker: ts.TypeChecker,
+    tsNode: ts.CallLikeExpression,
+    options?: {
+      useDeclaredParameterTypes?: boolean;
+    },
+  ): FunctionSignature | null {
+    const signature = checker.getResolvedSignature(tsNode);
+    if (!signature) {
+      return null;
+    }
+
+    const paramTypes = [];
+    let restType: RestType | null = null;
+
+    const parameters = signature.getParameters();
+    for (let index = 0; index < parameters.length; index += 1) {
+      const param = parameters[index];
+      const declaration = param.getDeclarations()?.[0];
+      const type =
+        options?.useDeclaredParameterTypes &&
+        declaration != null &&
+        ts.isParameter(declaration) &&
+        declaration.type != null
+          ? checker.getTypeFromTypeNode(declaration.type)
+          : checker.getTypeOfSymbolAtLocation(param, tsNode);
+      const constrainedType = checker.getBaseConstraintOfType(type) ?? type;
+
+      if (declaration && isRestParameterDeclaration(declaration)) {
+        if (checker.isTupleType(constrainedType)) {
+          restType = {
+            index,
+            kind: RestTypeKind.Tuple,
+            typeArguments: checker.getTypeArguments(constrainedType),
+          };
+        } else {
+          restType = {
+            index,
+            kind: RestTypeKind.Array,
+            type: nullThrows(
+              checker.getIndexTypeOfType(constrainedType, ts.IndexKind.Number),
+              'rest parameter type should always provide a number index type',
+            ),
+          };
+        }
+        break;
+      }
+
+      paramTypes.push(type);
+    }
+
+    return new FunctionSignature(paramTypes, restType);
+  }
+
+  public consumeRemainingArguments(): void {
+    this.hasConsumedArguments = true;
+  }
+
+  public getNextParameterType(): ts.Type | null {
+    const index = this.parameterTypeIndex;
+    this.parameterTypeIndex += 1;
+
+    if (index >= this.paramTypes.length || this.hasConsumedArguments) {
+      if (this.restType == null) {
+        return null;
+      }
+
+      switch (this.restType.kind) {
+        case RestTypeKind.Tuple: {
+          const { typeArguments } = this.restType;
+          if (this.hasConsumedArguments) {
+            return typeArguments[typeArguments.length - 1];
+          }
+
+          const typeIndex = index - this.restType.index;
+          if (typeIndex >= typeArguments.length) {
+            return typeArguments[typeArguments.length - 1];
+          }
+
+          return typeArguments[typeIndex];
+        }
+
+        case RestTypeKind.Array:
+          return this.restType.type;
+      }
+    }
+
+    return this.paramTypes[index];
+  }
+}

--- a/packages/eslint-plugin/src/util/index.ts
+++ b/packages/eslint-plugin/src/util/index.ts
@@ -4,6 +4,7 @@ export * from './astUtils';
 export * from './baseTypeUtils';
 export * from './collectUnusedVariables';
 export * from './createRule';
+export * from './FunctionSignature';
 export * from './getBaseTypesOfClassMember';
 export * from './getFixOrSuggest';
 export * from './getFunctionHeadLoc';

--- a/packages/eslint-plugin/tests/rules/no-unsafe-enum-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-enum-assignment.test.ts
@@ -1,0 +1,2601 @@
+import rule from '../../src/rules/no-unsafe-enum-assignment';
+import { createRuleTesterWithTypes } from '../RuleTester';
+
+const ruleTester = createRuleTesterWithTypes();
+
+ruleTester.run('no-unsafe-enum-assignment', rule, {
+  valid: [
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const fruit: Fruit = Fruit.Apple;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const getFruit = (): Fruit => Fruit.Apple;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      class Basket {
+        fruit: Fruit = Fruit.Apple;
+      }
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const box: { fruit: Fruit } = { fruit: Fruit.Apple };
+    `,
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare function Basket(props: { fruit: Fruit }): JSX.Element;
+
+        <Basket fruit={Fruit.Apple} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    `
+      ({ fruit: 1 });
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const fruits: [Fruit] = [Fruit.Apple];
+      void fruits;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const [fruit]: Fruit[] = [Fruit.Apple];
+      void fruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const [fruit]: [Fruit] = [Fruit.Apple] as Fruit[];
+      void fruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      let fruit: Fruit;
+      [fruit] = [Fruit.Apple];
+      void fruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takeFruit([fruit]: Fruit[] = [Fruit.Apple]): void {
+        void fruit;
+      }
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const getFruit = (): Fruit => {
+        return Fruit.Apple;
+      };
+
+      void getFruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesFruits(...fruits: Fruit[]): void {}
+
+      const fruits: Fruit[] = [Fruit.Apple];
+      takesFruits(...fruits);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const foo: { plain: string };
+
+      foo[0];
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      ({})[0];
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const [fruit]: [Fruit] = [Fruit.Apple];
+      void fruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const { fruit }: { fruit: Fruit } = {} as {};
+      void fruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const fruitKey: unique symbol;
+
+      type Basket = { [fruitKey]: Fruit };
+
+      const { [fruitKey]: fruit }: Basket = { [fruitKey]: Fruit.Apple };
+      void fruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const fruitKey: unique symbol;
+
+      interface Basket {
+        [fruitKey]: Fruit;
+      }
+
+      class TestBasket implements Basket {
+        [fruitKey] = Fruit.Apple;
+      }
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const fruit = Fruit.Apple as Fruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      class Basket {
+        fruit = Fruit.Apple;
+      }
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      interface Basket {
+        fruit: Fruit;
+      }
+
+      class TestBasket implements Basket {
+        fruit = Fruit.Apple;
+      }
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const foo: { [key in Fruit]: string };
+
+      foo[Fruit.Apple];
+      foo?.[Fruit.Apple];
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const foo: { [key in Fruit | number]: string };
+
+      foo[0];
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const something: any;
+
+      const fruit: Fruit = something;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const something: any;
+
+      function takesFruit(fruit: Fruit): void {}
+
+      takesFruit(something);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const something: unknown;
+
+      const fruit: Fruit = something as Fruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesFruitOrNull(fruit: Fruit | null): void {}
+
+      takesFruitOrNull(null);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesFruitOrUndefined(fruit: Fruit | undefined): void {}
+
+      takesFruitOrUndefined(undefined);
+    `,
+    `
+      enum Fruit {
+        Apple,
+        Banana,
+      }
+
+      declare const apple: Fruit;
+
+      const fruit: Fruit = apple;
+    `,
+    `
+      const enum Direction {
+        Up,
+        Down,
+      }
+
+      const dir: Direction = Direction.Up;
+    `,
+    `
+      enum Flags {
+        Read = 1 << 0,
+        Write = 1 << 1,
+      }
+
+      const combined: Flags = Flags.Read | Flags.Write;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      enum Vegetable {
+        Asparagus = 'asparagus',
+      }
+
+      function takesEither(val: Fruit | Vegetable): void {}
+
+      takesEither(Fruit.Apple);
+      takesEither(Vegetable.Asparagus);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      async function getFruit(): Promise<Fruit> {
+        return Fruit.Apple;
+      }
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function getFruitOrNull(): Fruit | null {
+        return null;
+      }
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare function tag(strings: TemplateStringsArray, fruit: Fruit): string;
+
+      tag\`\${Fruit.Apple}\`;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      class Basket {
+        constructor(public fruit: Fruit) {}
+      }
+
+      new Basket(Fruit.Apple);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const fruit = Fruit.Apple;
+      const box: { fruit: Fruit } = { fruit };
+    `,
+    `
+      enum Mixed {
+        A = 'a',
+        B = 1,
+      }
+
+      const val: Mixed = Mixed.A;
+      const val2: Mixed = Mixed.B;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      interface HasFruit {
+        fruit: Fruit;
+      }
+
+      interface HasNumber {
+        fruit: number;
+      }
+
+      class TestBasket implements HasFruit, HasNumber {
+        fruit = 1;
+      }
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesFruit(fruit: Fruit): void {}
+
+      takesFruit(...[Fruit.Apple]);
+    `,
+    `
+      enum Fruit {
+        Apple,
+        Banana,
+      }
+
+      const fruits: Fruit[] = [Fruit.Apple, Fruit.Banana];
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const fruits: Array<Fruit | number> = [1, Fruit.Apple];
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const bar: { [Fruit.Apple]: string };
+
+      bar[Fruit.Apple];
+      bar?.[Fruit.Apple];
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesNothing(): void {}
+
+      takesNothing();
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesRest(first: Fruit, ...rest: Fruit[]): void {}
+
+      takesRest(Fruit.Apple, Fruit.Apple, Fruit.Apple);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesFruits(first: Fruit, second: Fruit): void {}
+
+      takesFruits(...[Fruit.Apple, ...[Fruit.Apple]]);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const { ['fruit']: fruit }: { fruit: Fruit } = { fruit: Fruit.Apple };
+      void fruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const [, ...rest]: Fruit[] = [Fruit.Apple, Fruit.Apple];
+      void rest;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      let fruit: Fruit;
+      ({ fruit } = { fruit: Fruit.Apple });
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function pick({ fruit }: { fruit: Fruit } = { fruit: Fruit.Apple }): Fruit {
+        return fruit;
+      }
+
+      pick();
+    `,
+    {
+      code: `
+        enum Vegetable {
+          Asparagus = 'asparagus',
+        }
+
+        declare function Basket(props: { vegetable: Vegetable }): JSX.Element;
+
+        <Basket vegetable="asparagus" />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const x: Fruit;
+      const y: Fruit = x;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function noop(): void {
+        return;
+      }
+
+      noop();
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const fruits: Fruit[] = [...[Fruit.Apple]];
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takeFruit(fruit: Fruit): void {}
+      takeFruit(...[Fruit.Apple, ...[1]]);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesGeneric<T extends readonly unknown[]>(...args: T): void {}
+
+      takesGeneric(Fruit.Apple);
+    `,
+    `
+      enum Flags {
+        Read = 1 << 0,
+        Write = 1 << 1,
+      }
+
+      const combined: Flags = (Flags.Read as Flags) | Flags.Write;
+      void combined;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      interface Basket {
+        fruit: Fruit;
+      }
+
+      class Base {
+        fruit: Fruit = Fruit.Apple;
+      }
+
+      class Child extends Base implements Basket {
+        fruit = Fruit.Apple;
+      }
+
+      void Child;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      interface Basket {
+        fruit: Fruit;
+      }
+
+      class Child implements Basket {
+        other = Fruit.Apple;
+        fruit: Fruit = Fruit.Apple;
+      }
+
+      void Child;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const key = 'fruit' as const;
+      const { [key]: picked }: { fruit: Fruit } = { fruit: Fruit.Apple };
+      void picked;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const { fruit: picked }: { fruit: Fruit } = { fruit: Fruit.Apple };
+      void picked;
+    `,
+    `
+      enum Flags {
+        Read = 1 << 0,
+        Write = 1 << 1,
+      }
+
+      const combined: Flags = Flags.Read | (Flags.Write & Flags.Read);
+      void combined;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesFruit(fruit: Fruit): void {}
+      takesFruit(Fruit.Apple, Fruit.Apple);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const rec: Record<string, string>;
+      rec[Fruit.Apple];
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      doesNotExist(Fruit.Apple);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesFruits(fruits: Fruit[]): void {}
+
+      takesFruits([Fruit.Apple]);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      [1];
+    `,
+    `
+      const numbers: number[] = [1];
+      void numbers;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      interface Basket {
+        fruit: Fruit;
+      }
+
+      class TestBasket implements Basket {
+        #other = 1;
+        fruit = Fruit.Apple;
+      }
+
+      void TestBasket;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      interface Basket {
+        fruit: Fruit;
+      }
+
+      class TestBasket implements Basket {
+        other = 1;
+        fruit = Fruit.Apple;
+      }
+
+      void TestBasket;
+    `,
+    `
+      function foo(): void {}
+
+      foo[0];
+    `,
+    `
+      const foo = {};
+
+      foo[0];
+    `,
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare function Basket(props: { fruit?: Fruit }): JSX.Element;
+
+        <Basket fruit={/* empty */} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    // Generic direct constraints
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function identity<T extends Fruit>(value: T): T {
+        const next: T = value;
+        return next;
+      }
+
+      identity(Fruit.Apple);
+    `,
+    `
+      enum Vegetable {
+        Asparagus = 'asparagus',
+      }
+
+      function identity<T extends Vegetable>(value: T): T {
+        return value;
+      }
+
+      identity(Vegetable.Asparagus);
+    `,
+    `
+      const enum Direction {
+        Up,
+        Down,
+      }
+
+      function identity<T extends Direction>(value: T): T {
+        return value;
+      }
+
+      identity(Direction.Up);
+    `,
+    `
+      enum Mixed {
+        A = 'a',
+        B = 1,
+      }
+
+      function identity<T extends Mixed>(value: T): T {
+        return value;
+      }
+
+      identity(Mixed.A);
+      identity(Mixed.B);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function identity<T extends Fruit, V extends T>(value: V): V {
+        const next: V = value;
+        return next;
+      }
+
+      identity(Fruit.Apple);
+    `,
+    // Generic object wrappers
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesBox<T extends { fruit: Fruit }>(box: T): T {
+        const next: T = box;
+        return next;
+      }
+
+      takesBox({ fruit: Fruit.Apple });
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesNestedBox<T extends { box: { fruit: Fruit } }>(box: T): T {
+        return box;
+      }
+
+      takesNestedBox({ box: { fruit: Fruit.Apple } });
+    `,
+    // Generic arrays and tuples
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesArray<T extends Fruit[]>(value: T): T {
+        const next: T = value;
+        return next;
+      }
+
+      takesArray([Fruit.Apple]);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function takesReadonlyArray<T extends readonly Fruit[]>(value: T): T {
+        return value;
+      }
+
+      takesReadonlyArray([Fruit.Apple] as const);
+    `,
+    `
+      enum Fruit {
+        Apple,
+        Banana,
+      }
+
+      function takesTuple<T extends [Fruit, Fruit]>(...value: T): T {
+        return value;
+      }
+
+      takesTuple(Fruit.Apple, Fruit.Banana);
+    `,
+    `
+      enum Fruit {
+        Apple,
+        Banana,
+      }
+
+      function takesReadonlyTuple<T extends readonly [Fruit, Fruit]>(value: T): T {
+        return value;
+      }
+
+      takesReadonlyTuple([Fruit.Apple, Fruit.Banana] as const);
+    `,
+    `
+      enum Fruit {
+        Apple,
+        Banana,
+      }
+
+      function takesRestTuple<T extends [Fruit, ...Fruit[]]>(...value: T): T {
+        return value;
+      }
+
+      takesRestTuple(Fruit.Apple, Fruit.Banana);
+    `,
+    // Generic aliases, interfaces, and classes
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      type Box<T> = { fruit: T };
+
+      function takesAliasBox<T extends Fruit>(box: Box<T>): Box<T> {
+        return box;
+      }
+
+      takesAliasBox({ fruit: Fruit.Apple });
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      interface Box<T> {
+        fruit: T;
+      }
+
+      function takesInterfaceBox<T extends Fruit>(box: Box<T>): Box<T> {
+        return box;
+      }
+
+      takesInterfaceBox({ fruit: Fruit.Apple });
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      class Box<T> {
+        constructor(public fruit: T) {}
+      }
+
+      const box: Box<Fruit> = new Box(Fruit.Apple);
+      void box;
+    `,
+    // Async, heritage, and computed keys
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      async function getFruit<T extends Fruit>(value: T): Promise<T> {
+        return value;
+      }
+
+      void getFruit(Fruit.Apple);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      interface Basket<T> {
+        fruit: T;
+      }
+
+      class BasketImpl<T extends Fruit> implements Basket<T> {
+        fruit: T;
+
+        constructor(fruit: T) {
+          this.fruit = fruit;
+        }
+      }
+
+      void new BasketImpl(Fruit.Apple);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      class Base<T> {
+        fruit!: T;
+      }
+
+      class BasketImpl<T extends Fruit> extends Base<T> {
+        fruit: T;
+
+        constructor(fruit: T) {
+          super();
+          this.fruit = fruit;
+        }
+      }
+
+      void new BasketImpl(Fruit.Apple);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare const foo: { [key in Fruit]: string };
+
+      function readValue<K extends Fruit>(key: K): string {
+        return foo[key];
+      }
+
+      readValue(Fruit.Apple);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function destructureArray<T extends [Fruit]>(value: T): T {
+        const [fruit] = value;
+        void fruit;
+        return value;
+      }
+
+      destructureArray([Fruit.Apple]);
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const notFn = 1;
+      notFn(Fruit.Apple);
+
+      const notTag = 1;
+      notTag\`fruit\`;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      const box: { [key in Fruit]: number } = { [Fruit.Apple]: 1 };
+      void box;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      declare function takeBox(box: { fruit: Fruit }): void;
+
+      takeBox([Fruit.Apple]);
+
+      const value: {} = [Fruit.Apple];
+      void value;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      type BadThenable = {
+        then(onfulfilled: string): unknown;
+      };
+
+      async function getFruit(): Promise<Fruit> {
+        return {} as BadThenable;
+      }
+
+      void getFruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      type BadThenable = {
+        then(onfulfilled: string): unknown;
+      };
+
+      async function getFruit(): BadThenable {
+        return Promise.resolve(Fruit.Apple);
+      }
+
+      void getFruit;
+    `,
+    `
+      enum Fruit {
+        Apple,
+        Banana,
+      }
+
+      let foo: { [key in Fruit]: string } = {
+        [Fruit.Apple]: 'apple',
+        [Fruit.Banana]: 'banana',
+      };
+
+      foo[Math.random() > 0.5 ? Fruit.Apple : Fruit.Banana] = 'fruit';
+
+      const value = foo[Math.random() > 0.5 ? Fruit.Apple : Fruit.Banana];
+      void value;
+    `,
+    `
+      enum Fruit {
+        Apple,
+      }
+
+      function destructureObject<T extends { fruit: Fruit }>(value: T): T {
+        const { fruit } = value;
+        void fruit;
+        return value;
+      }
+
+      destructureObject({ fruit: Fruit.Apple });
+    `,
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare function Basket<T extends { fruit: Fruit }>(props: T): JSX.Element;
+
+        <Basket fruit={Fruit.Apple} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare namespace JSX {
+          interface IntrinsicElements {
+            div: {};
+          }
+        }
+
+        <div fruit={Fruit.Apple} />;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const fruit: Fruit = 1;
+      `,
+      errors: [
+        {
+          column: 15,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 31,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        let fruit = Fruit.Apple;
+        fruit = 1;
+      `,
+      errors: [
+        {
+          column: 9,
+          endColumn: 18,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesFruit(fruit: Fruit = 1) {}
+      `,
+      errors: [
+        {
+          column: 29,
+          endColumn: 45,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        class Basket {
+          fruit: Fruit = 1;
+        }
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 28,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        interface Basket {
+          fruit: Fruit;
+        }
+
+        class TestBasket implements Basket {
+          fruit = 1;
+        }
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 21,
+          line: 11,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const box: { fruit: Fruit } = { fruit: 1 };
+      `,
+      errors: [
+        {
+          column: 41,
+          endColumn: 49,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesFruit(fruit: Fruit): void {}
+
+        takesFruit(1);
+      `,
+      errors: [
+        {
+          column: 20,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 21,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare const maybeFruit: Fruit | number;
+
+        const fruit: Fruit = maybeFruit;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 40,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function getFruit(): Fruit {
+          return 1;
+        }
+      `,
+      errors: [
+        {
+          column: 11,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 20,
+          line: 7,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Vegetable {
+          Asparagus = 'asparagus',
+        }
+
+        const getVegetable = (): Vegetable => 'asparagus';
+      `,
+      errors: [
+        {
+          column: 47,
+          endColumn: 58,
+          line: 6,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const fruit = 1 as Fruit;
+      `,
+      errors: [
+        {
+          column: 23,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 33,
+          line: 6,
+          messageId: 'unsafeEnumAssertion',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const fruit = <Fruit>1;
+      `,
+      errors: [
+        {
+          column: 23,
+          endColumn: 31,
+          line: 6,
+          messageId: 'unsafeEnumAssertion',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Vegetable {
+          Asparagus = 'asparagus',
+        }
+
+        const vegetable: Vegetable = 'asparagus';
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 49,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesFruit(...fruit: [Fruit]): void {}
+
+        takesFruit(...([1] as const));
+      `,
+      errors: [
+        {
+          column: 20,
+          endColumn: 37,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesFruit(fruit: Fruit): void {}
+
+        takesFruit(...[1]);
+      `,
+      errors: [
+        {
+          column: 20,
+          endColumn: 26,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+          Banana,
+        }
+
+        function takesFruits(first: Fruit, second: Fruit): void {}
+
+        takesFruits(...[Fruit.Apple, 1]);
+      `,
+      errors: [
+        {
+          column: 21,
+          endColumn: 40,
+          line: 9,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+          Banana,
+        }
+
+        const fruits: Fruit[] = [1, 2];
+      `,
+      errors: [
+        {
+          column: 34,
+          endColumn: 35,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+        {
+          column: 37,
+          endColumn: 38,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesFruits(fruits: Fruit[]): void {}
+
+        takesFruits([1]);
+      `,
+      errors: [
+        {
+          column: 22,
+          endColumn: 23,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const basket: { fruit: Fruit } = { fruit: Fruit.Apple };
+
+        basket.fruit = 1;
+      `,
+      errors: [
+        {
+          column: 9,
+          endColumn: 25,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Vegetable {
+          Asparagus = 'asparagus',
+        }
+
+        declare function Basket(props: { vegetable: Vegetable }): JSX.Element;
+
+        <Basket vegetable={'asparagus'} />;
+      `,
+      errors: [
+        {
+          column: 28,
+          endColumn: 39,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare const foo: { [key in Fruit]: string };
+
+        foo[0];
+      `,
+      errors: [
+        {
+          column: 13,
+          data: { enumNames: "'Fruit'" },
+          endColumn: 14,
+          line: 8,
+          messageId: 'unsafeEnumAccess',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Vegetable {
+          Asparagus = 'asparagus',
+        }
+
+        declare const foo: { [key in Vegetable]: string };
+
+        foo?.['asparagus'];
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 26,
+          line: 8,
+          messageId: 'unsafeEnumAccess',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare const bar: { [Fruit.Apple]: string };
+
+        bar[0];
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 14,
+          line: 8,
+          messageId: 'unsafeEnumAccess',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare const bar: { [Fruit.Apple]: string };
+
+        bar?.[0];
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 16,
+          line: 8,
+          messageId: 'unsafeEnumAccess',
+        },
+      ],
+    },
+    {
+      code: `
+        const enum Direction {
+          Up,
+          Down,
+        }
+
+        const dir: Direction = 0;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 33,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        enum Vegetable {
+          Asparagus,
+        }
+
+        const fruit: Fruit = Vegetable.Asparagus;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 49,
+          line: 10,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        async function getFruit(): Promise<Fruit> {
+          return 1;
+        }
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 20,
+          line: 7,
+          messageId: 'unsafeEnumReturn',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare function tag(strings: TemplateStringsArray, fruit: Fruit): string;
+
+        tag\`\${1}\`;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 16,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        class Basket {
+          constructor(public fruit: Fruit) {}
+        }
+
+        new Basket(1);
+      `,
+      errors: [
+        {
+          column: 20,
+          endColumn: 21,
+          line: 10,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare const num: number;
+
+        const fruit: Fruit = num;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 33,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const fruit: Fruit = NaN;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 33,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const fruit: Fruit = Number.MAX_SAFE_INTEGER;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 53,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const a: Fruit = 1,
+          b: Fruit = Fruit.Apple;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 27,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const a: Fruit = 1,
+          b: Fruit = 2;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 27,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+        {
+          column: 11,
+          endColumn: 23,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        class Basket {
+          constructor(private fruit: Fruit = 1) {}
+        }
+      `,
+      errors: [
+        {
+          column: 31,
+          endColumn: 47,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare const fruit: number;
+
+        const box: { fruit: Fruit } = { fruit };
+      `,
+      errors: [
+        {
+          column: 41,
+          endColumn: 46,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const [fruit]: [Fruit] = [1];
+      `,
+      errors: [
+        {
+          column: 16,
+          endColumn: 21,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const { fruit = 1 }: { fruit?: Fruit } = {};
+        void fruit;
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesBasket({ fruit = 1 }: { fruit?: Fruit }): void {
+          void fruit;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesFruit([fruit]: [Fruit] = [1]): void {}
+      `,
+      errors: [
+        {
+          column: 30,
+          endColumn: 35,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const { fruit }: { fruit: Fruit } = { fruit: 1 };
+      `,
+      errors: [
+        {
+          column: 17,
+          endColumn: 22,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const { fruit: picked }: { fruit: Fruit } = { fruit: 1 };
+      `,
+      errors: [
+        {
+          column: 24,
+          endColumn: 30,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesBox({ fruit }: { fruit: Fruit } = { fruit: 1 }): void {}
+      `,
+      errors: [
+        {
+          column: 29,
+          endColumn: 34,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const fruits: Set<Fruit> = new Set([1, 2]);
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 51,
+          line: 6,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare const cond: boolean;
+
+        const fruit: Fruit = cond ? 1 : Fruit.Apple;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 52,
+          line: 8,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        class Basket {
+          accessor fruit: Fruit = 1;
+        }
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 37,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesFruit<T extends Fruit>(fruit: T): void {}
+
+        takesFruit(1);
+      `,
+      errors: [
+        {
+          column: 20,
+          endColumn: 21,
+          line: 8,
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        const x = [1, Fruit.Apple, 2] as const;
+        const y: readonly Fruit[] = x;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 38,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Flags {
+          Read = 1 << 0,
+          Write = 1 << 1,
+        }
+
+        const combined: Flags = 1 | 2;
+      `,
+      errors: [
+        {
+          column: 15,
+          endColumn: 38,
+          line: 7,
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesRest(first: Fruit, ...rest: Fruit[]): void {}
+
+        takesRest(Fruit.Apple, 1);
+      `,
+      errors: [
+        {
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesRest(first: Fruit, ...rest: Fruit[]): void {}
+
+        takesRest(Fruit.Apple, ...[1]);
+      `,
+      errors: [{ messageId: 'unsafeEnumArgument' }],
+    },
+    {
+      code: `
+        enum Flags {
+          Read = 1 << 0,
+          Write = 1 << 1,
+        }
+
+        const combined: Flags = Flags.Read + Flags.Write;
+      `,
+      errors: [
+        {
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesFruit(fruit: Fruit): void {}
+        const numbers: number[] = [1, 2, 3];
+
+        takesFruit(...[1, ...numbers]);
+      `,
+      errors: [
+        {
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Flags {
+          Read = 1 << 0,
+          Write = 1 << 1,
+        }
+
+        const combined: Flags = Flags.Read | (Flags.Write + Flags.Read);
+      `,
+      errors: [
+        {
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesFruits(...fruits: Fruit[]): void {}
+        const numbers: number[] = [1, 2, 3];
+
+        takesFruits(...[1, ...numbers]);
+      `,
+      errors: [
+        {
+          messageId: 'unsafeEnumArgument',
+        },
+        {
+          messageId: 'unsafeEnumArgument',
+        },
+      ],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        interface Basket {
+          fruit: Fruit;
+        }
+
+        class TestBasket implements Basket {
+          accessor fruit = 1;
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unsafeEnumAssignment',
+        },
+      ],
+    },
+    // Generic direct constraints
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function assignFruit<T extends Fruit>(): void {
+          const fruit: T = 1;
+          void fruit;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function getFruit<T extends Fruit>(): T {
+          return 1;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumReturn' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function castFruit<T extends Fruit>(): T {
+          return 1 as T;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssertion' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        class Box<T extends Fruit> {
+          constructor(public fruit: T) {}
+        }
+
+        new Box(1);
+      `,
+      errors: [{ messageId: 'unsafeEnumArgument' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare function Basket<T extends Fruit>(props: { fruit: T }): JSX.Element;
+
+        <Basket fruit={1} />;
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    // Generic string, const, and mixed enums
+    {
+      code: `
+        enum Vegetable {
+          Asparagus = 'asparagus',
+        }
+
+        function assignVegetable<T extends Vegetable>(): void {
+          const vegetable: T = 'asparagus';
+          void vegetable;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        const enum Direction {
+          Up,
+          Down,
+        }
+
+        function assignDirection<T extends Direction>(): void {
+          const direction: T = 0;
+          void direction;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        enum Mixed {
+          A = 'a',
+          B = 1,
+        }
+
+        function assignMixed<T extends Mixed>(): void {
+          const mixed: T = 'a';
+          void mixed;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function assignFruit<T extends Fruit, V extends T>(): V {
+          return 1;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumReturn' }],
+    },
+    // Generic object wrappers
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesBox<T extends { fruit: Fruit }>(box: T): void {}
+
+        takesBox({ fruit: 1 });
+      `,
+      errors: [{ messageId: 'unsafeEnumArgument' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function assignBox<T extends { fruit: Fruit }>(): void {
+          const box: T = { fruit: 1 };
+          void box;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function getBox<T extends { fruit: Fruit }>(): T {
+          return { fruit: 1 };
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumReturn' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function castBox<T extends { fruit: Fruit }>(): T {
+          return { fruit: 1 } as T;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssertion' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        class Box<T extends { fruit: Fruit }> {
+          constructor(public value: T) {}
+        }
+
+        new Box({ fruit: 1 });
+      `,
+      errors: [{ messageId: 'unsafeEnumArgument' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare function Basket<T extends { fruit: Fruit }>(props: T): JSX.Element;
+
+        <Basket fruit={1} />;
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+        },
+      },
+    },
+    // Nested object wrappers
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesNestedBox<T extends { box: { fruit: Fruit } }>(box: T): void {}
+
+        takesNestedBox({ box: { fruit: 1 } });
+      `,
+      errors: [{ messageId: 'unsafeEnumArgument' }],
+    },
+    // Generic arrays and readonly arrays
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesArray<T extends Fruit[]>(value: T): void {}
+
+        takesArray([1]);
+      `,
+      errors: [{ messageId: 'unsafeEnumArgument' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function assignArray<T extends Fruit[]>(): void {
+          const fruits: T = [1];
+          void fruits;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function getArray<T extends Fruit[]>(): T {
+          return [1];
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumReturn' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function castArray<T extends Fruit[]>(): T {
+          return [1] as T;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssertion' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesReadonlyArray<T extends readonly Fruit[]>(value: T): void {}
+
+        takesReadonlyArray([1] as const);
+      `,
+      errors: [{ messageId: 'unsafeEnumArgument' }],
+    },
+    // Generic array of object wrappers
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function takesBoxes<T extends Array<{ fruit: Fruit }>>(boxes: T): void {}
+
+        takesBoxes([{ fruit: 1 }]);
+      `,
+      errors: [{ messageId: 'unsafeEnumArgument' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function assignBoxes<T extends readonly { fruit: Fruit }[]>(): void {
+          const boxes: T = [{ fruit: 1 }] as const;
+          void boxes;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    // Generic tuples and rest tuples
+    {
+      code: `
+        enum Fruit {
+          Apple,
+          Banana,
+        }
+
+        function assignReadonlyTuple<T extends readonly [Fruit, Fruit]>(): void {
+          const value: T = [Fruit.Apple, 1] as const;
+          void value;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    // Generic aliases, interfaces, and classes
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        type Box<T> = { fruit: T };
+
+        function takesAliasBox<T extends Fruit>(box: Box<T>): void {}
+
+        takesAliasBox({ fruit: 1 });
+      `,
+      errors: [{ messageId: 'unsafeEnumArgument' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        interface Box<T> {
+          fruit: T;
+        }
+
+        const box: Box<Fruit> = { fruit: 1 };
+        void box;
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        class Box<T> {
+          constructor(public fruit: T) {}
+        }
+
+        const box: Box<Fruit> = new Box(1);
+        void box;
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    // Async returns and heritage clauses
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        async function getBox<T extends { fruit: Fruit }>(): Promise<T> {
+          return { fruit: 1 };
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumReturn' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        interface Basket<T> {
+          fruit: T;
+        }
+
+        class BasketImpl implements Basket<Fruit> {
+          fruit = 1;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        class Base<T> {
+          fruit!: T;
+        }
+
+        class BasketImpl extends Base<Fruit> {
+          fruit = 1;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        interface Basket<T> {
+          fruit: T;
+        }
+
+        class BasketImpl<T extends Fruit> implements Basket<T> {
+          fruit = 1;
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAssignment' }],
+    },
+    // Generic computed keys
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        declare const foo: { [key in Fruit]: string };
+
+        function readValue<K extends number>(key: K): string {
+          return foo[key];
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAccess' }],
+    },
+    {
+      code: `
+        enum Fruit {
+          Apple,
+        }
+
+        function readValue<K extends number>(
+          foo: { [P in Fruit]: string },
+          key: K,
+        ): string {
+          return foo[key];
+        }
+      `,
+      errors: [{ messageId: 'unsafeEnumAccess' }],
+    },
+  ],
+});

--- a/packages/type-utils/src/typeFlagUtils.ts
+++ b/packages/type-utils/src/typeFlagUtils.ts
@@ -7,8 +7,7 @@ const ANY_OR_UNKNOWN = ts.TypeFlags.Any | ts.TypeFlags.Unknown;
  * Gets all of the type flags in a type, iterating through unions automatically.
  */
 export function getTypeFlags(type: ts.Type): ts.TypeFlags {
-  // @ts-expect-error Since typescript 5.0, this is invalid, but uses 0 as the default value of TypeFlags.
-  let flags: ts.TypeFlags = 0;
+  let flags: ts.TypeFlags = ts.TypeFlags.Any ^ ts.TypeFlags.Any;
   for (const t of tsutils.unionConstituents(type)) {
     flags |= t.flags;
   }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #308
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a `no-unsafe-enum-assignment` rule to the `strict` preset. As noted in #308, it reports on any literal assignment to a location that's typed as an enum.

This is somewhat similar to `no-unsafe-assignment`, but for literals -> enums instead of `any` -> anything. In fact, this extracted several existing areas of code from `no-unsafe-*` rules into shared helpers:

* `no-unsafe-argument`: `RestTypeKind`, `RestType`, and `FunctionSignature`
* `no-unsafe-enum-comparison`: lots of utils in a new `isMismatchedEnumComparisonTypes`

Authored agentically _(don't worry, I do hate myself a little bit)_ with:

* Research: Claude 4.6 Sonnet
* Plan: GPT 5.4
* Implement: GPT 5.3 Codex

But I thoroughly reviewed these changes. I repeatedly looked over the code and either edited it myself or yelled at the AI to do better in specific ways. It took a _lot_ of prompting. It did save me a good amount of time overall.

At time of sending draft, I think this is mostly done. There's a bit of cleanup to do but it's 3am and I have a 9am flight.

💖