### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] avoid flagging number-to-enum assertions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -832,6 +832,80 @@ export default createRule<Options, MessageIds>({
       }
     }
 
+    /**
+     * Whether `identifier` is used as a computed member key (`values[color]`).
+     * Resolves the binding via `getScope` + `variable.references` so a later
+     * line like `values[color]` is found after `const color = ...`.
+     *
+     * @see https://github.com/typescript-eslint/typescript-eslint/issues/12271
+     */
+    function isIdentifierUsedAsComputedMemberProperty(
+      identifier: TSESTree.Identifier,
+    ): boolean {
+      const scope = context.sourceCode.getScope(identifier);
+      const variable = scope.variables.find(scopeVar =>
+        scopeVar.identifiers.includes(identifier),
+      );
+
+      if (!variable) {
+        return false;
+      }
+
+      return variable.references.some(reference => {
+        const referenceIdentifier = reference.identifier;
+        const parent = referenceIdentifier.parent;
+        return (
+          parent.type === AST_NODE_TYPES.MemberExpression &&
+          parent.computed &&
+          parent.property === referenceIdentifier
+        );
+      });
+    }
+
+    /**
+     * `number as Enum` used for enum-key indexing only (#12271). Does not
+     * exempt other sites (e.g. function arguments). Resolves operand and
+     * assertion-target types from the node.
+     *
+     * @see https://github.com/typescript-eslint/typescript-eslint/issues/12271
+     */
+    function isNumberToEnumAssertionUsedForIndexing(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+    ): boolean {
+      const expressionType = services.getTypeAtLocation(node.expression);
+      const assertedType = services.getTypeAtLocation(node.typeAnnotation);
+      const isExpressionNumberLike = isTypeFlagSet(
+        expressionType,
+        ts.TypeFlags.NumberLike,
+      );
+      const isAssertedTypeEnumLike = isTypeFlagSet(
+        assertedType,
+        ts.TypeFlags.EnumLike,
+      );
+
+      if (!isExpressionNumberLike || !isAssertedTypeEnumLike) {
+        return false;
+      }
+
+      if (
+        node.parent.type === AST_NODE_TYPES.MemberExpression &&
+        node.parent.computed &&
+        node.parent.property === node
+      ) {
+        return true;
+      }
+
+      if (
+        node.parent.type === AST_NODE_TYPES.VariableDeclarator &&
+        node.parent.init === node &&
+        node.parent.id.type === AST_NODE_TYPES.Identifier
+      ) {
+        return isIdentifierUsedAsComputedMemberProperty(node.parent.id);
+      }
+
+      return false;
+    }
+
     return {
       'TSAsExpression, TSTypeAssertion'(
         node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
@@ -870,19 +944,7 @@ export default createRule<Options, MessageIds>({
           : !typeAnnotationIsConstAssertion;
 
         if (typeIsUnchanged && wouldSameTypeBeInferred) {
-          // `node.expression` is the value before `as ...`. For cases like
-          // `+valueStr as Color`, the expression type is `number`.
-          //
-          // If a numeric expression is asserted to an enum-like type (`as Color`),
-          // that assertion can change/narrow the apparent type from `number` to
-          // the enum domain for downstream checks (for example enum-indexed access).
-          // Treat this as meaningful, so we do not report unnecessaryAssertion.
-          const expressionType = services.getTypeAtLocation(node.expression);
-          const isNumber = tsutils.isTypeFlagSet(
-            expressionType,
-            ts.TypeFlags.Number,
-          );
-          if (isNumber && isTypeFlagSet(castType, ts.TypeFlags.EnumLike)) {
+          if (isNumberToEnumAssertionUsedForIndexing(node)) {
             return;
           }
 

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -870,6 +870,19 @@ export default createRule<Options, MessageIds>({
           : !typeAnnotationIsConstAssertion;
 
         if (typeIsUnchanged && wouldSameTypeBeInferred) {
+          // `node.expression` is the value before `as ...`. For cases like
+          // `+valueStr as Color`, the expression type is `number`.
+          //
+          // If a numeric expression is asserted to an enum-like type (`as Color`),
+          // that assertion can change/narrow the apparent type from `number` to
+          // the enum domain for downstream checks (for example enum-indexed access).
+          // Treat this as meaningful, so we do not report unnecessaryAssertion.
+          const expressionType = services.getTypeAtLocation(node.expression);
+          const isNumber = (expressionType.flags & ts.TypeFlags.Number) !== 0;
+          if (isNumber && isTypeFlagSet(castType, ts.TypeFlags.EnumLike)) {
+            return;
+          }
+
           context.report({
             node,
             messageId: 'unnecessaryAssertion',

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -878,7 +878,10 @@ export default createRule<Options, MessageIds>({
           // the enum domain for downstream checks (for example enum-indexed access).
           // Treat this as meaningful, so we do not report unnecessaryAssertion.
           const expressionType = services.getTypeAtLocation(node.expression);
-          const isNumber = (expressionType.flags & ts.TypeFlags.Number) !== 0;
+          const isNumber = tsutils.isTypeFlagSet(
+            expressionType,
+            ts.TypeFlags.Number,
+          );
           if (isNumber && isTypeFlagSet(castType, ts.TypeFlags.EnumLike)) {
             return;
           }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -882,6 +882,7 @@ const test = inferred({
 });
 
 console.log(test.options.parameters.potato);
+    `,
     // reporter repro: should not flag enum-typed index usage assertions
     `
 enum Color { Red, Green, Blue }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -882,6 +882,55 @@ const test = inferred({
 });
 
 console.log(test.options.parameters.potato);
+    // reporter repro: should not flag enum-typed index usage assertions
+    `
+enum Color { Red, Green, Blue }
+const values: Record<Color, string> = {
+  [Color.Red]: '#f00',
+  [Color.Green]: '#0f0',
+  [Color.Blue]: '#00f',
+}
+
+function example1(valueStr: string) {
+  const color = +valueStr as Color;
+  values[color] = 'updated';
+}
+
+function eaxmple2(valueStr: string) {
+  const color: Color = +valueStr;
+  values[color] = 'updated';
+}
+
+function update3(valueStr: string) {
+  values[+valueStr as Color] = 'updated';
+}
+    `,
+    `
+    enum Color { Red, Green, Blue }
+const values: Record<Color, string> = {
+  [Color.Red]: '#f00',
+  [Color.Green]: '#0f0',
+  [Color.Blue]: '#00f',
+}
+
+function example1(valueStr: string) {
+  const color = +valueStr as Color;
+  values[color] = 'updated';
+}
+
+    `,
+    `
+    enum Color { Red, Green, Blue }
+const values: Record<Color, string> = {
+  [Color.Red]: '#f00',
+  [Color.Green]: '#0f0',
+  [Color.Blue]: '#00f',
+}
+
+function eaxmple2(valueStr: string) {
+  const color: Color = +valueStr;
+  values[color] = 'updated';
+}
     `,
   ],
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -883,7 +883,7 @@ const test = inferred({
 
 console.log(test.options.parameters.potato);
     `,
-    // reporter repro: should not flag enum-typed index usage assertions
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12271
     `
 enum Color {
   Red,
@@ -901,7 +901,7 @@ function example1(valueStr: string) {
   values[color] = 'updated';
 }
 
-function eaxmple2(valueStr: string) {
+function example2(valueStr: string) {
   const color: Color = +valueStr;
   values[color] = 'updated';
 }
@@ -939,7 +939,7 @@ const values: Record<Color, string> = {
   [Color.Blue]: '#00f',
 };
 
-function eaxmple2(valueStr: string) {
+function example2(valueStr: string) {
   const color: Color = +valueStr;
   values[color] = 'updated';
 }
@@ -947,6 +947,48 @@ function eaxmple2(valueStr: string) {
   ],
 
   invalid: [
+    // https://github.com/typescript-eslint/typescript-eslint/pull/12272#pullrequestreview-4170959967
+    {
+      code: `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+const values: Record<Color, string> = {
+  [Color.Red]: '#f00',
+  [Color.Green]: '#0f0',
+  [Color.Blue]: '#00f',
+};
+
+function update(valueStr: string) {
+  function subUpdate(color: Color) {
+    values[color] = 'updated';
+  }
+  subUpdate(+valueStr as Color);
+}
+      `,
+      errors: [{ messageId: 'unnecessaryAssertion' }],
+      output: `
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+const values: Record<Color, string> = {
+  [Color.Red]: '#f00',
+  [Color.Green]: '#0f0',
+  [Color.Blue]: '#00f',
+};
+
+function update(valueStr: string) {
+  function subUpdate(color: Color) {
+    values[color] = 'updated';
+  }
+  subUpdate(+valueStr);
+}
+      `,
+    },
     {
       code: 'const foo = <3>3;',
       errors: [{ column: 13, line: 1, messageId: 'unnecessaryAssertion' }],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -885,12 +885,16 @@ console.log(test.options.parameters.potato);
     `,
     // reporter repro: should not flag enum-typed index usage assertions
     `
-enum Color { Red, Green, Blue }
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
 const values: Record<Color, string> = {
   [Color.Red]: '#f00',
   [Color.Green]: '#0f0',
   [Color.Blue]: '#00f',
-}
+};
 
 function example1(valueStr: string) {
   const color = +valueStr as Color;
@@ -907,26 +911,33 @@ function update3(valueStr: string) {
 }
     `,
     `
-    enum Color { Red, Green, Blue }
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
 const values: Record<Color, string> = {
   [Color.Red]: '#f00',
   [Color.Green]: '#0f0',
   [Color.Blue]: '#00f',
-}
+};
 
 function example1(valueStr: string) {
   const color = +valueStr as Color;
   values[color] = 'updated';
 }
-
     `,
     `
-    enum Color { Red, Green, Blue }
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
 const values: Record<Color, string> = {
   [Color.Red]: '#f00',
   [Color.Green]: '#0f0',
   [Color.Blue]: '#00f',
-}
+};
 
 function eaxmple2(valueStr: string) {
   const color: Color = +valueStr;


### PR DESCRIPTION
## Summary

This PR handles following cases:

- **update3**() (values[+valueStr as Color] = 'updated') is treated as valid (false positive fixed from [#12271](https://github.com/typescript-eslint/typescript-eslint/issues/12271)).
- **example1**() (const color = +valueStr as Color; values[color] = 'updated') is treated as valid under the same indexing-focused exception. (See issue [#12271](https://github.com/typescript-eslint/typescript-eslint/issues/12271) for details)
- **example2**() (const color: Color = +valueStr; values[color] = 'updated') is unchanged (no assertion syntax for this rule). (See issue [#12271](https://github.com/typescript-eslint/typescript-eslint/issues/12271) for details)
- **subUpdate**(+valueStr as Color) remains invalid, per [review comment #4170959967](https://github.com/typescript-eslint/typescript-eslint/pull/12272#pullrequestreview-4170959967).
- Adds test cases for all of above cases.
- `isNumberToEnumAssertionUsedForIndexing()` detects direct computed-index usage (for example, values[+valueStr as Color]) and skips reporting for that.
- `isIdentifierUsedAsComputedMemberProperty()` detects when an identifier initialized from an assertion (for example, const color = +valueStr as Color) is later used as a computed index key (values[color]) and skips reporting for that as well.

## Test plan
- [x] `pnpm vitest --config=vitest.config.mts packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts`

Fixes typescript-eslint/typescript-eslint#12271