### PR TITLE
chore: remove obsolete `eslint-plugin-eslint-comments` typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },
   "devDependencies": {
-    "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.7.1",
     "@eslint/compat": "^2.0.2",
     "@eslint/config-helpers": "^0.5.2",
     "@eslint/eslintrc": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
   .:
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
-        specifier: ^4.5.0
-        version: 4.7.0(eslint@10.2.1(jiti@2.6.1))
+        specifier: ^4.7.1
+        version: 4.7.1(eslint@10.2.1(jiti@2.6.1))
       '@eslint/compat':
         specifier: ^2.0.2
         version: 2.0.2(eslint@10.2.1(jiti@2.6.1))
@@ -2795,8 +2795,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.7.0':
-    resolution: {integrity: sha512-wxyEBQOUAXp4HjnYWucQy7iq58RR1WXJhm6bjw+sGlMDEKJmzJVe2MLnd6iazmQFYGOxoUrw27EsJfpoqiI7tQ==}
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.1':
+    resolution: {integrity: sha512-Ql2nJFwA8wUGpILYGOQaT1glPsmvEwE0d+a+l7AALLzQvInqdbXJdx7aSu0DpUX9dB1wMVBMhm99/++S3MdEtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
@@ -12210,7 +12210,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
-  '@eslint-community/eslint-plugin-eslint-comments@4.7.0(eslint@10.2.1(jiti@2.6.1))':
+  '@eslint-community/eslint-plugin-eslint-comments@4.7.1(eslint@10.2.1(jiti@2.6.1))':
     dependencies:
       escape-string-regexp: 4.0.0
       eslint: 10.2.1(jiti@2.6.1)

--- a/typings/eslint-plugin-eslint-comments.d.ts
+++ b/typings/eslint-plugin-eslint-comments.d.ts
@@ -1,8 +1,0 @@
-declare module '@eslint-community/eslint-plugin-eslint-comments/configs' {
-  import type { Config } from '@eslint/config-helpers';
-
-  declare const exprt: {
-    recommended: Config;
-  };
-  export = exprt;
-}


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hi,

As of `@eslint-community/eslint-plugin-eslint-comments@4.6.0`, types are now supported natively, so the `typings/eslint-plugin-eslint-comments.d.ts` file is no longer necessary.

This will reduce clutter in the repo. 🎉

- https://github.com/eslint-community/eslint-plugin-eslint-comments/releases/tag/v4.6.0
- https://npmx.dev/package-code/@eslint-community/eslint-plugin-eslint-comments/v/4.7.1/package.json#L40