### PR TITLE
docs(eslint-plugin): clarify recursive allowArray checks

### DIFF
--- a/packages/eslint-plugin/docs/rules/restrict-template-expressions.mdx
+++ b/packages/eslint-plugin/docs/rules/restrict-template-expressions.mdx
@@ -137,6 +137,9 @@ const msg1 = typeof arg === 'string' ? arg : `arg = ${arg}`;
 
 {/* insert option description */}
 
+This option recursively checks array element types.
+For example, `string[]` and `string[][]` are allowed, but `object[]` is still reported.
+
 Examples of additional **correct** code for this rule with `{ allowArray: true }`:
 
 ```ts option='{ "allowArray": true }' showPlaygroundButton

--- a/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
@@ -168,6 +168,13 @@ ruleTester.run('restrict-template-expressions', rule, {
     },
     {
       code: `
+        declare const arg: string[][];
+        const msg = \`arg = \${arg}\`;
+      `,
+      options: [{ allowArray: true }],
+    },
+    {
+      code: `
         declare const arg: [number | undefined, string];
         const msg = \`arg = \${arg}\`;
       `,
@@ -512,6 +519,21 @@ ruleTester.run('restrict-template-expressions', rule, {
         },
       ],
       options: [{ allowArray: true, allowNullish: false }],
+    },
+    {
+      code: `
+        declare const arg: object[];
+        const msg = \`arg = \${arg}\`;
+      `,
+      errors: [
+        {
+          column: 30,
+          data: { type: 'object[]' },
+          line: 3,
+          messageId: 'invalidType',
+        },
+      ],
+      options: [{ allowArray: true }],
     },
     {
       code: 'const msg = `arg = ${Promise.resolve()}`;',


### PR DESCRIPTION
## Summary

- Clarifies that `restrict-template-expressions`'s `allowArray` option recursively checks array element types.
- Adds regression coverage for a nested string array being allowed and an object array still being reported.

Fixes #12466

## Testing

- `corepack pnpm nx test eslint-plugin -- restrict-template-expressions`
- `corepack pnpm exec prettier --check packages/eslint-plugin/docs/rules/restrict-template-expressions.mdx packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts`
- `corepack pnpm exec eslint packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts`
- `git diff --check`

## Notes

AI-assisted with Codex. I reviewed the diff and the linked issue before opening this PR.
