### PR TITLE
fix(eslint-plugin): [no-deprecated] object destructuring values should be treated as declarations

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -129,12 +129,13 @@ export default createRule<Options, MessageIds>({
         case AST_NODE_TYPES.Property:
           // foo in "const { foo } = bar" will be processed twice, as parent.key
           // and parent.value. The second is treated as a declaration.
-          if (parent.shorthand && parent.value === node) {
+
+          if (parent.value === node) {
+            // const { foo: bar } = baz; -- bar IS a declaration.
+            // const baz = { foo: bar }; -- bar IS NOT a declaration.
             return parent.parent.type === AST_NODE_TYPES.ObjectPattern;
           }
-          if (parent.value === node) {
-            return false;
-          }
+
           return parent.parent.type === AST_NODE_TYPES.ObjectExpression;
 
         case AST_NODE_TYPES.AssignmentPattern:

--- a/packages/eslint-plugin/src/rules/no-deprecated.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated.ts
@@ -135,7 +135,8 @@ export default createRule<Options, MessageIds>({
             // const baz = { foo: bar }; -- bar IS NOT a declaration.
             return parent.parent.type === AST_NODE_TYPES.ObjectPattern;
           }
-
+          // const { foo: bar } = baz; -- foo IS NOT a declaration.
+          // const baz = { foo: bar }; -- foo IS a declaration.
           return parent.parent.type === AST_NODE_TYPES.ObjectExpression;
 
         case AST_NODE_TYPES.AssignmentPattern:

--- a/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-deprecated.test.ts
@@ -710,6 +710,28 @@ exists('/foo');
       const key = null;
       const c = a[key as any];
     `,
+    `
+      interface Foo {
+        /** @deprecated */
+        deprecatedProperty: string;
+        notDeprecatedProperty: string;
+      }
+
+      declare const a: Foo;
+      const { notDeprecatedProperty: deprecatedProperty } = a;
+    `,
+    `
+      interface Foo {
+        /** @deprecated */
+        deprecatedProperty: string;
+        notDeprecatedProperty: string;
+      }
+      
+      declare const a: { foo: Foo };
+      const {
+        foo: { notDeprecatedProperty: deprecatedProperty },
+      } = a;
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12267 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This code previously already had correct logic as a special case for shorthand assignment `const { foo } = bar`, but that was actually the correct logic regardless of the shorthand assignment. The `bar` in `const { foo: bar } = baz` is obviously also a declaration and should never trigger no-deprecated.