### PR TITLE
fix(eslint-plugin): find redefined builtins through the full scope chain

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-conversion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-conversion.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import type { RuleFix, RuleFixer } from '@typescript-eslint/utils/ts-eslint';
 
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -260,7 +260,7 @@ export default createRule<Options, MessageIds>({
         const typeFlag =
           builtInTypeFlags[nodeCallee.name as keyof typeof builtInTypeFlags];
         const scope = context.sourceCode.getScope(node);
-        const variable = scope.set.get(nodeCallee.name);
+        const variable = ASTUtils.findVariable(scope, nodeCallee.name);
         if (
           !!variable?.defs.length ||
           !doesUnderlyingTypeMatchFlag(

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -1,6 +1,10 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 
-import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
+import {
+  AST_NODE_TYPES,
+  AST_TOKEN_TYPES,
+  ASTUtils,
+} from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -705,7 +709,7 @@ function isBuiltInBooleanCall(
     node.arguments[0]
   ) {
     const scope = context.sourceCode.getScope(node);
-    const variable = scope.set.get(AST_TOKEN_TYPES.Boolean);
+    const variable = ASTUtils.findVariable(scope, AST_TOKEN_TYPES.Boolean);
     return variable == null || variable.defs.length === 0;
   }
   return false;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-conversion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-conversion.test.ts
@@ -60,6 +60,44 @@ ruleTester.run('no-unnecessary-type-conversion', rule, {
       BigInt(3n);
       export {};
     `,
+
+    // a builtin redefined in an outer scope is not the global builtin
+    `
+      function String(value: string) {
+        return value;
+      }
+      function foo(s: string) {
+        return String(s);
+      }
+      export {};
+    `,
+    `
+      function Number(value: number) {
+        return value;
+      }
+      function foo(n: number) {
+        return Number(n);
+      }
+      export {};
+    `,
+    `
+      function Boolean(value: boolean) {
+        return value;
+      }
+      function foo(b: boolean) {
+        return Boolean(b);
+      }
+      export {};
+    `,
+    `
+      function BigInt(value: bigint) {
+        return value;
+      }
+      function foo(b: bigint) {
+        return BigInt(b);
+      }
+      export {};
+    `,
     `
       function toString(value: unknown) {
         return value;

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -1889,6 +1889,20 @@ const x = Boolean(a || b);
       ],
     },
     {
+      // the global Boolean is still recognized from a nested scope
+      code: `
+function outer() {
+  return (a: string | true | undefined, b: string | boolean | undefined) =>
+    Boolean(a || b);
+}
+      `,
+      options: [
+        {
+          ignoreBooleanCoercion: true,
+        },
+      ],
+    },
+    {
       code: `
 let a: string | boolean | undefined;
 let b: string | boolean | undefined;
@@ -10227,6 +10241,40 @@ let a: string | true | undefined;
 let b: string | boolean | undefined;
 
 const x = String(a ?? b);
+      `,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          ignoreBooleanCoercion: true,
+        },
+      ],
+    },
+    {
+      // a Boolean redefined in an outer scope is not the global builtin
+      code: `
+function outer() {
+  const Boolean = (x: unknown) => x;
+
+  return (a: string | true | undefined, b: string | boolean | undefined) =>
+    Boolean(a || b);
+}
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+          suggestions: [
+            {
+              messageId: 'suggestNullish',
+              output: `
+function outer() {
+  const Boolean = (x: unknown) => x;
+
+  return (a: string | true | undefined, b: string | boolean | undefined) =>
+    Boolean(a ?? b);
+}
       `,
             },
           ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses existing open issues: fixes #12522, fixes #12524
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22) — still `triage`; see the note below
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Both `no-unnecessary-type-conversion` and `prefer-nullish-coalescing` decide whether an identifier like `String` or `Boolean` is the global builtin with `scope.set.get(name)`, which only searches the current scope. When the builtin is redefined in an outer scope, the lookup misses it and the code is treated as the global builtin:

- `no-unnecessary-type-conversion` reports a false positive, and its suggestion rewrites `String(s)` to `s`, which changes behavior (#12522).
- `prefer-nullish-coalescing` with `ignoreBooleanCoercion` treats a local `Boolean` wrapper as the builtin and skips a real `||` → `??` report (#12524).

Both now use `ASTUtils.findVariable(scope, name)`, which walks the scope chain — the same check `no-base-to-string` already uses. Variables redefined in the same scope were already handled; this extends it to outer scopes.

Added valid cases for `no-unnecessary-type-conversion` (a builtin redefined in an outer scope) and an invalid case for `prefer-nullish-coalescing` (a `Boolean` redefined in an outer scope), plus a valid case confirming the global `Boolean` is still recognized from a nested scope.

Note: #12522 and #12524 are follow-ups to #12490, whose identical fix for `no-base-to-string` merged as #12492. Happy to wait if you'd like to triage these two first.
