### PR TITLE
fix(scope-manager): export ClassStaticBlockScope

### DIFF
--- a/packages/scope-manager/src/scope/index.ts
+++ b/packages/scope-manager/src/scope/index.ts
@@ -2,6 +2,7 @@ export * from './BlockScope';
 export * from './CatchScope';
 export * from './ClassFieldInitializerScope';
 export * from './ClassScope';
+export * from './ClassStaticBlockScope';
 export * from './ConditionalTypeScope';
 export * from './ForScope';
 export * from './FunctionExpressionNameScope';


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12459
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`ClassStaticBlockScope` was part of the internal scope model but missing from the public `@typescript-eslint/scope-manager` barrel export

 This PR exports it and adds a regression test to ensure it can be imported from the package entrypoint