### PR TITLE
fix(eslint-plugin): [no-floating-promises] work around stack overflow when using recursive types

### DIFF
--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -249,7 +249,7 @@ export default createRule<Options, MessageId>({
 
       const type = getTypeAtLocation(checker, tsNode);
 
-      /* v8 ignore if -- should never happen, just a safeguard  */
+      /* v8 ignore if -- @preserve should never happen, just a safeguard  */
       if (type == null) {
         return false;
       }
@@ -426,7 +426,7 @@ export default createRule<Options, MessageId>({
     function isPromiseLike(node: ts.Node, type?: ts.Type): boolean {
       type ??= getTypeAtLocation(checker, node);
 
-      /* v8 ignore if -- should never happen, just a safeguard  */
+      /* v8 ignore if -- @preserve should never happen, just a safeguard  */
       if (type == null) {
         return false;
       }

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -512,11 +512,11 @@ function isFunctionParam(
 function getTypeAtLocation(
   checker: ts.TypeChecker,
   node: ts.Node,
-): ts.Type | undefined {
+): ts.Type | null {
   try {
     return checker.getTypeAtLocation(node);
   } catch {
     // Workaround for https://github.com/typescript-eslint/typescript-eslint/issues/11947
-    return undefined;
+    return null;
   }
 }

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -245,10 +245,9 @@ export default createRule<Options, MessageId>({
         return false;
       }
 
-      const type = getTypeAtLocation(
-        services.program.getTypeChecker(),
-        services.esTreeNodeToTSNodeMap.get(node.callee),
-      );
+      const tsNode = services.esTreeNodeToTSNodeMap.get(node.callee);
+
+      const type = getTypeAtLocation(checker, tsNode);
 
       if (type == null) {
         return false;
@@ -285,10 +284,10 @@ export default createRule<Options, MessageId>({
     }
 
     function isValidRejectionHandler(rejectionHandler: TSESTree.Node): boolean {
-      return !!getTypeAtLocation(
-        services.program.getTypeChecker(),
-        services.esTreeNodeToTSNodeMap.get(rejectionHandler),
-      )?.getCallSignatures().length;
+      const checker = services.program.getTypeChecker();
+      const node = services.esTreeNodeToTSNodeMap.get(rejectionHandler);
+
+      return !!getTypeAtLocation(checker, node)?.getCallSignatures().length;
     }
 
     function isUnhandledPromise(

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -245,14 +245,7 @@ export default createRule<Options, MessageId>({
         return false;
       }
 
-      const tsNode = services.esTreeNodeToTSNodeMap.get(node.callee);
-
-      const type = getTypeAtLocation(checker, tsNode);
-
-      /* v8 ignore if -- @preserve should never happen, just a safeguard  */
-      if (type == null) {
-        return false;
-      }
+      const type = services.getTypeAtLocation(node.callee);
 
       if (
         valueMatchesSomeSpecifier(
@@ -285,9 +278,14 @@ export default createRule<Options, MessageId>({
     }
 
     function isValidRejectionHandler(rejectionHandler: TSESTree.Node): boolean {
-      const tsNode = services.esTreeNodeToTSNodeMap.get(rejectionHandler);
-
-      return !!getTypeAtLocation(checker, tsNode)?.getCallSignatures().length;
+      return (
+        services.program
+          .getTypeChecker()
+          .getTypeAtLocation(
+            services.esTreeNodeToTSNodeMap.get(rejectionHandler),
+          )
+          .getCallSignatures().length > 0
+      );
     }
 
     function isUnhandledPromise(
@@ -424,12 +422,7 @@ export default createRule<Options, MessageId>({
     }
 
     function isPromiseLike(node: ts.Node, type?: ts.Type): boolean {
-      type ??= getTypeAtLocation(checker, node);
-
-      /* v8 ignore if -- @preserve should never happen, just a safeguard  */
-      if (type == null) {
-        return false;
-      }
+      type ??= checker.getTypeAtLocation(node);
 
       // The highest priority is to allow anything allowlisted
       if (

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -249,6 +249,7 @@ export default createRule<Options, MessageId>({
 
       const type = getTypeAtLocation(checker, tsNode);
 
+      /* v8 ignore if -- should never happen, just a safeguard  */
       if (type == null) {
         return false;
       }
@@ -425,6 +426,7 @@ export default createRule<Options, MessageId>({
     function isPromiseLike(node: ts.Node, type?: ts.Type): boolean {
       type ??= getTypeAtLocation(checker, node);
 
+      /* v8 ignore if -- should never happen, just a safeguard  */
       if (type == null) {
         return false;
       }

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -284,10 +284,9 @@ export default createRule<Options, MessageId>({
     }
 
     function isValidRejectionHandler(rejectionHandler: TSESTree.Node): boolean {
-      const checker = services.program.getTypeChecker();
-      const node = services.esTreeNodeToTSNodeMap.get(rejectionHandler);
+      const tsNode = services.esTreeNodeToTSNodeMap.get(rejectionHandler);
 
-      return !!getTypeAtLocation(checker, node)?.getCallSignatures().length;
+      return !!getTypeAtLocation(checker, tsNode)?.getCallSignatures().length;
     }
 
     function isUnhandledPromise(

--- a/packages/eslint-plugin/src/rules/no-floating-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-floating-promises.ts
@@ -245,7 +245,14 @@ export default createRule<Options, MessageId>({
         return false;
       }
 
-      const type = services.getTypeAtLocation(node.callee);
+      const type = getTypeAtLocation(
+        services.program.getTypeChecker(),
+        services.esTreeNodeToTSNodeMap.get(node.callee),
+      );
+
+      if (type == null) {
+        return false;
+      }
 
       if (
         valueMatchesSomeSpecifier(
@@ -278,14 +285,10 @@ export default createRule<Options, MessageId>({
     }
 
     function isValidRejectionHandler(rejectionHandler: TSESTree.Node): boolean {
-      return (
-        services.program
-          .getTypeChecker()
-          .getTypeAtLocation(
-            services.esTreeNodeToTSNodeMap.get(rejectionHandler),
-          )
-          .getCallSignatures().length > 0
-      );
+      return !!getTypeAtLocation(
+        services.program.getTypeChecker(),
+        services.esTreeNodeToTSNodeMap.get(rejectionHandler),
+      )?.getCallSignatures().length;
     }
 
     function isUnhandledPromise(
@@ -394,7 +397,12 @@ export default createRule<Options, MessageId>({
     }
 
     function isPromiseArray(node: ts.Node): boolean {
-      const type = checker.getTypeAtLocation(node);
+      const type = getTypeAtLocation(checker, node);
+
+      if (type == null) {
+        return false;
+      }
+
       for (const ty of tsutils
         .unionConstituents(type)
         .map(t => checker.getApparentType(t))) {
@@ -417,7 +425,11 @@ export default createRule<Options, MessageId>({
     }
 
     function isPromiseLike(node: ts.Node, type?: ts.Type): boolean {
-      type ??= checker.getTypeAtLocation(node);
+      type ??= getTypeAtLocation(checker, node);
+
+      if (type == null) {
+        return false;
+      }
 
       // The highest priority is to allow anything allowlisted
       if (
@@ -502,4 +514,16 @@ function isFunctionParam(
     }
   }
   return false;
+}
+
+function getTypeAtLocation(
+  checker: ts.TypeChecker,
+  node: ts.Node,
+): ts.Type | undefined {
+  try {
+    return checker.getTypeAtLocation(node);
+  } catch {
+    // Workaround for https://github.com/typescript-eslint/typescript-eslint/issues/11947
+    return undefined;
+  }
 }

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -887,6 +887,33 @@ myAsyncFunction();
         },
       ],
     },
+
+    // This code makes TypeScript type checker to crash with infinite recursion
+    //
+    // See:
+    //  https://github.com/typescript-eslint/typescript-eslint/issues/11947
+    //  https://github.com/microsoft/TypeScript/issues/63441
+    `
+      interface CustomNode<P> {
+        getNextNode: () => CustomNode<P>;
+      }
+
+      declare const createNode: () => {
+        getNextNode: <T>() => CustomNode<T>;
+      };
+
+      function wrapNode<T>(getNode: () => CustomNode<T>) {
+        return getNode;
+      }
+
+      (async () => {
+        wrapNode(() => {
+          const node = createNode();
+
+          return wrapNode<typeof node.getNextNode<any>>(node.getNextNode);
+        });
+      })().catch(() => {});
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts
@@ -5614,5 +5614,89 @@ await Promise.reject('foo').then(...[], () => {});
         },
       ],
     },
+
+    // This code makes TypeScript type checker to crash with infinite recursion
+    //
+    // See:
+    //  https://github.com/typescript-eslint/typescript-eslint/issues/11947
+    //  https://github.com/microsoft/TypeScript/issues/63441
+    {
+      code: `
+        interface CustomNode<P> {
+          getNextNode: () => CustomNode<P>;
+        }
+
+        declare const createNode: () => {
+          getNextNode: <T>() => CustomNode<T>;
+        };
+
+        function wrapNode<T>(getNode: () => CustomNode<T>) {
+          return getNode;
+        }
+
+        (async () => {
+          wrapNode(() => {
+            const node = createNode();
+
+            return wrapNode<typeof node.getNextNode<any>>(node.getNextNode);
+          });
+        })();
+      `,
+      errors: [
+        {
+          messageId: 'floatingVoid',
+          suggestions: [
+            {
+              messageId: 'floatingFixVoid',
+              output: `
+        interface CustomNode<P> {
+          getNextNode: () => CustomNode<P>;
+        }
+
+        declare const createNode: () => {
+          getNextNode: <T>() => CustomNode<T>;
+        };
+
+        function wrapNode<T>(getNode: () => CustomNode<T>) {
+          return getNode;
+        }
+
+        void (async () => {
+          wrapNode(() => {
+            const node = createNode();
+
+            return wrapNode<typeof node.getNextNode<any>>(node.getNextNode);
+          });
+        })();
+      `,
+            },
+            {
+              messageId: 'floatingFixAwait',
+              output: `
+        interface CustomNode<P> {
+          getNextNode: () => CustomNode<P>;
+        }
+
+        declare const createNode: () => {
+          getNextNode: <T>() => CustomNode<T>;
+        };
+
+        function wrapNode<T>(getNode: () => CustomNode<T>) {
+          return getNode;
+        }
+
+        await (async () => {
+          wrapNode(() => {
+            const node = createNode();
+
+            return wrapNode<typeof node.getNextNode<any>>(node.getNextNode);
+          });
+        })();
+      `,
+            },
+          ],
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #11947
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a `try... catch` block to overcome the infinite recursion of [`symbolToNode`](https://github.com/microsoft/TypeScript/issues/63441)
