### PR TITLE
fix(eslint-plugin): [no-unnecessary-boolean-literal-compare] fix precedence bug in autofix

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -288,7 +288,8 @@ export default createRule<Options, MessageIds>({
               comparison.expression,
             );
 
-            // preserve truth table for cases when falsiness have opposite truth values
+            // In maybeNullish === false, nullish values have the same truth table
+            // as `true`.
             if (
               comparison.expressionIsNullableBoolean &&
               comparison.booleanLiteral === 'false'

--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -30,7 +30,7 @@ export type Options = [
 
 interface BooleanComparison {
   expression: TSESTree.Expression | TSESTree.PrivateIdentifier;
-  booleanLiteral: 'true' | 'false';
+  booleanLiteral: 'false' | 'true';
   negated: boolean;
 }
 
@@ -220,8 +220,8 @@ export default createRule<Options, MessageIds>({
         const negated = !comparisonType.isPositive;
 
         return {
-          expression,
           booleanLiteral,
+          expression,
           negated,
         };
       }
@@ -358,7 +358,8 @@ function getEqualsKind(operator: string): EqualsKind | undefined {
 }
 
 function booleanXor(arg0: boolean, ...args: boolean[]) {
-  return args.reduce((acc, curr) => acc !== curr, Boolean(arg0));
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-conversion
+  return args.reduce((acc, curr) => acc !== Boolean(curr), Boolean(arg0));
 }
 
 function parenthesize(text: string) {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -9,6 +9,7 @@ import {
   getConstraintInfo,
   getParserServices,
   isStrongPrecedenceNode,
+  isWeakPrecedenceParent,
 } from '../util';
 
 export type MessageIds =
@@ -29,7 +30,7 @@ export type Options = [
 
 interface BooleanComparison {
   expression: TSESTree.Expression | TSESTree.PrivateIdentifier;
-  literalBooleanInComparison: boolean;
+  booleanLiteral: 'true' | 'false';
   negated: boolean;
 }
 
@@ -215,12 +216,12 @@ export default createRule<Options, MessageIds>({
           continue;
         }
 
-        const { value: literalBooleanInComparison } = against;
+        const booleanLiteral = against.value ? 'true' : 'false';
         const negated = !comparisonType.isPositive;
 
         return {
           expression,
-          literalBooleanInComparison,
+          booleanLiteral,
           negated,
         };
       }
@@ -243,13 +244,13 @@ export default createRule<Options, MessageIds>({
 
         if (comparison.expressionIsNullableBoolean) {
           if (
-            comparison.literalBooleanInComparison &&
+            comparison.booleanLiteral === 'true' &&
             options.allowComparingNullableBooleansToTrue
           ) {
             return;
           }
           if (
-            !comparison.literalBooleanInComparison &&
+            comparison.booleanLiteral === 'false' &&
             options.allowComparingNullableBooleansToFalse
           ) {
             return;
@@ -259,7 +260,7 @@ export default createRule<Options, MessageIds>({
         context.report({
           node,
           messageId: comparison.expressionIsNullableBoolean
-            ? comparison.literalBooleanInComparison
+            ? comparison.booleanLiteral === 'true'
               ? comparison.negated
                 ? 'comparingNullableToTrueNegated'
                 : 'comparingNullableToTrueDirect'
@@ -267,43 +268,51 @@ export default createRule<Options, MessageIds>({
             : comparison.negated
               ? 'negated'
               : 'direct',
-          *fix(fixer) {
-            // 1. isUnaryNegation - parent negation
-            // 2. literalBooleanInComparison - is compared to literal boolean
-            // 3. negated - is expression negated
+          fix(fixer) {
+            const isWrappedInUnaryNegation = nodeIsUnaryNegation(node.parent);
+            const mutatedNode = isWrappedInUnaryNegation ? node.parent : node;
 
-            const isUnaryNegation = nodeIsUnaryNegation(node.parent);
-
-            const shouldNegate =
-              comparison.negated !== comparison.literalBooleanInComparison;
-
-            const mutatedNode = isUnaryNegation ? node.parent : node;
-
-            yield fixer.replaceText(
-              mutatedNode,
-              context.sourceCode.getText(comparison.expression),
+            // Whether the truth table of the overall expression being replaced
+            // is negated, _ignoring the nullish cases_.
+            const isOverallNegated = booleanXor(
+              isWrappedInUnaryNegation,
+              comparison.negated,
+              comparison.booleanLiteral === 'false',
             );
 
-            // if `isUnaryNegation === literalBooleanInComparison === !negated` is true - negate the expression
-            if (shouldNegate === isUnaryNegation) {
-              yield fixer.insertTextBefore(mutatedNode, '!');
+            // we'll build up the replacement text from the compared expression outwards.
+            let replacementText = context.sourceCode.getText(
+              comparison.expression,
+            );
+            let mayNeedParentheses = !isStrongPrecedenceNode(
+              comparison.expression,
+            );
 
-              // if the expression `exp` is not a strong precedence node, wrap it in parentheses
-              if (!isStrongPrecedenceNode(comparison.expression)) {
-                yield fixer.insertTextBefore(mutatedNode, '(');
-                yield fixer.insertTextAfter(mutatedNode, ')');
-              }
-            }
-
-            // if the expression `exp` is nullable, and we're not comparing to `true`, insert `?? true`
+            // preserve truth table for cases when falsiness have opposite truth values
             if (
               comparison.expressionIsNullableBoolean &&
-              !comparison.literalBooleanInComparison
+              comparison.booleanLiteral === 'false'
             ) {
-              // provide the default `true`
-              yield fixer.insertTextBefore(mutatedNode, '(');
-              yield fixer.insertTextAfter(mutatedNode, ' ?? true)');
+              if (mayNeedParentheses) {
+                replacementText = parenthesize(replacementText);
+              }
+              replacementText = `${replacementText} ?? true`;
+              mayNeedParentheses = true;
             }
+
+            if (isOverallNegated) {
+              if (mayNeedParentheses) {
+                replacementText = parenthesize(replacementText);
+              }
+              replacementText = `!${replacementText}`;
+              mayNeedParentheses = false;
+            }
+
+            if (mayNeedParentheses && isWeakPrecedenceParent(mutatedNode)) {
+              replacementText = parenthesize(replacementText);
+            }
+
+            return fixer.replaceText(mutatedNode, replacementText);
           },
         });
       },
@@ -345,4 +354,12 @@ function getEqualsKind(operator: string): EqualsKind | undefined {
     default:
       return undefined;
   }
+}
+
+function booleanXor(arg0: boolean, ...args: boolean[]) {
+  return args.reduce((acc, curr) => acc !== curr, Boolean(arg0));
+}
+
+function parenthesize(text: string) {
+  return `(${text})`;
 }

--- a/packages/eslint-plugin/src/util/getWrappingFixer.ts
+++ b/packages/eslint-plugin/src/util/getWrappingFixer.ts
@@ -130,7 +130,7 @@ export function isStrongPrecedenceNode(innerNode: TSESTree.Node): boolean {
 /**
  * Check if a node's parent could have different precedence if the node changes.
  */
-function isWeakPrecedenceParent(node: TSESTree.Node): boolean {
+export function isWeakPrecedenceParent(node: TSESTree.Node): boolean {
   const parent = node.parent;
   if (!parent) {
     return false;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
@@ -618,5 +618,24 @@ function foo(): boolean {}
         },
       ],
     },
+    {
+      code: `
+declare const a: boolean;
+declare const b: boolean;
+declare const c: boolean;
+(a || b) === true && c;
+      `,
+      errors: [
+        {
+          messageId: 'direct',
+        },
+      ],
+      output: `
+declare const a: boolean;
+declare const b: boolean;
+declare const c: boolean;
+(a || b) && c;
+      `,
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12412 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Took an opportunity to refactor the fixer a bit. The fixer previously operated by 
1. Replacing the whole text of the mutated node
2. Inserting and appending text to the mutated node multiple times thereafter

This was rather confusing to me, since it's highly dependent on the order in which ESLint processes insertions/appends to the same location. I reworked it to just build up the replacement string itself and then replace the mutated node, without touching it afterwards.

I also had a hard time making sense of the boolean conditions in the fixer. I simplified these down to just "does the overall comparison have negated truthiness compared to the original value?" and "do we need to flip the truth table of the nullish cases?"

Lastly, refactored `comparison.booleanLiteralInComparison` with type `boolean` to `comparison.booleanLiteral` with type `"true" | "false"`. The second way makes it clear that it's a value rather than a condition.

With the above in place, the fundamental fix is to detect if something like `expression === true` has been replaced with just `expression` and put parentheses if the surroundings require it. This has been achieved by tracking whether the current state of the replacement text being built up is a strong precedence node or not, and, if at the end, parentheses are needed, adding  a pair. 