### PR TITLE
docs(eslint-plugin): clarify no-redeclare type-value collision not covered by TypeScript

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-redeclare.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redeclare.mdx
@@ -15,8 +15,8 @@ import Admonition from '@theme/Admonition';
   <p>
     Some cases checked by this rule are also checked by the TypeScript compiler
     (variable redeclarations, function overloads, and declaration merging).
-    However, this rule additionally reports collisions between value declarations
-    (e.g., <code>const Foo</code>) and type declarations (e.g.,{' '}
+    However, this rule additionally reports collisions between value
+    declarations (e.g., <code>const Foo</code>) and type declarations (e.g.,{' '}
     <code>type Foo</code> or <code>interface Foo</code>), which TypeScript does{' '}
     <strong>not</strong> check.
   </p>

--- a/packages/eslint-plugin/docs/rules/no-redeclare.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redeclare.mdx
@@ -14,13 +14,7 @@ import TypeScriptOverlap from '@site/src/components/TypeScriptOverlap';
 <TypeScriptOverlap />
 
 It adds support for TypeScript function overloads and declaration merging.
-
-:::note
-The overlap with TypeScript applies only to true variable redeclarations.
-This rule also reports naming collisions between values (e.g., `const Foo`) and types
-(e.g., `type Foo` or `interface Foo`), which TypeScript does **not** check.
-This is intentional — such collisions are often accidental and can lead to confusing code.
-:::
+Unlike TypeScript, this rule also reports collisions between value and type declarations with the same name (e.g., `const Foo` and `type Foo`).
 
 ## Options
 

--- a/packages/eslint-plugin/docs/rules/no-redeclare.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redeclare.mdx
@@ -9,22 +9,12 @@ import TabItem from '@theme/TabItem';
 >
 > See **https://typescript-eslint.io/rules/no-redeclare** for documentation.
 
-import Admonition from '@theme/Admonition';
+import TypeScriptOverlap from '@site/src/components/TypeScriptOverlap';
 
-<Admonition type="danger">
-  <p>
-    Some cases checked by this rule are also checked by the TypeScript compiler
-    (variable redeclarations, function overloads, and declaration merging).
-    However, this rule additionally reports collisions between value
-    declarations (e.g., <code>const Foo</code>) and type declarations (e.g.,{' '}
-    <code>type Foo</code> or <code>interface Foo</code>), which TypeScript does{' '}
-    <strong>not</strong> check.
-  </p>
-  <p>
-    In new TypeScript projects, consider whether you need this rule based on
-    whether these additional cases matter to your codebase.
-  </p>
-</Admonition>
+<TypeScriptOverlap />
+
+It adds support for TypeScript function overloads and declaration merging.
+Unlike TypeScript, this rule also reports collisions between value declarations (e.g., `const Foo`) and type declarations (e.g., `type Foo` or `interface Foo`).
 
 ## Options
 

--- a/packages/eslint-plugin/docs/rules/no-redeclare.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redeclare.mdx
@@ -13,7 +13,14 @@ import TypeScriptOverlap from '@site/src/components/TypeScriptOverlap';
 
 <TypeScriptOverlap />
 
-It adds support for TypeScript function overloads, and declaration merging.
+It adds support for TypeScript function overloads and declaration merging.
+
+:::note
+The overlap with TypeScript applies only to true variable redeclarations.
+This rule also reports naming collisions between values (e.g., `const Foo`) and types
+(e.g., `type Foo` or `interface Foo`), which TypeScript does **not** check.
+This is intentional — such collisions are often accidental and can lead to confusing code.
+:::
 
 ## Options
 

--- a/packages/eslint-plugin/docs/rules/no-redeclare.mdx
+++ b/packages/eslint-plugin/docs/rules/no-redeclare.mdx
@@ -9,12 +9,22 @@ import TabItem from '@theme/TabItem';
 >
 > See **https://typescript-eslint.io/rules/no-redeclare** for documentation.
 
-import TypeScriptOverlap from '@site/src/components/TypeScriptOverlap';
+import Admonition from '@theme/Admonition';
 
-<TypeScriptOverlap />
-
-It adds support for TypeScript function overloads and declaration merging.
-Unlike TypeScript, this rule also reports collisions between value and type declarations with the same name (e.g., `const Foo` and `type Foo`).
+<Admonition type="danger">
+  <p>
+    Some cases checked by this rule are also checked by the TypeScript compiler
+    (variable redeclarations, function overloads, and declaration merging).
+    However, this rule additionally reports collisions between value declarations
+    (e.g., <code>const Foo</code>) and type declarations (e.g.,{' '}
+    <code>type Foo</code> or <code>interface Foo</code>), which TypeScript does{' '}
+    <strong>not</strong> check.
+  </p>
+  <p>
+    In new TypeScript projects, consider whether you need this rule based on
+    whether these additional cases matter to your codebase.
+  </p>
+</Admonition>
 
 ## Options
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise, we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: Closes #11461
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
