### PR TITLE
fix(eslint-plugin): preserve precedence in boolean literal autofix

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts
@@ -7,6 +7,7 @@ import * as ts from 'typescript';
 import {
   createRule,
   getConstraintInfo,
+  getMovedNodeCode,
   getParserServices,
   isStrongPrecedenceNode,
 } from '../util';
@@ -278,11 +279,13 @@ export default createRule<Options, MessageIds>({
               comparison.negated !== comparison.literalBooleanInComparison;
 
             const mutatedNode = isUnaryNegation ? node.parent : node;
+            const replacementText = getMovedNodeCode({
+              destinationNode: mutatedNode,
+              nodeToMove: comparison.expression,
+              sourceCode: context.sourceCode,
+            });
 
-            yield fixer.replaceText(
-              mutatedNode,
-              context.sourceCode.getText(comparison.expression),
-            );
+            yield fixer.replaceText(mutatedNode, replacementText);
 
             // if `isUnaryNegation === literalBooleanInComparison === !negated` is true - negate the expression
             if (shouldNegate === isUnaryNegation) {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts
@@ -441,6 +441,27 @@ function test(a?: boolean): boolean {
     },
     {
       code: `
+        declare const a: boolean;
+        declare const b: boolean;
+        declare const c: boolean;
+        if ((a || b) === true && c) {
+        }
+      `,
+      errors: [
+        {
+          messageId: 'direct',
+        },
+      ],
+      output: `
+        declare const a: boolean;
+        declare const b: boolean;
+        declare const c: boolean;
+        if ((a || b) && c) {
+        }
+      `,
+    },
+    {
+      code: `
         declare const varBoolean: boolean;
         if (!(varBoolean === false)) {
         }


### PR DESCRIPTION
## Summary
- preserve parentheses when `no-unnecessary-boolean-literal-compare` autofixes into a weaker-precedence parent expression
- add a regression test for `(a || b) === true && c`

Fixes #12412.

## Verification
- `pnpm exec prettier --check packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts`
- `git diff --check`
- `pnpm exec vitest run packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts`
- `pnpm exec nx typecheck eslint-plugin`
- `pnpm exec eslint --config=eslint.config.mjs packages/eslint-plugin/src/rules/no-unnecessary-boolean-literal-compare.ts packages/eslint-plugin/tests/rules/no-unnecessary-boolean-literal-compare.test.ts`

Note: `pnpm exec nx lint eslint-plugin` was attempted locally, but did not complete after several minutes; the two changed files were linted directly with the repo ESLint config instead.