### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] parenthesize object literal at left edge of expression statement

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -23,27 +23,47 @@ import {
   NullThrowsReasons,
 } from '../util';
 
-function isAtExpressionStatementStart(
+function isAtExpressionStatementStart(node: TSESTree.Node): boolean {
+  let current: TSESTree.Node = node;
+  while (true) {
+    const { parent } = current;
+    if (parent == null) {
+      return false;
+    }
+    if (parent.range[0] !== current.range[0]) {
+      return false;
+    }
+    if (parent.type === AST_NODE_TYPES.ExpressionStatement) {
+      return true;
+    }
+    current = parent;
+  }
+}
+
+function isAtArrowFunctionBodyStart(
   node: TSESTree.Node,
   sourceCode: TSESLint.SourceCode,
 ): boolean {
   let current: TSESTree.Node = node;
-  while (
-    current.parent != null &&
-    current.parent.type !== AST_NODE_TYPES.ExpressionStatement
-  ) {
-    if (
-      isParenthesized(current, sourceCode) ||
-      current.parent.range[0] !== current.range[0]
-    ) {
+  while (true) {
+    if (isParenthesized(current, sourceCode)) {
       return false;
     }
-    current = current.parent;
+    const { parent } = current;
+    if (parent == null) {
+      return false;
+    }
+    if (
+      parent.type === AST_NODE_TYPES.ArrowFunctionExpression &&
+      parent.body === current
+    ) {
+      return true;
+    }
+    if (parent.range[0] !== current.range[0]) {
+      return false;
+    }
+    current = parent;
   }
-  return (
-    current.parent?.type === AST_NODE_TYPES.ExpressionStatement &&
-    !isParenthesized(current, sourceCode)
-  );
 }
 
 export type Options = [
@@ -818,22 +838,24 @@ export default createRule<Options, MessageIds>({
             NullThrowsReasons.MissingToken('>', 'type annotation'),
           );
           // Removing the angle brackets leaves the asserted operand at the
-          // assertion's position. If its first token is `{`, `function`, or
-          // `class` and the assertion is at the left edge of an expression
-          // statement (or is a concise arrow body), that token would lead the
-          // statement and be parsed as a block / function or class declaration.
-          // Wrap the operand in parentheses to keep it an expression.
-          const firstOperandToken =
-            context.sourceCode.getTokenAfter(closingAngleBracket);
+          // assertion's position, so its first token leads whatever the
+          // assertion led. A leading `{`/`function`/`class` at the start of an
+          // expression statement is parsed as a block / function or class
+          // declaration, and a leading `{` at the start of a concise arrow body
+          // is parsed as a block body. In those positions the operand must be
+          // wrapped in parentheses to stay an expression.
+          const firstOperandToken = nullThrows(
+            context.sourceCode.getTokenAfter(closingAngleBracket),
+            NullThrowsReasons.MissingToken('operand', 'type assertion'),
+          );
+          const breaksExpressionStatement =
+            ['{', 'function', 'class'].includes(firstOperandToken.value) &&
+            isAtExpressionStatementStart(node);
+          const breaksArrowFunctionBody =
+            firstOperandToken.value === '{' &&
+            isAtArrowFunctionBodyStart(node, context.sourceCode);
           const needsParens =
-            firstOperandToken != null &&
-            (firstOperandToken.value === '{' ||
-              firstOperandToken.value === 'function' ||
-              firstOperandToken.value === 'class') &&
-            ((node.parent.type === AST_NODE_TYPES.ArrowFunctionExpression &&
-              node.parent.body === node) ||
-              isAtExpressionStatementStart(node, context.sourceCode)) &&
-            !isParenthesized(node, context.sourceCode);
+            breaksExpressionStatement || breaksArrowFunctionBody;
 
           const fixes: RuleFix[] = [];
           if (needsParens) {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -817,18 +817,23 @@ export default createRule<Options, MessageIds>({
             ),
             NullThrowsReasons.MissingToken('>', 'type annotation'),
           );
-          // Removing the angle-bracketed type can leave a bare object
-          // literal in a position where `{` is parsed as a block (concise
-          // arrow body, or the left edge of an expression statement). Wrap the
-          // result in parentheses to preserve the original expression
-          // semantics.
+          // Removing the angle brackets leaves the asserted operand at the
+          // assertion's position. If its first token is `{`, `function`, or
+          // `class` and the assertion is at the left edge of an expression
+          // statement (or is a concise arrow body), that token would lead the
+          // statement and be parsed as a block / function or class declaration.
+          // Wrap the operand in parentheses to keep it an expression.
+          const firstOperandToken =
+            context.sourceCode.getTokenAfter(closingAngleBracket);
           const needsParens =
-            node.expression.type === AST_NODE_TYPES.ObjectExpression &&
+            firstOperandToken != null &&
+            (firstOperandToken.value === '{' ||
+              firstOperandToken.value === 'function' ||
+              firstOperandToken.value === 'class') &&
             ((node.parent.type === AST_NODE_TYPES.ArrowFunctionExpression &&
               node.parent.body === node) ||
               isAtExpressionStatementStart(node, context.sourceCode)) &&
-            !isParenthesized(node, context.sourceCode) &&
-            !isParenthesized(node.expression, context.sourceCode);
+            !isParenthesized(node, context.sourceCode);
 
           const fixes: RuleFix[] = [];
           if (needsParens) {

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -1,5 +1,5 @@
 import type { Scope } from '@typescript-eslint/scope-manager';
-import type { TSESTree } from '@typescript-eslint/utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import type {
   ReportFixFunction,
   RuleFix,
@@ -22,6 +22,29 @@ import {
   nullThrows,
   NullThrowsReasons,
 } from '../util';
+
+function isAtExpressionStatementStart(
+  node: TSESTree.Node,
+  sourceCode: TSESLint.SourceCode,
+): boolean {
+  let current: TSESTree.Node = node;
+  while (
+    current.parent != null &&
+    current.parent.type !== AST_NODE_TYPES.ExpressionStatement
+  ) {
+    if (
+      isParenthesized(current, sourceCode) ||
+      current.parent.range[0] !== current.range[0]
+    ) {
+      return false;
+    }
+    current = current.parent;
+  }
+  return (
+    current.parent?.type === AST_NODE_TYPES.ExpressionStatement &&
+    !isParenthesized(current, sourceCode)
+  );
+}
 
 export type Options = [
   {
@@ -796,14 +819,14 @@ export default createRule<Options, MessageIds>({
           );
           // Removing the angle-bracketed type can leave a bare object
           // literal in a position where `{` is parsed as a block (concise
-          // arrow body, or the start of an expression statement). Wrap the
+          // arrow body, or the left edge of an expression statement). Wrap the
           // result in parentheses to preserve the original expression
           // semantics.
           const needsParens =
             node.expression.type === AST_NODE_TYPES.ObjectExpression &&
             ((node.parent.type === AST_NODE_TYPES.ArrowFunctionExpression &&
               node.parent.body === node) ||
-              node.parent.type === AST_NODE_TYPES.ExpressionStatement) &&
+              isAtExpressionStatementStart(node, context.sourceCode)) &&
             !isParenthesized(node, context.sourceCode) &&
             !isParenthesized(node.expression, context.sourceCode);
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2706,5 +2706,96 @@ fn1(() => {
       ],
       output: `({ a: 'foo' });`,
     },
+    {
+      code: "<{ a: string }>{ a: 'foo' } + 1;",
+      errors: [
+        {
+          column: 1,
+          endColumn: 28,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: "({ a: 'foo' }) + 1;",
+    },
+    {
+      code: "<{ a: string }>{ a: 'foo' } && true;",
+      errors: [
+        {
+          column: 1,
+          endColumn: 28,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: "({ a: 'foo' }) && true;",
+    },
+    {
+      code: "<{ a: string }>{ a: 'foo' } ? 1 : 2;",
+      errors: [
+        {
+          column: 1,
+          endColumn: 28,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: "({ a: 'foo' }) ? 1 : 2;",
+    },
+    {
+      code: "<{ a: string }>{ a: 'foo' }, foo();",
+      errors: [
+        {
+          column: 1,
+          endColumn: 28,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: "({ a: 'foo' }), foo();",
+    },
+    {
+      code: "<{ a: string }>{ a: 'foo' } + 1 + 2;",
+      errors: [
+        {
+          column: 1,
+          endColumn: 28,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: "({ a: 'foo' }) + 1 + 2;",
+    },
+    {
+      code: "(<{ a: string }>{ a: 'foo' }, 1);",
+      errors: [
+        {
+          column: 2,
+          endColumn: 29,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: "({ a: 'foo' }, 1);",
+    },
+    {
+      code: "1 + <{ a: string }>{ a: 'foo' };",
+      errors: [
+        {
+          column: 5,
+          endColumn: 32,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: "1 + { a: 'foo' };",
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2839,5 +2839,18 @@ fn1(() => {
       ],
       output: '(class Clazz {}.length);',
     },
+    {
+      code: 'const foo = () => <number>{ lol: 123 as number }.lol + 54321;',
+      errors: [
+        {
+          column: 19,
+          endColumn: 53,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: 'const foo = () => ({ lol: 123 as number }.lol) + 54321;',
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2797,5 +2797,47 @@ fn1(() => {
       ],
       output: "1 + { a: 'foo' };",
     },
+    // The assertion binds looser than member access, so its operand can be a
+    // member expression whose leading token is `{`, `function`, or `class` —
+    // each of which leads the statement after the fix and must be wrapped.
+    {
+      code: '<number>{ lol: 32 as number }.lol;',
+      errors: [
+        {
+          column: 1,
+          endColumn: 34,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: '({ lol: 32 as number }.lol);',
+    },
+    {
+      code: '<number>function Fun() {}.length;',
+      errors: [
+        {
+          column: 1,
+          endColumn: 33,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: '(function Fun() {}.length);',
+    },
+    {
+      code: '<number>class Clazz {}.length;',
+      errors: [
+        {
+          column: 1,
+          endColumn: 30,
+          endLine: 1,
+          line: 1,
+          messageId: 'unnecessaryAssertion',
+        },
+      ],
+      output: '(class Clazz {}.length);',
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2746,7 +2746,7 @@ fn1(() => {
       output: "({ a: 'foo' }) ? 1 : 2;",
     },
     {
-      code: "<{ a: string }>{ a: 'foo' }, foo();",
+      code: noFormat`<{ a: string }>{ a: 'foo' }, foo();`,
       errors: [
         {
           column: 1,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12418
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Follow-up to #12394. When a `<T>{ ... }` assertion is at the left edge of a larger expression statement, removing the `<...>` left a leading `{` that is parsed as a block (or silently changed semantics):

```ts
<{ a: number }>{ a: 1 } + 1;    // { a: 1 } + 1;
<{ a: number }>{ a: 1 }, foo();    // { a: 1 }, foo();
```
Replaced the direct ExpressionStatement parent check with an `isAtExpressionStatementStart` helper that walks up the ancestors keeping the node as the statement's leading token, so the fixer wraps the object literal in parens in these positions too (binary, logical, conditional, sequence, and nested). A leading keyword like new stops the walk, and an already-parenthesized ancestor isn't double wrapped.
