### PR TITLE
fix(eslint-plugin): respect ECMAScript line terminators in ts-comment rules

### DIFF
--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -1,6 +1,6 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 
-import { AST_TOKEN_TYPES } from '@typescript-eslint/utils';
+import { AST_TOKEN_TYPES, ASTUtils } from '@typescript-eslint/utils';
 
 import { createRule, getStringLength, nullThrows } from '../util';
 
@@ -192,7 +192,7 @@ export default createRule<Options, MessageIds>({
         );
       }
 
-      const commentLines = comment.value.split('\n');
+      const commentLines = comment.value.split(ASTUtils.LINEBREAK_MATCHER);
       return execDirectiveRegEx(
         commentDirectiveRegExMultiLine,
         commentLines[commentLines.length - 1],

--- a/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
+++ b/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import type { RuleFix, RuleFixer } from '@typescript-eslint/utils/ts-eslint';
 
-import { AST_TOKEN_TYPES } from '@typescript-eslint/utils';
+import { AST_TOKEN_TYPES, ASTUtils } from '@typescript-eslint/utils';
 
 import { createRule } from '../util';
 
@@ -49,7 +49,7 @@ export default createRule<[], MessageIds>({
       }
 
       // For multiline comments - we look at only the last line.
-      const commentlines = comment.value.split('\n');
+      const commentlines = comment.value.split(ASTUtils.LINEBREAK_MATCHER);
       return commentlines[commentlines.length - 1];
     }
 

--- a/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
@@ -335,6 +335,68 @@ if (false) {
       options: [{ 'ts-expect-error': true }],
     },
     {
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting -- intentionally testing a CRLF(`\r\n`) in the comment
+      code: '/* not on the last line\r\n * @ts-expect-error */',
+      errors: [
+        {
+          column: 1,
+          data: { directive: 'expect-error' },
+          line: 1,
+          messageId: 'tsDirectiveComment',
+        },
+      ],
+      options: [{ 'ts-expect-error': true }],
+    },
+    {
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting -- intentionally testing a CR(`\r`) in the comment
+      code: '/* not on the last line\r * @ts-expect-error */',
+      errors: [
+        {
+          column: 1,
+          data: { directive: 'expect-error' },
+          line: 1,
+          messageId: 'tsDirectiveComment',
+        },
+      ],
+      options: [{ 'ts-expect-error': true }],
+    },
+    {
+      code: '/* not on the last line\n * @ts-expect-error */',
+      errors: [
+        {
+          column: 1,
+          data: { directive: 'expect-error' },
+          line: 1,
+          messageId: 'tsDirectiveComment',
+        },
+      ],
+      options: [{ 'ts-expect-error': true }],
+    },
+    {
+      code: '/* not on the last line\u2028 * @ts-expect-error */',
+      errors: [
+        {
+          column: 1,
+          data: { directive: 'expect-error' },
+          line: 1,
+          messageId: 'tsDirectiveComment',
+        },
+      ],
+      options: [{ 'ts-expect-error': true }],
+    },
+    {
+      code: '/* not on the last line\u2029 * @ts-expect-error */',
+      errors: [
+        {
+          column: 1,
+          data: { directive: 'expect-error' },
+          line: 1,
+          messageId: 'tsDirectiveComment',
+        },
+      ],
+      options: [{ 'ts-expect-error': true }],
+    },
+    {
       code: '// @ts-expect-error',
       errors: [
         {

--- a/packages/eslint-plugin/tests/rules/prefer-ts-expect-error.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-ts-expect-error.test.ts
@@ -101,6 +101,63 @@ if (false) {
       output: '/* @ts-expect-error */',
     },
     {
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting -- intentionally testing a CRLF(`\r\n`) in the comment
+      code: '/* not on the last line\r\n * @ts-ignore */',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'preferExpectErrorComment',
+        },
+      ],
+      output: '/* not on the last line\r\n * @ts-expect-error */',
+    },
+    {
+      // eslint-disable-next-line @typescript-eslint/internal/plugin-test-formatting -- intentionally testing a CR(`\r`) in the comment
+      code: '/* not on the last line\r * @ts-ignore */',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'preferExpectErrorComment',
+        },
+      ],
+      output: '/* not on the last line\r * @ts-expect-error */',
+    },
+    {
+      code: '/* not on the last line\n * @ts-ignore */',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'preferExpectErrorComment',
+        },
+      ],
+      output: '/* not on the last line\n * @ts-expect-error */',
+    },
+    {
+      code: '/* not on the last line\u2028 * @ts-ignore */',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'preferExpectErrorComment',
+        },
+      ],
+      output: '/* not on the last line\u2028 * @ts-expect-error */',
+    },
+    {
+      code: '/* not on the last line\u2029 * @ts-ignore */',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'preferExpectErrorComment',
+        },
+      ],
+      output: '/* not on the last line\u2029 * @ts-expect-error */',
+    },
+    {
       code: `
 /**
  * Explaining comment

--- a/packages/utils/src/ast-utils/misc.ts
+++ b/packages/utils/src/ast-utils/misc.ts
@@ -1,5 +1,9 @@
 import type { TSESTree } from '../ts-estree';
 
+/**
+ * A regular expression to match line terminators.
+ * @see https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-LineTerminator
+ */
 export const LINEBREAK_MATCHER = /\r\n|[\r\n\u2028\u2029]/;
 
 /**

--- a/packages/utils/tests/ast-utils/misc.test.ts
+++ b/packages/utils/tests/ast-utils/misc.test.ts
@@ -1,0 +1,38 @@
+import { LINEBREAK_MATCHER } from '../../src/ast-utils/misc';
+
+describe('LINEBREAK_MATCHER', () => {
+  it('matches a CRLF', ({ expect }) => {
+    expect('before\r\nafter'.split(LINEBREAK_MATCHER)).toEqual([
+      'before',
+      'after',
+    ]);
+  });
+
+  it('matches a CR', ({ expect }) => {
+    expect('before\rafter'.split(LINEBREAK_MATCHER)).toEqual([
+      'before',
+      'after',
+    ]);
+  });
+
+  it('matches a LF', ({ expect }) => {
+    expect('before\nafter'.split(LINEBREAK_MATCHER)).toEqual([
+      'before',
+      'after',
+    ]);
+  });
+
+  it('matches a Unicode line separator', ({ expect }) => {
+    expect('before\u2028after'.split(LINEBREAK_MATCHER)).toEqual([
+      'before',
+      'after',
+    ]);
+  });
+
+  it('matches a Unicode paragraph separator', ({ expect }) => {
+    expect('before\u2029after'.split(LINEBREAK_MATCHER)).toEqual([
+      'before',
+      'after',
+    ]);
+  });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12353
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

This PR fixes an issue mentioned in #12353.

😄 

<!-- Description of what is changed and how the code change does that. -->
