### PR TITLE
chore: exclude OS-agnostic tests on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,8 +322,8 @@ jobs:
           - utils
           - visitor-keys
 
-        # Packages that have no platform-specific runtime behavior, or we don't
-        # care about OS-specific behavior, so skipping them on Windows to have less jobs to run.
+        # Packages that have no (or we don't care about their) platform-specific,
+        # runtime behavior, so skipping them on Windows to have less jobs to run.
         exclude:
           - os: windows-latest
             package: ast-spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,21 +308,40 @@ jobs:
         # note: do not run these packages on the oldest supported node versions -- we assume that the plugin tests have enough e2e coverage to prove everything works on the lowest node version
         node-version: [24]
         package:
-          [
-            { name: 'ast-spec', params: '' },
-            { name: 'eslint-plugin-internal', params: '' },
-            { name: 'parser', params: '' },
-            { name: 'project-service', params: '' },
-            { name: 'rule-schema-to-typescript-types', params: '' },
-            { name: 'rule-tester', params: '' },
-            { name: 'scope-manager', params: '' },
-            { name: 'tsconfig-utils', params: '' },
-            { name: 'type-utils', params: '' },
-            { name: 'typescript-eslint', params: '' },
-            { name: 'typescript-estree', params: '' },
-            { name: 'utils', params: '' },
-            { name: 'visitor-keys', params: '' },
-          ]
+          - ast-spec
+          - eslint-plugin-internal
+          - parser
+          - project-service
+          - rule-schema-to-typescript-types
+          - rule-tester
+          - scope-manager
+          - tsconfig-utils
+          - type-utils
+          - typescript-eslint
+          - typescript-estree
+          - utils
+          - visitor-keys
+
+        # Packages that have no platform-specific runtime behavior, or we don't
+        # care about OS-specific behavior, so skipping them on Windows to have less jobs to run.
+        exclude:
+          - os: windows-latest
+            package: ast-spec
+
+          - os: windows-latest
+            package: eslint-plugin-internal
+
+          - os: windows-latest
+            package: rule-schema-to-typescript-types
+
+          - os: windows-latest
+            package: scope-manager
+
+          - os: windows-latest
+            package: utils
+
+          - os: windows-latest
+            package: visitor-keys
     env:
       NX_CI_EXECUTION_ENV: '${{ matrix.os }} - Node ${{ matrix.node-version }}'
       COLLECT_COVERAGE: false
@@ -341,14 +360,14 @@ jobs:
 
       # collect coverage on just linux
       # we don't collect coverage on other OSs so that they run faster
-      - name: Run unit tests with coverage for ${{ matrix.package.name }}
+      - name: Run unit tests with coverage for ${{ matrix.package }}
         if: matrix.os == 'ubuntu-latest'
-        run: pnpm exec nx test ${{ matrix.package.name }} -- ${{ matrix.package.params }} --coverage
+        run: pnpm exec nx test ${{ matrix.package }} -- --coverage
         env:
           CI: true
-      - name: Run unit tests for ${{ matrix.package.name }}
+      - name: Run unit tests for ${{ matrix.package }}
         if: matrix.os != 'ubuntu-latest'
-        run: pnpm exec nx test ${{ matrix.package.name }} -- ${{ matrix.package.params }}
+        run: pnpm exec nx test ${{ matrix.package }}
         env:
           CI: true
 
@@ -356,8 +375,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: ${{ matrix.package.name }}-coverage-${{ strategy.job-index }}
-          path: packages/${{ matrix.package.name }}/coverage/lcov.info
+          name: ${{ matrix.package }}-coverage-${{ strategy.job-index }}
+          path: packages/${{ matrix.package }}/coverage/lcov.info
           # Sadly 1 day is the minimum
           retention-days: 1
 

--- a/packages/type-utils/vitest.config.mts
+++ b/packages/type-utils/vitest.config.mts
@@ -16,6 +16,7 @@ const vitestConfig = mergeConfig(
       },
 
       dir: path.join(import.meta.dirname, 'tests'),
+      include: getTestFiles(),
       name: packageJson.name.replace('@typescript-eslint/', ''),
       root: import.meta.dirname,
       setupFiles: ['./tests/test-utils/custom-matchers/custom-matchers.ts'],
@@ -23,5 +24,16 @@ const vitestConfig = mergeConfig(
     },
   }),
 );
+
+function getTestFiles() {
+  const isWindowsCI = process.platform === 'win32' && Boolean(process.env.CI);
+
+  if (isWindowsCI) {
+    // Test(s) that could be affected by OS.
+    return ['./tests/TypeOrValueSpecifier.test.ts'];
+  }
+
+  return undefined;
+}
 
 export default vitestConfig;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: #11204 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Removing Windows CI jobs of packages that aren't (or _shouldn't be_?) affected by OS.

I also included eslint-plugin-internal because I don't think we need to test it on Windows.
It's an internal tool that isn't worth the CI time it's taking, compared to the risk of it not working on Windows

The type-utils package should also be OS-agnostic, mostly. The only place I was afraid of was `typeDeclaredInFile` that has some path joining:

https://github.com/typescript-eslint/typescript-eslint/blob/5cf1b1f61e17943c7b598e779526e18ccac4ccd5/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInFile.ts#L17-L19

So I've included the only test that uses it instead of skipping the whole package, but I would like to exclude it completely if you think it's safe enough

It's slightly hard to measure the savings due to all the caches, but each of these jobs is around ~1m35s, so we should save around ~9m-10m of total billed time (if my math is correct)