### PR TITLE
fix: prefer-string-starts-ends-with false positive on escaped $ and \^ anchors

### DIFF
--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -292,13 +292,23 @@ export default createRule<Options, MessageIds>({
       }
 
       const { flags, source } = evaluated.value;
-      const isStartsWith = source.startsWith('^');
-      const isEndsWith = source.endsWith('$');
-      if (
-        isStartsWith === isEndsWith ||
-        flags.includes('i') ||
-        flags.includes('m')
-      ) {
+      if (flags.includes('i') || flags.includes('m')) {
+        return null;
+      }
+
+      const ast = regexpp.parsePattern(source, undefined, undefined, {
+        unicode: flags.includes('u'),
+      });
+      if (ast.alternatives.length !== 1) {
+        return null;
+      }
+      const elements = ast.alternatives[0].elements;
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+      const isStartsWith =
+        first?.type === 'Assertion' && first.kind === 'start';
+      const isEndsWith = last?.type === 'Assertion' && last.kind === 'end';
+      if (isStartsWith === isEndsWith) {
         return null;
       }
 

--- a/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
+++ b/packages/eslint-plugin/src/rules/prefer-string-starts-ends-with.ts
@@ -303,11 +303,14 @@ export default createRule<Options, MessageIds>({
         return null;
       }
       const elements = ast.alternatives[0].elements;
+      if (elements.length === 0) {
+        return null;
+      }
       const first = elements[0];
       const last = elements[elements.length - 1];
       const isStartsWith =
-        first?.type === 'Assertion' && first.kind === 'start';
-      const isEndsWith = last?.type === 'Assertion' && last.kind === 'end';
+        first.type === 'Assertion' && first.kind === 'start';
+      const isEndsWith = last.type === 'Assertion' && last.kind === 'end';
       if (isStartsWith === isEndsWith) {
         return null;
       }

--- a/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-string-starts-ends-with.test.ts
@@ -258,6 +258,28 @@ ruleTester.run('prefer-string-starts-ends-with', rule, {
         /^bar/.test();
       }
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12514
+    `
+      function f(s: string) {
+        /\\$/.test(s);
+      }
+    `,
+    `
+      function f(s: string) {
+        /foo\\$/.test(s);
+      }
+    `,
+    `
+      function f(s: string) {
+        /\\\\\\$/.test(s);
+      }
+    `,
+    // escaped caret is also not an anchor
+    `
+      function f(s: string) {
+        /\\^foo/.test(s);
+      }
+    `,
     `
       function f(x: { test(): void }, s: string) {
         x.test(s);


### PR DESCRIPTION
## Description

Fixes #12514

The `prefer-string-starts-ends-with` rule incorrectly flags regex patterns with escaped `\$` (e.g., `/foo\$/`) as using an end-of-string anchor. This happens because the rule uses a naive `source.endsWith("\$")` check that does not account for backslash escaping.

When a `$` is preceded by an odd number of backslashes, it is an escaped dollar sign (literal `$` character), not an end-of-string anchor.

### Root cause

In `parseRegExp`, lines 295-296:
```ts
const isStartsWith = source.startsWith("^");
const isEndsWith = source.endsWith("\$");
```

The fix uses the existing `regexpp` parser (already imported and used in `parseRegExpText`) to properly parse the regex AST and check for actual `Assertion` nodes with `kind: "start"` / `kind: "end"` instead of naive string matching.

### Test plan

- Added valid test cases for patterns with escaped `$` and `^` that should not trigger the rule
- Existing invalid test cases for real anchors continue to pass