### PR TITLE
docs: update TypeScript version reference in Dependency Version

### DIFF
--- a/docs/users/Dependency_Versions.mdx
+++ b/docs/users/Dependency_Versions.mdx
@@ -3,7 +3,6 @@ id: dependency-versions
 title: Dependency Versions
 ---
 
-import rootPackageJson from '../../package.json';
 import eslintPluginPackageJson from '../../packages/eslint-plugin/package.json';
 
 ## ESLint
@@ -34,7 +33,7 @@ Support for specific Current status releases are considered periodically.
 <blockquote>
   <p>
     The version range of TypeScript currently supported is{' '}
-    <code>{rootPackageJson.devDependencies.typescript}</code>.
+    <code>{eslintPluginPackageJson.peerDependencies.typescript}</code>.
   </p>
 </blockquote>
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hi,

I found that the TypeScript version range in the Dependency Version docs is now set to `catalog:` instead of a version number, so I’ve fixed it.

I think this reference hadn’t been updated since the PNPM migration.

https://typescript-eslint.io/users/dependency-versions#typescript

- Before: 

<img width="517" height="97" alt="image" src="https://github.com/user-attachments/assets/e6d65906-00c6-4f5d-af2e-3e43d8d418df" alt="before"/>

- After:

<img width="571" height="103" alt="image" src="https://github.com/user-attachments/assets/25307cf9-7606-45f5-b2ab-13ecdd3abb0e" alt="after" />

🍻 


