### PR TITLE
fix(typescript-eslint): avoid /ts-eslint type import for FlatConfig

### DIFF
--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -1,6 +1,4 @@
-// see the comment in config-helper.ts for why this doesn't use /ts-eslint
 import type { TSESLint } from '@typescript-eslint/utils';
-import type { FlatConfig } from '@typescript-eslint/utils/ts-eslint';
 
 import pluginBase from '@typescript-eslint/eslint-plugin';
 import rawPlugin from '@typescript-eslint/eslint-plugin/use-at-your-own-risk/raw-plugin';
@@ -16,10 +14,8 @@ import type {
 import { config } from './config-helper';
 import { getTSConfigRootDirFromStack } from './getTSConfigRootDirFromStack';
 
-export type { FlatConfig } from '@typescript-eslint/utils/ts-eslint';
-
 export const parser: CompatibleParser =
-  rawPlugin.parser as CompatibleParser satisfies FlatConfig.Parser;
+  rawPlugin.parser as CompatibleParser satisfies TSESLint.FlatConfig.Parser;
 
 /*
 we could build a plugin object here without the `configs` key - but if we do
@@ -45,7 +41,7 @@ would never be able to satisfy this constraint and thus users would be blocked
 from using them.
 */
 export const plugin: CompatiblePlugin =
-  pluginBase satisfies FlatConfig.Plugins['string'];
+  pluginBase satisfies TSESLint.FlatConfig.Plugins['string'];
 
 export const configs = createConfigsGetters({
   /**
@@ -146,7 +142,7 @@ export const configs = createConfigsGetters({
   stylisticTypeCheckedOnly: rawPlugin.flatConfigs[
     'flat/stylistic-type-checked-only'
   ] as CompatibleConfigArray,
-}) satisfies Record<string, FlatConfig.Config | FlatConfig.ConfigArray>;
+}) satisfies Record<string, TSESLint.FlatConfig.Config | TSESLint.FlatConfig.ConfigArray>;
 
 function createConfigsGetters<T extends object>(values: T): T {
   const configs = {};


### PR DESCRIPTION
Switch types in packages/typescript-eslint/src/index.ts to use TSESLint.FlatConfig so config typing doesn't rely on importing from @typescript-eslint/utils/ts-eslint.

Fixes typescript-eslint/typescript-eslint#10893

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
