### PR TITLE
docs(unified-signatures): fix parameter shadowing in first Incorrect example

### DIFF
--- a/packages/eslint-plugin/docs/rules/unified-signatures.mdx
+++ b/packages/eslint-plugin/docs/rules/unified-signatures.mdx
@@ -21,8 +21,8 @@ This rule reports when function overload signatures can be replaced by a single 
 <TabItem value="❌ Incorrect">
 
 ```ts
-function x(x: number): void;
-function x(x: string): void;
+function x(y: number): void;
+function x(y: string): void;
 ```
 
 ```ts


### PR DESCRIPTION
## Summary

Fixes confusing parameter shadowing in the `unified-signatures` rule docs.
Rename parameter `x` to `y` so it does not shadow the function name `x`.

## PR Checklist

- [x] Addresses an existing open issue: fixes #12501
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Renamed the parameter `x` to `y` in the first Incorrect example of the `unified-signatures` rule documentation to remove confusing identifier shadowing where both the function name and parameter were named `x`.

Fixes #12501

