### PR TITLE
docs: redirect /docs to getting-started

### DIFF
--- a/packages/website/docusaurus.config.mts
+++ b/packages/website/docusaurus.config.mts
@@ -293,6 +293,10 @@ const pluginPwaOptions: PluginPwaOptions = {
 const redirects: PluginRedirectOptions = {
   redirects: [
     {
+      from: '/docs',
+      to: '/getting-started',
+    },
+    {
       from: '/getting-started/typed-linting/monorepos',
       to: '/troubleshooting/typed-linting/monorepos',
     },


### PR DESCRIPTION
## Summary
- add a website redirect from `/docs` to `/getting-started`
- avoid sending users to a 404 for the docs nav path mentioned in #12217

Closes #12217.

## Testing
- verified the redirect entry was added to `packages/website/docusaurus.config.mts`
- attempted `pnpm exec nx build website` (currently blocked by an unrelated existing `website-eslint:build` failure resolving `@typescript-eslint/eslint-plugin/use-at-your-own-risk/raw-plugin` in this local checkout)