### PR TITLE
feat(ast-spec): tighten types of `ArrowFunction`, `YieldExpression`, `TSTypePredicate`

### DIFF
--- a/packages/ast-spec/src/expression/ArrowFunctionExpression/spec.ts
+++ b/packages/ast-spec/src/expression/ArrowFunctionExpression/spec.ts
@@ -6,7 +6,7 @@ import type { BlockStatement } from '../../statement/BlockStatement/spec';
 import type { Expression } from '../../unions/Expression';
 import type { Parameter } from '../../unions/Parameter';
 
-export interface ArrowFunctionExpression extends BaseNode {
+interface ArrowFunctionExpressionBase extends BaseNode {
   type: AST_NODE_TYPES.ArrowFunctionExpression;
   async: boolean;
   body: BlockStatement | Expression;
@@ -17,3 +17,17 @@ export interface ArrowFunctionExpression extends BaseNode {
   returnType: TSTypeAnnotation | undefined;
   typeParameters: TSTypeParameterDeclaration | undefined;
 }
+
+export interface ArrowFunctionExpressionWithExpressionBody extends ArrowFunctionExpressionBase {
+  body: Expression;
+  expression: true;
+}
+
+export interface ArrowFunctionExpressionWithBlockBody extends ArrowFunctionExpressionBase {
+  body: BlockStatement;
+  expression: false;
+}
+
+export type ArrowFunctionExpression =
+  | ArrowFunctionExpressionWithBlockBody
+  | ArrowFunctionExpressionWithExpressionBody;

--- a/packages/ast-spec/src/expression/YieldExpression/spec.ts
+++ b/packages/ast-spec/src/expression/YieldExpression/spec.ts
@@ -2,8 +2,19 @@ import type { AST_NODE_TYPES } from '../../ast-node-types';
 import type { BaseNode } from '../../base/BaseNode';
 import type { Expression } from '../../unions/Expression';
 
-export interface YieldExpression extends BaseNode {
+interface YieldExpressionBase extends BaseNode {
   type: AST_NODE_TYPES.YieldExpression;
   argument: Expression | null;
   delegate: boolean;
 }
+
+export interface YieldStarExpression extends YieldExpressionBase {
+  argument: Expression;
+  delegate: true;
+}
+
+export interface YieldNoStarExpression extends YieldExpressionBase {
+  delegate: false;
+}
+
+export type YieldExpression = YieldNoStarExpression | YieldStarExpression;

--- a/packages/ast-spec/src/type/TSTypePredicate/spec.ts
+++ b/packages/ast-spec/src/type/TSTypePredicate/spec.ts
@@ -4,9 +4,22 @@ import type { Identifier } from '../../expression/Identifier/spec';
 import type { TSTypeAnnotation } from '../../special/TSTypeAnnotation/spec';
 import type { TSThisType } from '../TSThisType/spec';
 
-export interface TSTypePredicate extends BaseNode {
+interface TSTypePredicateBase extends BaseNode {
   type: AST_NODE_TYPES.TSTypePredicate;
   asserts: boolean;
   parameterName: Identifier | TSThisType;
   typeAnnotation: TSTypeAnnotation | null;
 }
+
+export interface TSTypePredicateWithAsserts extends TSTypePredicateBase {
+  asserts: true;
+}
+
+export interface TSTypePredicateNoAsserts extends TSTypePredicateBase {
+  asserts: false;
+  typeAnnotation: TSTypeAnnotation;
+}
+
+export type TSTypePredicate =
+  | TSTypePredicateNoAsserts
+  | TSTypePredicateWithAsserts;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes partly #6434
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Create discriminated unions of the variants.

Note that the new types are exported (to avoid problems where reexported types can't be named), so we should make sure we're comfortable with the names of the newly exported types.