### PR TITLE
docs: declare strictNullChecks: false unsupported for typed linting

### DIFF
--- a/docs/getting-started/Typed_Linting.mdx
+++ b/docs/getting-started/Typed_Linting.mdx
@@ -10,6 +10,11 @@ Some typescript-eslint rules utilize TypeScript's type checking APIs to provide 
 This requires TypeScript to analyze your entire project instead of just the file being linted.
 As a result, these rules are slower than traditional lint rules but are much more powerful.
 
+:::caution
+Type-aware linting requires [`strictNullChecks`](https://www.typescriptlang.org/tsconfig#strictNullChecks) to be enabled in your TypeScript configuration.
+Using type-aware rules with `strictNullChecks: false` is unsupported and may produce incorrect or misleading results.
+:::
+
 To enable typed linting, there are two small changes you need to make to your config file:
 
 <Tabs groupId="eslint-config">


### PR DESCRIPTION
Adds a caution notice to the typed linting getting-started guide clarifying that strictNullChecks: true is required. Using type-aware rules without it is unsupported and may produce incorrect results.

Closes #11886

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: Closes #11886
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
