### PR TITLE
feat(eslint-plugin): [no-unnecessary-type-assertion] flag redundant 'as const' on literals in contextually-typed positions

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-type-assertion.mdx
@@ -79,6 +79,13 @@ With `@typescript-eslint/no-unnecessary-type-assertion: ["error", { checkLiteral
 const foo = 'foo' as const;
 ```
 
+`as const` on a literal is also flagged when the surrounding context already narrows to a literal (or union of literals) that accepts the asserted value — contextual typing alone preserves the literal-ness, so the assertion adds nothing:
+
+```ts option='{ "checkLiteralConstAssertions": true }' showPlaygroundButton
+type Recipient = { kind: 'a' | 'b' };
+const r: Recipient = { kind: 'a' as const };
+```
+
 See [#8721 False positives for "as const" assertions (issue comment)](https://github.com/typescript-eslint/typescript-eslint/issues/8721#issuecomment-2145291966) for more information on this option.
 
 ### `typesToIgnore`

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -273,6 +273,32 @@ export default createRule<Options, MessageIds>({
       return type.isLiteral() || tsutils.isBooleanLiteralType(type);
     }
 
+    // Asserts in arg position of a generic call can drive type-parameter
+    // inference (e.g. `id<T>('a' as const)` pins T to `'a'` instead of
+    // widening to `string`), so removing the assertion isn't safe even when
+    // the resolved contextual type looks like a literal.
+    function isArgumentOfGenericCall(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+    ): boolean {
+      const parent = node.parent;
+      if (
+        parent.type !== AST_NODE_TYPES.CallExpression &&
+        parent.type !== AST_NODE_TYPES.NewExpression
+      ) {
+        return false;
+      }
+      if (!parent.arguments.includes(node)) {
+        return false;
+      }
+      const calleeTsNode = services.esTreeNodeToTSNodeMap.get(parent.callee);
+      const calleeType = checker.getTypeAtLocation(calleeTsNode);
+      const signatures =
+        parent.type === AST_NODE_TYPES.NewExpression
+          ? calleeType.getConstructSignatures()
+          : calleeType.getCallSignatures();
+      return signatures.some(s => !!s.typeParameters?.length);
+    }
+
     function hasIndexSignature(type: ts.Type): boolean {
       return tsutils
         .unionConstituents(type)
@@ -879,6 +905,30 @@ export default createRule<Options, MessageIds>({
         }
 
         const originalNode = services.esTreeNodeToTSNodeMap.get(node);
+
+        if (
+          options.checkLiteralConstAssertions &&
+          typeAnnotationIsConstAssertion &&
+          castTypeIsLiteral &&
+          !isArgumentOfGenericCall(node)
+        ) {
+          const contextual = checker.getContextualType(originalNode);
+          if (
+            contextual &&
+            !isTypeFlagSet(contextual, ts.TypeFlags.Any) &&
+            tsutils
+              .unionConstituents(contextual)
+              .every(part => isTypeLiteral(part)) &&
+            checker.isTypeAssignableTo(castType, contextual)
+          ) {
+            context.report({
+              node,
+              messageId: 'contextuallyUnnecessary',
+              fix: createAssertionFixer(node),
+            });
+            return;
+          }
+        }
 
         const castIsAny =
           isTypeFlagSet(castType, ts.TypeFlags.Any) &&

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -273,12 +273,21 @@ export default createRule<Options, MessageIds>({
       return type.isLiteral() || tsutils.isBooleanLiteralType(type);
     }
 
-    // Asserts in arg position of a generic call can drive type-parameter
-    // inference (e.g. `id<T>('a' as const)` pins T to `'a'` instead of
-    // widening to `string`), so removing the assertion isn't safe even when
-    // the resolved contextual type looks like a literal.
-    function isArgumentOfGenericCall(
+    function isContextuallyLiteralConstAssertionType(
+      castType: ts.Type,
+      contextualType: ts.Type,
+    ): boolean {
+      return tsutils.unionConstituents(contextualType).every(part => {
+        return (
+          isTypeLiteral(part) ||
+          (checker.isTupleType(castType) && checker.isTupleType(part))
+        );
+      });
+    }
+
+    function isArgumentOfGenericCallWithUnsafeInference(
       node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+      contextualType: ts.Type,
     ): boolean {
       const parent = node.parent;
       if (
@@ -293,7 +302,73 @@ export default createRule<Options, MessageIds>({
         parent.type === AST_NODE_TYPES.NewExpression
           ? calleeType.getConstructSignatures()
           : calleeType.getCallSignatures();
-      return signatures.some(s => !!s.typeParameters?.length);
+      if (!signatures.some(signatureHasTypeParams)) {
+        return false;
+      }
+
+      if (signatures.length > 1) {
+        return true;
+      }
+
+      if (parent.type === AST_NODE_TYPES.NewExpression) {
+        const callTsNode = services.esTreeNodeToTSNodeMap.get(parent);
+        const callContextualType = checker.getContextualType(callTsNode);
+        if (callContextualType && !containsTypeVariable(callContextualType)) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    function isSubstitutionOfGenericTaggedTemplate(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+    ): boolean {
+      if (
+        node.parent.type !== AST_NODE_TYPES.TemplateLiteral ||
+        node.parent.parent.type !== AST_NODE_TYPES.TaggedTemplateExpression
+      ) {
+        return false;
+      }
+
+      const tagTsNode = services.esTreeNodeToTSNodeMap.get(
+        node.parent.parent.tag,
+      );
+      const tagType = checker.getTypeAtLocation(tagTsNode);
+      return tagType.getCallSignatures().some(signatureHasTypeParams);
+    }
+
+    function isConstAssertionPropertyInProblematicContext(
+      node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+      contextualType: ts.Type,
+    ): boolean {
+      const { parent } = node;
+      if (parent.type !== AST_NODE_TYPES.Property || parent.value !== node) {
+        return false;
+      }
+
+      const objectExpr = parent.parent;
+      if (objectExpr.type !== AST_NODE_TYPES.ObjectExpression) {
+        return false;
+      }
+
+      const objectParent = objectExpr.parent;
+      if (
+        objectParent.type === AST_NODE_TYPES.TSSatisfiesExpression ||
+        (objectParent.type === AST_NODE_TYPES.CallExpression &&
+          objectParent.parent.type === AST_NODE_TYPES.TSSatisfiesExpression)
+      ) {
+        return true;
+      }
+
+      const objectTsNode = services.esTreeNodeToTSNodeMap.get(objectExpr);
+      if (!checker.getContextualType(objectTsNode)?.isUnion()) {
+        return false;
+      }
+
+      return !tsutils
+        .unionConstituents(contextualType)
+        .every(part => isTypeLiteral(part));
     }
 
     function hasIndexSignature(type: ts.Type): boolean {
@@ -352,6 +427,10 @@ export default createRule<Options, MessageIds>({
 
     function hasTypeParams(sig: ts.Signature): boolean {
       return (sig.getTypeParameters()?.length ?? 0) > 0;
+    }
+
+    function signatureHasTypeParams(sig: ts.Signature): boolean {
+      return hasTypeParams(sig) || !!sig.typeParameters?.length;
     }
 
     function genericsMismatch(uncast: ts.Type, contextual: ts.Type): boolean {
@@ -906,16 +985,17 @@ export default createRule<Options, MessageIds>({
         if (
           options.checkLiteralConstAssertions &&
           typeAnnotationIsConstAssertion &&
-          castTypeIsLiteral &&
-          !isArgumentOfGenericCall(node)
+          (castTypeIsLiteral || checker.isTupleType(castType))
         ) {
           const contextual = checker.getContextualType(originalNode);
           if (
             contextual &&
             !isTypeFlagSet(contextual, ts.TypeFlags.Any) &&
-            tsutils
-              .unionConstituents(contextual)
-              .every(part => isTypeLiteral(part)) &&
+            !isTypeFlagSet(contextual, ts.TypeFlags.Unknown) &&
+            !isArgumentOfGenericCallWithUnsafeInference(node, contextual) &&
+            !isSubstitutionOfGenericTaggedTemplate(node) &&
+            !isConstAssertionPropertyInProblematicContext(node, contextual) &&
+            isContextuallyLiteralConstAssertionType(castType, contextual) &&
             checker.isTypeAssignableTo(castType, contextual)
           ) {
             context.report({

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -287,9 +287,6 @@ export default createRule<Options, MessageIds>({
       ) {
         return false;
       }
-      if (!parent.arguments.includes(node)) {
-        return false;
-      }
       const calleeTsNode = services.esTreeNodeToTSNodeMap.get(parent.callee);
       const calleeType = checker.getTypeAtLocation(calleeTsNode);
       const signatures =

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -287,7 +287,6 @@ export default createRule<Options, MessageIds>({
 
     function isArgumentOfGenericCallWithUnsafeInference(
       node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
-      contextualType: ts.Type,
     ): boolean {
       const parent = node.parent;
       if (
@@ -992,7 +991,7 @@ export default createRule<Options, MessageIds>({
             contextual &&
             !isTypeFlagSet(contextual, ts.TypeFlags.Any) &&
             !isTypeFlagSet(contextual, ts.TypeFlags.Unknown) &&
-            !isArgumentOfGenericCallWithUnsafeInference(node, contextual) &&
+            !isArgumentOfGenericCallWithUnsafeInference(node) &&
             !isSubstitutionOfGenericTaggedTemplate(node) &&
             !isConstAssertionPropertyInProblematicContext(node, contextual) &&
             isContextuallyLiteralConstAssertionType(castType, contextual) &&

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-type-assertion.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-unnecessary-type-assertion.shot
@@ -51,6 +51,12 @@ Options: { "checkLiteralConstAssertions": true }
 const foo = 'foo' as const;
             ~~~~~~~~~~~~~~ This assertion is unnecessary since it does not change the type of the expression.
 
+Options: { "checkLiteralConstAssertions": true }
+
+type Recipient = { kind: 'a' | 'b' };
+const r: Recipient = { kind: 'a' as const };
+                             ~~~~~~~~~~~~ This assertion is unnecessary since the receiver accepts the original type of the expression.
+
 Options: { "typesToIgnore": ["Foo"] }
 
 type Foo = 3;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -911,8 +911,13 @@ f('a' as const);
       `,
       options: [{ checkLiteralConstAssertions: true }],
     },
-    // Generic inference without a target annotation: removing `as const`
-    // would let T widen to string, so the rule must stay quiet.
+    {
+      code: `
+declare function f(x: unknown): void;
+f('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
     {
       code: `
 declare function id<T>(x: T): T;
@@ -934,7 +939,13 @@ const b = box('a' as const);
       `,
       options: [{ checkLiteralConstAssertions: true }],
     },
-    // Template literal substitution slot has contextual type `string`.
+    {
+      code: `
+declare function id<T extends 'a' | 'b'>(x: T): T;
+const r = id('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
     {
       code: `
 type Greeting = \`hello \${string}\`;
@@ -948,6 +959,39 @@ class Container<T> {
   constructor(public value: T) {}
 }
 const c = new Container('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    {
+      code: `
+declare function example(x: 'a' | 'b'): void;
+declare function example<T>(value: T): T;
+example('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    {
+      code: `
+declare function tag<T>(parts: TemplateStringsArray, ...substitutions: T[]): T;
+const example = tag\`prefix \${'a' as const}\`;
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    {
+      code: `
+class K {
+  m<T>(x: T): T {
+    return x;
+  }
+}
+new K().m('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    {
+      code: `
+type Recipient = { kind: 'a' | 'b' };
+const example = { kind: 'a' as const } satisfies Recipient;
       `,
       options: [{ checkLiteralConstAssertions: true }],
     },
@@ -2006,8 +2050,6 @@ declare function f(x: true): void;
 f(true);
       `,
     },
-    // Method receiver pins the type parameter, so the call's signature has
-    // no free type parameters and the rule can safely fire.
     {
       code: `
 const arr: ('a' | 'b')[] = [];
@@ -2018,6 +2060,146 @@ arr.push('a' as const);
       output: `
 const arr: ('a' | 'b')[] = [];
 arr.push('a');
+      `,
+    },
+    {
+      code: `
+class Container<T> {
+  constructor(public value: T) {}
+}
+const c: Container<'a' | 'b'> = new Container('a' as const);
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+class Container<T> {
+  constructor(public value: T) {}
+}
+const c: Container<'a' | 'b'> = new Container('a');
+      `,
+    },
+    {
+      code: `
+declare function f(x: readonly [1, 2]): void;
+f([1, 2] as const);
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+declare function f(x: readonly [1, 2]): void;
+f([1, 2]);
+      `,
+    },
+    {
+      code: `
+function example(): 'a' | 'b' {
+  return 'a' as const;
+}
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+function example(): 'a' | 'b' {
+  return 'a';
+}
+      `,
+    },
+    {
+      code: `
+const example: () => 'a' | 'b' = () => 'a' as const;
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+const example: () => 'a' | 'b' = () => 'a';
+      `,
+    },
+    {
+      code: `
+const example: ('a' | 'b')[] = ['a' as const];
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+const example: ('a' | 'b')[] = ['a'];
+      `,
+    },
+    {
+      code: `
+const t: ['a' | 'b', 'c' | 'd'] = ['a' as const, 'c' as const];
+      `,
+      errors: [
+        { messageId: 'contextuallyUnnecessary' },
+        { messageId: 'contextuallyUnnecessary' },
+      ],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+const t: ['a' | 'b', 'c' | 'd'] = ['a', 'c'];
+      `,
+    },
+    {
+      code: `
+function example(x: 'a' | 'b' = 'a' as const) {}
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+function example(x: 'a' | 'b' = 'a') {}
+      `,
+    },
+    {
+      code: `
+declare const value: boolean;
+const example: 'a' | 'b' = value ? ('a' as const) : ('b' as const);
+      `,
+      errors: [
+        { messageId: 'contextuallyUnnecessary' },
+        { messageId: 'contextuallyUnnecessary' },
+      ],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+declare const value: boolean;
+const example: 'a' | 'b' = value ? ('a') : ('b');
+      `,
+    },
+    {
+      code: `
+type Example = { outer: { inner: 'a' | 'b' } };
+const example: Example = { outer: { inner: 'a' as const } };
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+type Example = { outer: { inner: 'a' | 'b' } };
+const example: Example = { outer: { inner: 'a' } };
+      `,
+    },
+    {
+      code: `
+type Example = { kind: 'a'; value: number } | { kind: 'b'; value: string };
+const example: Example = { kind: 'a' as const, value: 1 };
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+type Example = { kind: 'a'; value: number } | { kind: 'b'; value: string };
+const example: Example = { kind: 'a', value: 1 };
+      `,
+    },
+    {
+      code: `
+class Example {
+  constructor(value: 'a' | 'b') {}
+}
+new Example('a' as const);
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+class Example {
+  constructor(value: 'a' | 'b') {}
+}
+new Example('a');
       `,
     },
     {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -942,6 +942,15 @@ const g: Greeting = \`hello \${'world' as const}\`;
       `,
       options: [{ checkLiteralConstAssertions: true }],
     },
+    {
+      code: `
+class Container<T> {
+  constructor(public value: T) {}
+}
+const c = new Container('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -883,6 +883,65 @@ const test = inferred({
 
 console.log(test.options.parameters.potato);
     `,
+    {
+      code: `
+type Config = { readonly kind: 'a'; readonly nested: readonly [1, 2] };
+const config: Config = { kind: 'a', nested: [1, 2] } as const;
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    {
+      code: `
+declare function f(x: string): void;
+f('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    {
+      code: `
+declare function f(x: string | 'a'): void;
+f('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    {
+      code: `
+declare function f(x: any): void;
+f('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    // Generic inference without a target annotation: removing `as const`
+    // would let T widen to string, so the rule must stay quiet.
+    {
+      code: `
+declare function id<T>(x: T): T;
+const r = id('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    {
+      code: `
+declare function arrayOf<T>(...items: T[]): T[];
+const a = arrayOf('a' as const, 'b' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    {
+      code: `
+declare function box<T>(v: T): { value: T };
+const b = box('a' as const);
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
+    // Template literal substitution slot has contextual type `string`.
+    {
+      code: `
+type Greeting = \`hello \${string}\`;
+const g: Greeting = \`hello \${'world' as const}\`;
+      `,
+      options: [{ checkLiteralConstAssertions: true }],
+    },
   ],
 
   invalid: [
@@ -1873,6 +1932,83 @@ enum T {
 
 declare const a: T.Value1;
 const b = a;
+      `,
+    },
+    {
+      code: `
+type Recipient = { kind: 'a' | 'b' };
+const r: Recipient = { kind: 'a' as const };
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+type Recipient = { kind: 'a' | 'b' };
+const r: Recipient = { kind: 'a' };
+      `,
+    },
+    {
+      code: `
+type Recipient = { kind: 'a' | 'b' };
+const rs: Recipient[] = [{ kind: 'a' as const }, { kind: 'b' as const }];
+      `,
+      errors: [
+        { messageId: 'contextuallyUnnecessary' },
+        { messageId: 'contextuallyUnnecessary' },
+      ],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+type Recipient = { kind: 'a' | 'b' };
+const rs: Recipient[] = [{ kind: 'a' }, { kind: 'b' }];
+      `,
+    },
+    {
+      code: `
+declare function f(x: 'a' | 'b'): void;
+f('a' as const);
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+declare function f(x: 'a' | 'b'): void;
+f('a');
+      `,
+    },
+    {
+      code: `
+declare function f(x: 1 | 2 | 3): void;
+f(1 as const);
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+declare function f(x: 1 | 2 | 3): void;
+f(1);
+      `,
+    },
+    {
+      code: `
+declare function f(x: true): void;
+f(true as const);
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+declare function f(x: true): void;
+f(true);
+      `,
+    },
+    // Method receiver pins the type parameter, so the call's signature has
+    // no free type parameters and the rule can safely fire.
+    {
+      code: `
+const arr: ('a' | 'b')[] = [];
+arr.push('a' as const);
+      `,
+      errors: [{ messageId: 'contextuallyUnnecessary' }],
+      options: [{ checkLiteralConstAssertions: true }],
+      output: `
+const arr: ('a' | 'b')[] = [];
+arr.push('a');
       `,
     },
     {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12308
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

With `checkLiteralConstAssertions` enabled, the rule already flags `const x = 'a' as const`. This adds the contextually-unnecessary case for the same option: `as const` on a literal whose surrounding type already narrows to a literal (or union of literals) that accepts the value.

```ts
type Recipient = { kind: 'a' | 'b' };
const r: Recipient = { kind: 'a' as const }; // flagged

declare function f(x: 'a' | 'b'): void;
f('a' as const); // flagged

const arr: ('a' | 'b')[] = [];
arr.push('a' as const); // flagged
```

Arguments to generic calls are skipped: `as const` there can drive type-parameter inference (in `id<T>('a' as const)`, removing it would let `T` widen from `'a'` to `string`). Method calls where `T` is pinned by the receiver are still checked because the resolved signature has no free type parameters.

Tests cover those invalid cases plus valid guards: object literal `as const` producing readonly/tuple types, primitive contextual type, contextual type with a non-literal member, `any` contextual type, three flavors of generic call without a target annotation, and a template-literal substitution slot.