### PR TITLE
test: make no-this-alias tests fully static

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,7 +1,47 @@
 {
-  "packages/eslint-plugin/tests/rules/no-this-alias.test.ts": {
+  "packages/eslint-plugin-internal/tests/rules/plugin-test-formatting.test.ts": {
     "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 14
+      "count": 26
+    }
+  },
+  "packages/eslint-plugin/tests/rules/dot-notation.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 1
+    }
+  },
+  "packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-case-insensitive-order.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 4
+    }
+  },
+  "packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-order.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 4
+    }
+  },
+  "packages/eslint-plugin/tests/rules/naming-convention/naming-convention.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 12
+    }
+  },
+  "packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 12
+    }
+  },
+  "packages/eslint-plugin/tests/rules/no-invalid-this.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 43
+    }
+  },
+  "packages/eslint-plugin/tests/rules/no-loop-func.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 2
+    }
+  },
+  "packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 44
     }
   },
   "packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts": {
@@ -9,14 +49,34 @@
       "count": 1
     }
   },
+  "packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 2
+    }
+  },
   "packages/eslint-plugin/tests/rules/no-useless-empty-export.test.ts": {
     "@typescript-eslint/internal/no-dynamic-tests": {
       "count": 9
     }
   },
+  "packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 42
+    }
+  },
   "packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts": {
     "@typescript-eslint/internal/no-dynamic-tests": {
       "count": 17
+    }
+  },
+  "packages/eslint-plugin/tests/rules/return-await.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 1
+    }
+  },
+  "packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts": {
+    "@typescript-eslint/internal/no-dynamic-tests": {
+      "count": 4
     }
   }
 }

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,57 +1,7 @@
 {
-  "packages/eslint-plugin-internal/tests/rules/plugin-test-formatting.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 26
-    }
-  },
-  "packages/eslint-plugin/tests/rules/dot-notation.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 1
-    }
-  },
-  "packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-case-insensitive-order.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 4
-    }
-  },
-  "packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-order.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 4
-    }
-  },
-  "packages/eslint-plugin/tests/rules/naming-convention/naming-convention.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 12
-    }
-  },
-  "packages/eslint-plugin/tests/rules/no-extraneous-class.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 12
-    }
-  },
-  "packages/eslint-plugin/tests/rules/no-invalid-this.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 43
-    }
-  },
-  "packages/eslint-plugin/tests/rules/no-loop-func.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 2
-    }
-  },
-  "packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 44
-    }
-  },
   "packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts": {
     "@typescript-eslint/internal/no-dynamic-tests": {
       "count": 1
-    }
-  },
-  "packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 2
     }
   },
   "packages/eslint-plugin/tests/rules/no-useless-empty-export.test.ts": {
@@ -59,24 +9,9 @@
       "count": 9
     }
   },
-  "packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 42
-    }
-  },
   "packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts": {
     "@typescript-eslint/internal/no-dynamic-tests": {
       "count": 17
-    }
-  },
-  "packages/eslint-plugin/tests/rules/return-await.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 1
-    }
-  },
-  "packages/eslint-plugin/tests/rules/sort-type-constituents.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 4
     }
   }
 }

--- a/packages/eslint-plugin/tests/rules/no-this-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-this-alias.test.ts
@@ -2,16 +2,6 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 
 import rule from '../../src/rules/no-this-alias';
 
-const idError = {
-  messageId: 'thisAssignment' as const,
-};
-const destructureError = {
-  messageId: 'thisDestructure' as const,
-};
-const arrayDestructureError = {
-  messageId: 'thisDestructure' as const,
-};
-
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-this-alias', rule, {
@@ -50,27 +40,18 @@ declare module 'foo' {
   invalid: [
     {
       code: 'const self = this;',
-      errors: [idError],
-      options: [
-        {
-          allowDestructuring: true,
-        },
-      ],
-    },
-    {
-      code: 'const self = this;',
-      errors: [idError],
+      errors: [{ messageId: 'thisAssignment' as const }],
     },
     {
       code: `
 let that;
 that = this;
       `,
-      errors: [idError],
+      errors: [{ messageId: 'thisAssignment' as const }],
     },
     {
       code: 'const { props, state } = this;',
-      errors: [destructureError],
+      errors: [{ messageId: 'thisDestructure' as const }],
       options: [
         {
           allowDestructuring: false,
@@ -88,7 +69,11 @@ const testLambda = () => {
   const inLambda = this;
 };
       `,
-      errors: [idError, idError, idError],
+      errors: [
+        { messageId: 'thisAssignment' as const },
+        { messageId: 'thisAssignment' as const },
+        { messageId: 'thisAssignment' as const },
+      ],
     },
     {
       code: `
@@ -112,13 +97,13 @@ class TestClass {
 }
       `,
       errors: [
-        idError,
-        idError,
-        idError,
-        destructureError,
-        destructureError,
-        arrayDestructureError,
-        arrayDestructureError,
+        { messageId: 'thisAssignment' as const },
+        { messageId: 'thisAssignment' as const },
+        { messageId: 'thisAssignment' as const },
+        { messageId: 'thisDestructure' as const },
+        { messageId: 'thisDestructure' as const },
+        { messageId: 'thisDestructure' as const },
+        { messageId: 'thisDestructure' as const },
       ],
       options: [
         {

--- a/packages/eslint-plugin/tests/rules/no-this-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-this-alias.test.ts
@@ -41,6 +41,15 @@ declare module 'foo' {
     {
       code: 'const self = this;',
       errors: [{ messageId: 'thisAssignment' as const }],
+      options: [
+        {
+          allowDestructuring: true,
+        },
+      ],
+    },
+    {
+      code: 'const self = this;',
+      errors: [{ messageId: 'thisAssignment' as const }],
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/no-this-alias.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-this-alias.test.ts
@@ -40,7 +40,7 @@ declare module 'foo' {
   invalid: [
     {
       code: 'const self = this;',
-      errors: [{ messageId: 'thisAssignment' as const }],
+      errors: [{ messageId: 'thisAssignment' }],
       options: [
         {
           allowDestructuring: true,
@@ -49,18 +49,18 @@ declare module 'foo' {
     },
     {
       code: 'const self = this;',
-      errors: [{ messageId: 'thisAssignment' as const }],
+      errors: [{ messageId: 'thisAssignment' }],
     },
     {
       code: `
 let that;
 that = this;
       `,
-      errors: [{ messageId: 'thisAssignment' as const }],
+      errors: [{ messageId: 'thisAssignment' }],
     },
     {
       code: 'const { props, state } = this;',
-      errors: [{ messageId: 'thisDestructure' as const }],
+      errors: [{ messageId: 'thisDestructure' }],
       options: [
         {
           allowDestructuring: false,
@@ -79,9 +79,9 @@ const testLambda = () => {
 };
       `,
       errors: [
-        { messageId: 'thisAssignment' as const },
-        { messageId: 'thisAssignment' as const },
-        { messageId: 'thisAssignment' as const },
+        { messageId: 'thisAssignment' },
+        { messageId: 'thisAssignment' },
+        { messageId: 'thisAssignment' },
       ],
     },
     {
@@ -106,13 +106,13 @@ class TestClass {
 }
       `,
       errors: [
-        { messageId: 'thisAssignment' as const },
-        { messageId: 'thisAssignment' as const },
-        { messageId: 'thisAssignment' as const },
-        { messageId: 'thisDestructure' as const },
-        { messageId: 'thisDestructure' as const },
-        { messageId: 'thisDestructure' as const },
-        { messageId: 'thisDestructure' as const },
+        { messageId: 'thisAssignment' },
+        { messageId: 'thisAssignment' },
+        { messageId: 'thisAssignment' },
+        { messageId: 'thisDestructure' },
+        { messageId: 'thisDestructure' },
+        { messageId: 'thisDestructure' },
+        { messageId: 'thisDestructure' },
       ],
       options: [
         {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12235
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues/12235)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Updated RuleTester cases in `no-this-alias.test.ts` to be fully static inline objects.

- Removed shared constants previously used for error definitions
- Inlined all `errors` objects directly within each test case
- Eliminated indirect or reusable test structures to ensure all cases are explicitly defined

This aligns with the repository’s effort to move away from dynamically constructed test cases and improve readability and maintainability.

No changes to rule behavior; this is a test-only update.