### PR TITLE
chore(eslint-plugin-internal): [plugin-test-formatting] ensure backslashes are escaped in fixer

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -29,11 +29,6 @@
       "count": 6
     }
   },
-  "packages/eslint-plugin-internal/tests/rules/plugin-test-formatting.test.ts": {
-    "eslint-plugin/require-test-error-positions": {
-      "count": 14
-    }
-  },
   "packages/eslint-plugin-internal/tests/rules/prefer-ast-types-enum.test.ts": {
     "eslint-plugin/require-test-error-positions": {
       "count": 3

--- a/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
+++ b/packages/eslint-plugin-internal/src/rules/plugin-test-formatting.ts
@@ -75,7 +75,7 @@ function doIndent(line: string, indent: number): string {
   return line;
 }
 
-function getQuote(code: string): "'" | '"' | null {
+function getSafeWrappingQuote(code: string): "'" | '"' | null {
   const hasSingleQuote = code.includes("'");
   const hasDoubleQuote = code.includes('"');
   if (hasSingleQuote && hasDoubleQuote) {
@@ -86,10 +86,18 @@ function getQuote(code: string): "'" | '"' | null {
   return hasSingleQuote ? '"' : "'";
 }
 
-function escapeTemplateString(code: string): string {
+function escapeForTemplateString(code: string): string {
   let fixed = code;
+  fixed = fixed.replaceAll('\\', '\\\\');
   fixed = fixed.replaceAll(BACKTICK_REGEX, '\\`');
   fixed = fixed.replaceAll(TEMPLATE_EXPR_OPENER, '\\${');
+  return fixed;
+}
+
+function escapeForStringLiteral(code: string, quote: string): string {
+  let fixed = code;
+  fixed = fixed.replaceAll('\\', '\\\\');
+  fixed = fixed.replaceAll(quote, `\\${quote}`);
   return fixed;
 }
 
@@ -264,16 +272,16 @@ export default createRule<Options, MessageIds>({
                 // formatted string is multiline, then have to use backticks
                 return fixer.replaceText(
                   literal,
-                  `\`${escapeTemplateString(output)}\``,
+                  `\`${escapeForTemplateString(output)}\``,
                 );
               }
 
-              const quote = quoteIn ?? getQuote(output);
-              if (quote == null) {
-                return null;
-              }
+              const quote = quoteIn ?? getSafeWrappingQuote(output) ?? "'";
 
-              return fixer.replaceText(literal, `${quote}${output}${quote}`);
+              return fixer.replaceText(
+                literal,
+                `${quote}${escapeForStringLiteral(output, quote)}${quote}`,
+              );
             },
           });
         }
@@ -302,7 +310,7 @@ export default createRule<Options, MessageIds>({
           node: literal,
           messageId: 'singleLineQuotes',
           fix(fixer) {
-            const quote = getQuote(text);
+            const quote = getSafeWrappingQuote(text);
             if (quote == null) {
               return null;
             }
@@ -445,7 +453,7 @@ export default createRule<Options, MessageIds>({
           fix(fixer) {
             return fixer.replaceText(
               literal,
-              `\`\n${escapeTemplateString(formattedIndented)}\n${doIndent(
+              `\`\n${escapeForTemplateString(formattedIndented)}\n${doIndent(
                 '',
                 parentIndent,
               )}\``,
@@ -474,7 +482,10 @@ export default createRule<Options, MessageIds>({
           messageId: 'noUnnecessaryNoFormat',
           fix(fixer) {
             if (expr.loc.start.line === expr.loc.end.line) {
-              return fixer.replaceText(expr, `'${escapeTemplateString(text)}'`);
+              return fixer.replaceText(
+                expr,
+                `'${escapeForTemplateString(text)}'`,
+              );
             }
             return fixer.replaceText(expr.tag, '');
           },

--- a/packages/eslint-plugin-internal/tests/rules/plugin-test-formatting.test.ts
+++ b/packages/eslint-plugin-internal/tests/rules/plugin-test-formatting.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable eslint-plugin/require-test-error-positions */
 import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
 
 import rule from '../../src/rules/plugin-test-formatting.js';
@@ -15,6 +14,10 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('plugin-test-formatting', rule, {
+  assertionOptions: {
+    requireData: true,
+    requireLocation: true,
+  },
   invalid: [
     // Literal
     {
@@ -922,21 +925,45 @@ ruleTester.run({
       `,
       errors: [
         {
+          column: 13,
+          endColumn: 18,
+          endLine: 5,
+          line: 5,
           messageId: 'singleLineQuotes',
         },
         {
+          column: 13,
+          endColumn: 2,
+          endLine: 9,
+          line: 8,
           messageId: 'templateLiteralEmptyEnds',
         },
         {
+          column: 13,
+          endColumn: 11,
+          endLine: 13,
+          line: 12,
           messageId: 'templateLiteralEmptyEnds',
         },
         {
+          column: 13,
+          endColumn: 18,
+          endLine: 18,
+          line: 18,
           messageId: 'singleLineQuotes',
         },
         {
+          column: 13,
+          endColumn: 2,
+          endLine: 22,
+          line: 21,
           messageId: 'templateLiteralEmptyEnds',
         },
         {
+          column: 13,
+          endColumn: 11,
+          endLine: 26,
+          line: 25,
           messageId: 'templateLiteralEmptyEnds',
         },
       ],
@@ -1092,12 +1119,24 @@ const test: RunTests = {
       `,
       errors: [
         {
+          column: 5,
+          endColumn: 44,
+          endLine: 4,
+          line: 4,
           messageId: 'invalidFormatting',
         },
         {
+          column: 13,
+          endColumn: 52,
+          endLine: 6,
+          line: 6,
           messageId: 'invalidFormatting',
         },
         {
+          column: 13,
+          endColumn: 52,
+          endLine: 11,
+          line: 11,
           messageId: 'invalidFormattingErrorTest',
         },
       ],
@@ -1139,12 +1178,24 @@ const test: RunTests<'', []> = {
       `,
       errors: [
         {
+          column: 5,
+          endColumn: 44,
+          endLine: 6,
+          line: 6,
           messageId: 'invalidFormatting',
         },
         {
+          column: 13,
+          endColumn: 52,
+          endLine: 8,
+          line: 8,
           messageId: 'invalidFormatting',
         },
         {
+          column: 13,
+          endColumn: 52,
+          endLine: 13,
+          line: 13,
           messageId: 'invalidFormattingErrorTest',
         },
       ],
@@ -1216,9 +1267,17 @@ const test: InvalidTestCase<'', []> = {
       `,
       errors: [
         {
+          column: 9,
+          endColumn: 49,
+          endLine: 5,
+          line: 5,
           messageId: 'invalidFormattingErrorTest',
         },
         {
+          column: 13,
+          endColumn: 53,
+          endLine: 8,
+          line: 8,
           messageId: 'invalidFormattingErrorTest',
         },
       ],
@@ -1262,6 +1321,10 @@ ruleTester.run({
       `,
       errors: [
         {
+          column: 13,
+          endColumn: 21,
+          endLine: 5,
+          line: 5,
           messageId: 'invalidFormatting',
         },
       ],
@@ -1296,6 +1359,10 @@ ruleTester.run({
       `,
       errors: [
         {
+          column: 13,
+          endColumn: 23,
+          endLine: 5,
+          line: 5,
           messageId: 'invalidFormatting',
         },
       ],
@@ -1331,6 +1398,10 @@ ruleTester.run({
       `,
       errors: [
         {
+          column: 13,
+          endColumn: 21,
+          endLine: 5,
+          line: 5,
           messageId: 'invalidFormatting',
         },
       ],
@@ -1368,6 +1439,10 @@ ${
       `,
       errors: [
         {
+          column: 13,
+          endColumn: 8,
+          endLine: 7,
+          line: 5,
           messageId: 'invalidFormatting',
         },
       ],

--- a/packages/eslint-plugin-internal/tests/rules/plugin-test-formatting.test.ts
+++ b/packages/eslint-plugin-internal/tests/rules/plugin-test-formatting.test.ts
@@ -1243,6 +1243,78 @@ const test: InvalidTestCase<'', []> = {
 };
       `,
     },
+    {
+      // ensure output has enough escaping for `code` with a 'quoted string'.
+      code: `
+ruleTester.run({
+  valid: [
+    {
+      code: ${
+        // The user types "'\\\\'"
+        // meaning the code they are testing is '\\' (which is missing a semicolon for prettier formatting)
+        // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
+        String.raw`"'\\\\'"`
+      },
+    },
+  ],
+});
+      `,
+      errors: [
+        {
+          messageId: 'invalidFormatting',
+        },
+      ],
+      output: `
+ruleTester.run({
+  valid: [
+    {
+      code: ${
+        // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
+        String.raw`"'\\\\';"`
+      },
+    },
+  ],
+});
+      `,
+    },
+    {
+      // ensure output has enough escaping for `code` with a `template string`.
+      code: `
+ruleTester.run({
+  valid: [
+    {
+      code: \`
+${
+  // The user types `'\\\\'` (but multiline)
+  // meaning the code they are testing is '\\' (which is missing a semicolon for prettier formatting)
+  // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
+  String.raw`'\\\\'`
+}
+      \`,
+    },
+  ],
+});
+      `,
+      errors: [
+        {
+          messageId: 'invalidFormatting',
+        },
+      ],
+      output: `
+ruleTester.run({
+  valid: [
+    {
+      code: \`
+${
+  // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
+  String.raw`'\\\\;'`
+}
+      \`,
+    },
+  ],
+});
+      `,
+    },
   ],
   valid: [
     // sanity check for valid tests non-object style
@@ -1423,5 +1495,21 @@ const test = [
   errors: [],
 }));
     `,
+    {
+      code: `
+ruleTester.run({
+  valid: [
+    {
+      code: ${
+        // The user types "'\\\\';"
+        // meaning the code they are testing is '\\';
+        // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
+        String.raw`"'\\\\';"`
+      },
+    },
+  ],
+});
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin-internal/tests/rules/plugin-test-formatting.test.ts
+++ b/packages/eslint-plugin-internal/tests/rules/plugin-test-formatting.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable eslint-plugin/require-test-error-positions */
 import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
 
 import rule from '../../src/rules/plugin-test-formatting.js';
@@ -1244,7 +1245,7 @@ const test: InvalidTestCase<'', []> = {
       `,
     },
     {
-      // ensure output has enough escaping for `code` with a 'quoted string'.
+      // ensure output has enough escaping for `code` with a "quoted string".
       code: `
 ruleTester.run({
   valid: [
@@ -1271,6 +1272,76 @@ ruleTester.run({
       code: ${
         // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
         String.raw`"'\\\\';"`
+      },
+    },
+  ],
+});
+      `,
+    },
+    {
+      // ensure output has enough escaping for `code` with a 'quoted string'.
+      code: `
+ruleTester.run({
+  valid: [
+    {
+      code: ${
+        // The user types '\'\\\\\''
+        // meaning the code they are testing is '\\' (which is missing a semicolon for prettier formatting)
+        // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
+        String.raw`'\'\\\\\''`
+      },
+    },
+  ],
+});
+      `,
+      errors: [
+        {
+          messageId: 'invalidFormatting',
+        },
+      ],
+      output: `
+ruleTester.run({
+  valid: [
+    {
+      code: ${
+        // fixes to " style
+        // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
+        String.raw`"'\\\\';"`
+      },
+    },
+  ],
+});
+      `,
+    },
+    {
+      // ensure output has enough escaping for `code` with a 'quoted string'.
+      code: `
+ruleTester.run({
+  valid: [
+    {
+      code: ${
+        // The user types '\'\"\''
+        // meaning the code they are testing is '"'
+        // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
+        String.raw`'\'\"\''`
+      },
+    },
+  ],
+});
+      `,
+      errors: [
+        {
+          messageId: 'invalidFormatting',
+        },
+      ],
+      output: `
+ruleTester.run({
+  valid: [
+    {
+      code: ${
+        // use '  and escape any ' in the string.
+        // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
+        String.raw`'\'"\';'`
       },
     },
   ],
@@ -1307,7 +1378,7 @@ ruleTester.run({
       code: \`
 ${
   // eslint-disable-next-line @typescript-eslint/internal/no-dynamic-tests
-  String.raw`'\\\\;'`
+  String.raw`'\\\\';`
 }
       \`,
     },


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Previously, writing 
```ts
{
  // string containing single backslash character in the linted program.
  // (missing final semicolon for prettier formatting)
  code: "'\\\\'", 
}
```
would fix to:
```ts
{
  code: "'\\';", // syntax error in the linted program.
}
```
Now it fixes to:
```ts
{
  code: "'\\\\';" // string containing single backslash character in the linted program.
}
```