### PR TITLE
fix(eslint-plugin): [prefer-optional-chain] do not extend chain past a === undefined guard with a lone === null check

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -805,8 +805,26 @@ export function analyzeChain(
         validatedOperands[validatedOperands.length - 1].comparedName,
       );
       if (comparisonResult === NodeComparisonResult.Subset) {
-        // the operands are comparable, so we can continue searching
-        subChain.push(currentOperand);
+        const chainSeed = subChain.flat()[0];
+        if (
+          operator === '||' &&
+          currentOperand.comparisonType ===
+            NullishComparisonType.StrictEqualNull &&
+          chainSeed?.comparisonType ===
+            NullishComparisonType.StrictEqualUndefined
+        ) {
+          // For OR chains with a `=== undefined` seed, extending the chain
+          // with a `=== null` subset changes semantics: when the parent is
+          // undefined, `parent?.child` returns `undefined`, and
+          // `undefined === null` is false (strict), but the original
+          // `parent === undefined` guard was true.
+          // e.g. `foo === undefined || foo.bar === null` must NOT merge to
+          // `foo?.bar === null`.
+          maybeReportThenReset(validatedOperands);
+        } else {
+          // the operands are comparable, so we can continue searching
+          subChain.push(currentOperand);
+        }
       } else if (comparisonResult === NodeComparisonResult.Invalid) {
         maybeReportThenReset(validatedOperands);
       } else {

--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -805,21 +805,30 @@ export function analyzeChain(
         validatedOperands[validatedOperands.length - 1].comparedName,
       );
       if (comparisonResult === NodeComparisonResult.Subset) {
-        const chainSeed = subChain.flat()[0];
         if (
           operator === '||' &&
           currentOperand.comparisonType ===
             NullishComparisonType.StrictEqualNull &&
-          chainSeed?.comparisonType ===
-            NullishComparisonType.StrictEqualUndefined
+          // A paired [=== null, === undefined] operand is semantically safe
+          // because it merges to `== null`. Only a lone `=== null` can
+          // produce a broken strict-equality check in the merged chain.
+          validatedOperands.length === 1 &&
+          subChain
+            .flat()
+            .some(
+              op =>
+                op.comparisonType ===
+                NullishComparisonType.StrictEqualUndefined,
+            )
         ) {
-          // For OR chains with a `=== undefined` seed, extending the chain
-          // with a `=== null` subset changes semantics: when the parent is
-          // undefined, `parent?.child` returns `undefined`, and
-          // `undefined === null` is false (strict), but the original
-          // `parent === undefined` guard was true.
+          // For OR chains that contain a `=== undefined` guard anywhere,
+          // extending the chain with a lone `=== null` subset changes
+          // semantics: when the guarded node is undefined, `node?.child`
+          // returns `undefined`, and `undefined === null` is false (strict),
+          // but the original `=== undefined` guard was true.
           // e.g. `foo === undefined || foo.bar === null` must NOT merge to
-          // `foo?.bar === null`.
+          // `foo?.bar === null`, and neither should a mid-chain form like
+          // `a == null || a.b === undefined || a.b.c === null`.
           maybeReportThenReset(validatedOperands);
         } else {
           // the operands are comparable, so we can continue searching

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -3522,6 +3522,20 @@ const baz = foo?.bar;
         declare const x: void | (() => void);
         x && x();
       `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      // `x === undefined || x.y === null` must NOT become `x?.y === null`:
+      // when x is undefined, `undefined?.y === null` is false (strict equality),
+      // but the original `x === undefined` guard returned true.
+      `
+        declare const foo: { bar: number | null } | undefined;
+        if (foo === undefined || foo.bar === null) {
+        }
+      `,
+      `
+        declare const foo: { bar: { baz: number | null } | undefined };
+        if (foo.bar === undefined || foo.bar.baz === null) {
+        }
+      `,
     ],
   });
 });

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -3536,6 +3536,14 @@ const baz = foo?.bar;
         if (foo.bar === undefined || foo.bar.baz === null) {
         }
       `,
+      // Mid-chain `=== undefined` guard: a.b === undefined is not the seed,
+      // but it still poisons the downstream `=== null` extension.
+      // `a.b === undefined || a.b.c === null` must NOT become `a.b?.c === null`.
+      `
+        declare const a: { b: { c: number | null } | undefined } | null | undefined;
+        if (a === null || a.b === undefined || a.b.c === null) {
+        }
+      `,
     ],
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11840
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

Credit to @kirkwaiblinger, who caught this in [#11702](https://github.com/typescript-eslint/typescript-eslint/pull/11702#discussion_r2438623987) and worked out why swapping to `== null` doesn't fully fix it either. This is the implementation.

## Overview

`prefer-optional-chain` was generating an incorrect auto-fix: `foo === undefined || foo.bar === null` would become `foo?.bar === null`. That's wrong. When `foo` is `undefined`, the original expression short-circuits to `true`, but `undefined?.bar === null` evaluates to `false` under strict equality.

The fix is in the `Subset` branch of `analyzeChain.ts`. Before adding a new operand to the chain, we now check whether any operand already in the chain has `StrictEqualUndefined`. If it does, and the incoming operand is a lone `=== null` (not the paired `=== null || === undefined` form), we break the chain rather than extend it.

The paired form (`a.b.c === null || a.b.c === undefined`) is excluded via `validatedOperands.length === 1` since it merges cleanly to `a.b.c == null` and doesn't have the same semantic problem.

Three regression tests: the original issue repro, a property-chain variant, and a mid-chain case where the `=== undefined` guard isn't the seed.