### PR TITLE
chore(website): configure the playground for all available file types

### DIFF
--- a/packages/website/src/components/linter/createLinter.ts
+++ b/packages/website/src/components/linter/createLinter.ts
@@ -24,6 +24,7 @@ import { createEventsBinder } from '../lib/createEventsBinder';
 import { parseESLintRC, parseTSConfig } from '../lib/parseConfig';
 import { defaultEslintLanguageConfig } from './config';
 import { createParser } from './createParser';
+import { fileTypes } from '../options';
 
 export interface CreateLinter {
   configs: string[];
@@ -66,7 +67,7 @@ export function createLinter(
   );
 
   const eslintLanguageConfig: FlatConfig.Config = {
-    files: ['**/*.ts', '**/*.tsx'],
+    files: fileTypes.map(extension => `**/*${extension}`),
     languageOptions: {
       ...defaultEslintLanguageConfig,
       parser,

--- a/packages/website/src/components/linter/createLinter.ts
+++ b/packages/website/src/components/linter/createLinter.ts
@@ -22,9 +22,9 @@ import type {
 import { createCompilerOptions } from '../lib/createCompilerOptions';
 import { createEventsBinder } from '../lib/createEventsBinder';
 import { parseESLintRC, parseTSConfig } from '../lib/parseConfig';
+import { fileTypes } from '../options';
 import { defaultEslintLanguageConfig } from './config';
 import { createParser } from './createParser';
-import { fileTypes } from '../options';
 
 export interface CreateLinter {
   configs: string[];

--- a/packages/website/src/components/linter/createLinter.ts
+++ b/packages/website/src/components/linter/createLinter.ts
@@ -121,7 +121,7 @@ export function createLinter(
       const lintMessage: Linter.LintMessage = {
         column: 1,
         line: 1,
-        message: String(e instanceof Error ? e.stack : e),
+        message: String(e instanceof Error ? `${e.message}\n\n${e.stack}` : e),
         ruleId: '',
         severity: 2,
         source: 'eslint',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12210
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The playground's ESLint configuration only configured `.ts` and `.tsx` files. None of the other file types were configured, so when ESLint parsed the config for a different file type it would fail to find the rules.

The ESLint configuration is now configured for all of the file extensions that can be selected.

I've also included the error message in the linter message instead of only the stack trace to make it easier to debug in the future.