### PR TITLE
docs: add files property to flat config examples

### DIFF
--- a/docs/getting-started/Typed_Linting.mdx
+++ b/docs/getting-started/Typed_Linting.mdx
@@ -30,6 +30,7 @@ export default defineConfig(
   // Added lines start
   tseslint.configs.recommendedTypeChecked,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         projectService: true,

--- a/docs/troubleshooting/faqs/Frameworks.mdx
+++ b/docs/troubleshooting/faqs/Frameworks.mdx
@@ -22,6 +22,7 @@ See [Changes to `extraFileExtensions` with `projectService`](../typed-linting/Pe
 export default defineConfig(
   // ... the rest of your config ...
   {
+    files: ['**/*.ts', '**/*.tsx', '**/*.vue'],
     languageOptions: {
       parserOptions: {
         // Add this line
@@ -67,6 +68,7 @@ import vueParser from 'vue-eslint-parser';
 export default defineConfig(
   // ... the rest of your config ...
   {
+    files: ['**/*.ts', '**/*.tsx', '**/*.vue'],
     languageOptions: {
       // Remove this line
       parser: tseslint.parser,

--- a/docs/troubleshooting/faqs/General.mdx
+++ b/docs/troubleshooting/faqs/General.mdx
@@ -248,6 +248,7 @@ import tseslint from 'typescript-eslint';
 export default defineConfig(
   tseslint.configs.recommendedTypeCheckedOnly,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         projectService: true,

--- a/docs/troubleshooting/typed-linting/Monorepos.mdx
+++ b/docs/troubleshooting/typed-linting/Monorepos.mdx
@@ -66,6 +66,7 @@ export default defineConfig(
   js.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         // Remove this line
@@ -122,6 +123,7 @@ export default defineConfig(
   js.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         // Remove this line

--- a/docs/troubleshooting/typed-linting/Performance.mdx
+++ b/docs/troubleshooting/typed-linting/Performance.mdx
@@ -184,6 +184,7 @@ export default defineConfig(
   js.configs.recommended,
   tseslint.configs.recommendedRequiringTypeChecking,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         // Remove this line

--- a/docs/troubleshooting/typed-linting/index.mdx
+++ b/docs/troubleshooting/typed-linting/index.mdx
@@ -81,6 +81,7 @@ export default defineConfig(
   tseslint.configs.recommendedTypeChecked,
   tseslint.configs.stylisticTypeChecked,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         projectService: true,
@@ -304,6 +305,7 @@ For example, if you use a specific `tsconfig.eslint.json` for linting, you'd spe
 
 ```js title="eslint.config.mjs"
 export default defineConfig({
+  files: ['**/*.ts', '**/*.tsx'],
   // ...
   languageOptions: {
     parserOptions: {

--- a/docs/users/Shared_Configurations.mdx
+++ b/docs/users/Shared_Configurations.mdx
@@ -377,6 +377,7 @@ export default defineConfig(
   js.configs.recommended,
   tseslint.configs.recommendedTypeChecked,
   {
+    files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
         projectService: true,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12092
- [x] That issue was mass-labeled as `accepting prs`
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Adds explicit `files` property to flat config examples that use `languageOptions`. This follows ESLint flat config best practices and makes it clear which files the configuration applies to.

### Changes

Updated the following documentation files to include `files: ['**/*.ts', '**/*.tsx']` in flat config examples:

- `docs/getting-started/Typed_Linting.mdx`
- `docs/troubleshooting/typed-linting/index.mdx`
- `docs/troubleshooting/typed-linting/Monorepos.mdx`
- `docs/troubleshooting/typed-linting/Performance.mdx`
- `docs/troubleshooting/faqs/General.mdx`
- `docs/troubleshooting/faqs/Frameworks.mdx`
- `docs/users/Shared_Configurations.mdx`

### Why This Matters

Without explicit `files`, users may be confused about which files the configuration applies to. Adding `files` makes the examples more complete and easier to understand.

Made with [Cursor](https://cursor.com)