### PR TITLE
fix: add require-test-error-positions suppression

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4,6 +4,11 @@
       "count": 3
     }
   },
+  "packages/eslint-plugin-internal/tests/rules/no-dynamic-tests.test.ts": {
+    "eslint-plugin/require-test-error-positions": {
+      "count": 16
+    }
+  },
   "packages/eslint-plugin-internal/tests/rules/no-multiple-lines-of-errors.test.ts": {
     "eslint-plugin/require-test-error-positions": {
       "count": 3


### PR DESCRIPTION
Fixes #12454.

Adds the missing eslint-plugin/require-test-error-positions suppression entry for packages/eslint-plugin-internal/tests/rules/no-dynamic-tests.test.ts.

This keeps the suppression file aligned with the current rule output without changing rule behavior or tests.

Verification:

- JSON parse check for eslint-suppressions.json
- pnpm exec prettier --check eslint-suppressions.json
- git diff --check