### PR TITLE
docs(eslint-plugin): [ban-ts-comment] fix wording of directive option descriptions

### DIFF
--- a/packages/eslint-plugin/src/rules/ban-ts-comment.ts
+++ b/packages/eslint-plugin/src/rules/ban-ts-comment.ts
@@ -92,22 +92,22 @@ export default createRule<Options, MessageIds>({
           'ts-check': {
             $ref: '#/items/0/$defs/directiveConfigSchema',
             description:
-              'Whether allow ts-check directives, and with which restrictions.',
+              'Whether to allow ts-check directives, and with which restrictions.',
           },
           'ts-expect-error': {
             $ref: '#/items/0/$defs/directiveConfigSchema',
             description:
-              'Whether and when expect-error directives, and with which restrictions.',
+              'Whether to allow ts-expect-error directives, and with which restrictions.',
           },
           'ts-ignore': {
             $ref: '#/items/0/$defs/directiveConfigSchema',
             description:
-              'Whether allow ts-ignore directives, and with which restrictions.',
+              'Whether to allow ts-ignore directives, and with which restrictions.',
           },
           'ts-nocheck': {
             $ref: '#/items/0/$defs/directiveConfigSchema',
             description:
-              'Whether allow ts-nocheck directives, and with which restrictions.',
+              'Whether to allow ts-nocheck directives, and with which restrictions.',
           },
         },
       },

--- a/packages/eslint-plugin/tests/schema-snapshots/ban-ts-comment.shot
+++ b/packages/eslint-plugin/tests/schema-snapshots/ban-ts-comment.shot
@@ -34,19 +34,19 @@
       },
       "ts-check": {
         "$ref": "#/items/0/$defs/directiveConfigSchema",
-        "description": "Whether allow ts-check directives, and with which restrictions."
+        "description": "Whether to allow ts-check directives, and with which restrictions."
       },
       "ts-expect-error": {
         "$ref": "#/items/0/$defs/directiveConfigSchema",
-        "description": "Whether and when expect-error directives, and with which restrictions."
+        "description": "Whether to allow ts-expect-error directives, and with which restrictions."
       },
       "ts-ignore": {
         "$ref": "#/items/0/$defs/directiveConfigSchema",
-        "description": "Whether allow ts-ignore directives, and with which restrictions."
+        "description": "Whether to allow ts-ignore directives, and with which restrictions."
       },
       "ts-nocheck": {
         "$ref": "#/items/0/$defs/directiveConfigSchema",
-        "description": "Whether allow ts-nocheck directives, and with which restrictions."
+        "description": "Whether to allow ts-nocheck directives, and with which restrictions."
       }
     },
     "type": "object"
@@ -65,13 +65,13 @@ type DirectiveConfigSchema =
 
 type Options = [
   {
-    /** Whether allow ts-check directives, and with which restrictions. */
+    /** Whether to allow ts-check directives, and with which restrictions. */
     'ts-check'?: DirectiveConfigSchema;
-    /** Whether and when expect-error directives, and with which restrictions. */
+    /** Whether to allow ts-expect-error directives, and with which restrictions. */
     'ts-expect-error'?: DirectiveConfigSchema;
-    /** Whether allow ts-ignore directives, and with which restrictions. */
+    /** Whether to allow ts-ignore directives, and with which restrictions. */
     'ts-ignore'?: DirectiveConfigSchema;
-    /** Whether allow ts-nocheck directives, and with which restrictions. */
+    /** Whether to allow ts-nocheck directives, and with which restrictions. */
     'ts-nocheck'?: DirectiveConfigSchema;
     /** A minimum character length for descriptions when `allow-with-description` is enabled. */
     minimumDescriptionLength?: number;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12464
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Fixes the schema `description` wording for the directive options of `ban-ts-comment`, which are surfaced both in the auto-generated Options section of the rule's docs page and as tooltips in editor autocomplete

The `ts-expect-error` description was broken in two ways:
- the verb `allow` was missing (`"Whether and when expect-error directives, …"` isn't a grammatical sentence), and
- the `ts-` prefix was missing (`expect-error` instead of `ts-expect-error`), unlike its three siblings

Per @kirkwaiblinger's review note on the issue, I fixed the ungrammatical `"Whether allow …"` on the other three options at the same time so all 4 are now consistent and grammatical:

| | Before | After |
| --- | --- | --- |
| `ts-check` | `Whether allow ts-check directives, and with which restrictions.` | `Whether to allow ts-check directives, and with which restrictions.` |
| `ts-expect-error` | `Whether and when expect-error directives, and with which restrictions.` | `Whether to allow ts-expect-error directives, and with which restrictions.` |
| `ts-ignore` | `Whether allow ts-ignore directives, and with which restrictions.` | `Whether to allow ts-ignore directives, and with which restrictions.` |
| `ts-nocheck` | `Whether allow ts-nocheck directives, and with which restrictions.` | `Whether to allow ts-nocheck directives, and with which restrictions.` |

The `ban-ts-comment` schema snapshot was regenerated (`vitest -u`) to match; the docs page's Options section is generated from the schema at build time, so no static docs file needed editing


