### PR TITLE
fix(eslint-plugin): avoid crashing no-unnecessary-type-arguments fixer

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
@@ -81,9 +81,9 @@ export default createRule<[], MessageIds>({
       tsNode: ParameterCapableTSNode,
     ): void {
       // Just check the last one. Must specify previous type parameters if the last one is specified.
-      const i = typeArguments.params.length - 1;
-      const typeArgument = typeArguments.params[i];
-      const typeParameter = typeParameters.at(i);
+      const typeArgumentIndex = typeArguments.params.length - 1;
+      const typeArgument = typeArguments.params[typeArgumentIndex];
+      const typeParameter = typeParameters.at(typeArgumentIndex);
 
       if (!typeParameter) {
         return;
@@ -101,8 +101,8 @@ export default createRule<[], MessageIds>({
           tsNode as ts.CallExpression | ts.NewExpression,
         );
 
-        parent.arguments.forEach((argument, i) => {
-          const parameter = sig?.parameters.at(i);
+        parent.arguments.forEach((argument, argumentIndex) => {
+          const parameter = sig?.parameters.at(argumentIndex);
 
           if (
             !parameter?.valueDeclaration ||
@@ -140,10 +140,10 @@ export default createRule<[], MessageIds>({
               messageId: 'canBeInferred',
               fix: fixer =>
                 fixer.removeRange(
-                  i === 0
+                  typeArgumentIndex === 0
                     ? typeArguments.range
                     : [
-                        typeArguments.params[i - 1].range[1],
+                        typeArguments.params[typeArgumentIndex - 1].range[1],
                         typeArgument.range[1],
                       ],
                 ),
@@ -166,9 +166,12 @@ export default createRule<[], MessageIds>({
         messageId: 'isDefaultParameterValue',
         fix: fixer =>
           fixer.removeRange(
-            i === 0
+            typeArgumentIndex === 0
               ? typeArguments.range
-              : [typeArguments.params[i - 1].range[1], typeArgument.range[1]],
+              : [
+                  typeArguments.params[typeArgumentIndex - 1].range[1],
+                  typeArgument.range[1],
+                ],
           ),
       });
     }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
@@ -1001,5 +1001,31 @@ function Button<T = string>() {
 const button = <Button />;
       `,
     },
+    {
+      code: `
+class Foo<T> {
+  public constructor(a: any, b: any, c: any, d: any) {}
+}
+interface Bar {
+  val: any;
+}
+const foo = new Foo<Bar>(0, 0, 0, { val: 0 });
+      `,
+      errors: [
+        {
+          line: 8,
+          messageId: 'canBeInferred',
+        },
+      ],
+      output: `
+class Foo<T> {
+  public constructor(a: any, b: any, c: any, d: any) {}
+}
+interface Bar {
+  val: any;
+}
+const foo = new Foo(0, 0, 0, { val: 0 });
+      `,
+    },
   ],
 });


### PR DESCRIPTION
## Problem

`@typescript-eslint/no-unnecessary-type-arguments` can throw while building fixes for constructor calls with a single explicit type argument and multiple runtime arguments.

## Reproduction / Observation

This reproduces on current `main` with code such as:

```ts
class Foo<T> {
  public constructor(a: any, b: any, c: any, d: any) {}
}
interface Bar {
  val: any;
}
const foo = new Foo<Bar>(0, 0, 0, { val: 0 });
```

The rule reports `canBeInferred`, then crashes while normalizing fixes with:

```text
TypeError: Cannot read properties of undefined (reading 'range')
```

## Root cause

`checkTSArgsAndParameters()` stores the last type-argument index in a local `i`, but the `parent.arguments.forEach((argument, i) => ...)` callback shadows that variable.

The fixer closure then reads the argument index instead of the type-argument index when computing the removal range. For calls with more runtime arguments than type arguments, that can access a non-existent `typeArguments.params[...]` entry.

## Change

- keep the type-argument index in a dedicated `typeArgumentIndex`
- use a separate `argumentIndex` for iterating call/new arguments
- add a regression test covering a constructor call that previously crashed

## Why this fix

This keeps the existing rule semantics and fixer behavior intact. The change only removes the accidental index shadowing that made the fixer read the wrong array slot.

## Risk

Low. The change is localized to fixer range calculation in one rule and is covered by an explicit regression test.

## Validation

- `pnpm vitest run packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts --config vitest.config.mts`
- `pnpm eslint packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts`

Fixes #12157.
