### PR TITLE
chore: fix failing integration tests

### DIFF
--- a/packages/integration-tests/tools/pack-packages.ts
+++ b/packages/integration-tests/tools/pack-packages.ts
@@ -111,6 +111,8 @@ export const setup = async (project: TestProject): Promise<void> => {
 
   const PNPM_CATALOG = await getPnpmCatalog();
 
+  const PNPM_WORKSPACE_CONTENT = await getPnpmWorkspaceContent();
+
   const BASE_DEPENDENCIES: PackageJSON['devDependencies'] = {
     ...tseslintPackages,
     eslint: PNPM_CATALOG.eslint,
@@ -142,6 +144,12 @@ export const setup = async (project: TestProject): Promise<void> => {
   await fs.writeFile(path.join(temp, '.npmrc'), NPMRC_CONTENT, {
     encoding: 'utf-8',
   });
+
+  await fs.writeFile(
+    path.join(temp, 'pnpm-workspace.yaml'),
+    PNPM_WORKSPACE_CONTENT,
+    { encoding: 'utf-8' },
+  );
 
   // We install the tarballs here once so that pnpm can cache them globally.
   // This solves 2 problems:
@@ -197,6 +205,12 @@ export const setup = async (project: TestProject): Promise<void> => {
         encoding: 'utf-8',
       });
 
+      await fs.writeFile(
+        path.join(testFolder, 'pnpm-workspace.yaml'),
+        PNPM_WORKSPACE_CONTENT,
+        { encoding: 'utf-8' },
+      );
+
       const { stderr, stdout } = await execFile(
         'pnpm',
         ['install', '--no-frozen-lockfile'],
@@ -248,4 +262,21 @@ async function getPnpmCatalog() {
   }
 
   return parsed.catalog;
+}
+
+// Using the root pnpm-workspace.yaml content but without the catalog, overrides, and packages,
+// so its contains only pnpm's settings without the monorepo-related stuff.
+async function getPnpmWorkspaceContent(): Promise<string> {
+  const pnpmWorkspace = await fs.readFile(
+    path.join(ROOT_DIR, 'pnpm-workspace.yaml'),
+    { encoding: 'utf-8' },
+  );
+
+  const parsed = yaml.parse(pnpmWorkspace) as Record<string, unknown>;
+
+  delete parsed.catalog;
+  delete parsed.overrides;
+  delete parsed.packages;
+
+  return yaml.stringify(parsed);
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ trustPolicy: 'no-downgrade'
 trustPolicyExclude:
   - detect-port@1.6.1
   - semver@6.3.1
+  - tinyexec@1.2.2
 
 catalog:
   '@eslint/js': ^10.0.1


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12391
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Using the same `pnpm-workspace.yaml` from the root, and adding an override for the non-trusted tinyexec@1.2.2 package
