### PR TITLE
docs(eslint-plugin): [no-unnecessary-condition] note checkTypePredicates assumes valid type predicates

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -190,6 +190,12 @@ function assertIsString(value: unknown): asserts value is string {
 assertIsString(s); // Unnecessary; s is always a string.
 ```
 
+:::note
+This option assumes that type predicates are valid, meaning the asserted type holds _if and only if_ the type guard returns `true` (or, for assertion functions, _if and only if_ the function returns rather than throwing).
+This is a requirement of a well-formed type predicate in TypeScript, but TypeScript does not enforce it: a function annotated as returning `x is T` is free to return `true` even when `x` is not a `T` at runtime.
+If a type predicate is written more loosely than the value it inspects — for example, a runtime validator deliberately re-checking a value the type system already considers narrow — then the check is not truly unnecessary, and this option may report a false positive on it.
+:::
+
 Whether this option makes sense for your project may vary.
 Some projects may intentionally use type predicates to ensure that runtime values do indeed match the types according to TypeScript, especially in test code.
 Often, it makes sense to use eslint-disable comments in these cases, with a comment indicating why the condition should be checked at runtime, despite appearing unnecessary.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12349
- [x] That issue was marked as [`accepting prs`](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+is%3Aopen+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/typescript-eslint/typescript-eslint/blob/main/CONTRIBUTING.md) were taken

## Overview

Adds a short note to the `checkTypePredicates` docs explaining the assumption it relies on: the rule only treats a type-guarded condition as unnecessary because it assumes the predicate is valid — i.e. the asserted type holds if and only if the guard returns `true` (or, for assertion functions, if and only if the function returns rather than throwing).

This is a requirement of a well-formed type predicate in TypeScript, but the compiler doesn't enforce it, so a predicate that's deliberately written looser than the value it inspects (e.g. a runtime validator re-checking an already-narrow value) isn't really unnecessary and can be flagged as a false positive. The note calls that out so the behavior isn't surprising, and leads into the existing guidance about using a disable comment for intentional runtime checks.

Per the issue, I intentionally left out the open question about the `asserts` variant, since that's still pending input from the TS side.

Doc-only change; no rule behavior changes.

💖
