### PR TITLE
fix(eslint-plugin): [require-array-sort-compare] handle constrained arrays

### DIFF
--- a/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
+++ b/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
@@ -57,7 +57,7 @@ export default createRule<Options, MessageIds>({
      * Check if a given node is an array which all elements are string.
      */
     function isStringArrayNode(node: TSESTree.Expression): boolean {
-      const type = services.getTypeAtLocation(node);
+      const type = getConstrainedTypeAtLocation(services, node);
 
       if (checker.isArrayType(type) || checker.isTupleType(type)) {
         const typeArgs = checker.getTypeArguments(type);

--- a/packages/eslint-plugin/tests/rules/require-array-sort-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-array-sort-compare.test.ts
@@ -118,6 +118,30 @@ ruleTester.run('require-array-sort-compare', rule, {
     },
     {
       code: `
+        function f<T extends string[]>(a: T) {
+          a.sort();
+        }
+      `,
+      options: [{ ignoreStringArrays: true }],
+    },
+    {
+      code: `
+        function f<T extends Array<string>>(a: T) {
+          a.sort();
+        }
+      `,
+      options: [{ ignoreStringArrays: true }],
+    },
+    {
+      code: `
+        function f<T extends string>(a: T[]) {
+          a.sort();
+        }
+      `,
+      options: [{ ignoreStringArrays: true }],
+    },
+    {
+      code: `
         function f(a: number[]) {
           a.toSorted((a, b) => a - b);
         }
@@ -182,6 +206,15 @@ ruleTester.run('require-array-sort-compare', rule, {
         }
       `,
       errors: [{ messageId: 'requireCompare' }],
+    },
+    {
+      code: `
+        function f<T extends string[]>(a: T) {
+          a.sort();
+        }
+      `,
+      errors: [{ messageId: 'requireCompare' }],
+      options: [{ ignoreStringArrays: false }],
     },
     {
       code: `


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12511
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Fixes a false positive in `require-array-sort-compare` when sorting a generic value constrained to `string[]`

The rule now checks the constrained type when deciding whether an array is string-only, so `T extends string[]` is handled the same way as `string[]`. Added regression tests for constrained string arrays and the `ignoreStringArrays: false` behavior
