### PR TITLE
fix(eslint-plugin): respect builtins redefined in an outer scope

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-conversion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-conversion.ts
@@ -1,7 +1,7 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import type { RuleFix, RuleFixer } from '@typescript-eslint/utils/ts-eslint';
 
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ASTUtils } from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -260,7 +260,7 @@ export default createRule<Options, MessageIds>({
         const typeFlag =
           builtInTypeFlags[nodeCallee.name as keyof typeof builtInTypeFlags];
         const scope = context.sourceCode.getScope(node);
-        const variable = scope.set.get(nodeCallee.name);
+        const variable = ASTUtils.findVariable(scope, nodeCallee.name);
         if (
           !!variable?.defs.length ||
           !doesUnderlyingTypeMatchFlag(

--- a/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
+++ b/packages/eslint-plugin/src/rules/prefer-nullish-coalescing.ts
@@ -1,6 +1,10 @@
 import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 
-import { AST_NODE_TYPES, AST_TOKEN_TYPES } from '@typescript-eslint/utils';
+import {
+  AST_NODE_TYPES,
+  AST_TOKEN_TYPES,
+  ASTUtils,
+} from '@typescript-eslint/utils';
 import * as tsutils from 'ts-api-utils';
 import * as ts from 'typescript';
 
@@ -705,7 +709,7 @@ function isBuiltInBooleanCall(
     node.arguments[0]
   ) {
     const scope = context.sourceCode.getScope(node);
-    const variable = scope.set.get(AST_TOKEN_TYPES.Boolean);
+    const variable = ASTUtils.findVariable(scope, AST_TOKEN_TYPES.Boolean);
     return variable == null || variable.defs.length === 0;
   }
   return false;

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-conversion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-conversion.test.ts
@@ -60,6 +60,32 @@ ruleTester.run('no-unnecessary-type-conversion', rule, {
       BigInt(3n);
       export {};
     `,
+    // a builtin redefined in an outer scope is still shadowed inside a nested scope
+    `
+      function String(value: unknown) {
+        return value;
+      }
+      function foo(s: string) {
+        return String(s);
+      }
+      export {};
+    `,
+    `
+      const String = (value: unknown) => value;
+      function foo(s: string) {
+        return String(s);
+      }
+      export {};
+    `,
+    `
+      function Number(value: unknown) {
+        return value;
+      }
+      function foo(n: number) {
+        return Number(n);
+      }
+      export {};
+    `,
     `
       function toString(value: unknown) {
         return value;

--- a/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
+++ b/packages/eslint-plugin/tests/rules/prefer-nullish-coalescing.test.ts
@@ -1889,6 +1889,20 @@ const x = Boolean(a || b);
       ],
     },
     {
+      // the global Boolean stays ignored when referenced from a nested scope
+      code: `
+let a: string | true | undefined;
+let b: string | boolean | undefined;
+
+const wrap = () => Boolean(a || b);
+      `,
+      options: [
+        {
+          ignoreBooleanCoercion: true,
+        },
+      ],
+    },
+    {
       code: `
 let a: string | boolean | undefined;
 let b: string | boolean | undefined;
@@ -10289,6 +10303,44 @@ let b: string | boolean | undefined;
 const x = Boolean(function weird() {
   return a ?? b;
 });
+      `,
+            },
+          ],
+        },
+      ],
+      options: [
+        {
+          ignoreBooleanCoercion: true,
+        },
+      ],
+    },
+    {
+      // Boolean redefined in an outer scope is not the global, so it must still be flagged
+      code: `
+function outer() {
+  const Boolean = (value: unknown) => value;
+
+  let a: string | true | undefined;
+  let b: string | boolean | undefined;
+
+  return () => Boolean(a || b);
+}
+      `,
+      errors: [
+        {
+          messageId: 'preferNullishOverOr',
+          suggestions: [
+            {
+              messageId: 'suggestNullish',
+              output: `
+function outer() {
+  const Boolean = (value: unknown) => value;
+
+  let a: string | true | undefined;
+  let b: string | boolean | undefined;
+
+  return () => Boolean(a ?? b);
+}
       `,
             },
           ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12522, fixes #12524
- [ ] That issue was marked as accepting prs (both are still in triage; this is the same root cause and fix as the just-merged #12492, which fixed #12490)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Both rules decide whether a global builtin is shadowed by looking the name up with `scope.set.get(...)`, which only checks the current scope. When the builtin is redefined in an outer scope and used in a nested one, the lookup misses it:

- `no-unnecessary-type-conversion` treats the local `String`/`Number`/`Boolean`/`BigInt` as the global, and its suggestion rewrites e.g. `String(s)` to `s`, which changes behavior (#12522).
- `prefer-nullish-coalescing` treats a locally-defined `Boolean` as the global under `ignoreBooleanCoercion`, so `a || b` is not flagged (#12524).

Switching to `ASTUtils.findVariable(scope, name)` walks the scope chain, the same change #12492 made for `no-base-to-string`. Added valid and invalid cases covering outer-scope redefinition in both rules.
