### PR TITLE
chore(eslint-plugin): switch auto-generated test cases to hand-written in dot-notation.test.ts

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4,11 +4,6 @@
       "count": 26
     }
   },
-  "packages/eslint-plugin/tests/rules/dot-notation.test.ts": {
-    "@typescript-eslint/internal/no-dynamic-tests": {
-      "count": 1
-    }
-  },
   "packages/eslint-plugin/tests/rules/member-ordering/member-ordering-alphabetically-case-insensitive-order.test.ts": {
     "@typescript-eslint/internal/no-dynamic-tests": {
       "count": 4

--- a/packages/eslint-plugin/tests/rules/dot-notation.test.ts
+++ b/packages/eslint-plugin/tests/rules/dot-notation.test.ts
@@ -314,32 +314,38 @@ a
       `,
     },
     {
-      code:
-        'getResource()\n' +
-        '    .then(function(){})\n' +
-        '    ["catch"](function(){})\n' +
-        '    .then(function(){})\n' +
-        '    ["catch"](function(){});',
+      code: `
+getResource()
+  .then(function () {})
+  ['catch'](function () {})
+  .then(function () {})
+  ['catch'](function () {});
+      `,
       errors: [
         {
-          column: 6,
-          data: { key: q('catch') },
-          line: 3,
+          column: 4,
+          data: {
+            key: '"catch"',
+          },
+          line: 4,
           messageId: 'useDot',
         },
         {
-          column: 6,
-          data: { key: q('catch') },
-          line: 5,
+          column: 4,
+          data: {
+            key: '"catch"',
+          },
+          line: 6,
           messageId: 'useDot',
         },
       ],
-      output:
-        'getResource()\n' +
-        '    .then(function(){})\n' +
-        '    .catch(function(){})\n' +
-        '    .then(function(){})\n' +
-        '    .catch(function(){});',
+      output: `
+getResource()
+  .then(function () {})
+  .catch(function () {})
+  .then(function () {})
+  .catch(function () {});
+      `,
     },
     {
       code: noFormat`


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12228 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

* Change dynamic test cases using spread and map to handwritten ones
* Zero (0) existing recurring cases have been removed
* No further recurring cases exist