### PR TITLE
chore: avoid deprecated `@eslint/js@10.0.0`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 catalogs:
   default:
     '@eslint/js':
-      specifier: ^10.0.0
+      specifier: ^10.0.1
       version: 10.0.1
     '@types/babel__code-frame':
       specifier: ^7.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - packages/*
 
 catalog:
-  '@eslint/js': ^10.0.0
+  '@eslint/js': ^10.0.1
   '@types/babel__code-frame': ^7.0.6
   '@types/mdast': ^4.0.4
   '@types/natural-compare': ^1.4.3


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hello, 

This PR simply updates the `@eslint/js` version range to `^10.0.1` to avoid accidental usage of the deprecated `@eslint/js@10.0.0`.

`@eslint/js@10.0.0` was accidentally released in the past due to an incorrect version bump, so it should not be used.

While the lock file already specifies the correct version, this update is just to ensure it.

Ref: https://www.npmjs.com/package/@eslint/js/v/10.0.0