### PR TITLE
chore: update deprecated configs in `.vscode/settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,10 +15,8 @@
 
   // typescript auto-format settings
   "typescript.tsdk": "node_modules/typescript/lib",
-  "js.preferences.importModuleSpecifier": "project-relative",
-  "ts.preferences.importModuleSpecifier": "project-relative",
-  "js.preferences.quoteStyle": "single",
-  "ts.preferences.quoteStyle": "single",
+  "js/ts.preferences.importModuleSpecifier": "project-relative",
+  "js/ts.preferences.quoteStyle": "single",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "nxConsole.generateAiAgentRules": true,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   "files.trimTrailingWhitespace": true,
 
   // typescript auto-format settings
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "js/ts.preferences.importModuleSpecifier": "project-relative",
   "js/ts.preferences.quoteStyle": "single",
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,10 +15,10 @@
 
   // typescript auto-format settings
   "typescript.tsdk": "node_modules/typescript/lib",
-  "javascript.preferences.importModuleSpecifier": "project-relative",
-  "typescript.preferences.importModuleSpecifier": "project-relative",
-  "javascript.preferences.quoteStyle": "single",
-  "typescript.preferences.quoteStyle": "single",
+  "js.preferences.importModuleSpecifier": "project-relative",
+  "ts.preferences.importModuleSpecifier": "project-relative",
+  "js.preferences.quoteStyle": "single",
+  "ts.preferences.quoteStyle": "single",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "nxConsole.generateAiAgentRules": true,
 }


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Hi,

While going through the files in this project, I found that some configuration settings in `.vscode/settings.json` are now deprecated.

<img width="600" height="117" alt="image" src="https://github.com/user-attachments/assets/bfba891f-3ce9-4283-8a95-e4f6047e82b3" alt="vscode deprecated" />

As mentioned in the deprecation notice, I've updated `javascript` and `typescript` to `js` and `ts`, respectively.

Please let me know if I made any mistakes!

:octocat: 

<!-- Description of what is changed and how the code change does that. -->
