### PR TITLE
chore: add Github Actions security analysis workflow

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -6,7 +6,7 @@ description: 'Prepares the repo for a job by running the build'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: build-cache
       with:
         path: |

--- a/.github/actions/prepare-install/action.yml
+++ b/.github/actions/prepare-install/action.yml
@@ -28,17 +28,17 @@ runs:
     - name: echo github.ref
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: echo ${{ github.ref }}
+      run: echo "$GITHUB_REF"
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       with:
         cache: true
         package_json_file: ${{ inputs.working-directory }}/package.json
         cache_dependency_path: ${{ inputs.working-directory }}/pnpm-lock.yaml
 
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}

--- a/.github/workflows/a11y-alt-bot.yml
+++ b/.github/workflows/a11y-alt-bot.yml
@@ -27,4 +27,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get action 'github/accessibility-alt-text-bot'
-        uses: github/accessibility-alt-text-bot@v1.7.1
+        uses: github/accessibility-alt-text-bot@531a7430c6930a39cae5a0aab2d165284468060f # v1.7.1

--- a/.github/workflows/breaking-change-validation.yml
+++ b/.github/workflows/breaking-change-validation.yml
@@ -5,7 +5,7 @@ on:
   # WARNING: Using pull_request_target here because we want to validate PRs on forks
   # pull_request_target can be UNSAFE because it runs in the TARGET repo context (not fork context).
   # DO NOT CHECK OUT THE REPO IN THIS WORKFLOW
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] See warning above.
     types:
       - opened
       - edited
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title and body
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
       NX_CI_EXECUTION_ENV: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Install
         uses: ./.github/actions/prepare-install
         with:
@@ -61,7 +63,9 @@ jobs:
       NX_CI_EXECUTION_ENV: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Install
         uses: ./.github/actions/prepare-install
         with:
@@ -78,7 +82,9 @@ jobs:
       NX_CI_EXECUTION_ENV: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Install
         uses: ./.github/actions/prepare-install
         with:
@@ -100,7 +106,9 @@ jobs:
       NX_CI_EXECUTION_ENV: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Install
         uses: ./.github/actions/prepare-install
         with:
@@ -122,7 +130,9 @@ jobs:
       NX_CI_EXECUTION_ENV: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Install
         uses: ./.github/actions/prepare-install
         with:
@@ -144,7 +154,9 @@ jobs:
       NX_CI_EXECUTION_ENV: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Install
         uses: ./.github/actions/prepare-install
         with:
@@ -162,7 +174,9 @@ jobs:
       NX_CI_EXECUTION_ENV: 'ubuntu-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Install
         uses: ./.github/actions/prepare-install
         with:
@@ -198,9 +212,10 @@ jobs:
           ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
+          persist-credentials: false
       - name: Install
         uses: ./.github/actions/prepare-install
         with:
@@ -223,7 +238,7 @@ jobs:
 
       - name: Store coverage for uploading
         if: env.PRIMARY_NODE_VERSION == matrix.node-version && matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.package.name }}-coverage-${{ strategy.job-index }}
           path: packages/${{ matrix.package.name }}/coverage/lcov.info
@@ -261,9 +276,10 @@ jobs:
       COLLECT_COVERAGE: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
+          persist-credentials: false
       - name: Install
         uses: ./.github/actions/prepare-install
         with:
@@ -286,7 +302,7 @@ jobs:
 
       - name: Store coverage for uploading
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.package.name }}-coverage-${{ strategy.job-index }}
           path: packages/${{ matrix.package.name }}/coverage/lcov.info
@@ -306,9 +322,10 @@ jobs:
       COLLECT_COVERAGE: false,
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
+          persist-credentials: false
       - name: Install
         uses: ./.github/actions/prepare-install
         with:
@@ -328,15 +345,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Download coverage reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: coverage
 
       - name: Publish code coverage report
-        uses: codecov/codecov-action@v5.5.2
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/**/lcov.info

--- a/.github/workflows/github-actions-security.yml
+++ b/.github/workflows/github-actions-security.yml
@@ -1,0 +1,22 @@
+name: GitHub Actions Security Analysis
+
+on:
+  pull_request:
+    branches: ['**']
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false # Fail workflow rather than showing PR annotations.
+          min-severity: medium

--- a/.github/workflows/github-actions-security.yml
+++ b/.github/workflows/github-actions-security.yml
@@ -1,8 +1,6 @@
 name: GitHub Actions Security Analysis
 
-on:
-  pull_request:
-    branches: ['**']
+on: pull_request
 
 permissions: {}
 

--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -18,14 +18,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   maybe_nx_migrate:
-    # Only run if it was the renovate bot that triggered the workflow (otherwise we'll create a loop)
-    if: contains('["renovate[bot]"]', github.actor) == true
+    # Only run if it was the renovate bot that opened the PR (otherwise we'll create a loop)
+    if: github.event.pull_request.user.login == 'renovate[bot]'
     name: Run nx migrate if required
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           # To ensure we can push from a different user (and therefore cause actions to rerun)
@@ -36,7 +39,7 @@ jobs:
         run: |
           git diff HEAD~1 -G"@nx/workspace" --exit-code package.json && echo "@nx/workspace unchanged" || echo "::set-output name=was-changed::true"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         if: ${{ steps.nrwl-workspace-package-check.outputs.was-changed == 'true' }}
         name: Install pnpm
         with:

--- a/.github/workflows/pr-review-requested.yml
+++ b/.github/workflows/pr-review-requested.yml
@@ -4,7 +4,7 @@ on:
   # WARNING: Using pull_request_target here because we need write permissions to remove labels from fork PRs
   # pull_request_target can be UNSAFE because it runs in the TARGET repo context (not fork context).
   # DO NOT CHECK OUT THE REPO IN THIS WORKFLOW
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] See warning above.
     types:
       - review_requested
 
@@ -16,7 +16,7 @@ jobs:
   pr_review_requested:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
         with:
           labels: |
             1 approval

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -5,7 +5,7 @@ on:
   # WARNING: Using pull_request_target here because we want to validate PRs on forks
   # pull_request_target can be UNSAFE because it runs in the TARGET repo context (not fork context).
   # DO NOT CHECK OUT THE REPO IN THIS WORKFLOW
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] See warning above.
     types:
       - opened
       - edited
@@ -20,7 +20,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/prettier-update.yml
+++ b/.github/workflows/prettier-update.yml
@@ -15,14 +15,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   maybe_prettier_update:
-    # Only run if it was the renovate bot that triggered the workflow (otherwise we'll create a loop)
-    if: contains('["renovate[bot]"]', github.actor) == true
+    # Only run if it was the renovate bot that opened the PR (otherwise we'll create a loop)
+    if: github.event.pull_request.user.login == 'renovate[bot]'
     name: Run prettier formatting if required
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false
@@ -32,7 +35,7 @@ jobs:
         run: |
           git diff HEAD~1 -G"prettier" --exit-code package.json && echo "prettier unchanged" || echo "::set-output name=was-changed::true"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         if: ${{ steps.prettier-package-check.outputs.was-changed == 'true' }}
         name: Install pnpm
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   # Triggered by completed CI runs (we check for successful status in the validate job) on main branch for canary releases
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers] Safe - actor is validated against a whitelist.
     workflows: ['CI']
     types: [completed]
     branches: [main]
@@ -81,6 +81,7 @@ jobs:
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           INPUT_FORCE_RELEASE: ${{ inputs.force_release_without_changes }}
           INPUT_FIRST_RELEASE: ${{ inputs.first_release }}
+          ACTOR: ${{ github.actor }}
         run: |
           SHOULD_RELEASE="false"
 
@@ -115,7 +116,6 @@ jobs:
           # Security: For manual triggers, only allow core maintainers to run releases
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ALLOWED_ACTORS=("JamesHenry" "bradzacher" "JoshuaKGoldberg")
-            ACTOR="${{ github.actor }}"
             IS_ALLOWED="false"
 
             for allowed in "${ALLOWED_ACTORS[@]}"; do
@@ -194,10 +194,11 @@ jobs:
       id-token: write # Required for trusted publishing
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # We need the full history for version calculation
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/prepare-install
@@ -219,8 +220,10 @@ jobs:
           OVERRIDE_MAJOR_VERSION: ${{ needs.validate.outputs.override_major_version }}
 
       - name: Publish canary packages
-        run: pnpm exec nx release publish --tag canary --verbose --dry-run=${{ needs.validate.outputs.dry_run }} --first-release=${{ needs.validate.outputs.first_release }}
+        run: pnpm exec nx release publish --tag canary --verbose --dry-run="$DRY_RUN" --first-release="$FIRST_RELEASE"
         env:
+          DRY_RUN: ${{ needs.validate.outputs.dry_run }}
+          FIRST_RELEASE: ${{ needs.validate.outputs.first_release }}
           # Enable npm provenance
           NPM_CONFIG_PROVENANCE: true
           # Disable distributed execution here for predictability
@@ -239,7 +242,8 @@ jobs:
       id-token: write # Required for trusted publishing
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # zizmor: ignore[artipacked] Need persisted token for push permissions.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # Need full history for changelog generation
           fetch-depth: 0
@@ -266,8 +270,11 @@ jobs:
           git config --global user.name "typescript-eslint[bot]"
 
       - name: Run stable release
-        run: pnpm run release --dry-run=${{ needs.validate.outputs.dry_run }} --force-release-without-changes=${{ needs.validate.outputs.force_release_without_changes }} --first-release=${{ needs.validate.outputs.first_release }} --verbose
+        run: pnpm run release --dry-run="$DRY_RUN" --force-release-without-changes="$FORCE_RELEASE_WITHOUT_CHANGES" --first-release="$FIRST_RELEASE" --verbose
         env:
+          DRY_RUN: ${{ needs.validate.outputs.dry_run }}
+          FORCE_RELEASE_WITHOUT_CHANGES: ${{ needs.validate.outputs.force_release_without_changes }}
+          FIRST_RELEASE: ${{ needs.validate.outputs.first_release }}
           # Enable npm provenance
           NPM_CONFIG_PROVENANCE: true
           # Disable distributed execution here for predictability


### PR DESCRIPTION


## PR Checklist

- [X] Addresses an existing open issue: fixes #12327
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Added a workflow on every PR to check for security issues in GH actions
Fixed all the currently reported issues (attached below)

Fixes TL;DR:
- Added `persist-credentials: false` where possible (e.g., where the checkout is for a read-only job)
- Ignored "dangerous trigger" issues with a comment about why it's required
- Moved all inputs that were used in commands/scripts to env vars, to avoid their expansion
- Used commit hashes for all external actions (some of them are out of date, but that's for another PR)
- Replaced unsafe `contains(...)` checks to equality checks

Open questions:
1. should we fail for any severity? Currently I've set it medium, but we can me more or less strict of we want to
2. do we want the workflow to fail or to show it as annotations on the PR using [Advanced Security](https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security)? I've currently set it to fail (errors will be shown in the workflow run log)
3. do we want to add CodeQL as well here? I'm asking because seems like zizmor reports any `pull_request_target` as dangerous, but doesn't catch the actual danger (i.e., checkout fork's head), as opposed to CodeQL which does catch it


<details>
<summary>Reported issues</summary>

```

	error[unpinned-uses]: unpinned action reference
	 --> ./.github/actions/prepare-build/action.yml:9:13
	  |
	9 |     - uses: actions/cache@v4
	  |             ^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	  |
	  = note: audit confidence → High
	  = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[template-injection]: code injection via template expansion
	  --> ./.github/actions/prepare-install/action.yml:31:21
	   |
	31 |       run: echo ${{ github.ref }}
	   |       ---           ^^^^^^^^^^ may expand into attacker-controllable code
	   |       |
	   |       this run block
	   |
	   = note: audit confidence → High
	   = note: this finding has an auto-fix
	   = help: audit documentation → https://docs.zizmor.sh/audits/#template-injection
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/actions/prepare-install/action.yml:34:13
	   |
	34 |       uses: pnpm/action-setup@v4
	   |             ^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/actions/prepare-install/action.yml:41:13
	   |
	41 |       uses: actions/setup-node@v4
	   |             ^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/a11y-alt-bot.yml:30:15
	   |
	30 |         uses: github/accessibility-alt-text-bot@v1.7.1
	   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[dangerous-triggers]: use of fundamentally insecure workflow trigger
	  --> ./.github/workflows/breaking-change-validation.yml:4:1
	   |
	 4 | / on:
	 5 | |   # WARNING: Using pull_request_target here because we want to validate PRs on forks
	 6 | |   # pull_request_target can be UNSAFE because it runs in the TARGET repo context (not fork context).
	 7 | |   # DO NOT CHECK OUT THE REPO IN THIS WORKFLOW
	...  |
	16 | | # IMPORTANT: Minimal permissions necessary for this workflow to function
	   | |________________________________________________________________________^ pull_request_target is almost always used insecurely
	   |
	   = note: audit confidence → Medium
	   = help: audit documentation → https://docs.zizmor.sh/audits/#dangerous-triggers
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/breaking-change-validation.yml:26:15
	   |
	26 |         uses: actions/github-script@v7
	   |               ^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	  --> ./.github/workflows/ci.yml:48:9
	   |
	48 |         - name: Checkout
	   |  _________^
	49 | |         uses: actions/checkout@v4
	   | |_________________________________^ does not set persist-credentials: false
	   |
	   = note: audit confidence → Low
	   = note: this finding has an auto-fix
	   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	  --> ./.github/workflows/ci.yml:63:9
	   |
	63 |         - name: Checkout
	   |  _________^
	64 | |         uses: actions/checkout@v4
	   | |_________________________________^ does not set persist-credentials: false
	   |
	   = note: audit confidence → Low
	   = note: this finding has an auto-fix
	   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	  --> ./.github/workflows/ci.yml:80:9
	   |
	80 |         - name: Checkout
	   |  _________^
	81 | |         uses: actions/checkout@v4
	   | |_________________________________^ does not set persist-credentials: false
	   |
	   = note: audit confidence → Low
	   = note: this finding has an auto-fix
	   = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	   --> ./.github/workflows/ci.yml:102:9
	    |
	102 |         - name: Checkout
	    |  _________^
	103 | |         uses: actions/checkout@v4
	    | |_________________________________^ does not set persist-credentials: false
	    |
	    = note: audit confidence → Low
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	   --> ./.github/workflows/ci.yml:124:9
	    |
	124 |         - name: Checkout
	    |  _________^
	125 | |         uses: actions/checkout@v4
	    | |_________________________________^ does not set persist-credentials: false
	    |
	    = note: audit confidence → Low
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	   --> ./.github/workflows/ci.yml:146:9
	    |
	146 |         - name: Checkout
	    |  _________^
	147 | |         uses: actions/checkout@v4
	    | |_________________________________^ does not set persist-credentials: false
	    |
	    = note: audit confidence → Low
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	   --> ./.github/workflows/ci.yml:164:9
	    |
	164 |         - name: Checkout
	    |  _________^
	165 | |         uses: actions/checkout@v4
	    | |_________________________________^ does not set persist-credentials: false
	    |
	    = note: audit confidence → Low
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	   --> ./.github/workflows/ci.yml:200:9
	    |
	200 |         - name: Checkout
	    |  _________^
	201 | |         uses: actions/checkout@v4
	202 | |         with:
	203 | |           fetch-depth: 2
	    | |________________________^ does not set persist-credentials: false
	    |
	    = note: audit confidence → Low
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	   --> ./.github/workflows/ci.yml:263:9
	    |
	263 |         - name: Checkout
	    |  _________^
	264 | |         uses: actions/checkout@v4
	265 | |         with:
	266 | |           fetch-depth: 2
	    | |________________________^ does not set persist-credentials: false
	    |
	    = note: audit confidence → Low
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	   --> ./.github/workflows/ci.yml:308:9
	    |
	308 |         - name: Checkout
	    |  _________^
	309 | |         uses: actions/checkout@v4
	310 | |         with:
	311 | |           fetch-depth: 2
	    | |________________________^ does not set persist-credentials: false
	    |
	    = note: audit confidence → Low
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	   --> ./.github/workflows/ci.yml:330:9
	    |
	330 |         - name: Checkout
	    |  _________^
	331 | |         uses: actions/checkout@v4
	    | |_________________________________^ does not set persist-credentials: false
	    |
	    = note: audit confidence → Low
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/ci.yml:49:15
	   |
	49 |         uses: actions/checkout@v4
	   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/ci.yml:64:15
	   |
	64 |         uses: actions/checkout@v4
	   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/ci.yml:81:15
	   |
	81 |         uses: actions/checkout@v4
	   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:103:15
	    |
	103 |         uses: actions/checkout@v4
	    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:125:15
	    |
	125 |         uses: actions/checkout@v4
	    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:147:15
	    |
	147 |         uses: actions/checkout@v4
	    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:165:15
	    |
	165 |         uses: actions/checkout@v4
	    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:201:15
	    |
	201 |         uses: actions/checkout@v4
	    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:226:15
	    |
	226 |         uses: actions/upload-artifact@v4
	    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:264:15
	    |
	264 |         uses: actions/checkout@v4
	    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:289:15
	    |
	289 |         uses: actions/upload-artifact@v4
	    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:309:15
	    |
	309 |         uses: actions/checkout@v4
	    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:331:15
	    |
	331 |         uses: actions/checkout@v4
	    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:334:15
	    |
	334 |         uses: actions/download-artifact@v4
	    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/ci.yml:339:15
	    |
	339 |         uses: codecov/codecov-action@v5.5.2
	    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unsound-contains]: unsound contains condition
	  --> ./.github/workflows/nx-migrate.yml:24:5
	   |
	24 |     if: contains('["renovate[bot]"]', github.actor) == true
	   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ contains(..) condition can be bypassed if attacker can control 'github.actor'
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unsound-contains
	
	warning[excessive-permissions]: overly broad permissions
	  --> ./.github/workflows/nx-migrate.yml:22:3
	   |
	22 | /   maybe_nx_migrate:
	23 | |     # Only run if it was the renovate bot that triggered the workflow (otherwise we'll create a loop)
	24 | |     if: contains('["renovate[bot]"]', github.actor) == true
	25 | |     name: Run nx migrate if required
	...  |
	92 | |           git commit -m "chore: run nx migrate for nx v$NX_VERSION"
	93 | |           git push
	   | |                   ^
	   | |                   |
	   | |___________________this job
	   |                     default permissions used due to no permissions: block
	   |
	   = note: audit confidence → Medium
	   = help: audit documentation → https://docs.zizmor.sh/audits/#excessive-permissions
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/nx-migrate.yml:28:15
	   |
	28 |       - uses: actions/checkout@v4
	   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/nx-migrate.yml:39:15
	   |
	39 |       - uses: pnpm/action-setup@v4
	   |               ^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[dangerous-triggers]: use of fundamentally insecure workflow trigger
	  --> ./.github/workflows/pr-review-requested.yml:3:1
	   |
	 3 | / on:
	 4 | |   # WARNING: Using pull_request_target here because we need write permissions to remove labels from fork PRs
	 5 | |   # pull_request_target can be UNSAFE because it runs in the TARGET repo context (not fork context).
	 6 | |   # DO NOT CHECK OUT THE REPO IN THIS WORKFLOW
	...  |
	11 | | # IMPORTANT: Minimal permissions necessary for this workflow to function
	   | |________________________________________________________________________^ pull_request_target is almost always used insecurely
	   |
	   = note: audit confidence → Medium
	   = help: audit documentation → https://docs.zizmor.sh/audits/#dangerous-triggers
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/pr-review-requested.yml:19:15
	   |
	19 |       - uses: actions-ecosystem/action-remove-labels@v1
	   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[dangerous-triggers]: use of fundamentally insecure workflow trigger
	  --> ./.github/workflows/pr-title-validation.yml:4:1
	   |
	 4 | / on:
	 5 | |   # WARNING: Using pull_request_target here because we want to validate PRs on forks
	 6 | |   # pull_request_target can be UNSAFE because it runs in the TARGET repo context (not fork context).
	 7 | |   # DO NOT CHECK OUT THE REPO IN THIS WORKFLOW
	...  |
	14 | | # IMPORTANT: Minimal permissions necessary for this workflow to function
	   | |________________________________________________________________________^ pull_request_target is almost always used insecurely
	   |
	   = note: audit confidence → Medium
	   = help: audit documentation → https://docs.zizmor.sh/audits/#dangerous-triggers
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/pr-title-validation.yml:23:15
	   |
	23 |       - uses: amannn/action-semantic-pull-request@v5
	   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unsound-contains]: unsound contains condition
	  --> ./.github/workflows/prettier-update.yml:21:5
	   |
	21 |     if: contains('["renovate[bot]"]', github.actor) == true
	   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ contains(..) condition can be bypassed if attacker can control 'github.actor'
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unsound-contains
	
	warning[excessive-permissions]: overly broad permissions
	  --> ./.github/workflows/prettier-update.yml:19:3
	   |
	19 | /   maybe_prettier_update:
	20 | |     # Only run if it was the renovate bot that triggered the workflow (otherwise we'll create a loop)
	21 | |     if: contains('["renovate[bot]"]', github.actor) == true
	22 | |     name: Run prettier formatting if required
	...  |
	62 | |             git push
	63 | |           fi
	   | |             ^
	   | |             |
	   | |_____________this job
	   |               default permissions used due to no permissions: block
	   |
	   = note: audit confidence → Medium
	   = help: audit documentation → https://docs.zizmor.sh/audits/#excessive-permissions
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/prettier-update.yml:25:15
	   |
	25 |       - uses: actions/checkout@v4
	   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	  --> ./.github/workflows/prettier-update.yml:35:15
	   |
	35 |       - uses: pnpm/action-setup@v4
	   |               ^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	   |
	   = note: audit confidence → High
	   = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	   --> ./.github/workflows/release.yml:196:9
	    |
	196 |         - name: Checkout
	    |  _________^
	197 | |         uses: actions/checkout@v4
	198 | |         with:
	199 | |           # We need the full history for version calculation
	200 | |           fetch-depth: 0
	    | |________________________^ does not set persist-credentials: false
	    |
	    = note: audit confidence → Low
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	warning[artipacked]: credential persistence through GitHub Actions artifacts
	   --> ./.github/workflows/release.yml:241:9
	    |
	241 |         - name: Checkout
	    |  _________^
	242 | |         uses: actions/checkout@v4
	243 | |         with:
	244 | |           # Need full history for changelog generation
	...   |
	247 | |           # Check out the repo with a specific fine-grained PAT to allow pushing back to the repo
	248 | |           token: ${{ secrets.GH_FINE_GRAINED_PAT }}
	    | |___________________________________________________^ does not set persist-credentials: false
	    |
	    = note: audit confidence → Low
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#artipacked
	
	error[dangerous-triggers]: use of fundamentally insecure workflow trigger
	  --> ./.github/workflows/release.yml:3:1
	   |
	 3 | / on:
	 4 | |   # Triggered by completed CI runs (we check for successful status in the validate job) on main branch for canary releases
	 5 | |   workflow_run:
	 6 | |     workflows: ['CI']
	...  |
	46 | | # Ensure only one release workflow runs at a time
	   | |_________________________________________________^ workflow_run is almost always used insecurely
	   |
	   = note: audit confidence → Medium
	   = help: audit documentation → https://docs.zizmor.sh/audits/#dangerous-triggers
	
	error[template-injection]: code injection via template expansion
	   --> ./.github/workflows/release.yml:118:24
	    |
	 84 |         run: |
	    |         --- this run block
	...
	118 |             ACTOR="${{ github.actor }}"
	    |                        ^^^^^^^^^^^^ may expand into attacker-controllable code
	    |
	    = note: audit confidence → High
	    = note: this finding has an auto-fix
	    = help: audit documentation → https://docs.zizmor.sh/audits/#template-injection
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/release.yml:197:15
	    |
	197 |         uses: actions/checkout@v4
	    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	error[unpinned-uses]: unpinned action reference
	   --> ./.github/workflows/release.yml:242:15
	    |
	242 |         uses: actions/checkout@v4
	    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
	    |
	    = note: audit confidence → High
	    = help: audit documentation → https://docs.zizmor.sh/audits/#unpinned-uses
	
	102 findings (5 ignored, 46 suppressed, 15 fixable): 0 informational, 0 low, 15 medium, 36 high
```
</details>