### PR TITLE
chore: improve Windows CI file-system performance

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -6,6 +6,19 @@ description: 'Prepares the repo for a job by running the build'
 runs:
   using: 'composite'
   steps:
+    # Warm the Nx project graph so the first `nx` invocation in the job skips
+    # rebuilding the graph from scratch. Nx revalidates against current file
+    # hashes, so a stale restore is safe (worst case: no speedup). Only on
+    # Windows, where cold graph construction spikes; on Linux it is already
+    # fast enough that the restore cost cancels the gain.
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      if: runner.os == 'Windows'
+      with:
+        path: .nx/workspace-data
+        key: ${{ runner.os }}-nx-${{ hashFiles('pnpm-lock.yaml', 'nx.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nx-
+
     - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: build-cache
       with:

--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -6,11 +6,7 @@ description: 'Prepares the repo for a job by running the build'
 runs:
   using: 'composite'
   steps:
-    # Warm the Nx project graph so the first `nx` invocation in the job skips
-    # rebuilding the graph from scratch. Nx revalidates against current file
-    # hashes, so a stale restore is safe (worst case: no speedup). Only on
-    # Windows, where cold graph construction spikes; on Linux it is already
-    # fast enough that the restore cost cancels the gain.
+    # Warm the Nx project graph cache on Windows for faster first cold Nx invocation.
     - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       if: runner.os == 'Windows'
       with:

--- a/.github/actions/prepare-install/action.yml
+++ b/.github/actions/prepare-install/action.yml
@@ -43,6 +43,20 @@ runs:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
 
+    # Cache the fully-linked node_modules so `pnpm install` becomes a fast
+    # no-op verify instead of re-linking the whole workspace. The linking step
+    # is the dominant cost of install on Windows runners (~51s median vs ~15s
+    # on Linux), so we only pay the restore cost where it wins. On Linux the
+    # fresh install is already as fast as restoring the large node_modules tree.
+    - name: Restore node_modules
+      if: runner.os == 'Windows'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          ${{ inputs.working-directory }}/node_modules
+          ${{ inputs.working-directory }}/packages/*/node_modules
+        key: ${{ runner.os }}-node-modules-${{ inputs.node-version }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', inputs.working-directory)) }}
+
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/prepare-install/action.yml
+++ b/.github/actions/prepare-install/action.yml
@@ -43,11 +43,7 @@ runs:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
 
-    # Cache the fully-linked node_modules so `pnpm install` becomes a fast
-    # no-op verify instead of re-linking the whole workspace. The linking step
-    # is the dominant cost of install on Windows runners (~51s median vs ~15s
-    # on Linux), so we only pay the restore cost where it wins. On Linux the
-    # fresh install is already as fast as restoring the large node_modules tree.
+    # Cache the fully-linked node_modules so `pnpm install` is faster on Windows.
     - name: Restore node_modules
       if: runner.os == 'Windows'
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -55,7 +51,7 @@ runs:
         path: |
           ${{ inputs.working-directory }}/node_modules
           ${{ inputs.working-directory }}/packages/*/node_modules
-        key: ${{ runner.os }}-node-modules-${{ inputs.node-version }}-${{ hashFiles(format('{0}/pnpm-lock.yaml', inputs.working-directory)) }}
+        key: ${{ runner.os }}-node-modules-${{ inputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: #11204 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Trying to keep a cached version of node_modules and nx workspace-data in Windows to avoid its slow FS operations in CI
