### PR TITLE
fix(eslint-plugin): [consistent-indexed-object-style] do not remove comments when fixing

### DIFF
--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -15,7 +15,8 @@ import {
 export type MessageIds =
   | 'preferIndexSignature'
   | 'preferIndexSignatureSuggestion'
-  | 'preferRecord';
+  | 'preferRecord'
+  | 'preferRecordSuggestion';
 export type Options = ['index-signature' | 'record'];
 
 export default createRule<Options, MessageIds>({
@@ -34,6 +35,8 @@ export default createRule<Options, MessageIds>({
       preferIndexSignatureSuggestion:
         'Change into an index signature instead of a record.',
       preferRecord: 'A record is preferred over an index signature.',
+      preferRecordSuggestion:
+        'Change into a record instead of an index signature.',
     },
     schema: [
       {
@@ -45,12 +48,23 @@ export default createRule<Options, MessageIds>({
   },
   defaultOptions: ['record'],
   create(context, [mode]) {
-    // The fixers rebuild the type from the text of a few sub-nodes, which would
-    // silently drop any comments that sit between those sub-nodes. To avoid
-    // deleting code, we withhold the fix when the node to be replaced contains
-    // comments.
-    function hasComments(node: TSESTree.Node): boolean {
-      return context.sourceCode.getCommentsInside(node).length > 0;
+    // The fixers rebuild the type from the text of a few sub-nodes, so a
+    // comment inside `node` but outside all of those preserved sub-nodes would
+    // be dropped by the fix. Returns true when at least one such comment exists.
+    function hasUnpreservedComments(
+      node: TSESTree.Node,
+      ...preserved: (TSESTree.Node | undefined)[]
+    ): boolean {
+      return context.sourceCode
+        .getCommentsInside(node)
+        .some(comment =>
+          preserved.every(
+            target =>
+              target == null ||
+              comment.range[0] < target.range[0] ||
+              comment.range[1] > target.range[1],
+          ),
+        );
     }
 
     function checkMembers(
@@ -100,19 +114,30 @@ export default createRule<Options, MessageIds>({
       context.report({
         node,
         messageId: 'preferRecord',
-        fix:
-          safeFix && !hasComments(node)
-            ? (fixer): TSESLint.RuleFix => {
-                const key = context.sourceCode.getText(keyType.typeAnnotation);
-                const value = context.sourceCode.getText(
+        ...getFixOrSuggest({
+          fixOrSuggest: !safeFix
+            ? 'none'
+            : hasUnpreservedComments(
+                  node,
+                  keyType.typeAnnotation,
                   valueType.typeAnnotation,
-                );
-                const record = member.readonly
-                  ? `Readonly<Record<${key}, ${value}>>`
-                  : `Record<${key}, ${value}>`;
-                return fixer.replaceText(node, `${prefix}${record}${postfix}`);
-              }
-            : null,
+                )
+              ? 'suggest'
+              : 'fix',
+          suggestion: {
+            messageId: 'preferRecordSuggestion',
+            fix: (fixer): TSESLint.RuleFix => {
+              const key = context.sourceCode.getText(keyType.typeAnnotation);
+              const value = context.sourceCode.getText(
+                valueType.typeAnnotation,
+              );
+              const record = member.readonly
+                ? `Readonly<Record<${key}, ${value}>>`
+                : `Record<${key}, ${value}>`;
+              return fixer.replaceText(node, `${prefix}${record}${postfix}`);
+            },
+          },
+        }),
       });
     }
 
@@ -143,9 +168,8 @@ export default createRule<Options, MessageIds>({
             node,
             messageId: 'preferIndexSignature',
             ...getFixOrSuggest({
-              fixOrSuggest: hasComments(node)
-                ? 'none'
-                : shouldFix
+              fixOrSuggest:
+                shouldFix && !hasUnpreservedComments(node, params[0], params[1])
                   ? 'fix'
                   : 'suggest',
               suggestion: {
@@ -230,32 +254,44 @@ export default createRule<Options, MessageIds>({
             }
           }
 
-          // There's no builtin Mutable<T> type, so we can't autofix it really.
-          const canFix = node.readonly !== '-' && !hasComments(node);
-
           context.report({
             node,
             messageId: 'preferRecord',
-            ...(canFix && {
-              fix: (fixer): ReturnType<ReportFixFunction> => {
-                const keyType = context.sourceCode.getText(constraint);
-                const valueType = node.typeAnnotation
-                  ? context.sourceCode.getText(node.typeAnnotation)
-                  : 'any';
+            ...getFixOrSuggest({
+              // There's no builtin Mutable<T> type, so a `-readonly` mapped
+              // type can't be represented as a Record and is left untouched.
+              fixOrSuggest:
+                node.readonly === '-'
+                  ? 'none'
+                  : hasUnpreservedComments(
+                        node,
+                        constraint,
+                        node.typeAnnotation,
+                      )
+                    ? 'suggest'
+                    : 'fix',
+              suggestion: {
+                messageId: 'preferRecordSuggestion',
+                fix: (fixer): ReturnType<ReportFixFunction> => {
+                  const keyType = context.sourceCode.getText(constraint);
+                  const valueType = node.typeAnnotation
+                    ? context.sourceCode.getText(node.typeAnnotation)
+                    : 'any';
 
-                let recordText = `Record<${keyType}, ${valueType}>`;
+                  let recordText = `Record<${keyType}, ${valueType}>`;
 
-                if (node.optional === '+' || node.optional === true) {
-                  recordText = `Partial<${recordText}>`;
-                } else if (node.optional === '-') {
-                  recordText = `Required<${recordText}>`;
-                }
+                  if (node.optional === '+' || node.optional === true) {
+                    recordText = `Partial<${recordText}>`;
+                  } else if (node.optional === '-') {
+                    recordText = `Required<${recordText}>`;
+                  }
 
-                if (node.readonly === '+' || node.readonly === true) {
-                  recordText = `Readonly<${recordText}>`;
-                }
+                  if (node.readonly === '+' || node.readonly === true) {
+                    recordText = `Readonly<${recordText}>`;
+                  }
 
-                return fixer.replaceText(node, recordText);
+                  return fixer.replaceText(node, recordText);
+                },
               },
             }),
           });

--- a/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
+++ b/packages/eslint-plugin/src/rules/consistent-indexed-object-style.ts
@@ -45,6 +45,14 @@ export default createRule<Options, MessageIds>({
   },
   defaultOptions: ['record'],
   create(context, [mode]) {
+    // The fixers rebuild the type from the text of a few sub-nodes, which would
+    // silently drop any comments that sit between those sub-nodes. To avoid
+    // deleting code, we withhold the fix when the node to be replaced contains
+    // comments.
+    function hasComments(node: TSESTree.Node): boolean {
+      return context.sourceCode.getCommentsInside(node).length > 0;
+    }
+
     function checkMembers(
       members: TSESTree.TypeElement[],
       node: TSESTree.TSInterfaceDeclaration | TSESTree.TSTypeLiteral,
@@ -92,18 +100,19 @@ export default createRule<Options, MessageIds>({
       context.report({
         node,
         messageId: 'preferRecord',
-        fix: safeFix
-          ? (fixer): TSESLint.RuleFix => {
-              const key = context.sourceCode.getText(keyType.typeAnnotation);
-              const value = context.sourceCode.getText(
-                valueType.typeAnnotation,
-              );
-              const record = member.readonly
-                ? `Readonly<Record<${key}, ${value}>>`
-                : `Record<${key}, ${value}>`;
-              return fixer.replaceText(node, `${prefix}${record}${postfix}`);
-            }
-          : null,
+        fix:
+          safeFix && !hasComments(node)
+            ? (fixer): TSESLint.RuleFix => {
+                const key = context.sourceCode.getText(keyType.typeAnnotation);
+                const value = context.sourceCode.getText(
+                  valueType.typeAnnotation,
+                );
+                const record = member.readonly
+                  ? `Readonly<Record<${key}, ${value}>>`
+                  : `Record<${key}, ${value}>`;
+                return fixer.replaceText(node, `${prefix}${record}${postfix}`);
+              }
+            : null,
       });
     }
 
@@ -134,7 +143,11 @@ export default createRule<Options, MessageIds>({
             node,
             messageId: 'preferIndexSignature',
             ...getFixOrSuggest({
-              fixOrSuggest: shouldFix ? 'fix' : 'suggest',
+              fixOrSuggest: hasComments(node)
+                ? 'none'
+                : shouldFix
+                  ? 'fix'
+                  : 'suggest',
               suggestion: {
                 messageId: 'preferIndexSignatureSuggestion',
                 fix: fixer => {
@@ -218,7 +231,7 @@ export default createRule<Options, MessageIds>({
           }
 
           // There's no builtin Mutable<T> type, so we can't autofix it really.
-          const canFix = node.readonly !== '-';
+          const canFix = node.readonly !== '-' && !hasComments(node);
 
           context.report({
             node,

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -1059,7 +1059,7 @@ type Test = {
           suggestions: [
             {
               messageId: 'preferRecordSuggestion',
-              output: noFormat`
+              output: `
 type Test = Record<| 'a' // 3
     | 'b' // 4
     | 'c' // 5

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -969,5 +969,62 @@ type Foo = {
 type Foo = Record<string, any>;
       `,
     },
+
+    // Comments inside the type would be dropped by the fixer, so it is withheld.
+    {
+      code: 'type Foo = { [key: string]: /* preserve me */ number };',
+      errors: [{ column: 12, line: 1, messageId: 'preferRecord' }],
+      output: null,
+    },
+    {
+      code: `
+interface Foo {
+  // preserve me
+  [key: string]: number;
+}
+      `,
+      errors: [{ column: 1, line: 2, messageId: 'preferRecord' }],
+      output: null,
+    },
+    {
+      code: `
+type Foo = {
+  // preserve me
+  [Key in 'a' | 'b']: number;
+};
+      `,
+      errors: [{ column: 12, line: 2, messageId: 'preferRecord' }],
+      output: null,
+    },
+    {
+      // reproduction of https://github.com/typescript-eslint/typescript-eslint/issues/10577
+      code: noFormat`
+type Test = {
+  // 1
+  [Key in // 2
+    | 'a' // 3
+    | 'b' // 4
+    | 'c' // 5
+    | 'd' // 6
+  ]: string; // 7
+  // 8
+};
+      `,
+      errors: [{ column: 13, line: 2, messageId: 'preferRecord' }],
+      output: null,
+    },
+    {
+      // index-signature mode: comment would be dropped, so no fix or suggestion
+      code: 'type Foo = Record<string, /* preserve me */ number>;',
+      errors: [
+        {
+          column: 12,
+          line: 1,
+          messageId: 'preferIndexSignature',
+          suggestions: [],
+        },
+      ],
+      options: ['index-signature'],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-indexed-object-style.test.ts
@@ -970,10 +970,23 @@ type Foo = Record<string, any>;
       `,
     },
 
-    // Comments inside the type would be dropped by the fixer, so it is withheld.
+    // A comment outside the sub-nodes the fixer keeps would be dropped, so the
+    // reshape is offered as an opt-in suggestion rather than an autofix.
     {
       code: 'type Foo = { [key: string]: /* preserve me */ number };',
-      errors: [{ column: 12, line: 1, messageId: 'preferRecord' }],
+      errors: [
+        {
+          column: 12,
+          line: 1,
+          messageId: 'preferRecord',
+          suggestions: [
+            {
+              messageId: 'preferRecordSuggestion',
+              output: 'type Foo = Record<string, number>;',
+            },
+          ],
+        },
+      ],
       output: null,
     },
     {
@@ -983,7 +996,21 @@ interface Foo {
   [key: string]: number;
 }
       `,
-      errors: [{ column: 1, line: 2, messageId: 'preferRecord' }],
+      errors: [
+        {
+          column: 1,
+          line: 2,
+          messageId: 'preferRecord',
+          suggestions: [
+            {
+              messageId: 'preferRecordSuggestion',
+              output: `
+type Foo = Record<string, number>;
+      `,
+            },
+          ],
+        },
+      ],
       output: null,
     },
     {
@@ -993,7 +1020,21 @@ type Foo = {
   [Key in 'a' | 'b']: number;
 };
       `,
-      errors: [{ column: 12, line: 2, messageId: 'preferRecord' }],
+      errors: [
+        {
+          column: 12,
+          line: 2,
+          messageId: 'preferRecord',
+          suggestions: [
+            {
+              messageId: 'preferRecordSuggestion',
+              output: `
+type Foo = Record<'a' | 'b', number>;
+      `,
+            },
+          ],
+        },
+      ],
       output: null,
     },
     {
@@ -1010,18 +1051,40 @@ type Test = {
   // 8
 };
       `,
-      errors: [{ column: 13, line: 2, messageId: 'preferRecord' }],
+      errors: [
+        {
+          column: 13,
+          line: 2,
+          messageId: 'preferRecord',
+          suggestions: [
+            {
+              messageId: 'preferRecordSuggestion',
+              output: noFormat`
+type Test = Record<| 'a' // 3
+    | 'b' // 4
+    | 'c' // 5
+    | 'd', string>;
+      `,
+            },
+          ],
+        },
+      ],
       output: null,
     },
     {
-      // index-signature mode: comment would be dropped, so no fix or suggestion
+      // index-signature mode: a dropped comment makes the reshape a suggestion.
       code: 'type Foo = Record<string, /* preserve me */ number>;',
       errors: [
         {
           column: 12,
           line: 1,
           messageId: 'preferIndexSignature',
-          suggestions: [],
+          suggestions: [
+            {
+              messageId: 'preferIndexSignatureSuggestion',
+              output: 'type Foo = { [key: string]: number };',
+            },
+          ],
         },
       ],
       options: ['index-signature'],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10577
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The `consistent-indexed-object-style` fixers build their replacement text by reading the text of a few specific sub-nodes (the key/value type annotations, or a mapped type's constraint and value) and stitching them into a `Record<...>` / index-signature string. Comments that sit anywhere else within the node being replaced are never copied over, so running the fix silently deletes them. In the mapped-type case from #10577 it can even produce syntactically broken output, because a trailing line comment ends up inside the generated `Record<...>` arguments.

This adds a small `hasComments` guard (using `getCommentsInside`) and uses it at each of the three fix sites. When the reported node contains any comments, the rule still reports the violation but withholds the fix and the index-signature suggestion, rather than emitting output that loses code. This follows the rule's existing pattern of skipping the fix whenever it can't safely produce equivalent output (e.g. the existing `Mutable<T>` and unsafe-fix cases).

Tests cover record mode (interface, type literal, and mapped type), index-signature mode, and the exact reproduction from the issue; each asserts that no fix or suggestion is applied.
