### PR TITLE
chore: fix nx release dry run issues

### DIFF
--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -112,7 +112,9 @@ if (options.dryRun) {
     '⚠️ NOTE: Reverting temporary package.json changes related to dry-run publishing...',
   );
   execaSync('git', [
-    'checkout',
+    'restore',
+    '--staged',
+    '--worktree',
     'packages/**/package.json',
     'package.json',
     'pnpm-lock.yaml',

--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -6,12 +6,6 @@ import {
 } from 'nx/release/index.js';
 import yargs from 'yargs';
 
-if (process.env.CI !== 'true') {
-  throw new Error(
-    'Releases cannot be run outside of CI, we use trusted publishing which requires an authenticated GitHub Actions environment',
-  );
-}
-
 const options = await yargs(process.argv.slice(2))
   .version(false)
   .option('version', {
@@ -44,6 +38,12 @@ const options = await yargs(process.argv.slice(2))
     type: 'boolean',
   })
   .parseAsync();
+
+if (process.env.CI !== 'true' && !options.dryRun) {
+  throw new Error(
+    'Releases cannot be run outside of CI, we use trusted publishing which requires an authenticated GitHub Actions environment',
+  );
+}
 
 const { projectsVersionData, workspaceVersion } = await releaseVersion({
   specifier: options.version,
@@ -94,7 +94,7 @@ if (options.dryRun) {
   console.log(
     '⚠️ NOTE: Applying canary version to package.json files so that dry-run publishing produces useful output...',
   );
-  execaSync('pnpm exec', ['tsx', 'tools/release/apply-canary-version.mts']);
+  execaSync('pnpm', ['exec', 'tsx', 'tools/release/apply-canary-version.mts']);
   console.log(
     '✅ Applied canary version to package.json files so that dry-run publishing produces useful output\n',
   );


### PR DESCRIPTION

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fixes three issues:

1. release.mts would refuse to run if `CI=true` was not set. I changed this check to allow dry runs.
2. `execa("pnpm exec", ["args"])` caused problems. It's supposed to be `execa("pnpm", ["exec", "args"])`.
3. `git checkout foo` doesn't work to restore `foo` if `foo` is staged. Therefore, I switched the git command to use `git restore --staged --worktree foo`, which does restore `foo` even if it's staged.