### PR TITLE
docs: update references to `@stylistic/eslint-plugin` rules in documentation

### DIFF
--- a/docs/troubleshooting/typed-linting/Performance.mdx
+++ b/docs/troubleshooting/typed-linting/Performance.mdx
@@ -225,9 +225,9 @@ See [Glob pattern in parser's option "project" slows down linting](https://githu
 
 ## Third-Party Plugins
 
-### `@stylistic/ts/indent` and other stylistic rules
+### `@stylistic/indent` and other stylistic rules
 
-The [`@stylistic/ts/indent` rule](https://eslint.style/rules/ts/indent#ts-indent) helps ensure your codebase follows a consistent indentation pattern.
+The [`@stylistic/indent` rule](https://eslint.style/rules/indent#ts-indent) helps ensure your codebase follows a consistent indentation pattern.
 However this involves a _lot_ of computations across every single token in a file.
 Across a large codebase, these can add up, and severely impact performance.
 

--- a/docs/troubleshooting/typed-linting/Performance.mdx
+++ b/docs/troubleshooting/typed-linting/Performance.mdx
@@ -227,7 +227,7 @@ See [Glob pattern in parser's option "project" slows down linting](https://githu
 
 ### `@stylistic/indent` and other stylistic rules
 
-The [`@stylistic/indent` rule](https://eslint.style/rules/indent#ts-indent) helps ensure your codebase follows a consistent indentation pattern.
+The [`@stylistic/indent` rule](https://eslint.style/rules/indent) helps ensure your codebase follows a consistent indentation pattern.
 However this involves a _lot_ of computations across every single token in a file.
 Across a large codebase, these can add up, and severely impact performance.
 

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-template-expression.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-template-expression.mdx
@@ -95,7 +95,7 @@ type WrappedIntersection = IntersectionWithString;
 :::info
 This rule does not aim to flag template literals without substitution expressions that could have been written as an ordinary string.
 That is to say, this rule will not help you turn `` `this` `` into `"this"`.
-If you are looking for such a rule, you can configure the [`@stylistic/ts/quotes`](https://eslint.style/rules/ts/quotes) rule to do this.
+If you are looking for such a rule, you can configure the [`@stylistic/quotes`](https://eslint.style/rules/quotes) rule to do this.
 :::
 
 ## When Not To Use It
@@ -105,4 +105,4 @@ When you want to allow string expressions inside template literals.
 ## Related To
 
 - [`restrict-template-expressions`](./restrict-template-expressions.mdx)
-- [`@stylistic/ts/quotes`](https://eslint.style/rules/ts/quotes)
+- [`@stylistic/quotes`](https://eslint.style/rules/quotes)


### PR DESCRIPTION


<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hello,

As of `@stylistic/eslint-plugin@5`, the rules using the `/ts` subpath have been removed and consolidated into a single package.

However, some documentation still depends on the old version, I’ve updated it accordingly.

- https://github.com/eslint-stylistic/eslint-stylistic/releases/tag/v5.0.0

🎉