### PR TITLE
fix(eslint-plugin): [unified-signatures] compare own type parameters by constraint

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -1,6 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
+import { getKeys } from '@typescript-eslint/visitor-keys';
 
 import type { Equal } from '../util';
 
@@ -206,19 +207,45 @@ export default createRule<Options, MessageIds>({
       b: SignatureDefinition,
       isTypeParameter: IsTypeParameter,
     ): Unify | undefined {
-      if (!signaturesCanBeUnified(a, b, isTypeParameter)) {
+      // Type parameters declared on the overloads themselves are compared by
+      // their constraint rather than by name, so that two overloads using the
+      // same constraint under different type parameter names can still unify.
+      const ownTypeParametersA = getOwnTypeParameterConstraints(a);
+      const ownTypeParametersB = getOwnTypeParameterConstraints(b);
+
+      if (
+        !signaturesCanBeUnified(
+          a,
+          b,
+          isTypeParameter,
+          ownTypeParametersA,
+          ownTypeParametersB,
+        )
+      ) {
         return undefined;
       }
 
       return a.params.length === b.params.length
-        ? signaturesDifferBySingleParameter(a.params, b.params)
-        : signaturesDifferByOptionalOrRestParameter(a, b);
+        ? signaturesDifferBySingleParameter(
+            a.params,
+            b.params,
+            ownTypeParametersA,
+            ownTypeParametersB,
+          )
+        : signaturesDifferByOptionalOrRestParameter(
+            a,
+            b,
+            ownTypeParametersA,
+            ownTypeParametersB,
+          );
     }
 
     function signaturesCanBeUnified(
       a: SignatureDefinition,
       b: SignatureDefinition,
       isTypeParameter: IsTypeParameter,
+      ownTypeParametersA: ReadonlyMap<string, string>,
+      ownTypeParametersB: ReadonlyMap<string, string>,
     ): boolean {
       // Must return the same type.
 
@@ -249,7 +276,12 @@ export default createRule<Options, MessageIds>({
       }
 
       return (
-        typesAreEqual(a.returnType, b.returnType) &&
+        typesAreEqual(
+          a.returnType,
+          b.returnType,
+          ownTypeParametersA,
+          ownTypeParametersB,
+        ) &&
         // Must take the same type parameters.
         // If one uses a type parameter (from outside) and the other doesn't, they shouldn't be joined.
         arraysAreEqual(aTypeParams, bTypeParams, typeParametersAreEqual) &&
@@ -262,6 +294,8 @@ export default createRule<Options, MessageIds>({
     function signaturesDifferBySingleParameter(
       types1: readonly TSESTree.Parameter[],
       types2: readonly TSESTree.Parameter[],
+      ownTypeParameters1: ReadonlyMap<string, string>,
+      ownTypeParameters2: ReadonlyMap<string, string>,
     ): Unify | undefined {
       const firstParam1 = types1[0];
       const firstParam2 = types2[0];
@@ -271,10 +305,16 @@ export default createRule<Options, MessageIds>({
         return undefined;
       }
 
+      const parametersAreEqualConsideringTypeParameters = (
+        p1: TSESTree.Parameter,
+        p2: TSESTree.Parameter,
+      ): boolean =>
+        parametersAreEqual(p1, p2, ownTypeParameters1, ownTypeParameters2);
+
       const index = getIndexOfFirstDifference(
         types1,
         types2,
-        parametersAreEqual,
+        parametersAreEqualConsideringTypeParameters,
       );
       if (index == null) {
         return undefined;
@@ -285,7 +325,7 @@ export default createRule<Options, MessageIds>({
         !arraysAreEqual(
           types1.slice(index + 1),
           types2.slice(index + 1),
-          parametersAreEqual,
+          parametersAreEqualConsideringTypeParameters,
         )
       ) {
         return undefined;
@@ -320,6 +360,8 @@ export default createRule<Options, MessageIds>({
     function signaturesDifferByOptionalOrRestParameter(
       a: SignatureDefinition,
       b: SignatureDefinition,
+      ownTypeParameters1: ReadonlyMap<string, string>,
+      ownTypeParameters2: ReadonlyMap<string, string>,
     ): Unify | undefined {
       const sig1 = a.params;
       const sig2 = b.params;
@@ -361,7 +403,14 @@ export default createRule<Options, MessageIds>({
           ? sig2i.parameter.typeAnnotation
           : sig2i.typeAnnotation;
 
-        if (!typesAreEqual(typeAnnotation1, typeAnnotation2)) {
+        if (
+          !typesAreEqual(
+            typeAnnotation1,
+            typeAnnotation2,
+            ownTypeParameters1,
+            ownTypeParameters2,
+          )
+        ) {
           return undefined;
         }
       }
@@ -438,6 +487,8 @@ export default createRule<Options, MessageIds>({
     function parametersAreEqual(
       a: TSESTree.Parameter,
       b: TSESTree.Parameter,
+      ownTypeParametersA: ReadonlyMap<string, string>,
+      ownTypeParametersB: ReadonlyMap<string, string>,
     ): boolean {
       const typeAnnotationA = isTSParameterProperty(a)
         ? a.parameter.typeAnnotation
@@ -448,7 +499,12 @@ export default createRule<Options, MessageIds>({
 
       return (
         parametersHaveEqualSigils(a, b) &&
-        typesAreEqual(typeAnnotationA, typeAnnotationB)
+        typesAreEqual(
+          typeAnnotationA,
+          typeAnnotationB,
+          ownTypeParametersA,
+          ownTypeParametersB,
+        )
       );
     }
 
@@ -483,30 +539,136 @@ export default createRule<Options, MessageIds>({
       a: TSESTree.TSTypeParameter,
       b: TSESTree.TSTypeParameter,
     ): boolean {
+      // The names are intentionally not compared: two overloads declaring a
+      // type parameter with the same constraint (and default) can be unified
+      // even if those parameters are named differently, e.g. `<T extends string>`
+      // and `<R extends string>`.
       return (
-        a.name.name === b.name.name &&
-        constraintsAreEqual(a.constraint, b.constraint)
+        constraintsAreEqual(a.constraint, b.constraint) &&
+        constraintsAreEqual(a.default, b.default)
       );
     }
 
     function typesAreEqual(
       a: TSESTree.TSTypeAnnotation | undefined,
       b: TSESTree.TSTypeAnnotation | undefined,
+      ownTypeParametersA: ReadonlyMap<string, string>,
+      ownTypeParametersB: ReadonlyMap<string, string>,
     ): boolean {
       return (
         a === b ||
         (a != null &&
           b != null &&
-          context.sourceCode.getText(a.typeAnnotation) ===
-            context.sourceCode.getText(b.typeAnnotation))
+          normalizeTypeText(a.typeAnnotation, ownTypeParametersA) ===
+            normalizeTypeText(b.typeAnnotation, ownTypeParametersB))
       );
+    }
+
+    /**
+     * Maps each type parameter declared on the signature itself to a token
+     * derived from its constraint. References to these parameters are then
+     * compared by constraint instead of by name, while references to type
+     * parameters from an outer scope (absent from the map) keep being compared
+     * by name.
+     */
+    function getOwnTypeParameterConstraints(
+      signature: SignatureDefinition,
+    ): ReadonlyMap<string, string> {
+      const constraints = new Map<string, string>();
+      for (const typeParameter of signature.typeParameters?.params ?? []) {
+        constraints.set(
+          typeParameter.name.name,
+          typeParameter.constraint == null
+            ? ''
+            : context.sourceCode.getText(typeParameter.constraint),
+        );
+      }
+      return constraints;
+    }
+
+    /**
+     * Returns the source text of a type node with every reference to one of the
+     * signature's own type parameters replaced by a token derived from that
+     * parameter's constraint. The token is wrapped in `\0`, which cannot appear
+     * in source code, so it can never collide with an unrelated type that
+     * happens to be spelled like the constraint.
+     */
+    function normalizeTypeText(
+      node: TSESTree.TypeNode,
+      ownTypeParameters: ReadonlyMap<string, string>,
+    ): string {
+      const text = context.sourceCode.getText(node);
+      if (ownTypeParameters.size === 0) {
+        return text;
+      }
+
+      const offset = node.range[0];
+      const replacements: { end: number; start: number; text: string }[] = [];
+      forEachTypeReference(node, reference => {
+        const constraint = ownTypeParameters.get(reference.name);
+        if (constraint != null) {
+          replacements.push({
+            start: reference.range[0] - offset,
+            end: reference.range[1] - offset,
+            text: `\0${constraint}\0`,
+          });
+        }
+      });
+      if (replacements.length === 0) {
+        return text;
+      }
+
+      replacements.sort((x, y) => x.start - y.start);
+      let result = '';
+      let lastIndex = 0;
+      for (const replacement of replacements) {
+        result += text.slice(lastIndex, replacement.start) + replacement.text;
+        lastIndex = replacement.end;
+      }
+      return result + text.slice(lastIndex);
+    }
+
+    /** Calls `callback` for the name of every type reference found within `node`. */
+    function forEachTypeReference(
+      node: TSESTree.Node,
+      callback: (reference: TSESTree.Identifier) => void,
+    ): void {
+      if (
+        node.type === AST_NODE_TYPES.TSTypeReference &&
+        isIdentifier(node.typeName)
+      ) {
+        callback(node.typeName);
+      }
+
+      const properties = node as unknown as Record<string, unknown>;
+      for (const key of getKeys(node)) {
+        const value = properties[key];
+        if (Array.isArray(value)) {
+          for (const child of value as unknown[]) {
+            if (isNode(child)) {
+              forEachTypeReference(child, callback);
+            }
+          }
+        } else if (isNode(value)) {
+          forEachTypeReference(value, callback);
+        }
+      }
+    }
+
+    function isNode(value: unknown): value is TSESTree.Node {
+      return value != null && typeof value === 'object' && 'type' in value;
     }
 
     function constraintsAreEqual(
       a: TSESTree.TypeNode | undefined,
       b: TSESTree.TypeNode | undefined,
     ): boolean {
-      return a === b || (a != null && a.type === b?.type);
+      return (
+        a === b ||
+        (a != null &&
+          b != null &&
+          context.sourceCode.getText(a) === context.sourceCode.getText(b))
+      );
     }
 
     /* Returns the first index where `a` and `b` differ. */

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -408,6 +408,57 @@ function f(this: void, a: boolean): void;
 function f(this: {}, a: boolean): void;
 function f(this: void | {}, a: boolean): void {}
     `,
+    // Type parameters with different constraints must not be unified, even when
+    // they are named differently.
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12143
+    `
+type A = 1 | 2;
+type B = 3 | 4;
+function a<T extends A>(s: T, param: string): string;
+function a<R extends B>(s: R): string;
+function a<T extends A | B>(s: T, param?: string): string {
+  return 'aaa';
+}
+    `,
+    // Type parameters with different constraints must not be unified, even when
+    // they are named the same.
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12143
+    `
+type A = 1 | 2;
+type B = 3 | 4;
+function b<T extends A>(s: T, param: string): string;
+function b<T extends B>(s: T): string;
+function b<T extends A | B>(s: T, param?: string): string {
+  return 'aaa';
+}
+    `,
+    // Type parameters with the same constraint but different defaults must not
+    // be unified.
+    `
+function withDefault<T extends string = 'a'>(x: T, param: string): void;
+function withDefault<R extends string = 'b'>(x: R): void;
+function withDefault<T extends string>(x: T, param?: string): void {}
+    `,
+    // A constrained and an unconstrained type parameter must not be unified.
+    `
+function mixed<T extends string>(x: T, param: string): void;
+function mixed<R>(x: R): void;
+function mixed<T extends string>(x: T, param?: string): void {}
+    `,
+    // An unconstrained and a constrained type parameter must not be unified.
+    `
+function mixedReversed<T>(x: T, param: string): void;
+function mixedReversed<R extends string>(x: R): void;
+function mixedReversed<T>(x: T, param?: string): void {}
+    `,
+    // Type parameters from an outer scope are still compared by name, so these
+    // methods cannot be unified.
+    `
+interface I<T, U> {
+  method(x: T, param: string): void;
+  method(x: U): void;
+}
+    `,
   ],
   invalid: [
     {
@@ -1253,6 +1304,136 @@ function f(this: string | number, a: boolean): void {}
           },
           line: 3,
           messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Type parameters with the same constraint should be unified even when
+      // they are named differently.
+      // https://github.com/typescript-eslint/typescript-eslint/issues/12143
+      code: `
+function c<T extends string>(s: T, param: string): string;
+function c<R extends string>(s: R): string;
+function c<T extends string>(s: T, param?: string): string {
+  return 'aaa';
+}
+      `,
+      errors: [
+        {
+          column: 36,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // Differently named type parameters that share a constraint are unified
+      // even when nested inside another generic type.
+      code: `
+function nested<T extends string>(x: Array<T>, param: string): void;
+function nested<R extends string>(x: Array<R>): void;
+function nested<T extends string>(x: Array<T>, param?: string): void {}
+      `,
+      errors: [
+        {
+          column: 48,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // The single differing parameter is detected even when another parameter
+      // references a differently named type parameter with the same constraint.
+      code: `
+function single<T extends string>(a: number, x: T): void;
+function single<R extends string>(a: string, x: R): void;
+function single<T extends string>(a: number | string, x: T): void {}
+      `,
+      errors: [
+        {
+          column: 35,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number',
+            type2: 'string',
+          },
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Qualified type names are compared by name while the renamed type
+      // parameters are still unified by their constraint.
+      code: `
+function qualified<T extends string>(x: A.B, y: T, z: string): void;
+function qualified<R extends string>(x: A.B, y: R): void;
+function qualified<T extends string>(x: A.B, y: T, z?: string): void {}
+      `,
+      errors: [
+        {
+          column: 52,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // Unconstrained type parameters are unified regardless of their names.
+      code: `
+function unconstrained<T>(x: T, param: string): void;
+function unconstrained<R>(x: R): void;
+function unconstrained<T>(x: T, param?: string): void {}
+      `,
+      errors: [
+        {
+          column: 33,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // A parameter referencing multiple differently named type parameters that
+      // share their constraints is still unified.
+      code: `
+function multiRef<T extends string, U extends number>(
+  x: Map<T, U>,
+  param: string,
+): void;
+function multiRef<R extends string, S extends number>(x: Map<R, S>): void;
+function multiRef<T extends string, U extends number>(
+  x: Map<T, U>,
+  param?: string,
+): void {}
+      `,
+      errors: [
+        {
+          column: 3,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+          },
+          line: 4,
+          messageId: 'omittingSingleParameter',
         },
       ],
     },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12143
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`unified-signatures` compared an overload's parameter (and return) types purely by their source text, which meant a type parameter was effectively compared by its **name** rather than its **constraint**. As noted in the issue, that caused two opposite bugs:

- a **false positive** when two overloads reuse the same type parameter name with different constraints — `function b` in the issue (`<T extends A>` vs `<T extends B>`) was incorrectly flagged as unifiable;
- a **false negative** when two overloads use different names for a type parameter with the same constraint — `function c` (`<T extends string>` vs `<R extends string>`) was not flagged even though the overloads can be combined.

This change compares type parameters declared on an overload by their constraint (and default) instead of their name:

- When stringifying a type for comparison, references to the overload's *own* type parameters are substituted with a token derived from that parameter's constraint. References to type parameters from an *outer* scope are left untouched, so they keep being compared by name (per the suggestion on the issue).
- `constraintsAreEqual` previously only compared the constraint node's *kind*, so any two type references (e.g. `A` and `B`) looked equal. It now compares the constraint text, which is what fixed the `function b` false positive.

## Testing

Added `valid`/`invalid` cases to `unified-signatures.test.ts` covering the issue's `a`/`b`/`c` examples plus: same vs. different constraints, same constraint with different defaults, constrained vs. unconstrained parameters, nested (`Array<T>`) and multiple (`Map<T, U>`) type-parameter references, qualified type names, and type parameters from an outer scope. Each new case was confirmed to fail before the fix and pass after. `lint`, `typecheck`, and the full `eslint-plugin` test suite pass locally, and the new lines are fully covered.

💖
