### PR TITLE
chore: change range strategy to "bump" for dev deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,6 +36,11 @@
       description: 'Label GHA ecosystem PRs appropriately.',
       matchManagers: ['github-actions'],
     },
+    {
+      description: 'Use range strategy "bump" for dev dependencies.',
+      matchDepTypes: ['devDependencies'],
+      rangeStrategy: 'bump',
+    },
   ],
 
   // We've found enabling patch updates on all dependencies is a lot of noise.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

discussed with @bradzacher in https://discord.com/channels/1026804805894672454/1506351063660368005. 

Thinking to give this approach a try so that the semver ranges for dev deps don't show woefully out of date minimum versions that won't actually work.

https://docs.renovatebot.com/configuration-options/#rangestrategy