### PR TITLE
fix(typescript-eslint): export Compatible* types from typescript-eslint to resolve pnpm TS error

### DIFF
--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -231,3 +231,11 @@ export {
   type InfiniteDepthConfigWithExtends,
   type ConfigArray,
 } from './config-helper';
+
+// https://github.com/typescript-eslint/typescript-eslint/issues/12134
+export type {
+  CompatibleConfig,
+  CompatibleConfigArray,
+  CompatibleParser,
+  CompatiblePlugin,
+} from './compatibility-types';


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12134
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I've intentionally not documented the types at https://typescript-eslint.io/packages/typescript-eslint, since they're not meant to be used, really.