### PR TITLE
chore: aggregate CI checks results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,31 @@ jobs:
           TYPESCRIPT_ESLINT_PROJECT_SERVICE: true
           PACKAGE: ${{ matrix.package }}
 
+  # Some test jobs are created dynamically and conditionally skipped (see affected-for-tests),
+  # so they can't be marked in the branch ruleset as required.
+  # This static job aggregates all other jobs and is the single check we require in the branch ruleset.
+  required_checks:
+    name: Required Checks
+    if: ${{ always() }}
+    needs:
+      - install
+      - affected-for-tests
+      - build
+      - generate_configs
+      - lint_without_build
+      - lint_with_build
+      - lint_with_build_eslint
+      - stylelint
+      - integration_tests
+      - plugin_unit_tests
+      - unit_tests
+      - unit_tests_project_service
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any dependency failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+
   upload_coverage:
     name: Upload Codecov Coverage
     environment: ${{ (github.repository == 'typescript-eslint/typescript-eslint' && github.ref == 'refs/heads/main') && 'main' || '' }} # Have to specify per job


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12494
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

This is the simplest solution I was able to think of. Not ideal because we need to manually set the dependencies of `required_checks`

EDIT: Actually, this is basically the same as setting them in the branch ruelset, I guess?

cc @bradzacher, will need your help configuring this in the repo settings
