### PR TITLE
feat(eslint-plugin): [no-unnecessary-type-assertion] flag contextually-unnecessary const assertions on literals

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.mdx
@@ -79,6 +79,13 @@ With `@typescript-eslint/no-unnecessary-type-assertion: ["error", { checkLiteral
 const foo = 'foo' as const;
 ```
 
+`as const` on a literal is also flagged when the surrounding context already narrows to a literal (or union of literals) that accepts the asserted value — contextual typing alone preserves the literal-ness, so the assertion adds nothing:
+
+```ts option='{ "checkLiteralConstAssertions": true }' showPlaygroundButton
+type Recipient = { kind: 'a' | 'b' };
+const r: Recipient = { kind: 'a' as const };
+```
+
 See [#8721 False positives for "as const" assertions (issue comment)](https://github.com/typescript-eslint/typescript-eslint/issues/8721#issuecomment-2145291966) for more information on this option.
 
 ### `typesToIgnore`

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -878,6 +878,37 @@ export default createRule<Options, MessageIds>({
           return;
         }
 
+        // Contextually-unnecessary const assertions on literal types: when
+        // the surrounding context already narrows to a literal (or literal
+        // union) that accepts the asserted value, contextual typing alone
+        // would preserve the literal — `as const` adds nothing. Gated on
+        // `checkLiteralConstAssertions` for parity with the
+        // explicitly-unnecessary case above.
+        if (
+          options.checkLiteralConstAssertions &&
+          typeAnnotationIsConstAssertion &&
+          castTypeIsLiteral
+        ) {
+          const constAssertionTsNode = services.esTreeNodeToTSNodeMap.get(node);
+          const constAssertionContextualType =
+            checker.getContextualType(constAssertionTsNode);
+          if (
+            constAssertionContextualType &&
+            !isTypeFlagSet(constAssertionContextualType, ts.TypeFlags.Any) &&
+            tsutils
+              .unionConstituents(constAssertionContextualType)
+              .every(part => isTypeLiteral(part)) &&
+            checker.isTypeAssignableTo(castType, constAssertionContextualType)
+          ) {
+            context.report({
+              node,
+              messageId: 'contextuallyUnnecessary',
+              fix: createAssertionFixer(node),
+            });
+            return;
+          }
+        }
+
         const originalNode = services.esTreeNodeToTSNodeMap.get(node);
 
         const castIsAny =

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-type-assertion.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-type-assertion.shot
@@ -51,6 +51,12 @@ Options: { "checkLiteralConstAssertions": true }
 const foo = 'foo' as const;
             ~~~~~~~~~~~~~~ This assertion is unnecessary since it does not change the type of the expression.
 
+Options: { "checkLiteralConstAssertions": true }
+
+type Recipient = { kind: 'a' | 'b' };
+const r: Recipient = { kind: 'a' as const };
+                             ~~~~~~~~~~~~ This assertion is unnecessary since the receiver accepts the original type of the expression.
+
 Options: { "typesToIgnore": ["Foo"] }
 
 type Foo = 3;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -883,6 +883,41 @@ const test = inferred({
 
 console.log(test.options.parameters.potato);
     `,
+    // \`as const\` on an object literal preserves \`readonly\` and tuple-ness;
+    // contextual typing alone wouldn't replicate that, so removing it would
+    // change the type. Keep it valid.
+    {
+      code: `
+type Config = { readonly kind: 'a'; readonly nested: readonly [1, 2] };
+const config: Config = { kind: 'a', nested: [1, 2] } as const;
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    // \`as const\` widens to a primitive without context — keep valid.
+    {
+      code: `
+declare function f(x: string): void;
+f('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    // Contextual type contains a non-literal member — removing \`as const\`
+    // could widen. Keep valid.
+    {
+      code: `
+declare function f(x: string | 'a'): void;
+f('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    // \`any\` contextual type — removing the assertion is risky. Keep valid.
+    {
+      code: `
+declare function f(x: any): void;
+f('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
   ],
 
   invalid: [
@@ -1873,6 +1908,75 @@ enum T {
 
 declare const a: T.Value1;
 const b = a;
+      `,
+    },
+    // Contextually unnecessary const assertion: object property typed as a
+    // literal union — contextual typing alone preserves the literal.
+    {
+      code: `
+type Recipient = { kind: 'a' | 'b' };
+const r: Recipient = { kind: 'a' as const };
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+type Recipient = { kind: 'a' | 'b' };
+const r: Recipient = { kind: 'a' };
+      `,
+    },
+    // Same situation, array of typed objects.
+    {
+      code: `
+type Recipient = { kind: 'a' | 'b' };
+const rs: Recipient[] = [{ kind: 'a' as const }, { kind: 'b' as const }];
+      `,
+      errors: [
+        { messageId: 'contextuallyUnnecessary' },
+        { messageId: 'contextuallyUnnecessary' },
+      ],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+type Recipient = { kind: 'a' | 'b' };
+const rs: Recipient[] = [{ kind: 'a' }, { kind: 'b' }];
+      `,
+    },
+    // Function argument whose parameter type is a literal union.
+    {
+      code: `
+declare function f(x: 'a' | 'b'): void;
+f('a' as const);
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+declare function f(x: 'a' | 'b'): void;
+f('a');
+      `,
+    },
+    // Numeric literal narrowed by a literal-union parameter type.
+    {
+      code: `
+declare function f(x: 1 | 2 | 3): void;
+f(1 as const);
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+declare function f(x: 1 | 2 | 3): void;
+f(1);
+      `,
+    },
+    // Boolean literal with a boolean-literal contextual type.
+    {
+      code: `
+declare function f(x: true): void;
+f(true as const);
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+declare function f(x: true): void;
+f(true);
       `,
     },
     {


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: no current open issue tracks this exact case. The closest is closed #1734, which added the `as const` baseline support; PR #10979 (referenced from #8721) added the `checkLiteralConstAssertions` option for the false-positive direction. The contextually-unnecessary direction has remained as a missing case (an explicit `// TODO - add contextually unnecessary check for this` comment lived in this file for several years and was removed without being implemented). Happy to file a tracking issue if maintainers prefer.
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

When `checkLiteralConstAssertions` is enabled, `as const` is currently only flagged in narrow positions (e.g. `const x = 'a' as const;`). This PR extends the same option to also flag `as const` on literal expressions whose surrounding context already narrows to a literal type (or union of literals) accepting the asserted value — TypeScript's contextual typing alone preserves the literal-ness in these positions, so the assertion adds nothing.

### Examples now flagged

```ts
type Recipient = { kind: 'a' | 'b' };
const r: Recipient = { kind: 'a' as const };
//                              ^^^^^^^^^^^^ contextuallyUnnecessary

type Recipient = { kind: 'a' | 'b' };
const rs: Recipient[] = [{ kind: 'a' as const }, { kind: 'b' as const }];

declare function f(x: 'a' | 'b'): void;
f('a' as const);
//^^^^^^^^^^^^^ contextuallyUnnecessary

declare function f(x: 1 | 2 | 3): void;
f(1 as const);

declare function f(x: true): void;
f(true as const);
```

### False-positive guards (kept valid)

- `as const` on object/array literals that produce `readonly` / tuple types — contextual typing alone wouldn't reproduce the readonly nature.
- Contextual types containing a non-literal member (e.g. `x: string | 'a'`) — removing the assertion could allow widening.
- `any`-typed contexts.
- Declarations without contextual narrowing (existing `unnecessaryAssertion` path already handles `const x = 'a' as const` etc.; this PR is purely additive).

### Implementation

A small block placed right after the existing `unnecessaryAssertion` report path. Gated on `checkLiteralConstAssertions` for parity. Uses `checker.getContextualType` and verifies every union constituent is a literal type before reporting.

```ts
if (
  options.checkLiteralConstAssertions &&
  typeAnnotationIsConstAssertion &&
  castTypeIsLiteral
) {
  const tsNode = services.esTreeNodeToTSNodeMap.get(node);
  const contextual = checker.getContextualType(tsNode);
  if (
    contextual &&
    !isTypeFlagSet(contextual, ts.TypeFlags.Any) &&
    tsutils.unionConstituents(contextual).every(part => isTypeLiteral(part)) &&
    checker.isTypeAssignableTo(castType, contextual)
  ) {
    context.report({
      node,
      messageId: 'contextuallyUnnecessary',
      fix: createAssertionFixer(node),
    });
    return;
  }
}
```

### Tests

- 5 new invalid cases (object property in typed object, array of typed objects, function arg with literal-union param, numeric literal, boolean literal)
- 4 new valid cases (object literal with readonly tuple, primitive contextual type, contextual type with non-literal member, `any` contextual type)
- All 232 pre-existing tests still pass; new total is 241 in this rule's file
- Full `packages/eslint-plugin` suite (29,351 tests) passes locally

### Real-world signal

This caught a redundant `as const` in a real production codebase that previously needed manual review (an array of objects whose property type was a literal union — the assertion was added before the parent annotation existed and remained as dead noise). The auto-fix produces correct, still-typechecking output.