### PR TITLE
chore: add pnpm security configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Security: verify integrity of packages in the store
+verify-store-integrity=true
+
+# Automatically install peer dependencies
+auto-install-peers=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,13 @@
 packages:
   - packages/*
 
+# Security: only allow specific packages to run lifecycle scripts
+# This prevents supply chain attacks from malicious postinstall scripts
+onlyBuiltDependencies:
+  - '@swc/core'
+  - esbuild
+  - nx
+
 catalog:
   '@eslint/js': ^10.0.0
   '@types/babel__code-frame': ^7.0.6


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12330
- [x] That issue was mass-labeled as `accepting prs`
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Adds security-focused pnpm configuration to protect against supply chain attacks.

### Changes

#### `.npmrc`
- `verify-store-integrity=true` - Ensures package integrity verification in the store
- `auto-install-peers=true` - Automatically installs peer dependencies

#### `pnpm-workspace.yaml`
- `onlyBuiltDependencies` - Restricts lifecycle scripts to trusted packages only:
  - `@swc/core` - Required for SWC compilation
  - `esbuild` - Required for bundling
  - `nx` - Required for monorepo tooling

### Why This Matters

Supply chain attacks through malicious `postinstall` scripts are a growing concern. By explicitly allowlisting which packages can run lifecycle scripts, we prevent untrusted dependencies from executing arbitrary code during installation.

### Testing

Verified that `pnpm install` completes successfully with the new configuration.