### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] handle optional-chained calls to overloaded functions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -555,11 +555,9 @@ export default createRule<Options, MessageIds>({
       }
       // An optional-chained callee (`foo?.bar(...)`) types as `<method> | undefined`,
       // and a union exposes no call signatures — strip the nullability first.
-      const calleeType = checker.getNonNullableType(
-        checker.getTypeAtLocation(
-          services.esTreeNodeToTSNodeMap.get(parent.callee),
-        ),
-      );
+      const calleeType = services
+        .getTypeAtLocation(parent.callee)
+        .getNonNullableType();
       const signatures = calleeType.getCallSignatures();
       if (signatures.length <= 1) {
         return false;

--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -553,8 +553,12 @@ export default createRule<Options, MessageIds>({
       ) {
         return false;
       }
-      const calleeType = checker.getTypeAtLocation(
-        services.esTreeNodeToTSNodeMap.get(parent.callee),
+      // An optional-chained callee (`foo?.bar(...)`) types as `<method> | undefined`,
+      // and a union exposes no call signatures — strip the nullability first.
+      const calleeType = checker.getNonNullableType(
+        checker.getTypeAtLocation(
+          services.esTreeNodeToTSNodeMap.get(parent.callee),
+        ),
       );
       const signatures = calleeType.getCallSignatures();
       if (signatures.length <= 1) {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -2876,9 +2876,6 @@ fn1(() => {
       ],
       output: 'const foo = () => ({ lol: 123 as number }.lol) + 54321;',
     },
-    // optional-chained call to a non-overloaded callee: assertions that are
-    // genuinely unnecessary must still be reported
-    // https://github.com/typescript-eslint/typescript-eslint/issues/12485
     {
       code: `
 declare const maybeFn: ((arg: string | number) => void) | undefined;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -900,6 +900,30 @@ const test = inferred({
 
 console.log(test.options.parameters.potato);
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12485
+    `
+declare const items: string[] | undefined;
+
+const counts = items?.reduce(
+  (acc, item) => {
+    acc[item] = (acc[item] ?? 0) + 1;
+    return acc;
+  },
+  {} as Record<string, number>,
+);
+    `,
+    `
+declare const o:
+  | {
+      fn<U>(g: (memo: U) => U, initial: U): U;
+      fn<T>(g: (memo: T) => T): T | undefined;
+    }
+  | undefined;
+enum E {
+  A = 1,
+}
+const x: E | undefined = o?.fn(n => n | 0, 0 as E);
+    `,
   ],
 
   invalid: [
@@ -2851,6 +2875,28 @@ fn1(() => {
         },
       ],
       output: 'const foo = () => ({ lol: 123 as number }.lol) + 54321;',
+    },
+    // optional-chained call to a non-overloaded callee: assertions that are
+    // genuinely unnecessary must still be reported
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12485
+    {
+      code: `
+declare const maybeFn: ((arg: string | number) => void) | undefined;
+declare const s: string;
+maybeFn?.(s as string | number);
+      `,
+      errors: [
+        {
+          column: 11,
+          line: 4,
+          messageId: 'contextuallyUnnecessary',
+        },
+      ],
+      output: `
+declare const maybeFn: ((arg: string | number) => void) | undefined;
+declare const s: string;
+maybeFn?.(s);
+      `,
     },
   ],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12485
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview
Bug is when it is optionally undefined and the lint method of checking does it overload and see zero signatures because of undefined, when it actually can be a lot of them. Fix before checking if we have other signatures. We normalize it so we actually can see the true amount of signatures. Previously we did not use getNonNullableType. Now to normalize it we use checker.getNonNullableType().
🦆
