### PR TITLE
feat(eslint-plugin): [no-misused-promises] detect async usage of a sync dispose usage

### DIFF
--- a/packages/eslint-plugin/src/rules/no-misused-promises.ts
+++ b/packages/eslint-plugin/src/rules/no-misused-promises.ts
@@ -408,12 +408,48 @@ export default createRule<Options, MessageId>({
 
     function checkVariableDeclaration(node: TSESTree.VariableDeclarator): void {
       const tsNode = services.esTreeNodeToTSNodeMap.get(node);
-      if (
-        tsNode.initializer == null ||
-        node.init == null ||
-        node.id.typeAnnotation == null
-      ) {
+      if (tsNode.initializer == null || node.init == null) {
         return;
+      }
+
+      if (
+        node.parent.kind === 'using' &&
+        hasWellKnownSymbolWithThenableReturn(
+          checker,
+          tsNode.initializer,
+          checker.getTypeAtLocation(tsNode.initializer),
+          'dispose',
+        )
+      ) {
+        context.report({
+          node: node.init,
+          messageId: 'voidReturnVariable',
+        });
+      }
+
+      if (node.id.typeAnnotation == null) {
+        return;
+      }
+
+      const variableType = services.getTypeAtLocation(node.id);
+      if (
+        hasWellKnownSymbolWithVoidReturn(
+          checker,
+          tsNode.name,
+          variableType,
+          'dispose',
+        ) &&
+        hasWellKnownSymbolWithThenableReturn(
+          checker,
+          tsNode.initializer,
+          checker.getTypeAtLocation(tsNode.initializer),
+          'dispose',
+        )
+      ) {
+        context.report({
+          node: node.init,
+          messageId: 'voidReturnVariable',
+        });
       }
 
       // syntactically ignore some known-good cases to avoid touching type info
@@ -1014,4 +1050,56 @@ function isStaticMember(node: TSESTree.Node): boolean {
       node.type === AST_NODE_TYPES.AccessorProperty) &&
     node.static
   );
+}
+
+function hasWellKnownSymbolWithThenableReturn(
+  checker: ts.TypeChecker,
+  node: ts.Node,
+  type: ts.Type,
+  symbolName: 'asyncDispose' | 'dispose',
+): boolean {
+  return tsutils
+    .unionConstituents(checker.getApparentType(type))
+    .some(typePart => {
+      const symbol = tsutils.getWellKnownSymbolPropertyOfType(
+        typePart,
+        symbolName,
+        checker,
+      );
+      if (symbol == null) {
+        return false;
+      }
+
+      return isThenableReturningFunctionType(
+        checker,
+        node,
+        checker.getTypeOfSymbolAtLocation(symbol, node),
+      );
+    });
+}
+
+function hasWellKnownSymbolWithVoidReturn(
+  checker: ts.TypeChecker,
+  node: ts.Node,
+  type: ts.Type,
+  symbolName: 'asyncDispose' | 'dispose',
+): boolean {
+  return tsutils
+    .unionConstituents(checker.getApparentType(type))
+    .some(typePart => {
+      const symbol = tsutils.getWellKnownSymbolPropertyOfType(
+        typePart,
+        symbolName,
+        checker,
+      );
+      if (symbol == null) {
+        return false;
+      }
+
+      return isVoidReturningFunctionType(
+        checker,
+        node,
+        checker.getTypeOfSymbolAtLocation(symbol, node),
+      );
+    });
 }

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -1104,6 +1104,11 @@ async function test() {
   };
 }
     `,
+    `
+using c = {
+  async [Symbol.asyncDispose]() {},
+};
+    `,
   ],
 
   invalid: [

--- a/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-misused-promises.test.ts
@@ -1092,6 +1092,18 @@ Promise.reject(3).finally(async () => {});
 const f = 'finally';
 Promise.reject(3)[f](async () => {});
     `,
+    `
+using a = {
+  [Symbol.dispose]() {},
+};
+    `,
+    `
+async function test() {
+  await using b = {
+    async [Symbol.asyncDispose]() {},
+  };
+}
+    `,
   ],
 
   invalid: [
@@ -2656,6 +2668,48 @@ const a: A = {
           endLine: 4,
           line: 4,
           messageId: 'voidReturnProperty',
+        },
+      ],
+    },
+    {
+      code: `
+interface Disposable {
+  [Symbol.dispose](): void;
+}
+
+const a = {
+  async [Symbol.dispose]() {},
+};
+const b: Disposable = a;
+      `,
+      errors: [
+        {
+          messageId: 'voidReturnVariable',
+        },
+      ],
+    },
+    {
+      code: `
+using c = {
+  async [Symbol.dispose]() {},
+};
+      `,
+      errors: [
+        {
+          messageId: 'voidReturnVariable',
+        },
+      ],
+    },
+    {
+      code: `
+const d = {
+  async [Symbol.dispose]() {},
+};
+using e = d;
+      `,
+      errors: [
+        {
+          messageId: 'voidReturnVariable',
         },
       ],
     },


### PR DESCRIPTION
closes 

<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #10357
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Detect returning Promise from a synchronous dispose function