### PR TITLE
docs: add docusaurus-plugin-copy-page-button to website

### DIFF
--- a/packages/website/docusaurus.config.mts
+++ b/packages/website/docusaurus.config.mts
@@ -409,6 +409,7 @@ const config: Config = {
     ['@docusaurus/plugin-content-docs', pluginContentDocsOptions],
     ['@docusaurus/plugin-pwa', pluginPwaOptions],
     ['@docusaurus/plugin-client-redirects', redirects],
+    'docusaurus-plugin-copy-page-button',
   ],
   presets: [['classic', presetClassicOptions]],
   projectName: 'typescript-eslint',

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -43,6 +43,7 @@
     "@uiw/react-shields": "2.0.2",
     "acorn": "^8.16.0",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.8.0",
     "docusaurus-plugin-typedoc": "^1.4.2",
     "eslint": "*",
     "gray-matter": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -928,6 +928,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      docusaurus-plugin-copy-page-button:
+        specifier: ^0.8.0
+        version: 0.8.0(@docusaurus/core@3.7.0(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(acorn@8.16.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17))(@mdx-js/react@3.1.0(@types/react@18.3.21)(react@18.3.1))(@rspack/core@1.7.4(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(acorn@8.16.0)(eslint@10.4.0(jiti@2.7.0))(lightningcss@1.31.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.2))(react@18.3.1)
       docusaurus-plugin-typedoc:
         specifier: ^1.4.2
         version: 1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.15(typescript@6.0.2)))
@@ -5436,6 +5439,13 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  docusaurus-plugin-copy-page-button@0.8.0:
+    resolution: {integrity: sha512-WsdA9yDlOevHuKiHMq/aZJvLViyYmlyYEPtYaIvL09qScZLu27Lyx7ABycgYz10t389nnz7NcfSKD3ghMs62fg==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
+      react: ^18.0.0 || ^19.0.0
 
   docusaurus-plugin-typedoc@1.4.2:
     resolution: {integrity: sha512-1qerRejLSYxEWdyVPLDMMeKFPLA/37yZAsdwJy9ThHFQR78+v3b5spSbk67VHGLr2mAn4FVHu0aGJ6p7iWotSg==}
@@ -15100,6 +15110,11 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  docusaurus-plugin-copy-page-button@0.8.0(@docusaurus/core@3.7.0(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(acorn@8.16.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17))(@mdx-js/react@3.1.0(@types/react@18.3.21)(react@18.3.1))(@rspack/core@1.7.4(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(acorn@8.16.0)(eslint@10.4.0(jiti@2.7.0))(lightningcss@1.31.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.2))(react@18.3.1):
+    dependencies:
+      '@docusaurus/core': 3.7.0(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.15.8(@swc/helpers@0.5.17))(acorn@8.16.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17))(@mdx-js/react@3.1.0(@types/react@18.3.21)(react@18.3.1))(@rspack/core@1.7.4(@swc/helpers@0.5.17))(@swc/core@1.15.8(@swc/helpers@0.5.17))(acorn@8.16.0)(eslint@10.4.0(jiti@2.7.0))(lightningcss@1.31.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.2)
+      react: 18.3.1
 
   docusaurus-plugin-typedoc@1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.15(typescript@6.0.2))):
     dependencies:


### PR DESCRIPTION
This PR
- adds docusaurus-plugin-copy-page-button to packages/website/package.json
- adds the plugin string to plugins in packages/website/docusaurus.config.mts
- pinned to `^0.8.0` (resolves to 0.8.0) to satisfy your `minimumReleaseAge: 10080` policy — 0.8.1 is only 4 days old; happy to bump once it ages in
- puts a "Copy page" button in the docs sidebar — exports current page as clean markdown
- adds one-click "Open in Claude / ChatGPT / Gemini" actions that prefill the markdown

why useful for typescript-eslint specifically:
the rules pages and the typed-linting / custom-rule guides are dense and very easy to misconfigure. the common flow is reading a rule or config page → asking an LLM "how do I turn this on for my project / why is this firing", and right now that means selecting the page and cleaning it up by hand. this drops the exact page in as context in one click.

zero config, auto-injects into the TOC sidebar, theme-aware.

shipping on React Native, Redux Toolkit, Puppeteer, pnpm, PlayCanvas, Arbitrum, Cardano, Sui, Nillion, Flare, Kaia, and ~20 other docs sites. listed on the Docusaurus community plugins page.

happy to close/rebase if not a fit
- repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
