### PR TITLE
fix(website): fix playground extends configs

### DIFF
--- a/packages/website-eslint/src/index.js
+++ b/packages/website-eslint/src/index.js
@@ -41,6 +41,7 @@ for (const [name, value] of Object.entries(js.configs)) {
 
 for (const [name, value] of Object.entries(rawPlugin.flatConfigs)) {
   configs[`@typescript-eslint/${name}`] = value;
+  configs[`plugin:@typescript-eslint/${name.replace(/^flat\//, '')}`] = value;
 }
 
 exports.configs = configs;

--- a/packages/website/src/components/linter/createLinter.ts
+++ b/packages/website/src/components/linter/createLinter.ts
@@ -26,6 +26,20 @@ import { fileTypes } from '../options';
 import { defaultEslintLanguageConfig } from './config';
 import { createParser } from './createParser';
 
+const TYPESCRIPT_ESLINT_BASE_CONFIG_NAME = 'typescript-eslint/base';
+
+function appendExtendedConfig(
+  eslintExtendedConfig: FlatConfig.ConfigArray,
+  maybeConfig: FlatConfig.Config | FlatConfig.ConfigArray,
+): void {
+  const configs = Array.isArray(maybeConfig) ? maybeConfig : [maybeConfig];
+  eslintExtendedConfig.push(
+    ...configs.filter(config => {
+      return config.name !== TYPESCRIPT_ESLINT_BASE_CONFIG_NAME;
+    }),
+  );
+}
+
 export interface CreateLinter {
   configs: string[];
   onLint(cb: LinterOnLint): () => void;
@@ -163,15 +177,12 @@ export function createLinter(
     try {
       const file = system.readFile(fileName) ?? '{}';
       const parsed = parseESLintRC(file);
+      eslintExtendedConfig.length = 0;
       eslintRulesConfig.rules = parsed.rules;
       for (const extendsName of parsed.extends) {
         const maybeConfig = configs.get(extendsName);
         if (maybeConfig) {
-          if (Array.isArray(maybeConfig)) {
-            eslintExtendedConfig.push(...maybeConfig);
-          } else {
-            eslintExtendedConfig.push(maybeConfig);
-          }
+          appendExtendedConfig(eslintExtendedConfig, maybeConfig);
         }
       }
       console.log('[Editor] Updating', fileName, [


### PR DESCRIPTION
Fixes #12367.

The playground already installs its own TypeScript parser and `@typescript-eslint` plugin before applying user-selected `extends` configs. The bundled flat configs include `typescript-eslint/base`, which registers that same plugin again and causes ESLint's "Cannot redefine plugin" error.

This skips that base config when applying playground extends, resets the applied extended config list whenever `.eslintrc` changes, and exposes legacy `plugin:@typescript-eslint/...` aliases to the playground config list so older playground links keep resolving.

Validation:
- `pnpm exec nx run website-eslint:build`
- `pnpm exec nx run website-eslint:typecheck`
- `pnpm exec nx run website:typecheck`
- `pnpm exec eslint --config=eslint.config.mjs packages/website/src/components/linter/createLinter.ts packages/website-eslint/src/index.js`
- `pnpm exec prettier --check packages/website/src/components/linter/createLinter.ts packages/website-eslint/src/index.js`
- `git diff --check`
- local Browser QA on `/play/` with both `@typescript-eslint/flat/recommended-type-checked` and `plugin:@typescript-eslint/recommended-type-checked`
