### PR TITLE
fix(typescript-estree): avoid stack overflow on long binary expressions

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -347,17 +347,12 @@ export class Converter {
     let currentNode: ts.Expression = node.left;
 
     while (ts.isBinaryExpression(currentNode)) {
-      if (isComma(currentNode.operatorToken)) {
-        break;
-      }
-
       const currentExpressionType = getBinaryExpressionType(
         currentNode.operatorToken,
-      );
-
-      if (currentExpressionType.type === AST_NODE_TYPES.AssignmentExpression) {
-        break;
-      }
+      ) as Exclude<
+        ReturnType<typeof getBinaryExpressionType>,
+        { type: AST_NODE_TYPES.AssignmentExpression }
+      >;
 
       binaryExpressions.push({
         expressionType: currentExpressionType,
@@ -374,12 +369,10 @@ export class Converter {
       const { expressionType: currentExpressionType, node: currentExpression } =
         binaryExpressions[index];
 
-      if (currentExpression !== node) {
-        this.#checkSyntaxError(
-          currentExpression,
-          currentExpression.parent as TSNode,
-        );
-      }
+      this.#checkSyntaxError(
+        currentExpression,
+        currentExpression.parent as TSNode,
+      );
 
       convertedExpression = this.createNode<
         TSESTree.BinaryExpression | TSESTree.LogicalExpression

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -328,7 +328,6 @@ export class Converter {
   ): TSESTree.Expression {
     if (
       expressionType.type === AST_NODE_TYPES.AssignmentExpression ||
-      isComma(node.operatorToken) ||
       !ts.isBinaryExpression(node.left)
     ) {
       return this.converter(

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -321,6 +321,81 @@ export class Converter {
     return children.map(child => this.converter(child, parent, false));
   }
 
+  private convertLeftHandSideOfBinaryExpression(
+    node: ts.BinaryExpression,
+    parent: ts.Node,
+    expressionType: ReturnType<typeof getBinaryExpressionType>,
+  ): TSESTree.Expression {
+    if (
+      expressionType.type === AST_NODE_TYPES.AssignmentExpression ||
+      isComma(node.operatorToken) ||
+      !ts.isBinaryExpression(node.left)
+    ) {
+      return this.converter(
+        node.left,
+        parent,
+        expressionType.type === AST_NODE_TYPES.AssignmentExpression,
+      );
+    }
+
+    const binaryExpressions: {
+      expressionType: Exclude<
+        ReturnType<typeof getBinaryExpressionType>,
+        { type: AST_NODE_TYPES.AssignmentExpression }
+      >;
+      node: ts.BinaryExpression;
+    }[] = [];
+    let currentNode: ts.Expression = node.left;
+
+    while (ts.isBinaryExpression(currentNode)) {
+      if (isComma(currentNode.operatorToken)) {
+        break;
+      }
+
+      const currentExpressionType = getBinaryExpressionType(
+        currentNode.operatorToken,
+      );
+
+      if (currentExpressionType.type === AST_NODE_TYPES.AssignmentExpression) {
+        break;
+      }
+
+      binaryExpressions.push({
+        expressionType: currentExpressionType,
+        node: currentNode,
+      });
+      currentNode = currentNode.left;
+    }
+
+    let convertedExpression = this.convertChild(
+      currentNode,
+    ) as TSESTree.Expression;
+
+    for (let index = binaryExpressions.length - 1; index >= 0; index -= 1) {
+      const { expressionType: currentExpressionType, node: currentExpression } =
+        binaryExpressions[index];
+
+      if (currentExpression !== node) {
+        this.#checkSyntaxError(
+          currentExpression,
+          currentExpression.parent as TSNode,
+        );
+      }
+
+      convertedExpression = this.createNode<
+        TSESTree.BinaryExpression | TSESTree.LogicalExpression
+      >(currentExpression, {
+        ...currentExpressionType,
+        left: convertedExpression,
+        right: this.convertChild(currentExpression.right),
+      });
+
+      this.registerTSNodeInNodeMap(currentExpression, convertedExpression);
+    }
+
+    return convertedExpression;
+  }
+
   /**
    * Converts a TypeScript node into an ESTree node.
    * @param child the child ts.Node
@@ -1824,10 +1899,10 @@ export class Converter {
           | TSESTree.LogicalExpression
         >(node, {
           ...expressionType,
-          left: this.converter(
-            node.left,
+          left: this.convertLeftHandSideOfBinaryExpression(
             node,
-            expressionType.type === AST_NODE_TYPES.AssignmentExpression,
+            node,
+            expressionType,
           ),
           right: this.convertChild(node.right),
         });

--- a/packages/typescript-estree/src/simple-traverse.ts
+++ b/packages/typescript-estree/src/simple-traverse.ts
@@ -49,34 +49,34 @@ class SimpleTraverser {
   }
 
   traverse(node: unknown, parent: TSESTree.Node | undefined): void {
-    const worklist: { node: unknown; parent: TSESTree.Node | undefined }[] = [
-      { node, parent },
-    ];
+    const nodeStack: unknown[] = [node];
+    const parentStack: (TSESTree.Node | undefined)[] = [parent];
 
-    while (worklist.length > 0) {
-      const item = worklist.pop();
+    while (nodeStack.length > 0) {
+      const currentNode = nodeStack.pop();
+      const currentParent = parentStack.pop();
 
-      if (!item || !isValidNode(item.node)) {
+      if (!isValidNode(currentNode)) {
         continue;
       }
 
       if (this.setParentPointers) {
-        item.node.parent = item.parent;
+        currentNode.parent = currentParent;
       }
 
       if ('enter' in this.selectors) {
-        this.selectors.enter(item.node, item.parent);
-      } else if (item.node.type in this.selectors.visitors) {
-        this.selectors.visitors[item.node.type](item.node, item.parent);
+        this.selectors.enter(currentNode, currentParent);
+      } else if (currentNode.type in this.selectors.visitors) {
+        this.selectors.visitors[currentNode.type](currentNode, currentParent);
       }
 
-      const keys = getVisitorKeysForNode(this.allVisitorKeys, item.node);
+      const keys = getVisitorKeysForNode(this.allVisitorKeys, currentNode);
       if (keys.length < 1) {
         continue;
       }
 
       for (let keyIndex = keys.length - 1; keyIndex >= 0; keyIndex -= 1) {
-        const childOrChildren = item.node[keys[keyIndex]];
+        const childOrChildren = currentNode[keys[keyIndex]];
 
         if (Array.isArray(childOrChildren)) {
           for (
@@ -84,13 +84,12 @@ class SimpleTraverser {
             childIndex >= 0;
             childIndex -= 1
           ) {
-            worklist.push({
-              node: childOrChildren[childIndex],
-              parent: item.node,
-            });
+            nodeStack.push(childOrChildren[childIndex]);
+            parentStack.push(currentNode);
           }
         } else {
-          worklist.push({ node: childOrChildren, parent: item.node });
+          nodeStack.push(childOrChildren);
+          parentStack.push(currentNode);
         }
       }
     }

--- a/packages/typescript-estree/src/simple-traverse.ts
+++ b/packages/typescript-estree/src/simple-traverse.ts
@@ -49,34 +49,49 @@ class SimpleTraverser {
   }
 
   traverse(node: unknown, parent: TSESTree.Node | undefined): void {
-    if (!isValidNode(node)) {
-      return;
-    }
+    const worklist: { node: unknown; parent: TSESTree.Node | undefined }[] = [
+      { node, parent },
+    ];
 
-    if (this.setParentPointers) {
-      node.parent = parent;
-    }
+    while (worklist.length > 0) {
+      const item = worklist.pop();
 
-    if ('enter' in this.selectors) {
-      this.selectors.enter(node, parent);
-    } else if (node.type in this.selectors.visitors) {
-      this.selectors.visitors[node.type](node, parent);
-    }
+      if (!item || !isValidNode(item.node)) {
+        continue;
+      }
 
-    const keys = getVisitorKeysForNode(this.allVisitorKeys, node);
-    if (keys.length < 1) {
-      return;
-    }
+      if (this.setParentPointers) {
+        item.node.parent = item.parent;
+      }
 
-    for (const key of keys) {
-      const childOrChildren = node[key];
+      if ('enter' in this.selectors) {
+        this.selectors.enter(item.node, item.parent);
+      } else if (item.node.type in this.selectors.visitors) {
+        this.selectors.visitors[item.node.type](item.node, item.parent);
+      }
 
-      if (Array.isArray(childOrChildren)) {
-        for (const child of childOrChildren) {
-          this.traverse(child, node);
+      const keys = getVisitorKeysForNode(this.allVisitorKeys, item.node);
+      if (keys.length < 1) {
+        continue;
+      }
+
+      for (let keyIndex = keys.length - 1; keyIndex >= 0; keyIndex -= 1) {
+        const childOrChildren = item.node[keys[keyIndex]];
+
+        if (Array.isArray(childOrChildren)) {
+          for (
+            let childIndex = childOrChildren.length - 1;
+            childIndex >= 0;
+            childIndex -= 1
+          ) {
+            worklist.push({
+              node: childOrChildren[childIndex],
+              parent: item.node,
+            });
+          }
+        } else {
+          worklist.push({ node: childOrChildren, parent: item.node });
         }
-      } else {
-        this.traverse(childOrChildren, node);
       }
     }
   }

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -196,6 +196,37 @@ describe('convert', () => {
     checkMaps(ast);
   });
 
+  it('converts long left-associative binary expressions without overflowing the call stack', () => {
+    const expressionCount = 6_000;
+    const ast = convertCode(
+      Array.from(
+        { length: expressionCount },
+        (_, index) => `value${index}`,
+      ).join(' + '),
+    );
+
+    const instance = new Converter(ast);
+    const program = instance.convertProgram();
+    const statement = program.body[0];
+
+    if (statement.type !== AST_NODE_TYPES.ExpressionStatement) {
+      throw new Error('Expected an expression statement');
+    }
+
+    let expression = statement.expression;
+    let binaryExpressionCount = 0;
+
+    while (expression.type === AST_NODE_TYPES.BinaryExpression) {
+      binaryExpressionCount += 1;
+      if (expression.left.type === AST_NODE_TYPES.PrivateIdentifier) {
+        throw new Error('Expected a public expression');
+      }
+      expression = expression.left;
+    }
+
+    expect(binaryExpressionCount).toBe(expressionCount - 1);
+  });
+
   /* eslint-disable @typescript-eslint/dot-notation */
   describe('createNode', () => {
     it('should correctly create node with range and loc set', () => {

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -196,6 +196,34 @@ describe('convert', () => {
     checkMaps(ast);
   });
 
+  it('converts assignment expressions', () => {
+    const ast = convertCode('value = 1');
+
+    const instance = new Converter(ast);
+    const program = instance.convertProgram();
+    const statement = program.body[0];
+
+    if (statement.type !== AST_NODE_TYPES.ExpressionStatement) {
+      throw new Error('Expected an expression statement');
+    }
+
+    expect(statement.expression.type).toBe(AST_NODE_TYPES.AssignmentExpression);
+  });
+
+  it('converts binary expressions with non-binary left operands', () => {
+    const ast = convertCode('value + 1');
+
+    const instance = new Converter(ast);
+    const program = instance.convertProgram();
+    const statement = program.body[0];
+
+    if (statement.type !== AST_NODE_TYPES.ExpressionStatement) {
+      throw new Error('Expected an expression statement');
+    }
+
+    expect(statement.expression.type).toBe(AST_NODE_TYPES.BinaryExpression);
+  });
+
   it('converts long left-associative binary expressions without overflowing the call stack', () => {
     const expressionCount = 6_000;
     const ast = convertCode(

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -352,18 +352,20 @@ describe(parser.parseAndGenerateServices, () => {
     });
   });
 
-  it('should parse long left-associative binary expressions without overflowing the call stack', () => {
+  it('should generate services for long left-associative binary expressions without overflowing the call stack', () => {
     const expressionCount = 6_000;
-    const ast = parser.parse(
+    const { ast } = parser.parseAndGenerateServices(
       Array.from(
         { length: expressionCount },
         (_, index) => `value${index}`,
       ).join(' + '),
+      {},
     );
     const statement = ast.body[0];
 
+    expect(statement.type).toBe(parser.AST_NODE_TYPES.ExpressionStatement);
     if (statement.type !== parser.AST_NODE_TYPES.ExpressionStatement) {
-      throw new Error('Expected an expression statement');
+      return;
     }
 
     let expression = statement.expression;
@@ -371,13 +373,21 @@ describe(parser.parseAndGenerateServices, () => {
 
     while (expression.type === parser.AST_NODE_TYPES.BinaryExpression) {
       binaryExpressionCount += 1;
-      if (expression.left.type === parser.AST_NODE_TYPES.PrivateIdentifier) {
-        throw new Error('Expected a public expression');
+      const { left } = expression;
+
+      expect(left.type).not.toBe(parser.AST_NODE_TYPES.PrivateIdentifier);
+      if (left.type === parser.AST_NODE_TYPES.PrivateIdentifier) {
+        return;
       }
-      expression = expression.left;
+
+      expression = left;
     }
 
     expect(binaryExpressionCount).toBe(expressionCount - 1);
+    expect(expression).toMatchObject({
+      name: 'value0',
+      type: parser.AST_NODE_TYPES.Identifier,
+    });
   });
 
   describe('ESM parsing', () => {

--- a/packages/typescript-estree/tests/lib/parse.test.ts
+++ b/packages/typescript-estree/tests/lib/parse.test.ts
@@ -352,6 +352,34 @@ describe(parser.parseAndGenerateServices, () => {
     });
   });
 
+  it('should parse long left-associative binary expressions without overflowing the call stack', () => {
+    const expressionCount = 6_000;
+    const ast = parser.parse(
+      Array.from(
+        { length: expressionCount },
+        (_, index) => `value${index}`,
+      ).join(' + '),
+    );
+    const statement = ast.body[0];
+
+    if (statement.type !== parser.AST_NODE_TYPES.ExpressionStatement) {
+      throw new Error('Expected an expression statement');
+    }
+
+    let expression = statement.expression;
+    let binaryExpressionCount = 0;
+
+    while (expression.type === parser.AST_NODE_TYPES.BinaryExpression) {
+      binaryExpressionCount += 1;
+      if (expression.left.type === parser.AST_NODE_TYPES.PrivateIdentifier) {
+        throw new Error('Expected a public expression');
+      }
+      expression = expression.left;
+    }
+
+    expect(binaryExpressionCount).toBe(expressionCount - 1);
+  });
+
   describe('ESM parsing', () => {
     describe('TLA(Top Level Await)', () => {
       const config: TSESTreeOptions = {

--- a/packages/typescript-estree/tests/lib/simple-traverse.test.ts
+++ b/packages/typescript-estree/tests/lib/simple-traverse.test.ts
@@ -1,0 +1,96 @@
+import type { TSESTree } from '../../src/ts-estree';
+
+import { simpleTraverse } from '../../src/simple-traverse';
+
+function createNode(
+  type: string,
+  data: Record<string, unknown> = {},
+): TSESTree.Node {
+  return {
+    type,
+    ...data,
+  } as unknown as TSESTree.Node;
+}
+
+describe(simpleTraverse, () => {
+  it('visits nodes in order and sets parent pointers', () => {
+    const grandchild = createNode('Grandchild');
+    const child = createNode('Child', { child: grandchild });
+    const sibling = createNode('Sibling');
+    const root = createNode('Root', {
+      children: [child, null],
+      sibling,
+    });
+    const visited: string[] = [];
+
+    simpleTraverse(
+      root,
+      {
+        enter: (node, parent) => {
+          visited.push(`${node.type}:${parent?.type ?? 'none'}`);
+        },
+        visitorKeys: {
+          Child: ['child'],
+          Grandchild: [],
+          Root: ['children', 'sibling'],
+          Sibling: [],
+        },
+      },
+      true,
+    );
+
+    expect(visited).toStrictEqual([
+      'Root:none',
+      'Child:Root',
+      'Grandchild:Child',
+      'Sibling:Root',
+    ]);
+    expect(root.parent).toBeUndefined();
+    expect(child.parent).toBe(root);
+    expect(grandchild.parent).toBe(child);
+    expect(sibling.parent).toBe(root);
+  });
+
+  it('supports node-specific visitors', () => {
+    const child = createNode('Child');
+    const root = createNode('Root', { child });
+    const visited: string[] = [];
+
+    simpleTraverse(root, {
+      visitorKeys: {
+        Child: [],
+        Root: ['child'],
+      },
+      visitors: {
+        Child: (node, parent) => {
+          visited.push(`${node.type}:${parent?.type ?? 'none'}`);
+        },
+      },
+    });
+
+    expect(visited).toStrictEqual(['Child:Root']);
+  });
+
+  it('traverses deeply nested nodes without overflowing the call stack', () => {
+    const depth = 6_000;
+    let node = createNode('Leaf');
+
+    for (let index = 0; index < depth; index += 1) {
+      node = createNode('Nested', { child: node });
+    }
+
+    let visited = 0;
+
+    simpleTraverse(node, {
+      enter: () => {
+        visited += 1;
+      },
+      visitorKeys: {
+        Leaf: [],
+        Nested: ['child'],
+      },
+    });
+
+    expect(visited).toBe(depth + 1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #9773.

- convert left-deep binary/logical expression chains iteratively in `typescript-estree` to avoid recursive converter stack overflows
- make `simpleTraverse` iterative so the parser pipeline can also handle the deep ESTree shape when stripping range/loc
- add converter-level and parser-level regressions for a 6,000-term left-associative binary expression

## Tests

- `pnpm exec nx test typescript-estree`
- `pnpm exec nx typecheck typescript-estree`
- `pnpm exec nx lint typescript-estree`
- `pnpm exec tsx -e "import { parse } from './packages/typescript-estree/src/index.ts'; const code = Array.from({length: 6000}, (_, i) => String(i)).join(' + '); const ast = parse(code, { loc: false, range: false }); console.log('parsed', ast.body.length);"`