### PR TITLE
docs(website): make rule option default value human-friendly

### DIFF
--- a/packages/website/plugins/generated-rule-docs/insertions/insertRuleOptions.ts
+++ b/packages/website/plugins/generated-rule-docs/insertions/insertRuleOptions.ts
@@ -78,10 +78,18 @@ export function insertRuleOptions(page: RuleDocsPage): void {
       0,
       // eslint-disable-next-line @typescript-eslint/internal/eqeq-nullish -- I don't know whether this is safe to fix
       defaultValue !== undefined
-        ? `${option.description} Default: \`${JSON.stringify(defaultValue)}\`.`
+        ? `${option.description} Default: \`${formatDefaultValue(defaultValue)}\`.`
         : option.description,
     );
   }
+}
+
+function formatDefaultValue(defaultValue: unknown): string {
+  if (Array.isArray(defaultValue)) {
+    return `[${defaultValue.map(formatDefaultValue).join(', ')}]`;
+  }
+
+  return JSON.stringify(defaultValue, null, 1).replaceAll(/\s+/g, ' ');
 }
 
 const OPTION_COMMENT = `/* insert option description */`;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12470 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Formats arrays manually, so we don't have spaces before/after brackets, and format everything else with plain `JSON.stringify`'s `space` param
