### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] avoid false positive in logical assignment assertions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -614,6 +614,19 @@ export default createRule<Options, MessageIds>({
       return assignmentParent.type !== AST_NODE_TYPES.ExpressionStatement;
     }
 
+    function isRightHandSideOfLogicalAssignment(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+    ): boolean {
+      const { parent } = node;
+      return (
+        parent.type === AST_NODE_TYPES.AssignmentExpression &&
+        parent.right === node &&
+        (parent.operator === '&&=' ||
+          parent.operator === '||=' ||
+          parent.operator === '??=')
+      );
+    }
+
     function isInGenericContext(
       node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
     ): boolean {
@@ -700,6 +713,7 @@ export default createRule<Options, MessageIds>({
         isInDestructuringDeclaration(node) ||
         isPropertyInProblematicContext(node) ||
         isAssignmentInNonStatementContext(node) ||
+        isRightHandSideOfLogicalAssignment(node) ||
         isArgumentToOverloadedFunction(node)
       ) {
         return true;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -316,6 +316,19 @@ const item = arr[0] as object;
 declare const arr: (object | undefined)[];
 const item = <object>arr[0];
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12245
+    `
+const array: object[] = [{}];
+
+let nullish: object | undefined;
+nullish ??= array[1] as object | undefined;
+
+let falsy: object | undefined;
+falsy ||= array[1] as object | undefined;
+
+let truthy: object | undefined = {};
+truthy &&= array[1] as object | undefined;
+    `,
     {
       code: `
 function foo(item: string) {}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12245
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Skips the contextual unnecessary-assertion check for logical assignment RHS expressions, where TypeScript's flow analysis can otherwise change the apparent type after assignment.

Adds a regression test for the `??=` array access case from #12245.

💖