### PR TITLE
feat: remove redundant package.json "files"

### DIFF
--- a/packages/ast-spec/package.json
+++ b/packages/ast-spec/package.json
@@ -13,10 +13,7 @@
   },
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "package.json",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "repository": {
     "type": "git",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -7,10 +7,7 @@
     "!**/*.tsbuildinfo",
     "index.d.ts",
     "raw-plugin.d.ts",
-    "rules.d.ts",
-    "package.json",
-    "./README.md",
-    "LICENSE"
+    "rules.d.ts"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -4,9 +4,7 @@
   "description": "An ESLint custom parser which leverages TypeScript ESTree",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/project-service/package.json
+++ b/packages/project-service/package.json
@@ -4,10 +4,7 @@
   "description": "Standalone TypeScript project service wrapper for linting.",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "package.json",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -4,9 +4,7 @@
   "description": "Tooling to test ESLint rules",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/scope-manager/package.json
+++ b/packages/scope-manager/package.json
@@ -4,10 +4,7 @@
   "description": "TypeScript scope analyser for ESLint",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "package.json",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/tsconfig-utils/package.json
+++ b/packages/tsconfig-utils/package.json
@@ -4,10 +4,7 @@
   "description": "Utilities for collecting TSConfigs for linting scenarios.",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "package.json",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -4,10 +4,7 @@
   "description": "Type utilities for working with TypeScript + ESLint together",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "package.json",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,10 +4,7 @@
   "description": "Types for the TypeScript-ESTree AST spec",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "package.json",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/typescript-eslint/package.json
+++ b/packages/typescript-eslint/package.json
@@ -4,9 +4,7 @@
   "description": "Tooling which enables you to use TypeScript with ESLint",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/typescript-estree/package.json
+++ b/packages/typescript-estree/package.json
@@ -4,9 +4,7 @@
   "description": "A parser that converts TypeScript source code into an ESTree compatible form",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,10 +4,7 @@
   "description": "Utilities for working with TypeScript + ESLint together",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "package.json",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {

--- a/packages/visitor-keys/package.json
+++ b/packages/visitor-keys/package.json
@@ -4,10 +4,7 @@
   "description": "Visitor keys used to help traverse the TypeScript-ESTree AST",
   "files": [
     "dist",
-    "!**/*.tsbuildinfo",
-    "package.json",
-    "README.md",
-    "LICENSE"
+    "!**/*.tsbuildinfo"
   ],
   "type": "commonjs",
   "exports": {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

following up to https://github.com/typescript-eslint/typescript-eslint/pull/12441#issuecomment-4763743757, these _should_ all be redundant ([see also npm docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files)), so we might as well remove them.