### PR TITLE
chore(website): correct ESLint capitalization typos in playground

### DIFF
--- a/packages/website/src/components/OptionsSelector.tsx
+++ b/packages/website/src/components/OptionsSelector.tsx
@@ -74,8 +74,8 @@ function OptionsSelectorContent({
             value={state.ts}
           />
         </InputLabel>
-        <InputLabel name="Eslint">{process.env.ESLINT_VERSION}</InputLabel>
-        <InputLabel name="TSESlint">{process.env.TS_ESLINT_VERSION}</InputLabel>
+        <InputLabel name="ESLint">{process.env.ESLINT_VERSION}</InputLabel>
+        <InputLabel name="TSESLint">{process.env.TS_ESLINT_VERSION}</InputLabel>
       </Expander>
       <Expander label="Options">
         <InputLabel name="File type">


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: [minor documentation typos](https://typescript-eslint.io/contributing/pull-requests/)
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Hi, 

I thought it was a minor documentation typo, so I opened a PR directly. If that's not appropriate, please let me know and I'd be happy to open a separate issue!

In this PR I corrected the capitalization of the ESLint branding in the playground:

- `Eslint` -> `ESLint`
- `TSESlint` -> `TSESLint`

I noticed the rest of the documentation consistently uses `ESLint`, and the playground was the only exception.

- Before:

<img width="308" height="80" alt="image" src="https://github.com/user-attachments/assets/988276a7-e956-4368-9da0-d237eb287364" alt="before"/>

- After:

<img width="307" height="90" alt="image" src="https://github.com/user-attachments/assets/9412370e-b788-45d2-9899-4bb740caa992" alt="after"/>


🌟 

<!-- Description of what is changed and how the code change does that. -->

