### PR TITLE
fix(eslint-plugin): [unbound-method] handle union and intersection types in member access

### DIFF
--- a/packages/eslint-plugin/src/rules/unbound-method.ts
+++ b/packages/eslint-plugin/src/rules/unbound-method.ts
@@ -216,7 +216,34 @@ export default createRule<Options, MessageIds>({
           return;
         }
 
-        checkIfMethodAndReport(node, services.getSymbolAtLocation(node));
+        if (checkIfMethodAndReport(node, services.getSymbolAtLocation(node))) {
+          return;
+        }
+
+        // When accessing a property on a union type, TypeScript may not
+        // resolve a single symbol for the member expression if the property
+        // kind differs between constituents (e.g. a method on one type and a
+        // non-method property on another). Iterate the union/intersection
+        // constituents of the object's type so we still report such cases,
+        // matching the behavior already implemented for destructuring via
+        // ObjectPattern.
+        if (node.computed || node.property.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+        const propertyName = node.property.name;
+        const constituents = tsutils
+          .unionConstituents(services.getTypeAtLocation(node.object))
+          .flatMap(unionPart => tsutils.intersectionConstituents(unionPart));
+        if (constituents.length <= 1) {
+          return;
+        }
+        for (const constituent of constituents) {
+          if (
+            checkIfMethodAndReport(node, constituent.getProperty(propertyName))
+          ) {
+            return;
+          }
+        }
       },
       ObjectPattern(node): void {
         if (isNodeInsideTypeDeclaration(node)) {

--- a/packages/eslint-plugin/tests/rules/unbound-method.test.ts
+++ b/packages/eslint-plugin/tests/rules/unbound-method.test.ts
@@ -1241,5 +1241,78 @@ const f = objectLiteral.f;
         },
       ],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/11683
+    {
+      code: `
+class Foo {
+  bazz() {}
+}
+class Bar {
+  bazz = 1;
+}
+declare const union: Foo | Bar;
+const unbound = union.bazz;
+      `,
+      errors: [
+        {
+          line: 9,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  bazz() {}
+}
+class Bar {
+  bazz = 1;
+}
+class Baz {
+  bazz = 'str';
+}
+declare const union: Foo | Bar | Baz;
+const unbound = union.bazz;
+      `,
+      errors: [
+        {
+          line: 12,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  unbound = function () {};
+}
+class Bar {
+  unbound = 1;
+}
+declare const union: Foo | Bar;
+const unbound = union.unbound;
+      `,
+      errors: [
+        {
+          line: 9,
+          messageId: 'unbound',
+        },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  unbound() {}
+}
+declare const intersection: Foo & { other: number };
+const unbound = intersection.unbound;
+      `,
+      errors: [
+        {
+          line: 6,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11683
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`unbound-method` already handles destructuring from a union via its `ObjectPattern` visitor, but the `MemberExpression` visitor only looked up a single symbol via `services.getSymbolAtLocation(node)`. When the property resolves to different kinds across union constituents (e.g. a method on one type and a data property on another), TypeScript does not produce a single symbol for the member expression, so the rule silently failed to report.

This extends the `MemberExpression` visitor to mirror the `ObjectPattern` behavior: when the initial symbol lookup does not report, it iterates the union/intersection constituents of the object's type with `tsutils.unionConstituents(...).flatMap(intersectionConstituents)` and checks each constituent's property symbol, returning on the first reported constituent. Computed and non-`Identifier` properties are skipped, and single-constituent types short-circuit so the existing path is unchanged for non-union access.

Regression tests cover the original issue repro (`Foo | Bar` with a method on one side and a field on the other), a 3-way union, a function-property union that reports `unbound`, and an intersection case.