### PR TITLE
fix(eslint-plugin): avoid escaped dollar regex autofixes

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -252,7 +252,10 @@ export default createRule<Options, MessageIds>({
      * @param pattern The RegExp pattern text to parse.
      * @param unicode Whether the RegExp is unicode.
      */
-    function parseRegExpText(pattern: string, unicode: boolean): string | null {
+    function parseRegExpText(
+      pattern: string,
+      unicode: boolean,
+    ): { isEndsWith: boolean; isStartsWith: boolean; text: string } | null {
       // Parse it.
       const ast = regexpp.parsePattern(pattern, undefined, undefined, {
         unicode,
@@ -262,9 +265,20 @@ export default createRule<Options, MessageIds>({
       }
 
       // Drop `^`/`$` assertion.
-      const chars = ast.alternatives[0].elements;
+      const chars = [...ast.alternatives[0].elements];
+      if (chars.length === 0) {
+        return null;
+      }
+
       const first = chars[0];
-      if (first.type === 'Assertion' && first.kind === 'start') {
+      const last = chars[chars.length - 1];
+      const isStartsWith = first.type === 'Assertion' && first.kind === 'start';
+      const isEndsWith = last.type === 'Assertion' && last.kind === 'end';
+      if (isStartsWith === isEndsWith) {
+        return null;
+      }
+
+      if (isStartsWith) {
         chars.shift();
       } else {
         chars.pop();
@@ -276,7 +290,8 @@ export default createRule<Options, MessageIds>({
       }
 
       // To string.
-      return String.fromCodePoint(...chars.map(c => c.value));
+      const text = String.fromCodePoint(...chars.map(c => c.value));
+      return { isEndsWith, isStartsWith, text };
     }
 
     /**
@@ -292,22 +307,11 @@ export default createRule<Options, MessageIds>({
       }
 
       const { flags, source } = evaluated.value;
-      const isStartsWith = source.startsWith('^');
-      const isEndsWith = source.endsWith('$');
-      if (
-        isStartsWith === isEndsWith ||
-        flags.includes('i') ||
-        flags.includes('m')
-      ) {
+      if (flags.includes('i') || flags.includes('m')) {
         return null;
       }
 
-      const text = parseRegExpText(source, flags.includes('u'));
-      if (text == null) {
-        return null;
-      }
-
-      return { isEndsWith, isStartsWith, text };
+      return parseRegExpText(source, flags.includes('u'));
     }
 
     function getLeftNode(

--- a/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
@@ -179,6 +179,11 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
     `,
     `
       function f(s: string) {
+        s.match(/bar\\$/) !== null;
+      }
+    `,
+    `
+      function f(s: string) {
         s.match(/^foo$/) !== null;
       }
     `,
@@ -251,6 +256,11 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
     `
       function f(s: string) {
         pattern.test(s);
+      }
+    `,
+    `
+      function f(s: string) {
+        /bar\\$/.test(s);
       }
     `,
     `


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12514
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`prefer-string-starts-ends-with` was checking the raw regex source to decide whether a pattern ended with `$`. That made escaped dollar literals like `/bar\$/` look like end anchors, so the rule could incorrectly suggest `s.endsWith("bar")`.

This uses the parsed regex AST to require an actual start/end assertion before reporting, and adds valid cases for both `String#match` and `RegExp#test`.

Validation:

- `pnpm -w exec nx test eslint-plugin -- prefer-string-starts-ends-with.test.ts`
- `pnpm -w exec nx typecheck eslint-plugin`
- `pnpm -w exec eslint --config=eslint.config.mjs packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts`
- `pnpm -w exec prettier --check packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts && git diff --check`

💖