### PR TITLE
docs: mention AI policy in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
@@ -6,6 +6,10 @@ labels:
   - 'package: eslint-plugin'
   - triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI while preparing this issue, please read and follow our [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: checkboxes
     id: preliminary-checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-enhancement-rule-option.yaml
+++ b/.github/ISSUE_TEMPLATE/02-enhancement-rule-option.yaml
@@ -6,6 +6,10 @@ labels:
   - 'package: eslint-plugin'
   - triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI while preparing this issue, please read and follow our [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: checkboxes
     id: preliminary-checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-enhancement-new-rule.yaml
+++ b/.github/ISSUE_TEMPLATE/03-enhancement-new-rule.yaml
@@ -6,6 +6,10 @@ labels:
   - 'package: eslint-plugin'
   - triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI while preparing this issue, please read and follow our [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: checkboxes
     id: preliminary-checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/04-enhancement-new-base-rule-extension.yaml
+++ b/.github/ISSUE_TEMPLATE/04-enhancement-new-base-rule-extension.yaml
@@ -7,6 +7,10 @@ labels:
   - triage
 body:
   - type: markdown
+    attributes:
+      value: |
+        If you used AI while preparing this issue, please read and follow our [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+  - type: markdown
     id: preamble
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/05-documentation-request.yml
+++ b/.github/ISSUE_TEMPLATE/05-documentation-request.yml
@@ -5,6 +5,10 @@ labels:
   - documentation
   - triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI while preparing this issue, please read and follow our [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: checkboxes
     id: preliminary-checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
+++ b/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
@@ -5,6 +5,10 @@ labels:
   - bug
   - triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI while preparing this issue, please read and follow our [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: checkboxes
     id: preliminary-checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
+++ b/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
@@ -5,6 +5,10 @@ labels:
   - enhancement
   - triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI while preparing this issue, please read and follow our [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: checkboxes
     id: preliminary-checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/08-bug-report-complex.yaml
+++ b/.github/ISSUE_TEMPLATE/08-bug-report-complex.yaml
@@ -8,6 +8,10 @@ body:
   - type: markdown
     attributes:
       value: |
+        If you used AI while preparing this issue, please read and follow our [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+  - type: markdown
+    attributes:
+      value: |
         An isolated reproduction is one we can clone locally and get running without other projects or existing knowledge of your project. If we cannot reproduce your bug quickly with the provided steps, we may not be able to take action on this issue. Help us to help you!
   - type: checkboxes
     id: preliminary-checks

--- a/.github/ISSUE_TEMPLATE/09-config-change.yaml
+++ b/.github/ISSUE_TEMPLATE/09-config-change.yaml
@@ -6,6 +6,10 @@ labels:
   - 'preset config change'
   - triage
 body:
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI while preparing this issue, please read and follow our [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: checkboxes
     id: preliminary-checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/10-repo-maintenance.yaml
+++ b/.github/ISSUE_TEMPLATE/10-repo-maintenance.yaml
@@ -8,6 +8,10 @@ body:
   - type: markdown
     attributes:
       value: |
+        If you used AI while preparing this issue, please read and follow our [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+  - type: markdown
+    attributes:
+      value: |
         This issue form is specifically for work done in this repository. Only use it if you are suggesting a change to repository tooling. Don't use it for work in any other repository.
   - type: textarea
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ Otherwise we may not be able to review your PR.
 - [ ] Addresses an existing open issue: fixes #000
 - [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
 - [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
+- [ ] I have read and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/) if this PR was AI-assisted
 
 ## Overview
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12414
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] I have read and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/) if this PR was AI-assisted

## Overview

## Summary

Adds short links to the AI Contribution Policy from the pull request template and issue forms.

## Reproduction

The project already has `docs/contributing/AI_Contribution_Policy.mdx`, but `.github/pull_request_template.md` and the issue forms did not mention it directly.

## Root cause

The policy was discoverable from the contributing docs, but contributors starting from GitHub's issue and PR templates could submit without seeing a direct reminder.

## Changes

- Added an AI policy checklist item to `.github/pull_request_template.md`.
- Added a short markdown note to each issue form under `.github/ISSUE_TEMPLATE`.
- Kept the issue notes informational only, without adding new required fields.

## Tests

- `git diff --check`
- `ruby --disable-gems -e '<parse all .github/ISSUE_TEMPLATE/*.{yaml,yml} files>'`
- `npx prettier --check .github/pull_request_template.md .github/ISSUE_TEMPLATE/*.yaml .github/ISSUE_TEMPLATE/*.yml`

I also tried `pnpm exec prettier --check ...`, but this local environment's Corepack failed before running pnpm with a keyid/signature error.

## Screenshots/Logs

Not applicable; template-only change.

💖