### PR TITLE
chore: add `unifiedjs.vscode-mdx` to `.vscode/extensions.json`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,6 +6,7 @@
       "esbenp.prettier-vscode",
       "streetsidesoftware.code-spell-checker",
       "mrmlnc.vscode-json5",
+      "unifiedjs.vscode-mdx",
       "vitest.explorer"
   ],
   "unwantedRecommendations": ["hookyqr.beautify", "dbaeumer.jshint"]


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hi,

I noticed that the `typescript-eslint` repository contains many `.mdx` files, but the VS Code extension for them isn't currently recommended in the workspace settings.

Since `unifiedjs.vscode-mdx` is the official plugin, I think adding it to the recommended extensions would be helpful 🙌

- https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx

:octocat: 