### PR TITLE
feat(eslint-plugin): [no-restricted-imports] deprecate extension rule

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-restricted-imports.mdx
+++ b/packages/eslint-plugin/docs/rules/no-restricted-imports.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 :::danger Deprecated
 
-This rule has been deprecated because the base [`eslint/no-restricted-imports`](https://eslint.org/docs/rules/no-restricted-imports) rule added native support for TypeScript import syntaxes (`import type`, inline `type` specifiers, and `import x = require(...)`).
+This rule has been deprecated because, as of [ESLint v9.37.0](https://github.com/eslint/eslint/releases/tag/v9.37.0), the base [`eslint/no-restricted-imports`](https://eslint.org/docs/rules/no-restricted-imports) rule added native support for TypeScript import syntaxes (`import type`, inline `type` specifiers, and `import x = require(...)`).
 There is no longer any need to use this extension rule.
 
 :::

--- a/packages/eslint-plugin/docs/rules/no-restricted-imports.mdx
+++ b/packages/eslint-plugin/docs/rules/no-restricted-imports.mdx
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 
 :::danger Deprecated
 
-This rule has been deprecated because, as of [ESLint v9.37.0](https://github.com/eslint/eslint/releases/tag/v9.37.0), the base [`eslint/no-restricted-imports`](https://eslint.org/docs/rules/no-restricted-imports) rule added native support for TypeScript import syntaxes (`import type`, inline `type` specifiers, and `import x = require(...)`).
+As of [ESLint v9.37.0](https://github.com/eslint/eslint/releases/tag/v9.37.0), the base [`eslint/no-restricted-imports`](https://eslint.org/docs/rules/no-restricted-imports) rule supports TypeScript import syntaxes (`import type`, inline `type` specifiers, and `import x = require(...)`).
 There is no longer any need to use this extension rule.
 
 :::

--- a/packages/eslint-plugin/docs/rules/no-restricted-imports.mdx
+++ b/packages/eslint-plugin/docs/rules/no-restricted-imports.mdx
@@ -9,6 +9,13 @@ import TabItem from '@theme/TabItem';
 >
 > See **https://typescript-eslint.io/rules/no-restricted-imports** for documentation.
 
+:::danger Deprecated
+
+This rule has been deprecated because the base [`eslint/no-restricted-imports`](https://eslint.org/docs/rules/no-restricted-imports) rule added native support for TypeScript import syntaxes (`import type`, inline `type` specifiers, and `import x = require(...)`).
+There is no longer any need to use this extension rule.
+
+:::
+
 It adds support for type import syntaxes:
 
 - `import type X from "..."`

--- a/packages/eslint-plugin/src/configs/eslintrc/all.ts
+++ b/packages/eslint-plugin/src/configs/eslintrc/all.ts
@@ -84,8 +84,6 @@ export = {
     '@typescript-eslint/no-redeclare': 'error',
     '@typescript-eslint/no-redundant-type-constituents': 'error',
     '@typescript-eslint/no-require-imports': 'error',
-    'no-restricted-imports': 'off',
-    '@typescript-eslint/no-restricted-imports': 'error',
     '@typescript-eslint/no-restricted-types': 'error',
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': 'error',

--- a/packages/eslint-plugin/src/configs/flat/all.ts
+++ b/packages/eslint-plugin/src/configs/flat/all.ts
@@ -97,8 +97,6 @@ export default (
       '@typescript-eslint/no-redeclare': 'error',
       '@typescript-eslint/no-redundant-type-constituents': 'error',
       '@typescript-eslint/no-require-imports': 'error',
-      'no-restricted-imports': 'off',
-      '@typescript-eslint/no-restricted-imports': 'error',
       '@typescript-eslint/no-restricted-types': 'error',
       'no-shadow': 'off',
       '@typescript-eslint/no-shadow': 'error',

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -235,7 +235,7 @@ export default createRule<Options, MessageIds>({
     type: 'suggestion',
     // defaultOptions, -- base rule does not use defaultOptions
     deprecated: {
-      deprecatedSince: '8.63.0',
+      deprecatedSince: '8.64.0',
       replacedBy: [
         {
           rule: {

--- a/packages/eslint-plugin/src/rules/no-restricted-imports.ts
+++ b/packages/eslint-plugin/src/rules/no-restricted-imports.ts
@@ -234,6 +234,18 @@ export default createRule<Options, MessageIds>({
   meta: {
     type: 'suggestion',
     // defaultOptions, -- base rule does not use defaultOptions
+    deprecated: {
+      deprecatedSince: '8.63.0',
+      replacedBy: [
+        {
+          rule: {
+            name: 'no-restricted-imports',
+            url: 'https://eslint.org/docs/latest/rules/no-restricted-imports',
+          },
+        },
+      ],
+      url: 'https://github.com/typescript-eslint/typescript-eslint/pull/12527',
+    },
     docs: {
       description: 'Disallow specified modules when loaded by `import`',
       extendsBaseRule: true,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #11889
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Marking no-restricted-imports as deprecated because ESLint's own no-restricted-imports now handles TypeScript import syntax on its own. Deprecating rather than removing it, since we still support older ESLint versions that don't have this yet  so the rule still works and nothing breaks
🦔