### PR TITLE
docs(eslint-plugin): clarify checkTypePredicates assumptions

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -157,23 +157,6 @@ while (thisIsTrue) {
 
 {/* insert option description */}
 
-:::note
-This option assumes that type predicates accurately describe their runtime behavior.
-
-For a type predicate such as `isString(value): value is string`, TypeScript's
-control-flow analysis assumes that the function returns `true` if and only if
-`value` has the asserted type. If a predicate performs additional runtime checks
-that are not represented in its return type, this option may report conditions
-that are still meaningful at runtime.
-
-For assertion functions such as `assertIsString(value): asserts value is string`,
-TypeScript similarly assumes that the value has the asserted type whenever the
-function returns normally. If an assertion function's runtime behavior does not
-match its declared assertion type, this option may produce unexpected reports.
-Consider disabling this option or suppressing the rule for cases where the
-assertion function intentionally performs additional runtime checks.
-:::
-
 Example of additional incorrect code with `{ checkTypePredicates: true }`:
 
 ```ts option='{ "checkTypePredicates": true }' showPlaygroundButton
@@ -211,6 +194,14 @@ Whether this option makes sense for your project may vary.
 Some projects may intentionally use type predicates to ensure that runtime values do indeed match the types according to TypeScript, especially in test code.
 Often, it makes sense to use eslint-disable comments in these cases, with a comment indicating why the condition should be checked at runtime, despite appearing unnecessary.
 However, in some contexts, it may be more appropriate to keep this option disabled entirely.
+
+:::note
+This option assumes that type predicates accurately describe their runtime behavior.
+
+For a type predicate such as `isString(value): value is string`, TypeScript's control-flow analysis assumes that the function returns `true` if and only if `value` has the asserted type. If a predicate performs additional runtime checks that are not represented in its return type, this option may report conditions that are still meaningful at runtime.
+
+For assertion functions such as `assertIsString(value): asserts value is string`, TypeScript similarly assumes that the value has the asserted type whenever the function returns normally.
+:::
 
 ### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`
 

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -157,6 +157,23 @@ while (thisIsTrue) {
 
 {/* insert option description */}
 
+:::note
+This option assumes that type predicates accurately describe their runtime behavior.
+
+For a type predicate such as `isString(value): value is string`, TypeScript's
+control-flow analysis assumes that the function returns `true` if and only if
+`value` has the asserted type. If a predicate performs additional runtime checks
+that are not represented in its return type, this option may report conditions
+that are still meaningful at runtime.
+
+For assertion functions such as `assertIsString(value): asserts value is string`,
+TypeScript similarly assumes that the value has the asserted type whenever the
+function returns normally. If an assertion function's runtime behavior does not
+match its declared assertion type, this option may produce unexpected reports.
+Consider disabling this option or suppressing the rule for cases where the
+assertion function intentionally performs additional runtime checks.
+:::
+
 Example of additional incorrect code with `{ checkTypePredicates: true }`:
 
 ```ts option='{ "checkTypePredicates": true }' showPlaygroundButton

--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -198,9 +198,9 @@ However, in some contexts, it may be more appropriate to keep this option disabl
 :::note
 This option assumes that type predicates accurately describe their runtime behavior.
 
-For a type predicate such as `isString(value): value is string`, TypeScript's control-flow analysis assumes that the function returns `true` if and only if `value` has the asserted type. If a predicate performs additional runtime checks that are not represented in its return type, this option may report conditions that are still meaningful at runtime.
+For a type predicate such as `isString(value): value is string`, TypeScript's control-flow analysis assumes that the function returns `true` if and only if `value` has the asserted type (`string`). If a predicate performs additional runtime checks that are not represented in its return type, this option may report conditions that are still meaningful at runtime.
 
-For assertion functions such as `assertIsString(value): asserts value is string`, TypeScript similarly assumes that the value has the asserted type whenever the function returns normally.
+This option assumes that a well-formed assertion function follows the same if-and-only-if semantics as a type predicate. For example, `assertIsString(value): asserts value is string` is assumed not to throw when `value` is already a string, and if it returns normally, then `value` is a string. Some assertion-function typings in the wild, such as Node's `assert.strictEqual()`, do not follow this assumption. In those cases, this option may report a runtime-meaningful assertion as unnecessary, so you may need to disable the option or suppress the report.
 :::
 
 ### `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #12349
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a note to the `checkTypePredicates` section of `no-unnecessary-condition`
to clarify that the option assumes type predicates accurately describe their
runtime behavior.

The note explains that TypeScript's control-flow analysis assumes a predicate
returns `true` if and only if the value has the asserted type. It also clarifies
the related behavior for assertion functions, where TypeScript narrows based on
the function returning normally.

It also advises disabling the option or suppressing the rule in cases where an
assertion function intentionally performs additional runtime checks that are not
fully represented by its declared assertion type.