### PR TITLE
docs: add a troubleshooting section for out-of-memory errors

### DIFF
--- a/docs/troubleshooting/typed-linting/Performance.mdx
+++ b/docs/troubleshooting/typed-linting/Performance.mdx
@@ -46,6 +46,24 @@ You can enable the setting by prepending your ESLint command like:
 NODE_OPTIONS=--max-semi-space-size=256 eslint <rest of your command>
 ```
 
+## Out of Memory
+
+Typed linting holds TypeScript's program and type information in memory while ESLint runs.
+On large projects, or projects with especially large or complex types, that can be enough to exhaust Node's default heap and crash the process with an out-of-memory (OOM) error such as `FATAL ERROR: ... JavaScript heap out of memory`.
+
+The same things that make type checking slow tend to make it memory-hungry, so the investigation steps under [Slow TypeScript Types](#slow-typescript-types) apply here too.
+In particular, [Performance Tracing](https://github.com/microsoft/TypeScript/wiki/Performance#performance-tracing) and the TypeScript Wiki's notes on [writing easy-to-compile code](https://github.com/microsoft/TypeScript/wiki/Performance#writing-easy-to-compile-code) can help you find and simplify the types that are consuming the most memory.
+Reducing the number of files included in typed linting (see [Wide includes in your `tsconfig`](#wide-includes-in-your-tsconfig)) also lowers peak memory usage.
+
+If your project is simply large enough that it needs more memory than Node allows by default, you can raise the heap limit with the [`--max-old-space-size` option](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-mib).
+For example, to allow up to 8 GB:
+
+```bash
+NODE_OPTIONS=--max-old-space-size=8192 eslint <rest of your command>
+```
+
+Raising the heap limit treats the symptom rather than the cause: if memory usage keeps growing, it's worth investigating your types and includes as above rather than continually increasing the limit.
+
 ## Wide includes in your `tsconfig`
 
 When using type-aware linting, you provide us with one or more tsconfigs.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10273
- [x] That issue was marked as [`accepting prs`](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+is%3Aopen+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The performance troubleshooting page covers slow linting but not out-of-memory crashes, which come up fairly often with large or complex types. This adds an "Out of Memory" section right after the existing Node memory tip.

It points back to the same slow-types investigation steps (since the things that make type checking memory-hungry are the same things that make it slow), links the TypeScript wiki notes on performance tracing and writing easy-to-compile code, and documents the `NODE_OPTIONS=--max-old-space-size` workaround for projects that genuinely need a bigger heap. I also added a short note that bumping the heap limit is treating the symptom, so people don't just keep raising it instead of looking at their types.

Docs-only change.

💖
