### PR TITLE
fix(eslint-plugin): [no-unnecessary-template-expression] respect ECMAScript line terminators

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-template-expression.ts
@@ -1,6 +1,6 @@
 import type { TSESLint } from '@typescript-eslint/utils';
 
-import { TSESTree, AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { TSESTree, AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -485,5 +485,5 @@ function isWhitespace(x: string): boolean {
 }
 
 function startsWithNewLine(x: string): boolean {
-  return x.startsWith('\n') || x.startsWith('\r\n');
+  return ASTUtils.LINEBREAK_MATCHER.exec(x)?.index === 0;
 }

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-template-expression.test.ts
@@ -141,7 +141,19 @@ this code has trailing whitespace: \${\`    \`}
     \`;
     `,
     noFormat`
-\`this code has trailing whitespace with a windows \\\r new line: \${' '}\r\n\`;
+\`this code has trailing whitespace with a CRLF (windows \\\r) new line: \${' '}\r\n\`;
+    `,
+    noFormat`
+\`this code has trailing whitespace with a CR new line: \${' '}\r\`;
+    `,
+    `
+\`this code has trailing whitespace with a LF new line: \${' '}\n\`;
+    `,
+    `
+\`this code has trailing whitespace with a LS new line: \${' '}\u2028\`;
+    `,
+    `
+\`this code has trailing whitespace with a PS new line: \${' '}\u2029\`;
     `,
     `
 \`trailing position interpolated empty string also makes whitespace clear    \${''}
@@ -208,7 +220,19 @@ type Foo =
 \`;
     `,
     noFormat`
-type Foo = \`this code has trailing whitespace with a windows \\\r new line: \${\` \`}\r\n\`;
+type Foo = \`this code has trailing whitespace with a CRLF (windows \\\r) new line: \${\` \`}\r\n\`;
+    `,
+    noFormat`
+type Foo = \`this code has trailing whitespace with a CR new line: \${\` \`}\r\`;
+    `,
+    `
+type Foo = \`this code has trailing whitespace with a LF new line: \${\` \`}\n\`;
+    `,
+    `
+type Foo = \`this code has trailing whitespace with a LS new line: \${\` \`}\u2028\`;
+    `,
+    `
+type Foo = \`this code has trailing whitespace with a PS new line: \${\` \`}\u2029\`;
     `,
     "type Foo = `${'foo' | 'bar' | null}`;",
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: 
    - https://github.com/typescript-eslint/typescript-eslint/issues/12353
    - https://github.com/typescript-eslint/typescript-eslint/pull/12352
    - https://github.com/typescript-eslint/typescript-eslint/pull/12374
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Hi,

This PR follows up on https://github.com/typescript-eslint/typescript-eslint/issues/12353, https://github.com/typescript-eslint/typescript-eslint/pull/12352, and https://github.com/typescript-eslint/typescript-eslint/pull/12374.

I also found that the `no-unnecessary-template-expression` rule didn’t respect ECMAScript line terminators, so I’ve updated it accordingly, as in the PRs mentioned above.

Please let me know if any adjustments are needed.

🎸