### PR TITLE
chore(eslint-plugin): defer type checks to improve rules performance

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -392,8 +392,8 @@ export default createRule<Options, MessageIds>({
         if (getTypeName(checker, leftType) === 'string') {
           checkExpression(node.right, rightType);
         } else if (
-          getTypeName(checker, rightType) === 'string' &&
-          node.left.type !== AST_NODE_TYPES.PrivateIdentifier
+          node.left.type !== AST_NODE_TYPES.PrivateIdentifier &&
+          getTypeName(checker, rightType) === 'string'
         ) {
           checkExpression(node.left, leftType);
         }

--- a/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-confusing-void-expression.ts
@@ -119,15 +119,15 @@ export default createRule<Options, MessageId>({
           | TSESTree.CallExpression
           | TSESTree.TaggedTemplateExpression,
       ): void {
-        const type = getConstrainedTypeAtLocation(services, node);
-        if (!tsutils.isTypeFlagSet(type, ts.TypeFlags.VoidLike)) {
-          // not a void expression
-          return;
-        }
-
         const invalidAncestor = findInvalidAncestor(node);
         if (invalidAncestor == null) {
           // void expression is in valid position
+          return;
+        }
+
+        const type = getConstrainedTypeAtLocation(services, node);
+        if (!tsutils.isTypeFlagSet(type, ts.TypeFlags.VoidLike)) {
+          // not a void expression
           return;
         }
 

--- a/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
+++ b/packages/eslint-plugin/src/rules/no-duplicate-type-constituents.ts
@@ -192,19 +192,32 @@ export default createRule<Options, MessageIds>({
       cachedTypeMap: Map<Type, TSESTree.TypeNode>,
       forEachNodeType?: (type: Type, node: TSESTree.TypeNode) => void,
     ): void {
+      const reportDuplicate = (previous: TSESTree.TypeNode) => {
+        report('duplicate', constituentNode, {
+          type: unionOrIntersection,
+          previous: sourceCode.getText(previous),
+        });
+      };
+
+      // Check duplicates in the AST before type lookup for better performance.
+      let duplicatedPrevious = uniqueConstituents.find(ele =>
+        isSameAstNode(ele, constituentNode),
+      );
+
+      if (duplicatedPrevious) {
+        reportDuplicate(duplicatedPrevious);
+        return;
+      }
+
       const type = parserServices.getTypeAtLocation(constituentNode);
       if (tsutils.isIntrinsicErrorType(type)) {
         return;
       }
-      const duplicatedPrevious =
-        uniqueConstituents.find(ele => isSameAstNode(ele, constituentNode)) ??
-        cachedTypeMap.get(type);
+
+      duplicatedPrevious = cachedTypeMap.get(type);
 
       if (duplicatedPrevious) {
-        report('duplicate', constituentNode, {
-          type: unionOrIntersection,
-          previous: sourceCode.getText(duplicatedPrevious),
-        });
+        reportDuplicate(duplicatedPrevious);
         return;
       }
 

--- a/packages/eslint-plugin/src/rules/no-unsafe-return.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-return.ts
@@ -53,6 +53,11 @@ export default createRule({
       returnNode: TSESTree.Node,
       reportingNode: TSESTree.Node = returnNode,
     ): void {
+      const functionNode = getParentFunctionNode(returnNode);
+      /* istanbul ignore if */ if (!functionNode) {
+        return;
+      }
+
       const tsNode = services.esTreeNodeToTSNodeMap.get(returnNode);
       const type = checker.getTypeAtLocation(tsNode);
 
@@ -62,10 +67,6 @@ export default createRule({
         services.program,
         tsNode,
       );
-      const functionNode = getParentFunctionNode(returnNode);
-      /* istanbul ignore if */ if (!functionNode) {
-        return;
-      }
 
       // function has an explicit return type, so ensure it's a safe return
       const returnNodeType = services.getTypeAtLocation(returnNode);

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -290,11 +290,6 @@ export default createRule<Options, MessageIds>({
         | TSESTree.LogicalExpression;
       testNode: TSESTree.Node;
     }): boolean {
-      const testType = parserServices.getTypeAtLocation(testNode);
-      if (!isTypeEligibleForPreferNullish(testType)) {
-        return false;
-      }
-
       if (ignoreConditionalTests === true && isConditionalTest(node)) {
         return false;
       }
@@ -307,6 +302,11 @@ export default createRule<Options, MessageIds>({
           node.parent.type === AST_NODE_TYPES.CallExpression
         )
       ) {
+        return false;
+      }
+
+      const testType = parserServices.getTypeAtLocation(testNode);
+      if (!isTypeEligibleForPreferNullish(testType)) {
         return false;
       }
 

--- a/packages/eslint-plugin/src/rules/strict-void-return.ts
+++ b/packages/eslint-plugin/src/rules/strict-void-return.ts
@@ -154,6 +154,10 @@ export default util.createRule<Options, MessageId>({
     function checkFunctionCallNode(
       callNode: TSESTree.CallExpression | TSESTree.NewExpression,
     ): void {
+      if (callNode.arguments.length === 0) {
+        return;
+      }
+
       const callTsNode = parserServices.esTreeNodeToTSNodeMap.get(callNode);
 
       const funcType = checker.getTypeAtLocation(callTsNode.expression);


### PR DESCRIPTION
I was working on #11204, and realized that some rules might benefit from deferring the type checks after the AST structure checks.

I ran some benchmarks locally (M4 Pro, 24GB) against `packages/eslint-plugin`:

<details>
<summary><code>prefer-nullish-coalescing</code> is about ~7% faster</summary>

```
$ hyperfine "eslint-before-fix" "eslint-after-fix"

Benchmark 1: eslint-before-fix
  Time (mean ± σ):      7.472 s ±  0.132 s    [User: 8.215 s, System: 0.979 s]
  Range (min … max):    7.288 s …  7.703 s    10 runs

Benchmark 2: eslint-after-fix
  Time (mean ± σ):      6.961 s ±  0.145 s    [User: 7.613 s, System: 0.964 s]
  Range (min … max):    6.845 s …  7.290 s    10 runs

Summary
  eslint-after-fix ran
    1.07 ± 0.03 times faster than eslint-before-fix
```

</details>

<details>
<summary><code>no-base-to-string</code> is about ~4% faster</summary>

```
$ hyperfine "eslint-before-fix" "eslint-after-fix"

Benchmark 1: eslint-before-fix
  Time (mean ± σ):      6.189 s ±  0.163 s    [User: 6.511 s, System: 0.807 s]
  Range (min … max):    5.981 s …  6.473 s    10 runs

Benchmark 2: eslint-after-fix
  Time (mean ± σ):      5.930 s ±  0.207 s    [User: 6.294 s, System: 0.734 s]
  Range (min … max):    5.730 s …  6.372 s    10 runs

Summary
  eslint-after-fix ran
    1.04 ± 0.04 times faster than eslint-before-fix
```

</details>

<details>
<summary><code>no-confusing-void-expression</code> is about ~32% faster</summary>

```
$ hyperfine "eslint-before-fix" "eslint-after-fix"

Benchmark 1: eslint-before-fix
  Time (mean ± σ):     11.270 s ±  0.129 s    [User: 13.346 s, System: 1.549 s]
  Range (min … max):   11.064 s … 11.468 s    10 runs

Benchmark 2: eslint-after-fix
  Time (mean ± σ):      8.534 s ±  0.122 s    [User: 10.208 s, System: 1.316 s]
  Range (min … max):    8.344 s …  8.742 s    10 runs

Summary
  eslint-after-fix ran
    1.32 ± 0.02 times faster than eslint-before-fix
```

</details>

<details>
<summary><code>no-duplicate-type-constituents</code> is about ~2% faster</summary>

```
$ hyperfine "eslint-before-fix" "eslint-after-fix"

Benchmark 1: eslint-before-fix
  Time (mean ± σ):      5.369 s ±  0.166 s    [User: 4.750 s, System: 0.703 s]
  Range (min … max):    5.211 s …  5.757 s    10 runs

Benchmark 2: eslint-after-fix
  Time (mean ± σ):      5.249 s ±  0.058 s    [User: 4.657 s, System: 0.663 s]
  Range (min … max):    5.190 s …  5.343 s    10 runs

Summary
  eslint-after-fix ran
    1.02 ± 0.03 times faster than eslint-before-fix
```

</details>

<details>
<summary><code>no-unsafe-return</code> is about ~3% faster</summary>

```
$ hyperfine "eslint-before-fix" "eslint-after-fix"

Benchmark 1: eslint-before-fix
  Time (mean ± σ):      8.811 s ±  0.113 s    [User: 10.341 s, System: 1.229 s]
  Range (min … max):    8.671 s …  9.040 s    10 runs

Benchmark 2: eslint-after-fix
  Time (mean ± σ):      8.566 s ±  0.104 s    [User: 10.145 s, System: 1.144 s]
  Range (min … max):    8.460 s …  8.823 s    10 runs

Summary
  eslint-after-fix ran
    1.03 ± 0.02 times faster than eslint-before-fix
```

</details>

<details>
<summary><code>strict-void-return</code> is about ~2% faster</summary>

```
$ hyperfine "eslint-before-fix" "eslint-after-fix"

Benchmark 1: eslint-before-fix
  Time (mean ± σ):     12.029 s ±  0.236 s    [User: 14.407 s, System: 1.470 s]
  Range (min … max):   11.789 s … 12.471 s    10 runs

Benchmark 2: eslint-after-fix
  Time (mean ± σ):     11.830 s ±  0.117 s    [User: 14.200 s, System: 1.518 s]
  Range (min … max):   11.650 s … 12.016 s    10 runs

Summary
  eslint-after-fix ran
    1.02 ± 0.02 times faster than eslint-before-fix
```

</details>

<details>
<summary>Running all rules is about ~1% faster (probably negligible, which is why it doesn't really help with #11204)</summary>

```
$ hyperfine "eslint-before-fix" "eslint-after-fix"

Benchmark 1: eslint-before-fix
  Time (mean ± σ):     25.464 s ±  0.492 s    [User: 30.937 s, System: 3.279 s]
  Range (min … max):   24.840 s … 26.408 s    10 runs

Benchmark 2: eslint-after-fix
  Time (mean ± σ):     25.179 s ±  0.382 s    [User: 30.511 s, System: 3.244 s]
  Range (min … max):   24.710 s … 25.806 s    10 runs

Summary
  eslint-after-fix ran
    1.01 ± 0.02 times faster than eslint-before-fix
```

</details>


Some rules (i.e., `require-array-sort-compare`, `prefer-regexp-exec`) didn't show any performance gains from this change.

I guess they will in codebases that actually violate them. Currently, they're basically skipping the type checks anyway in our codebase, thanks to selectors like `CallExpression[arguments.length=1] > MemberExpression` together with a member name check (`.match`, `.sort`, etc.).
(Violating codebases might also show more performance gains for the rules in this PR, actually)

I'll open PRs for these rules if we go forward with this PR and decide that it's worth it.
___

<sup>Thanks to AI it was much faster to find areas where it was applicable</sup>
