### PR TITLE
chore(eslint-plugin): switch auto-generated test cases to hand-written in no-unsafe-enum-comparison.test.ts

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -54,11 +54,6 @@
       "count": 1
     }
   },
-  "packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 2
-    }
-  },
   "packages/eslint-plugin/tests/rules/no-useless-empty-export.test.ts": {
     "@typescript-eslint/internal/no-dynamic-tests": {
       "count": 9

--- a/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-enum-comparison.test.ts
@@ -498,15 +498,19 @@ ruleTester.run('no-unsafe-enum-comparison', rule, {
       errors: [{ messageId: 'mismatchedCondition' }],
     },
     {
-      code:
-        'enum Fruit { Apple, Banana, Cherry }' +
-        `enum Fruit2 {
+      code: `
+enum Fruit {
+  Apple,
+  Banana,
+  Cherry,
+}
+enum Fruit2 {
   Apple2,
   Banana2,
   Cherry2,
 }
-      Fruit.Apple === Fruit2.Apple2;
-        `,
+Fruit.Apple === Fruit2.Apple2;
+      `,
       errors: [{ messageId: 'mismatchedCondition' }],
     },
     {
@@ -526,16 +530,20 @@ ruleTester.run('no-unsafe-enum-comparison', rule, {
       errors: [{ messageId: 'mismatchedCondition' }],
     },
     {
-      code:
-        'enum Fruit { Apple, Banana, Cherry }' +
-        `enum Fruit2 {
+      code: `
+enum Fruit {
+  Apple,
+  Banana,
+  Cherry,
+}
+enum Fruit2 {
   Apple2,
   Banana2,
   Cherry2,
 }
-      const fruit = Fruit.Apple;
-      fruit === Fruit2.Apple2;
-        `,
+const fruit = Fruit.Apple;
+fruit === Fruit2.Apple2;
+      `,
       errors: [{ messageId: 'mismatchedCondition' }],
     },
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12238 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

* Change dynamic test cases using spread and map to handwritten ones
* Zero (0) existing recurring cases have been removed
* No further recurring cases exist