### PR TITLE
fix(eslint-plugin): [no-meaningless-void-operator] report on non-call expressions

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-meaningless-void-operator.mdx
+++ b/packages/eslint-plugin/docs/rules/no-meaningless-void-operator.mdx
@@ -15,7 +15,8 @@ For example, it is recommended as one way of suppressing [`@typescript-eslint/no
 
 This rule helps an authors catch API changes where previously a value was being discarded at a call site, but the callee changed so it no longer returns a value.
 When combined with [no-unused-expressions](https://eslint.org/docs/rules/no-unused-expressions), it also helps _readers_ of the code by ensuring consistency: a statement that looks like `void foo();` is **always** discarding a return value, and a statement that looks like `foo();` is **never** discarding a return value.
-This rule reports on any `void` operator whose argument is already of type `void` or `undefined`.
+
+This rule reports on any `void` operator whose argument is already of type `void` or `undefined`, as well as any `void` operator applied to an expression that does not produce a value to discard (anything other than a call, `new`, `await`, or `yield` expression — for example `void box` or `void box.value`).
 
 ## Examples
 
@@ -29,6 +30,10 @@ void (() => {})();
 
 function foo() {}
 void foo();
+
+declare const box: { value: string };
+void box;
+void box.value;
 ```
 
 </TabItem>
@@ -41,8 +46,7 @@ function foo() {}
 foo(); // nothing to discard
 
 function bar(x: number) {
-  void x; // discarding a number
-  return 2;
+  return x + 1;
 }
 void bar(1); // discarding a number
 ```

--- a/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
+++ b/packages/eslint-plugin/src/rules/no-meaningless-void-operator.ts
@@ -1,6 +1,6 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 
-import { ESLintUtils } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -11,6 +11,21 @@ export type Options = [
     checkNever: boolean;
   },
 ];
+
+function isMeaninglessVoidArgument(node: TSESTree.Expression): boolean {
+  // `void` is meaningless on expressions that don't produce a value via a
+  // side-effecting operation (call, new, await, yield). Without one of those,
+  // there is no return value to discard.
+  switch (node.type) {
+    case AST_NODE_TYPES.Identifier:
+    case AST_NODE_TYPES.MemberExpression:
+      return true;
+    case AST_NODE_TYPES.ChainExpression:
+      return isMeaninglessVoidArgument(node.expression);
+    default:
+      return false;
+  }
+}
 
 export default createRule<Options, 'meaninglessVoidOperator' | 'removeVoid'>({
   name: 'no-meaningless-void-operator',
@@ -89,6 +104,22 @@ export default createRule<Options, 'meaninglessVoidOperator' | 'removeVoid'>({
             data: { type: checker.typeToString(argType) },
             suggest: [{ messageId: 'removeVoid', fix }],
           });
+        } else if (isMeaninglessVoidArgument(node.argument)) {
+          // Issue #12214: argument is an identifier or member access (no call,
+          // new, await, or yield). There is no return value to discard, so
+          // `void` is meaningless. Skip when the argument is `never` without
+          // `checkNever`, to preserve that option's explicit opt-in semantics.
+          const isOnlyNever = unionParts.every(part =>
+            tsutils.isTypeFlagSet(part, ts.TypeFlags.Never),
+          );
+          if (!isOnlyNever || checkNever) {
+            context.report({
+              node,
+              messageId: 'meaninglessVoidOperator',
+              data: { type: checker.typeToString(argType) },
+              fix,
+            });
+          }
         }
       },
     };

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-meaningless-void-operator.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-meaningless-void-operator.shot
@@ -7,6 +7,12 @@ function foo() {}
 void foo();
 ~~~~~~~~~~ void operator shouldn't be used on void; it should convey that a return value is being ignored
 
+declare const box: { value: string };
+void box;
+~~~~~~~~ void operator shouldn't be used on { value: string; }; it should convey that a return value is being ignored
+void box.value;
+~~~~~~~~~~~~~~ void operator shouldn't be used on string; it should convey that a return value is being ignored
+
 Correct
 
 (() => {})();
@@ -15,7 +21,6 @@ function foo() {}
 foo(); // nothing to discard
 
 function bar(x: number) {
-  void x; // discarding a number
-  return 2;
+  return x + 1;
 }
 void bar(1); // discarding a number

--- a/packages/eslint-plugin/tests/rules/no-meaningless-void-operator.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-meaningless-void-operator.test.ts
@@ -11,8 +11,7 @@ ruleTester.run('no-meaningless-void-operator', rule, {
 function foo() {}
 foo(); // nothing to discard
 
-function bar(x: number) {
-  void x;
+function bar(): number {
   return 2;
 }
 void bar(); // discarding a number
@@ -128,6 +127,29 @@ void box.value;
       output: `
 declare const box: { value: { toUpperCase(): string } };
 box.value;
+      `,
+    },
+    {
+      // `void` on a parameter to silence unused-variable warnings is exactly
+      // the anti-pattern issue #12214 calls out — flag it.
+      code: `
+function bar(x: number) {
+  void x;
+  return 2;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          line: 3,
+          messageId: 'meaninglessVoidOperator',
+        },
+      ],
+      output: `
+function bar(x: number) {
+  x;
+  return 2;
+}
       `,
     },
   ],

--- a/packages/eslint-plugin/tests/rules/no-meaningless-void-operator.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-meaningless-void-operator.test.ts
@@ -78,5 +78,57 @@ function bar(x: never) {
       options: [{ checkNever: true }],
       output: null,
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12214
+    {
+      code: `
+declare const box: { value: string };
+void box;
+      `,
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          messageId: 'meaninglessVoidOperator',
+        },
+      ],
+      output: `
+declare const box: { value: string };
+box;
+      `,
+    },
+    {
+      code: `
+declare const box: { value: string };
+void box.value;
+      `,
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          messageId: 'meaninglessVoidOperator',
+        },
+      ],
+      output: `
+declare const box: { value: string };
+box.value;
+      `,
+    },
+    {
+      code: `
+declare const box: { value: { toUpperCase(): string } };
+void box.value;
+      `,
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          messageId: 'meaninglessVoidOperator',
+        },
+      ],
+      output: `
+declare const box: { value: { toUpperCase(): string } };
+box.value;
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-meaningless-void-operator.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-meaningless-void-operator.test.ts
@@ -21,6 +21,11 @@ function bar(x: never) {
   void x;
 }
     `,
+    // ChainExpression wrapping a call still produces a value to discard.
+    `
+declare const box: { method(): string } | undefined;
+void box?.method();
+    `,
   ],
   invalid: [
     {
@@ -150,6 +155,24 @@ function bar(x: number) {
   x;
   return 2;
 }
+      `,
+    },
+    {
+      // ChainExpression wrapping a member access — recurse and report.
+      code: `
+declare const box: { value: string } | undefined;
+void box?.value;
+      `,
+      errors: [
+        {
+          column: 1,
+          line: 3,
+          messageId: 'meaninglessVoidOperator',
+        },
+      ],
+      output: `
+declare const box: { value: string } | undefined;
+box?.value;
       `,
     },
   ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12214
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Reports `void` applied to expressions that don't produce a value via a side effect — e.g. `void box`, `void box.value`, `void box?.value`. These join the existing type-driven cases. Calls (`void bar()`), `new`, `await`, and `yield` are still allowed since they may legitimately discard a return value.

Implemented as an additional `else if` branch in the existing `UnaryExpression[operator="void"]` handler. The existing fixer is reused (`void X;` → `X;`). Skips when the argument's type is `never` and `checkNever` is `false`, to preserve that option's opt-in semantics.

The previously-valid example `function bar(x: number) { void x; }` is now reported, per the issue body. The rule's doc example was updated accordingly.
