### PR TITLE
feat(rule-tester): added updates of RuleTester from upstream

### DIFF
--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -29,9 +29,11 @@ import type {
   RuleTesterConfig,
   RunTests,
   SuggestionOutput,
+  TestCaseError,
   TesterConfigWithDefaults,
   ValidTestCase,
 } from './types';
+import type { AssertionOptions } from './types/AssertionOptions';
 
 import { TestFramework } from './TestFramework';
 import { ajvBuilder } from './utils/ajv';
@@ -579,6 +581,7 @@ export class RuleTester extends TestFramework {
                   // no need to pass no infer type parameter down to private methods
                   invalid,
                   seenInvalidTestCases,
+                  test.assertionOptions,
                 );
               } finally {
                 this.#runHook(invalid, 'after');
@@ -897,6 +900,7 @@ export class RuleTester extends TestFramework {
     rule: RuleModule<MessageIds, Options>,
     item: InvalidTestCase<MessageIds, Options>,
     seenInvalidTestCases: Set<string>,
+    assertionOptions: AssertionOptions = {},
   ): void {
     assert.ok(
       typeof item.code === 'string',
@@ -984,6 +988,8 @@ export class RuleTester extends TestFramework {
       );
 
       const hasMessageOfThisRule = messages.some(m => m.ruleId === ruleName);
+
+      const { requireLocation = false } = assertionOptions;
 
       // console.log({ messages });
       for (let i = 0, l = item.errors.length; i < l; i++) {
@@ -1114,6 +1120,22 @@ export class RuleTester extends TestFramework {
               message.endColumn,
               error.endColumn,
               `Error endColumn should be ${error.endColumn}`,
+            );
+          }
+
+          if (requireLocation) {
+            const locationProperties: (keyof Pick<
+              TestCaseError<MessageIds>,
+              'column' | 'endColumn' | 'endLine' | 'line'
+            >)[] = ['line', 'column', 'endLine', 'endColumn'];
+
+            const missingKeys = locationProperties.filter(
+              key =>
+                !hasOwnProperty(error, key) && hasOwnProperty(message, key),
+            );
+            assert.ok(
+              missingKeys.length === 0,
+              `Error is missing expected location properties: ${missingKeys.join(', ')}`,
             );
           }
 

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -989,7 +989,7 @@ export class RuleTester extends TestFramework {
 
       const hasMessageOfThisRule = messages.some(m => m.ruleId === ruleName);
 
-      const { requireLocation = false } = assertionOptions;
+      const { requireData = false, requireLocation = false } = assertionOptions;
 
       // console.log({ messages });
       for (let i = 0, l = item.errors.length; i < l; i++) {
@@ -1083,6 +1083,16 @@ export class RuleTester extends TestFramework {
                 message.message,
                 rehydratedMessage,
                 `Hydrated message "${rehydratedMessage}" does not match "${message.message}"`,
+              );
+            } else {
+              const requiresDataProperty =
+                requireData === true || requireData === 'error';
+              const hasPlaceholders =
+                getMessagePlaceholders(rule.meta.messages[error.messageId])
+                  .length > 0;
+              assert.ok(
+                !requiresDataProperty || !hasPlaceholders,
+                `Error should specify the 'data' property as the referenced message has placeholders.`,
               );
             }
           } else {
@@ -1232,10 +1242,13 @@ export class RuleTester extends TestFramework {
                         `${suggestionPrefix} messageId should be '${expectedSuggestion.messageId}' but got '${actualSuggestion.messageId}' instead.`,
                       );
 
+                      const rawSuggestionMessage =
+                        rule.meta.messages[expectedSuggestion.messageId];
+
                       const unsubstitutedPlaceholders =
                         getUnsubstitutedMessagePlaceholders(
                           actualSuggestion.desc,
-                          rule.meta.messages[expectedSuggestion.messageId],
+                          rawSuggestionMessage,
                           expectedSuggestion.data,
                         );
 
@@ -1256,6 +1269,16 @@ export class RuleTester extends TestFramework {
                           actualSuggestion.desc,
                           rehydratedDesc,
                           `${suggestionPrefix} Hydrated test desc "${rehydratedDesc}" does not match received desc "${actualSuggestion.desc}".`,
+                        );
+                      } else {
+                        const requiresDataProperty =
+                          requireData === true || requireData === 'suggestion';
+                        const hasPlaceholders =
+                          getMessagePlaceholders(rawSuggestionMessage).length >
+                          0;
+                        assert.ok(
+                          !requiresDataProperty || !hasPlaceholders,
+                          `${suggestionPrefix} Suggestion should specify the 'data' property as the referenced message has placeholders.`,
                         );
                       }
                     } else if (hasOwnProperty(expectedSuggestion, 'data')) {

--- a/packages/rule-tester/src/RuleTester.ts
+++ b/packages/rule-tester/src/RuleTester.ts
@@ -461,6 +461,39 @@ export class RuleTester extends TestFramework {
   }
 
   /**
+   * Verifies that the assertion options are valid
+   * @throws {Error} if the options aren't the correct type
+   */
+  private verifyAssertionOptions(
+    assertionOption: AssertionOptions | undefined,
+  ): void {
+    if (assertionOption == null) {
+      return;
+    }
+
+    const dataOption = assertionOption.requireData;
+
+    if (
+      dataOption != null &&
+      typeof dataOption !== 'boolean' &&
+      dataOption !== 'error' &&
+      dataOption !== 'suggestion'
+    ) {
+      throw new Error(
+        "The assertion option `requireData` should be of type boolean | 'error' | 'suggestion'",
+      );
+    }
+
+    const locationOption = assertionOption.requireLocation;
+
+    if (locationOption != null && typeof locationOption !== 'boolean') {
+      throw new Error(
+        'The assertion option `requireLocation` should be of type boolean',
+      );
+    }
+  }
+
+  /**
    * Adds a new rule test to execute.
    */
   run<MessageIds extends string, Options extends readonly unknown[]>(
@@ -468,6 +501,8 @@ export class RuleTester extends TestFramework {
     rule: RuleModule<MessageIds, Options>,
     test: RunTests<TSUtils.NoInfer<MessageIds>, TSUtils.NoInfer<Options>>,
   ): void {
+    this.verifyAssertionOptions(test.assertionOptions);
+
     const constructor = this.constructor as typeof RuleTester;
 
     if (

--- a/packages/rule-tester/src/types/AssertionOptions.ts
+++ b/packages/rule-tester/src/types/AssertionOptions.ts
@@ -1,5 +1,11 @@
 export interface AssertionOptions {
   /**
+   * - If `true`, each error object and each suggestion object must also specify `data` if the message referenced by `messageId` has placeholders.
+   * - If `'error'`, each error object must also specify `data` if the message referenced by `messageId` has placeholders.
+   * - If `'suggestion'`, each suggestion object must also specify `data` if the message referenced by `messageId` has placeholders.
+   */
+  readonly requireData?: boolean | 'error' | 'suggestion';
+  /**
    * If `true`, each `errors` block must contain location properties `line`, `column`, `endLine`, and `endColumn`. Properties `endLine` and `endColumn` may be omitted if the actual error does not contain them.
    */
   readonly requireLocation?: boolean;

--- a/packages/rule-tester/src/types/AssertionOptions.ts
+++ b/packages/rule-tester/src/types/AssertionOptions.ts
@@ -1,0 +1,6 @@
+export interface AssertionOptions {
+  /**
+   * If `true`, each `errors` block must contain location properties `line`, `column`, `endLine`, and `endColumn`. Properties `endLine` and `endColumn` may be omitted if the actual error does not contain them.
+   */
+  readonly requireLocation?: boolean;
+}

--- a/packages/rule-tester/src/types/AssertionOptions.ts
+++ b/packages/rule-tester/src/types/AssertionOptions.ts
@@ -3,10 +3,12 @@ export interface AssertionOptions {
    * - If `true`, each error object and each suggestion object must also specify `data` if the message referenced by `messageId` has placeholders.
    * - If `'error'`, each error object must also specify `data` if the message referenced by `messageId` has placeholders.
    * - If `'suggestion'`, each suggestion object must also specify `data` if the message referenced by `messageId` has placeholders.
+   * @default `false`
    */
   readonly requireData?: boolean | 'error' | 'suggestion';
   /**
    * If `true`, each `errors` block must contain location properties `line`, `column`, `endLine`, and `endColumn`. Properties `endLine` and `endColumn` may be omitted if the actual error does not contain them.
+   * @default `false`
    */
   readonly requireLocation?: boolean;
 }

--- a/packages/rule-tester/src/types/index.ts
+++ b/packages/rule-tester/src/types/index.ts
@@ -1,3 +1,4 @@
+import type { AssertionOptions } from './AssertionOptions';
 import type { InvalidTestCase } from './InvalidTestCase';
 import type { RuleTesterConfig } from './RuleTesterConfig';
 import type { ValidTestCase } from './ValidTestCase';
@@ -16,6 +17,7 @@ export interface RunTests<
   MessageIds extends string,
   Options extends readonly unknown[],
 > {
+  readonly assertionOptions?: AssertionOptions;
   readonly invalid: readonly InvalidTestCase<MessageIds, Options>[];
   // RuleTester.run also accepts strings for valid cases
   readonly valid: readonly (string | ValidTestCase<Options>)[];
@@ -25,6 +27,7 @@ export interface NormalizedRunTests<
   MessageIds extends string,
   Options extends readonly unknown[],
 > {
+  readonly assertionOptions?: AssertionOptions;
   readonly invalid: readonly InvalidTestCase<MessageIds, Options>[];
   readonly valid: readonly ValidTestCase<Options>[];
 }

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -1088,14 +1088,69 @@ describe('RuleTester - AssertionOptions', () => {
     vi.restoreAllMocks();
   });
 
-  const positionRule: RuleModule<'noEnd' | 'withEnd'> = {
+  const assertionRule: RuleModule<
+    | 'bothData'
+    | 'errorData'
+    | 'noEnd'
+    | 'suggestionBothData'
+    | 'suggestionData'
+    | 'suggestionErrorData'
+    | 'suggestionSuggestionData'
+    | 'withEnd'
+  > = {
     create(context) {
       return {
+        'Identifier[name=bothData]'(node): void {
+          context.report({
+            data: { bar: 'John', foo: 'Jane' },
+            messageId: 'bothData',
+            node,
+            suggest: [
+              {
+                data: { bar: 'Jane', foo: 'John' },
+                fix(fixer) {
+                  return fixer.replaceText(node, 'fixed');
+                },
+                messageId: 'suggestionBothData',
+              },
+            ],
+          });
+        },
+        'Identifier[name=errorData]'(node): void {
+          context.report({
+            data: { bar: 'Jane', foo: 'John' },
+            messageId: 'errorData',
+            node,
+            suggest: [
+              {
+                fix(fixer) {
+                  return fixer.replaceText(node, 'fixed');
+                },
+                messageId: 'suggestionErrorData',
+              },
+            ],
+          });
+        },
         'Identifier[name=noEnd]'(node): void {
           context.report({
             loc: { column: 0, line: 1 },
             messageId: 'noEnd',
             node,
+          });
+        },
+        'Identifier[name=suggestionData]'(node): void {
+          context.report({
+            messageId: 'suggestionData',
+            node,
+            suggest: [
+              {
+                data: { bar: 'John', foo: 'Jane' },
+                fix(fixer) {
+                  return fixer.replaceText(node, 'fixed');
+                },
+                messageId: 'suggestionSuggestionData',
+              },
+            ],
           });
         },
         'Identifier[name=withEnd]'(node): void {
@@ -1111,8 +1166,15 @@ describe('RuleTester - AssertionOptions', () => {
       };
     },
     meta: {
+      hasSuggestions: true,
       messages: {
+        bothData: '{{foo}} and {{bar}} are nincompoops',
+        errorData: '{{foo}} and {{bar}} are hopeless',
         noEnd: 'noEnd',
+        suggestionBothData: '{{foo}} and {{bar}} should not be nincompoops',
+        suggestionData: 'love is in the air',
+        suggestionErrorData: 'game over man',
+        suggestionSuggestionData: '{{foo}} should confess to {{bar}}',
         withEnd: 'noEnd',
       },
       schema: [],
@@ -1125,7 +1187,7 @@ describe('RuleTester - AssertionOptions', () => {
   describe('requireLocation', () => {
     describe('unset', () => {
       it('should allow shorthand', () => {
-        ruleTester.run('position-rule', positionRule, {
+        ruleTester.run('position-rule', assertionRule, {
           assertionOptions: {},
           invalid: [
             {
@@ -1138,7 +1200,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow longhand', () => {
-        ruleTester.run('position-rule', positionRule, {
+        ruleTester.run('position-rule', assertionRule, {
           assertionOptions: {},
           invalid: [
             {
@@ -1169,7 +1231,7 @@ describe('RuleTester - AssertionOptions', () => {
 
     describe('false', () => {
       it('should allow shorthand', () => {
-        ruleTester.run('position-rule', positionRule, {
+        ruleTester.run('position-rule', assertionRule, {
           assertionOptions: { requireLocation: false },
           invalid: [
             {
@@ -1182,7 +1244,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow longhand', () => {
-        ruleTester.run('position-rule', positionRule, {
+        ruleTester.run('position-rule', assertionRule, {
           assertionOptions: { requireLocation: false },
           invalid: [
             {
@@ -1214,7 +1276,7 @@ describe('RuleTester - AssertionOptions', () => {
     describe('true', () => {
       it('should fail if all location properties are missing - no end', () => {
         expect(() =>
-          ruleTester.run('position-rule', positionRule, {
+          ruleTester.run('position-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1231,7 +1293,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should fail if all location properties are missing - with end', () => {
         expect(() =>
-          ruleTester.run('position-rule', positionRule, {
+          ruleTester.run('position-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1248,7 +1310,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should fail if line is missing', () => {
         expect(() =>
-          ruleTester.run('position-rule', positionRule, {
+          ruleTester.run('position-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1265,7 +1327,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should fail if column is missing', () => {
         expect(() =>
-          ruleTester.run('position-rule', positionRule, {
+          ruleTester.run('position-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1282,7 +1344,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should fail if endLine is missing', () => {
         expect(() =>
-          ruleTester.run('position-rule', positionRule, {
+          ruleTester.run('position-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1301,7 +1363,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should fail if endColumn is missing', () => {
         expect(() =>
-          ruleTester.run('position-rule', positionRule, {
+          ruleTester.run('position-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1319,7 +1381,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should pass for error without end location', () => {
-        ruleTester.run('position-rule', positionRule, {
+        ruleTester.run('position-rule', assertionRule, {
           assertionOptions: { requireLocation: true },
           invalid: [
             {
@@ -1329,6 +1391,687 @@ describe('RuleTester - AssertionOptions', () => {
           ],
           valid: [],
         });
+      });
+    });
+  });
+
+  describe('requireData', () => {
+    describe('unset', () => {
+      it('should allow not setting data for errors', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: {},
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  messageId: 'bothData',
+                  suggestions: [
+                    { messageId: 'suggestionBothData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'errorData',
+              errors: [
+                {
+                  messageId: 'errorData',
+                  suggestions: [
+                    { messageId: 'suggestionErrorData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow not setting data for suggestions', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: {},
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  messageId: 'bothData',
+                  suggestions: [
+                    { messageId: 'suggestionBothData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'suggestionData',
+              errors: [
+                {
+                  messageId: 'suggestionData',
+                  suggestions: [
+                    { messageId: 'suggestionSuggestionData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+    });
+
+    describe('false', () => {
+      it('should allow not setting data for errors', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: false },
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  messageId: 'bothData',
+                  suggestions: [
+                    { messageId: 'suggestionBothData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'errorData',
+              errors: [
+                {
+                  messageId: 'errorData',
+                  suggestions: [
+                    { messageId: 'suggestionErrorData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow not setting data for suggestions', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: false },
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  messageId: 'bothData',
+                  suggestions: [
+                    { messageId: 'suggestionBothData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'suggestionData',
+              errors: [
+                {
+                  messageId: 'suggestionData',
+                  suggestions: [
+                    { messageId: 'suggestionSuggestionData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+    });
+
+    describe('true', () => {
+      it('should allow not specifying data for error messages without placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: true },
+          invalid: [
+            {
+              code: 'withEnd',
+              errors: [{ messageId: 'withEnd' }],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow specifying error data when there are placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: true },
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  data: { bar: 'John', foo: 'Jane' },
+                  messageId: 'bothData',
+                  suggestions: [
+                    {
+                      data: { bar: 'Jane', foo: 'John' },
+                      messageId: 'suggestionBothData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'errorData',
+              errors: [
+                {
+                  data: { bar: 'Jane', foo: 'John' },
+                  messageId: 'errorData',
+                  suggestions: [
+                    { messageId: 'suggestionErrorData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow specifying suggestion data when there are placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: true },
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  data: { bar: 'John', foo: 'Jane' },
+                  messageId: 'bothData',
+                  suggestions: [
+                    {
+                      data: { bar: 'Jane', foo: 'John' },
+                      messageId: 'suggestionBothData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'suggestionData',
+              errors: [
+                {
+                  messageId: 'suggestionData',
+                  suggestions: [
+                    {
+                      data: { bar: 'John', foo: 'Jane' },
+                      messageId: 'suggestionSuggestionData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should disallow not specifying error data when there are placeholders', () => {
+        expect(() =>
+          ruleTester.run('data-rule', assertionRule, {
+            assertionOptions: { requireData: true },
+            invalid: [
+              {
+                code: 'bothData',
+                errors: [
+                  {
+                    messageId: 'bothData',
+                    suggestions: [
+                      {
+                        data: { bar: 'Jane', foo: 'John' },
+                        messageId: 'suggestionBothData',
+                        output: 'fixed',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          "Error should specify the 'data' property as the referenced message has placeholders.",
+        );
+        expect(() =>
+          ruleTester.run('data-rule', assertionRule, {
+            assertionOptions: { requireData: true },
+            invalid: [
+              {
+                code: 'errorData',
+                errors: [
+                  {
+                    messageId: 'errorData',
+                    suggestions: [
+                      { messageId: 'suggestionErrorData', output: 'fixed' },
+                    ],
+                  },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          "Error should specify the 'data' property as the referenced message has placeholders.",
+        );
+      });
+
+      it('should disallow not specifying suggestion data when there are placeholders', () => {
+        expect(() =>
+          ruleTester.run('data-rule', assertionRule, {
+            assertionOptions: { requireData: true },
+            invalid: [
+              {
+                code: 'bothData',
+                errors: [
+                  {
+                    data: { bar: 'John', foo: 'Jane' },
+                    messageId: 'bothData',
+                    suggestions: [
+                      {
+                        messageId: 'suggestionBothData',
+                        output: 'fixed',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          "Error Suggestion at index 0: Suggestion should specify the 'data' property as the referenced message has placeholders.",
+        );
+        expect(() =>
+          ruleTester.run('data-rule', assertionRule, {
+            assertionOptions: { requireData: true },
+            invalid: [
+              {
+                code: 'suggestionData',
+                errors: [
+                  {
+                    messageId: 'suggestionData',
+                    suggestions: [
+                      {
+                        messageId: 'suggestionSuggestionData',
+                        output: 'fixed',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          "Error Suggestion at index 0: Suggestion should specify the 'data' property as the referenced message has placeholders.",
+        );
+      });
+    });
+
+    describe('error', () => {
+      it('should allow not specifying data for error messages without placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: 'error' },
+          invalid: [
+            {
+              code: 'withEnd',
+              errors: [{ messageId: 'withEnd' }],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow specifying error data when there are placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: 'error' },
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  data: { bar: 'John', foo: 'Jane' },
+                  messageId: 'bothData',
+                  suggestions: [
+                    {
+                      data: { bar: 'Jane', foo: 'John' },
+                      messageId: 'suggestionBothData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'errorData',
+              errors: [
+                {
+                  data: { bar: 'Jane', foo: 'John' },
+                  messageId: 'errorData',
+                  suggestions: [
+                    { messageId: 'suggestionErrorData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow specifying suggestion data when there are placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: 'error' },
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  data: { bar: 'John', foo: 'Jane' },
+                  messageId: 'bothData',
+                  suggestions: [
+                    {
+                      data: { bar: 'Jane', foo: 'John' },
+                      messageId: 'suggestionBothData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'suggestionData',
+              errors: [
+                {
+                  messageId: 'suggestionData',
+                  suggestions: [
+                    {
+                      data: { bar: 'John', foo: 'Jane' },
+                      messageId: 'suggestionSuggestionData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should disallow not specifying error data when there are placeholders', () => {
+        expect(() =>
+          ruleTester.run('data-rule', assertionRule, {
+            assertionOptions: { requireData: 'error' },
+            invalid: [
+              {
+                code: 'bothData',
+                errors: [
+                  {
+                    messageId: 'bothData',
+                    suggestions: [
+                      {
+                        data: { bar: 'Jane', foo: 'John' },
+                        messageId: 'suggestionBothData',
+                        output: 'fixed',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          "Error should specify the 'data' property as the referenced message has placeholders.",
+        );
+        expect(() =>
+          ruleTester.run('data-rule', assertionRule, {
+            assertionOptions: { requireData: true },
+            invalid: [
+              {
+                code: 'errorData',
+                errors: [
+                  {
+                    messageId: 'errorData',
+                    suggestions: [
+                      { messageId: 'suggestionErrorData', output: 'fixed' },
+                    ],
+                  },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          "Error should specify the 'data' property as the referenced message has placeholders.",
+        );
+      });
+
+      it('should allow not specifying suggestion data when there are placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: 'error' },
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  data: { bar: 'John', foo: 'Jane' },
+                  messageId: 'bothData',
+                  suggestions: [
+                    {
+                      messageId: 'suggestionBothData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'suggestionData',
+              errors: [
+                {
+                  messageId: 'suggestionData',
+                  suggestions: [
+                    {
+                      messageId: 'suggestionSuggestionData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+    });
+
+    describe('suggestion', () => {
+      it('should allow not specifying data for error messages without placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: 'suggestion' },
+          invalid: [
+            {
+              code: 'withEnd',
+              errors: [{ messageId: 'withEnd' }],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow specifying error data when there are placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: 'suggestion' },
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  data: { bar: 'John', foo: 'Jane' },
+                  messageId: 'bothData',
+                  suggestions: [
+                    {
+                      data: { bar: 'Jane', foo: 'John' },
+                      messageId: 'suggestionBothData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'errorData',
+              errors: [
+                {
+                  data: { bar: 'Jane', foo: 'John' },
+                  messageId: 'errorData',
+                  suggestions: [
+                    { messageId: 'suggestionErrorData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow specifying suggestion data when there are placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: 'suggestion' },
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  data: { bar: 'John', foo: 'Jane' },
+                  messageId: 'bothData',
+                  suggestions: [
+                    {
+                      data: { bar: 'Jane', foo: 'John' },
+                      messageId: 'suggestionBothData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'suggestionData',
+              errors: [
+                {
+                  messageId: 'suggestionData',
+                  suggestions: [
+                    {
+                      data: { bar: 'John', foo: 'Jane' },
+                      messageId: 'suggestionSuggestionData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow not specifying error data when there are placeholders', () => {
+        ruleTester.run('data-rule', assertionRule, {
+          assertionOptions: { requireData: 'suggestion' },
+          invalid: [
+            {
+              code: 'bothData',
+              errors: [
+                {
+                  messageId: 'bothData',
+                  suggestions: [
+                    {
+                      data: { bar: 'Jane', foo: 'John' },
+                      messageId: 'suggestionBothData',
+                      output: 'fixed',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              code: 'errorData',
+              errors: [
+                {
+                  messageId: 'errorData',
+                  suggestions: [
+                    { messageId: 'suggestionErrorData', output: 'fixed' },
+                  ],
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should disallow not specifying suggestion data when there are placeholders', () => {
+        expect(() =>
+          ruleTester.run('data-rule', assertionRule, {
+            assertionOptions: { requireData: 'suggestion' },
+            invalid: [
+              {
+                code: 'bothData',
+                errors: [
+                  {
+                    data: { bar: 'John', foo: 'Jane' },
+                    messageId: 'bothData',
+                    suggestions: [
+                      {
+                        messageId: 'suggestionBothData',
+                        output: 'fixed',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          "Error Suggestion at index 0: Suggestion should specify the 'data' property as the referenced message has placeholders.",
+        );
+        expect(() =>
+          ruleTester.run('data-rule', assertionRule, {
+            assertionOptions: { requireData: 'suggestion' },
+            invalid: [
+              {
+                code: 'suggestionData',
+                errors: [
+                  {
+                    messageId: 'suggestionData',
+                    suggestions: [
+                      {
+                        messageId: 'suggestionSuggestionData',
+                        output: 'fixed',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          "Error Suggestion at index 0: Suggestion should specify the 'data' property as the referenced message has placeholders.",
+        );
       });
     });
   });

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -1083,6 +1083,257 @@ describe(RuleTester, () => {
   });
 });
 
+describe('RuleTester - AssertionOptions', () => {
+  beforeAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  const positionRule: RuleModule<'noEnd' | 'withEnd'> = {
+    create(context) {
+      return {
+        'Identifier[name=noEnd]'(node): void {
+          context.report({
+            loc: { column: 0, line: 1 },
+            messageId: 'noEnd',
+            node,
+          });
+        },
+        'Identifier[name=withEnd]'(node): void {
+          context.report({
+            loc: {
+              end: { column: 1, line: 2 },
+              start: { column: 0, line: 1 },
+            },
+            messageId: 'withEnd',
+            node,
+          });
+        },
+      };
+    },
+    meta: {
+      messages: {
+        noEnd: 'noEnd',
+        withEnd: 'noEnd',
+      },
+      schema: [],
+      type: 'problem',
+    },
+  };
+
+  const ruleTester = new RuleTester();
+
+  describe('requireLocation', () => {
+    describe('unset', () => {
+      it('should allow shorthand', () => {
+        ruleTester.run('position-rule', positionRule, {
+          assertionOptions: {},
+          invalid: [
+            {
+              code: 'noEnd',
+              errors: [{ messageId: 'noEnd' }],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow longhand', () => {
+        ruleTester.run('position-rule', positionRule, {
+          assertionOptions: {},
+          invalid: [
+            {
+              code: 'noEnd',
+              errors: [{ column: 1, line: 1, messageId: 'noEnd' }],
+            },
+            {
+              code: 'withEnd',
+              errors: [{ column: 1, line: 1, messageId: 'withEnd' }],
+            },
+            {
+              code: 'withEnd',
+              errors: [
+                {
+                  column: 1,
+                  endColumn: 2,
+                  endLine: 2,
+                  line: 1,
+                  messageId: 'withEnd',
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+    });
+
+    describe('false', () => {
+      it('should allow shorthand', () => {
+        ruleTester.run('position-rule', positionRule, {
+          assertionOptions: { requireLocation: false },
+          invalid: [
+            {
+              code: 'noEnd',
+              errors: [{ messageId: 'noEnd' }],
+            },
+          ],
+          valid: [],
+        });
+      });
+
+      it('should allow longhand', () => {
+        ruleTester.run('position-rule', positionRule, {
+          assertionOptions: { requireLocation: false },
+          invalid: [
+            {
+              code: 'noEnd',
+              errors: [{ column: 1, line: 1, messageId: 'noEnd' }],
+            },
+            {
+              code: 'withEnd',
+              errors: [{ column: 1, line: 1, messageId: 'withEnd' }],
+            },
+            {
+              code: 'withEnd',
+              errors: [
+                {
+                  column: 1,
+                  endColumn: 2,
+                  endLine: 2,
+                  line: 1,
+                  messageId: 'withEnd',
+                },
+              ],
+            },
+          ],
+          valid: [],
+        });
+      });
+    });
+
+    describe('true', () => {
+      it('should fail if all location properties are missing - no end', () => {
+        expect(() =>
+          ruleTester.run('position-rule', positionRule, {
+            assertionOptions: { requireLocation: true },
+            invalid: [
+              {
+                code: 'noEnd',
+                errors: [{ messageId: 'noEnd' }],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          'Error is missing expected location properties: line, column',
+        );
+      });
+
+      it('should fail if all location properties are missing - with end', () => {
+        expect(() =>
+          ruleTester.run('position-rule', positionRule, {
+            assertionOptions: { requireLocation: true },
+            invalid: [
+              {
+                code: 'withEnd',
+                errors: [{ messageId: 'withEnd' }],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          'Error is missing expected location properties: line, column, endLine, endColumn',
+        );
+      });
+
+      it('should fail if line is missing', () => {
+        expect(() =>
+          ruleTester.run('position-rule', positionRule, {
+            assertionOptions: { requireLocation: true },
+            invalid: [
+              {
+                code: 'withEnd',
+                errors: [
+                  { column: 1, endColumn: 2, endLine: 2, messageId: 'withEnd' },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError('Error is missing expected location properties: line');
+      });
+
+      it('should fail if column is missing', () => {
+        expect(() =>
+          ruleTester.run('position-rule', positionRule, {
+            assertionOptions: { requireLocation: true },
+            invalid: [
+              {
+                code: 'withEnd',
+                errors: [
+                  { endColumn: 2, endLine: 2, line: 1, messageId: 'withEnd' },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError('Error is missing expected location properties: column');
+      });
+
+      it('should fail if endLine is missing', () => {
+        expect(() =>
+          ruleTester.run('position-rule', positionRule, {
+            assertionOptions: { requireLocation: true },
+            invalid: [
+              {
+                code: 'withEnd',
+                errors: [
+                  { column: 1, endColumn: 2, line: 1, messageId: 'withEnd' },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          'Error is missing expected location properties: endLine',
+        );
+      });
+
+      it('should fail if endColumn is missing', () => {
+        expect(() =>
+          ruleTester.run('position-rule', positionRule, {
+            assertionOptions: { requireLocation: true },
+            invalid: [
+              {
+                code: 'withEnd',
+                errors: [
+                  { column: 1, endLine: 2, line: 1, messageId: 'withEnd' },
+                ],
+              },
+            ],
+            valid: [],
+          }),
+        ).toThrowError(
+          'Error is missing expected location properties: endColumn',
+        );
+      });
+
+      it('should pass for error without end location', () => {
+        ruleTester.run('position-rule', positionRule, {
+          assertionOptions: { requireLocation: true },
+          invalid: [
+            {
+              code: 'noEnd',
+              errors: [{ column: 1, line: 1, messageId: 'noEnd' }],
+            },
+          ],
+          valid: [],
+        });
+      });
+    });
+  });
+});
+
 describe('RuleTester - hooks', () => {
   beforeAll(() => {
     vi.restoreAllMocks();

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -1184,6 +1184,97 @@ describe('RuleTester - AssertionOptions', () => {
 
   const ruleTester = new RuleTester();
 
+  describe('AssertionOptions shape', () => {
+    it('should accept unset options', () => {
+      ruleTester.run('assertion-rule', assertionRule, {
+        invalid: [
+          {
+            code: 'noEnd',
+            errors: [{ messageId: 'noEnd' }],
+          },
+        ],
+        valid: [],
+      });
+    });
+
+    it('should accept empty options', () => {
+      ruleTester.run('assertion-rule', assertionRule, {
+        assertionOptions: {},
+        invalid: [
+          {
+            code: 'noEnd',
+            errors: [{ messageId: 'noEnd' }],
+          },
+        ],
+        valid: [],
+      });
+    });
+
+    describe('requireLocation type', () => {
+      it('should throw error if not boolean', () => {
+        expect(() => {
+          ruleTester.run('assertion-rule', assertionRule, {
+            assertionOptions: {
+              // @ts-expect-error Verifying a wrongly typed option
+              requireLocation: 'true',
+            },
+            invalid: [
+              {
+                code: 'noEnd',
+                errors: [{ messageId: 'noEnd' }],
+              },
+            ],
+            valid: [],
+          });
+        }).toThrow(
+          'The assertion option `requireLocation` should be of type boolean',
+        );
+      });
+    });
+
+    describe('requireData type', () => {
+      it('should throw error if not boolean nor string', () => {
+        expect(() => {
+          ruleTester.run('assertion-rule', assertionRule, {
+            assertionOptions: {
+              // @ts-expect-error Verifying a wrongly typed option
+              requireData: 8,
+            },
+            invalid: [
+              {
+                code: 'noEnd',
+                errors: [{ messageId: 'noEnd' }],
+              },
+            ],
+            valid: [],
+          });
+        }).toThrow(
+          "The assertion option `requireData` should be of type boolean | 'error' | 'suggestion'",
+        );
+      });
+
+      it('should throw error if incorrect string', () => {
+        expect(() => {
+          ruleTester.run('assertion-rule', assertionRule, {
+            assertionOptions: {
+              // @ts-expect-error Verifying a wrongly typed option
+              requireData: 'foo',
+            },
+            invalid: [
+              {
+                code: 'noEnd',
+                errors: [{ messageId: 'noEnd' }],
+              },
+            ],
+            valid: [],
+          });
+        }).toThrow(
+          "The assertion option `requireData` should be of type boolean | 'error' | 'suggestion'",
+        );
+      });
+    });
+  });
+
   describe('requireLocation', () => {
     describe('unset', () => {
       it('should allow shorthand', () => {

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -1286,7 +1286,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
+        ).toThrow(
           'Error is missing expected location properties: line, column',
         );
       });
@@ -1303,7 +1303,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
+        ).toThrow(
           'Error is missing expected location properties: line, column, endLine, endColumn',
         );
       });
@@ -1322,7 +1322,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError('Error is missing expected location properties: line');
+        ).toThrow('Error is missing expected location properties: line');
       });
 
       it('should fail if column is missing', () => {
@@ -1339,7 +1339,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError('Error is missing expected location properties: column');
+        ).toThrow('Error is missing expected location properties: column');
       });
 
       it('should fail if endLine is missing', () => {
@@ -1356,9 +1356,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
-          'Error is missing expected location properties: endLine',
-        );
+        ).toThrow('Error is missing expected location properties: endLine');
       });
 
       it('should fail if endColumn is missing', () => {
@@ -1375,9 +1373,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
-          'Error is missing expected location properties: endColumn',
-        );
+        ).toThrow('Error is missing expected location properties: endColumn');
       });
 
       it('should pass for error without end location', () => {
@@ -1638,7 +1634,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
+        ).toThrow(
           "Error should specify the 'data' property as the referenced message has placeholders.",
         );
         expect(() =>
@@ -1659,7 +1655,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
+        ).toThrow(
           "Error should specify the 'data' property as the referenced message has placeholders.",
         );
       });
@@ -1687,7 +1683,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
+        ).toThrow(
           "Error Suggestion at index 0: Suggestion should specify the 'data' property as the referenced message has placeholders.",
         );
         expect(() =>
@@ -1711,7 +1707,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
+        ).toThrow(
           "Error Suggestion at index 0: Suggestion should specify the 'data' property as the referenced message has placeholders.",
         );
       });
@@ -1831,7 +1827,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
+        ).toThrow(
           "Error should specify the 'data' property as the referenced message has placeholders.",
         );
         expect(() =>
@@ -1852,7 +1848,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
+        ).toThrow(
           "Error should specify the 'data' property as the referenced message has placeholders.",
         );
       });
@@ -2045,7 +2041,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
+        ).toThrow(
           "Error Suggestion at index 0: Suggestion should specify the 'data' property as the referenced message has placeholders.",
         );
         expect(() =>
@@ -2069,7 +2065,7 @@ describe('RuleTester - AssertionOptions', () => {
             ],
             valid: [],
           }),
-        ).toThrowError(
+        ).toThrow(
           "Error Suggestion at index 0: Suggestion should specify the 'data' property as the referenced message has placeholders.",
         );
       });

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -1278,7 +1278,7 @@ describe('RuleTester - AssertionOptions', () => {
   describe('requireLocation', () => {
     describe('unset', () => {
       it('should allow shorthand', () => {
-        ruleTester.run('position-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: {},
           invalid: [
             {
@@ -1291,7 +1291,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow longhand', () => {
-        ruleTester.run('position-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: {},
           invalid: [
             {
@@ -1322,7 +1322,7 @@ describe('RuleTester - AssertionOptions', () => {
 
     describe('false', () => {
       it('should allow shorthand', () => {
-        ruleTester.run('position-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireLocation: false },
           invalid: [
             {
@@ -1335,7 +1335,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow longhand', () => {
-        ruleTester.run('position-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireLocation: false },
           invalid: [
             {
@@ -1367,7 +1367,7 @@ describe('RuleTester - AssertionOptions', () => {
     describe('true', () => {
       it('should fail if all location properties are missing - no end', () => {
         expect(() =>
-          ruleTester.run('position-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1384,7 +1384,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should fail if all location properties are missing - with end', () => {
         expect(() =>
-          ruleTester.run('position-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1401,7 +1401,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should fail if line is missing', () => {
         expect(() =>
-          ruleTester.run('position-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1418,7 +1418,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should fail if column is missing', () => {
         expect(() =>
-          ruleTester.run('position-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1435,7 +1435,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should fail if endLine is missing', () => {
         expect(() =>
-          ruleTester.run('position-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1452,7 +1452,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should fail if endColumn is missing', () => {
         expect(() =>
-          ruleTester.run('position-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireLocation: true },
             invalid: [
               {
@@ -1468,7 +1468,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should pass for error without end location', () => {
-        ruleTester.run('position-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireLocation: true },
           invalid: [
             {
@@ -1485,7 +1485,7 @@ describe('RuleTester - AssertionOptions', () => {
   describe('requireData', () => {
     describe('unset', () => {
       it('should allow not setting data for errors', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: {},
           invalid: [
             {
@@ -1516,7 +1516,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow not setting data for suggestions', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: {},
           invalid: [
             {
@@ -1549,7 +1549,7 @@ describe('RuleTester - AssertionOptions', () => {
 
     describe('false', () => {
       it('should allow not setting data for errors', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: false },
           invalid: [
             {
@@ -1580,7 +1580,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow not setting data for suggestions', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: false },
           invalid: [
             {
@@ -1613,7 +1613,7 @@ describe('RuleTester - AssertionOptions', () => {
 
     describe('true', () => {
       it('should allow not specifying data for error messages without placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: true },
           invalid: [
             {
@@ -1626,7 +1626,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow specifying error data when there are placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: true },
           invalid: [
             {
@@ -1663,7 +1663,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow specifying suggestion data when there are placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: true },
           invalid: [
             {
@@ -1704,7 +1704,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should disallow not specifying error data when there are placeholders', () => {
         expect(() =>
-          ruleTester.run('data-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireData: true },
             invalid: [
               {
@@ -1729,7 +1729,7 @@ describe('RuleTester - AssertionOptions', () => {
           "Error should specify the 'data' property as the referenced message has placeholders.",
         );
         expect(() =>
-          ruleTester.run('data-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireData: true },
             invalid: [
               {
@@ -1753,7 +1753,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should disallow not specifying suggestion data when there are placeholders', () => {
         expect(() =>
-          ruleTester.run('data-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireData: true },
             invalid: [
               {
@@ -1778,7 +1778,7 @@ describe('RuleTester - AssertionOptions', () => {
           "Error Suggestion at index 0: Suggestion should specify the 'data' property as the referenced message has placeholders.",
         );
         expect(() =>
-          ruleTester.run('data-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireData: true },
             invalid: [
               {
@@ -1806,7 +1806,7 @@ describe('RuleTester - AssertionOptions', () => {
 
     describe('error', () => {
       it('should allow not specifying data for error messages without placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: 'error' },
           invalid: [
             {
@@ -1819,7 +1819,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow specifying error data when there are placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: 'error' },
           invalid: [
             {
@@ -1856,7 +1856,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow specifying suggestion data when there are placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: 'error' },
           invalid: [
             {
@@ -1897,7 +1897,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should disallow not specifying error data when there are placeholders', () => {
         expect(() =>
-          ruleTester.run('data-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireData: 'error' },
             invalid: [
               {
@@ -1922,7 +1922,7 @@ describe('RuleTester - AssertionOptions', () => {
           "Error should specify the 'data' property as the referenced message has placeholders.",
         );
         expect(() =>
-          ruleTester.run('data-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireData: true },
             invalid: [
               {
@@ -1945,7 +1945,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow not specifying suggestion data when there are placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: 'error' },
           invalid: [
             {
@@ -1985,7 +1985,7 @@ describe('RuleTester - AssertionOptions', () => {
 
     describe('suggestion', () => {
       it('should allow not specifying data for error messages without placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: 'suggestion' },
           invalid: [
             {
@@ -1998,7 +1998,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow specifying error data when there are placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: 'suggestion' },
           invalid: [
             {
@@ -2035,7 +2035,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow specifying suggestion data when there are placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: 'suggestion' },
           invalid: [
             {
@@ -2075,7 +2075,7 @@ describe('RuleTester - AssertionOptions', () => {
       });
 
       it('should allow not specifying error data when there are placeholders', () => {
-        ruleTester.run('data-rule', assertionRule, {
+        ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireData: 'suggestion' },
           invalid: [
             {
@@ -2111,7 +2111,7 @@ describe('RuleTester - AssertionOptions', () => {
 
       it('should disallow not specifying suggestion data when there are placeholders', () => {
         expect(() =>
-          ruleTester.run('data-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireData: 'suggestion' },
             invalid: [
               {
@@ -2136,7 +2136,7 @@ describe('RuleTester - AssertionOptions', () => {
           "Error Suggestion at index 0: Suggestion should specify the 'data' property as the referenced message has placeholders.",
         );
         expect(() =>
-          ruleTester.run('data-rule', assertionRule, {
+          ruleTester.run('assertion-rule', assertionRule, {
             assertionOptions: { requireData: 'suggestion' },
             invalid: [
               {

--- a/packages/rule-tester/tests/RuleTester.test.ts
+++ b/packages/rule-tester/tests/RuleTester.test.ts
@@ -1277,7 +1277,7 @@ describe('RuleTester - AssertionOptions', () => {
 
   describe('requireLocation', () => {
     describe('unset', () => {
-      it('should allow shorthand', () => {
+      it('should allow no location specified', () => {
         ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: {},
           invalid: [
@@ -1290,7 +1290,7 @@ describe('RuleTester - AssertionOptions', () => {
         });
       });
 
-      it('should allow longhand', () => {
+      it('should allow location specified', () => {
         ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: {},
           invalid: [
@@ -1321,7 +1321,7 @@ describe('RuleTester - AssertionOptions', () => {
     });
 
     describe('false', () => {
-      it('should allow shorthand', () => {
+      it('should allow no location specified', () => {
         ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireLocation: false },
           invalid: [
@@ -1334,7 +1334,7 @@ describe('RuleTester - AssertionOptions', () => {
         });
       });
 
-      it('should allow longhand', () => {
+      it('should allow location specified', () => {
         ruleTester.run('assertion-rule', assertionRule, {
           assertionOptions: { requireLocation: false },
           invalid: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12141 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

* Added the `requireData` assertion option
* Added the `requireLocation` assertion option
* Ignored the `requireMessage` assertion option, since `messageId` is required for errors
* Added relevant tests