### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] preserve index signatures in undefined unions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -274,7 +274,9 @@ export default createRule<Options, MessageIds>({
     }
 
     function hasIndexSignature(type: ts.Type): boolean {
-      return checker.getIndexInfosOfType(type).length > 0;
+      return tsutils
+        .unionConstituents(type)
+        .some(part => checker.getIndexInfosOfType(part).length > 0);
     }
 
     function getTypeArguments(type: ts.Type): readonly ts.Type[] {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -845,6 +845,11 @@ fn({
 declare const a: number[] | number | undefined;
 const b: number[] = a ?? ([0] as any);
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12249
+    `
+const context: { meta: Record<string, unknown> | undefined } = { meta: {} };
+const meta = context.meta as { schema?: object } | undefined;
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12249
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
