### PR TITLE
fix: require-array-sort-compare false positive on type parameter constrained to string array

### DIFF
--- a/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
+++ b/packages/eslint-plugin/src/rules/require-array-sort-compare.ts
@@ -57,7 +57,7 @@ export default createRule<Options, MessageIds>({
      * Check if a given node is an array which all elements are string.
      */
     function isStringArrayNode(node: TSESTree.Expression): boolean {
-      const type = services.getTypeAtLocation(node);
+      const type = getConstrainedTypeAtLocation(services, node);
 
       if (checker.isArrayType(type) || checker.isTupleType(type)) {
         const typeArgs = checker.getTypeArguments(type);

--- a/packages/eslint-plugin/tests/rules/require-array-sort-compare.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-array-sort-compare.test.ts
@@ -116,6 +116,23 @@ ruleTester.run('require-array-sort-compare', rule, {
       `,
       options: [{ ignoreStringArrays: true }],
     },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12511
+    {
+      code: `
+        function f<T extends string[]>(a: T) {
+          a.sort();
+        }
+      `,
+      options: [{ ignoreStringArrays: true }],
+    },
+    {
+      code: `
+        function f<T extends ReadonlyArray<string>>(a: T) {
+          a.sort();
+        }
+      `,
+      options: [{ ignoreStringArrays: true }],
+    },
     {
       code: `
         function f(a: number[]) {
@@ -190,6 +207,24 @@ ruleTester.run('require-array-sort-compare', rule, {
         }
       `,
       errors: [{ messageId: 'requireCompare' }],
+    },
+    {
+      code: `
+        function f<T extends string[]>(a: T) {
+          a.sort();
+        }
+      `,
+      errors: [{ messageId: 'requireCompare' }],
+      options: [{ ignoreStringArrays: false }],
+    },
+    {
+      code: `
+        function f<T extends ReadonlyArray<string>>(a: T) {
+          a.sort();
+        }
+      `,
+      errors: [{ messageId: 'requireCompare' }],
+      options: [{ ignoreStringArrays: false }],
     },
     // optional chain
     {


### PR DESCRIPTION
## Description

Fixes #12511

The `require-array-sort-compare` rule was incorrectly reporting a false positive when `ignoreStringArrays` is `true` (the default) and the array type is a generic type parameter constrained to `string[]` or `ReadonlyArray<string>`.

### Root cause

`isStringArrayNode()` used `services.getTypeAtLocation()` which returns the unconstrained type (e.g., `T`), while the reporting check on line 82 uses `getConstrainedTypeAtLocation()` which resolves the constraint (e.g., `string[]`). This inconsistency meant that for `T extends string[]`, the string-array exemption was never applied because `T` is not directly an array type.

### Fix

Changed `isStringArrayNode()` to use `getConstrainedTypeAtLocation()` instead of `services.getTypeAtLocation()`, consistent with how the rest of the rule resolves types.

### Test plan

Added:
- Valid test: `function f<T extends string[]>(a: T) { a.sort(); }` with `ignoreStringArrays: true` (should not report)
- Valid test: `function f<T extends ReadonlyArray<string>>(a: T) { a.sort(); }` with `ignoreStringArrays: true` (should not report)
- Invalid test: same function signatures with `ignoreStringArrays: false` (should report)
- Existing tests continue to pass