### PR TITLE
docs: [no-base-to-string] clarify ignoredTypeNames description

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
+++ b/packages/eslint-plugin/docs/rules/no-base-to-string.mdx
@@ -84,8 +84,8 @@ const errorMessage = 'Found unexpected value: ' + JSON.stringify(o);
 
 {/* insert option description */}
 
-This is useful for types missing `toString()` or `toLocaleString()` (but actually has `toString()` or `toLocaleString()`).
-There are some types missing `toString()` or `toLocaleString()` in old versions of TypeScript, like `RegExp`, `URL`, `URLSearchParams` etc.
+This is useful for types whose type definitions do not declare `toString()` or `toLocaleString()`, even though the values have a useful implementation at runtime.
+This can happen in older versions of TypeScript, where types like `RegExp`, `URL`, and `URLSearchParams` were missing those declarations.
 
 The following patterns are considered correct with the default options:
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12481
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Reworded the ignoredTypeNames docs since the old phrasing `"missing toString() but actually has toString()"` was contradictory

