### PR TITLE
chore(eslint-plugin): switch auto-generated test cases to hand-written in member-ordering-alphabetically-case-insensitive-order.test.ts

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -9,11 +9,6 @@
       "count": 1
     }
   },
-  "packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-case-insensitive-order.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 4
-    }
-  },
   "packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-order.test.ts": {
     "@typescript-eslint/internal/no-dynamic-tests": {
       "count": 4

--- a/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-case-insensitive-order.test.ts
+++ b/packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-case-insensitive-order.test.ts
@@ -1,14 +1,10 @@
-import type { RunTests } from '@typescript-eslint/rule-tester';
-
 import { RuleTester } from '@typescript-eslint/rule-tester';
-
-import type { MessageIds, Options } from '../../../src/rules/member-ordering';
 
 import rule, { defaultOrder } from '../../../src/rules/member-ordering';
 
 const ruleTester = new RuleTester();
 
-const sortedCiWithoutGrouping: RunTests<MessageIds, Options> = {
+ruleTester.run('member-ordering-alphabetically-case-insensitive-order', rule, {
   invalid: [
     // default option + interface + wrong order (multiple)
     {
@@ -152,103 +148,6 @@ const foo = class Foo {
         },
       ],
     },
-  ],
-  valid: [
-    // default option + interface + lower/upper case
-    {
-      code: `
-interface Foo {
-  a: b;
-  B: b;
-}
-      `,
-      options: [
-        {
-          default: {
-            memberTypes: 'never',
-            order: 'alphabetically-case-insensitive',
-          },
-        },
-      ],
-    },
-
-    // default option + type literal + lower/upper case
-    {
-      code: `
-type Foo = {
-  a: b;
-  B: b;
-};
-      `,
-      options: [
-        {
-          default: {
-            memberTypes: 'never',
-            order: 'alphabetically-case-insensitive',
-          },
-        },
-      ],
-    },
-
-    // default option + class + lower/upper case
-    {
-      code: `
-class Foo {
-  public static a: string;
-  public static B: string;
-}
-      `,
-      options: [
-        {
-          default: {
-            memberTypes: 'never',
-            order: 'alphabetically-case-insensitive',
-          },
-        },
-      ],
-    },
-
-    // default option + class expression + lower/upper case
-    {
-      code: `
-const foo = class Foo {
-  public static a: string;
-  public static B: string;
-};
-      `,
-      options: [
-        {
-          default: {
-            memberTypes: 'never',
-            order: 'alphabetically-case-insensitive',
-          },
-        },
-      ],
-    },
-
-    // default option + class + decorators
-    {
-      code: `
-class Foo {
-  public static a: string;
-  @Dec() static B: string;
-  public static c: string;
-}
-      `,
-      options: [
-        {
-          default: {
-            memberTypes: 'never',
-            order: 'alphabetically-case-insensitive',
-          },
-        },
-      ],
-    },
-  ],
-};
-
-const sortedCiWithGrouping: RunTests<MessageIds, Options> = {
-  invalid: [
     // default option + interface + wrong order within group and wrong group order + alphabetically
     {
       code: `
@@ -460,6 +359,96 @@ const foo = class Foo {
     },
   ],
   valid: [
+    // default option + interface + lower/upper case
+    {
+      code: `
+interface Foo {
+  a: b;
+  B: b;
+}
+      `,
+      options: [
+        {
+          default: {
+            memberTypes: 'never',
+            order: 'alphabetically-case-insensitive',
+          },
+        },
+      ],
+    },
+
+    // default option + type literal + lower/upper case
+    {
+      code: `
+type Foo = {
+  a: b;
+  B: b;
+};
+      `,
+      options: [
+        {
+          default: {
+            memberTypes: 'never',
+            order: 'alphabetically-case-insensitive',
+          },
+        },
+      ],
+    },
+
+    // default option + class + lower/upper case
+    {
+      code: `
+class Foo {
+  public static a: string;
+  public static B: string;
+}
+      `,
+      options: [
+        {
+          default: {
+            memberTypes: 'never',
+            order: 'alphabetically-case-insensitive',
+          },
+        },
+      ],
+    },
+
+    // default option + class expression + lower/upper case
+    {
+      code: `
+const foo = class Foo {
+  public static a: string;
+  public static B: string;
+};
+      `,
+      options: [
+        {
+          default: {
+            memberTypes: 'never',
+            order: 'alphabetically-case-insensitive',
+          },
+        },
+      ],
+    },
+
+    // default option + class + decorators
+    {
+      code: `
+class Foo {
+  public static a: string;
+  @Dec() static B: string;
+  public static c: string;
+}
+      `,
+      options: [
+        {
+          default: {
+            memberTypes: 'never',
+            order: 'alphabetically-case-insensitive',
+          },
+        },
+      ],
+    },
     // default option + interface + default order + alphabetically
     {
       code: `
@@ -721,12 +710,4 @@ class Foo {
       ],
     },
   ],
-};
-
-ruleTester.run('member-ordering-alphabetically-case-insensitive-order', rule, {
-  invalid: [
-    ...sortedCiWithoutGrouping.invalid,
-    ...sortedCiWithGrouping.invalid,
-  ],
-  valid: [...sortedCiWithoutGrouping.valid, ...sortedCiWithGrouping.valid],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12229 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

* Change dynamic test cases using spread and map to handwritten ones
* Zero (0) existing recurring cases have been removed
* No further recurring cases exist