### PR TITLE
feat(eslint-plugin): [no-loop-func] support `using` / `await using` declarations and deprecate the rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-loop-func.mdx
+++ b/packages/eslint-plugin/docs/rules/no-loop-func.mdx
@@ -9,4 +9,11 @@ import TabItem from '@theme/TabItem';
 >
 > See **https://typescript-eslint.io/rules/no-loop-func** for documentation.
 
+:::danger Deprecated
+
+This rule has been deprecated because the base [`eslint/no-loop-func`](https://eslint.org/docs/rules/no-loop-func) rule now handles TypeScript syntax, including [`using` and `await using` declarations](https://github.com/tc39/proposal-explicit-resource-management).
+There is no longer any need to use this extension rule.
+
+:::
+
 It adds support for TypeScript types.

--- a/packages/eslint-plugin/docs/rules/no-loop-func.mdx
+++ b/packages/eslint-plugin/docs/rules/no-loop-func.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 :::danger Deprecated
 
-This rule has been deprecated because the base [`eslint/no-loop-func`](https://eslint.org/docs/rules/no-loop-func) rule now handles TypeScript syntax, including [`using` and `await using` declarations](https://github.com/tc39/proposal-explicit-resource-management).
+This rule has been deprecated because the base [`eslint/no-loop-func`](https://eslint.org/docs/rules/no-loop-func) rule now handles TypeScript syntax.
 There is no longer any need to use this extension rule.
 
 :::

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -67,8 +67,6 @@ export = {
     'no-invalid-this': 'off',
     '@typescript-eslint/no-invalid-this': 'error',
     '@typescript-eslint/no-invalid-void-type': 'error',
-    'no-loop-func': 'off',
-    '@typescript-eslint/no-loop-func': 'error',
     'no-magic-numbers': 'off',
     '@typescript-eslint/no-magic-numbers': 'error',
     '@typescript-eslint/no-meaningless-void-operator': 'error',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -80,8 +80,6 @@ export default (
       'no-invalid-this': 'off',
       '@typescript-eslint/no-invalid-this': 'error',
       '@typescript-eslint/no-invalid-void-type': 'error',
-      'no-loop-func': 'off',
-      '@typescript-eslint/no-loop-func': 'error',
       'no-magic-numbers': 'off',
       '@typescript-eslint/no-magic-numbers': 'error',
       '@typescript-eslint/no-meaningless-void-operator': 'error',

--- a/packages/eslint-plugin/src/rules/no-loop-func.ts
+++ b/packages/eslint-plugin/src/rules/no-loop-func.ts
@@ -1,7 +1,3 @@
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
-
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
-
 import type {
   InferMessageIdsTypeFromRule,
   InferOptionsTypeFromRule,
@@ -10,16 +6,31 @@ import type {
 import { createRule } from '../util';
 import { getESLintCoreRule } from '../util/getESLintCoreRule';
 
-const baseRule = getESLintCoreRule('no-loop-func');
+const baseRule: ReturnType<typeof getESLintCoreRule> =
+  getESLintCoreRule('no-loop-func');
 
-export type Options = InferOptionsTypeFromRule<typeof baseRule>;
-export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+export type Options = InferOptionsTypeFromRule<NonNullable<typeof baseRule>>;
+export type MessageIds = InferMessageIdsTypeFromRule<
+  NonNullable<typeof baseRule>
+>;
 
 export default createRule<Options, MessageIds>({
   name: 'no-loop-func',
   meta: {
     type: 'suggestion',
     // defaultOptions, -- base rule does not use defaultOptions
+    deprecated: {
+      deprecatedSince: '8.64.0',
+      replacedBy: [
+        {
+          rule: {
+            name: 'no-loop-func',
+            url: 'https://eslint.org/docs/latest/rules/no-loop-func',
+          },
+        },
+      ],
+      url: 'https://github.com/typescript-eslint/typescript-eslint/issues/12496',
+    },
     docs: {
       description:
         'Disallow function declarations that contain unsafe references inside loop statements',
@@ -31,234 +42,6 @@ export default createRule<Options, MessageIds>({
   },
   defaultOptions: [],
   create(context) {
-    const SKIPPED_IIFE_NODES = new Set<
-      | TSESTree.ArrowFunctionExpression
-      | TSESTree.FunctionDeclaration
-      | TSESTree.FunctionExpression
-    >();
-
-    /**
-     * Gets the containing loop node of a specified node.
-     *
-     * We don't need to check nested functions, so this ignores those.
-     * `Scope.through` contains references of nested functions.
-     *
-     * @param node An AST node to get.
-     * @returns The containing loop node of the specified node, or `null`.
-     */
-    function getContainingLoopNode(node: TSESTree.Node): TSESTree.Node | null {
-      for (
-        let currentNode = node;
-        currentNode.parent;
-        currentNode = currentNode.parent
-      ) {
-        const parent = currentNode.parent;
-
-        switch (parent.type) {
-          case AST_NODE_TYPES.WhileStatement:
-          case AST_NODE_TYPES.DoWhileStatement:
-            return parent;
-
-          case AST_NODE_TYPES.ForStatement:
-            // `init` is outside of the loop.
-            if (parent.init !== currentNode) {
-              return parent;
-            }
-            break;
-
-          case AST_NODE_TYPES.ForInStatement:
-          case AST_NODE_TYPES.ForOfStatement:
-            // `right` is outside of the loop.
-            if (parent.right !== currentNode) {
-              return parent;
-            }
-            break;
-
-          case AST_NODE_TYPES.ArrowFunctionExpression:
-          case AST_NODE_TYPES.FunctionExpression:
-          case AST_NODE_TYPES.FunctionDeclaration:
-            // We don't need to check nested functions.
-
-            // We need to check nested functions only in case of IIFE.
-            if (SKIPPED_IIFE_NODES.has(parent)) {
-              break;
-            }
-            return null;
-
-          default:
-            break;
-        }
-      }
-
-      return null;
-    }
-
-    /**
-     * Gets the containing loop node of a given node.
-     * If the loop was nested, this returns the most outer loop.
-     * @param node A node to get. This is a loop node.
-     * @param excludedNode A node that the result node should not include.
-     * @returns The most outer loop node.
-     */
-    function getTopLoopNode(
-      node: TSESTree.Node,
-      excludedNode: TSESTree.Node | null | undefined,
-    ): TSESTree.Node {
-      const border = excludedNode ? excludedNode.range[1] : 0;
-      let retv = node;
-      let containingLoopNode: TSESTree.Node | null = node;
-
-      while (containingLoopNode && containingLoopNode.range[0] >= border) {
-        retv = containingLoopNode;
-        containingLoopNode = getContainingLoopNode(containingLoopNode);
-      }
-
-      return retv;
-    }
-
-    /**
-     * Checks whether a given reference which refers to an upper scope's variable is
-     * safe or not.
-     * @param loopNode A containing loop node.
-     * @param reference A reference to check.
-     * @returns `true` if the reference is safe or not.
-     */
-    function isSafe(
-      loopNode: TSESTree.Node,
-      reference: TSESLint.Scope.Reference,
-    ): boolean {
-      const variable = reference.resolved;
-      const definition = variable?.defs[0];
-      const declaration = definition?.parent;
-      const kind =
-        declaration?.type === AST_NODE_TYPES.VariableDeclaration
-          ? declaration.kind
-          : '';
-
-      // type references are all safe
-      // this only really matters for global types that haven't been configured
-      if (reference.isTypeReference) {
-        return true;
-      }
-
-      // Variables which are declared by `const` is safe.
-      if (kind === 'const') {
-        return true;
-      }
-
-      /*
-       * Variables which are declared by `let` in the loop is safe.
-       * It's a different instance from the next loop step's.
-       */
-      if (
-        kind === 'let' &&
-        declaration &&
-        declaration.range[0] > loopNode.range[0] &&
-        declaration.range[1] < loopNode.range[1]
-      ) {
-        return true;
-      }
-
-      /*
-       * WriteReferences which exist after this border are unsafe because those
-       * can modify the variable.
-       */
-      const border = getTopLoopNode(
-        loopNode,
-        kind === 'let' ? declaration : null,
-      ).range[0];
-
-      /**
-       * Checks whether a given reference is safe or not.
-       * The reference is every reference of the upper scope's variable we are
-       * looking now.
-       *
-       * It's safe if the reference matches one of the following condition.
-       * - is readonly.
-       * - doesn't exist inside a local function and after the border.
-       *
-       * @param upperRef A reference to check.
-       * @returns `true` if the reference is safe.
-       */
-      function isSafeReference(upperRef: TSESLint.Scope.Reference): boolean {
-        const id = upperRef.identifier;
-
-        return (
-          !upperRef.isWrite() ||
-          (variable?.scope.variableScope === upperRef.from.variableScope &&
-            id.range[0] < border)
-        );
-      }
-
-      return variable?.references.every(isSafeReference) ?? false;
-    }
-
-    /**
-     * Reports functions which match the following condition:
-     * - has a loop node in ancestors.
-     * - has any references which refers to an unsafe variable.
-     *
-     * @param node The AST node to check.
-     */
-    function checkForLoops(
-      node:
-        | TSESTree.ArrowFunctionExpression
-        | TSESTree.FunctionDeclaration
-        | TSESTree.FunctionExpression,
-    ): void {
-      const loopNode = getContainingLoopNode(node);
-
-      if (!loopNode) {
-        return;
-      }
-
-      const references = context.sourceCode.getScope(node).through;
-
-      if (!(node.async || node.generator) && isIIFE(node)) {
-        const isFunctionExpression =
-          node.type === AST_NODE_TYPES.FunctionExpression;
-
-        // Check if the function is referenced elsewhere in the code
-        const isFunctionReferenced =
-          isFunctionExpression && node.id
-            ? references.some(r => r.identifier.name === node.id?.name)
-            : false;
-
-        if (!isFunctionReferenced) {
-          SKIPPED_IIFE_NODES.add(node);
-          return;
-        }
-      }
-
-      const unsafeRefs = references
-        .filter(r => r.resolved && !isSafe(loopNode, r))
-        .map(r => r.identifier.name);
-
-      if (unsafeRefs.length > 0) {
-        context.report({
-          node,
-          messageId: 'unsafeRefs',
-          data: { varNames: `'${unsafeRefs.join("', '")}'` },
-        });
-      }
-    }
-
-    return {
-      ArrowFunctionExpression: checkForLoops,
-      FunctionDeclaration: checkForLoops,
-      FunctionExpression: checkForLoops,
-    };
+    return baseRule.create(context);
   },
 });
-
-function isIIFE(
-  node:
-    | TSESTree.ArrowFunctionExpression
-    | TSESTree.FunctionDeclaration
-    | TSESTree.FunctionExpression,
-): boolean {
-  return (
-    node.parent.type === AST_NODE_TYPES.CallExpression &&
-    node.parent.callee === node
-  );
-}

--- a/packages/eslint-plugin/src/rules/no-loop-func.ts
+++ b/packages/eslint-plugin/src/rules/no-loop-func.ts
@@ -9,10 +9,8 @@ import { getESLintCoreRule } from '../util/getESLintCoreRule';
 const baseRule: ReturnType<typeof getESLintCoreRule> =
   getESLintCoreRule('no-loop-func');
 
-export type Options = InferOptionsTypeFromRule<NonNullable<typeof baseRule>>;
-export type MessageIds = InferMessageIdsTypeFromRule<
-  NonNullable<typeof baseRule>
->;
+export type Options = InferOptionsTypeFromRule<typeof baseRule>;
+export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
 
 export default createRule<Options, MessageIds>({
   name: 'no-loop-func',

--- a/packages/eslint-plugin/src/rules/no-loop-func.ts
+++ b/packages/eslint-plugin/src/rules/no-loop-func.ts
@@ -1,3 +1,7 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
 import type {
   InferMessageIdsTypeFromRule,
   InferOptionsTypeFromRule,
@@ -6,11 +10,12 @@ import type {
 import { createRule } from '../util';
 import { getESLintCoreRule } from '../util/getESLintCoreRule';
 
-const baseRule: ReturnType<typeof getESLintCoreRule> =
-  getESLintCoreRule('no-loop-func');
+const baseRule = getESLintCoreRule('no-loop-func');
 
 export type Options = InferOptionsTypeFromRule<typeof baseRule>;
 export type MessageIds = InferMessageIdsTypeFromRule<typeof baseRule>;
+
+const CONSTANT_BINDINGS = new Set(['await using', 'const', 'using']);
 
 export default createRule<Options, MessageIds>({
   name: 'no-loop-func',
@@ -40,6 +45,235 @@ export default createRule<Options, MessageIds>({
   },
   defaultOptions: [],
   create(context) {
-    return baseRule.create(context);
+    const SKIPPED_IIFE_NODES = new Set<
+      | TSESTree.ArrowFunctionExpression
+      | TSESTree.FunctionDeclaration
+      | TSESTree.FunctionExpression
+    >();
+
+    /**
+     * Gets the containing loop node of a specified node.
+     *
+     * We don't need to check nested functions, so this ignores those.
+     * `Scope.through` contains references of nested functions.
+     *
+     * @param node An AST node to get.
+     * @returns The containing loop node of the specified node, or `null`.
+     */
+    function getContainingLoopNode(node: TSESTree.Node): TSESTree.Node | null {
+      for (
+        let currentNode = node;
+        currentNode.parent;
+        currentNode = currentNode.parent
+      ) {
+        const parent = currentNode.parent;
+
+        switch (parent.type) {
+          case AST_NODE_TYPES.WhileStatement:
+          case AST_NODE_TYPES.DoWhileStatement:
+            return parent;
+
+          case AST_NODE_TYPES.ForStatement:
+            // `init` is outside of the loop.
+            if (parent.init !== currentNode) {
+              return parent;
+            }
+            break;
+
+          case AST_NODE_TYPES.ForInStatement:
+          case AST_NODE_TYPES.ForOfStatement:
+            // `right` is outside of the loop.
+            if (parent.right !== currentNode) {
+              return parent;
+            }
+            break;
+
+          case AST_NODE_TYPES.ArrowFunctionExpression:
+          case AST_NODE_TYPES.FunctionExpression:
+          case AST_NODE_TYPES.FunctionDeclaration:
+            // We don't need to check nested functions.
+
+            // We need to check nested functions only in case of IIFE.
+            if (SKIPPED_IIFE_NODES.has(parent)) {
+              break;
+            }
+            return null;
+
+          default:
+            break;
+        }
+      }
+
+      return null;
+    }
+
+    /**
+     * Gets the containing loop node of a given node.
+     * If the loop was nested, this returns the most outer loop.
+     * @param node A node to get. This is a loop node.
+     * @param excludedNode A node that the result node should not include.
+     * @returns The most outer loop node.
+     */
+    function getTopLoopNode(
+      node: TSESTree.Node,
+      excludedNode: TSESTree.Node | null | undefined,
+    ): TSESTree.Node {
+      const border = excludedNode ? excludedNode.range[1] : 0;
+      let retv = node;
+      let containingLoopNode: TSESTree.Node | null = node;
+
+      while (containingLoopNode && containingLoopNode.range[0] >= border) {
+        retv = containingLoopNode;
+        containingLoopNode = getContainingLoopNode(containingLoopNode);
+      }
+
+      return retv;
+    }
+
+    /**
+     * Checks whether a given reference which refers to an upper scope's variable is
+     * safe or not.
+     * @param loopNode A containing loop node.
+     * @param reference A reference to check.
+     * @returns `true` if the reference is safe or not.
+     */
+    function isSafe(
+      loopNode: TSESTree.Node,
+      reference: TSESLint.Scope.Reference,
+    ): boolean {
+      const variable = reference.resolved;
+      const definition = variable?.defs[0];
+      const declaration = definition?.parent;
+      const kind =
+        declaration?.type === AST_NODE_TYPES.VariableDeclaration
+          ? declaration.kind
+          : '';
+
+      // type references are all safe
+      // this only really matters for global types that haven't been configured
+      if (reference.isTypeReference) {
+        return true;
+      }
+
+      // Variables which are declared by `const`, `using`, or `await using` are
+      // safe. They can't be reassigned, so each iteration captures a fresh one.
+      if (CONSTANT_BINDINGS.has(kind)) {
+        return true;
+      }
+
+      /*
+       * Variables which are declared by `let` in the loop is safe.
+       * It's a different instance from the next loop step's.
+       */
+      if (
+        kind === 'let' &&
+        declaration &&
+        declaration.range[0] > loopNode.range[0] &&
+        declaration.range[1] < loopNode.range[1]
+      ) {
+        return true;
+      }
+
+      /*
+       * WriteReferences which exist after this border are unsafe because those
+       * can modify the variable.
+       */
+      const border = getTopLoopNode(
+        loopNode,
+        kind === 'let' ? declaration : null,
+      ).range[0];
+
+      /**
+       * Checks whether a given reference is safe or not.
+       * The reference is every reference of the upper scope's variable we are
+       * looking now.
+       *
+       * It's safe if the reference matches one of the following condition.
+       * - is readonly.
+       * - doesn't exist inside a local function and after the border.
+       *
+       * @param upperRef A reference to check.
+       * @returns `true` if the reference is safe.
+       */
+      function isSafeReference(upperRef: TSESLint.Scope.Reference): boolean {
+        const id = upperRef.identifier;
+
+        return (
+          !upperRef.isWrite() ||
+          (variable?.scope.variableScope === upperRef.from.variableScope &&
+            id.range[0] < border)
+        );
+      }
+
+      return variable?.references.every(isSafeReference) ?? false;
+    }
+
+    /**
+     * Reports functions which match the following condition:
+     * - has a loop node in ancestors.
+     * - has any references which refers to an unsafe variable.
+     *
+     * @param node The AST node to check.
+     */
+    function checkForLoops(
+      node:
+        | TSESTree.ArrowFunctionExpression
+        | TSESTree.FunctionDeclaration
+        | TSESTree.FunctionExpression,
+    ): void {
+      const loopNode = getContainingLoopNode(node);
+
+      if (!loopNode) {
+        return;
+      }
+
+      const references = context.sourceCode.getScope(node).through;
+
+      if (!(node.async || node.generator) && isIIFE(node)) {
+        const isFunctionExpression =
+          node.type === AST_NODE_TYPES.FunctionExpression;
+
+        // Check if the function is referenced elsewhere in the code
+        const isFunctionReferenced =
+          isFunctionExpression && node.id
+            ? references.some(r => r.identifier.name === node.id?.name)
+            : false;
+
+        if (!isFunctionReferenced) {
+          SKIPPED_IIFE_NODES.add(node);
+          return;
+        }
+      }
+
+      const unsafeRefs = references
+        .filter(r => r.resolved && !isSafe(loopNode, r))
+        .map(r => r.identifier.name);
+
+      if (unsafeRefs.length > 0) {
+        context.report({
+          node,
+          messageId: 'unsafeRefs',
+          data: { varNames: `'${unsafeRefs.join("', '")}'` },
+        });
+      }
+    }
+
+    return {
+      ArrowFunctionExpression: checkForLoops,
+      FunctionDeclaration: checkForLoops,
+      FunctionExpression: checkForLoops,
+    };
   },
 });
+
+function isIIFE(
+  node:
+    | TSESTree.ArrowFunctionExpression
+    | TSESTree.FunctionDeclaration
+    | TSESTree.FunctionExpression,
+): boolean {
+  return (
+    node.parent.type === AST_NODE_TYPES.CallExpression &&
+    node.parent.callee === node
+  );
+}

--- a/packages/eslint-plugin/tests/rules/no-loop-func.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-loop-func.test.ts
@@ -52,6 +52,22 @@ for (let i = 0; i < 10; i += 1) {
   someArray = someArray.filter((item: MyType) => !!item);
 }
     `,
+    `
+declare function getResource(): Disposable;
+for (let i = 0; i < 3; i++) {
+  using resource = getResource();
+  const fn = () => resource;
+}
+    `,
+    `
+declare function getResource(): AsyncDisposable;
+async function f() {
+  for (let i = 0; i < 3; i++) {
+    await using resource = getResource();
+    const fn = () => resource;
+  }
+}
+    `,
   ],
   invalid: [],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12496
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->

`using` / `await using` are now treated as safe bindings, same as `const`

Couldn't just delegate to the base rule since core only added this in ESLint 9.25 and we still support 8.57, so I backfilled it here. Also deprecated the rule.