### PR TITLE
fix(rule-tester): add TypeScript as a peer dependency

### DIFF
--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -53,7 +53,8 @@
     "semver": "^7.7.3"
   },
   "peerDependencies": {
-    "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+    "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+    "typescript": ">=4.8.4 <6.1.0"
   },
   "devDependencies": {
     "@types/json-stable-stringify-without-jsonify": "^1.0.2",


### PR DESCRIPTION


<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Added TypeScript as a peer dependency. This is because `@typescript-eslint/parser` lists `typescript` [as its peerDependency](https://github.com/typescript-eslint/typescript-eslint/blob/52457932e5507b5ca01e720a541f3f8d01e09b9d/packages/parser/package.json#L51). This forces `@typescript-eslint/rule-tester` to either declare `typescript` as its dependency or forward the burden using peerDependencies. I think the latter is the better approach.