### PR TITLE
docs: [restrict-template-expressions] clarify `allowArray` option behavior

### DIFF
--- a/packages/eslint-plugin/docs/rules/restrict-template-expressions.mdx
+++ b/packages/eslint-plugin/docs/rules/restrict-template-expressions.mdx
@@ -137,8 +137,7 @@ const msg1 = typeof arg === 'string' ? arg : `arg = ${arg}`;
 
 {/* insert option description */}
 
-This option recursively checks the type of each array element.
-For example, an error is reported if an array element has an unacceptable type.
+This option recursively checks the type of each array element, so an error is reported if any element has an unacceptable type.
 
 Examples of additional **correct** code for this rule with `{ allowArray: true }`:
 

--- a/packages/eslint-plugin/docs/rules/restrict-template-expressions.mdx
+++ b/packages/eslint-plugin/docs/rules/restrict-template-expressions.mdx
@@ -137,6 +137,9 @@ const msg1 = typeof arg === 'string' ? arg : `arg = ${arg}`;
 
 {/* insert option description */}
 
+This option recursively checks the type of each array element.
+For example, an error is reported if an array element has an unacceptable type.
+
 Examples of additional **correct** code for this rule with `{ allowArray: true }`:
 
 ```ts option='{ "allowArray": true }' showPlaygroundButton

--- a/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
@@ -194,13 +194,6 @@ ruleTester.run('restrict-template-expressions', rule, {
       `,
       options: [{ allowAny: true, allowArray: true }],
     },
-    {
-      code: `
-        declare const arg: (HasToString | string)[];
-        const msg = \`arg = \${arg}\`;
-      `,
-      options: [{ allowArray: true }],
-    },
     // allowAny
     {
       code: `

--- a/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
@@ -124,7 +124,7 @@ ruleTester.run('restrict-template-expressions', rule, {
     // allowArray
     {
       code: `
-        const arg: string[] = [];
+        const arg = [];
         const msg = \`arg = \${arg}\`;
       `,
       options: [{ allowArray: true }],
@@ -132,16 +132,9 @@ ruleTester.run('restrict-template-expressions', rule, {
     {
       code: `
         const arg = [];
-        const msg = \`arg = \${arg}\`;
-      `,
-      options: [{ allowAny: true, allowArray: true }],
-    },
-    {
-      code: `
-        const arg = [];
         const msg = \`arg = \${arg || 'default'}\`;
       `,
-      options: [{ allowAny: true, allowArray: true }],
+      options: [{ allowArray: true }],
     },
     {
       code: `
@@ -156,14 +149,14 @@ ruleTester.run('restrict-template-expressions', rule, {
         declare const arg: [number, string];
         const msg = \`arg = \${arg}\`;
       `,
-      options: [{ allowArray: true, allowNumber: true }],
+      options: [{ allowArray: true }],
     },
     {
       code: `
         const arg = [1, 'a'] as const;
         const msg = \`arg = \${arg || 'default'}\`;
       `,
-      options: [{ allowArray: true, allowNumber: true }],
+      options: [{ allowArray: true }],
     },
     {
       code: `
@@ -178,11 +171,32 @@ ruleTester.run('restrict-template-expressions', rule, {
         declare const arg: [number | undefined, string];
         const msg = \`arg = \${arg}\`;
       `,
-      options: [{ allowArray: true, allowNullish: true, allowNumber: true }],
+      options: [{ allowArray: true, allowNullish: true }],
     },
     {
       code: `
         declare const arg: string[][];
+        const msg = \`arg = \${arg}\`;
+      `,
+      options: [{ allowArray: true }],
+    },
+    {
+      code: `
+        declare const arg: never[];
+        const msg = \`arg = \${arg}\`;
+      `,
+      options: [{ allowArray: true, allowNever: true }],
+    },
+    {
+      code: `
+        declare const arg: any[];
+        const msg = \`arg = \${arg}\`;
+      `,
+      options: [{ allowAny: true, allowArray: true }],
+    },
+    {
+      code: `
+        declare const arg: (HasToString | string)[];
         const msg = \`arg = \${arg}\`;
       `,
       options: [{ allowArray: true }],
@@ -561,6 +575,51 @@ ruleTester.run('restrict-template-expressions', rule, {
         {
           column: 30,
           data: { type: 'object[]' },
+          line: 3,
+          messageId: 'invalidType',
+        },
+      ],
+      options: [{ allowArray: true }],
+    },
+    {
+      code: `
+        declare const arg: (object | string)[];
+        const msg = \`arg = \${arg}\`;
+      `,
+      errors: [
+        {
+          column: 30,
+          data: { type: '(string | object)[]' },
+          line: 3,
+          messageId: 'invalidType',
+        },
+      ],
+      options: [{ allowArray: true }],
+    },
+    {
+      code: `
+        declare const arg: object[][];
+        const msg = \`arg = \${arg}\`;
+      `,
+      errors: [
+        {
+          column: 30,
+          data: { type: 'object[][]' },
+          line: 3,
+          messageId: 'invalidType',
+        },
+      ],
+      options: [{ allowArray: true }],
+    },
+    {
+      code: `
+        declare const arg: (object | string)[][];
+        const msg = \`arg = \${arg}\`;
+      `,
+      errors: [
+        {
+          column: 30,
+          data: { type: '(string | object)[][]' },
           line: 3,
           messageId: 'invalidType',
         },

--- a/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
+++ b/packages/eslint-plugin/tests/rules/restrict-template-expressions.test.ts
@@ -124,7 +124,7 @@ ruleTester.run('restrict-template-expressions', rule, {
     // allowArray
     {
       code: `
-        const arg = [];
+        const arg: string[] = [];
         const msg = \`arg = \${arg}\`;
       `,
       options: [{ allowArray: true }],
@@ -132,9 +132,16 @@ ruleTester.run('restrict-template-expressions', rule, {
     {
       code: `
         const arg = [];
+        const msg = \`arg = \${arg}\`;
+      `,
+      options: [{ allowAny: true, allowArray: true }],
+    },
+    {
+      code: `
+        const arg = [];
         const msg = \`arg = \${arg || 'default'}\`;
       `,
-      options: [{ allowArray: true }],
+      options: [{ allowAny: true, allowArray: true }],
     },
     {
       code: `
@@ -149,14 +156,14 @@ ruleTester.run('restrict-template-expressions', rule, {
         declare const arg: [number, string];
         const msg = \`arg = \${arg}\`;
       `,
-      options: [{ allowArray: true }],
+      options: [{ allowArray: true, allowNumber: true }],
     },
     {
       code: `
         const arg = [1, 'a'] as const;
         const msg = \`arg = \${arg || 'default'}\`;
       `,
-      options: [{ allowArray: true }],
+      options: [{ allowArray: true, allowNumber: true }],
     },
     {
       code: `
@@ -171,7 +178,14 @@ ruleTester.run('restrict-template-expressions', rule, {
         declare const arg: [number | undefined, string];
         const msg = \`arg = \${arg}\`;
       `,
-      options: [{ allowArray: true, allowNullish: true }],
+      options: [{ allowArray: true, allowNullish: true, allowNumber: true }],
+    },
+    {
+      code: `
+        declare const arg: string[][];
+        const msg = \`arg = \${arg}\`;
+      `,
+      options: [{ allowArray: true }],
     },
     // allowAny
     {
@@ -498,6 +512,7 @@ ruleTester.run('restrict-template-expressions', rule, {
           messageId: 'invalidType',
         },
       ],
+      options: [{ allowArray: true, allowNumber: false }],
     },
     {
       code: `
@@ -536,6 +551,21 @@ ruleTester.run('restrict-template-expressions', rule, {
         },
       ],
       options: [{ allowArray: true, allowNullish: false }],
+    },
+    {
+      code: `
+        declare const arg: object[];
+        const msg = \`arg = \${arg}\`;
+      `,
+      errors: [
+        {
+          column: 30,
+          data: { type: 'object[]' },
+          line: 3,
+          messageId: 'invalidType',
+        },
+      ],
+      options: [{ allowArray: true }],
     },
     {
       code: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

## Summary

Clarify that the `allowArray` option recursively checks the type of each array element, and add a test case covering the documented behavior.

Fixes #12466