### PR TITLE
fix(eslint-plugin): [no-base-to-string] don't flag a shadowed String() call

### DIFF
--- a/packages/eslint-plugin/src/rules/no-base-to-string.ts
+++ b/packages/eslint-plugin/src/rules/no-base-to-string.ts
@@ -1,6 +1,6 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -307,7 +307,7 @@ export default createRule<Options, MessageIds>({
       ) {
         const scope = context.sourceCode.getScope(node);
         // eslint-disable-next-line @typescript-eslint/internal/prefer-ast-types-enum
-        const variable = scope.set.get('String');
+        const variable = ASTUtils.findVariable(scope, 'String');
         return !variable?.defs.length;
       }
       return false;

--- a/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-base-to-string.test.ts
@@ -220,6 +220,24 @@ ruleTester.run('no-base-to-string', rule, {
     'String(() => {});',
     'String(function () {});',
     `
+const String = (value: unknown) => 'safe';
+String({});
+    `,
+    `
+const String = (value: unknown) => 'safe';
+function f() {
+  String({});
+}
+    `,
+    `
+function String(value: unknown) {
+  return 'safe';
+}
+function f() {
+  String({});
+}
+    `,
+    `
 function someFunction() {}
 someFunction.toString();
 let text = \`\${someFunction}\`;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12490
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`isBuiltInStringCall` only looked at the call's immediate scope to decide whether `String` was the global constructor, so a user-defined `String` in an outer scope wasn't found and nested `String(...)` calls got flagged

Switched to `ASTUtils.findVariable`, which walks the scope chain, so a `String` shadowed at any depth is recognized as user-defined.


