### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] parenthesize object literal at left edge of expression statement

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -1,5 +1,5 @@
 import type { Scope } from '@typescript-eslint/scope-manager';
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import type {
   ReportFixFunction,
   RuleFix,
@@ -22,6 +22,53 @@ import {
   nullThrows,
   NullThrowsReasons,
 } from '../util';
+
+/**
+ * Determines whether `node` sits at the left edge of an `ExpressionStatement` —
+ * i.e. whether it contributes the statement's leading token. Removing an
+ * angle-bracket assertion around an object literal in such a position would
+ * leave a leading `{`, which is parsed as a block rather than an object literal,
+ * so the fixer must wrap the result in parentheses. This walks up through the
+ * "left edge" parents (the operand positions that keep `node` leading) until it
+ * reaches the `ExpressionStatement`. If any node along the way is already
+ * parenthesized, the leading `{` is protected and no extra parentheses are
+ * needed.
+ */
+function isAtExpressionStatementStart(
+  node: TSESTree.Node,
+  sourceCode: Readonly<TSESLint.SourceCode>,
+): boolean {
+  let current: TSESTree.Node = node;
+  for (let parent = current.parent; parent; parent = current.parent) {
+    if (isParenthesized(current, sourceCode)) {
+      return false;
+    }
+    switch (parent.type) {
+      case AST_NODE_TYPES.ExpressionStatement:
+        return parent.expression === current;
+      case AST_NODE_TYPES.BinaryExpression:
+      case AST_NODE_TYPES.LogicalExpression:
+        if (parent.left !== current) {
+          return false;
+        }
+        break;
+      case AST_NODE_TYPES.ConditionalExpression:
+        if (parent.test !== current) {
+          return false;
+        }
+        break;
+      case AST_NODE_TYPES.SequenceExpression:
+        if (parent.expressions[0] !== current) {
+          return false;
+        }
+        break;
+      default:
+        return false;
+    }
+    current = parent;
+  }
+  return false;
+}
 
 export type Options = [
   {
@@ -803,7 +850,7 @@ export default createRule<Options, MessageIds>({
             node.expression.type === AST_NODE_TYPES.ObjectExpression &&
             ((node.parent.type === AST_NODE_TYPES.ArrowFunctionExpression &&
               node.parent.body === node) ||
-              node.parent.type === AST_NODE_TYPES.ExpressionStatement) &&
+              isAtExpressionStatementStart(node, context.sourceCode)) &&
             !isParenthesized(node, context.sourceCode) &&
             !isParenthesized(node.expression, context.sourceCode);
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2706,5 +2706,31 @@ fn1(() => {
       ],
       output: `({ a: 'foo' });`,
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12418
+    // An object-literal assertion at the left edge of a larger expression
+    // statement must be parenthesized so the leading `{` is not parsed as a
+    // block.
+    {
+      code: "<{ a: string }>{ a: 'foo' } + 1;",
+      errors: [{ messageId: 'unnecessaryAssertion' }],
+      output: "({ a: 'foo' }) + 1;",
+    },
+    {
+      code: "<{ a: string }>{ a: 'foo' } && true;",
+      errors: [{ messageId: 'unnecessaryAssertion' }],
+      output: "({ a: 'foo' }) && true;",
+    },
+    {
+      code: "<{ a: string }>{ a: 'foo' } ? 1 : 2;",
+      errors: [{ messageId: 'unnecessaryAssertion' }],
+      output: "({ a: 'foo' }) ? 1 : 2;",
+    },
+    {
+      // Already protected by the outer parentheses, so the fixer must not add
+      // another pair around the object literal.
+      code: "(<{ a: string }>{ a: 'foo' }, 1);",
+      errors: [{ messageId: 'unnecessaryAssertion' }],
+      output: "({ a: 'foo' }, 1);",
+    },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12418
- [x] That issue was marked as [`accepting prs`](https://github.com/typescript-eslint/typescript-eslint/issues/12418)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Follow-up to #12393 / #12394, which made the fixer wrap a bare object-literal assertion in parentheses when the assertion is the *entire* expression statement (or an arrow concise body). It did not cover the broader class where the assertion sits at the **left edge** of a larger expression that is itself an expression statement, so the leading `{` after the fix still leads the statement and is parsed as a block:

```ts
<{ a: string }>{ a: 'foo' } + 1;      // fixed to: { a: 'foo' } + 1;   ❌ block + leading-`+`
<{ a: string }>{ a: 'foo' } && true;  // fixed to: { a: 'foo' } && true; ❌
<{ a: string }>{ a: 'foo' } ? 1 : 2;  // fixed to: { a: 'foo' } ? 1 : 2; ❌
```

This now wraps the result in parentheses:

```ts
({ a: 'foo' }) + 1;
({ a: 'foo' }) && true;
({ a: 'foo' }) ? 1 : 2;
```

## Approach

Added `isAtExpressionStatementStart`, which walks up the "left edge" parents (`BinaryExpression.left`, `LogicalExpression.left`, `ConditionalExpression.test`, `SequenceExpression.expressions[0]`) until it reaches the `ExpressionStatement`. If any node along the chain is already parenthesized, the leading `{` is protected and no extra parentheses are added (so an already-parenthesized expression is not double-wrapped). `needsParens` in the fixer now uses this instead of only checking for a direct `ExpressionStatement` parent.

Note: member/call/tagged-template object-literal positions don't trigger this rule (the object literal keeps its fresh literal type there, so the assertion is *necessary*), so they are not reachable for the fixer and aren't included.

## Tests

Added invalid cases for the binary / logical / conditional / sequence left-edge positions, plus an already-parenthesized case asserting the fixer does not double-wrap.