### PR TITLE
fix: add "files" to rule-schema-to-typescript-types

### DIFF
--- a/packages/rule-schema-to-typescript-types/package.json
+++ b/packages/rule-schema-to-typescript-types/package.json
@@ -10,6 +10,10 @@
     },
     "./package.json": "./package.json"
   },
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
   "engines": {
     "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
   },


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The npm package has _all_ files, since `pnpm pack` includes all files when `"files"` isn't specified. 

https://www.npmjs.com/package/@typescript-eslint/rule-schema-to-typescript-types?activeTab=code

Instead, we should only include the `dist` files and omit the development stuff.