### PR TITLE
docs: add `defineConfig` imports to rule config examples

### DIFF
--- a/packages/website/plugins/generated-rule-docs/insertions/insertBaseRuleReferences.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertBaseRuleReferences.ts
@@ -39,7 +39,9 @@ export function insertBaseRuleReferences(page: RuleDocsPage): string {
               lang: 'js',
               meta: 'title="eslint.config.mjs"',
               type: 'code',
-              value: `export default defineConfig({
+              value: `import { defineConfig } from "eslint/config";
+
+export default defineConfig({
   rules: ${getRulesString(extendsBaseRuleName, page.file.stem, true)}
 });`,
             },

--- a/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertNewRuleReferences.ts
@@ -85,7 +85,9 @@ export async function insertNewRuleReferences(
               lang: 'js',
               meta: 'title="eslint.config.mjs"',
               type: 'code',
-              value: `export default defineConfig(${eslintConfig});`,
+              value: `import { defineConfig } from "eslint/config";
+
+export default defineConfig(${eslintConfig});`,
             },
           ],
           name: 'TabItem',


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hello,

I noticed that the rule configuration examples use `defineConfig` without showing its import statement. This adds the import so the examples are complete and can be copied as-is.

- Before:

<img width="970" height="206" alt="image" src="https://github.com/user-attachments/assets/b3ec1a04-f1f9-4808-86fd-7b5297596ead" alt="before"/>

- After:

<img width="967" height="246" alt="image" src="https://github.com/user-attachments/assets/5336c5c5-7572-46ef-ae1f-fbb3ea4d7a34" alt="after"/>


🌟
