### PR TITLE
docs(eslint-plugin): clarify checkTypePredicates option

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
+++ b/packages/eslint-plugin/docs/rules/no-unnecessary-condition.mdx
@@ -155,7 +155,9 @@ while (thisIsTrue) {
 
 ### `checkTypePredicates`
 
-{/* insert option description */}
+When `true`, this option also checks conditions involving TypeScript type predicates (`value is T`) and assertion signatures (`asserts value is T`).
+
+This option assumes that type predicates and assertion functions are implemented correctly. Like TypeScript itself, this rule trusts their declared types and does not verify that their runtime implementation matches those declarations.
 
 Example of additional incorrect code with `{ checkTypePredicates: true }`:
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #12356
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

## Description

Adds documentation for the `checkTypePredicates` option of the `no-unnecessary-condition` rule.

The new documentation explains that the option checks TypeScript type predicates and assertion signatures, and clarifies that the rule assumes those predicates are implemented correctly, matching TypeScript's behavior.

Closes #12356
