### PR TITLE
docs: update ESLint FAQ example to use `no-unused-vars` rule

### DIFF
--- a/docs/troubleshooting/faqs/ESLint.mdx
+++ b/docs/troubleshooting/faqs/ESLint.mdx
@@ -15,13 +15,13 @@ The first step is to [check our list of "extension" rules here](/rules/#extensio
 An extension rule is a rule which extends the base ESLint rules to support TypeScript syntax.
 If you find it in there, give it a go to see if it works for you.
 You can configure it by disabling the base rule, and turning on the extension rule.
-Here's an example with the `semi` rule:
+Here's an example with the `no-unused-vars` rule:
 
 ```json
 {
   "rules": {
-    "semi": "off",
-    "@typescript-eslint/semi": "error"
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "error"
   }
 }
 ```
@@ -134,7 +134,7 @@ See [#9582](https://github.com/typescript-eslint/typescript-eslint/issues/9582 '
 [ESLint's `--cache` option](https://eslint.org/docs/latest/use/command-line-interface#caching) caches on a per-file basis.
 You can use it, but it will only work reliably for untyped rules -- and even then, not always.
 
-Any ESLint rule that checks logic across files, including many rules from `eslint-plugin-import`, creates cross-file dependencies.
+Any ESLint rule that checks logic across files, including many rules from [`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import), creates cross-file dependencies.
 [Typed lint rules](../../getting-started/Typed_Linting.mdx) almost always have dependencies on types across files in practice.
 ESLint's caching doesn't account for those cross-file dependencies.
 

--- a/docs/troubleshooting/faqs/Frameworks.mdx
+++ b/docs/troubleshooting/faqs/Frameworks.mdx
@@ -51,9 +51,9 @@ module.exports = {
 </TabItem>
 </Tabs>
 
-## I am running into errors when parsing TypeScript in my .vue files
+## I am running into errors when parsing TypeScript in my `.vue` files
 
-If you are running into issues parsing .vue files, it might be because parsers like [`vue-eslint-parser`](https://www.npmjs.com/package/vue-eslint-parser) are required to parse `.vue` files. In this case you can move `@typescript-eslint/parser` inside `parserOptions` and use `vue-eslint-parser` as the top level parser.
+If you are running into issues parsing `.vue` files, it might be because parsers like [`vue-eslint-parser`](https://www.npmjs.com/package/vue-eslint-parser) are required to parse `.vue` files. In this case you can move `@typescript-eslint/parser` inside `parserOptions` and use `vue-eslint-parser` as the top level parser.
 
 <Tabs groupId="eslint-config">
 <TabItem value="Flat Config">


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hi,

As of ESLint v11, formatting rules are scheduled to be removed, so using the `semi` rule in the documentation could cause confusion in future ESLint versions. I’ve replaced it with `no-unused-vars` to avoid that.

Ref: https://github.com/eslint/eslint/issues/20097#issuecomment-3309780717

I also made minor documentation updates: switched the `eslint-plugin-import` reference to an external link and wrapped the `.vue` extension in backticks.

Please let me know if I made any mistakes 😄

🛩️ 