### PR TITLE
docs: mention AI policy in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
@@ -20,6 +20,10 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: input
     id: playground-link
     attributes:

--- a/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report-plugin.yaml
@@ -20,10 +20,8 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
-  - type: markdown
-    attributes:
-      value: |
-        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+        - label: If I used AI assistance to prepare this issue, I have reviewed and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+          required: true
   - type: input
     id: playground-link
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-enhancement-rule-option.yaml
+++ b/.github/ISSUE_TEMPLATE/02-enhancement-rule-option.yaml
@@ -18,10 +18,8 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
-  - type: markdown
-    attributes:
-      value: |
-        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+        - label: If I used AI assistance to prepare this issue, I have reviewed and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+          required: true
   - type: checkboxes
     id: rule-fits-the-brief
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-enhancement-rule-option.yaml
+++ b/.github/ISSUE_TEMPLATE/02-enhancement-rule-option.yaml
@@ -18,6 +18,10 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: checkboxes
     id: rule-fits-the-brief
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-enhancement-new-rule.yaml
+++ b/.github/ISSUE_TEMPLATE/03-enhancement-new-rule.yaml
@@ -18,10 +18,8 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
-  - type: markdown
-    attributes:
-      value: |
-        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+        - label: If I used AI assistance to prepare this issue, I have reviewed and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+          required: true
   - type: checkboxes
     id: rule-fits-the-brief
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-enhancement-new-rule.yaml
+++ b/.github/ISSUE_TEMPLATE/03-enhancement-new-rule.yaml
@@ -18,6 +18,10 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: checkboxes
     id: rule-fits-the-brief
     attributes:

--- a/.github/ISSUE_TEMPLATE/04-enhancement-new-base-rule-extension.yaml
+++ b/.github/ISSUE_TEMPLATE/04-enhancement-new-base-rule-extension.yaml
@@ -25,6 +25,10 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: checkboxes
     id: rule-fits-the-brief
     attributes:

--- a/.github/ISSUE_TEMPLATE/04-enhancement-new-base-rule-extension.yaml
+++ b/.github/ISSUE_TEMPLATE/04-enhancement-new-base-rule-extension.yaml
@@ -25,10 +25,8 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
-  - type: markdown
-    attributes:
-      value: |
-        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+        - label: If I used AI assistance to prepare this issue, I have reviewed and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+          required: true
   - type: checkboxes
     id: rule-fits-the-brief
     attributes:

--- a/.github/ISSUE_TEMPLATE/05-documentation-request.yml
+++ b/.github/ISSUE_TEMPLATE/05-documentation-request.yml
@@ -14,10 +14,8 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
-  - type: markdown
-    attributes:
-      value: |
-        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+        - label: If I used AI assistance to prepare this issue, I have reviewed and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+          required: true
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/05-documentation-request.yml
+++ b/.github/ISSUE_TEMPLATE/05-documentation-request.yml
@@ -17,6 +17,10 @@ body:
   - type: markdown
     attributes:
       value: |
+        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+  - type: markdown
+    attributes:
+      value: |
         If your request is for help, not documentation, please ask on [StackOverflow](https://stackoverflow.com/questions/tagged/typescript-eslint)
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
+++ b/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
@@ -19,10 +19,8 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
-  - type: markdown
-    attributes:
-      value: |
-        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+        - label: If I used AI assistance to prepare this issue, I have reviewed and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+          required: true
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
+++ b/.github/ISSUE_TEMPLATE/06-bug-report-other.yaml
@@ -22,6 +22,10 @@ body:
   - type: markdown
     attributes:
       value: |
+        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+  - type: markdown
+    attributes:
+      value: |
         **All typescript-eslint bug reports need an isolated reproduction** we can clone locally and get running without other projects or existing knowledge of your project.
         If you can't provide one, your report will likely be closed without action.
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
+++ b/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
@@ -17,10 +17,8 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
-  - type: markdown
-    attributes:
-      value: |
-        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+        - label: If I used AI assistance to prepare this issue, I have reviewed and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+          required: true
   - type: dropdown
     id: package
     attributes:

--- a/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
+++ b/.github/ISSUE_TEMPLATE/07-enhancement-other.yaml
@@ -17,6 +17,10 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: dropdown
     id: package
     attributes:

--- a/.github/ISSUE_TEMPLATE/08-bug-report-complex.yaml
+++ b/.github/ISSUE_TEMPLATE/08-bug-report-complex.yaml
@@ -23,10 +23,8 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
-  - type: markdown
-    attributes:
-      value: |
-        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+        - label: If I used AI assistance to prepare this issue, I have reviewed and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+          required: true
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/08-bug-report-complex.yaml
+++ b/.github/ISSUE_TEMPLATE/08-bug-report-complex.yaml
@@ -23,6 +23,10 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/09-config-change.yaml
+++ b/.github/ISSUE_TEMPLATE/09-config-change.yaml
@@ -16,10 +16,8 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
-  - type: markdown
-    attributes:
-      value: |
-        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+        - label: If I used AI assistance to prepare this issue, I have reviewed and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+          required: true
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/09-config-change.yaml
+++ b/.github/ISSUE_TEMPLATE/09-config-change.yaml
@@ -16,6 +16,10 @@ body:
           required: true
         - label: I have [read the FAQ](https://typescript-eslint.io/linting/troubleshooting) and my problem is not listed.
           required: true
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/10-repo-maintenance.yaml
+++ b/.github/ISSUE_TEMPLATE/10-repo-maintenance.yaml
@@ -9,6 +9,10 @@ body:
     attributes:
       value: |
         This issue form is specifically for work done in this repository. Only use it if you are suggesting a change to repository tooling. Don't use it for work in any other repository.
+  - type: markdown
+    attributes:
+      value: |
+        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
   - type: textarea
     attributes:
       label: Suggestion

--- a/.github/ISSUE_TEMPLATE/10-repo-maintenance.yaml
+++ b/.github/ISSUE_TEMPLATE/10-repo-maintenance.yaml
@@ -9,10 +9,13 @@ body:
     attributes:
       value: |
         This issue form is specifically for work done in this repository. Only use it if you are suggesting a change to repository tooling. Don't use it for work in any other repository.
-  - type: markdown
+  - type: checkboxes
+    id: ai-policy
     attributes:
-      value: |
-        If you used AI assistance to prepare this issue, please review and follow the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+      label: AI Assistance
+      options:
+        - label: If I used AI assistance to prepare this issue, I have reviewed and followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/).
+          required: true
   - type: textarea
     attributes:
       label: Suggestion

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ Otherwise we may not be able to review your PR.
 - [ ] Addresses an existing open issue: fixes #000
 - [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
 - [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
+- [ ] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)
 
 ## Overview
 


### PR DESCRIPTION
﻿## PR Checklist

- [x] Addresses an existing open issue: fixes #12414
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

This follows #12414 by adding a short AI policy reminder to the issue and PR templates, so contributors see the rule before opening a new thread.

I used AI assistance for this small template edit and reviewed the result against the project policy.

I checked the change with `git diff --check` and `npx --yes prettier --check .github/pull_request_template.md .github/ISSUE_TEMPLATE/*.yml .github/ISSUE_TEMPLATE/*.yaml`.
