### PR TITLE
fix(type-utils): match TypeOrValueSpecifier package names on path boundaries

### DIFF
--- a/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
+++ b/packages/type-utils/src/typeOrValueSpecifiers/typeDeclaredInPackageDeclarationFile.ts
@@ -28,6 +28,27 @@ function typeDeclaredInDeclareModule(
   );
 }
 
+function packageNameMatches(
+  packageName: string,
+  typesPackageName: string,
+  packageIdName: string,
+): boolean {
+  // A package id name takes one of two forms:
+  //   - `<packageName>/<subpath>` for packages that ship their own types
+  //     (e.g. `typescript/lib/typescript.d.ts`), or
+  //   - `@types/<typesPackageName>/<subpath>` for `@types` packages
+  //     (e.g. `@types/babel__code-frame/index.d.ts`).
+  // The package name must match along path-component boundaries, so that
+  // (for example) `@angular/common` does not match a specifier for
+  // `@angular/common/http` or vice versa.
+  const candidate = packageIdName.startsWith('@types/')
+    ? packageIdName.slice('@types/'.length)
+    : packageIdName;
+  return [packageName, typesPackageName].some(
+    name => candidate === name || candidate.startsWith(`${name}/`),
+  );
+}
+
 function typeDeclaredInDeclarationFile(
   packageName: string,
   declarationFiles: ts.SourceFile[],
@@ -36,12 +57,11 @@ function typeDeclaredInDeclarationFile(
   // Handle scoped packages: if the name starts with @, remove it and replace / with __
   const typesPackageName = packageName.replace(/^@([^/]+)\//, '$1__');
 
-  const matcher = new RegExp(`${packageName}|${typesPackageName}`);
   return declarationFiles.some(declaration => {
     const packageIdName = program.sourceFileToPackageName.get(declaration.path);
     return (
       packageIdName != null &&
-      matcher.test(packageIdName) &&
+      packageNameMatches(packageName, typesPackageName, packageIdName) &&
       program.isSourceFileFromExternalLibrary(declaration)
     );
   });

--- a/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
+++ b/packages/type-utils/tests/TypeOrValueSpecifier.test.ts
@@ -439,6 +439,37 @@ describe('TypeOrValueSpecifier', () => {
     );
 
     it.for([
+      // `package` must match along package-name boundaries: a value that is
+      // only a partial prefix of the importing package must not match.
+      [
+        'import {SemVer} from "semver"; type Test = SemVer;',
+        { from: 'package', name: 'SemVer', package: 'sem' },
+      ],
+      [
+        'import {SemVer} from "semver"; type Test = SemVer;',
+        { from: 'package', name: 'SemVer', package: 'semve' },
+      ],
+      [
+        'import type {Node} from "typescript"; type Test = Node;',
+        { from: 'package', name: 'Node', package: 'type' },
+      ],
+      // A partial path component of a scoped package must not match either.
+      [
+        'import {BabelCodeFrameOptions} from "@babel/code-frame"; type Test = BabelCodeFrameOptions;',
+        {
+          from: 'package',
+          name: 'BabelCodeFrameOptions',
+          package: '@babel/code',
+        },
+      ],
+    ] as const satisfies [string, TypeOrValueSpecifier][])(
+      "doesn't match a package specifier that is only a partial prefix: %s\n\t%s",
+      ([code, typeOrValueSpecifier], { expect }) => {
+        expect(code).not.toMatchSpecifier(typeOrValueSpecifier);
+      },
+    );
+
+    it.for([
       [
         `
           type Other = { __otherBrand: true };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11946
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`TypeOrValueSpecifier`'s `{ from: 'package', package: '...' }` matching unexpectedly matched arbitrary substring prefixes of a package name. For example, `{ from: 'package', name: 'HttpErrorResponse', package: '@angular/com' }` matched a type imported from `@angular/common/http`, even though `@angular/com` is not a real package.

The cause was in `typeDeclaredInDeclarationFile`, which built an **unanchored** `RegExp` from the package name and tested it against the resolved package id:

```ts
const matcher = new RegExp(`${packageName}|${typesPackageName}`);
// ...
matcher.test(packageIdName)
```

Because the regex was unanchored (and never escaped), `@angular/com` matched as a substring of `@angular/common/http/...`. (It also meant regex metacharacters in a package name were interpreted rather than matched literally.)

Per the [maintainer consensus on the issue](https://github.com/typescript-eslint/typescript-eslint/issues/11946#issuecomment-2622879933), package names should match along **path-component boundaries**:

- `@angular/common` should match `@angular/common` and `@angular/common/http`, but not `@angular/com` or a different `@angular/...` package.

This PR replaces the unanchored substring regex with an explicit boundary check. The resolved package id is one of:

- `<packageName>/<subpath>` for packages that ship their own types (e.g. `typescript/lib/typescript.d.ts`), or
- `@types/<typesPackageName>/<subpath>` for `@types` packages (e.g. `@types/babel__code-frame/index.d.ts`).

After optionally stripping a leading `@types/`, the package name now must either equal the candidate or be followed by a `/`, so partial path components no longer match.

### Tests

Added a `TypeOrValueSpecifier` test block asserting that partial prefixes do **not** match (e.g. `sem`/`semve` against `semver`, `type` against `typescript`, `@babel/code` against `@babel/code-frame`). These cases fail on `main` and pass with the fix. All existing matching/mismatching package-specifier tests continue to pass, as do the `only-throw-error`, `restrict-template-expressions`, and `no-floating-promises` rule suites that consume this helper.
