### PR TITLE
docs: add a General FAQ entry on structuring configs with non-JS/TS files

### DIFF
--- a/docs/troubleshooting/faqs/General.mdx
+++ b/docs/troubleshooting/faqs/General.mdx
@@ -66,6 +66,36 @@ module.exports = {
 </TabItem>
 </Tabs>
 
+## How should I structure my config for projects with non-JS/TS files?
+
+Projects often lint more than just JavaScript and TypeScript — for example linting `package.json` with [`eslint-plugin-package-json`](https://www.npmjs.com/package/eslint-plugin-package-json), or Markdown, CSS, and so on.
+When that happens it can be tempting to enable the JS/TS rules globally and then turn them back off for the other file types.
+We instead recommend scoping each set of rules to the files it applies to with [`files`](https://eslint.org/docs/latest/use/configure/configuration-files#specifying-files-and-ignores), so that each config block only ever runs on the files it's meant for:
+
+```js title="eslint.config.mjs"
+import js from '@eslint/js';
+import packageJson from 'eslint-plugin-package-json/configs/recommended';
+import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
+
+export default defineConfig(
+  {
+    files: ['**/*.{js,ts}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.strictTypeChecked,
+      tseslint.configs.stylisticTypeChecked,
+    ],
+  },
+  {
+    files: ['**/package.json'],
+    extends: [packageJson],
+  },
+);
+```
+
+This keeps each tool's rules targeted, avoids having to remember which rules to disable on which files, and makes it clear at a glance what runs where.
+
 ## How can I ban `<specific language feature>`?
 
 ESLint core contains the rule [`no-restricted-syntax`](https://eslint.org/docs/rules/no-restricted-syntax).


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9859
- [x] That issue was marked as [`accepting prs`](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aissue+is%3Aopen+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Adds a General FAQ entry for the common situation where a project lints more than just JS/TS — for example `package.json` via eslint-plugin-package-json, or Markdown/CSS.

It recommends scoping each plugin's rules to the files it applies to with `files`, instead of enabling the JS/TS rules globally and then turning them back off for the other file types. The example uses the current `defineConfig` + `files`/`extends` style (matching the rest of our docs) with one block for `**/*.{js,ts}` and one for `**/package.json`.

This is the structure suggested by the maintainer note in the issue; I updated the example to the current config style.

Docs-only change.

💖
