### PR TITLE
fix: exclude tsbuildinfo from published packages

### DIFF
--- a/packages/ast-spec/package.json
+++ b/packages/ast-spec/package.json
@@ -13,7 +13,7 @@
   },
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -4,7 +4,7 @@
   "description": "TypeScript plugin for ESLint",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "index.d.ts",
     "raw-plugin.d.ts",
     "rules.d.ts",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -4,7 +4,7 @@
   "description": "An ESLint custom parser which leverages TypeScript ESTree",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "README.md",
     "LICENSE"
   ],

--- a/packages/project-service/package.json
+++ b/packages/project-service/package.json
@@ -4,7 +4,7 @@
   "description": "Standalone TypeScript project service wrapper for linting.",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -4,7 +4,7 @@
   "description": "Tooling to test ESLint rules",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "README.md",
     "LICENSE"
   ],

--- a/packages/scope-manager/package.json
+++ b/packages/scope-manager/package.json
@@ -4,7 +4,7 @@
   "description": "TypeScript scope analyser for ESLint",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/tsconfig-utils/package.json
+++ b/packages/tsconfig-utils/package.json
@@ -4,7 +4,7 @@
   "description": "Utilities for collecting TSConfigs for linting scenarios.",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -4,7 +4,7 @@
   "description": "Type utilities for working with TypeScript + ESLint together",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,7 +4,7 @@
   "description": "Types for the TypeScript-ESTree AST spec",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -4,7 +4,7 @@
   "description": "Tooling which enables you to use TypeScript with ESLint",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "README.md",
     "LICENSE"
   ],

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -4,7 +4,7 @@
   "description": "A parser that converts TypeScript source code into an ESTree compatible form",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "README.md",
     "LICENSE"
   ],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,7 @@
   "description": "Utilities for working with TypeScript + ESLint together",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/visitor-keys/package.json
+++ b/packages/visitor-keys/package.json
@@ -4,7 +4,7 @@
   "description": "Visitor keys used to help traverse the TypeScript-ESTree AST",
   "files": [
     "dist",
-    "!*.tsbuildinfo",
+    "!dist/*.tsbuildinfo",
     "package.json",
     "README.md",
     "LICENSE"

--- a/packages/website-eslint/package.json
+++ b/packages/website-eslint/package.json
@@ -4,7 +4,7 @@
   "description": "ESLint which works in browsers.",
   "files": [
     "dist",
-    "!*.tsbuildinfo"
+    "!dist/*.tsbuildinfo"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Fix: exclude `.tsbuildinfo` from published packages

### Root cause

The current exclusion pattern:

```json
"!*.tsbuildinfo"
```

only matches files at the package root level.

However, `tsconfig.build.json` explicitly emits the build cache to:

```
dist/tsconfig.build.tsbuildinfo
```

As a result, the file is unintentionally included in the published npm package.

---

### Fix

Updated the pattern to:

```json
"!dist/*.tsbuildinfo"
```

This correctly excludes the `.tsbuildinfo` file from the `dist/` directory where it is actually generated.

---

### Why not `!**/*.tsbuildinfo`?

While `!**/*.tsbuildinfo` would also work, it is overly broad.

- `!dist/*.tsbuildinfo` precisely targets the actual output location  
- Keeps the intent explicit and aligned with `tsBuildInfoFile`  
- Avoids masking potential future misconfigurations  

---

### Verification

- Ran `pnpm build` and `pnpm test` successfully  
- Verified via `pnpm pack` that `.tsbuildinfo` is no longer included in the tarball  

Checked explicitly:

```bash
tar -tf typescript-eslint-typescript-estree-8.58.0.tgz | findstr tsbuildinfo
```

No `.tsbuildinfo` files are present in the output.

_(See attached screenshot below for verification)_

---

### Summary

This change ensures `.tsbuildinfo` (a TypeScript build cache file) is not included in published packages, using a precise and intention-aligned exclusion pattern.
<img width="642" height="319" alt="Screenshot 2026-04-01 151021" src="https://github.com/user-attachments/assets/4ea71efe-47da-41eb-a982-63df9fb1f51c" />
<img width="703" height="127" alt="Screenshot 2026-04-01 150932" src="https://github.com/user-attachments/assets/b749ba09-ee62-4c39-9dd7-6fdbffa8f5df" />
