### PR TITLE
docs: clarify consistent-type-imports guidance for verbatimModuleSyntax

### DIFF
--- a/docs/troubleshooting/faqs/TypeScript.mdx
+++ b/docs/troubleshooting/faqs/TypeScript.mdx
@@ -71,7 +71,7 @@ Therefore, you'll need to configure the rule to permit `import x = require('foo'
 
 Known rules that conflict with or require special configuration to be used with `verbatimModuleSyntax` include:
 
-- [consistent-type-imports](/rules/consistent-type-imports#comparison-with-importsnotusedasvalues--verbatimmodulesyntax): can overlap with TypeScript's diagnostics, but still provides lint-level enforcement and autofixes for explicit `import type`
+- [consistent-type-imports](/rules/consistent-type-imports#comparison-with-importsnotusedasvalues--verbatimmodulesyntax): can overlap with TypeScript's diagnostics; keep it if you want ESLint autofixes and style enforcement for explicit `import type`, or disable it if TypeScript's diagnostics are sufficient
 - [no-import-type-side-effects](/rules/no-import-type-side-effects): a rule that is only needed at all when using `verbatimModuleSyntax`
 - [no-namespace](/rules/no-namespace#when-not-to-use-it): some reports [need to be ignored](/rules/no-namespace#when-not-to-use-it)
 - [no-require-imports](/rules/no-require-imports): requires [configuring its `allowAsImport` option](/rules/no-require-imports#allowasimport)

--- a/docs/troubleshooting/faqs/TypeScript.mdx
+++ b/docs/troubleshooting/faqs/TypeScript.mdx
@@ -71,7 +71,7 @@ Therefore, you'll need to configure the rule to permit `import x = require('foo'
 
 Known rules that conflict with or require special configuration to be used with `verbatimModuleSyntax` include:
 
-- [consistent-type-imports](/rules/consistent-type-imports#comparison-with-importsnotusedasvalues--verbatimmodulesyntax): should be disabled
+- [consistent-type-imports](/rules/consistent-type-imports#comparison-with-importsnotusedasvalues--verbatimmodulesyntax): can overlap with TypeScript's diagnostics, but still provides lint-level enforcement and autofixes for explicit `import type`
 - [no-import-type-side-effects](/rules/no-import-type-side-effects): a rule that is only needed at all when using `verbatimModuleSyntax`
 - [no-namespace](/rules/no-namespace#when-not-to-use-it): some reports [need to be ignored](/rules/no-namespace#when-not-to-use-it)
 - [no-require-imports](/rules/no-require-imports): requires [configuring its `allowAsImport` option](/rules/no-require-imports#allowasimport)

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx
@@ -113,23 +113,18 @@ Otherwise you can explicitly tell our tooling to analyze your code as if the com
 ## Comparison with `importsNotUsedAsValues` / `verbatimModuleSyntax`
 
 [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) was introduced in TypeScript v5.0 (as a replacement for `importsNotUsedAsValues`).
-It is not a direct replacement for this rule.
-`consistent-type-imports` is an ESLint rule that enforces how you _write_ imports.
-`verbatimModuleSyntax` is a TypeScript compiler option that controls how those imports are preserved in emitted JavaScript.
-
-There are a few important behavior differences:
+This rule and `verbatimModuleSyntax` overlap in some situations, but there are a few behavior differences:
 | Situation | `consistent-type-imports` (ESLint) | `verbatimModuleSyntax` (TypeScript) |
 | -------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------- |
-| `import { Foo } from 'foo'; type T = Foo;` | Reports and can auto-fix to `import type` | Allowed, and the import is preserved in emitted JavaScript |
+| Unused imports | Ignored (consider using [`@typescript-eslint/no-unused-vars`](/rules/no-unused-vars)) | Type error |
 | Usage with `emitDecoratorMetadata` & `experimentalDecorators` | Ignores files that contain decorators | Reports on files that contain decorators |
 | Failures detected | Does not fail `tsc` build; can be auto-fixed with `--fix` | Fails `tsc` build; cannot be auto-fixed on the command-line |
-| `import { type T } from 'T';` | Allowed with `fixStyle: 'inline-type-imports'`; use `fixStyle: 'separate-type-imports'` to prefer `import type` | Emits `import {} from 'T'` |
+| `import { type T } from 'T';` | TypeScript will emit nothing (it "elides" the import) | TypeScript emits `import {} from 'T'` |
 
-If your goal is to make type-only imports explicit in source code, keep this rule enabled even when using `verbatimModuleSyntax`.
-If your goal is only predictable emit semantics, `verbatimModuleSyntax` may be sufficient on its own.
-
-Projects that use both often also want [`no-import-type-side-effects`](./no-import-type-side-effects.mdx), especially when using inline `type` specifiers.
-If the overlap between ESLint and TypeScript diagnostics is noisy in your project, you can choose one of them as the source of truth.
+Because there are some differences, using both this rule and `verbatimModuleSyntax` at the same time can lead to duplicate reports on the same import.
+For example, TypeScript may report that a type must be imported using `import type`, and this rule may also report that the import should use your configured style.
+If you want ESLint autofixes and style enforcement for explicit `import type`, keep this rule enabled.
+If TypeScript's diagnostics are sufficient for your project, you can disable this rule to avoid duplicate reports.
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx
@@ -113,17 +113,23 @@ Otherwise you can explicitly tell our tooling to analyze your code as if the com
 ## Comparison with `importsNotUsedAsValues` / `verbatimModuleSyntax`
 
 [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax) was introduced in TypeScript v5.0 (as a replacement for `importsNotUsedAsValues`).
-This rule and `verbatimModuleSyntax` _mostly_ behave in the same way.
-There are a few behavior differences:
+It is not a direct replacement for this rule.
+`consistent-type-imports` is an ESLint rule that enforces how you _write_ imports.
+`verbatimModuleSyntax` is a TypeScript compiler option that controls how those imports are preserved in emitted JavaScript.
+
+There are a few important behavior differences:
 | Situation | `consistent-type-imports` (ESLint) | `verbatimModuleSyntax` (TypeScript) |
 | -------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------- |
-| Unused imports | Ignored (consider using [`@typescript-eslint/no-unused-vars`](/rules/no-unused-vars)) | Type error |
-| Usage with `emitDecoratorMetadata` & `experimentalDecorations` | Ignores files that contain decorators | Reports on files that contain decorators |
+| `import { Foo } from 'foo'; type T = Foo;` | Reports and can auto-fix to `import type` | Allowed, and the import is preserved in emitted JavaScript |
+| Usage with `emitDecoratorMetadata` & `experimentalDecorators` | Ignores files that contain decorators | Reports on files that contain decorators |
 | Failures detected | Does not fail `tsc` build; can be auto-fixed with `--fix` | Fails `tsc` build; cannot be auto-fixed on the command-line |
-| `import { type T } from 'T';` | TypeScript will emit nothing (it "elides" the import) | TypeScript emits `import {} from 'T'` |
+| `import { type T } from 'T';` | Allowed with `fixStyle: 'inline-type-imports'`; use `fixStyle: 'separate-type-imports'` to prefer `import type` | Emits `import {} from 'T'` |
 
-Because there are some differences, using both this rule and `verbatimModuleSyntax` at the same time can lead to conflicting errors.
-As such we recommend that you only ever use one _or_ the other -- never both.
+If your goal is to make type-only imports explicit in source code, keep this rule enabled even when using `verbatimModuleSyntax`.
+If your goal is only predictable emit semantics, `verbatimModuleSyntax` may be sufficient on its own.
+
+Projects that use both often also want [`no-import-type-side-effects`](./no-import-type-side-effects.mdx), especially when using inline `type` specifiers.
+If the overlap between ESLint and TypeScript diagnostics is noisy in your project, you can choose one of them as the source of truth.
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-type-imports.mdx
@@ -121,7 +121,7 @@ This rule and `verbatimModuleSyntax` overlap in some situations, but there are a
 | Failures detected | Does not fail `tsc` build; can be auto-fixed with `--fix` | Fails `tsc` build; cannot be auto-fixed on the command-line |
 | `import { type T } from 'T';` | TypeScript will emit nothing (it "elides" the import) | TypeScript emits `import {} from 'T'` |
 
-Because there are some differences, using both this rule and `verbatimModuleSyntax` at the same time can lead to duplicate reports on the same import.
+Because they have slightly different goals, using both this rule and `verbatimModuleSyntax` at the same time can lead to conflicting and/or duplicate reports on the same import.
 For example, TypeScript may report that a type must be imported using `import type`, and this rule may also report that the import should use your configured style.
 If you want ESLint autofixes and style enforcement for explicit `import type`, keep this rule enabled.
 If TypeScript's diagnostics are sufficient for your project, you can disable this rule to avoid duplicate reports.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11681
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Clarifies that `verbatimModuleSyntax` is not a direct replacement for `consistent-type-imports`.

The docs now explain the distinct responsibilities of the compiler option and the rule, update the comparison section, and align the FAQ wording so it no longer recommends disabling the rule outright when `verbatimModuleSyntax` is enabled.

💖
