### PR TITLE
chore(website): reset stale playground extends config on edit

### DIFF
--- a/packages/website/src/components/linter/createLinter.ts
+++ b/packages/website/src/components/linter/createLinter.ts
@@ -163,17 +163,23 @@ export function createLinter(
     try {
       const file = system.readFile(fileName) ?? '{}';
       const parsed = parseESLintRC(file);
+      const nextExtendedConfig: FlatConfig.ConfigArray = [];
+
       eslintRulesConfig.rules = parsed.rules;
       for (const extendsName of parsed.extends) {
         const maybeConfig = configs.get(extendsName);
         if (maybeConfig) {
           if (Array.isArray(maybeConfig)) {
-            eslintExtendedConfig.push(...maybeConfig);
+            nextExtendedConfig.push(...maybeConfig);
           } else {
-            eslintExtendedConfig.push(maybeConfig);
+            nextExtendedConfig.push(maybeConfig);
           }
         }
       }
+
+      eslintExtendedConfig.length = 0;
+      eslintExtendedConfig.push(...nextExtendedConfig);
+
       console.log('[Editor] Updating', fileName, [
         eslintLanguageConfig,
         ...eslintExtendedConfig,


### PR DESCRIPTION
## Summary

This resets the playground's accumulated `extends` config each time `/.eslintrc` is reapplied.

## Why

After the ESLint v10 playground refactor, the website linter started keeping a long-lived `eslintExtendedConfig` array and only appending to it on config edits. That means removing an `extends` entry from `/.eslintrc` can leave the previously extended config active for later lint runs.

This change rebuilds the extended config into a fresh array and then replaces the previous contents in one shot, so the active config always matches the latest editor state.

Closes #12363.

## Validation

- `pnpm exec tsc -p packages/website/tsconfig.json --noEmit`
- `pnpm exec eslint packages/website/src/components/linter/createLinter.ts`

## Notes

I kept this PR to the regression fix itself. I didn't add new website test infrastructure here because `packages/website` isn't currently part of the repo's Vitest project set, and I wanted to keep the first pass focused.
