### PR TITLE
feat(ast-spec): change type of `UnaryExpression.prefix` to always `true`

### DIFF
--- a/packages/ast-spec/src/base/UnaryExpressionBase.ts
+++ b/packages/ast-spec/src/base/UnaryExpressionBase.ts
@@ -1,8 +1,0 @@
-import type { Expression } from '../unions/Expression';
-import type { BaseNode } from './BaseNode';
-
-export interface UnaryExpressionBase extends BaseNode {
-  argument: Expression;
-  operator: string;
-  prefix: boolean;
-}

--- a/packages/ast-spec/src/expression/UnaryExpression/spec.ts
+++ b/packages/ast-spec/src/expression/UnaryExpression/spec.ts
@@ -1,10 +1,21 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
-import type { UnaryExpressionBase } from '../../base/UnaryExpressionBase';
+import type { BaseNode } from '../../base/BaseNode';
+import type { Expression } from '../../unions/Expression';
+
+interface UnaryExpressionBase extends BaseNode {
+  type: AST_NODE_TYPES.UnaryExpression;
+  argument: Expression;
+  operator: string;
+  /**
+   * @deprecated The `prefix` property is always `true` and is only present for historical reasons.
+   * See https://github.com/estree/estree/pull/118.
+   */
+  prefix: true;
+}
 
 interface UnaryExpressionSpecific<
   T extends string,
 > extends UnaryExpressionBase {
-  type: AST_NODE_TYPES.UnaryExpression;
   operator: T;
 }
 

--- a/packages/ast-spec/src/expression/UpdateExpression/spec.ts
+++ b/packages/ast-spec/src/expression/UpdateExpression/spec.ts
@@ -1,7 +1,9 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
-import type { UnaryExpressionBase } from '../../base/UnaryExpressionBase';
+import type { Expression } from '../../unions/Expression';
 
-export interface UpdateExpression extends UnaryExpressionBase {
+export interface UpdateExpression {
   type: AST_NODE_TYPES.UpdateExpression;
+  argument: Expression;
   operator: '++' | '--';
+  prefix: boolean;
 }

--- a/packages/ast-spec/src/expression/UpdateExpression/spec.ts
+++ b/packages/ast-spec/src/expression/UpdateExpression/spec.ts
@@ -1,7 +1,8 @@
 import type { AST_NODE_TYPES } from '../../ast-node-types';
+import type { BaseNode } from '../../base/BaseNode';
 import type { Expression } from '../../unions/Expression';
 
-export interface UpdateExpression {
+export interface UpdateExpression extends BaseNode {
   type: AST_NODE_TYPES.UpdateExpression;
   argument: Expression;
   operator: '++' | '--';

--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -230,9 +230,7 @@ export default createRule<Options, MessageIds>({
 
     function nodeIsUnaryNegation(node: TSESTree.Node): boolean {
       return (
-        node.type === AST_NODE_TYPES.UnaryExpression &&
-        node.prefix &&
-        node.operator === '!'
+        node.type === AST_NODE_TYPES.UnaryExpression && node.operator === '!'
       );
     }
 

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -1740,11 +1740,21 @@ export class Converter {
             prefix: node.kind === SyntaxKind.PrefixUnaryExpression,
           });
         }
+        const isPrefixUnaryExpression =
+          node.kind === SyntaxKind.PrefixUnaryExpression;
+        if (!isPrefixUnaryExpression) {
+          this.#throwError(
+            node,
+            `Unexpected PrefixUnaryExpression with operator ${operator}`,
+          );
+        }
         return this.createNode<TSESTree.UnaryExpression>(node, {
           type: AST_NODE_TYPES.UnaryExpression,
           argument: this.convertChild(node.operand),
           operator,
-          prefix: node.kind === SyntaxKind.PrefixUnaryExpression,
+          // Guaranteed to be true in a valid AST (and asserted above) but
+          // technically could be false at runtime with allowInvalidAST: true.
+          prefix: isPrefixUnaryExpression as true,
         });
       }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes partly #6434
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

### Slight restructuring of the type hierarchy in ast-spec...

Right now, `UpdateExpression` and `UnaryExpression`s have a common base interface `UnaryExpressionBase`, in which `prefix` is given as `boolean`. I'm 90% sure that `UnaryExpressionBase` is not user-visible, and therefore, it is safe to remove it as a common base. If anyone knows, please let me know if that's not true! I've assumed this to be true in this PR, and removed the common base (there's now a base interface for the `UnaryExpression`s only, that's called `UnaryExpressionBase`, but it's still internal).

If that assumption is incorrect, I can easily change this PR to keep `UnaryExpressionBase` as is, remaining a common base for the `UnaryExpression`s and `UpdateExpression`, but still update the exported `UnaryExpression` union slightly differently to have `prefix: true`. 

### Deprecated `prefix`

I figured it made sense to add `/** @deprecated */` to `UnaryExpression`'s `prefix` property to discourage reading it and explain that it's always `true`, even though it will never be removed. But lmk if that isn't the right move 🤷 

### Other

otherwise there's just minor downstream changes