### PR TITLE
fix(eslint-plugin): [no-floating-promises] avoid recursive type lookup crashes

### DIFF
--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -1,8 +1,8 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
-import type * as ts from 'typescript';
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
+import * as ts from 'typescript';
 
 import type { TypeOrValueSpecifier } from '../util';
 
@@ -394,7 +394,10 @@ export default createRule<Options, MessageId>({
     }
 
     function isPromiseArray(node: ts.Node): boolean {
-      const type = checker.getTypeAtLocation(node);
+      const type = getSafeTypeAtLocation(node);
+      if (!type) {
+        return false;
+      }
       for (const ty of tsutils
         .unionConstituents(type)
         .map(t => checker.getApparentType(t))) {
@@ -417,7 +420,10 @@ export default createRule<Options, MessageId>({
     }
 
     function isPromiseLike(node: ts.Node, type?: ts.Type): boolean {
-      type ??= checker.getTypeAtLocation(node);
+      type ??= getSafeTypeAtLocation(node);
+      if (!type) {
+        return false;
+      }
 
       // The highest priority is to allow anything allowlisted
       if (
@@ -472,6 +478,38 @@ export default createRule<Options, MessageId>({
       }
       return false;
     }
+
+    function getSafeTypeAtLocation(node: ts.Node): ts.Type | undefined {
+      try {
+        return checker.getTypeAtLocation(node);
+      } catch (error) {
+        // Work around recursive type display failures in TypeScript for some
+        // deeply nested generic call expressions.
+        if (
+          isMaximumCallStackSizeExceededError(error) &&
+          (ts.isCallExpression(node) || ts.isNewExpression(node))
+        ) {
+          return getCallLikeReturnType(node);
+        }
+
+        throw error;
+      }
+    }
+
+    function getCallLikeReturnType(
+      node: ts.CallExpression | ts.NewExpression,
+    ): ts.Type | undefined {
+      const calleeType = getSafeTypeAtLocation(node.expression);
+      if (!calleeType) {
+        return undefined;
+      }
+
+      const signatures = ts.isCallExpression(node)
+        ? checker.getSignaturesOfType(calleeType, ts.SignatureKind.Call)
+        : checker.getSignaturesOfType(calleeType, ts.SignatureKind.Construct);
+
+      return signatures[0]?.getReturnType();
+    }
   },
 });
 
@@ -502,4 +540,13 @@ function isFunctionParam(
     }
   }
   return false;
+}
+
+function isMaximumCallStackSizeExceededError(
+  error: unknown,
+): error is RangeError {
+  return (
+    error instanceof RangeError &&
+    error.message === 'Maximum call stack size exceeded'
+  );
 }

--- a/packages/eslint-plugin/tests/fixtures/bootstrap-vue-next.d.ts
+++ b/packages/eslint-plugin/tests/fixtures/bootstrap-vue-next.d.ts
@@ -1,0 +1,71 @@
+declare module 'bootstrap-vue-next' {
+  export type ControllerKey = symbol | string;
+
+  export interface PromiseWithComponent<T, P>
+    extends Promise<void>, PromiseWithComponentInternal<T, P> {}
+
+  export interface PromiseWithComponentInternal<T, P> {
+    id: ControllerKey;
+    ref: T | null;
+    show: () => PromiseWithComponent<T, P>;
+    hide: (trigger?: string) => PromiseWithComponent<T, P>;
+    toggle: () => PromiseWithComponent<T, P>;
+    set: (value: Partial<P>) => PromiseWithComponent<T, P>;
+    get: () => P | undefined;
+    destroy: () => void;
+  }
+
+  export interface OrchestratorCreateOptions {
+    keep?: boolean;
+    resolveOnHide?: boolean;
+  }
+
+  export interface ComponentLike {
+    render(): unknown;
+  }
+
+  export declare const BModal: ComponentLike;
+
+  export type ModalOrchestratorParam<ComponentProps = Record<string, unknown>> =
+    ComponentProps & {
+      title?: string;
+      body?: string;
+      options?: OrchestratorCreateOptions;
+      props?: Record<string, unknown>;
+      slots?: {
+        default?: ComponentProps | Readonly<ComponentLike>;
+      };
+    };
+
+  export type ModalOrchestratorCreateParam<
+    ComponentProps = Record<string, unknown>,
+  > =
+    | ModalOrchestratorParam<ComponentProps>
+    | {
+        value: ModalOrchestratorParam<ComponentProps>;
+      };
+
+  export declare const useModal: () => {
+    show: (id?: ControllerKey) => void;
+    hide: (trigger?: string, id?: ControllerKey) => void;
+    hideAll: (trigger?: string) => void;
+    current: () => {
+      show(): void;
+      hide(trigger?: string): void;
+      modal: ComponentLike | null | undefined;
+    } | null;
+    create: <ComponentProps = Record<string, unknown>>(
+      obj?: ModalOrchestratorCreateParam<ComponentProps>,
+      options?: OrchestratorCreateOptions,
+    ) => PromiseWithComponent<
+      typeof BModal,
+      ModalOrchestratorParam<ComponentProps>
+    >;
+    _isOrchestratorInstalled: {
+      value: boolean;
+    };
+    store: {
+      value: unknown[];
+    };
+  };
+}

--- a/packages/eslint-plugin/tests/fixtures/tsconfig.json
+++ b/packages/eslint-plugin/tests/fixtures/tsconfig.json
@@ -12,6 +12,7 @@
     "file.ts",
     "consistent-type-exports.ts",
     "deprecated.ts",
+    "bootstrap-vue-next.d.ts",
     "mixed-enums-decl.ts",
     "react.tsx",
     "var-declaration.ts",

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -5666,8 +5666,10 @@ describe('no-floating-promises fallback type lookup', () => {
     );
 
     assert.isDefined(expressionStatement);
+    assert.isNotNull(services.program);
 
-    const checker = services.program.getTypeChecker();
+    const program = services.program;
+    const checker = program.getTypeChecker();
     const checkerOverride = createCheckerOverride?.(
       checker,
       services,
@@ -5675,8 +5677,8 @@ describe('no-floating-promises fallback type lookup', () => {
     );
 
     if (checkerOverride) {
-      vi.spyOn(services.program, 'getTypeChecker').mockReturnValue(
-        checkerOverride,
+      vi.spyOn(program, 'getTypeChecker').mockImplementation(
+        () => checkerOverride,
       );
     }
 

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -5644,11 +5644,16 @@ await Promise.reject('foo').then(...[], () => {});
 
 describe('no-floating-promises fallback type lookup', () => {
   const parserOptions = {
+    disallowAutomaticSingleRunInference: true,
     filePath: path.join(rootDir, 'react.tsx'),
     project: './tsconfig.json',
     projectService: false,
     tsconfigRootDir: rootDir,
   } as const;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   function createRuleListener(
     code: string,

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -887,6 +887,26 @@ myAsyncFunction();
         },
       ],
     },
+    {
+      code: `
+import { vi } from 'vitest';
+
+vi.mock('bootstrap-vue-next', async importActual => {
+  const actual = await importActual<typeof import('bootstrap-vue-next')>();
+  return {
+    ...actual,
+    useModal: vi.fn<typeof actual.useModal>(() => {
+      const result = actual.useModal();
+      return {
+        ...result,
+        create: vi.fn<typeof result.create<unknown>>(result.create),
+      };
+    }),
+  };
+});
+      `,
+      filename: 'react.tsx',
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -1,4 +1,9 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+
+import { parseForESLint } from '@typescript-eslint/parser';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import * as path from 'node:path';
+import * as ts from 'typescript';
 
 import rule from '../../src/rules/no-floating-promises';
 import { createRuleTesterWithTypes, getFixturesRootDir } from '../RuleTester';
@@ -5635,4 +5640,180 @@ await Promise.reject('foo').then(...[], () => {});
       ],
     },
   ],
+});
+
+describe('no-floating-promises fallback type lookup', () => {
+  const parserOptions = {
+    filePath: path.join(rootDir, 'react.tsx'),
+    project: './tsconfig.json',
+    projectService: false,
+    tsconfigRootDir: rootDir,
+  } as const;
+
+  function createRuleListener(
+    code: string,
+    createCheckerOverride?: (
+      checker: ts.TypeChecker,
+      services: ReturnType<typeof parseForESLint>['services'],
+      expressionStatement: TSESTree.ExpressionStatement,
+    ) => ts.TypeChecker,
+  ) {
+    const { ast, services } = parseForESLint(code, parserOptions);
+    const report = vi.fn();
+
+    const expressionStatement = ast.body.find(
+      statement => statement.type === AST_NODE_TYPES.ExpressionStatement,
+    );
+
+    assert.isDefined(expressionStatement);
+
+    const checker = services.program.getTypeChecker();
+    const checkerOverride = createCheckerOverride?.(
+      checker,
+      services,
+      expressionStatement,
+    );
+
+    if (checkerOverride) {
+      vi.spyOn(services.program, 'getTypeChecker').mockReturnValue(
+        checkerOverride,
+      );
+    }
+
+    const listener = rule.create({
+      languageOptions: {
+        parser: {
+          meta: {
+            name: '@typescript-eslint/parser',
+          },
+        },
+      },
+      options: [],
+      report,
+      sourceCode: {
+        ...ast,
+        parserServices: services,
+        text: code,
+      },
+    } as never);
+
+    return {
+      ExpressionStatement: listener.ExpressionStatement!,
+      expressionStatement,
+      report,
+      services,
+    };
+  }
+
+  it('rethrows non-recursion type lookup errors', () => {
+    const { ExpressionStatement, expressionStatement } = createRuleListener(
+      'Promise.resolve();',
+      (checker, services, statement) => {
+        const tsNode = services.esTreeNodeToTSNodeMap.get(statement.expression);
+
+        return {
+          ...checker,
+          getTypeAtLocation(node: ts.Node) {
+            if (node === tsNode) {
+              throw new Error('boom');
+            }
+
+            return checker.getTypeAtLocation(node);
+          },
+        };
+      },
+    );
+
+    expect(() => ExpressionStatement(expressionStatement)).toThrowError('boom');
+  });
+
+  it('returns early when the fallback cannot resolve a callee type', () => {
+    const { ExpressionStatement, expressionStatement, report } =
+      createRuleListener(
+        'Promise.resolve();',
+        (checker, services, statement) => {
+          assert(statement.expression.type === AST_NODE_TYPES.CallExpression);
+
+          const expressionTsNode = services.esTreeNodeToTSNodeMap.get(
+            statement.expression,
+          );
+          const calleeTsNode = services.esTreeNodeToTSNodeMap.get(
+            statement.expression.callee,
+          );
+
+          return {
+            ...checker,
+            getTypeAtLocation(node: ts.Node) {
+              if (node === expressionTsNode) {
+                throw new RangeError('Maximum call stack size exceeded');
+              }
+              if (node === calleeTsNode) {
+                return undefined as never;
+              }
+
+              return checker.getTypeAtLocation(node);
+            },
+          };
+        },
+      );
+
+    ExpressionStatement(expressionStatement);
+
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it('uses construct signatures in the fallback for new expressions', () => {
+    const getSignaturesOfType = vi.fn();
+    const { ExpressionStatement, expressionStatement, report } =
+      createRuleListener(
+        'new Promise((resolve) => resolve());',
+        (checker, services, statement) => {
+          assert(statement.expression.type === AST_NODE_TYPES.NewExpression);
+
+          const expressionTsNode = services.esTreeNodeToTSNodeMap.get(
+            statement.expression,
+          );
+
+          getSignaturesOfType.mockImplementation(
+            checker.getSignaturesOfType.bind(checker),
+          );
+
+          return {
+            ...checker,
+            getSignaturesOfType,
+            getTypeAtLocation(node: ts.Node) {
+              if (node === expressionTsNode) {
+                throw new RangeError('Maximum call stack size exceeded');
+              }
+
+              return checker.getTypeAtLocation(node);
+            },
+          };
+        },
+      );
+
+    ExpressionStatement(expressionStatement);
+
+    expect(report).toHaveBeenCalledOnce();
+    expect(getSignaturesOfType).toHaveBeenCalledWith(
+      expect.anything(),
+      ts.SignatureKind.Construct,
+    );
+  });
+
+  it('returns false when no thenable signature matches', () => {
+    const { ExpressionStatement, expressionStatement, report } =
+      createRuleListener(`
+interface ThenableWithoutRejection {
+  then(onFulfilled: () => void): ThenableWithoutRejection;
+}
+
+declare const thenableWithoutRejection: ThenableWithoutRejection;
+thenableWithoutRejection;
+      `);
+
+    ExpressionStatement(expressionStatement);
+
+    expect(report).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- handle the #11947 stack overflow in `no-floating-promises`, where `checker.getTypeAtLocation()` can recurse on deeply nested generic call expressions
- fall back to the callee return type for call and `new` expressions so the rule can still determine whether the expression is promise-like without crashing
- add a regression test for the `vi.mock()` repro and a local `bootstrap-vue-next` fixture declaration for the typed test setup

Fixes #11947

## Validation
- `pnpm exec eslint "packages/eslint-plugin/src/rules/no-floating-promises.ts" "packages/eslint-plugin/tests/rules/no-floating-promises.test.ts"`
- `pnpm exec vitest run packages/eslint-plugin/tests/rules/no-floating-promises.test.ts --config packages/eslint-plugin/vitest.config.mts`