### PR TITLE
fix(project-service): throw error cause in `getParsedConfigFileFromTSServer`

### DIFF
--- a/packages/project-service/package.json
+++ b/packages/project-service/package.json
@@ -70,6 +70,11 @@
     "name": "project-service",
     "includedScripts": [
       "clean"
-    ]
+    ],
+    "targets": {
+      "lint": {
+        "command": "eslint"
+      }
+    }
   }
 }

--- a/packages/project-service/src/getParsedConfigFileFromTSServer.ts
+++ b/packages/project-service/src/getParsedConfigFileFromTSServer.ts
@@ -14,6 +14,7 @@ export function getParsedConfigFileFromTSServer(
     if (throwOnFailure) {
       throw new Error(
         `Could not read Project Service default project '${defaultProject}': ${(error as Error).message}`,
+        { cause: error },
       );
     }
   }

--- a/packages/project-service/tests/getParsedConfigFileFromTSServer.test.ts
+++ b/packages/project-service/tests/getParsedConfigFileFromTSServer.test.ts
@@ -58,4 +58,20 @@ describe(getParsedConfigFileFromTSServer, () => {
       ),
     );
   });
+
+  it('preserves the error cause when throwOnFailure is true', () => {
+    mockGetParsedConfigFile.mockImplementationOnce(() => {
+      throw new Error('Oh no!');
+    });
+
+    let actual: unknown;
+
+    try {
+      getParsedConfigFileFromTSServer(mockTSServer, 'tsconfig.json', true);
+    } catch (error) {
+      actual = error;
+    }
+
+    expect((actual as { cause?: unknown }).cause).toBeDefined();
+  });
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hi,

This PR updates the `getParsedConfigFileFromTSServer` function to include the [error cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) when `throwOnFailure` is set to `true`.

Although the current ESLint configuration enables the [`preserve-caught-error`](https://eslint.org/docs/latest/rules/preserve-caught-error) rule, it was only showing up in the IDE and wasn't detected in CI because the `nx` configuration was missing the ESLint setup.

For example, I can see the `preserve-caught-error` rule error occurring in my IDE:

<img width="712" height="170" alt="image" src="https://github.com/user-attachments/assets/07a015d3-e010-4b13-aa7d-666e8f75f1f8" alt="IDE Error"/>

To address this, I've made three changes:

- Added `lint` to `nx`.
- Added the error cause to `getParsedConfigFileFromTSServer`.
- Added a test case to ensure this behavior.

Sorry if I should have opened an issue for this first. If that’s the case, please let me know and I’d be happy to open one.