### PR TITLE
docs: add tsconfigRootDir to example config for typed linting

### DIFF
--- a/docs/getting-started/Typed_Linting.mdx
+++ b/docs/getting-started/Typed_Linting.mdx
@@ -33,6 +33,7 @@ export default defineConfig(
     languageOptions: {
       parserOptions: {
         projectService: true,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
   },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR adds the missing `tsconfigRootDir` option to the example configuration for typed linting.

While working with the example, I noticed that `tsconfigRootDir` is referenced in the documentation below but not actually included in the config itself. This can lead to confusion or misconfiguration when users try to enable typed linting based on the example.

There wasn’t an existing issue for this, but the fix seemed straightforward and unambiguous, so I went ahead and opened a PR directly.