### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] preserve evolving array assertions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -317,6 +317,18 @@ export default createRule<Options, MessageIds>({
       return typeContains(type, t => isTypeFlagSet(t, ts.TypeFlags.Any));
     }
 
+    // `NonInferrableType` is an internal object flag used for auto/evolving
+    // `any` types and is intentionally not exposed in TypeScript's d.ts.
+    const nonInferrableTypeObjectFlag = 1 << 18;
+
+    function isNonInferrableAnyType(type: ts.Type): boolean {
+      return (
+        isTypeFlagSet(type, ts.TypeFlags.Any) &&
+        ((type as ts.ObjectType).objectFlags & nonInferrableTypeObjectFlag) !==
+          0
+      );
+    }
+
     function containsTypeVariable(type: ts.Type): boolean {
       return typeContains(type, t =>
         isTypeFlagSet(t, ts.TypeFlags.TypeVariable | ts.TypeFlags.Index),
@@ -893,6 +905,8 @@ export default createRule<Options, MessageIds>({
             contextualType,
             ts.TypeFlags.Any,
           );
+          const contextualTypeIsNonInferrableAny =
+            isNonInferrableAnyType(contextualType);
 
           const isCallArgument =
             (node.parent.type === AST_NODE_TYPES.CallExpression ||
@@ -900,7 +914,9 @@ export default createRule<Options, MessageIds>({
             node.parent.arguments.includes(node);
 
           const anyInvolvedInContextualCheck = contextualTypeIsAny
-            ? isCallArgument && !containsAny(castType)
+            ? isCallArgument &&
+              !containsAny(castType) &&
+              !contextualTypeIsNonInferrableAny
             : !containsAny(contextualType);
 
           const isNullishLiteralToUnion =

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -317,15 +317,17 @@ export default createRule<Options, MessageIds>({
       return typeContains(type, t => isTypeFlagSet(t, ts.TypeFlags.Any));
     }
 
-    // `NonInferrableType` is an internal object flag used for auto/evolving
-    // `any` types and is intentionally not exposed in TypeScript's d.ts.
-    const nonInferrableTypeObjectFlag = 1 << 18;
-
     function isNonInferrableAnyType(type: ts.Type): boolean {
       return (
         isTypeFlagSet(type, ts.TypeFlags.Any) &&
-        ((type as ts.ObjectType).objectFlags & nonInferrableTypeObjectFlag) !==
-          0
+        tsutils.isObjectFlagSet(
+          type as ts.ObjectType,
+          (
+            ts.ObjectFlags as typeof ts.ObjectFlags & {
+              NonInferrableType: ts.ObjectFlags;
+            }
+          ).NonInferrableType,
+        )
       );
     }
 
@@ -905,18 +907,12 @@ export default createRule<Options, MessageIds>({
             contextualType,
             ts.TypeFlags.Any,
           );
-          const contextualTypeIsNonInferrableAny =
-            isNonInferrableAnyType(contextualType);
-
-          const isCallArgument =
-            (node.parent.type === AST_NODE_TYPES.CallExpression ||
-              node.parent.type === AST_NODE_TYPES.NewExpression) &&
-            node.parent.arguments.includes(node);
-
           const anyInvolvedInContextualCheck = contextualTypeIsAny
-            ? isCallArgument &&
+            ? (node.parent.type === AST_NODE_TYPES.CallExpression ||
+                node.parent.type === AST_NODE_TYPES.NewExpression) &&
+              node.parent.arguments.includes(node) &&
               !containsAny(castType) &&
-              !contextualTypeIsNonInferrableAny
+              !isNonInferrableAnyType(contextualType)
             : !containsAny(contextualType);
 
           const isNullishLiteralToUnion =

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -883,6 +883,22 @@ const test = inferred({
 
 console.log(test.options.parameters.potato);
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12268
+    `
+function foo() {
+  const arr = [];
+
+  for (let i = 0; i < 1; i++) {
+    arr.push({ x: 1 } as { x: number; y: number });
+  }
+
+  for (let i = 0; i < 1; i++) {
+    arr[i].y = 2;
+  }
+
+  return arr;
+}
+    `,
   ],
 
   invalid: [


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12268
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Updates `no-unnecessary-type-assertion` so it does not report assertions that provide the element shape for an evolving `any[]` array.

This preserves assertions such as `{ x: 1 } as { x: number; y: number }` when a later array access depends on the asserted property.

Tested with:

- `pnpm exec vitest run packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts --config packages/eslint-plugin/vitest.config.mts`
- `pnpm exec eslint packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts`
- `git diff --check`
