### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] fix crash "TypeError: checker.getTypeArguments is not a function"

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -277,6 +277,12 @@ export default createRule<Options, MessageIds>({
       return checker.getIndexInfosOfType(type).length > 0;
     }
 
+    function getTypeArguments(type: ts.Type): readonly ts.Type[] {
+      return tsutils.isTypeReference(type)
+        ? checker.getTypeArguments(type)
+        : [];
+    }
+
     function typeContains(
       type: ts.Type,
       predicate: (type: ts.Type) => boolean,
@@ -293,7 +299,7 @@ export default createRule<Options, MessageIds>({
         return type.types.some(t => typeContains(t, predicate, seen));
       }
       const nestedTypes = [
-        ...checker.getTypeArguments(type as ts.TypeReference),
+        ...getTypeArguments(type),
         ...type
           .getCallSignatures()
           .flatMap(sig => [
@@ -358,8 +364,8 @@ export default createRule<Options, MessageIds>({
     }
 
     function haveSameTypeArguments(uncast: ts.Type, cast: ts.Type): boolean {
-      const uncastArgs = checker.getTypeArguments(uncast as ts.TypeReference);
-      const castArgs = checker.getTypeArguments(cast as ts.TypeReference);
+      const uncastArgs = getTypeArguments(uncast);
+      const castArgs = getTypeArguments(cast);
       return (
         uncastArgs.length === castArgs.length &&
         uncastArgs.every((arg, i) => arg === castArgs[i])
@@ -514,9 +520,7 @@ export default createRule<Options, MessageIds>({
           ts.isParameter(param.valueDeclaration) &&
           param.valueDeclaration.dotDotDotToken
         ) {
-          const typeArgs = checker.getTypeArguments(
-            paramType as ts.TypeReference,
-          );
+          const typeArgs = getTypeArguments(paramType);
           if (typeArgs.length > 0) {
             paramType = typeArgs[0];
           }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -796,6 +796,30 @@ enum E {
 }
 const x: E = fn(n => n | 0, 0 as E);
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12244
+    `
+type BasePayload = { id: string };
+
+abstract class AbstractHandler {
+  constructor(_ctx: { token: number }) {}
+}
+
+abstract class AbstractPayloadHandler<
+  TPayload extends BasePayload = BasePayload,
+> extends AbstractHandler {}
+
+type HandlerCtor = new (ctx: { token: number }) => AbstractHandler;
+
+declare const registeredHandlers: HandlerCtor[];
+
+function example<TItem extends BasePayload>(
+  handlerClass: typeof AbstractPayloadHandler<TItem>,
+) {
+  registeredHandlers.includes(
+    handlerClass as new (...args: any[]) => AbstractPayloadHandler<TItem>,
+  );
+}
+    `,
     `
 function fn<T extends { type: string }, K extends string, V>(
   node: T,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12244
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
