### PR TITLE
chore(eslint-plugin): switch auto-generated test cases to hand-written in return-await.test.ts

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -74,11 +74,6 @@
       "count": 17
     }
   },
-  "packages/eslint-plugin/tests/rules/return-await.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 1
-    }
-  },
   "packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts": {
     "@typescript-eslint/internal/no-dynamic-tests": {
       "count": 4

--- a/packages/eslint-plugin/tests/rules/return-await.test.ts
+++ b/packages/eslint-plugin/tests/rules/return-await.test.ts
@@ -1,5 +1,3 @@
-import type { InvalidTestCase } from '@typescript-eslint/rule-tester';
-
 import { noFormat } from '@typescript-eslint/rule-tester';
 
 import rule from '../../src/rules/return-await';
@@ -578,10 +576,8 @@ class C<R extends unknown> {
       output: 'const test = async () => Promise.resolve(1);',
     },
 
-    ...['error-handling-correctness-only', 'always', 'in-try-catch'].map(
-      option =>
-        ({
-          code: `
+    {
+      code: `
         async function test() {
           try {
             return Promise.resolve(1);
@@ -592,14 +588,14 @@ class C<R extends unknown> {
           }
         }
       `,
-          errors: [
+      errors: [
+        {
+          line: 4,
+          messageId: 'requiredPromiseAwait',
+          suggestions: [
             {
-              line: 4,
-              messageId: 'requiredPromiseAwait',
-              suggestions: [
-                {
-                  messageId: 'requiredPromiseAwaitSuggestion',
-                  output: `
+              messageId: 'requiredPromiseAwaitSuggestion',
+              output: `
         async function test() {
           try {
             return await Promise.resolve(1);
@@ -610,16 +606,16 @@ class C<R extends unknown> {
           }
         }
       `,
-                },
-              ],
             },
+          ],
+        },
+        {
+          line: 6,
+          messageId: 'requiredPromiseAwait',
+          suggestions: [
             {
-              line: 6,
-              messageId: 'requiredPromiseAwait',
-              suggestions: [
-                {
-                  messageId: 'requiredPromiseAwaitSuggestion',
-                  output: `
+              messageId: 'requiredPromiseAwaitSuggestion',
+              output: `
         async function test() {
           try {
             return Promise.resolve(1);
@@ -630,17 +626,127 @@ class C<R extends unknown> {
           }
         }
       `,
-                },
-              ],
             },
           ],
-          options: [option],
-          output: null,
-        }) satisfies InvalidTestCase<
-          'requiredPromiseAwait' | 'requiredPromiseAwaitSuggestion',
-          [string]
-        >,
-    ),
+        },
+      ],
+      options: ['error-handling-correctness-only'],
+      output: null,
+    },
+    {
+      code: `
+        async function test() {
+          try {
+            return Promise.resolve(1);
+          } catch (e) {
+            return Promise.resolve(2);
+          } finally {
+            console.log('cleanup');
+          }
+        }
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'requiredPromiseAwait',
+          suggestions: [
+            {
+              messageId: 'requiredPromiseAwaitSuggestion',
+              output: `
+        async function test() {
+          try {
+            return await Promise.resolve(1);
+          } catch (e) {
+            return Promise.resolve(2);
+          } finally {
+            console.log('cleanup');
+          }
+        }
+      `,
+            },
+          ],
+        },
+        {
+          line: 6,
+          messageId: 'requiredPromiseAwait',
+          suggestions: [
+            {
+              messageId: 'requiredPromiseAwaitSuggestion',
+              output: `
+        async function test() {
+          try {
+            return Promise.resolve(1);
+          } catch (e) {
+            return await Promise.resolve(2);
+          } finally {
+            console.log('cleanup');
+          }
+        }
+      `,
+            },
+          ],
+        },
+      ],
+      options: ['always'],
+      output: null,
+    },
+    {
+      code: `
+        async function test() {
+          try {
+            return Promise.resolve(1);
+          } catch (e) {
+            return Promise.resolve(2);
+          } finally {
+            console.log('cleanup');
+          }
+        }
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'requiredPromiseAwait',
+          suggestions: [
+            {
+              messageId: 'requiredPromiseAwaitSuggestion',
+              output: `
+        async function test() {
+          try {
+            return await Promise.resolve(1);
+          } catch (e) {
+            return Promise.resolve(2);
+          } finally {
+            console.log('cleanup');
+          }
+        }
+      `,
+            },
+          ],
+        },
+        {
+          line: 6,
+          messageId: 'requiredPromiseAwait',
+          suggestions: [
+            {
+              messageId: 'requiredPromiseAwaitSuggestion',
+              output: `
+        async function test() {
+          try {
+            return Promise.resolve(1);
+          } catch (e) {
+            return await Promise.resolve(2);
+          } finally {
+            console.log('cleanup');
+          }
+        }
+      `,
+            },
+          ],
+        },
+      ],
+      options: ['in-try-catch'],
+      output: null,
+    },
 
     {
       code: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #11049 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
* Change dynamic test cases using spread and map to handwritten ones
* Zero (0) existing recurring cases have been removed
* No further recurring cases exist