### PR TITLE
docs: [ban-ts-comment] clarify that `@ts-expect-error` is allowed by default

### DIFF
--- a/packages/eslint-plugin/docs/rules/ban-ts-comment.mdx
+++ b/packages/eslint-plugin/docs/rules/ban-ts-comment.mdx
@@ -26,7 +26,7 @@ This rule lets you set which comment directives you want to allow in your codeba
 
 ## Options
 
-By default, only `@ts-check` is allowed, as it enables rather than suppresses errors.
+By default, `@ts-check` is allowed, as it enables rather than suppresses errors, and `@ts-expect-error` is allowed when it includes a description. `@ts-ignore` and `@ts-nocheck` are reported.
 
 ### `ts-expect-error`, `ts-ignore`, `ts-nocheck`, `ts-check` directives
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12480
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

The docs said only `@ts-check` is allowed by default, but the recommended config also allows described `@ts-expect-error` comments

This fixes that wording while keeping the note about `@ts-check` enabling errors rather than suppressing them