### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] treat void as nullish in no-unnecessary-condition

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -45,7 +45,9 @@ function isAlwaysNullish(type: ts.Type): boolean {
  * `any` or `unknown` to be nullable.
  */
 function isPossiblyNullish(type: ts.Type): boolean {
-  return tsutils.unionConstituents(type).some(isNullishType);
+  return tsutils
+    .unionConstituents(type)
+    .some(t => isNullishType(t) || isTypeFlagSet(t, ts.TypeFlags.Void));
 }
 
 function toStaticValue(

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -73,6 +73,10 @@ const result1 = foo() === undefined;
 const result2 = foo() == null;
     `,
     `
+declare function foo(): number | void;
+foo() ?? 1;
+    `,
+    `
 declare const bigInt: 0n | 1n;
 if (bigInt) {
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12226
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

treat `void` as nullish in `no-unnecessary-condition` for the `??` operator.

`void` behaves like `undefined` at runtime, but was not considered nullish by the rule, causing a false positive.

added a test for this case (test count: 298 → 299). All tests pass.