### PR TITLE
fix(eslint-plugin): handle generic shadowing namespace refs

### DIFF
--- a/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts
@@ -102,6 +102,26 @@ baz<Bar>();
     },
     {
       code: `
+import type * as T from 'a.js';
+
+class Bar<T> implements T.Foo {}
+new Bar();
+      `,
+      errors: [
+        {
+          column: 11,
+          data: {
+            action: 'defined',
+            additional: '',
+            varName: 'T',
+          },
+          line: 4,
+          messageId: 'unusedVar',
+        },
+      ],
+    },
+    {
+      code: `
 import { Nullable } from 'nullable';
 const a: string = 'hello';
 console.log(a);
@@ -2160,6 +2180,15 @@ export class B {
 interface Base {}
 class Thing implements Base {}
 new Thing();
+    `,
+    `
+import type * as T from 'a.js';
+
+export class Bar<T> implements T.Foo {
+  someMethod(value: T): void {
+    console.log(value);
+  }
+}
     `,
     `
 interface Base {}

--- a/packages/scope-manager/src/referencer/Reference.ts
+++ b/packages/scope-manager/src/referencer/Reference.ts
@@ -22,6 +22,7 @@ const generator = createIdGenerator();
 export enum ReferenceTypeFlag {
   Value = 0x1,
   Type = 0x2,
+  TypeQualifiedName = 0x4,
 }
 
 /**
@@ -103,6 +104,13 @@ export class Reference {
    */
   public get isTypeReference(): boolean {
     return (this.#referenceType & ReferenceTypeFlag.Type) !== 0;
+  }
+
+  /**
+   * True if this reference is the left-hand side of a qualified type name
+   */
+  public get isTypeQualifiedNameReference(): boolean {
+    return (this.#referenceType & ReferenceTypeFlag.TypeQualifiedName) !== 0;
   }
 
   /**

--- a/packages/scope-manager/src/referencer/TypeVisitor.ts
+++ b/packages/scope-manager/src/referencer/TypeVisitor.ts
@@ -85,7 +85,11 @@ export class TypeVisitor extends Visitor {
   }
 
   protected MemberExpression(node: TSESTree.MemberExpression): void {
-    this.visit(node.object);
+    if (node.object.type === AST_NODE_TYPES.Identifier) {
+      this.#referencer.currentScope().referenceTypeQualifiedName(node.object);
+    } else {
+      this.visit(node.object);
+    }
     // don't visit the property
   }
 
@@ -226,7 +230,11 @@ export class TypeVisitor extends Visitor {
   }
 
   protected TSQualifiedName(node: TSESTree.TSQualifiedName): void {
-    this.visit(node.left);
+    if (node.left.type === AST_NODE_TYPES.Identifier) {
+      this.#referencer.currentScope().referenceTypeQualifiedName(node.left);
+    } else {
+      this.visit(node.left);
+    }
     // we don't visit the right as it a name on the thing, not a name to reference
   }
 

--- a/packages/scope-manager/src/scope/ScopeBase.ts
+++ b/packages/scope-manager/src/scope/ScopeBase.ts
@@ -12,6 +12,7 @@ import type { Scope } from './Scope';
 import type { TSModuleScope } from './TSModuleScope';
 
 import { assert } from '../assert';
+import { DefinitionType } from '../definition';
 import { createIdGenerator } from '../ID';
 import {
   Reference,
@@ -110,6 +111,18 @@ function registerScope(scopeManager: ScopeManager, scope: Scope): void {
   } else {
     scopeManager.nodeToScope.set(scope.block, [scope]);
   }
+}
+
+function isTypeQualifiedNameVariable(variable: Variable): boolean {
+  return (
+    variable.defs.length === 0 ||
+    variable.defs.some(
+      def =>
+        def.type === DefinitionType.ImportBinding ||
+        def.type === DefinitionType.TSEnumName ||
+        def.type === DefinitionType.TSModuleName,
+    )
+  );
 }
 
 const generator = createIdGenerator();
@@ -231,6 +244,13 @@ export abstract class ScopeBase<
       }
 
       if (!this.isValidResolution(ref, variable)) {
+        return false;
+      }
+
+      if (
+        ref.isTypeQualifiedNameReference &&
+        !isTypeQualifiedNameVariable(variable)
+      ) {
         return false;
       }
 
@@ -406,6 +426,21 @@ export abstract class ScopeBase<
       null,
       false,
       ReferenceTypeFlag.Type,
+    );
+
+    this.references.push(ref);
+    this.leftToResolve?.push(ref);
+  }
+
+  public referenceTypeQualifiedName(node: TSESTree.Identifier): void {
+    const ref = new Reference(
+      node,
+      this as Scope,
+      ReferenceFlag.Read,
+      null,
+      null,
+      false,
+      ReferenceTypeFlag.Type | ReferenceTypeFlag.TypeQualifiedName,
     );
 
     this.references.push(ref);

--- a/packages/scope-manager/tests/fixtures/type-declaration/qualified-name.ts
+++ b/packages/scope-manager/tests/fixtures/type-declaration/qualified-name.ts
@@ -1,2 +1,3 @@
 type T = 1;
 type A = T.B;
+interface C extends T.B.C {}

--- a/packages/scope-manager/tests/fixtures/type-declaration/qualified-name.ts.shot
+++ b/packages/scope-manager/tests/fixtures/type-declaration/qualified-name.ts.shot
@@ -25,13 +25,33 @@ ScopeManager {
       isValueVariable: false,
       isTypeVariable: true,
     },
+    Variable$4 {
+      defs: [
+        TypeDefinition$3 {
+          name: Identifier<"C">,
+          node: TSInterfaceDeclaration$3,
+        },
+      ],
+      name: "C",
+      references: [],
+      isValueVariable: false,
+      isTypeVariable: true,
+    },
   ],
   scopes: [
     GlobalScope$1 {
-      block: Program$3,
+      block: Program$4,
       isStrict: false,
       references: [
         Reference$1 {
+          identifier: Identifier<"T">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: null,
+        },
+        Reference$2 {
           identifier: Identifier<"T">,
           isRead: true,
           isTypeReference: true,
@@ -44,6 +64,7 @@ ScopeManager {
         "const" => ImplicitGlobalConstTypeVariable,
         "T" => Variable$2,
         "A" => Variable$3,
+        "C" => Variable$4,
       },
       type: "global",
       upper: null,
@@ -51,6 +72,7 @@ ScopeManager {
         ImplicitGlobalConstTypeVariable,
         Variable$2,
         Variable$3,
+        Variable$4,
       ],
     },
   ],

--- a/packages/scope-manager/tests/fixtures/type-declaration/qualified-name.ts.shot
+++ b/packages/scope-manager/tests/fixtures/type-declaration/qualified-name.ts.shot
@@ -9,16 +9,7 @@ ScopeManager {
         },
       ],
       name: "T",
-      references: [
-        Reference$1 {
-          identifier: Identifier<"T">,
-          isRead: true,
-          isTypeReference: true,
-          isValueReference: false,
-          isWrite: false,
-          resolved: Variable$2,
-        },
-      ],
+      references: [],
       isValueVariable: false,
       isTypeVariable: true,
     },
@@ -40,7 +31,14 @@ ScopeManager {
       block: Program$3,
       isStrict: false,
       references: [
-        Reference$1,
+        Reference$1 {
+          identifier: Identifier<"T">,
+          isRead: true,
+          isTypeReference: true,
+          isValueReference: false,
+          isWrite: false,
+          resolved: null,
+        },
       ],
       set: Map {
         "const" => ImplicitGlobalConstTypeVariable,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10746
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This updates scope-manager to distinguish the left-hand side of qualified type names from ordinary type references.

For `implements T.Foo`, the `T.` qualifier should resolve to namespace/import-style bindings, not to a same-named generic type parameter. This keeps an imported namespace marked as used while still reporting an actually unused generic type parameter.

Tests run:

- `corepack pnpm exec vitest packages/eslint-plugin/tests/rules/no-unused-vars/no-unused-vars.test.ts`
- `corepack pnpm exec vitest packages/scope-manager/tests/fixtures.test.ts`
- `corepack pnpm exec nx build scope-manager`