### PR TITLE
fix(eslint-plugin): [unified-signatures] compare renamed type parameters

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -1,6 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
+import { getKeys } from '@typescript-eslint/visitor-keys';
 
 import type { Equal } from '../util';
 
@@ -28,6 +29,8 @@ type Unify =
  * In: `interface I<T> { m<U>(x: U): T }`, only `T` is an outer type parameter.
  */
 type IsTypeParameter = (typeName: string) => boolean;
+type TypeParameterReplacements = ReadonlyMap<string, string>;
+type TypeNodeOrAnnotation = TSESTree.TSTypeAnnotation | TSESTree.TypeNode;
 
 type ScopeNode =
   | TSESTree.ClassBody
@@ -206,19 +209,42 @@ export default createRule<Options, MessageIds>({
       b: SignatureDefinition,
       isTypeParameter: IsTypeParameter,
     ): Unify | undefined {
-      if (!signaturesCanBeUnified(a, b, isTypeParameter)) {
+      const aTypeParameterReplacements = getTypeParameterReplacements(a);
+      const bTypeParameterReplacements = getTypeParameterReplacements(b);
+
+      if (
+        !signaturesCanBeUnified(
+          a,
+          b,
+          isTypeParameter,
+          aTypeParameterReplacements,
+          bTypeParameterReplacements,
+        )
+      ) {
         return undefined;
       }
 
       return a.params.length === b.params.length
-        ? signaturesDifferBySingleParameter(a.params, b.params)
-        : signaturesDifferByOptionalOrRestParameter(a, b);
+        ? signaturesDifferBySingleParameter(
+            a.params,
+            b.params,
+            aTypeParameterReplacements,
+            bTypeParameterReplacements,
+          )
+        : signaturesDifferByOptionalOrRestParameter(
+            a,
+            b,
+            aTypeParameterReplacements,
+            bTypeParameterReplacements,
+          );
     }
 
     function signaturesCanBeUnified(
       a: SignatureDefinition,
       b: SignatureDefinition,
       isTypeParameter: IsTypeParameter,
+      aTypeParameterReplacements: TypeParameterReplacements,
+      bTypeParameterReplacements: TypeParameterReplacements,
     ): boolean {
       // Must return the same type.
 
@@ -249,10 +275,22 @@ export default createRule<Options, MessageIds>({
       }
 
       return (
-        typesAreEqual(a.returnType, b.returnType) &&
+        typesAreEqual(
+          a.returnType,
+          b.returnType,
+          aTypeParameterReplacements,
+          bTypeParameterReplacements,
+        ) &&
         // Must take the same type parameters.
         // If one uses a type parameter (from outside) and the other doesn't, they shouldn't be joined.
-        arraysAreEqual(aTypeParams, bTypeParams, typeParametersAreEqual) &&
+        arraysAreEqual(aTypeParams, bTypeParams, (aTypeParam, bTypeParam) =>
+          typeParametersAreEqual(
+            aTypeParam,
+            bTypeParam,
+            aTypeParameterReplacements,
+            bTypeParameterReplacements,
+          ),
+        ) &&
         signatureUsesTypeParameter(a, isTypeParameter) ===
           signatureUsesTypeParameter(b, isTypeParameter)
       );
@@ -262,6 +300,8 @@ export default createRule<Options, MessageIds>({
     function signaturesDifferBySingleParameter(
       types1: readonly TSESTree.Parameter[],
       types2: readonly TSESTree.Parameter[],
+      typeParameterReplacements1: TypeParameterReplacements,
+      typeParameterReplacements2: TypeParameterReplacements,
     ): Unify | undefined {
       const firstParam1 = types1[0];
       const firstParam2 = types2[0];
@@ -271,10 +311,21 @@ export default createRule<Options, MessageIds>({
         return undefined;
       }
 
+      const parametersAreEqualWithTypeParameterReplacements = (
+        a: TSESTree.Parameter,
+        b: TSESTree.Parameter,
+      ): boolean =>
+        parametersAreEqual(
+          a,
+          b,
+          typeParameterReplacements1,
+          typeParameterReplacements2,
+        );
+
       const index = getIndexOfFirstDifference(
         types1,
         types2,
-        parametersAreEqual,
+        parametersAreEqualWithTypeParameterReplacements,
       );
       if (index == null) {
         return undefined;
@@ -285,7 +336,7 @@ export default createRule<Options, MessageIds>({
         !arraysAreEqual(
           types1.slice(index + 1),
           types2.slice(index + 1),
-          parametersAreEqual,
+          parametersAreEqualWithTypeParameterReplacements,
         )
       ) {
         return undefined;
@@ -320,6 +371,8 @@ export default createRule<Options, MessageIds>({
     function signaturesDifferByOptionalOrRestParameter(
       a: SignatureDefinition,
       b: SignatureDefinition,
+      typeParameterReplacements1: TypeParameterReplacements,
+      typeParameterReplacements2: TypeParameterReplacements,
     ): Unify | undefined {
       const sig1 = a.params;
       const sig2 = b.params;
@@ -361,7 +414,14 @@ export default createRule<Options, MessageIds>({
           ? sig2i.parameter.typeAnnotation
           : sig2i.typeAnnotation;
 
-        if (!typesAreEqual(typeAnnotation1, typeAnnotation2)) {
+        if (
+          !typesAreEqual(
+            typeAnnotation1,
+            typeAnnotation2,
+            typeParameterReplacements1,
+            typeParameterReplacements2,
+          )
+        ) {
           return undefined;
         }
       }
@@ -438,6 +498,8 @@ export default createRule<Options, MessageIds>({
     function parametersAreEqual(
       a: TSESTree.Parameter,
       b: TSESTree.Parameter,
+      aTypeParameterReplacements: TypeParameterReplacements,
+      bTypeParameterReplacements: TypeParameterReplacements,
     ): boolean {
       const typeAnnotationA = isTSParameterProperty(a)
         ? a.parameter.typeAnnotation
@@ -448,7 +510,12 @@ export default createRule<Options, MessageIds>({
 
       return (
         parametersHaveEqualSigils(a, b) &&
-        typesAreEqual(typeAnnotationA, typeAnnotationB)
+        typesAreEqual(
+          typeAnnotationA,
+          typeAnnotationB,
+          aTypeParameterReplacements,
+          bTypeParameterReplacements,
+        )
       );
     }
 
@@ -482,31 +549,131 @@ export default createRule<Options, MessageIds>({
     function typeParametersAreEqual(
       a: TSESTree.TSTypeParameter,
       b: TSESTree.TSTypeParameter,
+      aTypeParameterReplacements: TypeParameterReplacements,
+      bTypeParameterReplacements: TypeParameterReplacements,
     ): boolean {
       return (
-        a.name.name === b.name.name &&
-        constraintsAreEqual(a.constraint, b.constraint)
+        typesAreEqual(
+          a.constraint,
+          b.constraint,
+          aTypeParameterReplacements,
+          bTypeParameterReplacements,
+        ) &&
+        typesAreEqual(
+          a.default,
+          b.default,
+          aTypeParameterReplacements,
+          bTypeParameterReplacements,
+        )
       );
     }
 
     function typesAreEqual(
-      a: TSESTree.TSTypeAnnotation | undefined,
-      b: TSESTree.TSTypeAnnotation | undefined,
+      a: TypeNodeOrAnnotation | undefined,
+      b: TypeNodeOrAnnotation | undefined,
+      aTypeParameterReplacements: TypeParameterReplacements,
+      bTypeParameterReplacements: TypeParameterReplacements,
     ): boolean {
+      const aTypeNode = getTypeNode(a);
+      const bTypeNode = getTypeNode(b);
+
       return (
-        a === b ||
-        (a != null &&
-          b != null &&
-          context.sourceCode.getText(a.typeAnnotation) ===
-            context.sourceCode.getText(b.typeAnnotation))
+        aTypeNode === bTypeNode ||
+        (aTypeNode != null &&
+          bTypeNode != null &&
+          normalizeTypeText(aTypeNode, aTypeParameterReplacements) ===
+            normalizeTypeText(bTypeNode, bTypeParameterReplacements))
       );
     }
 
-    function constraintsAreEqual(
-      a: TSESTree.TypeNode | undefined,
-      b: TSESTree.TypeNode | undefined,
-    ): boolean {
-      return a === b || (a != null && a.type === b?.type);
+    function getTypeNode(
+      node: TypeNodeOrAnnotation | undefined,
+    ): TSESTree.TypeNode | undefined {
+      return node?.type === AST_NODE_TYPES.TSTypeAnnotation
+        ? node.typeAnnotation
+        : node;
+    }
+
+    function getTypeParameterReplacements(
+      signature: SignatureDefinition,
+    ): TypeParameterReplacements {
+      const replacements = new Map<string, string>();
+      for (const [index, typeParameter] of (
+        signature.typeParameters?.params ?? []
+      ).entries()) {
+        replacements.set(typeParameter.name.name, `\0typeParameter:${index}\0`);
+      }
+      return replacements;
+    }
+
+    function normalizeTypeText(
+      node: TSESTree.TypeNode,
+      typeParameterReplacements: TypeParameterReplacements,
+    ): string {
+      const text = context.sourceCode.getText(node);
+      if (typeParameterReplacements.size === 0) {
+        return text;
+      }
+
+      const offset = node.range[0];
+      const replacements: { end: number; start: number; text: string }[] = [];
+      forEachTypeReference(node, reference => {
+        const replacement = typeParameterReplacements.get(reference.name);
+        if (replacement != null) {
+          replacements.push({
+            start: reference.range[0] - offset,
+            end: reference.range[1] - offset,
+            text: replacement,
+          });
+        }
+      });
+
+      if (replacements.length === 0) {
+        return text;
+      }
+
+      replacements.sort((a, b) => a.start - b.start);
+
+      let result = '';
+      let lastIndex = 0;
+      for (const replacement of replacements) {
+        result += text.slice(lastIndex, replacement.start);
+        result += replacement.text;
+        lastIndex = replacement.end;
+      }
+
+      return result + text.slice(lastIndex);
+    }
+
+    function forEachTypeReference(
+      node: TSESTree.Node,
+      callback: (reference: TSESTree.Identifier) => void,
+    ): void {
+      if (
+        node.type === AST_NODE_TYPES.TSTypeReference &&
+        isIdentifier(node.typeName)
+      ) {
+        callback(node.typeName);
+      }
+
+      const properties = node as unknown as Record<string, unknown>;
+      for (const key of getKeys(node)) {
+        const value = properties[key];
+
+        if (Array.isArray(value)) {
+          for (const child of value) {
+            if (isNode(child)) {
+              forEachTypeReference(child, callback);
+            }
+          }
+        } else if (isNode(value)) {
+          forEachTypeReference(value, callback);
+        }
+      }
+    }
+
+    function isNode(value: unknown): value is TSESTree.Node {
+      return value != null && typeof value === 'object' && 'type' in value;
     }
 
     /* Returns the first index where `a` and `b` differ. */

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -1,7 +1,7 @@
+import type { ScopeVariable } from '@typescript-eslint/scope-manager';
 import type { TSESTree } from '@typescript-eslint/utils';
 
 import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
-import { getKeys } from '@typescript-eslint/visitor-keys';
 
 import type { Equal } from '../util';
 
@@ -28,10 +28,12 @@ type Unify =
  * Returns true if typeName is the name of an *outer* type parameter.
  * In: `interface I<T> { m<U>(x: U): T }`, only `T` is an outer type parameter.
  */
-type IsTypeParameter = (typeName: string) => boolean;
-type TypeParameterReplacements = ReadonlyMap<string, string>;
-type TypeParameterNames = ReadonlySet<string>;
 type TypeNodeOrAnnotation = TSESTree.TSTypeAnnotation | TSESTree.TypeNode;
+interface TypeParameterReferenceReplacement {
+  end: number;
+  start: number;
+  text: string;
+}
 
 type ScopeNode =
   | TSESTree.ClassBody
@@ -186,7 +188,7 @@ export default createRule<Options, MessageIds>({
       typeParameters?: TSESTree.TSTypeParameterDeclaration,
     ): Failure[] {
       const result: Failure[] = [];
-      const isTypeParameter = getIsTypeParameter(typeParameters);
+      const typeParameterVariables = getTypeParameterVariables(typeParameters);
       for (const overloads of signatures) {
         forEachPair(overloads, (a, b) => {
           const signature0 = (a as Partial<MethodDefinition>).value ?? a;
@@ -195,7 +197,7 @@ export default createRule<Options, MessageIds>({
           const unify = compareSignatures(
             signature0 as SignatureDefinition,
             signature1 as SignatureDefinition,
-            isTypeParameter,
+            typeParameterVariables,
           );
           if (unify != null) {
             result.push({ only2: overloads.length === 2, unify });
@@ -208,44 +210,44 @@ export default createRule<Options, MessageIds>({
     function compareSignatures(
       a: SignatureDefinition,
       b: SignatureDefinition,
-      isTypeParameter: IsTypeParameter,
+      typeParameterVariables: readonly ScopeVariable[],
     ): Unify | undefined {
-      const aTypeParameterReplacements = getTypeParameterReplacements(a);
-      const bTypeParameterReplacements = getTypeParameterReplacements(b);
-
-      if (
-        !signaturesCanBeUnified(
+      const aTypeParameterReferenceReplacements =
+        getTypeParameterReferenceReplacements(a);
+      const bTypeParameterReferenceReplacements =
+        getTypeParameterReferenceReplacements(b);
+      const typesEqual = (
+        a: TypeNodeOrAnnotation | undefined,
+        b: TypeNodeOrAnnotation | undefined,
+      ): boolean =>
+        typesAreEqual(
           a,
           b,
-          isTypeParameter,
-          aTypeParameterReplacements,
-          bTypeParameterReplacements,
-        )
-      ) {
+          aTypeParameterReferenceReplacements,
+          bTypeParameterReferenceReplacements,
+        );
+      const parametersEqual = (
+        a: TSESTree.Parameter,
+        b: TSESTree.Parameter,
+      ): boolean => parametersAreEqual(a, b, typesEqual);
+
+      if (!signaturesCanBeUnified(a, b, typeParameterVariables, typesEqual)) {
         return undefined;
       }
 
       return a.params.length === b.params.length
-        ? signaturesDifferBySingleParameter(
-            a.params,
-            b.params,
-            aTypeParameterReplacements,
-            bTypeParameterReplacements,
-          )
-        : signaturesDifferByOptionalOrRestParameter(
-            a,
-            b,
-            aTypeParameterReplacements,
-            bTypeParameterReplacements,
-          );
+        ? signaturesDifferBySingleParameter(a.params, b.params, parametersEqual)
+        : signaturesDifferByOptionalOrRestParameter(a, b, typesEqual);
     }
 
     function signaturesCanBeUnified(
       a: SignatureDefinition,
       b: SignatureDefinition,
-      isTypeParameter: IsTypeParameter,
-      aTypeParameterReplacements: TypeParameterReplacements,
-      bTypeParameterReplacements: TypeParameterReplacements,
+      typeParameterVariables: readonly ScopeVariable[],
+      typesEqual: (
+        a: TypeNodeOrAnnotation | undefined,
+        b: TypeNodeOrAnnotation | undefined,
+      ) => boolean,
     ): boolean {
       // Must return the same type.
 
@@ -276,24 +278,14 @@ export default createRule<Options, MessageIds>({
       }
 
       return (
-        typesAreEqual(
-          a.returnType,
-          b.returnType,
-          aTypeParameterReplacements,
-          bTypeParameterReplacements,
-        ) &&
+        typesEqual(a.returnType, b.returnType) &&
         // Must take the same type parameters.
         // If one uses a type parameter (from outside) and the other doesn't, they shouldn't be joined.
         arraysAreEqual(aTypeParams, bTypeParams, (aTypeParam, bTypeParam) =>
-          typeParametersAreEqual(
-            aTypeParam,
-            bTypeParam,
-            aTypeParameterReplacements,
-            bTypeParameterReplacements,
-          ),
+          typeParametersAreEqual(aTypeParam, bTypeParam, typesEqual),
         ) &&
-        signatureUsesTypeParameter(a, isTypeParameter) ===
-          signatureUsesTypeParameter(b, isTypeParameter)
+        signatureUsesTypeParameter(a, typeParameterVariables) ===
+          signatureUsesTypeParameter(b, typeParameterVariables)
       );
     }
 
@@ -301,8 +293,7 @@ export default createRule<Options, MessageIds>({
     function signaturesDifferBySingleParameter(
       types1: readonly TSESTree.Parameter[],
       types2: readonly TSESTree.Parameter[],
-      typeParameterReplacements1: TypeParameterReplacements,
-      typeParameterReplacements2: TypeParameterReplacements,
+      parametersEqual: Equal<TSESTree.Parameter>,
     ): Unify | undefined {
       const firstParam1 = types1[0];
       const firstParam2 = types2[0];
@@ -312,22 +303,7 @@ export default createRule<Options, MessageIds>({
         return undefined;
       }
 
-      const parametersAreEqualWithTypeParameterReplacements = (
-        a: TSESTree.Parameter,
-        b: TSESTree.Parameter,
-      ): boolean =>
-        parametersAreEqual(
-          a,
-          b,
-          typeParameterReplacements1,
-          typeParameterReplacements2,
-        );
-
-      const index = getIndexOfFirstDifference(
-        types1,
-        types2,
-        parametersAreEqualWithTypeParameterReplacements,
-      );
+      const index = getIndexOfFirstDifference(types1, types2, parametersEqual);
       if (index == null) {
         return undefined;
       }
@@ -337,7 +313,7 @@ export default createRule<Options, MessageIds>({
         !arraysAreEqual(
           types1.slice(index + 1),
           types2.slice(index + 1),
-          parametersAreEqualWithTypeParameterReplacements,
+          parametersEqual,
         )
       ) {
         return undefined;
@@ -372,8 +348,10 @@ export default createRule<Options, MessageIds>({
     function signaturesDifferByOptionalOrRestParameter(
       a: SignatureDefinition,
       b: SignatureDefinition,
-      typeParameterReplacements1: TypeParameterReplacements,
-      typeParameterReplacements2: TypeParameterReplacements,
+      typesEqual: (
+        a: TypeNodeOrAnnotation | undefined,
+        b: TypeNodeOrAnnotation | undefined,
+      ) => boolean,
     ): Unify | undefined {
       const sig1 = a.params;
       const sig2 = b.params;
@@ -408,19 +386,10 @@ export default createRule<Options, MessageIds>({
       for (let i = 0; i < minLength; i++) {
         const sig1i = sig1[i];
         const sig2i = sig2[i];
-        const typeAnnotation1 = isTSParameterProperty(sig1i)
-          ? sig1i.parameter.typeAnnotation
-          : sig1i.typeAnnotation;
-        const typeAnnotation2 = isTSParameterProperty(sig2i)
-          ? sig2i.parameter.typeAnnotation
-          : sig2i.typeAnnotation;
-
         if (
-          !typesAreEqual(
-            typeAnnotation1,
-            typeAnnotation2,
-            typeParameterReplacements1,
-            typeParameterReplacements2,
+          !typesEqual(
+            getParameterTypeAnnotation(sig1i),
+            getParameterTypeAnnotation(sig2i),
           )
         ) {
           return undefined;
@@ -441,148 +410,42 @@ export default createRule<Options, MessageIds>({
       };
     }
 
-    /** Given type parameters, returns a function to test whether a type is one of those parameters. */
-    function getIsTypeParameter(
+    function getTypeParameterVariables(
       typeParameters?: TSESTree.TSTypeParameterDeclaration,
-    ): IsTypeParameter {
-      const typeParameterNames = getTypeParameterNames(typeParameters);
-      return typeName => typeParameterNames.has(typeName);
+    ): ScopeVariable[] {
+      return (
+        typeParameters?.params.flatMap(typeParameter =>
+          context.sourceCode
+            .getDeclaredVariables(typeParameter)
+            .filter(isTypeVariable),
+        ) ?? []
+      );
     }
 
     /** True if any of the outer type parameters are used in a signature. */
     function signatureUsesTypeParameter(
       sig: SignatureDefinition,
-      isTypeParameter: IsTypeParameter,
+      typeParameterVariables: readonly ScopeVariable[],
     ): boolean {
-      const shadowedTypeParameters = getTypeParameterNames(sig.typeParameters);
-
       return sig.params.some((p: TSESTree.Parameter) =>
-        typeContainsTypeParameter(
-          isTSParameterProperty(p)
-            ? p.parameter.typeAnnotation
-            : p.typeAnnotation,
-          shadowedTypeParameters,
-        ),
+        typeContainsTypeParameter(getParameterTypeAnnotation(p)),
       );
 
       function typeContainsTypeParameter(
         type: TypeNodeOrAnnotation | undefined,
-        shadowedTypeParameters: TypeParameterNames,
       ): boolean {
         const typeNode = getTypeNode(type);
         if (typeNode == null) {
           return false;
         }
 
-        let containsTypeParameter = false;
-        forEachTypeReference(
-          typeNode,
-          reference => {
-            if (isTypeParameter(reference.name)) {
-              containsTypeParameter = true;
-            }
-          },
-          shadowedTypeParameters,
+        return typeParameterVariables.some(variable =>
+          variable.references.some(
+            reference =>
+              reference.isTypeReference &&
+              isInRange(reference.identifier, typeNode),
+          ),
         );
-
-        return containsTypeParameter;
-      }
-    }
-
-    function getTypeParameterNames(
-      typeParameters: TSESTree.TSTypeParameterDeclaration | undefined,
-    ): TypeParameterNames {
-      const typeParameterNames = new Set<string>();
-      for (const typeParameter of typeParameters?.params ?? []) {
-        typeParameterNames.add(typeParameter.name.name);
-      }
-      return typeParameterNames;
-    }
-
-    function getNodeTypeParameters(
-      node: TSESTree.Node,
-    ): TSESTree.TSTypeParameterDeclaration | undefined {
-      const typeParameters = (node as { typeParameters?: unknown })
-        .typeParameters;
-      return isNode(typeParameters) &&
-        typeParameters.type === AST_NODE_TYPES.TSTypeParameterDeclaration
-        ? typeParameters
-        : undefined;
-    }
-
-    function shadowTypeParameters(
-      node: TSESTree.Node,
-      shadowedTypeParameters: TypeParameterNames,
-    ): TypeParameterNames {
-      const typeParameters = getNodeTypeParameters(node);
-      if (typeParameters == null) {
-        return shadowedTypeParameters;
-      }
-
-      const nextShadowedTypeParameters = new Set(shadowedTypeParameters);
-      for (const typeParameter of typeParameters.params) {
-        nextShadowedTypeParameters.add(typeParameter.name.name);
-      }
-      return nextShadowedTypeParameters;
-    }
-
-    function shadowTypeParameterName(
-      shadowedTypeParameters: TypeParameterNames,
-      typeParameterName: string,
-    ): TypeParameterNames {
-      const nextShadowedTypeParameters = new Set(shadowedTypeParameters);
-      nextShadowedTypeParameters.add(typeParameterName);
-      return nextShadowedTypeParameters;
-    }
-
-    function shadowTypeParameterNames(
-      shadowedTypeParameters: TypeParameterNames,
-      typeParameterNames: TypeParameterNames,
-    ): TypeParameterNames {
-      if (typeParameterNames.size === 0) {
-        return shadowedTypeParameters;
-      }
-
-      const nextShadowedTypeParameters = new Set(shadowedTypeParameters);
-      for (const typeParameterName of typeParameterNames) {
-        nextShadowedTypeParameters.add(typeParameterName);
-      }
-      return nextShadowedTypeParameters;
-    }
-
-    function getInferTypeParameterNames(
-      node: TSESTree.Node,
-    ): TypeParameterNames {
-      const typeParameterNames = new Set<string>();
-
-      visit(node);
-
-      return typeParameterNames;
-
-      function visit(node: TSESTree.Node): void {
-        if (node.type === AST_NODE_TYPES.TSInferType) {
-          typeParameterNames.add(node.typeParameter.name.name);
-          return;
-        }
-
-        if (node.type === AST_NODE_TYPES.TSConditionalType) {
-          return;
-        }
-
-        const properties = node as unknown as Record<string, unknown>;
-        for (const key of getKeys(node)) {
-          const value = properties[key];
-
-          if (Array.isArray(value)) {
-            for (const child of value) {
-              if (isNode(child)) {
-                visit(child);
-              }
-            }
-          } else if (isNode(value)) {
-            visit(value);
-          }
-        }
       }
     }
 
@@ -595,25 +458,23 @@ export default createRule<Options, MessageIds>({
     function parametersAreEqual(
       a: TSESTree.Parameter,
       b: TSESTree.Parameter,
-      aTypeParameterReplacements: TypeParameterReplacements,
-      bTypeParameterReplacements: TypeParameterReplacements,
+      typesEqual: (
+        a: TypeNodeOrAnnotation | undefined,
+        b: TypeNodeOrAnnotation | undefined,
+      ) => boolean,
     ): boolean {
-      const typeAnnotationA = isTSParameterProperty(a)
-        ? a.parameter.typeAnnotation
-        : a.typeAnnotation;
-      const typeAnnotationB = isTSParameterProperty(b)
-        ? b.parameter.typeAnnotation
-        : b.typeAnnotation;
-
       return (
         parametersHaveEqualSigils(a, b) &&
-        typesAreEqual(
-          typeAnnotationA,
-          typeAnnotationB,
-          aTypeParameterReplacements,
-          bTypeParameterReplacements,
-        )
+        typesEqual(getParameterTypeAnnotation(a), getParameterTypeAnnotation(b))
       );
+    }
+
+    function getParameterTypeAnnotation(
+      param: TSESTree.Parameter,
+    ): TSESTree.TSTypeAnnotation | undefined {
+      return isTSParameterProperty(param)
+        ? param.parameter.typeAnnotation
+        : param.typeAnnotation;
     }
 
     /** True for optional/rest parameters. */
@@ -646,30 +507,22 @@ export default createRule<Options, MessageIds>({
     function typeParametersAreEqual(
       a: TSESTree.TSTypeParameter,
       b: TSESTree.TSTypeParameter,
-      aTypeParameterReplacements: TypeParameterReplacements,
-      bTypeParameterReplacements: TypeParameterReplacements,
+      typesEqual: (
+        a: TypeNodeOrAnnotation | undefined,
+        b: TypeNodeOrAnnotation | undefined,
+      ) => boolean,
     ): boolean {
       return (
-        typesAreEqual(
-          a.constraint,
-          b.constraint,
-          aTypeParameterReplacements,
-          bTypeParameterReplacements,
-        ) &&
-        typesAreEqual(
-          a.default,
-          b.default,
-          aTypeParameterReplacements,
-          bTypeParameterReplacements,
-        )
+        typesEqual(a.constraint, b.constraint) &&
+        typesEqual(a.default, b.default)
       );
     }
 
     function typesAreEqual(
       a: TypeNodeOrAnnotation | undefined,
       b: TypeNodeOrAnnotation | undefined,
-      aTypeParameterReplacements: TypeParameterReplacements,
-      bTypeParameterReplacements: TypeParameterReplacements,
+      aTypeParameterReferenceReplacements: readonly TypeParameterReferenceReplacement[],
+      bTypeParameterReferenceReplacements: readonly TypeParameterReferenceReplacement[],
     ): boolean {
       const aTypeNode = getTypeNode(a);
       const bTypeNode = getTypeNode(b);
@@ -678,8 +531,8 @@ export default createRule<Options, MessageIds>({
         aTypeNode === bTypeNode ||
         (aTypeNode != null &&
           bTypeNode != null &&
-          normalizeTypeText(aTypeNode, aTypeParameterReplacements) ===
-            normalizeTypeText(bTypeNode, bTypeParameterReplacements))
+          normalizeTypeText(aTypeNode, aTypeParameterReferenceReplacements) ===
+            normalizeTypeText(bTypeNode, bTypeParameterReferenceReplacements))
       );
     }
 
@@ -691,39 +544,55 @@ export default createRule<Options, MessageIds>({
         : node;
     }
 
-    function getTypeParameterReplacements(
+    function getTypeParameterReferenceReplacements(
       signature: SignatureDefinition,
-    ): TypeParameterReplacements {
-      const replacements = new Map<string, string>();
+    ): TypeParameterReferenceReplacement[] {
+      const replacements: TypeParameterReferenceReplacement[] = [];
       for (const [index, typeParameter] of (
         signature.typeParameters?.params ?? []
       ).entries()) {
-        replacements.set(typeParameter.name.name, `\0typeParameter:${index}\0`);
+        const replacement = `\0typeParameter:${index}\0`;
+        for (const variable of context.sourceCode.getDeclaredVariables(
+          typeParameter,
+        )) {
+          if (!isTypeVariable(variable)) {
+            continue;
+          }
+
+          for (const reference of variable.references) {
+            if (reference.isTypeReference) {
+              replacements.push({
+                start: reference.identifier.range[0],
+                end: reference.identifier.range[1],
+                text: replacement,
+              });
+            }
+          }
+        }
       }
       return replacements;
     }
 
     function normalizeTypeText(
       node: TSESTree.TypeNode,
-      typeParameterReplacements: TypeParameterReplacements,
+      typeParameterReferenceReplacements: readonly TypeParameterReferenceReplacement[],
     ): string {
       const text = context.sourceCode.getText(node);
-      if (typeParameterReplacements.size === 0) {
+      if (typeParameterReferenceReplacements.length === 0) {
         return text;
       }
 
       const offset = node.range[0];
       const replacements: { end: number; start: number; text: string }[] = [];
-      forEachTypeReference(node, reference => {
-        const replacement = typeParameterReplacements.get(reference.name);
-        if (replacement != null) {
+      for (const replacement of typeParameterReferenceReplacements) {
+        if (isRangeInRange(replacement, node)) {
           replacements.push({
-            start: reference.range[0] - offset,
-            end: reference.range[1] - offset,
-            text: replacement,
+            start: replacement.start - offset,
+            end: replacement.end - offset,
+            text: replacement.text,
           });
         }
-      });
+      }
 
       if (replacements.length === 0) {
         return text;
@@ -742,96 +611,19 @@ export default createRule<Options, MessageIds>({
       return result + text.slice(lastIndex);
     }
 
-    function forEachTypeReference(
-      node: TSESTree.Node,
-      callback: (reference: TSESTree.Identifier) => void,
-      shadowedTypeParameters: TypeParameterNames = new Set(),
-    ): void {
-      if (node.type === AST_NODE_TYPES.TSMappedType) {
-        const mappedTypeShadowedTypeParameters = shadowTypeParameterName(
-          shadowedTypeParameters,
-          node.key.name,
-        );
-
-        forEachTypeReference(node.constraint, callback, shadowedTypeParameters);
-
-        if (node.nameType != null) {
-          forEachTypeReference(
-            node.nameType,
-            callback,
-            mappedTypeShadowedTypeParameters,
-          );
-        }
-        if (node.typeAnnotation != null) {
-          forEachTypeReference(
-            node.typeAnnotation,
-            callback,
-            mappedTypeShadowedTypeParameters,
-          );
-        }
-
-        return;
-      }
-
-      if (node.type === AST_NODE_TYPES.TSConditionalType) {
-        const inferredTypeParameters = getInferTypeParameterNames(
-          node.extendsType,
-        );
-        const inferredShadowedTypeParameters = shadowTypeParameterNames(
-          shadowedTypeParameters,
-          inferredTypeParameters,
-        );
-
-        forEachTypeReference(node.checkType, callback, shadowedTypeParameters);
-        forEachTypeReference(
-          node.extendsType,
-          callback,
-          inferredShadowedTypeParameters,
-        );
-        forEachTypeReference(
-          node.trueType,
-          callback,
-          inferredShadowedTypeParameters,
-        );
-        forEachTypeReference(node.falseType, callback, shadowedTypeParameters);
-
-        return;
-      }
-
-      if (
-        node.type === AST_NODE_TYPES.TSTypeReference &&
-        isIdentifier(node.typeName) &&
-        !shadowedTypeParameters.has(node.typeName.name)
-      ) {
-        callback(node.typeName);
-      }
-
-      const childShadowedTypeParameters = shadowTypeParameters(
-        node,
-        shadowedTypeParameters,
-      );
-      const properties = node as unknown as Record<string, unknown>;
-      for (const key of getKeys(node)) {
-        const value = properties[key];
-
-        if (Array.isArray(value)) {
-          for (const child of value) {
-            if (isNode(child)) {
-              forEachTypeReference(
-                child,
-                callback,
-                childShadowedTypeParameters,
-              );
-            }
-          }
-        } else if (isNode(value)) {
-          forEachTypeReference(value, callback, childShadowedTypeParameters);
-        }
-      }
+    function isInRange(node: TSESTree.Node, range: TSESTree.Node): boolean {
+      return node.range[0] >= range.range[0] && node.range[1] <= range.range[1];
     }
 
-    function isNode(value: unknown): value is TSESTree.Node {
-      return value != null && typeof value === 'object' && 'type' in value;
+    function isRangeInRange(
+      range: Pick<TypeParameterReferenceReplacement, 'end' | 'start'>,
+      node: TSESTree.Node,
+    ): boolean {
+      return range.start >= node.range[0] && range.end <= node.range[1];
+    }
+
+    function isTypeVariable(variable: ScopeVariable): boolean {
+      return 'isTypeVariable' in variable && variable.isTypeVariable;
     }
 
     /* Returns the first index where `a` and `b` differ. */

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -526,6 +526,66 @@ export default createRule<Options, MessageIds>({
       return nextShadowedTypeParameters;
     }
 
+    function shadowTypeParameterName(
+      shadowedTypeParameters: TypeParameterNames,
+      typeParameterName: string,
+    ): TypeParameterNames {
+      const nextShadowedTypeParameters = new Set(shadowedTypeParameters);
+      nextShadowedTypeParameters.add(typeParameterName);
+      return nextShadowedTypeParameters;
+    }
+
+    function shadowTypeParameterNames(
+      shadowedTypeParameters: TypeParameterNames,
+      typeParameterNames: TypeParameterNames,
+    ): TypeParameterNames {
+      if (typeParameterNames.size === 0) {
+        return shadowedTypeParameters;
+      }
+
+      const nextShadowedTypeParameters = new Set(shadowedTypeParameters);
+      for (const typeParameterName of typeParameterNames) {
+        nextShadowedTypeParameters.add(typeParameterName);
+      }
+      return nextShadowedTypeParameters;
+    }
+
+    function getInferTypeParameterNames(
+      node: TSESTree.Node,
+    ): TypeParameterNames {
+      const typeParameterNames = new Set<string>();
+
+      visit(node);
+
+      return typeParameterNames;
+
+      function visit(node: TSESTree.Node): void {
+        if (node.type === AST_NODE_TYPES.TSInferType) {
+          typeParameterNames.add(node.typeParameter.name.name);
+          return;
+        }
+
+        if (node.type === AST_NODE_TYPES.TSConditionalType) {
+          return;
+        }
+
+        const properties = node as unknown as Record<string, unknown>;
+        for (const key of getKeys(node)) {
+          const value = properties[key];
+
+          if (Array.isArray(value)) {
+            for (const child of value) {
+              if (isNode(child)) {
+                visit(child);
+              }
+            }
+          } else if (isNode(value)) {
+            visit(value);
+          }
+        }
+      }
+    }
+
     function isTSParameterProperty(
       node: TSESTree.Node,
     ): node is TSESTree.TSParameterProperty {
@@ -687,6 +747,57 @@ export default createRule<Options, MessageIds>({
       callback: (reference: TSESTree.Identifier) => void,
       shadowedTypeParameters: TypeParameterNames = new Set(),
     ): void {
+      if (node.type === AST_NODE_TYPES.TSMappedType) {
+        const mappedTypeShadowedTypeParameters = shadowTypeParameterName(
+          shadowedTypeParameters,
+          node.key.name,
+        );
+
+        forEachTypeReference(node.constraint, callback, shadowedTypeParameters);
+
+        if (node.nameType != null) {
+          forEachTypeReference(
+            node.nameType,
+            callback,
+            mappedTypeShadowedTypeParameters,
+          );
+        }
+        if (node.typeAnnotation != null) {
+          forEachTypeReference(
+            node.typeAnnotation,
+            callback,
+            mappedTypeShadowedTypeParameters,
+          );
+        }
+
+        return;
+      }
+
+      if (node.type === AST_NODE_TYPES.TSConditionalType) {
+        const inferredTypeParameters = getInferTypeParameterNames(
+          node.extendsType,
+        );
+        const inferredShadowedTypeParameters = shadowTypeParameterNames(
+          shadowedTypeParameters,
+          inferredTypeParameters,
+        );
+
+        forEachTypeReference(node.checkType, callback, shadowedTypeParameters);
+        forEachTypeReference(
+          node.extendsType,
+          callback,
+          inferredShadowedTypeParameters,
+        );
+        forEachTypeReference(
+          node.trueType,
+          callback,
+          inferredShadowedTypeParameters,
+        );
+        forEachTypeReference(node.falseType, callback, shadowedTypeParameters);
+
+        return;
+      }
+
       if (
         node.type === AST_NODE_TYPES.TSTypeReference &&
         isIdentifier(node.typeName) &&

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -30,6 +30,7 @@ type Unify =
  */
 type IsTypeParameter = (typeName: string) => boolean;
 type TypeParameterReplacements = ReadonlyMap<string, string>;
+type TypeParameterNames = ReadonlySet<string>;
 type TypeNodeOrAnnotation = TSESTree.TSTypeAnnotation | TSESTree.TypeNode;
 
 type ScopeNode =
@@ -444,15 +445,8 @@ export default createRule<Options, MessageIds>({
     function getIsTypeParameter(
       typeParameters?: TSESTree.TSTypeParameterDeclaration,
     ): IsTypeParameter {
-      if (typeParameters == null) {
-        return () => false;
-      }
-
-      const set = new Set<string>();
-      for (const t of typeParameters.params) {
-        set.add(t.name.name);
-      }
-      return typeName => set.has(typeName);
+      const typeParameterNames = getTypeParameterNames(typeParameters);
+      return typeName => typeParameterNames.has(typeName);
     }
 
     /** True if any of the outer type parameters are used in a signature. */
@@ -460,33 +454,76 @@ export default createRule<Options, MessageIds>({
       sig: SignatureDefinition,
       isTypeParameter: IsTypeParameter,
     ): boolean {
+      const shadowedTypeParameters = getTypeParameterNames(sig.typeParameters);
+
       return sig.params.some((p: TSESTree.Parameter) =>
         typeContainsTypeParameter(
           isTSParameterProperty(p)
             ? p.parameter.typeAnnotation
             : p.typeAnnotation,
+          shadowedTypeParameters,
         ),
       );
 
       function typeContainsTypeParameter(
-        type?: TSESTree.TSTypeAnnotation | TSESTree.TypeNode,
+        type: TypeNodeOrAnnotation | undefined,
+        shadowedTypeParameters: TypeParameterNames,
       ): boolean {
-        if (!type) {
+        const typeNode = getTypeNode(type);
+        if (typeNode == null) {
           return false;
         }
 
-        if (type.type === AST_NODE_TYPES.TSTypeReference) {
-          const typeName = type.typeName;
-          if (isIdentifier(typeName) && isTypeParameter(typeName.name)) {
-            return true;
-          }
-        }
-
-        return typeContainsTypeParameter(
-          (type as Partial<TSESTree.TSTypeAnnotation>).typeAnnotation ??
-            (type as TSESTree.TSArrayType).elementType,
+        let containsTypeParameter = false;
+        forEachTypeReference(
+          typeNode,
+          reference => {
+            if (isTypeParameter(reference.name)) {
+              containsTypeParameter = true;
+            }
+          },
+          shadowedTypeParameters,
         );
+
+        return containsTypeParameter;
       }
+    }
+
+    function getTypeParameterNames(
+      typeParameters: TSESTree.TSTypeParameterDeclaration | undefined,
+    ): TypeParameterNames {
+      const typeParameterNames = new Set<string>();
+      for (const typeParameter of typeParameters?.params ?? []) {
+        typeParameterNames.add(typeParameter.name.name);
+      }
+      return typeParameterNames;
+    }
+
+    function getNodeTypeParameters(
+      node: TSESTree.Node,
+    ): TSESTree.TSTypeParameterDeclaration | undefined {
+      const typeParameters = (node as { typeParameters?: unknown })
+        .typeParameters;
+      return isNode(typeParameters) &&
+        typeParameters.type === AST_NODE_TYPES.TSTypeParameterDeclaration
+        ? typeParameters
+        : undefined;
+    }
+
+    function shadowTypeParameters(
+      node: TSESTree.Node,
+      shadowedTypeParameters: TypeParameterNames,
+    ): TypeParameterNames {
+      const typeParameters = getNodeTypeParameters(node);
+      if (typeParameters == null) {
+        return shadowedTypeParameters;
+      }
+
+      const nextShadowedTypeParameters = new Set(shadowedTypeParameters);
+      for (const typeParameter of typeParameters.params) {
+        nextShadowedTypeParameters.add(typeParameter.name.name);
+      }
+      return nextShadowedTypeParameters;
     }
 
     function isTSParameterProperty(
@@ -648,14 +685,20 @@ export default createRule<Options, MessageIds>({
     function forEachTypeReference(
       node: TSESTree.Node,
       callback: (reference: TSESTree.Identifier) => void,
+      shadowedTypeParameters: TypeParameterNames = new Set(),
     ): void {
       if (
         node.type === AST_NODE_TYPES.TSTypeReference &&
-        isIdentifier(node.typeName)
+        isIdentifier(node.typeName) &&
+        !shadowedTypeParameters.has(node.typeName.name)
       ) {
         callback(node.typeName);
       }
 
+      const childShadowedTypeParameters = shadowTypeParameters(
+        node,
+        shadowedTypeParameters,
+      );
       const properties = node as unknown as Record<string, unknown>;
       for (const key of getKeys(node)) {
         const value = properties[key];
@@ -663,11 +706,15 @@ export default createRule<Options, MessageIds>({
         if (Array.isArray(value)) {
           for (const child of value) {
             if (isNode(child)) {
-              forEachTypeReference(child, callback);
+              forEachTypeReference(
+                child,
+                callback,
+                childShadowedTypeParameters,
+              );
             }
           }
         } else if (isNode(value)) {
-          forEachTypeReference(value, callback);
+          forEachTypeReference(value, callback, childShadowedTypeParameters);
         }
       }
     }

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -167,6 +167,12 @@ interface I<T> {
 function h<K extends string>(x: { [K in 'a' | 'b']: K }, y: string): void;
 function h<J extends string>(x: { [K in 'a' | 'b']: J }): void;
     `,
+    // Mapped type keys shadow same-named signature type parameters in name
+    // remapping too.
+    `
+function h<K extends string>(x: { [K in 'a' | 'b' as K]: K }, y: string): void;
+function h<J extends string>(x: { [K in 'a' | 'b' as K]: J }): void;
+    `,
     // Same name, different scopes
     `
 declare function foo(n: number): number;
@@ -918,6 +924,46 @@ function f<R extends string, S extends number>(x: Map<R, S>): void;
           endColumn: 71,
           endLine: 2,
           line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // Conditional types without infer type parameters should still normalize
+      // signature type parameters.
+      code: `
+type Wrapper<T> = T;
+function f<U>(x: string extends Wrapper<U> ? U : never, y: string): void;
+function f<V>(x: string extends Wrapper<V> ? V : never): void;
+      `,
+      errors: [
+        {
+          column: 57,
+          endColumn: 66,
+          endLine: 3,
+          line: 3,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // Nested conditional infer type parameters should not shadow the outer
+      // conditional type's true branch.
+      code: `
+function f<U>(
+  x: string extends (number extends infer U ? U : never) ? U : never,
+  y: string,
+): void;
+function f<V>(
+  x: string extends (number extends infer U ? U : never) ? V : never,
+): void;
+      `,
+      errors: [
+        {
+          column: 3,
+          endColumn: 12,
+          endLine: 4,
+          line: 4,
           messageId: 'omittingSingleParameter',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -154,6 +154,14 @@ interface Box<T> {
   f<U extends string>(x: U): void;
 }
     `,
+    // A signature's own type parameters shadow outer type parameters with the
+    // same name.
+    `
+interface I<T> {
+  m<T>(x: T): void;
+  m<U>(x: T): void;
+}
+    `,
     // Same name, different scopes
     `
 declare function foo(n: number): number;
@@ -905,6 +913,42 @@ function f<R extends string, S extends number>(x: Map<R, S>): void;
           endColumn: 71,
           endLine: 2,
           line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // Nested type parameters should shadow same-named signature type
+      // parameters when normalizing type references.
+      code: `
+function f<T extends string>(x: <T>(y: T) => T, z: string): void;
+function f<R extends string>(x: <T>(y: T) => T): void;
+      `,
+      errors: [
+        {
+          column: 49,
+          endColumn: 58,
+          endLine: 2,
+          line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // A signature's own type parameters should not be treated as outer type
+      // parameter references just because they share the same name.
+      code: `
+interface I<T> {
+  f<T extends string>(x: T, y: number): void;
+  f<R extends string>(x: R): void;
+}
+      `,
+      errors: [
+        {
+          column: 29,
+          endColumn: 38,
+          endLine: 3,
+          line: 3,
           messageId: 'omittingSingleParameter',
         },
       ],

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -162,6 +162,11 @@ interface I<T> {
   m<U>(x: T): void;
 }
     `,
+    // Mapped type keys shadow same-named signature type parameters.
+    `
+function h<K extends string>(x: { [K in 'a' | 'b']: K }, y: string): void;
+function h<J extends string>(x: { [K in 'a' | 'b']: J }): void;
+    `,
     // Same name, different scopes
     `
 declare function foo(n: number): number;
@@ -911,6 +916,40 @@ function f<R extends string, S extends number>(x: Map<R, S>): void;
         {
           column: 62,
           endColumn: 71,
+          endLine: 2,
+          line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // Mapped type keys should shadow same-named signature type parameters
+      // when normalizing type references.
+      code: `
+function f<K extends string>(x: { [K in 'a' | 'b']: K }, y: string): void;
+function f<J extends string>(x: { [K in 'a' | 'b']: K }, y: number): void;
+      `,
+      errors: [
+        {
+          column: 58,
+          endColumn: 67,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Conditional infer type parameters should shadow same-named signature type
+      // parameters when normalizing type references.
+      code: `
+function g<U>(x: string extends infer U ? U : never, y: string): void;
+function g<V>(x: string extends infer U ? U : never): void;
+      `,
+      errors: [
+        {
+          column: 54,
+          endColumn: 63,
           endLine: 2,
           line: 2,
           messageId: 'omittingSingleParameter',

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -118,6 +118,42 @@ interface I {
 function f<T extends number>(x: T[]): void;
 function f<T extends string>(x: T): void;
     `,
+    // Type parameters with different constraints must not be unified, even when
+    // they are named differently.
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12143
+    `
+type A = 1 | 2;
+type B = 3 | 4;
+function f<T extends A>(x: T, y: string): void;
+function f<R extends B>(x: R): void;
+    `,
+    // Type parameters with different constraints must not be unified, even when
+    // they share a name.
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12143
+    `
+type A = 1 | 2;
+type B = 3 | 4;
+function f<T extends A>(x: T, y: string): void;
+function f<T extends B>(x: T): void;
+    `,
+    // Type parameters with different defaults must not be unified.
+    `
+function f<T extends string = 'a'>(x: T, y: string): void;
+function f<R extends string = 'b'>(x: R): void;
+    `,
+    // Type parameters with different defaults must not be unified, even when
+    // they share a name.
+    `
+function f<T extends string = 'a'>(x: T, y: string): void;
+function f<T extends string = 'b'>(x: T): void;
+    `,
+    // Outer type parameters are bindings, not local placeholder names.
+    `
+interface Box<T> {
+  f(x: T, y: string): void;
+  f<U extends string>(x: U): void;
+}
+    `,
     // Same name, different scopes
     `
 declare function foo(n: number): number;
@@ -801,6 +837,75 @@ function f<T>(x: T): void;
           },
           line: 3,
           messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Type parameters with the same constraint should be unified even when
+      // they are named differently.
+      // https://github.com/typescript-eslint/typescript-eslint/issues/12143
+      code: `
+function f<T extends string>(x: T, y: string): void;
+function f<R extends string>(x: R): void;
+      `,
+      errors: [
+        {
+          column: 36,
+          endColumn: 45,
+          endLine: 2,
+          line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // Differently named type parameters that share a constraint should be
+      // unified when nested in another type.
+      code: `
+function f<T extends string>(x: Array<T>, y: string): void;
+function f<R extends string>(x: Array<R>): void;
+      `,
+      errors: [
+        {
+          column: 43,
+          endColumn: 52,
+          endLine: 2,
+          line: 2,
+          messageId: 'omittingSingleParameter',
+        },
+      ],
+    },
+    {
+      // A later parameter should still compare equal when it uses a renamed
+      // type parameter with the same constraint.
+      code: `
+function f<T extends string>(x: number, y: T): void;
+function f<R extends string>(x: string, y: R): void;
+      `,
+      errors: [
+        {
+          column: 30,
+          endColumn: 39,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+    },
+    {
+      // Multiple renamed type parameters with matching constraints should be
+      // compared by position.
+      code: `
+function f<T extends string, U extends number>(x: Map<T, U>, y: string): void;
+function f<R extends string, S extends number>(x: Map<R, S>): void;
+      `,
+      errors: [
+        {
+          column: 62,
+          endColumn: 71,
+          endLine: 2,
+          line: 2,
+          messageId: 'omittingSingleParameter',
         },
       ],
     },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12143
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`unified-signatures` compared overload-local type parameter names as part of checking whether two signatures could be unified. That meant equivalent overloads such as `<T extends string>` and `<R extends string>` were treated as different, while same-named type parameters with different constraint/default types could still be treated as equivalent.

This PR normalizes each signature's own type parameter references by position before comparing parameter, return, constraint, and default type text. The traversal skips references shadowed by nested type parameter declarations, mapped type keys, and conditional `infer` type parameters; the outer type parameter usage check uses the same shadowing-aware traversal.

Added regression cases for renamed type parameters, different constraints/defaults, nested references, shadowed type parameters, mapped type keys, conditional `infer` type parameters, multiple type parameters, and outer type parameter bindings.

💖