### PR TITLE
docs: clarify package-manager requirement when global-linking locally

### DIFF
--- a/docs/contributing/local-development/Local_Linking.mdx
+++ b/docs/contributing/local-development/Local_Linking.mdx
@@ -33,6 +33,15 @@ The command to put instead of that `#` comment, depends on the local downstream 
 - [Yarn v1 / classic](https://classic.yarnpkg.com/lang/en/docs/cli/link/ 'Yarn v1 / classic docs'): `yarn link`
 - [Yarn v2 / v3 / berry](https://yarnpkg.com/cli/link 'Yarn v2 / v3 / berry docs'): _skip this step altogether_
 
+:::note
+This command runs from the `typescript-eslint` repository, but the package manager it uses must match the **downstream** repository — that's where the global symlinks need to be registered.
+The `typescript-eslint` repository pins its own package manager with the [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field in `package.json`, which [Corepack](https://nodejs.org/api/corepack.html) enforces.
+If the downstream repository uses a different package manager, you may see an error such as `This project is configured to use yarn`, or a later `yarn link` in the downstream repository may fail with `No registered package found`.
+
+To work around this, run the global link command in an environment that uses the downstream repository's package manager — for example, by temporarily switching the pinned version with `yarn set version <version>` (Yarn) or by removing the `packageManager` field from `package.json` for the duration of the link.
+Remember to revert that change before committing.
+:::
+
 Additionally, if you haven't yet built the typescript-eslint repository, do so now:
 
 ```shell


### PR DESCRIPTION
Fixes #8961.

The Local Linking guide says to run your downstream repo's package
manager's global link command from the typescript-eslint repository
root, but the repository pins its own package manager via the
`packageManager` field in `package.json`. Corepack enforces that field,
so running a different package manager from the repo root fails:

- a downstream Yarn v1 project later hits `No registered package found`
- pnpm hits `This project is configured to use yarn`

Both are the same root cause and both are reported in the issue. I added
a short note after the global-link command list explaining why the
mismatch happens and how to work around it (temporarily switching the
pinned version with `yarn set version`, or removing the `packageManager`
field for the duration of the link and reverting it before committing).

Docs-only, no behavior change. 🔗
