### PR TITLE
fix(typescript-estree): forbid invalid definite assignment assertions in class properties

### DIFF
--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-and-initializer/fixture.ts
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-and-initializer/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  bar! = 1
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-and-initializer/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-and-initializer/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > definite-assignment-and-initializer > TSESTree - Error`]
+TSError
+  1 | class Foo {
+> 2 |   bar! = 1
+    |   ^^^^^^^^ Declarations with initializers cannot also have definite assignment assertions.
+  3 | }
+  4 |

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-and-initializer/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-and-initializer/snapshots/2-Babel-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > definite-assignment-and-initializer > Babel - Error`]
+NO ERROR

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-and-initializer/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-and-initializer/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > definite-assignment-and-initializer > Error Alignment`]
+TSESTree errored but Babel didn't

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-no-type/fixture.ts
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-no-type/fixture.ts
@@ -1,0 +1,3 @@
+class Foo {
+  bar!
+}

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-no-type/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-no-type/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > definite-assignment-no-type > TSESTree - Error`]
+TSError
+  1 | class Foo {
+> 2 |   bar!
+    |   ^^^^ Declarations with definite assignment assertions must also have type annotations.
+  3 | }
+  4 |

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-no-type/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-no-type/snapshots/2-Babel-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > definite-assignment-no-type > Babel - Error`]
+NO ERROR

--- a/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-no-type/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/element/PropertyDefinition/fixtures/_error_/definite-assignment-no-type/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > element > PropertyDefinition > _error_ > definite-assignment-no-type > Error Alignment`]
+TSESTree errored but Babel didn't

--- a/packages/ast-spec/tests/fixtures-with-differences-errors.shot
+++ b/packages/ast-spec/tests/fixtures-with-differences-errors.shot
@@ -50,6 +50,8 @@ exports[`AST Fixtures > List fixtures with Error differences`]
     "declaration/VariableDeclaration/fixtures/_error_/var-id-definite-no-init/fixture.ts",
     "declaration/VariableDeclaration/fixtures/_error_/var-id-definite-type-init/fixture.ts",
     "element/AccessorProperty/fixtures/_error_/modifier-abstract-accessor-with-value/fixture.ts",
+    "element/PropertyDefinition/fixtures/_error_/definite-assignment-and-initializer/fixture.ts",
+    "element/PropertyDefinition/fixtures/_error_/definite-assignment-no-type/fixture.ts",
     "expression/UpdateExpression/fixtures/_error_/call-expr/fixture.ts",
     "expression/UpdateExpression/fixtures/_error_/paren-expr/fixture.ts",
     "legacy-fixtures/basics/fixtures/_error_/abstract-class-with-abstract-constructor/fixture.ts",

--- a/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-inferrable-types.test.ts
@@ -689,10 +689,9 @@ class Foo {
       output: 'const fn = (a = 5) => {};',
     },
     {
-      // This is invalid TS semantic, but it's trivial to make valid anyway
       code: `
 class A {
-  a!: number = 1;
+  a: number = 1;
 }
       `,
       errors: [

--- a/packages/typescript-estree/src/check-syntax-errors.ts
+++ b/packages/typescript-estree/src/check-syntax-errors.ts
@@ -247,6 +247,20 @@ export function checkSyntaxError(
         );
       }
 
+      if (node.exclamationToken) {
+        if (node.initializer) {
+          throw createError(
+            node,
+            'Declarations with initializers cannot also have definite assignment assertions.',
+          );
+        } else if (!node.type) {
+          throw createError(
+            node,
+            'Declarations with definite assignment assertions must also have type annotations.',
+          );
+        }
+      }
+
       if (
         node.name.kind === SyntaxKind.StringLiteral &&
         node.name.text === 'constructor'


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12532
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

`class C { x! }` and `class C { x! = 1 }` are grammatically invalid in TypeScript (TS1264 and TS1263), the same way `let x!` and `let x! = 1` are, but `typescript-estree` only threw for the variable-declaration cases. This extends the `PropertyDeclaration` handling in `check-syntax-errors.ts` to throw those two errors for class properties too, mirroring the existing `VariableDeclaration` logic, and adds `_error_` fixtures for both.
