### PR TITLE
docs(eslint-plugin): [no-base-to-string] correct documented default for ignoredTypeNames

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
+++ b/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
@@ -87,7 +87,7 @@ const errorMessage = 'Found unexpected value: ' + JSON.stringify(o);
 This is useful for types missing `toString()` or `toLocaleString()` (but actually has `toString()` or `toLocaleString()`).
 There are some types missing `toString()` or `toLocaleString()` in old versions of TypeScript, like `RegExp`, `URL`, `URLSearchParams` etc.
 
-The following patterns are considered correct with the default options `{ ignoredTypeNames: ["RegExp"] }`:
+The following patterns are considered correct with the options `{ ignoredTypeNames: ["RegExp"] }`:
 
 ```ts option='{ "ignoredTypeNames": ["RegExp"] }' showPlaygroundButton
 `${/regex/}`;

--- a/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
+++ b/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
@@ -87,9 +87,9 @@ const errorMessage = 'Found unexpected value: ' + JSON.stringify(o);
 This is useful for types missing `toString()` or `toLocaleString()` (but actually has `toString()` or `toLocaleString()`).
 There are some types missing `toString()` or `toLocaleString()` in old versions of TypeScript, like `RegExp`, `URL`, `URLSearchParams` etc.
 
-The following patterns are considered correct with the options `{ ignoredTypeNames: ["RegExp"] }`:
+The following patterns are considered correct with the default options:
 
-```ts option='{ "ignoredTypeNames": ["RegExp"] }' showPlaygroundButton
+```ts showPlaygroundButton
 `${/regex/}`;
 '' + /regex/;
 /regex/.toString();
@@ -97,6 +97,10 @@ let value = /regex/;
 value.toString();
 let text = `${value}`;
 String(/regex/);
+
+'' + new Error('error');
+`${new URL('https://example.com')}`;
+String(new URLSearchParams({ key: 'value' }));
 ```
 
 ### `checkUnknown`

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-base-to-string.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-base-to-string.shot
@@ -47,7 +47,7 @@ const literalWithToString = {
 
 `Value: ${literalWithToString}`;
 
-Options: { "ignoredTypeNames": ["RegExp"] }
+
 
 `${/regex/}`;
 '' + /regex/;
@@ -56,6 +56,10 @@ let value = /regex/;
 value.toString();
 let text = `${value}`;
 String(/regex/);
+
+'' + new Error('error');
+`${new URL('https://example.com')}`;
+String(new URLSearchParams({ key: 'value' }));
 
 Options: { "checkUnknown": true }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12463 12463
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

The `ignoredTypeNames` section stated that `{ ignoredTypeNames: ["RegExp"] }` was the **default options**, but the rule's actual default is `["Error", "RegExp", "URL", "URLSearchParams"]`

Rather than duplicating the full default list in the prose, this removes the misleading "default" wording entirely, per the [maintainer's suggestion in the issue](https://github.com/typescript-eslint/typescript-eslint/issues/12463#issuecomment-4850623310) - the correct default is already documented just above via the auto-inserted option description (`Default: ["Error","RegExp","URL","URLSearchParams"]`)
