### PR TITLE
docs: import @eslint/js as js

### DIFF
--- a/docs/getting-started/Quickstart.mdx
+++ b/docs/getting-started/Quickstart.mdx
@@ -34,12 +34,12 @@ Next, create an `eslint.config.mjs` config file in the root of your project, and
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommended,
 );
 ```
@@ -49,7 +49,7 @@ This code will enable our [recommended configuration](../users/Shared_Configurat
 #### Details
 
 - `defineConfig(...)` is an optional helper function built in to current versions of ESLint. See [the ESLint configuration docs](https://eslint.org/docs/latest/use/configure/configuration-files) for more detail.
-- `'@eslint/js'` / `eslint.configs.recommended` turns on [eslint's recommended config](https://www.npmjs.com/package/@eslint/js).
+- `'@eslint/js'` / `js.configs.recommended` turns on [eslint's recommended config](https://www.npmjs.com/package/@eslint/js).
 - `tseslint.configs.recommended` turns on [our recommended config](../users/Shared_Configurations.mdx#recommended).
 
 <details>
@@ -102,7 +102,7 @@ We recommend you consider enabling the following two configs:
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   // Remove this line
   tseslint.configs.recommended,
   // Add this line

--- a/docs/getting-started/Typed_Linting.mdx
+++ b/docs/getting-started/Typed_Linting.mdx
@@ -19,12 +19,12 @@ To enable typed linting, there are two small changes you need to make to your co
 2. Add `languageOptions.parserOptions` to tell our parser how to find the TSConfig for each source file.
 
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   // Remove this line
   tseslint.configs.recommended,
   // Added lines start
@@ -99,7 +99,7 @@ If you enabled the [`strict` shared config](../users/Shared_Configurations.mdx#s
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   // Removed lines start
   tseslint.configs.strict,
   tseslint.configs.stylistic,

--- a/docs/packages/TypeScript_ESLint.mdx
+++ b/docs/packages/TypeScript_ESLint.mdx
@@ -37,12 +37,12 @@ We recommend getting started by using the default ESLint setup with our shared c
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommended,
 );
 ```
@@ -72,11 +72,11 @@ Additionally, if you provide invalid values, it can trigger informative TypeScri
 ```ts title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommended,
   {
     /*... */
@@ -91,12 +91,12 @@ export default tseslint.config(
 ```ts title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 /** @type {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigFile} */
 export default [
-  eslint.configs.recommended,
+  js.configs.recommended,
   ...tseslint.configs.recommended,
   {
     /*... */
@@ -123,7 +123,7 @@ This allows you to more easily extend shared configs for specific file patterns 
 export default tseslint.config({
   files: ['**/*.ts'],
   extends: [
-    eslint.configs.recommended,
+    js.configs.recommended,
     tseslint.configs.recommended,
   ],
   rules: {
@@ -136,7 +136,7 @@ export default tseslint.config({
 
 export default [
   ...[
-    eslint.configs.recommended,
+    js.configs.recommended,
     ...tseslint.configs.recommended,
   ].map(conf => ({
     ...conf,
@@ -255,7 +255,7 @@ You can declare our plugin and parser in your config via this package, for examp
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import jestPlugin from 'eslint-plugin-jest';
 import tseslint from 'typescript-eslint';
@@ -300,7 +300,7 @@ This config:
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import jestPlugin from 'eslint-plugin-jest';
 import tseslint from 'typescript-eslint';
@@ -310,7 +310,7 @@ export default defineConfig(
     // config with just ignores is the replacement for `.eslintignore`
     ignores: ['**/build/**', '**/dist/**', 'src/some/file/to/ignore.ts'],
   },
-  eslint.configs.recommended,
+  js.configs.recommended,
   {
     plugins: {
       '@typescript-eslint': tseslint.plugin,

--- a/docs/troubleshooting/faqs/General.mdx
+++ b/docs/troubleshooting/faqs/General.mdx
@@ -241,7 +241,7 @@ For example, the following config enables only the recommended config's type-che
 
 {/* prettier-ignore */}
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 

--- a/docs/troubleshooting/typed-linting/Monorepos.mdx
+++ b/docs/troubleshooting/typed-linting/Monorepos.mdx
@@ -56,8 +56,14 @@ For each file being linted, the first matching project path will be used as its 
 <TabItem value="Flat Config">
 
 ```js title="eslint.config.mjs"
+// @ts-check
+
+import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {
@@ -106,8 +112,14 @@ Instead of globs that use `**` to recursively check all folders, prefer paths th
 <TabItem value="Flat Config">
 
 ```js title="eslint.config.mjs"
+// @ts-check
+
+import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {

--- a/docs/troubleshooting/typed-linting/Performance.mdx
+++ b/docs/troubleshooting/typed-linting/Performance.mdx
@@ -177,11 +177,11 @@ Instead of globs that use `**` to recursively check all folders, prefer paths th
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommendedRequiringTypeChecking,
   {
     languageOptions: {

--- a/docs/troubleshooting/typed-linting/index.mdx
+++ b/docs/troubleshooting/typed-linting/index.mdx
@@ -70,8 +70,14 @@ You can combine ESLint's [overrides](https://eslint.org/docs/latest/use/configur
 <TabItem value="Flat Config">
 
 ```js title="eslint.config.mjs"
+// @ts-check
+
+import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   tseslint.configs.stylisticTypeChecked,
   {

--- a/docs/users/Shared_Configurations.mdx
+++ b/docs/users/Shared_Configurations.mdx
@@ -20,12 +20,12 @@ See [Getting Started > Quickstart](../getting-started/Quickstart.mdx) first to s
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommended,
 );
 ```
@@ -39,7 +39,7 @@ If your project does not enable [typed linting](../getting-started/Typed_Linting
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommended,
   tseslint.configs.stylistic,
 );
@@ -76,7 +76,7 @@ To use type-checking, you also need to configure `languageOptions.parserOptions`
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   // Added lines start
   tseslint.configs.recommendedTypeChecked,
   tseslint.configs.stylisticTypeChecked,
@@ -374,7 +374,7 @@ If you use type-aware rules from other plugins, you will need to manually disabl
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {
@@ -437,7 +437,7 @@ Additionally, it enables rules that promote using the more modern constructs Typ
 
 ```js title="eslint.config.mjs"
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.eslintRecommended,
 );
 ```

--- a/docs/users/What_About_Formatting.mdx
+++ b/docs/users/What_About_Formatting.mdx
@@ -49,14 +49,14 @@ Using this config by adding it to the end of your `extends`:
 ```js title="eslint.config.mjs"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import { defineConfig } from 'eslint/config';
 import someOtherConfig from 'eslint-config-other-configuration-that-enables-formatting-rules';
 import prettierConfig from 'eslint-config-prettier';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig(
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.recommended,
   someOtherConfig,
   // Add this line

--- a/packages/website/blog/2024-02-12-announcing-typescript-eslint-v7.md
+++ b/packages/website/blog/2024-02-12-announcing-typescript-eslint-v7.md
@@ -51,11 +51,11 @@ The simplest of this new tooling would be the following which will enable the ES
 ```js title="eslint.config.js"
 // @ts-check
 
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
+  js.configs.recommended,
   ...tseslint.configs.recommended,
 );
 ```

--- a/packages/website/blog/2024-05-27-announcing-typescript-eslint-v8-beta.mdx
+++ b/packages/website/blog/2024-05-27-announcing-typescript-eslint-v8-beta.mdx
@@ -85,11 +85,11 @@ It's been experimentally available since v6.1.0 under the name `EXPERIMENTAL_use
 You can use the new project service in your configuration instead of the previous `parserOptions.project`:
 
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
+  js.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {
@@ -115,11 +115,11 @@ Typed linting for out-of-project files can be done by specifying two properties 
 - `defaultProject`: path to a TypeScript configuration file to use for the slower default project
 
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
+  js.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {

--- a/packages/website/blog/2024-07-31-announcing-typescript-eslint-v8.md
+++ b/packages/website/blog/2024-07-31-announcing-typescript-eslint-v8.md
@@ -73,11 +73,11 @@ It's been experimentally available since v6.1.0 under the name `EXPERIMENTAL_use
 You can use the new project service in your configuration instead of the previous `parserOptions.project`:
 
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
+  js.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {
@@ -103,11 +103,11 @@ Typed linting for out-of-project files can be done by specifying two properties 
 - `defaultProject`: path to a TypeScript configuration file to use for the slower default project
 
 ```js title="eslint.config.mjs"
-import eslint from '@eslint/js';
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
+  js.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {

--- a/packages/website/blog/2024-09-30-typed-linting.md
+++ b/packages/website/blog/2024-09-30-typed-linting.md
@@ -215,10 +215,11 @@ You can add typed linting to your ESLint configuration by following the steps in
 We recommend doing so by enabling [`parserOptions.projectService`](/packages/parser#projectservice):
 
 ```js title="eslint.config.js"
+import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  eslint.configs.recommended,
+  js.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
   {
     languageOptions: {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12099
- [x] That issue was marked as accepting prs
- [x] Steps in Contributing were taken

## Overview

This PR updates documentation and website blog examples to align with ESLint’s current flat-config convention by importing `@eslint/js` as `js` (instead of `eslint`) and updating usages from `eslint.configs.*` to `js.configs.*`. It also makes a few code snippets self-contained by adding missing imports so the examples remain copy/pasteable.

Fixes #12099.

Ran locally:
- `pnpm run check-format`
- `pnpm run lint-markdown`