### PR TITLE
fix(eslint-plugin): [no-shadow] correct rule to match ESLint v10 handling

### DIFF
--- a/packages/eslint-plugin/src/rules/no-shadow.ts
+++ b/packages/eslint-plugin/src/rules/no-shadow.ts
@@ -462,35 +462,84 @@ export default createRule<Options, MessageIds>({
     }
 
     /**
-     * Checks if a variable is inside the initializer of scopeVar.
+     * Finds the uppermost expression node that can evaluate to the given one,
+     * unwrapping through LogicalExpression and non-test ConditionalExpression branches.
+     * @param node The node to unwrap.
+     * @returns The topmost unwrapped node.
+     */
+    function unwrapExpression(node: TSESTree.Node): TSESTree.Node {
+      const { parent } = node;
+      if (
+        parent?.type === AST_NODE_TYPES.LogicalExpression ||
+        (parent?.type === AST_NODE_TYPES.ConditionalExpression &&
+          parent.test !== node)
+      ) {
+        return unwrapExpression(parent);
+      }
+      return node;
+    }
+
+    /**
+     * Checks if a variable is the name of a function or class expression that is
+     * directly assigned (or transparently through `||`/`?:`) as the initializer
+     * of scopeVar.
      *
-     * To avoid reporting at declarations such as `var a = function a() {};`.
-     * But it should report `var a = function(a) {};` or `var a = function() { function a() {} };`.
+     * Allows `var a = function a() {}` but reports `var a = wrap(function a() {})`.
      * @param variable The variable to check.
      * @param scopeVar The scope variable to look for.
-     * @returns Whether or not the variable is inside initializer of scopeVar.
+     * @returns Whether or not the variable is the direct initializer name of scopeVar.
      */
     function isOnInitializer(
       variable: TSESLint.Scope.Variable,
       scopeVar: TSESLint.Scope.Variable,
     ): boolean {
-      const outerScope = scopeVar.scope;
       const outerDef = scopeVar.defs.at(0);
-      const outer = outerDef?.parent?.range;
-      const innerScope = variable.scope;
       const innerDef = variable.defs.at(0);
-      const inner = innerDef?.name.range;
 
-      return !!(
-        outer &&
-        inner &&
-        outer[0] < inner[0] &&
-        inner[1] < outer[1] &&
-        ((innerDef.type === DefinitionType.FunctionName &&
-          innerDef.node.type === AST_NODE_TYPES.FunctionExpression) ||
-          innerDef.node.type === AST_NODE_TYPES.ClassExpression) &&
-        outerScope === innerScope.upper
-      );
+      if (!outerDef || !innerDef) {
+        return false;
+      }
+
+      if (
+        !(
+          (innerDef.type === DefinitionType.FunctionName &&
+            innerDef.node.type === AST_NODE_TYPES.FunctionExpression) ||
+          (innerDef.type === DefinitionType.ClassName &&
+            innerDef.node.type === AST_NODE_TYPES.ClassExpression)
+        )
+      ) {
+        return false;
+      }
+
+      const outerIdentifier = outerDef.name;
+      let initializerNode: TSESTree.Node | null | undefined;
+
+      if (outerIdentifier.parent.type === AST_NODE_TYPES.VariableDeclarator) {
+        initializerNode = (
+          outerIdentifier.parent as TSESTree.VariableDeclarator
+        ).init;
+      } else if (
+        outerIdentifier.parent.type === AST_NODE_TYPES.AssignmentPattern
+      ) {
+        initializerNode = outerIdentifier.parent.right;
+      }
+
+      if (!initializerNode) {
+        return false;
+      }
+
+      const nodeToCheck = innerDef.node;
+
+      if (
+        !(
+          initializerNode.range[0] <= nodeToCheck.range[0] &&
+          nodeToCheck.range[1] <= initializerNode.range[1]
+        )
+      ) {
+        return false;
+      }
+
+      return initializerNode === unwrapExpression(nodeToCheck);
     }
 
     /**

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow-eslint.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow-eslint.test.ts
@@ -988,6 +988,22 @@ function foo(a = wrap(function a() {})) {}
       ],
       languageOptions: { parserOptions: { ecmaVersion: 6 } },
     },
+    {
+      code: `
+var a = 1;
+var b = function a() {};
+      `,
+      errors: [
+        {
+          data: {
+            name: 'a',
+            shadowedColumn: 5,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+    },
   ],
   valid: [
     `

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow-eslint.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow-eslint.test.ts
@@ -925,6 +925,53 @@ function foo(cb) {
         },
       ],
     },
+    {
+      code: `
+const FooBarComponent = memo(function FooBarComponent() {});
+      `,
+      errors: [
+        {
+          data: {
+            name: 'FooBarComponent',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+    },
+    {
+      code: `
+const FooBarComponent = memo(class FooBarComponent {});
+      `,
+      errors: [
+        {
+          data: {
+            name: 'FooBarComponent',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaVersion: 6 } },
+    },
+    {
+      code: `
+const FooBarComponent = memo(function FooBarComponent() {});
+      `,
+      errors: [
+        {
+          data: {
+            name: 'FooBarComponent',
+            shadowedColumn: 7,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+      options: [{ ignoreOnInitialization: true }],
+    },
   ],
   valid: [
     `
@@ -943,6 +990,18 @@ setTimeout(function () {
   doSomething();
 })();
     `,
+    {
+      code: `
+var a = foo || function a() {};
+      `,
+      languageOptions: { parserOptions: { ecmaVersion: 6 } },
+    },
+    {
+      code: `
+var a = foo ? function a() {} : bar;
+      `,
+      languageOptions: { parserOptions: { ecmaVersion: 6 } },
+    },
     `
 var arguments;
 function bar() {}

--- a/packages/eslint-plugin/tests/rules/no-shadow/no-shadow-eslint.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-shadow/no-shadow-eslint.test.ts
@@ -972,6 +972,22 @@ const FooBarComponent = memo(function FooBarComponent() {});
       ],
       options: [{ ignoreOnInitialization: true }],
     },
+    {
+      code: `
+function foo(a = wrap(function a() {})) {}
+      `,
+      errors: [
+        {
+          data: {
+            name: 'a',
+            shadowedColumn: 14,
+            shadowedLine: 2,
+          },
+          messageId: 'noShadow',
+        },
+      ],
+      languageOptions: { parserOptions: { ecmaVersion: 6 } },
+    },
   ],
   valid: [
     `
@@ -999,6 +1015,12 @@ var a = foo || function a() {};
     {
       code: `
 var a = foo ? function a() {} : bar;
+      `,
+      languageOptions: { parserOptions: { ecmaVersion: 6 } },
+    },
+    {
+      code: `
+function foo(a = function a() {}) {}
       `,
       languageOptions: { parserOptions: { ecmaVersion: 6 } },
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12070 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The `no-shadow` rule reports when a variable in an inner scope "shadows" (reuses the same name and hides) a variable in an outer scope. There is a deliberate exception when named function/class expressions are assigned directly to a variable of the same name that is allowed, common, and a harmless self-reference:

```typescript
var a = function a() {};
```

In this case, the function's inner name only exists inside of the function itself, so reporting it as a shadow would be noisy and unhelpful.

### The Bug

The `isOnInitializer` helper previously used a range-containment check to decide if this exception should be applied, by asking "is the inner variable located _somewhere inside_ the declaration of the outer variable?" This definition was too loose because it suppressed shadow reports for named expressions _anywhere_ inside an initializer, not _just_ direct initializers, such as this case that should be reported because the inner definition is a genuinely separate binding that shadows the outer one:

```typescript
const FooBarComponent = memo(function FooBarComponent() {});
```

ESLint v10 started to correctly report these cases.

### The Fix

Instead of asking "is the inner name _somewhere inside_ the initializer?", this PR rewrites to ask "is the inner expression _literally_ the initializer?" It does this by:

1. Rewriting `isOnInitializer` to walk from the outer variable to its actual initializer node
2. Checking whether the inner function/class expression **is** that node through an identity check and not just range-containment

The `unwrapExpression` helper handles these still-valid cases where the function expression can transparently become `a` at runtime:

```typescript
var a = foo || function a() {};
var a = foo ? function a() {} : bar;
```

The previous code also had a check for class expressions that verified the node type but not the definition type, even though a definition bundles both. The fix adds a missing `DefinitionType.ClassName` check for class expressions so that both `innerDef.node.type` and `innerDef.type` are now checked.

Fixes #12070.

💖