### PR TITLE
docs: fix shadowed parameter name in unified-signatures example

### DIFF
--- a/packages/eslint-plugin/docs/rules/unified-signatures.mdx
+++ b/packages/eslint-plugin/docs/rules/unified-signatures.mdx
@@ -22,7 +22,7 @@ This rule reports when function overload signatures can be replaced by a single 
 
 ```ts
 function x(x: number): void;
-function x(x: string): void;
+function x(y: string): void;
 ```
 
 ```ts

--- a/packages/eslint-plugin/docs/rules/unified-signatures.mdx
+++ b/packages/eslint-plugin/docs/rules/unified-signatures.mdx
@@ -21,7 +21,7 @@ This rule reports when function overload signatures can be replaced by a single 
 <TabItem value="❌ Incorrect">
 
 ```ts
-function x(x: number): void;
+function x(y: number): void;
 function x(y: string): void;
 ```
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unified-signatures.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unified-signatures.shot
@@ -1,6 +1,6 @@
 Incorrect
 
-function x(x: number): void;
+function x(y: number): void;
 function x(y: string): void;
            ~~~~~~~~~ These overloads can be combined into one signature taking `number | string`.
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unified-signatures.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unified-signatures.shot
@@ -1,7 +1,7 @@
 Incorrect
 
 function x(x: number): void;
-function x(x: string): void;
+function x(y: string): void;
            ~~~~~~~~~ These overloads can be combined into one signature taking `number | string`.
 
 Incorrect


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12501
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Updates the `unified-signatures` rule docs so the first incorrect example does not reuse `x` as both the function name and parameter name.

The second overload now uses `y` as the parameter name, matching the issue request and making the example a bit clearer.