### PR TITLE
chore: fix some problems with generate-website-dts

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -105,7 +105,8 @@
   "nx": {
     "name": "website",
     "includedScripts": [
-      "clean"
+      "clean",
+      "generate-website-dts"
     ],
     "targets": {
       "build": {

--- a/packages/website/src/vendor/sandbox.d.ts
+++ b/packages/website/src/vendor/sandbox.d.ts
@@ -8,7 +8,7 @@
  *          pnpm run generate-website-dts     *
  **********************************************/
 
-import type * as ts from 'typescript';
+import type * as TS from 'typescript';
 import type * as MonacoEditor from 'monaco-editor';
 type TypeScriptWorker = MonacoEditor.languages.typescript.TypeScriptWorker;
 import type lzstring from 'lz-string';
@@ -91,7 +91,7 @@ export declare function defaultPlaygroundSettings(): {
 export declare const createTypeScriptSandbox: (
   partialConfig: Partial<SandboxConfig>,
   monaco: Monaco,
-  ts: typeof ts,
+  ts: typeof TS,
 ) => {
   /** The same config you passed in */
   config:
@@ -136,6 +136,7 @@ export declare const createTypeScriptSandbox: (
       };
   /** A list of TypeScript versions you can use with the TypeScript sandbox */
   supportedVersions: readonly [
+    '6.0.3',
     '5.9.3',
     '5.8.3',
     '5.7.3',
@@ -182,7 +183,7 @@ export declare const createTypeScriptSandbox: (
   getEmitResult: (
     emitOnlyDtsFiles?: boolean,
     forceDtsEmit?: boolean,
-  ) => Promise<ts.EmitOutput>;
+  ) => Promise<TS.EmitOutput>;
   /** Gets just the JavaScript for your sandbox, will transpile if in TS only */
   getRunnableJS: () => Promise<string>;
   /** Gets the DTS output of the main code in the editor */
@@ -196,9 +197,9 @@ export declare const createTypeScriptSandbox: (
   /** Shortcut for setting the model's text content which would update the editor */
   setText: (text: string) => void;
   /** Gets the AST of the current text in monaco - uses `createTSProgram`, so the performance caveat applies there too */
-  getAST: () => Promise<ts.SourceFile>;
+  getAST: () => Promise<TS.SourceFile>;
   /** The module you get from require("typescript") */
-  ts: typeof ts;
+  ts: typeof TS;
   /** Create a new Program, a TypeScript data model which represents the entire project. As well as some of the
    * primitive objects you would normally need to do work with the files.
    *
@@ -213,17 +214,17 @@ export declare const createTypeScriptSandbox: (
    * when the monaco model changes.
    */
   setupTSVFS: (fsMapAdditions?: Map<string, string>) => Promise<{
-    program: ts.Program;
-    system: ts.System;
+    program: TS.Program;
+    system: TS.System;
     host: {
-      compilerHost: ts.CompilerHost;
-      updateFile: (sourceFile: ts.SourceFile) => boolean;
-      deleteFile: (sourceFile: ts.SourceFile) => boolean;
+      compilerHost: TS.CompilerHost;
+      updateFile: (sourceFile: TS.SourceFile) => boolean;
+      deleteFile: (sourceFile: TS.SourceFile) => boolean;
     };
     fsMap: Map<string, string>;
   }>;
   /** Uses the above call setupTSVFS, but only returns the program */
-  createTSProgram: () => Promise<ts.Program>;
+  createTSProgram: () => Promise<TS.Program>;
   /** The Sandbox's default compiler options  */
   compilerDefaults: {
     [x: string]: MonacoEditor.languages.typescript.CompilerOptionsValue;

--- a/packages/website/src/vendor/typescript-vfs.d.ts
+++ b/packages/website/src/vendor/typescript-vfs.d.ts
@@ -8,14 +8,14 @@
  *          pnpm run generate-website-dts     *
  **********************************************/
 
-import type * as ts from 'typescript';
-type System = ts.System;
-type CompilerOptions = ts.CompilerOptions;
-type CustomTransformers = ts.CustomTransformers;
-type LanguageServiceHost = ts.LanguageServiceHost;
-type CompilerHost = ts.CompilerHost;
-type SourceFile = ts.SourceFile;
-type TS = typeof ts;
+import type * as TS from 'typescript';
+type System = TS.System;
+type CompilerOptions = TS.CompilerOptions;
+type CustomTransformers = TS.CustomTransformers;
+type LanguageServiceHost = TS.LanguageServiceHost;
+type CompilerHost = TS.CompilerHost;
+type SourceFile = TS.SourceFile;
+type TS = typeof TS;
 type FetchLike = (url: string) => Promise<{
   json(): Promise<any>;
   text(): Promise<string>;
@@ -27,13 +27,13 @@ interface LocalStorageLike {
 }
 export interface VirtualTypeScriptEnvironment {
   sys: System;
-  languageService: ts.LanguageService;
-  getSourceFile: (fileName: string) => ts.SourceFile | undefined;
+  languageService: TS.LanguageService;
+  getSourceFile: (fileName: string) => TS.SourceFile | undefined;
   createFile: (fileName: string, content: string) => void;
   updateFile: (
     fileName: string,
     content: string,
-    replaceTextSpan?: ts.TextSpan,
+    replaceTextSpan?: TS.TextSpan,
   ) => void;
   deleteFile: (fileName: string) => void;
 }
@@ -75,7 +75,7 @@ export declare const knownLibFilesForCompilerOptions: (
  */
 export declare const createDefaultMapFromNodeModules: (
   _compilerOptions: CompilerOptions,
-  _ts?: typeof ts,
+  _ts?: typeof TS,
   tsLibDirectory?: string,
 ) => Map<string, string>;
 /**
@@ -155,7 +155,7 @@ export declare function createVirtualLanguageServiceHost(
   customTransformers?: CustomTransformers,
 ): {
   languageServiceHost: LanguageServiceHost;
-  updateFile: (sourceFile: ts.SourceFile) => void;
-  deleteFile: (sourceFile: ts.SourceFile) => void;
+  updateFile: (sourceFile: TS.SourceFile) => void;
+  deleteFile: (sourceFile: TS.SourceFile) => void;
 };
 export {};

--- a/packages/website/tools/generate-website-dts.mts
+++ b/packages/website/tools/generate-website-dts.mts
@@ -60,7 +60,7 @@ ${text.replace(regex, safeName)}`;
 function processFiles(text: string): string {
   let result = text;
   result = injectImports(result, 'monaco-editor', 'MonacoEditor');
-  result = injectImports(result, 'typescript', 'ts');
+  result = injectImports(result, 'typescript', 'TS');
   result = replaceImports(result, './vendor/lzstring.min', 'lz-string');
   result = replaceImports(
     result,


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

previously, `pnpm generate-website-dts` failed due to the way `nx` hijacks the package scripts. Now it succeeds.

Also changed `import ts from 'typescript'` to `import TS from 'typescript'`, because the d.ts files have a name collision (basically, `function f(ts: typeof ts)`, which is a TS error for a circular declaration).