### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-arguments] handle instantiation expressions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-arguments.ts
@@ -111,6 +111,12 @@ export default createRule<[], MessageIds>({
 
     return {
       TSTypeParameterInstantiation(node): void {
+        // TypeScript does not apply default type parameters in instantiation
+        // expressions, so explicit type args here are always meaningful.
+        if (node.parent.type === AST_NODE_TYPES.TSInstantiationExpression) {
+          return;
+        }
+
         const expression = services.esTreeNodeToTSNodeMap.get(node);
         const typeParameters = getTypeParametersFromNode(
           node,

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-arguments.test.ts
@@ -197,6 +197,15 @@ const button = <Button<string> />;
         },
       },
     },
+    `
+function f<T = number>() {}
+const g = f<number>;
+    `,
+    `
+function f<T = number>() {}
+function takesFn(fn: () => void) {}
+takesFn(f<number>);
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7042
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Added an early return when `TSTypeParameterInstantiation` appears as a child of `TSInstantiationExpression`, and included test cases covering both variable assignment and function argument contexts.

