### PR TITLE
fix(rule-schema-to-typescript-types): respect ECMAScript line terminators

### DIFF
--- a/packages/rule-schema-to-typescript-types/src/printAST.ts
+++ b/packages/rule-schema-to-typescript-types/src/printAST.ts
@@ -1,3 +1,4 @@
+import { ASTUtils } from '@typescript-eslint/utils';
 import naturalCompare from 'natural-compare';
 
 import type { SchemaAST, TupleAST } from './types.js';
@@ -22,7 +23,7 @@ function printComment({
 
   const commentLines: string[] = [];
   for (const line of commentLinesIn) {
-    commentLines.push(...line.split('\n'));
+    commentLines.push(...line.split(ASTUtils.LINEBREAK_MATCHER));
   }
 
   if (commentLines.length === 1) {

--- a/packages/rule-schema-to-typescript-types/tests/index.test.ts
+++ b/packages/rule-schema-to-typescript-types/tests/index.test.ts
@@ -51,6 +51,103 @@ describe(schemaToTypes, () => {
     `);
   });
 
+  it('returns a multiline comment when the schema description contains CRLF line terminators', () => {
+    const actual = schemaToTypes([
+      {
+        description: 'My schema items.\r\nMore details.\r\nEven more details.',
+        items: { type: 'string' },
+        type: 'array',
+      },
+    ]);
+
+    expect(actual).toMatchInlineSnapshot(`
+      "type Options = [/**
+       * My schema items.
+       * More details.
+       * Even more details.
+       */
+      string[]]"
+    `);
+  });
+
+  it('returns a multiline comment when the schema description contains CR line terminators', () => {
+    const actual = schemaToTypes([
+      {
+        description: 'My schema items.\rMore details.\rEven more details.',
+        items: { type: 'string' },
+        type: 'array',
+      },
+    ]);
+
+    expect(actual).toMatchInlineSnapshot(`
+      "type Options = [/**
+       * My schema items.
+       * More details.
+       * Even more details.
+       */
+      string[]]"
+    `);
+  });
+
+  it('returns a multiline comment when the schema description contains LF line terminators', () => {
+    const actual = schemaToTypes([
+      {
+        description: 'My schema items.\nMore details.\nEven more details.',
+        items: { type: 'string' },
+        type: 'array',
+      },
+    ]);
+
+    expect(actual).toMatchInlineSnapshot(`
+      "type Options = [/**
+       * My schema items.
+       * More details.
+       * Even more details.
+       */
+      string[]]"
+    `);
+  });
+
+  it('returns a multiline comment when the schema description contains LS line terminators', () => {
+    const actual = schemaToTypes([
+      {
+        description:
+          'My schema items.\u2028More details.\u2028Even more details.',
+        items: { type: 'string' },
+        type: 'array',
+      },
+    ]);
+
+    expect(actual).toMatchInlineSnapshot(`
+      "type Options = [/**
+       * My schema items.
+       * More details.
+       * Even more details.
+       */
+      string[]]"
+    `);
+  });
+
+  it('returns a multiline comment when the schema description contains PS line terminators', () => {
+    const actual = schemaToTypes([
+      {
+        description:
+          'My schema items.\u2029More details.\u2029Even more details.',
+        items: { type: 'string' },
+        type: 'array',
+      },
+    ]);
+
+    expect(actual).toMatchInlineSnapshot(`
+      "type Options = [/**
+       * My schema items.
+       * More details.
+       * Even more details.
+       */
+      string[]]"
+    `);
+  });
+
   it('factors in one $ref property when a $defs property exists at the top level', () => {
     const actual = schemaToTypes([
       {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -29,7 +29,6 @@ const vitestConfig = mergeConfig(
         'packages/*/vitest.config.mts',
         '!packages/website/vitest.config.mts',
         '!packages/website-eslint/vitest.config.mts',
-        '!packages/rule-schema-to-typescript-types/vitest.config.mts',
         '!packages/types/vitest.config.mts',
       ],
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: https://github.com/typescript-eslint/typescript-eslint/issues/12353, https://github.com/typescript-eslint/typescript-eslint/pull/12352
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hello,

This PR follows up on https://github.com/typescript-eslint/typescript-eslint/pull/12352 and https://github.com/typescript-eslint/typescript-eslint/pull/12353.

While going through the codebase, I also found that when `rule-schema-typescript-types` converts `description` values with line terminators, it currently only splits lines on LF (`\n`). Other valid line terminators like CR, LS, and PS are ignored, even though some users may use them according to the ECMAScript standard.

I’ve updated the logic to correctly recognize the other ECMAScript line terminator types, as done in https://github.com/typescript-eslint/typescript-eslint/pull/12352 and https://github.com/typescript-eslint/typescript-eslint/pull/12353.

🌟 
