### PR TITLE
chore(eslint-plugin-internal): [no-dynamic-tests] restrict where noFormat can occur

### DIFF
--- a/packages/eslint-plugin-internal/src/rules/no-dynamic-tests.ts
+++ b/packages/eslint-plugin-internal/src/rules/no-dynamic-tests.ts
@@ -1,4 +1,3 @@
-import type { InvalidTestCase } from '@typescript-eslint/rule-tester';
 import type { TSESTree } from '@typescript-eslint/utils';
 
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
@@ -13,19 +12,33 @@ export default createRule({
     docs: {
       description: 'Disallow dynamic syntax in RuleTester test arrays',
     },
+    fixable: 'code',
     messages: {
       noDynamicTests:
         'Dynamic syntax is not allowed in RuleTester test arrays. Use static values only.',
+      noFormatNotAllowedHere:
+        'Dynamic syntax is not allowed in RuleTester test arrays. noFormat is only for the input code, not for other properties.',
     },
     schema: [],
   },
   defaultOptions: [],
   create(context) {
-    function reportDynamicElements(node: TSESTree.Node): void {
+    function reportDynamicElements(
+      node: TSESTree.Node,
+      fieldStack: string[],
+    ): void {
       switch (node.type) {
+        case AST_NODE_TYPES.Identifier:
+          if (node.name === 'undefined') {
+            break;
+          }
+          context.report({
+            node,
+            messageId: 'noDynamicTests',
+          });
+          break;
         case AST_NODE_TYPES.CallExpression:
         case AST_NODE_TYPES.SpreadElement:
-        case AST_NODE_TYPES.Identifier:
         case AST_NODE_TYPES.BinaryExpression:
         case AST_NODE_TYPES.ConditionalExpression:
         case AST_NODE_TYPES.MemberExpression:
@@ -36,13 +49,13 @@ export default createRule({
           break;
         case AST_NODE_TYPES.TemplateLiteral:
           node.expressions.forEach(expr => {
-            reportDynamicElements(expr);
+            reportDynamicElements(expr, fieldStack);
           });
           break;
         case AST_NODE_TYPES.ArrayExpression:
           node.elements.forEach(element => {
             if (element) {
-              reportDynamicElements(element);
+              reportDynamicElements(element, fieldStack);
             }
           });
           break;
@@ -55,36 +68,60 @@ export default createRule({
               });
             } else {
               // InvalidTestCase extends ValidTestCase
-              type TestCaseKey = keyof InvalidTestCase<string, []>;
-              const keyToValidate: TestCaseKey[] = ['code', 'errors'];
+              const keyToValidate = [
+                'code',
+                'errors',
+                'output',
+                'suggestions',
+                'messageId',
+              ];
 
               if (
                 prop.key.type === AST_NODE_TYPES.Identifier &&
-                keyToValidate.includes(prop.key.name as TestCaseKey)
+                keyToValidate.includes(prop.key.name)
               ) {
-                reportDynamicElements(prop.value);
+                reportDynamicElements(prop.value, [
+                  ...fieldStack,
+                  prop.key.name,
+                ]);
               } else if (
                 prop.key.type === AST_NODE_TYPES.Literal &&
-                keyToValidate.includes(prop.key.value as TestCaseKey)
+                keyToValidate.includes(prop.key.value as string)
               ) {
-                reportDynamicElements(prop.value);
+                reportDynamicElements(prop.value, [
+                  ...fieldStack,
+                  prop.key.value as string,
+                ]);
               }
             }
           });
           break;
-        case AST_NODE_TYPES.TaggedTemplateExpression:
+        case AST_NODE_TYPES.TaggedTemplateExpression: {
           if (
-            !(
-              node.tag.type === AST_NODE_TYPES.Identifier &&
-              node.tag.name === 'noFormat'
-            )
+            node.tag.type === AST_NODE_TYPES.Identifier &&
+            node.tag.name === 'noFormat'
           ) {
+            // allow noFormat for the 'code' field only (or if a valid test case is using the string shorthand)
+            if (
+              fieldStack.length === 1 ||
+              (fieldStack.length === 2 && fieldStack.at(-1) === 'code')
+            ) {
+              break;
+            }
             context.report({
               node: node.tag,
-              messageId: 'noDynamicTests',
+              messageId: 'noFormatNotAllowedHere',
+              fix: fixer => fixer.remove(node.tag),
             });
+            break;
           }
+
+          context.report({
+            node: node.tag,
+            messageId: 'noDynamicTests',
+          });
           break;
+        }
         case AST_NODE_TYPES.Literal:
         default:
           break;
@@ -105,10 +142,11 @@ export default createRule({
             (prop.key.name === 'valid' || prop.key.name === 'invalid');
 
           if (isTestCases) {
+            const propName = (prop.key as TSESTree.Identifier).name;
             if (prop.value.type === AST_NODE_TYPES.ArrayExpression) {
               prop.value.elements.forEach(element => {
                 if (element) {
-                  reportDynamicElements(element);
+                  reportDynamicElements(element, [propName]);
                 }
               });
             } else {

--- a/packages/eslint-plugin-internal/tests/rules/no-dynamic-tests.test.ts
+++ b/packages/eslint-plugin-internal/tests/rules/no-dynamic-tests.test.ts
@@ -235,6 +235,87 @@ ruleTester.run('test', rule, {
         },
       ],
     },
+    // noFormat not allowed on non-code fields (e.g. output)
+    {
+      code: `
+ruleTester.run('test', rule, {
+  valid: [],
+  invalid: [
+    {
+      code: 'var x = 1;',
+      errors: [{ messageId: 'error' }],
+      output: noFormat\`var x = 1;\`,
+    },
+  ],
+});
+      `,
+      errors: [
+        {
+          messageId: 'noFormatNotAllowedHere',
+        },
+      ],
+      output: `
+ruleTester.run('test', rule, {
+  valid: [],
+  invalid: [
+    {
+      code: 'var x = 1;',
+      errors: [{ messageId: 'error' }],
+      output: \`var x = 1;\`,
+    },
+  ],
+});
+      `,
+    },
+    {
+      code: `
+ruleTester.run('test', rule, {
+  valid: [],
+  invalid: [
+    {
+      code: 'var x = 1;',
+      errors: [
+        {
+          messageId: 'error',
+          suggestions: [
+            {
+              messageId: 'suggestion',
+              output: noFormat\`var x = 1;\`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+      `,
+      errors: [
+        {
+          messageId: 'noFormatNotAllowedHere',
+        },
+      ],
+      output: `
+ruleTester.run('test', rule, {
+  valid: [],
+  invalid: [
+    {
+      code: 'var x = 1;',
+      errors: [
+        {
+          messageId: 'error',
+          suggestions: [
+            {
+              messageId: 'suggestion',
+              output: \`var x = 1;\`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+      `,
+    },
   ],
   valid: [
     {
@@ -277,6 +358,14 @@ ruleTester.run('test', rule, {
     {
       code: `
 ruleTester.run('test', rule, {
+  valid: [{ code: noFormat\`const x = 1;\` }],
+  invalid: [],
+});
+      `,
+    },
+    {
+      code: `
+ruleTester.run('test', rule, {
   code: "import type { ValueOf } from './utils';",
   filename: path.resolve(
     PACKAGES_DIR,
@@ -285,5 +374,23 @@ ruleTester.run('test', rule, {
 });
       `,
     },
+    `
+ruleTester.run('test', rule, {
+  valid: [],
+  invalid: [
+    {
+      code: 'x.y!;',
+      errors: [
+        {
+          column: 1,
+          line: 1,
+          messageId: 'noNonNull',
+          suggestions: undefined,
+        },
+      ],
+    },
+  ],
+});
+    `,
   ],
 });

--- a/packages/eslint-plugin/tests/rules/consistent-type-exports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-exports.test.ts
@@ -107,7 +107,8 @@ export { A };
         'export type { Type1 as "🍎" } from \'./consistent-type-exports\';',
     },
     {
-      code: "export { Type1, value1 } from './consistent-type-exports';",
+      code: `
+export { Type1, value1 } from './consistent-type-exports';`,
       errors: [
         {
           column: 1,
@@ -115,9 +116,9 @@ export { A };
           messageId: 'singleExportIsType',
         },
       ],
-      output:
-        `export type { Type1 } from './consistent-type-exports';\n` +
-        `export { value1 } from './consistent-type-exports';`,
+      output: `
+export type { Type1 } from './consistent-type-exports';
+export { value1 } from './consistent-type-exports';`,
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/consistent-type-exports.test.ts
+++ b/packages/eslint-plugin/tests/rules/consistent-type-exports.test.ts
@@ -107,8 +107,7 @@ export { A };
         'export type { Type1 as "🍎" } from \'./consistent-type-exports\';',
     },
     {
-      code: `
-export { Type1, value1 } from './consistent-type-exports';`,
+      code: "export { Type1, value1 } from './consistent-type-exports';",
       errors: [
         {
           column: 1,
@@ -116,8 +115,7 @@ export { Type1, value1 } from './consistent-type-exports';`,
           messageId: 'singleExportIsType',
         },
       ],
-      output: `
-export type { Type1 } from './consistent-type-exports';
+      output: `export type { Type1 } from './consistent-type-exports';
 export { value1 } from './consistent-type-exports';`,
     },
     {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -2400,7 +2400,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = { bar: true };
 foo.bar;
 foo ?. bar;
@@ -2421,7 +2421,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = { bar: true };
 foo?.bar;
 foo . bar;
@@ -2442,7 +2442,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = { bar: true };
 foo?.bar;
 foo ?. bar;
@@ -2463,7 +2463,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = { bar: true };
 foo?.bar;
 foo ?. bar;
@@ -2497,7 +2497,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = () => {};
 foo();
 foo ?. ();
@@ -2518,7 +2518,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = () => {};
 foo?.();
 foo  ();
@@ -2539,7 +2539,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = () => {};
 foo?.();
 foo ?. ();
@@ -2560,7 +2560,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = () => {};
 foo?.();
 foo ?. ();
@@ -2594,7 +2594,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = () => {};
 foo(bar);
 foo ?. (bar);
@@ -2615,7 +2615,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = () => {};
 foo?.(bar);
 foo  (bar);
@@ -2636,7 +2636,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = () => {};
 foo?.(bar);
 foo ?. (bar);
@@ -2657,7 +2657,7 @@ foo
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 let foo = () => {};
 foo?.(bar);
 foo ?. (bar);
@@ -3535,7 +3535,7 @@ foo?.bar()?.toExponential();
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 type Foo = { bar: () => number } | null;
 declare const foo: Foo;
 foo?.bar().toExponential();
@@ -3561,7 +3561,7 @@ foo?.bar?.baz()?.qux?.toExponential();
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 type Foo = { bar: null | { baz: () => { qux: number } } } | null;
 declare const foo: Foo;
 foo?.bar?.baz().qux?.toExponential();
@@ -3578,7 +3578,7 @@ foo?.bar?.baz().qux?.toExponential();
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 type Foo = { bar: null | { baz: () => { qux: number } } } | null;
 declare const foo: Foo;
 foo?.bar?.baz()?.qux.toExponential();
@@ -3604,7 +3604,7 @@ foo?.()?.toExponential();
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 type Foo = (() => number) | null;
 declare const foo: Foo;
 foo?.().toExponential();
@@ -3630,7 +3630,7 @@ foo?.['bar']()?.toExponential();
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 type Foo = { [key: string]: () => number } | null;
 declare const foo: Foo;
 foo?.['bar']().toExponential();
@@ -3656,7 +3656,7 @@ foo?.['bar']?.()?.toExponential();
           suggestions: [
             {
               messageId: 'suggestRemoveOptionalChain',
-              output: noFormat`
+              output: `
 type Foo = { [key: string]: () => number } | null;
 declare const foo: Foo;
 foo?.['bar']?.().toExponential();


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

I've been seeing various contributors put `` output: noFormat`foo` `` in the test cases lately. 

For example:
- https://github.com/typescript-eslint/typescript-eslint/pull/12396/changes#diff-07e2388bab16715b95d01a1f7225c8ea3f50831f7498aef04841014865d196c2R1062
- https://github.com/typescript-eslint/typescript-eslint/pull/12394/changes/BASE..b2cac85f2c38a4aa02f47c050fdf770c085caa5b#diff-7b9bf9719c933ad74cf2dceef7a175157e4ce4ba7bd57e3c7c948dc4ed494e11R2654

Figured let's use our internal linting to ensure those don't creep in.