### PR TITLE
fix(eslint-plugin): avoid unsafe optional-chain comparison fixes

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
+++ b/packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts
@@ -134,12 +134,14 @@ type OperandAnalyzer = (
   operand: ValidOperand,
   index: number,
   chain: readonly ValidOperand[],
+  hasLastChainOperand: boolean,
 ) => readonly [ValidOperand, ValidOperand] | readonly [ValidOperand] | null;
 const analyzeAndChainOperand: OperandAnalyzer = (
   parserServices,
   operand,
   index,
   chain,
+  hasLastChainOperand,
 ) => {
   switch (operand.comparisonType) {
     case NullishComparisonType.Boolean:
@@ -158,16 +160,13 @@ const analyzeAndChainOperand: OperandAnalyzer = (
         return [operand, nextOperand];
       }
       if (
-        nextOperand &&
+        (nextOperand || hasLastChainOperand) &&
         !includesType(
           parserServices,
           operand.comparedName,
           ts.TypeFlags.Undefined,
         )
       ) {
-        // we know the next operand is not an `undefined` check and that this
-        // operand includes `undefined` - which means that making this an
-        // optional chain would change the runtime behavior of the expression
         return [operand];
       }
       return null;
@@ -205,6 +204,7 @@ const analyzeOrChainOperand: OperandAnalyzer = (
   operand,
   index,
   chain,
+  _hasLastChainOperand,
 ) => {
   switch (operand.comparisonType) {
     case NullishComparisonType.NotBoolean:
@@ -264,6 +264,84 @@ const analyzeOrChainOperand: OperandAnalyzer = (
       return null;
   }
 };
+
+const nullishShortCircuitFlags: Record<
+  '&&' | '||',
+  Partial<Record<NullishComparisonType, ts.TypeFlags>>
+> = {
+  '&&': {
+    [NullishComparisonType.Boolean]: ts.TypeFlags.Null | ts.TypeFlags.Undefined,
+    [NullishComparisonType.NotEqualNullOrUndefined]:
+      ts.TypeFlags.Null | ts.TypeFlags.Undefined,
+    [NullishComparisonType.NotStrictEqualNull]: ts.TypeFlags.Null,
+    [NullishComparisonType.NotStrictEqualUndefined]: ts.TypeFlags.Undefined,
+  },
+  '||': {
+    [NullishComparisonType.EqualNullOrUndefined]:
+      ts.TypeFlags.Null | ts.TypeFlags.Undefined,
+    [NullishComparisonType.NotBoolean]:
+      ts.TypeFlags.Null | ts.TypeFlags.Undefined,
+    [NullishComparisonType.StrictEqualNull]: ts.TypeFlags.Null,
+    [NullishComparisonType.StrictEqualUndefined]: ts.TypeFlags.Undefined,
+  },
+};
+
+function getNullishShortCircuitFlags(
+  operator: '&&' | '||',
+  operand: ValidOperand,
+): ts.TypeFlags | undefined {
+  return nullishShortCircuitFlags[operator][operand.comparisonType];
+}
+
+function getComparisonResultForUndefined(
+  comparisonType: NullishComparisonType,
+): boolean {
+  switch (comparisonType) {
+    case NullishComparisonType.EqualNullOrUndefined:
+    case NullishComparisonType.NotBoolean:
+    case NullishComparisonType.NotStrictEqualNull:
+    case NullishComparisonType.StrictEqualUndefined:
+      return true;
+
+    case NullishComparisonType.Boolean:
+    case NullishComparisonType.NotEqualNullOrUndefined:
+    case NullishComparisonType.NotStrictEqualUndefined:
+    case NullishComparisonType.StrictEqualNull:
+      return false;
+  }
+}
+
+function isSafeToReportChain(
+  parserServices: ParserServicesWithTypeInformation,
+  operator: '&&' | '||',
+  subChain: ValidOperand[],
+  lastChain: LastChainOperandForReport | ValidOperand | undefined,
+): boolean {
+  const lastOperand = lastChain ?? subChain.at(-1);
+  if (!lastOperand || 'comparisonValue' in lastOperand) {
+    return true;
+  }
+
+  const expectedResultForShortCircuit = operator === '||';
+  if (
+    getComparisonResultForUndefined(lastOperand.comparisonType) ===
+    expectedResultForShortCircuit
+  ) {
+    return true;
+  }
+
+  const operandsThatBecomeOptional = lastChain
+    ? subChain
+    : subChain.slice(0, -1);
+  return !operandsThatBecomeOptional.some(operand => {
+    const shortCircuitFlags = getNullishShortCircuitFlags(operator, operand);
+
+    return (
+      shortCircuitFlags != null &&
+      includesType(parserServices, operand.comparedName, shortCircuitFlags)
+    );
+  });
+}
 
 const resolveOperandSubset = (
   previousOperand: ValidOperand,
@@ -726,21 +804,27 @@ export function analyzeChain(
       const maybeNullishNodes = lastChain
         ? subChainFlat.map(({ node }) => node)
         : subChainFlat.slice(0, -1).map(({ node }) => node);
-      checkNullishAndReport(
-        context,
-        parserServices,
-        options,
-        maybeNullishNodes,
-        getReportDescriptor(
-          context.sourceCode,
+      // Optional chaining short-circuits to `undefined`; keep reporting only
+      // when that preserves the earlier operands' short-circuit result.
+      if (
+        isSafeToReportChain(parserServices, operator, subChainFlat, lastChain)
+      ) {
+        checkNullishAndReport(
+          context,
           parserServices,
-          node,
-          operator,
           options,
-          subChainFlat,
-          lastChain,
-        ),
-      );
+          maybeNullishNodes,
+          getReportDescriptor(
+            context.sourceCode,
+            parserServices,
+            node,
+            operator,
+            options,
+            subChainFlat,
+            lastChain,
+          ),
+        );
+      }
     }
 
     // we've reached the end of a chain of logical expressions
@@ -763,7 +847,13 @@ export function analyzeChain(
     const lastOperand = subChain.flat().at(-1);
     const operand = chain[i];
 
-    const validatedOperands = analyzeOperand(parserServices, operand, i, chain);
+    const validatedOperands = analyzeOperand(
+      parserServices,
+      operand,
+      i,
+      chain,
+      lastChainOperand != null,
+    );
     if (!validatedOperands) {
       // TODO - #7170
       // check if the name is a superset/equal - if it is, then it likely

--- a/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts
@@ -1618,8 +1618,130 @@ describe('chain ending with comparison', () => {
         errors: [{ messageId: 'preferOptionalChain' }],
         output: 'foo?.bar == 0',
       },
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      {
+        code: `
+          declare const foo: { bar: number | undefined } | null;
+          foo === null || foo.bar === undefined;
+        `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+          declare const foo: { bar: number | undefined } | null;
+          foo?.bar === undefined;
+        `,
+      },
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      {
+        code: `
+          declare const foo: { bar: number | null } | undefined;
+          foo === undefined || foo.bar !== null;
+        `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+          declare const foo: { bar: number | null } | undefined;
+          foo?.bar !== null;
+        `,
+      },
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      {
+        code: `
+          declare const foo: { bar: number | null } | null;
+          foo !== null && foo.bar === null;
+        `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+          declare const foo: { bar: number | null } | null;
+          foo?.bar === null;
+        `,
+      },
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      {
+        code: `
+          declare const foo: { bar: number | undefined } | undefined;
+          foo !== undefined && foo.bar !== undefined;
+        `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+          declare const foo: { bar: number | undefined } | undefined;
+          foo?.bar !== undefined;
+        `,
+      },
+      {
+        code: `
+          declare const foo: { bar: { baz: number | undefined } | undefined } | undefined;
+          foo !== undefined && foo.bar !== undefined && foo.bar.baz !== undefined;
+        `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+          declare const foo: { bar: { baz: number | undefined } | undefined } | undefined;
+          foo?.bar?.baz !== undefined;
+        `,
+      },
+      {
+        code: `
+          declare const foo: { bar: { baz: number | undefined } | undefined } | undefined;
+          foo === undefined || foo.bar === undefined || foo.bar.baz === undefined;
+        `,
+        errors: [{ messageId: 'preferOptionalChain', suggestions: null }],
+        output: `
+          declare const foo: { bar: { baz: number | undefined } | undefined } | undefined;
+          foo?.bar?.baz === undefined;
+        `,
+      },
     ],
     valid: [
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      `
+        declare const foo: { bar: number | null } | undefined;
+        foo === undefined || foo.bar === null;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      `
+        declare const foo: { bar: number | null } | null;
+        foo === null || foo.bar === null;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      `
+        declare const foo: { bar: number | null } | undefined;
+        foo !== undefined && foo.bar !== null;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      `
+        declare const foo: { bar: number | null } | null;
+        foo !== null && foo.bar !== null;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      `
+        declare const foo: { bar: number | undefined } | null;
+        foo === null || foo.bar !== undefined;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      `
+        declare const foo: { bar: number | null } | undefined;
+        foo === undefined || foo.bar != null;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      `
+        declare const foo: { bar: number | undefined } | null;
+        foo !== null && foo.bar === undefined;
+      `,
+      // https://github.com/typescript-eslint/typescript-eslint/issues/11840
+      `
+        declare const foo: { bar: number | null } | undefined;
+        foo !== undefined && foo.bar == null;
+      `,
+      `
+        declare const foo: { bar: { baz: number | null } | null } | null;
+        foo !== null && foo.bar !== null && foo.bar.baz !== null;
+      `,
+      `
+        declare const foo: { bar: { baz: number | null } | null } | undefined;
+        foo !== undefined && foo.bar !== null && foo.bar.baz !== null;
+      `,
+      `
+        declare const foo: { bar: { baz: number | null } | null } | null | undefined;
+        !foo || foo.bar === null || foo.bar.baz === null;
+      `,
       'foo && foo.bar == undeclaredVar;',
       'foo && foo.bar == null;',
       'foo && foo.bar == undefined;',
@@ -2658,102 +2780,6 @@ describe('hand-crafted cases', () => {
           null != foo &&
             'undefined' !== typeof foo.bar &&
             null !== foo.bar &&
-            null !== foo.bar.baz &&
-            'undefined' !== typeof foo.bar.baz;
-        `,
-        errors: [
-          {
-            messageId: 'preferOptionalChain',
-            suggestions: [
-              {
-                messageId: 'optionalChainSuggest',
-                output: `
-          null !== foo?.bar?.baz &&
-            'undefined' !== typeof foo.bar.baz;
-        `,
-              },
-            ],
-          },
-        ],
-        output: null,
-      },
-      {
-        code: `
-          foo != null &&
-            typeof foo.bar !== 'undefined' &&
-            foo.bar !== null &&
-            foo.bar.baz !== null &&
-            typeof foo.bar.baz !== 'undefined';
-        `,
-        errors: [
-          {
-            messageId: 'preferOptionalChain',
-            suggestions: [
-              {
-                messageId: 'optionalChainSuggest',
-                output: `
-          foo?.bar?.baz !== null &&
-            typeof foo.bar.baz !== 'undefined';
-        `,
-              },
-            ],
-          },
-        ],
-        output: null,
-      },
-      {
-        code: `
-          null != foo &&
-            'undefined' !== typeof foo.bar &&
-            null !== foo.bar &&
-            null !== foo.bar.baz &&
-            undefined !== foo.bar.baz;
-        `,
-        errors: [
-          {
-            messageId: 'preferOptionalChain',
-            suggestions: [
-              {
-                messageId: 'optionalChainSuggest',
-                output: `
-          null !== foo?.bar?.baz &&
-            undefined !== foo.bar.baz;
-        `,
-              },
-            ],
-          },
-        ],
-        output: null,
-      },
-      {
-        code: `
-          foo != null &&
-            typeof foo.bar !== 'undefined' &&
-            foo.bar !== null &&
-            foo.bar.baz !== null &&
-            foo.bar.baz !== undefined;
-        `,
-        errors: [
-          {
-            messageId: 'preferOptionalChain',
-            suggestions: [
-              {
-                messageId: 'optionalChainSuggest',
-                output: `
-          foo?.bar?.baz !== null &&
-            foo.bar.baz !== undefined;
-        `,
-              },
-            ],
-          },
-        ],
-        output: null,
-      },
-      {
-        code: `
-          null != foo &&
-            'undefined' !== typeof foo.bar &&
-            null !== foo.bar &&
             undefined !== foo.bar.baz &&
             null !== foo.bar.baz;
         `,
@@ -3373,6 +3399,34 @@ const baz = foo?.bar;
         declare const foo: { bar: string | null } | null;
         foo != null && foo.bar !== null;
       `,
+      `
+        null != foo &&
+          'undefined' !== typeof foo.bar &&
+          null !== foo.bar &&
+          null !== foo.bar.baz &&
+          'undefined' !== typeof foo.bar.baz;
+      `,
+      `
+        foo != null &&
+          typeof foo.bar !== 'undefined' &&
+          foo.bar !== null &&
+          foo.bar.baz !== null &&
+          typeof foo.bar.baz !== 'undefined';
+      `,
+      `
+        null != foo &&
+          'undefined' !== typeof foo.bar &&
+          null !== foo.bar &&
+          null !== foo.bar.baz &&
+          undefined !== foo.bar.baz;
+      `,
+      `
+        foo != null &&
+          typeof foo.bar !== 'undefined' &&
+          foo.bar !== null &&
+          foo.bar.baz !== null &&
+          foo.bar.baz !== undefined;
+      `,
       {
         code: `
           declare const x: string;
@@ -3674,16 +3728,18 @@ describe('base cases', () => {
     describe('strict nullish equality checks', () => {
       describe('=== null', () => {
         ruleTester.run('prefer-optional-chain', rule, {
+          invalid: [],
           // with the `| null | undefined` type - `=== null` doesn't cover the
           // `undefined` case - so optional chaining is not a valid conversion
-          valid: BaseCases({
-            mutateCode: c => c.replaceAll('||', '=== null ||'),
-            mutateOutput: identity,
-            operator: '||',
-          }),
-          // but if the type is just `| null` - then it covers the cases and is
-          // a valid conversion
-          invalid: [
+          valid: [
+            ...BaseCases({
+              mutateCode: c => c.replaceAll('||', '=== null ||'),
+              mutateOutput: identity,
+              operator: '||',
+            }),
+            // Ending the chain with `=== null` is unsafe even when the
+            // narrowed type is only `| null`, because optional chaining
+            // short-circuits to `undefined`.
             ...BaseCases({
               mutateCode: c =>
                 c


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11840
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`prefer-optional-chain` now skips reports when an optional-chain rewrite would short-circuit to `undefined` and change the truth value of a final nullish comparison.

For example, `foo === null || foo.bar === null` is not equivalent to `foo?.bar === null`, because `foo?.bar` evaluates to `undefined` when `foo` is `null`.

This keeps safe final-comparison cases reportable and adds coverage for unsafe and safe `null`/`undefined` comparison endings.

Validation:

- `pnpm exec eslint --config=eslint.config.mjs packages/eslint-plugin/src/rules/prefer-optional-chain-utils/analyzeChain.ts packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts`
- `pnpm exec vitest run --config packages/eslint-plugin/vitest.config.mts packages/eslint-plugin/tests/rules/prefer-optional-chain/prefer-optional-chain.test.ts`
- `pnpm nx typecheck eslint-plugin`

## Why these cases are suppressed rather than reported without a fix

`prefer-optional-chain` only reports chains that can be safely rewritten
with `?.`. When an optional-chain rewrite would short-circuit to
`undefined` and that changes the truth value of a trailing nullish
comparison, the rewrite is not equivalent — so the rule should not
report it at all, consistent with the rule's existing design of only
flagging safely-rewritable chains.

### Safe vs unsafe trailing-comparison matrix

| Original | Rewrite | Safe? | Reason |
|---|---|---|---|
| `foo === undefined \|\| foo.bar === undefined` | `foo?.bar === undefined` | ✅ | short-circuit yields `undefined`, `undefined === undefined` is `true` — matches `\|\|` short-circuit |
| `foo === null \|\| foo.bar === undefined` | `foo?.bar === undefined` | ✅ | short-circuit yields `undefined`, `undefined === undefined` is `true` — matches |
| `foo === undefined \|\| foo.bar === null` | `foo?.bar === null` | ❌ | short-circuit yields `undefined`, `undefined === null` is `false` — does **not** match `\|\|` short-circuit (`true`) |
| `foo === null \|\| foo.bar === null` | `foo?.bar === null` | ❌ | same as above |
| `foo !== undefined && foo.bar !== undefined` | `foo?.bar !== undefined` | ✅ | short-circuit yields `undefined`, `undefined !== undefined` is `false` — matches `&&` short-circuit |
| `foo !== null && foo.bar === null` | `foo?.bar === null` | ✅ | short-circuit yields `undefined`, `undefined === null` is `false` — matches `&&` short-circuit |
| `foo !== null && foo.bar !== null` | `foo?.bar !== null` | ❌ | short-circuit yields `undefined`, `undefined !== null` is `true` — does **not** match `&&` short-circuit (`false`) |

### Previously-deleted invalid cases

The four hand-crafted cases removed from `invalid` were all `&&` chains
ending in `!== null` / `!== undefined` where a mid-chain operand could
short-circuit to `undefined`. After the rewrite, the trailing
`null !== undefined` / `undefined !== undefined` comparison would evaluate
to `true`, preventing the `&&` from short-circuiting and causing the
subsequent property access (e.g. `foo.bar.baz`) to throw. They are now in
`valid` because no safe optional-chain rewrite exists for them.

### Implementation notes

- `isSafeToReportChain` checks whether the short-circuit result of the
  trailing comparison (when the chain short-circuits to `undefined`)
  matches the expected short-circuit value of the logical operator
  (`true` for `||`, `false` for `&&`). If it matches, the rewrite is
  safe. If not, it additionally verifies that no operand that would
  become optional actually includes the short-circuiting nullish type.
- `getComparisonResultForUndefined` encodes what each comparison type
  evaluates to when its left side is `undefined`.
- `nullishShortCircuitFlags` maps each `(operator, comparisonType)`
  pair to the type flag that would cause a short-circuit to change
  the comparison result.
