### PR TITLE
chore(eslint-plugin): switch auto-generated test cases to hand-written in no-extraneous-class.test.ts

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -24,11 +24,6 @@
       "count": 12
     }
   },
-  "packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 12
-    }
-  },
   "packages/eslint-plugin/tests/rules/no-invalid-this.test.ts": {
     "@typescript-eslint/internal/no-dynamic-tests": {
       "count": 43

--- a/packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts
@@ -2,16 +2,6 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 
 import rule from '../../src/rules/no-extraneous-class';
 
-const empty = {
-  messageId: 'empty' as const,
-};
-const onlyStatic = {
-  messageId: 'onlyStatic' as const,
-};
-const onlyConstructor = {
-  messageId: 'onlyConstructor' as const,
-};
-
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-extraneous-class', rule, {
@@ -130,7 +120,11 @@ abstract class Foo {
   invalid: [
     {
       code: 'class Foo {}',
-      errors: [empty],
+      errors: [
+        {
+          messageId: 'empty',
+        },
+      ],
     },
     {
       code: `
@@ -149,7 +143,14 @@ export class Bar {
   }
 }
       `,
-      errors: [onlyStatic, onlyStatic],
+      errors: [
+        {
+          messageId: 'onlyStatic',
+        },
+        {
+          messageId: 'onlyStatic',
+        },
+      ],
     },
     {
       code: `
@@ -157,7 +158,11 @@ class Foo {
   constructor() {}
 }
       `,
-      errors: [onlyConstructor],
+      errors: [
+        {
+          messageId: 'onlyConstructor',
+        },
+      ],
     },
     {
       code: `
@@ -171,7 +176,14 @@ export class AClass {
   }
 }
       `,
-      errors: [onlyStatic, empty],
+      errors: [
+        {
+          messageId: 'onlyStatic',
+        },
+        {
+          messageId: 'empty',
+        },
+      ],
     },
     {
       // https://github.com/typescript-eslint/typescript-eslint/issues/170
@@ -180,7 +192,11 @@ export default class {
   static hello() {}
 }
       `,
-      errors: [onlyStatic],
+      errors: [
+        {
+          messageId: 'onlyStatic',
+        },
+      ],
     },
     {
       code: `
@@ -216,7 +232,11 @@ class Foo {
       code: `
 abstract class Foo {}
       `,
-      errors: [empty],
+      errors: [
+        {
+          messageId: 'empty',
+        },
+      ],
     },
     {
       code: `
@@ -224,7 +244,11 @@ abstract class Foo {
   static property: string;
 }
       `,
-      errors: [onlyStatic],
+      errors: [
+        {
+          messageId: 'onlyStatic',
+        },
+      ],
     },
     {
       code: `
@@ -232,7 +256,11 @@ abstract class Foo {
   constructor() {}
 }
       `,
-      errors: [onlyConstructor],
+      errors: [
+        {
+          messageId: 'onlyConstructor',
+        },
+      ],
     },
     {
       code: `
@@ -240,7 +268,11 @@ class Foo {
   static accessor prop: string;
 }
       `,
-      errors: [onlyStatic],
+      errors: [
+        {
+          messageId: 'onlyStatic',
+        },
+      ],
     },
     {
       code: `
@@ -248,7 +280,11 @@ abstract class Foo {
   static accessor prop: string;
 }
       `,
-      errors: [onlyStatic],
+      errors: [
+        {
+          messageId: 'onlyStatic',
+        },
+      ],
     },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12232 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

* Change dynamic test cases using spread and map to handwritten ones
* Zero (0) existing recurring cases have been removed
* No further recurring cases exist