### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] wrap object literal in parens when removing TSTypeAssertion in arrow body

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -1,6 +1,9 @@
 import type { Scope } from '@typescript-eslint/scope-manager';
 import type { TSESTree } from '@typescript-eslint/utils';
-import type { ReportFixFunction } from '@typescript-eslint/utils/ts-eslint';
+import type {
+  ReportFixFunction,
+  RuleFix,
+} from '@typescript-eslint/utils/ts-eslint';
 
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
@@ -14,6 +17,7 @@ import {
   getModifiers,
   getParserServices,
   isNullableType,
+  isParenthesized,
   isTypeFlagSet,
   nullThrows,
   NullThrowsReasons,
@@ -781,20 +785,33 @@ export default createRule<Options, MessageIds>({
             ),
             NullThrowsReasons.MissingToken('>', 'type annotation'),
           );
-          if (
+          // Removing the angle-bracketed type can leave a bare object
+          // literal in a position where `{` is parsed as a block (concise
+          // arrow body, or the start of an expression statement). Wrap the
+          // result in parentheses to preserve the original expression
+          // semantics.
+          const needsParens =
             node.expression.type === AST_NODE_TYPES.ObjectExpression &&
-            node.parent.type === AST_NODE_TYPES.ArrowFunctionExpression &&
-            node.parent.body === node
-          ) {
-            return fixer.replaceText(
-              node,
-              `(${context.sourceCode.getText(node.expression)})`,
-            );
+            ((node.parent.type === AST_NODE_TYPES.ArrowFunctionExpression &&
+              node.parent.body === node) ||
+              node.parent.type === AST_NODE_TYPES.ExpressionStatement) &&
+            !isParenthesized(node, context.sourceCode) &&
+            !isParenthesized(node.expression, context.sourceCode);
+
+          const fixes: RuleFix[] = [];
+          if (needsParens) {
+            fixes.push(fixer.insertTextBefore(node, '('));
           }
-          return fixer.removeRange([
-            openingAngleBracket.range[0],
-            closingAngleBracket.range[1],
-          ]);
+          fixes.push(
+            fixer.removeRange([
+              openingAngleBracket.range[0],
+              closingAngleBracket.range[1],
+            ]),
+          );
+          if (needsParens) {
+            fixes.push(fixer.insertTextAfter(node, ')'));
+          }
+          return fixes;
         }
         const asToken = nullThrows(
           context.sourceCode.getTokenAfter(

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -781,6 +781,16 @@ export default createRule<Options, MessageIds>({
             ),
             NullThrowsReasons.MissingToken('>', 'type annotation'),
           );
+          if (
+            node.expression.type === AST_NODE_TYPES.ObjectExpression &&
+            node.parent.type === AST_NODE_TYPES.ArrowFunctionExpression &&
+            node.parent.body === node
+          ) {
+            return fixer.replaceText(
+              node,
+              `(${context.sourceCode.getText(node.expression)})`,
+            );
+          }
           return fixer.removeRange([
             openingAngleBracket.range[0],
             closingAngleBracket.range[1],

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2633,7 +2633,7 @@ fn1(() => {
           messageId: 'contextuallyUnnecessary',
         },
       ],
-      output: noFormat`[].map(() => ({ a: false, b: false }));`,
+      output: `[].map(() => ({ a: false, b: false }));`,
     },
     {
       code: noFormat`[].map(() => /* 1 */ <{ a: false; b: false }> /* 2 */ { a: false, b: false } /* 3 */);`,
@@ -2642,7 +2642,7 @@ fn1(() => {
           messageId: 'contextuallyUnnecessary',
         },
       ],
-      output: noFormat`[].map(() => /* 1 */ ( /* 2 */ { a: false, b: false }) /* 3 */);`,
+      output: `[].map(() => /* 1 */ ( /* 2 */ { a: false, b: false }) /* 3 */);`,
     },
     {
       code: noFormat`[].map(() => <{ a: false; b: false }>({ a: false, b: false }));`,
@@ -2651,7 +2651,7 @@ fn1(() => {
           messageId: 'contextuallyUnnecessary',
         },
       ],
-      output: noFormat`[].map(() => ({ a: false, b: false }));`,
+      output: `[].map(() => ({ a: false, b: false }));`,
     },
     {
       code: noFormat`[].map(() => (<{ a: false; b: false }>{ a: false, b: false }));`,
@@ -2660,7 +2660,7 @@ fn1(() => {
           messageId: 'contextuallyUnnecessary',
         },
       ],
-      output: noFormat`[].map(() => ({ a: false, b: false }));`,
+      output: `[].map(() => ({ a: false, b: false }));`,
     },
     {
       code: "<{ a: string }>{ a: 'foo' };",
@@ -2669,7 +2669,7 @@ fn1(() => {
           messageId: 'unnecessaryAssertion',
         },
       ],
-      output: noFormat`({ a: 'foo' });`,
+      output: `({ a: 'foo' });`,
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2635,5 +2635,41 @@ fn1(() => {
       ],
       output: noFormat`[].map(() => ({ a: false, b: false }));`,
     },
+    {
+      code: noFormat`[].map(() => /* 1 */ <{ a: false; b: false }> /* 2 */ { a: false, b: false } /* 3 */);`,
+      errors: [
+        {
+          messageId: 'contextuallyUnnecessary',
+        },
+      ],
+      output: noFormat`[].map(() => /* 1 */ ( /* 2 */ { a: false, b: false }) /* 3 */);`,
+    },
+    {
+      code: noFormat`[].map(() => <{ a: false; b: false }>({ a: false, b: false }));`,
+      errors: [
+        {
+          messageId: 'contextuallyUnnecessary',
+        },
+      ],
+      output: noFormat`[].map(() => ({ a: false, b: false }));`,
+    },
+    {
+      code: noFormat`[].map(() => (<{ a: false; b: false }>{ a: false, b: false }));`,
+      errors: [
+        {
+          messageId: 'contextuallyUnnecessary',
+        },
+      ],
+      output: noFormat`[].map(() => ({ a: false, b: false }));`,
+    },
+    {
+      code: "<{ a: string }>{ a: 'foo' };",
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: noFormat`({ a: 'foo' });`,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2626,5 +2626,14 @@ fn1(() => {
 });
       `,
     },
+    {
+      code: '[].map(() => <{ a: false; b: false }>{ a: false, b: false });',
+      errors: [
+        {
+          messageId: 'contextuallyUnnecessary',
+        },
+      ],
+      output: noFormat`[].map(() => ({ a: false, b: false }));`,
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12393
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The single-assertion autofixer for `no-unnecessary-type-assertion` removed an angle-bracket assertion (`<T>expr`) by deleting just the `<...>` tokens. That works fine in most positions, but when the asserted value is an object literal that is the concise body of an arrow function, dropping the brackets turns `() => <T>{ ... }` into `() => { ... }`, which the parser reads as a block statement rather than an object literal — so the autofix output is a syntax error (the case from #12393).

The fix detects exactly that shape (object literal expression whose parent is an arrow function and is its body) and replaces the whole assertion with the object literal wrapped in parentheses, producing `() => ({ ... })`. This reuses the same condition the rule already applies to the double-assertion path a few lines below, so the two fixers now behave consistently.

I only added an `invalid` test case here: the assertion is still (correctly) flagged as unnecessary, so there is no new `valid` behavior to cover — the change is purely to the fix output. I confirmed the new test fails on `main` (the rule tester reports a fatal parsing error in the autofix) and passes with the change.

Disclosure: I used an AI assistant to help locate the relevant code and draft the fix. I reviewed and understand the change, and verified it locally (full rule test suite + lint).

💖
