### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] preserve phantom type arguments in generic inference

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -280,9 +280,10 @@ export default createRule<Options, MessageIds>({
     }
 
     function getTypeArguments(type: ts.Type): readonly ts.Type[] {
-      return tsutils.isTypeReference(type)
-        ? checker.getTypeArguments(type)
-        : [];
+      return (
+        type.aliasTypeArguments ??
+        (tsutils.isTypeReference(type) ? checker.getTypeArguments(type) : [])
+      );
     }
 
     function typeContains(
@@ -320,6 +321,10 @@ export default createRule<Options, MessageIds>({
       return typeContains(type, t =>
         isTypeFlagSet(t, ts.TypeFlags.TypeVariable | ts.TypeFlags.Index),
       );
+    }
+
+    function hasPhantomTypeArguments(type: ts.Type): boolean {
+      return isEmptyObjectType(type) && getTypeArguments(type).length > 0;
     }
 
     function hasTypeParams(sig: ts.Signature): boolean {
@@ -658,6 +663,19 @@ export default createRule<Options, MessageIds>({
       return false;
     }
 
+    function hasPhantomTypeArgumentMismatch(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+      uncastType: ts.Type,
+      contextualType: ts.Type,
+    ): boolean {
+      return (
+        isInGenericContext(node) &&
+        (hasPhantomTypeArguments(uncastType) ||
+          hasPhantomTypeArguments(contextualType)) &&
+        !haveSameTypeArguments(uncastType, contextualType)
+      );
+    }
+
     const SKIP_PARENT_TYPES = new Set([
       AST_NODE_TYPES.TSAsExpression,
       AST_NODE_TYPES.TSTypeAssertion,
@@ -882,6 +900,7 @@ export default createRule<Options, MessageIds>({
             !typeAnnotationIsConstAssertion &&
             !containsAny(uncastType) &&
             anyInvolvedInContextualCheck &&
+            !hasPhantomTypeArgumentMismatch(node, uncastType, contextualType) &&
             (castIsAny || !genericsMismatch(uncastType, contextualType)) &&
             (contextualTypeIsAny ||
               checker.isTypeAssignableTo(uncastType, contextualType)) &&

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -852,19 +852,23 @@ const meta = context.meta as { schema?: object } | undefined;
     `,
     // https://github.com/typescript-eslint/typescript-eslint/issues/12250
     `
-type Test<T extends Record<string, unknown>> = {}
+type Test<T extends Record<string, unknown>> = {};
 
-function inferred<T extends Test<never>[]>(_input: { addons?: T }): {
-  options: T extends Test<infer C>[] ? C : never
+function inferred<T extends Test<never>[]>(_input: {
+  addons?: T;
+}): {
+  options: T extends Test<infer C>[] ? C : never;
 } {
   return {
-    options: {} as T extends Test<infer C>[] ? C : never
-  }
+    options: {} as T extends Test<infer C>[] ? C : never,
+  };
 }
 
-const test = inferred({ addons: [{} as Test<{ parameters: { potato: boolean } }>] });
+const test = inferred({
+  addons: [{} as Test<{ parameters: { potato: boolean } }>],
+});
 
-console.log(test.options.parameters.potato)
+console.log(test.options.parameters.potato);
     `,
   ],
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -850,6 +850,22 @@ const b: number[] = a ?? ([0] as any);
 const context: { meta: Record<string, unknown> | undefined } = { meta: {} };
 const meta = context.meta as { schema?: object } | undefined;
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12250
+    `
+type Test<T extends Record<string, unknown>> = {}
+
+function inferred<T extends Test<never>[]>(_input: { addons?: T }): {
+  options: T extends Test<infer C>[] ? C : never
+} {
+  return {
+    options: {} as T extends Test<infer C>[] ? C : never
+  }
+}
+
+const test = inferred({ addons: [{} as Test<{ parameters: { potato: boolean } }>] });
+
+console.log(test.options.parameters.potato)
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12250
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
