### PR TITLE
docs: update stale links to latest

### DIFF
--- a/docs/troubleshooting/faqs/ESLint.mdx
+++ b/docs/troubleshooting/faqs/ESLint.mdx
@@ -113,7 +113,7 @@ Two common solutions in TypeScript for declaring the existence of a global varia
 [Using global variables is generally discouraged](https://stackoverflow.com/questions/10525582/why-are-global-variables-considered-bad-practice).
 If possible, it's best to avoid declaring globals altogether.
 
-If you absolutely must use one of the two strategies, then you can use an [ESLint configuration comment](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) to disable rules as needed.
+If you absolutely must use one of the two strategies, then you can use an [ESLint configuration comment](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) to disable rules as needed.
 For example:
 
 ```ts

--- a/packages/eslint-plugin/docs/rules/README.md
+++ b/packages/eslint-plugin/docs/rules/README.md
@@ -58,7 +58,7 @@ module.exports = {
 
 ## Frozen Rules
 
-When rules are feature complete, they are marked as frozen (indicated with ❄️ in the documentation). This applies to standalone rules that are complete, as well as [extension rules](#extension-rules) whose underlying core ESLint rules are frozen. After that point, we expect users to use [disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) when they find an edge case that isn’t covered.
+When rules are feature complete, they are marked as frozen (indicated with ❄️ in the documentation). This applies to standalone rules that are complete, as well as [extension rules](#extension-rules) whose underlying core ESLint rules are frozen. After that point, we expect users to use [disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) when they find an edge case that isn’t covered.
 
 When a rule is frozen, it means:
 

--- a/packages/eslint-plugin/docs/rules/adjacent-overload-signatures.mdx
+++ b/packages/eslint-plugin/docs/rules/adjacent-overload-signatures.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 Function overload signatures represent multiple ways a function can be called, potentially with different return types.
 It's typical for an interface or type alias describing a function to place all overload signatures next to each other.
-If Signatures placed elsewhere in the type are easier to be missed by future developers reading the code.
+If signatures placed elsewhere in the type are easier to be missed by future developers reading the code.
 
 ## Examples
 
@@ -98,7 +98,7 @@ export function foo(sn: string | number): void;
 
 It can sometimes be useful to place overload signatures alongside other meaningful parts of a type.
 For example, if each of a function's overloads corresponds to a different property, you might wish to put each overloads next to its corresponding property.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/await-thenable.mdx
+++ b/packages/eslint-plugin/docs/rules/await-thenable.mdx
@@ -181,4 +181,4 @@ async function shouldAwait() {
 If you want to allow code to `await` non-Promise values.
 For example, if your framework is in transition from one style of asynchronous code to another, it may be useful to include `await`s unnecessarily.
 This is generally not preferred but can sometimes be useful for visual consistency.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/ban-ts-comment.mdx
+++ b/packages/eslint-plugin/docs/rules/ban-ts-comment.mdx
@@ -158,7 +158,7 @@ if (false) {
 ## When Not To Use It
 
 If your project or its dependencies were not architected with strong type safety in mind, it can be difficult to always adhere to proper TypeScript semantics.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/class-methods-use-this.mdx
+++ b/packages/eslint-plugin/docs/rules/class-methods-use-this.mdx
@@ -132,4 +132,4 @@ class Derived implements Base {
 ## When Not To Use It
 
 If your project dynamically changes `this` scopes around in a way TypeScript has difficulties modeling, this rule may not be viable to use.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/consistent-type-definitions.mdx
+++ b/packages/eslint-plugin/docs/rules/consistent-type-definitions.mdx
@@ -125,7 +125,7 @@ However, keep in mind that inconsistent style can harm readability in a project.
 We recommend picking a single option for this rule that works best for your project.
 
 You might occasionally need to a different definition type in specific cases, such as if your project is a dependency or dependent of another project that relies on a specific type definition style.
-Consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+Consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/no-duplicate-enum-values.mdx
+++ b/packages/eslint-plugin/docs/rules/no-duplicate-enum-values.mdx
@@ -61,6 +61,6 @@ enum E {
 
 It can sometimes be useful to include duplicate enum members for very specific use cases.
 For example, when renaming an enum member, it can sometimes be useful to keep the old name until a scheduled major breaking change.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 In general, if your project intentionally duplicates enum member values, you can avoid this rule.

--- a/packages/eslint-plugin/docs/rules/no-duplicate-type-constituents.mdx
+++ b/packages/eslint-plugin/docs/rules/no-duplicate-type-constituents.mdx
@@ -80,7 +80,7 @@ When set to true, duplicate checks on union type constituents are ignored.
 ## When Not To Use It
 
 It can sometimes be useful for the sake of documentation to include aliases for the same type.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 > In some of those cases, [branded types](https://basarat.gitbook.io/typescript/main-1/nominaltyping#using-interfaces) might be a type-safe way to represent the underlying data types.
 

--- a/packages/eslint-plugin/docs/rules/no-dynamic-delete.mdx
+++ b/packages/eslint-plugin/docs/rules/no-dynamic-delete.mdx
@@ -58,7 +58,7 @@ delete container['Infinity'];
 ## When Not To Use It
 
 When you know your keys are safe to delete, this rule can be unnecessary.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 Do not consider this rule as performance advice before profiling your code's bottlenecks.
 Even repeated minor performance slowdowns likely do not significantly affect your application's general perceived speed.

--- a/packages/eslint-plugin/docs/rules/no-empty-function.mdx
+++ b/packages/eslint-plugin/docs/rules/no-empty-function.mdx
@@ -87,8 +87,8 @@ class Foo extends Base {
 ## When Not To Use It
 
 If you are working with external APIs that require functions even if they do nothing, then you may want to avoid this rule.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 Test code often violates this rule as well.
 If your testing setup doesn't support "mock" or "spy" functions such as [`jest.fn()`](https://jestjs.io/docs/mock-functions), [`sinon.spy()`](https://sinonjs.org/releases/latest/spies), or [`vi.fn()`](https://vitest.dev/guide/mocking.html), you may wish to disable this rule in test files.
-Again, if those cases aren't extremely common, you might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule in test files.
+Again, if those cases aren't extremely common, you might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule in test files.

--- a/packages/eslint-plugin/docs/rules/no-empty-object-type.mdx
+++ b/packages/eslint-plugin/docs/rules/no-empty-object-type.mdx
@@ -28,7 +28,7 @@ To avoid confusion around the `{}` type allowing any _non-nullish value_, this r
 That includes interfaces and object type aliases with no fields.
 
 :::tip
-If you do have a use case for an API allowing `{}`, you can always configure the [rule's options](#options), use an [ESLint disable comment](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1), or [disable the rule in your ESLint config](https://eslint.org/docs/latest/use/configure/rules#using-configuration-files-1).
+If you do have a use case for an API allowing `{}`, you can always configure the [rule's options](#options), use an [ESLint disable comment](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments), or [disable the rule in your ESLint config](https://eslint.org/docs/latest/use/configure/rules#using-configuration-files-1).
 :::
 
 Note that this rule does not report on:

--- a/packages/eslint-plugin/docs/rules/no-explicit-any.mdx
+++ b/packages/eslint-plugin/docs/rules/no-explicit-any.mdx
@@ -238,7 +238,7 @@ Most commonly:
 - If an external package doesn't yet have typings and you want to use `any` pending adding a `.d.ts` for it
 - You're working with particularly complex or nuanced code that can't yet be represented in the TypeScript type system
 
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-extraneous-class.mdx
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-class.mdx
@@ -326,4 +326,4 @@ class Constants {
 ## When Not To Use It
 
 If your project was set up before modern class and namespace practices, and you don't have the time to switch over, you might not be practically able to use this rule.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
+++ b/packages/eslint-plugin/docs/rules/no-floating-promises.mdx
@@ -140,7 +140,7 @@ Placing the [`void` operator](https://developer.mozilla.org/en-US/docs/Web/JavaS
 
 :::warning
 Voiding a Promise doesn't handle it or change the runtime behavior.
-The outcome is just ignored, like disabling the rule with an [ESLint disable comment](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1).
+The outcome is just ignored, like disabling the rule with an [ESLint disable comment](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments).
 Such Promise rejections will still be unhandled.
 :::
 
@@ -271,7 +271,7 @@ safe('...', () => {});
 
 This rule can be difficult to enable on large existing projects that set up many floating Promises.
 Alternately, if you're not worried about crashes from floating or misused Promises -such as if you have global unhandled Promise handlers registered- then in some cases it may be safe to not use this rule.
-You might consider using `void`s and/or [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using `void`s and/or [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-for-in-array.mdx
+++ b/packages/eslint-plugin/docs/rules/no-for-in-array.mdx
@@ -64,4 +64,4 @@ for (const [i, value] of array.entries()) {
 ## When Not To Use It
 
 If your project is a rare one that intentionally loops over string indices of arrays, you can turn off this rule.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/no-implied-eval.mdx
+++ b/packages/eslint-plugin/docs/rules/no-implied-eval.mdx
@@ -103,4 +103,4 @@ setTimeout(Foo.fn, 100);
 ## When Not To Use It
 
 If your project is a rare one that needs to allow `new Function()` or `setTimeout()`, `setInterval()`, `setImmediate()` and `execScript()` with string arguments, then you can disable this rule.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/no-magic-numbers.mdx
+++ b/packages/eslint-plugin/docs/rules/no-magic-numbers.mdx
@@ -128,4 +128,4 @@ type Baz = Parameters<Foo>[2];
 
 If your project frequently deals with constant numbers and you don't wish to take up extra space to declare them, this rule might not be for you.
 We recommend at least using descriptive comments and/or names to describe constants.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/no-misused-new.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misused-new.mdx
@@ -50,4 +50,4 @@ interface I {
 ## When Not To Use It
 
 If you intentionally want a class with a `new` method, and you're confident nobody working in your code will mistake it with a constructor, you might not want this rule.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/no-misused-promises.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misused-promises.mdx
@@ -303,7 +303,7 @@ console.log({ foo: 42, ...(await awaitData()) });
 
 This rule can be difficult to enable on large existing projects that set up many misused Promises.
 Alternately, if you're not worried about crashes from floating or misused Promises -such as if you have global unhandled Promise handlers registered- then in some cases it may be safe to not use this rule.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/no-misused-spread.mdx
+++ b/packages/eslint-plugin/docs/rules/no-misused-spread.mdx
@@ -138,7 +138,7 @@ See the shared [`TypeOrValueSpecifier` format](/packages/type-utils/type-or-valu
 
 If your application intentionally works with raw data in unusual ways, such as directly manipulating class prototype chains, you might not want this rule.
 
-If your use cases for unusual spreads only involve a few types, you might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) and/or the [`allow` option](#allow) instead of completely disabling this rule.
+If your use cases for unusual spreads only involve a few types, you might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) and/or the [`allow` option](#allow) instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/no-namespace.mdx
+++ b/packages/eslint-plugin/docs/rules/no-namespace.mdx
@@ -144,7 +144,7 @@ You can learn more about this at:
 If your project uses this syntax, either because it was architected before modern modules and namespaces, or because a module option such as `verbatimModuleSyntax` requires it, it may be difficult to migrate off of namespaces.
 In that case you may not be able to use this rule for parts of your project.
 
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/no-non-null-asserted-nullish-coalescing.mdx
+++ b/packages/eslint-plugin/docs/rules/no-non-null-asserted-nullish-coalescing.mdx
@@ -52,7 +52,7 @@ x! ?? '';
 ## When Not To Use It
 
 If your project's types don't yet fully describe whether certain values may be nullable, such as if you're transitioning to `strictNullChecks`, this rule might create many false reports.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/no-non-null-asserted-optional-chain.mdx
+++ b/packages/eslint-plugin/docs/rules/no-non-null-asserted-optional-chain.mdx
@@ -38,7 +38,7 @@ foo?.bar();
 ## When Not To Use It
 
 If your project's types don't yet fully describe whether certain values may be nullable, such as if you're transitioning to `strictNullChecks`, this rule might create many false reports.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/no-non-null-assertion.mdx
+++ b/packages/eslint-plugin/docs/rules/no-non-null-assertion.mdx
@@ -45,4 +45,4 @@ const includesBaz = example.property?.includes('baz') ?? false;
 ## When Not To Use It
 
 If your project's types don't yet fully describe whether certain values may be nullable, such as if you're transitioning to `strictNullChecks`, this rule might create many false reports.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/no-require-imports.mdx
+++ b/packages/eslint-plugin/docs/rules/no-require-imports.mdx
@@ -107,7 +107,7 @@ We don't directly provide a way to _prohibit_ ES Module syntax from being used; 
 If you are authoring CommonJS modules _and_ your project frequently uses dynamic `require`s, then this rule might not be applicable to you.
 Otherwise, the `allowAsImport` option probably suits your needs.
 
-If only a subset of your project uses dynamic `require`s then you might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+If only a subset of your project uses dynamic `require`s then you might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-this-alias.mdx
+++ b/packages/eslint-plugin/docs/rules/no-this-alias.mdx
@@ -121,4 +121,4 @@ class Example {
 ## When Not To Use It
 
 If your project is structured in a way that it needs to assign `this` to variables, this rule is likely not for you.
-If only a subset of your project assigns `this` to variables then you might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+If only a subset of your project assigns `this` to variables then you might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -309,7 +309,7 @@ This only happens if your object type is not sufficiently constrained; most obje
 ## When Not To Use It
 
 If your project is not accurately typed, such as if it's in the process of being converted to TypeScript or is susceptible to [trade-offs in control flow analysis](https://github.com/Microsoft/TypeScript/issues/9998), it may be difficult to enable this rule for particularly non-type-safe areas of code.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-unsafe-argument.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-argument.mdx
@@ -86,7 +86,7 @@ foo(1 as any, new Set<any>(), [] as any[]);
 
 If your codebase has many existing `any`s or areas of unsafe code, it may be difficult to enable this rule.
 It may be easier to skip the `no-unsafe-*` rules pending increasing type safety in unsafe areas of your project.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-unsafe-assignment.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-assignment.mdx
@@ -89,7 +89,7 @@ const x: Set<unknown> = y as Set<any>;
 
 If your codebase has many existing `any`s or areas of unsafe code, it may be difficult to enable this rule.
 It may be easier to skip the `no-unsafe-*` rules pending increasing type safety in unsafe areas of your project.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-unsafe-call.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-call.mdx
@@ -108,7 +108,7 @@ function callSafe(maybeFunction: unknown): void {
 
 If your codebase has many existing `any`s or areas of unsafe code, it may be difficult to enable this rule.
 It may be easier to skip the `no-unsafe-*` rules pending increasing type safety in unsafe areas of your project.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-unsafe-declaration-merging.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-declaration-merging.mdx
@@ -58,7 +58,7 @@ function Qux() {}
 ## When Not To Use It
 
 If your project intentionally defines classes and interfaces with unsafe declaration merging patterns, this rule might not be for you.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/no-unsafe-enum-comparison.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-enum-comparison.mdx
@@ -95,4 +95,4 @@ Alternately, you might consider making use of a validation library like [Zod](ht
 See further discussion of this topic in [#8557](https://github.com/typescript-eslint/typescript-eslint/issues/8557).
 
 Finally, in the rare case of relying on an third party enums that are only imported as `type`s, it may be difficult to adhere to this rule.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/no-unsafe-function-type.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-function-type.mdx
@@ -54,7 +54,7 @@ identity = value => value;
 ## When Not To Use It
 
 If your project is still onboarding to TypeScript, it might be difficult to fully replace all unsafe `Function` types with more precise function types.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-unsafe-member-access.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-member-access.mdx
@@ -106,7 +106,7 @@ However, it still results in an `any`-typed value, which is unsafe.
 
 If your codebase has many existing `any`s or areas of unsafe code, it may be difficult to enable this rule.
 It may be easier to skip the `no-unsafe-*` rules pending increasing type safety in unsafe areas of your project.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-unsafe-return.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-return.mdx
@@ -129,7 +129,7 @@ For `Promise<any>` in particular, see also [`@typescript-eslint/promise-function
 
 If your codebase has many existing `any`s or areas of unsafe code, it may be difficult to enable this rule.
 It may be easier to skip the `no-unsafe-*` rules pending increasing type safety in unsafe areas of your project.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-unsafe-type-assertion.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unsafe-type-assertion.mdx
@@ -54,7 +54,7 @@ const number = items[0] as number | string | undefined;
 
 If your codebase has many unsafe type assertions, then it may be difficult to enable this rule.
 It may be easier to skip the `no-unsafe-*` rules pending increasing type safety in unsafe areas of your project.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 If your project frequently stubs objects in test files, the rule may trigger a lot of reports. Consider disabling the rule for such files to reduce frequent warnings.
 

--- a/packages/eslint-plugin/docs/rules/no-var-requires.mdx
+++ b/packages/eslint-plugin/docs/rules/no-var-requires.mdx
@@ -70,7 +70,7 @@ const foo = require('../package.json');
 ## When Not To Use It
 
 If your project frequently uses older CommonJS `require`s, then this rule might not be applicable to you.
-If only a subset of your project uses `require`s then you might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+If only a subset of your project uses `require`s then you might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Related To
 

--- a/packages/eslint-plugin/docs/rules/no-wrapper-object-types.mdx
+++ b/packages/eslint-plugin/docs/rules/no-wrapper-object-types.mdx
@@ -61,7 +61,7 @@ let myObject: object = "Type 'string' is not assignable to type 'object'.";
 ## When Not To Use It
 
 If your project is a rare one that intentionally deals with the class equivalents of primitives, it might not be worthwhile to use this rule.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/prefer-for-of.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-for-of.mdx
@@ -67,4 +67,4 @@ See [aka.ms/tsconfig#lib](http://aka.ms/tsconfig#lib) for more information.
 Note that this rule does not use type information to determine whether iterated elements are arrays.
 It only checks if a `.length` property is used in a loop.
 If your project loops over objects that happen to have `.length`, this rule may report false positives.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/prefer-function-type.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-function-type.mdx
@@ -94,5 +94,5 @@ If you specifically want to use an interface or type literal with a single call 
 
 This rule has a known edge case of sometimes triggering on global augmentations such as `interface Function`.
 These edge cases are rare and often symptomatic of odd code.
-We recommend you use an [inline ESLint disable comment](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1).
+We recommend you use an [inline ESLint disable comment](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments).
 See [#454](https://github.com/typescript-eslint/typescript-eslint/issues/454) for details.

--- a/packages/eslint-plugin/docs/rules/prefer-optional-chain.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-optional-chain.mdx
@@ -293,7 +293,7 @@ thing2 && thing2.toString();
 ## When Not To Use It
 
 If your project is not accurately typed, such as if it's in the process of being converted to TypeScript or is susceptible to [trade-offs in control flow analysis](https://github.com/Microsoft/TypeScript/issues/9998), it may be difficult to enable this rule for particularly non-type-safe areas of code.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-reduce-type-parameter.mdx
@@ -63,4 +63,4 @@ It will suggest instead pass the asserted type to `Array#reduce` as a generic ty
 
 This rule can sometimes be difficult to work around when creating objects using a `.reduce`.
 See [[prefer-reduce-type-parameter] unfixable reporting #3440](https://github.com/typescript-eslint/typescript-eslint/issues/3440) for more details.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.mdx
@@ -79,7 +79,7 @@ const isOptionEnabled = (key: string): boolean => {
 ## When Not To Use It
 
 If you are compiling against multiple versions of TypeScript and using `@ts-ignore` to ignore version-specific type errors, this rule might get in your way.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/promise-function-async.mdx
+++ b/packages/eslint-plugin/docs/rules/promise-function-async.mdx
@@ -140,4 +140,4 @@ const returnsBluebird = async () => new Bluebird(() => {});
 ## When Not To Use It
 
 This rule can be difficult to enable on projects that use APIs which require functions to always be `async`.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) along with filing issues on your dependencies for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) along with filing issues on your dependencies for those specific situations instead of completely disabling this rule.

--- a/packages/eslint-plugin/docs/rules/related-getter-setter-pairs.mdx
+++ b/packages/eslint-plugin/docs/rules/related-getter-setter-pairs.mdx
@@ -52,7 +52,7 @@ interface Box {
 ## When Not To Use It
 
 If your project needs to model unusual relationships between data, such as older DOM types, this rule may not be useful for you.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## Further Reading
 

--- a/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.mdx
+++ b/packages/eslint-plugin/docs/rules/switch-exhaustiveness-check.mdx
@@ -30,7 +30,7 @@ Additionally, if a new value is added to the union type and you're using [`consi
 It can sometimes be useful to include a redundant `default` case on an exhaustive `switch` statement if it's possible for values to have types not represented by the union type.
 For example, in applications that can have version mismatches between clients and servers, it's possible for a server running a newer software version to send a value not recognized by the client's older typings.
 
-If your project has a small number of intentionally redundant `default` cases, you might want to use an [inline ESLint disable comment](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for each of them.
+If your project has a small number of intentionally redundant `default` cases, you might want to use an [inline ESLint disable comment](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for each of them.
 
 If your project has many intentionally redundant `default` cases, you may want to disable `allowDefaultCaseForExhaustiveSwitch` and use the [`default-case` core ESLint rule](https://eslint.org/docs/latest/rules/default-case) along with [a `satisfies never` check](https://www.typescriptlang.org/play?#code/C4TwDgpgBAYgTgVwJbCgXigcgIZjAGwkygB8sAjbAO2u0wG4AoRgMwSoGNgkB7KqBAGcI8ZMAAULRCgBcsacACUcwcDhIqAcygBvRlCiCA7ig4ALKJIWLd+g1A7ZhWXASJy99+3AjAEcfhw8QgApZA4iJi8AX2YvR2dMShoaTA87Lx8-AIpaGjCkCIYMqFiSgBMIFmwEfGB0rwMpMUNsbkEWJAhBKCoIADcIOCjGrP9A9gBrKh4jKgKikYNY5cZYoA).
 

--- a/packages/eslint-plugin/docs/rules/triple-slash-reference.mdx
+++ b/packages/eslint-plugin/docs/rules/triple-slash-reference.mdx
@@ -122,7 +122,7 @@ import { valueA, valueB } from 'code';
 Most modern TypeScript projects generally use `import` statements to bring in types.
 It's rare to need a `///` triple-slash reference outside of auto-generated code.
 If your project is a rare one with one of those use cases, this rule might not be for you.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 ## When Not To Use It
 

--- a/packages/eslint-plugin/docs/rules/unbound-method.mdx
+++ b/packages/eslint-plugin/docs/rules/unbound-method.mdx
@@ -109,6 +109,6 @@ log();
 If your project dynamically changes `this` scopes around in a way TypeScript has difficulties modeling, this rule may not be viable to use.
 For example, some functions have an additional parameter for specifying the `this` context, such as `Reflect.apply`, and array methods like `Array.prototype.map`.
 This semantic is not easily expressed by TypeScript.
-You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1) for those specific situations instead of completely disabling this rule.
+You might consider using [ESLint disable comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments) for those specific situations instead of completely disabling this rule.
 
 If you're wanting to use `toBeCalled` and similar matches in `jest` tests, you can disable this rule for your test files in favor of [`eslint-plugin-jest`'s version of this rule](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md).

--- a/packages/website/blog/2025-01-21-avoiding-anys.mdx
+++ b/packages/website/blog/2025-01-21-avoiding-anys.mdx
@@ -34,7 +34,7 @@ Enabling `noImplicitAny` is a great first step towards better project type safet
 ## Banning Unsafe Types
 
 The first line of defense against `any` for many repositories is adding lint rules that report on explicitly written unsafe types.
-Developers can always [disable ESLint rules with inline comments](https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1), so this isn't guaranteed to prevent explicit `any`s from popping up.
+Developers can always [disable ESLint rules with inline comments](https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments), so this isn't guaranteed to prevent explicit `any`s from popping up.
 But these lint rules put an immediate restriction on unsafe types -- and help guide towards better alternatives.
 
 ### Banning Explicit `any`s


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hi,

I've found that some links went stale and pointed to the wrong hash fragments, so I've updated them.

This change was introduced by PR https://github.com/eslint/eslint/pull/20449 in the `eslint` repository.

- Before: https://eslint.org/docs/latest/use/configure/rules#using-configuration-comments-1
- After: https://eslint.org/docs/latest/use/configure/rules#use-configuration-comments

🐼
