### PR TITLE
chore: replace yargs with Node.js built-in parseArgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@types/natural-compare": "catalog:",
     "@types/node": "catalog:",
     "@types/semver": "^7.7.1",
-    "@types/yargs": "^17.0.35",
     "@typescript-eslint/eslint-plugin": "workspace:^",
     "@typescript-eslint/eslint-plugin-internal": "workspace:^",
     "@typescript-eslint/parser": "workspace:^",
@@ -105,8 +104,7 @@
     "typescript": "catalog:",
     "typescript-eslint": "workspace:^",
     "vite": "7.3.0",
-    "vitest": "catalog:",
-    "yargs": "17.7.2"
+    "vitest": "catalog:"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "nx": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,9 +122,6 @@ importers:
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
-      '@types/yargs':
-        specifier: ^17.0.35
-        version: 17.0.35
       '@typescript-eslint/eslint-plugin':
         specifier: workspace:^
         version: link:packages/eslint-plugin
@@ -239,9 +236,6 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(vite@7.3.0(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.31.1)(terser@5.39.2)(tsx@4.22.3)(yaml@2.9.0))
-      yargs:
-        specifier: 17.7.2
-        version: 17.7.2
 
   packages/ast-spec:
     devDependencies:

--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -28,7 +28,7 @@ const optionDescriptions = {
   verbose: 'Whether or not to enable verbose logging, defaults to false',
   version:
     'Explicit version specifier to use, if overriding conventional commits',
-};
+} satisfies Record<keyof typeof parseArgsOptions, string>
 
 const parseArgsOptions = {
   'dry-run': {
@@ -55,7 +55,7 @@ const parseArgsOptions = {
   version: {
     type: 'string',
   },
-} as const;
+} satisfies ParseArgsOptionsConfig;;
 
 function printHelp(): void {
   console.log('Options:');
@@ -72,7 +72,7 @@ function printHelp(): void {
   }
 }
 
-const { values } = parseArgs({
+const { values: rawOptions } = parseArgs({
   args: process.argv.slice(2),
   options: parseArgsOptions,
 });

--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -12,6 +12,17 @@ if (process.env.CI !== 'true') {
   );
 }
 
+function booleanOption(value: string): boolean {
+  const normalizedValue = value.toLowerCase().trim();
+  const allowedValues = ['', 'true', 'false'];
+
+  if (!allowedValues.includes(normalizedValue)) {
+    throw new Error(`Invalid boolean value: "${value}"`);
+  }
+
+  return normalizedValue !== 'false';
+}
+
 const { values } = parseArgs({
   args: process.argv.slice(2),
   options: {
@@ -44,10 +55,11 @@ const { values } = parseArgs({
 });
 
 const options = {
-  dryRun: values['dry-run'] === 'true',
-  firstRelease: values['first-release'] === 'true',
-  forceReleaseWithoutChanges:
-    values['force-release-without-changes'] === 'true',
+  dryRun: booleanOption(values['dry-run']),
+  firstRelease: booleanOption(values['first-release']),
+  forceReleaseWithoutChanges: booleanOption(
+    values['force-release-without-changes'],
+  ),
   verbose: values.verbose,
   version: values.version,
 };

--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -1,3 +1,5 @@
+import type { ParseArgsConfig } from 'node:util';
+
 import { execaSync } from 'execa';
 import { parseArgs } from 'node:util';
 import {
@@ -16,19 +18,6 @@ function booleanOption(value: string): boolean {
 
   return normalizedValue !== 'false';
 }
-
-const optionDescriptions = {
-  'dry-run':
-    'Whether to perform a dry-run of the release process, defaults to true',
-  'first-release':
-    'Whether or not one of more of the packages are being released for the first time',
-  'force-release-without-changes':
-    'Whether to do a release regardless of if there have been changes',
-  help: 'Show help',
-  verbose: 'Whether or not to enable verbose logging, defaults to false',
-  version:
-    'Explicit version specifier to use, if overriding conventional commits',
-} satisfies Record<keyof typeof parseArgsOptions, string>
 
 const parseArgsOptions = {
   'dry-run': {
@@ -55,7 +44,20 @@ const parseArgsOptions = {
   version: {
     type: 'string',
   },
-} satisfies ParseArgsOptionsConfig;;
+} as const satisfies ParseArgsConfig['options'];
+
+const optionDescriptions: Record<keyof typeof parseArgsOptions, string> = {
+  'dry-run':
+    'Whether to perform a dry-run of the release process, defaults to true',
+  'first-release':
+    'Whether or not one of more of the packages are being released for the first time',
+  'force-release-without-changes':
+    'Whether to do a release regardless of if there have been changes',
+  help: 'Show help',
+  verbose: 'Whether or not to enable verbose logging, defaults to false',
+  version:
+    'Explicit version specifier to use, if overriding conventional commits',
+};
 
 function printHelp(): void {
   console.log('Options:');
@@ -77,20 +79,20 @@ const { values: rawOptions } = parseArgs({
   options: parseArgsOptions,
 });
 
-if (values.help) {
+if (rawOptions.help) {
   printHelp();
   // eslint-disable-next-line no-process-exit
   process.exit(0);
 }
 
 const options = {
-  dryRun: booleanOption(values['dry-run']),
-  firstRelease: booleanOption(values['first-release']),
+  dryRun: booleanOption(rawOptions['dry-run']),
+  firstRelease: booleanOption(rawOptions['first-release']),
   forceReleaseWithoutChanges: booleanOption(
-    values['force-release-without-changes'],
+    rawOptions['force-release-without-changes'],
   ),
-  verbose: values.verbose,
-  version: values.version,
+  verbose: rawOptions.verbose,
+  version: rawOptions.version,
 };
 
 if (process.env.CI !== 'true' && !options.dryRun) {

--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -12,31 +12,45 @@ if (process.env.CI !== 'true') {
   );
 }
 
-const { values: options } = parseArgs({
+const { values } = parseArgs({
   args: process.argv.slice(2),
   options: {
-    dryRun: {
-      default: true,
+    // Whether to perform a dry-run of the release process, defaults to true
+    'dry-run': {
+      default: 'true',
       short: 'd',
-      type: 'boolean',
+      type: 'string',
     },
-    firstRelease: {
-      default: false,
-      type: 'boolean',
+    // Whether or not one of more of the packages are being released for the first time
+    'first-release': {
+      default: 'false',
+      type: 'string',
     },
-    forceReleaseWithoutChanges: {
-      default: false,
-      type: 'boolean',
+    // Whether to do a release regardless of if there have been changes
+    'force-release-without-changes': {
+      default: 'false',
+      type: 'string',
     },
+    // Whether or not to enable verbose logging, defaults to false
     verbose: {
       default: false,
       type: 'boolean',
     },
+    // Explicit version specifier to use, if overriding conventional commits
     version: {
       type: 'string',
     },
   },
 });
+
+const options = {
+  dryRun: values['dry-run'] === 'true',
+  firstRelease: values['first-release'] === 'true',
+  forceReleaseWithoutChanges:
+    values['force-release-without-changes'] === 'true',
+  verbose: values.verbose,
+  version: values.version,
+};
 
 const { projectsVersionData, workspaceVersion } = await releaseVersion({
   specifier: options.version,

--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -17,36 +17,71 @@ function booleanOption(value: string): boolean {
   return normalizedValue !== 'false';
 }
 
+const optionDescriptions = {
+  'dry-run':
+    'Whether to perform a dry-run of the release process, defaults to true',
+  'first-release':
+    'Whether or not one of more of the packages are being released for the first time',
+  'force-release-without-changes':
+    'Whether to do a release regardless of if there have been changes',
+  help: 'Show help',
+  verbose: 'Whether or not to enable verbose logging, defaults to false',
+  version:
+    'Explicit version specifier to use, if overriding conventional commits',
+};
+
+const parseArgsOptions = {
+  'dry-run': {
+    default: 'true',
+    short: 'd',
+    type: 'string',
+  },
+  'first-release': {
+    default: 'false',
+    type: 'string',
+  },
+  'force-release-without-changes': {
+    default: 'false',
+    type: 'string',
+  },
+  help: {
+    default: false,
+    type: 'boolean',
+  },
+  verbose: {
+    default: false,
+    type: 'boolean',
+  },
+  version: {
+    type: 'string',
+  },
+} as const;
+
+function printHelp(): void {
+  console.log('Options:');
+  for (const [name, config] of Object.entries(parseArgsOptions)) {
+    const short = 'short' in config ? `-${config.short}, ` : '    ';
+    const defaultStr =
+      'default' in config ? ` [default: ${String(config.default)}]` : '';
+    const description =
+      optionDescriptions[name as keyof typeof optionDescriptions];
+
+    console.log(
+      `  ${short}--${name.padEnd(35)} ${description} [${config.type}]${defaultStr}`,
+    );
+  }
+}
+
 const { values } = parseArgs({
   args: process.argv.slice(2),
-  options: {
-    // Whether to perform a dry-run of the release process, defaults to true
-    'dry-run': {
-      default: 'true',
-      short: 'd',
-      type: 'string',
-    },
-    // Whether or not one of more of the packages are being released for the first time
-    'first-release': {
-      default: 'false',
-      type: 'string',
-    },
-    // Whether to do a release regardless of if there have been changes
-    'force-release-without-changes': {
-      default: 'false',
-      type: 'string',
-    },
-    // Whether or not to enable verbose logging, defaults to false
-    verbose: {
-      default: false,
-      type: 'boolean',
-    },
-    // Explicit version specifier to use, if overriding conventional commits
-    version: {
-      type: 'string',
-    },
-  },
+  options: parseArgsOptions,
 });
+
+if (values.help) {
+  printHelp();
+  // eslint-disable-next-line no-process-exit
+  process.exit(0);
+}
 
 const options = {
   dryRun: booleanOption(values['dry-run']),

--- a/tools/release/release.mts
+++ b/tools/release/release.mts
@@ -1,10 +1,10 @@
 import { execaSync } from 'execa';
+import { parseArgs } from 'node:util';
 import {
   releaseChangelog,
   releasePublish,
   releaseVersion,
 } from 'nx/release/index.js';
-import yargs from 'yargs';
 
 if (process.env.CI !== 'true') {
   throw new Error(
@@ -12,38 +12,31 @@ if (process.env.CI !== 'true') {
   );
 }
 
-const options = await yargs(process.argv.slice(2))
-  .version(false)
-  .option('version', {
-    description:
-      'Explicit version specifier to use, if overriding conventional commits',
-    type: 'string',
-  })
-  .option('dryRun', {
-    alias: 'd',
-    default: true,
-    description:
-      'Whether to perform a dry-run of the release process, defaults to true',
-    type: 'boolean',
-  })
-  .option('forceReleaseWithoutChanges', {
-    default: false,
-    description:
-      'Whether to do a release regardless of if there have been changes',
-    type: 'boolean',
-  })
-  .option('verbose', {
-    default: false,
-    description: 'Whether or not to enable verbose logging, defaults to false',
-    type: 'boolean',
-  })
-  .option('firstRelease', {
-    default: false,
-    description:
-      'Whether or not one of more of the packages are being released for the first time',
-    type: 'boolean',
-  })
-  .parseAsync();
+const { values: options } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    dryRun: {
+      default: true,
+      short: 'd',
+      type: 'boolean',
+    },
+    firstRelease: {
+      default: false,
+      type: 'boolean',
+    },
+    forceReleaseWithoutChanges: {
+      default: false,
+      type: 'boolean',
+    },
+    verbose: {
+      default: false,
+      type: 'boolean',
+    },
+    version: {
+      type: 'string',
+    },
+  },
+});
 
 const { projectsVersionData, workspaceVersion } = await releaseVersion({
   specifier: options.version,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12431 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

- Remove yargs dev dependency
- Replace yargs with builtin `util.parseArgs` in release script

:octocat: 