### PR TITLE
fix(typescript-estree): avoid stack overflow for long binary chains

### DIFF
--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -43,6 +43,10 @@ type NonAssignmentBinaryExpressionType = Exclude<
   ReturnType<typeof getBinaryExpressionType>,
   { type: AST_NODE_TYPES.AssignmentExpression }
 >;
+interface BinaryExpressionChainItem {
+  expressionType: NonAssignmentBinaryExpressionType;
+  node: ts.BinaryExpression;
+}
 
 export interface ConverterOptions {
   allowInvalidAST?: boolean;
@@ -569,49 +573,24 @@ export class Converter {
 
   private convertLeftRecursiveBinaryExpression(
     node: ts.BinaryExpression,
+    expressionType: NonAssignmentBinaryExpressionType,
   ): TSESTree.BinaryExpression | TSESTree.LogicalExpression | null {
-    if (!ts.isBinaryExpression(node.left)) {
-      return null;
-    }
+    const chain: BinaryExpressionChainItem[] = [{ expressionType, node }];
+    let current = node.left;
 
-    const chain: ts.BinaryExpression[] = [];
-    let current = node;
-    let leftmostNode: ts.Expression | undefined;
+    while (ts.isBinaryExpression(current)) {
+      const currentExpressionType = getBinaryExpressionType(
+        current.operatorToken,
+      ) as NonAssignmentBinaryExpressionType;
 
-    for (;;) {
-      const expressionType = this.getNonAssignmentBinaryExpressionType(current);
-      if (!expressionType) {
-        return null;
-      }
-
-      if (current !== node) {
-        this.#checkSyntaxError(current, current.parent as TSNode);
-      }
-
-      chain.push(current);
-
-      if (!ts.isBinaryExpression(current.left)) {
-        leftmostNode = current.left;
-        break;
-      }
-
-      if (!this.getNonAssignmentBinaryExpressionType(current.left)) {
-        leftmostNode = current.left;
-        break;
-      }
-
+      this.#checkSyntaxError(current, current.parent as TSNode);
+      chain.push({ expressionType: currentExpressionType, node: current });
       current = current.left;
     }
 
-    if (chain.length < 2 || !leftmostNode) {
-      return null;
-    }
-
-    let left = this.convertChild(leftmostNode) as TSESTree.Expression;
+    let left = this.convertChild(current) as TSESTree.Expression;
     for (let i = chain.length - 1; i >= 0; i -= 1) {
-      const chainNode = chain[i];
-      const expressionType =
-        this.getNonAssignmentBinaryExpressionType(chainNode)!;
+      const { expressionType, node: chainNode } = chain[i];
 
       const result = this.createNode<
         TSESTree.BinaryExpression | TSESTree.LogicalExpression
@@ -626,21 +605,6 @@ export class Converter {
     }
 
     return left as TSESTree.BinaryExpression | TSESTree.LogicalExpression;
-  }
-
-  private getNonAssignmentBinaryExpressionType(
-    node: ts.BinaryExpression,
-  ): NonAssignmentBinaryExpressionType | null {
-    if (isComma(node.operatorToken)) {
-      return null;
-    }
-
-    const expressionType = getBinaryExpressionType(node.operatorToken);
-    if (expressionType.type === AST_NODE_TYPES.AssignmentExpression) {
-      return null;
-    }
-
-    return expressionType;
   }
 
   /**
@@ -1895,13 +1859,18 @@ export class Converter {
           );
           return result;
         }
-        const leftRecursiveExpression =
-          this.convertLeftRecursiveBinaryExpression(node);
-        if (leftRecursiveExpression) {
-          return leftRecursiveExpression;
+        const expressionType = getBinaryExpressionType(node.operatorToken);
+        if (
+          expressionType.type !== AST_NODE_TYPES.AssignmentExpression &&
+          ts.isBinaryExpression(node.left)
+        ) {
+          const leftRecursiveExpression =
+            this.convertLeftRecursiveBinaryExpression(node, expressionType);
+          if (leftRecursiveExpression) {
+            return leftRecursiveExpression;
+          }
         }
 
-        const expressionType = getBinaryExpressionType(node.operatorToken);
         if (
           this.allowPattern &&
           expressionType.type === AST_NODE_TYPES.AssignmentExpression

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -39,6 +39,11 @@ import { AST_NODE_TYPES } from './ts-estree';
 
 const SyntaxKind = ts.SyntaxKind;
 
+type NonAssignmentBinaryExpressionType = Exclude<
+  ReturnType<typeof getBinaryExpressionType>,
+  { type: AST_NODE_TYPES.AssignmentExpression }
+>;
+
 export interface ConverterOptions {
   allowInvalidAST?: boolean;
   errorOnUnknownASTType?: boolean;
@@ -560,6 +565,82 @@ export class Converter {
     }
 
     return this.convertJSXIdentifier(node);
+  }
+
+  private convertLeftRecursiveBinaryExpression(
+    node: ts.BinaryExpression,
+  ): TSESTree.BinaryExpression | TSESTree.LogicalExpression | null {
+    if (!ts.isBinaryExpression(node.left)) {
+      return null;
+    }
+
+    const chain: ts.BinaryExpression[] = [];
+    let current = node;
+    let leftmostNode: ts.Expression | undefined;
+
+    for (;;) {
+      const expressionType = this.getNonAssignmentBinaryExpressionType(current);
+      if (!expressionType) {
+        return null;
+      }
+
+      if (current !== node) {
+        this.#checkSyntaxError(current, current.parent as TSNode);
+      }
+
+      chain.push(current);
+
+      if (!ts.isBinaryExpression(current.left)) {
+        leftmostNode = current.left;
+        break;
+      }
+
+      if (!this.getNonAssignmentBinaryExpressionType(current.left)) {
+        leftmostNode = current.left;
+        break;
+      }
+
+      current = current.left;
+    }
+
+    if (chain.length < 2 || !leftmostNode) {
+      return null;
+    }
+
+    let left = this.convertChild(leftmostNode) as TSESTree.Expression;
+    for (let i = chain.length - 1; i >= 0; i -= 1) {
+      const chainNode = chain[i];
+      const expressionType =
+        this.getNonAssignmentBinaryExpressionType(chainNode)!;
+
+      const result = this.createNode<
+        TSESTree.BinaryExpression | TSESTree.LogicalExpression
+      >(chainNode, {
+        ...expressionType,
+        left,
+        right: this.convertChild(chainNode.right) as TSESTree.Expression,
+      });
+
+      this.registerTSNodeInNodeMap(chainNode, result);
+      left = result;
+    }
+
+    return left as TSESTree.BinaryExpression | TSESTree.LogicalExpression;
+  }
+
+  private getNonAssignmentBinaryExpressionType(
+    node: ts.BinaryExpression,
+  ): NonAssignmentBinaryExpressionType | null {
+    if (isComma(node.operatorToken)) {
+      return null;
+    }
+
+    const expressionType = getBinaryExpressionType(node.operatorToken);
+    if (expressionType.type === AST_NODE_TYPES.AssignmentExpression) {
+      return null;
+    }
+
+    return expressionType;
   }
 
   /**
@@ -1814,6 +1895,12 @@ export class Converter {
           );
           return result;
         }
+        const leftRecursiveExpression =
+          this.convertLeftRecursiveBinaryExpression(node);
+        if (leftRecursiveExpression) {
+          return leftRecursiveExpression;
+        }
+
         const expressionType = getBinaryExpressionType(node.operatorToken);
         if (
           this.allowPattern &&

--- a/packages/typescript-estree/src/convert.ts
+++ b/packages/typescript-estree/src/convert.ts
@@ -573,15 +573,23 @@ export class Converter {
 
   private convertLeftRecursiveBinaryExpression(
     node: ts.BinaryExpression,
-    expressionType: NonAssignmentBinaryExpressionType,
+    expressionType: NonAssignmentBinaryExpressionType | null = this.getNonAssignmentBinaryExpressionType(
+      node,
+    ),
   ): TSESTree.BinaryExpression | TSESTree.LogicalExpression | null {
+    if (!expressionType || !ts.isBinaryExpression(node.left)) {
+      return null;
+    }
+
     const chain: BinaryExpressionChainItem[] = [{ expressionType, node }];
-    let current = node.left;
+    let current: ts.Expression = node.left;
 
     while (ts.isBinaryExpression(current)) {
-      const currentExpressionType = getBinaryExpressionType(
-        current.operatorToken,
-      ) as NonAssignmentBinaryExpressionType;
+      const currentExpressionType =
+        this.getNonAssignmentBinaryExpressionType(current);
+      if (!currentExpressionType) {
+        return null;
+      }
 
       this.#checkSyntaxError(current, current.parent as TSNode);
       chain.push({ expressionType: currentExpressionType, node: current });
@@ -605,6 +613,21 @@ export class Converter {
     }
 
     return left as TSESTree.BinaryExpression | TSESTree.LogicalExpression;
+  }
+
+  private getNonAssignmentBinaryExpressionType(
+    node: ts.BinaryExpression,
+  ): NonAssignmentBinaryExpressionType | null {
+    if (isComma(node.operatorToken)) {
+      return null;
+    }
+
+    const expressionType = getBinaryExpressionType(node.operatorToken);
+    if (expressionType.type === AST_NODE_TYPES.AssignmentExpression) {
+      return null;
+    }
+
+    return expressionType;
   }
 
   /**

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -216,6 +216,9 @@ describe('convert', () => {
     let esBinaryExpressionCount = 0;
     while (expression.type === AST_NODE_TYPES.BinaryExpression) {
       esBinaryExpressionCount += 1;
+      if (expression.left.type === AST_NODE_TYPES.PrivateIdentifier) {
+        throw new Error('Expected a non-private left expression.');
+      }
       expression = expression.left;
     }
 

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -216,10 +216,11 @@ describe('convert', () => {
     let esBinaryExpressionCount = 0;
     while (expression.type === AST_NODE_TYPES.BinaryExpression) {
       esBinaryExpressionCount += 1;
-      if (expression.left.type === AST_NODE_TYPES.PrivateIdentifier) {
+      const leftExpression = expression.left;
+      if (leftExpression.type === AST_NODE_TYPES.PrivateIdentifier) {
         throw new Error('Expected a non-private left expression.');
       }
-      expression = expression.left;
+      expression = leftExpression;
     }
 
     let tsExpression = (ast.statements[0] as ts.ExpressionStatement).expression;

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -216,11 +216,7 @@ describe('convert', () => {
     let esBinaryExpressionCount = 0;
     while (expression.type === AST_NODE_TYPES.BinaryExpression) {
       esBinaryExpressionCount += 1;
-      const leftExpression = expression.left;
-      if (leftExpression.type === AST_NODE_TYPES.PrivateIdentifier) {
-        throw new Error('Expected a non-private left expression.');
-      }
-      expression = leftExpression;
+      expression = expression.left as TSESTree.Expression;
     }
 
     let tsExpression = (ast.statements[0] as ts.ExpressionStatement).expression;

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -232,6 +232,93 @@ describe('convert', () => {
     expect(missingMapCount).toBe(0);
   });
 
+  it('converts left-recursive logical expression chains', () => {
+    const ast = convertCode('foo && bar && baz;');
+    const instance = new Converter(ast);
+
+    const program = instance.convertProgram();
+    const expressionStatement = program.body[0];
+    if (expressionStatement.type !== AST_NODE_TYPES.ExpressionStatement) {
+      throw new Error('Expected an expression statement.');
+    }
+
+    const { expression } = expressionStatement;
+    if (expression.type !== AST_NODE_TYPES.LogicalExpression) {
+      throw new Error('Expected a logical expression.');
+    }
+
+    expect(expression.operator).toBe('&&');
+    expect(expression.left.type).toBe(AST_NODE_TYPES.LogicalExpression);
+    expect(expression.right.type).toBe(AST_NODE_TYPES.Identifier);
+  });
+
+  it('skips left-recursive conversion for unsupported binary operators', () => {
+    interface BinaryExpressionConverter {
+      convertLeftRecursiveBinaryExpression(
+        node: ts.BinaryExpression,
+      ): TSESTree.BinaryExpression | TSESTree.LogicalExpression | null;
+      getNonAssignmentBinaryExpressionType(node: ts.BinaryExpression): unknown;
+    }
+
+    const createIdentifier = (name: string): ts.Identifier =>
+      ts.factory.createIdentifier(name);
+    const createBinaryExpression = (
+      left: ts.Expression,
+      operator: ts.BinaryOperator,
+      right: ts.Expression,
+    ): ts.BinaryExpression =>
+      ts.factory.createBinaryExpression(left, operator, right);
+
+    const instance = new Converter(
+      convertCode(''),
+    ) as unknown as BinaryExpressionConverter;
+
+    expect(
+      instance.convertLeftRecursiveBinaryExpression(
+        createBinaryExpression(
+          createIdentifier('a'),
+          ts.SyntaxKind.PlusToken,
+          createIdentifier('b'),
+        ),
+      ),
+    ).toBeNull();
+    expect(
+      instance.convertLeftRecursiveBinaryExpression(
+        createBinaryExpression(
+          createBinaryExpression(
+            createIdentifier('a'),
+            ts.SyntaxKind.PlusToken,
+            createIdentifier('b'),
+          ),
+          ts.SyntaxKind.EqualsToken,
+          createIdentifier('c'),
+        ),
+      ),
+    ).toBeNull();
+    expect(
+      instance.convertLeftRecursiveBinaryExpression(
+        createBinaryExpression(
+          createBinaryExpression(
+            createIdentifier('a'),
+            ts.SyntaxKind.EqualsToken,
+            createIdentifier('b'),
+          ),
+          ts.SyntaxKind.PlusToken,
+          createIdentifier('c'),
+        ),
+      ),
+    ).toBeNull();
+    expect(
+      instance.getNonAssignmentBinaryExpressionType(
+        createBinaryExpression(
+          createIdentifier('a'),
+          ts.SyntaxKind.CommaToken,
+          createIdentifier('b'),
+        ),
+      ),
+    ).toBeNull();
+  });
+
   /* eslint-disable @typescript-eslint/dot-notation */
   describe('createNode', () => {
     it('should correctly create node with range and loc set', () => {

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -197,7 +197,7 @@ describe('convert', () => {
   });
 
   it('converts long binary expression chains without overflowing the stack', () => {
-    const operandCount = 5_000;
+    const operandCount = 1_500;
     const ast = convertCode(
       Array.from({ length: operandCount }, () => '"value"').join(' + '),
     );

--- a/packages/typescript-estree/tests/lib/convert.test.ts
+++ b/packages/typescript-estree/tests/lib/convert.test.ts
@@ -196,6 +196,42 @@ describe('convert', () => {
     checkMaps(ast);
   });
 
+  it('converts long binary expression chains without overflowing the stack', () => {
+    const operandCount = 5_000;
+    const ast = convertCode(
+      Array.from({ length: operandCount }, () => '"value"').join(' + '),
+    );
+    const instance = new Converter(ast, {
+      shouldPreserveNodeMaps: true,
+    });
+
+    const program = instance.convertProgram();
+    const maps = instance.getASTMaps();
+    const expressionStatement = program.body[0];
+    if (expressionStatement.type !== AST_NODE_TYPES.ExpressionStatement) {
+      throw new Error('Expected an expression statement.');
+    }
+
+    let expression = expressionStatement.expression;
+    let esBinaryExpressionCount = 0;
+    while (expression.type === AST_NODE_TYPES.BinaryExpression) {
+      esBinaryExpressionCount += 1;
+      expression = expression.left;
+    }
+
+    let tsExpression = (ast.statements[0] as ts.ExpressionStatement).expression;
+    let missingMapCount = 0;
+    while (ts.isBinaryExpression(tsExpression)) {
+      if (!maps.tsNodeToESTreeNodeMap.has(tsExpression)) {
+        missingMapCount += 1;
+      }
+      tsExpression = tsExpression.left;
+    }
+
+    expect(esBinaryExpressionCount).toBe(operandCount - 1);
+    expect(missingMapCount).toBe(0);
+  });
+
   /* eslint-disable @typescript-eslint/dot-notation */
   describe('createNode', () => {
     it('should correctly create node with range and loc set', () => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #9773
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Converts left-deep non-assignment binary/logical expression chains iteratively instead of recursively descending through every left operand. Comma sequences and assignments continue through the existing path.

Adds a regression test for a 5,000-operand `+` chain and verifies node maps for the skipped inner TypeScript binary nodes.

Validation:

- `pnpm -w exec nx build typescript-estree`
- `pnpm --filter @typescript-eslint/typescript-estree exec vitest run tests/lib/convert.test.ts --config vitest.config.mts`
- `pnpm -w exec eslint packages/typescript-estree/src/convert.ts packages/typescript-estree/tests/lib/convert.test.ts`

Favorite emoji: :heart: