### PR TITLE
docs: align unified-signatures correct example parameter

### DIFF
--- a/packages/eslint-plugin/docs/rules/unified-signatures.mdx
+++ b/packages/eslint-plugin/docs/rules/unified-signatures.mdx
@@ -34,7 +34,7 @@ function y(...x: number[]): void;
 <TabItem value="✅ Correct">
 
 ```ts
-function x(x: number | string): void;
+function x(y: number | string): void;
 ```
 
 ```ts

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unified-signatures.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/unified-signatures.shot
@@ -12,7 +12,7 @@ function y(...x: number[]): void;
 
 Correct
 
-function x(x: number | string): void;
+function x(y: number | string): void;
 
 Correct
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses existing review feedback from #12502
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Updates the `unified-signatures` docs so the “Correct” example uses the same non-shadowing parameter name as the preceding overload example.

This follows up on review feedback from #12502.