### PR TITLE
fix(eslint-plugin): handle all ECMAScript line terminators in ban-ts-comment

### DIFF
--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -192,7 +192,8 @@ export default createRule<Options, MessageIds>({
         );
       }
 
-      const commentLines = comment.value.split('\n');
+      // Split on all ECMAScript line terminators (LF, CR, CRLF, LS, PS)
+      const commentLines = comment.value.split(/\r?\n|\r|\u2028|\u2029/);
       return execDirectiveRegEx(
         commentDirectiveRegExMultiLine,
         commentLines[commentLines.length - 1],

--- a/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
+++ b/packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts
@@ -49,7 +49,8 @@ export default createRule<[], MessageIds>({
       }
 
       // For multiline comments - we look at only the last line.
-      const commentlines = comment.value.split('\n');
+      // Split on all ECMAScript line terminators (LF, CR, CRLF, LS, PS)
+      const commentlines = comment.value.split(/\r?\n|\r|\u2028|\u2029/);
       return commentlines[commentlines.length - 1];
     }
 

--- a/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
+++ b/packages/eslint-plugin/tests/rules/ban-ts-comment.test.ts
@@ -1331,3 +1331,67 @@ if (false) {
     },
   ],
 });
+
+// Tests for ECMAScript line terminators (fixes #12353)
+ruleTester.run('ban-ts-comment with non-LF line terminators', rule, {
+  valid: [],
+  invalid: [
+    {
+      // CR line terminator
+      code: noFormat`/* first line\r * @ts-expect-error */`,
+      errors: [
+        {
+          column: 1,
+          data: { directive: 'expect-error' },
+          line: 1,
+          messageId: 'tsDirectiveComment',
+        },
+      ],
+      options: [{ 'ts-expect-error': true }],
+    },
+    {
+      // Line Separator (U+2028)
+      code: '/* first line\u2028 * @ts-expect-error */',
+      errors: [
+        {
+          column: 1,
+          data: { directive: 'expect-error' },
+          line: 1,
+          messageId: 'tsDirectiveComment',
+        },
+      ],
+      options: [{ 'ts-expect-error': true }],
+    },
+    {
+      // Paragraph Separator (U+2029)
+      code: '/* first line\u2029 * @ts-expect-error */',
+      errors: [
+        {
+          column: 1,
+          data: { directive: 'expect-error' },
+          line: 1,
+          messageId: 'tsDirectiveComment',
+        },
+      ],
+      options: [{ 'ts-expect-error': true }],
+    },
+    {
+      // CRLF line terminator
+      code: noFormat`/* first line\r\n * @ts-ignore */`,
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'tsIgnoreInsteadOfExpectError',
+          suggestions: [
+            {
+              messageId: 'replaceTsIgnoreWithTsExpectError',
+              output: '/* first line\r\n * @ts-expect-error */',
+            },
+          ],
+        },
+      ],
+      options: [{ 'ts-ignore': true }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/rules/prefer-ts-expect-error.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-ts-expect-error.test.ts
@@ -1,4 +1,4 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
 
 import rule from '../../src/rules/prefer-ts-expect-error';
 
@@ -148,6 +148,55 @@ if (false) {
 /*
 // @ts-expect-error in a block with single line comments */
       `,
+    },
+    // Tests for ECMAScript line terminators (fixes #12353)
+    {
+      // CR line terminator
+      code: noFormat`/* first line\r * @ts-ignore */`,
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'preferExpectErrorComment',
+        },
+      ],
+      output: '/* first line\r * @ts-expect-error */',
+    },
+    {
+      // Line Separator (U+2028)
+      code: '/* first line\u2028 * @ts-ignore */',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'preferExpectErrorComment',
+        },
+      ],
+      output: '/* first line\u2028 * @ts-expect-error */',
+    },
+    {
+      // Paragraph Separator (U+2029)
+      code: '/* first line\u2029 * @ts-ignore */',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'preferExpectErrorComment',
+        },
+      ],
+      output: '/* first line\u2029 * @ts-expect-error */',
+    },
+    {
+      // CRLF line terminator
+      code: noFormat`/* first line\r\n * @ts-ignore */`,
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'preferExpectErrorComment',
+        },
+      ],
+      output: '/* first line\r\n * @ts-expect-error */',
     },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12353
- [x] That issue was mass-labeled as `accepting prs`
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

The `ban-ts-comment` and `prefer-ts-expect-error` rules split multiline comments using only `\n`, which fails to detect directives when comments use other ECMAScript line terminators.

### The Problem

ECMAScript defines four line terminators:
- LF (`\n`) - Line Feed
- CR (`\r`) - Carriage Return  
- LS (`\u2028`) - Line Separator
- PS (`\u2029`) - Paragraph Separator

When a multiline comment uses CR, CRLF, LS, or PS as line endings, the rules fail to find the directive on the last line.

### The Fix

Updated the line splitting regex from `split('\n')` to `split(/\r?\n|\r|\u2028|\u2029/)` to handle all valid ECMAScript line terminators.

### Changes

- `packages/eslint-plugin/src/rules/ban-ts-comment.ts` - Updated line splitting
- `packages/eslint-plugin/src/rules/prefer-ts-expect-error.ts` - Updated line splitting  
- Added test cases for CR, CRLF, LS, and PS line terminators

Made with [Cursor](https://cursor.com)