### PR TITLE
feat: add warning when TS 7 is detected

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,3 +1,21 @@
+/* eslint-disable import/first -- intentionally executing code before rest of the require()s. This will not work with ESM. */
+
+import * as ts from 'typescript';
+
+const [versionMajor, _versionMinor] = ts.versionMajorMinor
+  .split('.')
+  .map(Number);
+
+if (versionMajor >= 7) {
+  throw new Error(
+    [
+      'typescript-eslint does not support TS 7.',
+      'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
+      "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
+    ].join('\n'),
+  );
+}
+
 import rawPlugin from './raw-plugin';
 
 export = rawPlugin.plugin;

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -15,7 +15,7 @@ if (versionMajor >= 7) {
       "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS >=7.1",
     ].join('\n'),
   );
-  throw new Error('typescript-eslint does not support TS 7.');
+  throw new Error('typescript-eslint does not support TS 7.0');
 }
 
 import rawPlugin from './raw-plugin';

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -10,7 +10,7 @@ if (versionMajor >= 7) {
   // eslint-disable-next-line no-console
   console.error(
     [
-      'typescript-eslint does not support TS 7.',
+      'typescript-eslint does not support TS 7.0.',
       'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
       "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
     ].join('\n'),

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -12,7 +12,7 @@ if (versionMajor >= 7) {
     [
       'typescript-eslint does not support TS 7.0.',
       'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
-      "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
+      "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS >=7.1",
     ].join('\n'),
   );
   throw new Error('typescript-eslint does not support TS 7.');

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -7,13 +7,15 @@ const [versionMajor, _versionMinor] = ts.versionMajorMinor
   .map(Number);
 
 if (versionMajor >= 7) {
-  throw new Error(
+  // eslint-disable-next-line no-console
+  console.error(
     [
       'typescript-eslint does not support TS 7.',
       'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
       "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
     ].join('\n'),
   );
+  throw new Error('typescript-eslint does not support TS 7.');
 }
 
 import rawPlugin from './raw-plugin';

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -15,7 +15,7 @@ if (versionMajor >= 7) {
       "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS >=7.1",
     ].join('\n'),
   );
-  throw new Error('typescript-eslint does not support TS 7.0');
+  throw new Error('typescript-eslint does not support TS 7.0.');
 }
 
 import rawPlugin from './raw-plugin';

--- a/packages/integration-tests/fixtures/ts7/imports-eslint-plugin.mjs
+++ b/packages/integration-tests/fixtures/ts7/imports-eslint-plugin.mjs
@@ -1,0 +1,3 @@
+import tseslintPlugin from '@typescript-eslint/eslint-plugin';
+
+console.log(Object.keys(tseslintPlugin.rules));

--- a/packages/integration-tests/fixtures/ts7/imports-parser.mjs
+++ b/packages/integration-tests/fixtures/ts7/imports-parser.mjs
@@ -1,0 +1,3 @@
+import * as tseslintParser from '@typescript-eslint/parser';
+
+console.log(tseslintParser.version);

--- a/packages/integration-tests/fixtures/ts7/imports-typescript-eslint.mjs
+++ b/packages/integration-tests/fixtures/ts7/imports-typescript-eslint.mjs
@@ -1,0 +1,3 @@
+import tseslint from 'typescript-eslint';
+
+export default [...tseslint.configs.recommended];

--- a/packages/integration-tests/fixtures/ts7/package.json
+++ b/packages/integration-tests/fixtures/ts7/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "typescript": "7.0.2"
+  }
+}

--- a/packages/integration-tests/tests/ts7.test.ts
+++ b/packages/integration-tests/tests/ts7.test.ts
@@ -1,11 +1,5 @@
 import { nodeIntegrationTest } from '../tools/integration-test-base';
 
-// TypeScript 7's `typescript` package exports only `version` and
-// `versionMajorMinor` — the rest of the compiler API is absent. Each package
-// entry point must throw our friendly error before anything else touches the
-// TS API, which is only guaranteed by CJS execution order — so this must be
-// tested against the built packages in a real node process, not via vitest
-// module mocking.
 const TS7_ERROR_MESSAGE = [
   'typescript-eslint does not support TS 7.',
   'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',

--- a/packages/integration-tests/tests/ts7.test.ts
+++ b/packages/integration-tests/tests/ts7.test.ts
@@ -1,9 +1,9 @@
 import { nodeIntegrationTest } from '../tools/integration-test-base';
 
 const TS7_ERROR_MESSAGE = [
-  'typescript-eslint does not support TS 7.',
+  'typescript-eslint does not support TS 7.0',
   'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
-  "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
+  "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS >=7.1",
 ].join('\n');
 
 for (const scriptName of [

--- a/packages/integration-tests/tests/ts7.test.ts
+++ b/packages/integration-tests/tests/ts7.test.ts
@@ -1,0 +1,23 @@
+import { nodeIntegrationTest } from '../tools/integration-test-base';
+
+// TypeScript 7's `typescript` package exports only `version` and
+// `versionMajorMinor` — the rest of the compiler API is absent. Each package
+// entry point must throw our friendly error before anything else touches the
+// TS API, which is only guaranteed by CJS execution order — so this must be
+// tested against the built packages in a real node process, not via vitest
+// module mocking.
+const TS7_ERROR_MESSAGE = [
+  'typescript-eslint does not support TS 7.',
+  'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
+  "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
+].join('\n');
+
+for (const scriptName of [
+  'imports-eslint-plugin.mjs',
+  'imports-parser.mjs',
+  'imports-typescript-eslint.mjs',
+]) {
+  nodeIntegrationTest(__filename, scriptName, stderr => {
+    expect(stderr).toContain(TS7_ERROR_MESSAGE);
+  });
+}

--- a/packages/integration-tests/tests/ts7.test.ts
+++ b/packages/integration-tests/tests/ts7.test.ts
@@ -1,7 +1,7 @@
 import { nodeIntegrationTest } from '../tools/integration-test-base';
 
 const TS7_ERROR_MESSAGE = [
-  'typescript-eslint does not support TS 7.0',
+  'typescript-eslint does not support TS 7.0.',
   'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
   "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS >=7.1",
 ].join('\n');

--- a/packages/integration-tests/tools/integration-test-base.ts
+++ b/packages/integration-tests/tools/integration-test-base.ts
@@ -104,7 +104,7 @@ export function nodeIntegrationTest(
 
     const stderr =
       result.status === 'rejected'
-        ? String((result.reason as { stderr: string }).stderr)
+        ? (result.reason as { stderr: string }).stderr
         : result.value.stderr;
 
     assertOutput(stderr);

--- a/packages/integration-tests/tools/integration-test-base.ts
+++ b/packages/integration-tests/tools/integration-test-base.ts
@@ -90,6 +90,27 @@ export function eslintIntegrationTest(
   });
 }
 
+export function nodeIntegrationTest(
+  testFilename: string,
+  scriptName: string,
+  assertOutput: (stderr: string) => void,
+): void {
+  integrationTest(`node ${scriptName}`, testFilename, async testFolder => {
+    const [result] = await Promise.allSettled([
+      execFile('node', [scriptName], {
+        cwd: testFolder,
+      }),
+    ]);
+
+    const stderr =
+      result.status === 'rejected'
+        ? String((result.reason as { stderr: string }).stderr)
+        : result.value.stderr;
+
+    assertOutput(stderr);
+  });
+}
+
 export function typescriptIntegrationTest(
   testName: string,
   testFilename: string,

--- a/packages/integration-tests/tools/pack-packages.ts
+++ b/packages/integration-tests/tools/pack-packages.ts
@@ -278,5 +278,9 @@ async function getPnpmWorkspaceContent(): Promise<string> {
   delete parsed.overrides;
   delete parsed.packages;
 
+  // the ts7 fixture installs typescript releases newer than the root
+  // minimumReleaseAge allows; `@typescript/*` covers TS 7's native binaries
+  parsed.minimumReleaseAgeExclude = ['typescript', '@typescript/*'];
+
   return yaml.stringify(parsed);
 }

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -10,12 +10,12 @@ if (versionMajor >= 7) {
   // eslint-disable-next-line no-console
   console.error(
     [
-      'typescript-eslint does not support TS 7.0',
+      'typescript-eslint does not support TS 7.0.',
       'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
       "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS >=7.1",
     ].join('\n'),
   );
-  throw new Error('typescript-eslint does not support TS 7.0');
+  throw new Error('typescript-eslint does not support TS 7.0.');
 }
 
 export { parse, parseForESLint, type ParserOptions } from './parser';

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -7,13 +7,15 @@ const [versionMajor, _versionMinor] = ts.versionMajorMinor
   .map(Number);
 
 if (versionMajor >= 7) {
-  throw new Error(
+  // eslint-disable-next-line no-console
+  console.error(
     [
       'typescript-eslint does not support TS 7.',
       'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
       "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
     ].join('\n'),
   );
+  throw new Error('typescript-eslint does not support TS 7.');
 }
 
 export { parse, parseForESLint, type ParserOptions } from './parser';

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,3 +1,21 @@
+import * as ts from 'typescript';
+
+// intentionally executing code before rest of the require()s. This will not work with ESM.
+
+const [versionMajor, _versionMinor] = ts.versionMajorMinor
+  .split('.')
+  .map(Number);
+
+if (versionMajor >= 7) {
+  throw new Error(
+    [
+      'typescript-eslint does not support TS 7.',
+      'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
+      "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
+    ].join('\n'),
+  );
+}
+
 export { parse, parseForESLint, type ParserOptions } from './parser';
 export {
   clearCaches,

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -10,12 +10,12 @@ if (versionMajor >= 7) {
   // eslint-disable-next-line no-console
   console.error(
     [
-      'typescript-eslint does not support TS 7.',
+      'typescript-eslint does not support TS 7.0',
       'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
-      "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
+      "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS >=7.1",
     ].join('\n'),
   );
-  throw new Error('typescript-eslint does not support TS 7.');
+  throw new Error('typescript-eslint does not support TS 7.0');
 }
 
 export { parse, parseForESLint, type ParserOptions } from './parser';

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -10,12 +10,12 @@ if (versionMajor >= 7) {
   // eslint-disable-next-line no-console
   console.error(
     [
-      'typescript-eslint does not support TS 7.',
+      'typescript-eslint does not support TS 7.0',
       'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
-      "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
+      "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS >=7.1",
     ].join('\n'),
   );
-  throw new Error('typescript-eslint does not support TS 7.');
+  throw new Error('typescript-eslint does not support TS 7.0');
 }
 
 // see the comment in config-helper.ts for why this doesn't use /ts-eslint

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -7,13 +7,15 @@ const [versionMajor, _versionMinor] = ts.versionMajorMinor
   .map(Number);
 
 if (versionMajor >= 7) {
-  throw new Error(
+  // eslint-disable-next-line no-console
+  console.error(
     [
       'typescript-eslint does not support TS 7.',
       'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
       "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
     ].join('\n'),
   );
+  throw new Error('typescript-eslint does not support TS 7.');
 }
 
 // see the comment in config-helper.ts for why this doesn't use /ts-eslint

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -10,12 +10,12 @@ if (versionMajor >= 7) {
   // eslint-disable-next-line no-console
   console.error(
     [
-      'typescript-eslint does not support TS 7.0',
+      'typescript-eslint does not support TS 7.0.',
       'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
       "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS >=7.1",
     ].join('\n'),
   );
-  throw new Error('typescript-eslint does not support TS 7.0');
+  throw new Error('typescript-eslint does not support TS 7.0.');
 }
 
 // see the comment in config-helper.ts for why this doesn't use /ts-eslint

--- a/packages/typescript-eslint/src/index.ts
+++ b/packages/typescript-eslint/src/index.ts
@@ -1,3 +1,21 @@
+/* eslint-disable import/first -- intentionally executing code before rest of the require()s. This will not work with ESM. */
+
+import * as ts from 'typescript';
+
+const [versionMajor, _versionMinor] = ts.versionMajorMinor
+  .split('.')
+  .map(Number);
+
+if (versionMajor >= 7) {
+  throw new Error(
+    [
+      'typescript-eslint does not support TS 7.',
+      'Please see https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0 to run typescript-eslint using the TS 6 API.',
+      "See also https://github.com/typescript-eslint/typescript-eslint/issues/10940 for tracking typescript-eslint's support for TS 7",
+    ].join('\n'),
+  );
+}
+
 // see the comment in config-helper.ts for why this doesn't use /ts-eslint
 import type { TSESLint } from '@typescript-eslint/utils';
 import type { FlatConfig } from '@typescript-eslint/utils/ts-eslint';


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12521 
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

One of the times I'm thankful for CJS 🙃 

This simply inserts code that asserts on the TS version at the 3 main user-facing entry points:
- require('typescript-eslint')
- require('@typescript-eslint/eslint-plugin')
- require('@typescript-eslint/parser')

We'd have to think a bit harder about this if/when we're ESM one day, since ESM doesn't allow code to be executed prior to resolving the import graph (though there are ways around this). Either way, I think we just use this approach for now for simplicity, and can adapt if needed in the future.

The testing is done purely with integration tests. I tried module mocking with vitest, but vitest seems to run the TS source files _as if_ they're ESM, rather than CJS. Therefore, the version check isn't executed before the imports, which error on module load. The integration test approach is slightly clunky, but faithful to what users will actually encounter.

FYI please bikeshed on the error message as appropriate. I only thought deeply about solving the technical problem of surfacing error messages and testing for them.