### PR TITLE
fix(ast-spec): allow TSInstantiationExpression and TSSatisfiesExpression in LeftHandSideExpression

### DIFF
--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-satisfies/fixture.ts
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-satisfies/fixture.ts
@@ -1,0 +1,1 @@
+class Foo extends (Set satisfies any) {}

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-satisfies/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-satisfies/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,77 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [],
+
+        range: [38, 40],
+        loc: {
+          start: { column: 38, line: 1 },
+          end: { column: 40, line: 1 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: TSSatisfiesExpression {
+        type: "TSSatisfiesExpression",
+        expression: Identifier {
+          type: "Identifier",
+          decorators: [],
+          name: "Set",
+          optional: false,
+
+          range: [19, 22],
+          loc: {
+            start: { column: 19, line: 1 },
+            end: { column: 22, line: 1 },
+          },
+        },
+        typeAnnotation: TSAnyKeyword {
+          type: "TSAnyKeyword",
+
+          range: [33, 36],
+          loc: {
+            start: { column: 33, line: 1 },
+            end: { column: 36, line: 1 },
+          },
+        },
+
+        range: [19, 36],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 36, line: 1 },
+        },
+      },
+
+      range: [0, 40],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 40, line: 1 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 41],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 2 },
+  },
+}

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-satisfies/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-satisfies/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,102 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "extends",
+
+    range: [10, 17],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 17, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [18, 19],
+    loc: {
+      start: { column: 18, line: 1 },
+      end: { column: 19, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Set",
+
+    range: [19, 22],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 22, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "satisfies",
+
+    range: [23, 32],
+    loc: {
+      start: { column: 23, line: 1 },
+      end: { column: 32, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "any",
+
+    range: [33, 36],
+    loc: {
+      start: { column: 33, line: 1 },
+      end: { column: 36, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [36, 37],
+    loc: {
+      start: { column: 36, line: 1 },
+      end: { column: 37, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [38, 39],
+    loc: {
+      start: { column: 38, line: 1 },
+      end: { column: 39, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [39, 40],
+    loc: {
+      start: { column: 39, line: 1 },
+      end: { column: 40, line: 1 },
+    },
+  },
+]

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-satisfies/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-satisfies/snapshots/3-Babel-AST.shot
@@ -1,0 +1,77 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [],
+
+        range: [38, 40],
+        loc: {
+          start: { column: 38, line: 1 },
+          end: { column: 40, line: 1 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: TSSatisfiesExpression {
+        type: "TSSatisfiesExpression",
+        expression: Identifier {
+          type: "Identifier",
+          decorators: [],
+          name: "Set",
+          optional: false,
+
+          range: [19, 22],
+          loc: {
+            start: { column: 19, line: 1 },
+            end: { column: 22, line: 1 },
+          },
+        },
+        typeAnnotation: TSAnyKeyword {
+          type: "TSAnyKeyword",
+
+          range: [33, 36],
+          loc: {
+            start: { column: 33, line: 1 },
+            end: { column: 36, line: 1 },
+          },
+        },
+
+        range: [19, 36],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 36, line: 1 },
+        },
+      },
+
+      range: [0, 40],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 40, line: 1 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 41],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 2 },
+  },
+}

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-satisfies/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-satisfies/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,102 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "extends",
+
+    range: [10, 17],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 17, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [18, 19],
+    loc: {
+      start: { column: 18, line: 1 },
+      end: { column: 19, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Set",
+
+    range: [19, 22],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 22, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "satisfies",
+
+    range: [23, 32],
+    loc: {
+      start: { column: 23, line: 1 },
+      end: { column: 32, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "any",
+
+    range: [33, 36],
+    loc: {
+      start: { column: 33, line: 1 },
+      end: { column: 36, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [36, 37],
+    loc: {
+      start: { column: 36, line: 1 },
+      end: { column: 37, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [38, 39],
+    loc: {
+      start: { column: 38, line: 1 },
+      end: { column: 39, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [39, 40],
+    loc: {
+      start: { column: 39, line: 1 },
+      end: { column: 40, line: 1 },
+    },
+  },
+]

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/fixture.ts
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/fixture.ts
@@ -1,0 +1,1 @@
+class Foo extends Set<string> {}

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/snapshots/1-TSESTree-AST.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/snapshots/1-TSESTree-AST.shot
@@ -1,0 +1,88 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [],
+
+        range: [32, 34],
+        loc: {
+          start: { column: 32, line: 1 },
+          end: { column: 34, line: 1 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: TSInstantiationExpression {
+        type: "TSInstantiationExpression",
+        expression: Identifier {
+          type: "Identifier",
+          decorators: [],
+          name: "Set",
+          optional: false,
+
+          range: [19, 22],
+          loc: {
+            start: { column: 19, line: 1 },
+            end: { column: 22, line: 1 },
+          },
+        },
+        typeArguments: TSTypeParameterInstantiation {
+          type: "TSTypeParameterInstantiation",
+          params: [
+            TSStringKeyword {
+              type: "TSStringKeyword",
+
+              range: [23, 29],
+              loc: {
+                start: { column: 23, line: 1 },
+                end: { column: 29, line: 1 },
+              },
+            },
+          ],
+
+          range: [22, 30],
+          loc: {
+            start: { column: 22, line: 1 },
+            end: { column: 30, line: 1 },
+          },
+        },
+
+        range: [19, 30],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 30, line: 1 },
+        },
+      },
+
+      range: [0, 34],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 34, line: 1 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 35],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 2 },
+  },
+}

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/snapshots/2-TSESTree-Tokens.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/snapshots/2-TSESTree-Tokens.shot
@@ -1,0 +1,112 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "extends",
+
+    range: [10, 17],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 17, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [18, 19],
+    loc: {
+      start: { column: 18, line: 1 },
+      end: { column: 19, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Set",
+
+    range: [19, 22],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 22, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [22, 23],
+    loc: {
+      start: { column: 22, line: 1 },
+      end: { column: 23, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "string",
+
+    range: [23, 29],
+    loc: {
+      start: { column: 23, line: 1 },
+      end: { column: 29, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [29, 30],
+    loc: {
+      start: { column: 29, line: 1 },
+      end: { column: 30, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [30, 31],
+    loc: {
+      start: { column: 30, line: 1 },
+      end: { column: 31, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [32, 33],
+    loc: {
+      start: { column: 32, line: 1 },
+      end: { column: 33, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [33, 34],
+    loc: {
+      start: { column: 33, line: 1 },
+      end: { column: 34, line: 1 },
+    },
+  },
+]

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/snapshots/3-Babel-AST.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/snapshots/3-Babel-AST.shot
@@ -1,0 +1,79 @@
+Program {
+  type: "Program",
+  body: [
+    ClassDeclaration {
+      type: "ClassDeclaration",
+      abstract: false,
+      body: ClassBody {
+        type: "ClassBody",
+        body: [],
+
+        range: [32, 34],
+        loc: {
+          start: { column: 32, line: 1 },
+          end: { column: 34, line: 1 },
+        },
+      },
+      declare: false,
+      decorators: [],
+      id: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Foo",
+        optional: false,
+
+        range: [6, 9],
+        loc: {
+          start: { column: 6, line: 1 },
+          end: { column: 9, line: 1 },
+        },
+      },
+      implements: [],
+      superClass: Identifier {
+        type: "Identifier",
+        decorators: [],
+        name: "Set",
+        optional: false,
+
+        range: [19, 22],
+        loc: {
+          start: { column: 19, line: 1 },
+          end: { column: 22, line: 1 },
+        },
+      },
+      superTypeParameters: TSTypeParameterInstantiation {
+        type: "TSTypeParameterInstantiation",
+        params: [
+          TSStringKeyword {
+            type: "TSStringKeyword",
+
+            range: [23, 29],
+            loc: {
+              start: { column: 23, line: 1 },
+              end: { column: 29, line: 1 },
+            },
+          },
+        ],
+
+        range: [22, 30],
+        loc: {
+          start: { column: 22, line: 1 },
+          end: { column: 30, line: 1 },
+        },
+      },
+
+      range: [0, 34],
+      loc: {
+        start: { column: 0, line: 1 },
+        end: { column: 34, line: 1 },
+      },
+    },
+  ],
+  sourceType: "script",
+
+  range: [0, 35],
+  loc: {
+    start: { column: 0, line: 1 },
+    end: { column: 0, line: 2 },
+  },
+}

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/snapshots/4-Babel-Tokens.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/snapshots/4-Babel-Tokens.shot
@@ -1,0 +1,112 @@
+[
+  Keyword {
+    type: "Keyword",
+    value: "class",
+
+    range: [0, 5],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 5, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Foo",
+
+    range: [6, 9],
+    loc: {
+      start: { column: 6, line: 1 },
+      end: { column: 9, line: 1 },
+    },
+  },
+  Keyword {
+    type: "Keyword",
+    value: "extends",
+
+    range: [10, 17],
+    loc: {
+      start: { column: 10, line: 1 },
+      end: { column: 17, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "(",
+
+    range: [18, 19],
+    loc: {
+      start: { column: 18, line: 1 },
+      end: { column: 19, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "Set",
+
+    range: [19, 22],
+    loc: {
+      start: { column: 19, line: 1 },
+      end: { column: 22, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "<",
+
+    range: [22, 23],
+    loc: {
+      start: { column: 22, line: 1 },
+      end: { column: 23, line: 1 },
+    },
+  },
+  Identifier {
+    type: "Identifier",
+    value: "string",
+
+    range: [23, 29],
+    loc: {
+      start: { column: 23, line: 1 },
+      end: { column: 29, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ">",
+
+    range: [29, 30],
+    loc: {
+      start: { column: 29, line: 1 },
+      end: { column: 30, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: ")",
+
+    range: [30, 31],
+    loc: {
+      start: { column: 30, line: 1 },
+      end: { column: 31, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "{",
+
+    range: [32, 33],
+    loc: {
+      start: { column: 32, line: 1 },
+      end: { column: 33, line: 1 },
+    },
+  },
+  Punctuator {
+    type: "Punctuator",
+    value: "}",
+
+    range: [33, 34],
+    loc: {
+      start: { column: 33, line: 1 },
+      end: { column: 34, line: 1 },
+    },
+  },
+]

--- a/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/snapshots/5-AST-Alignment-AST.shot
+++ b/packages/ast-spec/src/declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/snapshots/5-AST-Alignment-AST.shot
@@ -1,0 +1,117 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > declaration > ClassDeclaration > extends-parenthesized-type-param > AST Alignment - AST`]
+Snapshot Diff:
+- TSESTree
++ Babel
+
+  Program {
+    type: 'Program',
+    body: Array [
+      ClassDeclaration {
+        type: 'ClassDeclaration',
+        abstract: false,
+        body: ClassBody {
+          type: 'ClassBody',
+          body: Array [],
+
+          range: [32, 34],
+          loc: {
+            start: { column: 32, line: 1 },
+            end: { column: 34, line: 1 },
+          },
+        },
+        declare: false,
+        decorators: Array [],
+        id: Identifier {
+          type: 'Identifier',
+          decorators: Array [],
+          name: 'Foo',
+          optional: false,
+
+          range: [6, 9],
+          loc: {
+            start: { column: 6, line: 1 },
+            end: { column: 9, line: 1 },
+          },
+        },
+        implements: Array [],
+-       superClass: TSInstantiationExpression {
+-         type: 'TSInstantiationExpression',
+-         expression: Identifier {
+-           type: 'Identifier',
+-           decorators: Array [],
+-           name: 'Set',
+-           optional: false,
++       superClass: Identifier {
++         type: 'Identifier',
++         decorators: Array [],
++         name: 'Set',
++         optional: false,
+
+-           range: [19, 22],
+-           loc: {
+-             start: { column: 19, line: 1 },
+-             end: { column: 22, line: 1 },
+-           },
++         range: [19, 22],
++         loc: {
++           start: { column: 19, line: 1 },
++           end: { column: 22, line: 1 },
+          },
+-         typeArguments: TSTypeParameterInstantiation {
+-           type: 'TSTypeParameterInstantiation',
+-           params: Array [
+-             TSStringKeyword {
+-               type: 'TSStringKeyword',
++       },
++       superTypeParameters: TSTypeParameterInstantiation {
++         type: 'TSTypeParameterInstantiation',
++         params: Array [
++           TSStringKeyword {
++             type: 'TSStringKeyword',
+
+-               range: [23, 29],
+-               loc: {
+-                 start: { column: 23, line: 1 },
+-                 end: { column: 29, line: 1 },
+-               },
++             range: [23, 29],
++             loc: {
++               start: { column: 23, line: 1 },
++               end: { column: 29, line: 1 },
+              },
+-           ],
+-
+-           range: [22, 30],
+-           loc: {
+-             start: { column: 22, line: 1 },
+-             end: { column: 30, line: 1 },
+            },
+-         },
++         ],
+
+-         range: [19, 30],
++         range: [22, 30],
+          loc: {
+-           start: { column: 19, line: 1 },
++           start: { column: 22, line: 1 },
+            end: { column: 30, line: 1 },
+          },
+        },
+
+        range: [0, 34],
+        loc: {
+          start: { column: 0, line: 1 },
+          end: { column: 34, line: 1 },
+        },
+      },
+    ],
+    sourceType: 'script',
+
+    range: [0, 35],
+    loc: {
+      start: { column: 0, line: 1 },
+      end: { column: 0, line: 2 },
+    },
+  }

--- a/packages/ast-spec/src/unions/LeftHandSideExpression.ts
+++ b/packages/ast-spec/src/unions/LeftHandSideExpression.ts
@@ -14,7 +14,9 @@ import type { Super } from '../expression/Super/spec';
 import type { TaggedTemplateExpression } from '../expression/TaggedTemplateExpression/spec';
 import type { ThisExpression } from '../expression/ThisExpression/spec';
 import type { TSAsExpression } from '../expression/TSAsExpression/spec';
+import type { TSInstantiationExpression } from '../expression/TSInstantiationExpression/spec';
 import type { TSNonNullExpression } from '../expression/TSNonNullExpression/spec';
+import type { TSSatisfiesExpression } from '../expression/TSSatisfiesExpression/spec';
 import type { TSTypeAssertion } from '../expression/TSTypeAssertion/spec';
 import type { ArrayPattern } from '../parameter/ArrayPattern/spec';
 import type { ObjectPattern } from '../parameter/ObjectPattern/spec';
@@ -40,5 +42,7 @@ export type LeftHandSideExpression =
   | TaggedTemplateExpression
   | ThisExpression
   | TSAsExpression
+  | TSInstantiationExpression
   | TSNonNullExpression
+  | TSSatisfiesExpression
   | TSTypeAssertion;

--- a/packages/ast-spec/tests/fixtures-with-differences-ast.shot
+++ b/packages/ast-spec/tests/fixtures-with-differences-ast.shot
@@ -2,6 +2,7 @@
 
 exports[`AST Fixtures > List fixtures with AST differences`]
 [
+  "declaration/ClassDeclaration/fixtures/extends-parenthesized-type-param/fixture.ts",
   "declaration/ClassDeclaration/fixtures/extends-type-param/fixture.ts",
   "declaration/ClassDeclaration/fixtures/implements-many/fixture.ts",
   "declaration/ClassDeclaration/fixtures/implements-one/fixture.ts",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12012
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR updates the `LeftHandSideExpression` type union to include `TSInstantiationExpression` and `TSSatisfiesExpression`. 

<!-- Description of what is changed and how the code change does that. -->
