### PR TITLE
fix(eslint-plugin): dedupe unified-signatures union message

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -138,6 +138,10 @@ export default createRule<Options, MessageIds>({
             const typeAnnotation1 = isTSParameterProperty(p1)
               ? p1.parameter.typeAnnotation
               : p1.typeAnnotation;
+            const [type1, type2] = getUnifiedTypeTexts(
+              typeAnnotation0?.typeAnnotation,
+              typeAnnotation1?.typeAnnotation,
+            );
 
             context.report({
               loc: p1.loc,
@@ -145,12 +149,8 @@ export default createRule<Options, MessageIds>({
               messageId: 'singleParameterDifference',
               data: {
                 failureStringStart: failureStringStart(lineOfOtherOverload),
-                type1: context.sourceCode.getText(
-                  typeAnnotation0?.typeAnnotation,
-                ),
-                type2: context.sourceCode.getText(
-                  typeAnnotation1?.typeAnnotation,
-                ),
+                type1,
+                type2,
               },
             });
             break;
@@ -500,6 +500,28 @@ export default createRule<Options, MessageIds>({
           context.sourceCode.getText(a.typeAnnotation) ===
             context.sourceCode.getText(b.typeAnnotation))
       );
+    }
+
+    function getUnifiedTypeTexts(
+      a: TSESTree.TypeNode | undefined,
+      b: TSESTree.TypeNode | undefined,
+    ): [string, string] {
+      const textA = context.sourceCode.getText(a);
+      const textB = context.sourceCode.getText(b);
+      const typesA = getUnionTypeTexts(a);
+      const typesB = getUnionTypeTexts(b);
+      const seenTypes = new Set(typesA);
+      const uniqueTypesB = typesB.filter(type => !seenTypes.has(type));
+
+      return uniqueTypesB.length === typesB.length || uniqueTypesB.length === 0
+        ? [textA, textB]
+        : [typesA.join(' | '), uniqueTypesB.join(' | ')];
+    }
+
+    function getUnionTypeTexts(type: TSESTree.TypeNode | undefined): string[] {
+      return type?.type === AST_NODE_TYPES.TSUnionType
+        ? type.types.map(type => context.sourceCode.getText(type))
+        : [context.sourceCode.getText(type)];
     }
 
     function constraintsAreEqual(

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -742,6 +742,28 @@ interface I {
       ],
     },
     {
+      code: `
+function f(a: number | string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number | string',
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
       // Works with tuples.
       code: `
 interface I {

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -880,6 +880,54 @@ function f(a: string | boolean): void;
       options: [{ ignoreDifferentlyNamedParameters: true }],
     },
     {
+      code: noFormat`
+function f(a: number | /* Hey */ string & { brand: true }): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number | /* Hey */ string & { brand: true }',
+            type2: 'string | boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: noFormat`
+function f(a: number | string & {
+  brand: true
+}): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: `number | string & {
+  brand: true
+}`,
+            type2: 'string | boolean',
+          },
+          endColumn: 31,
+          endLine: 5,
+          line: 5,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
       // Works with tuples.
       code: `
 interface I {

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -1,4 +1,4 @@
-import { RuleTester } from '@typescript-eslint/rule-tester';
+import { noFormat, RuleTester } from '@typescript-eslint/rule-tester';
 
 import rule from '../../src/rules/unified-signatures';
 
@@ -758,6 +758,122 @@ function f(a: string | boolean): void;
           endColumn: 31,
           endLine: 3,
           line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: `
+function f(a: number | string /* shared */): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number | string',
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: `
+function f(a: 'hello | world' | string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: "'hello | world' | string",
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: `
+function f(a: number | string): void;
+function f(a: string | boolean): void;
+function f(a: string | bigint): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 2 can be combined into one signature',
+            type1: 'number | string',
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 3,
+          line: 3,
+          messageId: 'singleParameterDifference',
+        },
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 2 can be combined into one signature',
+            type1: 'number | string',
+            type2: 'bigint',
+          },
+          endColumn: 30,
+          endLine: 4,
+          line: 4,
+          messageId: 'singleParameterDifference',
+        },
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'This overload and the one on line 3 can be combined into one signature',
+            type1: 'string | boolean',
+            type2: 'bigint',
+          },
+          endColumn: 30,
+          endLine: 4,
+          line: 4,
+          messageId: 'singleParameterDifference',
+        },
+      ],
+      options: [{ ignoreDifferentlyNamedParameters: true }],
+    },
+    {
+      code: noFormat`
+function f(a: number        |
+    string): void;
+function f(a: string | boolean): void;
+      `,
+      errors: [
+        {
+          column: 12,
+          data: {
+            failureStringStart:
+              'These overloads can be combined into one signature',
+            type1: 'number | string',
+            type2: 'boolean',
+          },
+          endColumn: 31,
+          endLine: 4,
+          line: 4,
           messageId: 'singleParameterDifference',
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`unified-signatures` was building the suggested union text directly from the two differing parameter annotations. When both annotations were unions and shared a member, the report message repeated that shared type, for example `number | string | string | boolean`.

This keeps the rule behavior the same and only dedupes top-level union members while preparing the report data. I added a regression test for the overload pair from #12504.

Checked locally:

- `./node_modules/.bin/nx test eslint-plugin -- unified-signatures.test.ts`
- `./node_modules/.bin/nx typecheck eslint-plugin`
- `./node_modules/.bin/prettier --check packages/eslint-plugin/src/rules/unified-signatures.ts packages/eslint-plugin/tests/rules/unified-signatures.test.ts`
- `git diff --check`
