### PR TITLE
fix(type-utils): exact package name matching to prevent prefix false positives

### DIFF
--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -28,6 +28,18 @@ function typeDeclaredInDeclareModule(
   );
 }
 
+/**
+ * Extracts the bare package name from a module specifier that may include
+ * subpath segments (e.g. `@angular/common/http` → `@angular/common`,
+ * `lodash/fp` → `lodash`).
+ */
+function extractPackageName(moduleSpecifier: string): string {
+  if (moduleSpecifier.startsWith('@')) {
+    return moduleSpecifier.split('/').slice(0, 2).join('/');
+  }
+  return moduleSpecifier.split('/')[0];
+}
+
 function typeDeclaredInDeclarationFile(
   packageName: string,
   declarationFiles: ts.SourceFile[],
@@ -36,13 +48,19 @@ function typeDeclaredInDeclarationFile(
   // Handle scoped packages: if the name starts with @, remove it and replace / with __
   const typesPackageName = packageName.replace(/^@([^/]+)\//, '$1__');
 
-  const matcher = new RegExp(`${packageName}|${typesPackageName}`);
   return declarationFiles.some(declaration => {
+    if (!program.isSourceFileFromExternalLibrary(declaration)) {
+      return false;
+    }
     const packageIdName = program.sourceFileToPackageName.get(declaration.path);
+    if (packageIdName == null) {
+      return false;
+    }
+    const extracted = extractPackageName(packageIdName);
     return (
-      packageIdName != null &&
-      matcher.test(packageIdName) &&
-      program.isSourceFileFromExternalLibrary(declaration)
+      extracted === packageName ||
+      extracted === typesPackageName ||
+      extracted === `@types/${typesPackageName}`
     );
   });
 }

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -576,6 +576,23 @@ describe('TypeOrValueSpecifier', () => {
         'import type {Node as TsNode} from "typescript"; type Test = TsNode;',
         { from: 'package', name: 'TsNode', package: 'typescript' },
       ],
+      // Regression for #11946: a package name prefix must NOT match the full package name.
+      [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: 'Node', package: 'typescrip' },
+      ],
+      [
+        'import {SemVer} from "semver"; type Test = SemVer;',
+        { from: 'package', name: 'SemVer', package: 'semve' },
+      ],
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@babel/code',
+        },
+      ],
     ] as const satisfies [string, TypeOrValueSpecifier][])(
       "doesn't match a mismatched package specifier: %s\n\t%s",
       ([code, typeOrValueSpecifier], { expect }) => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11946
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The `typeDeclaredInDeclarationFile` helper was building a regex from the user-supplied package name with no anchors, so a specifier like `"typescrip"` would match against `"typescript"` because `RegExp.test` only needs a substring. The same applied to scoped packages: `"@babel/code"` matched `"@babel/code-frame"`.

The fix adds an `extractPackageName` helper that strips any subpath segments from the specifier returned by `sourceFileToPackageName` (e.g. `@angular/common/http` → `@angular/common`, `lodash/fp` → `lodash`), then compares with `===` against the user-supplied name and its `@types/…` form. Three regression tests assert that truncated package names no longer produce false positives.

I used AI assistance in developing this fix per the [AI policy](https://typescript-eslint.io/contributing/ai-policy).