### PR TITLE
fix(eslint-plugin): [prefer-string-starts-ends-with] handle escaped $ ending regex literals

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -294,7 +294,7 @@ export default createRule<Options, MessageIds>({
       const { flags, source } = evaluated.value;
       const isStartsWith = source.startsWith('^');
       // ends with a $ preceded by an even number of backslashes (or zero)
-      const isEndsWith = /(?<!\\)(?:\\\\)*\$/.test(source);
+      const isEndsWith = /(?<!\\)(?:\\\\)*\$$/.test(source);
       if (
         isStartsWith === isEndsWith ||
         flags.includes('i') ||

--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -293,7 +293,8 @@ export default createRule<Options, MessageIds>({
 
       const { flags, source } = evaluated.value;
       const isStartsWith = source.startsWith('^');
-      const isEndsWith = source.endsWith('$');
+      // ends with a $ preceded by an even number of backslashes (or zero)
+      const isEndsWith = /(?<!\\)(?:\\\\)*\$/.test(source);
       if (
         isStartsWith === isEndsWith ||
         flags.includes('i') ||

--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -294,7 +294,7 @@ export default createRule<Options, MessageIds>({
       const { flags, source } = evaluated.value;
       const isStartsWith = source.startsWith('^');
       // ends with a $ preceded by an even number of backslashes (or zero)
-      const isEndsWith = /(?<!\\)(?:\\\\)*\$$/.test(source);
+      const isEndsWith = /[^\\](\\\\)*\$$/.test(source);
       if (
         isStartsWith === isEndsWith ||
         flags.includes('i') ||

--- a/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
@@ -302,8 +302,12 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
       `,
       options: [{ allowSingleElementEquality: 'always' }],
     },
-    '/foo\\$/.test(s);',
-    '/foo\\\\\\$/.test(s);',
+    "/foo\\$/.test('string');",
+    "/foo\\\\\\$/.test('string');",
+    "/beforeAnchor$afterAnchor/.test('string');",
+    "/beforeDollarSign\\$afterDollarSign/.test('string');",
+    "/beforeAnchor\\\\$afterAnchor/.test('string');",
+    '/[$]/.test(string);',
   ],
   invalid: [
     // String indexing.
@@ -1183,9 +1187,14 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
       `,
     },
     {
-      code: '/foo\\\\$/.test(s);',
+      code: "/foo$/.test('string');",
       errors: [{ messageId: 'preferEndsWith' }],
-      output: 's.endsWith("foo\\\\");',
+      output: '\'string\'.endsWith("foo");',
+    },
+    {
+      code: "/foo\\\\$/.test('string');",
+      errors: [{ messageId: 'preferEndsWith' }],
+      output: '\'string\'.endsWith("foo\\\\");',
     },
   ],
 });

--- a/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
@@ -302,6 +302,8 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
       `,
       options: [{ allowSingleElementEquality: 'always' }],
     },
+    '/foo\\$/.test(s);',
+    '/foo\\\\\\$/.test(s);',
   ],
   invalid: [
     // String indexing.
@@ -1179,6 +1181,11 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
           s.startsWith(needle);
         }
       `,
+    },
+    {
+      code: '/foo\\\\$/.test(s);',
+      errors: [{ messageId: 'preferEndsWith' }],
+      output: 's.endsWith("foo\\\\");',
     },
   ],
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12514 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [ ] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

even number of backslashes => anchor
odd number of backslashes => escaped $