### PR TITLE
fix: no-loop-func false positive on `using` and `await using` declarations

### DIFF
--- a/packages/eslint-plugin/src/rules/no-loop-func.ts
+++ b/packages/eslint-plugin/src/rules/no-loop-func.ts
@@ -142,7 +142,7 @@ export default createRule<Options, MessageIds>({
       }
 
       // Variables which are declared by `const` is safe.
-      if (kind === 'const') {
+      if (kind === 'const' || kind === 'using' || kind === 'await using') {
         return true;
       }
 

--- a/packages/eslint-plugin/tests/rules/no-loop-func.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-loop-func.test.ts
@@ -52,6 +52,36 @@ for (let i = 0; i < 10; i += 1) {
   someArray = someArray.filter((item: MyType) => !!item);
 }
     `,
+    {
+      code: `
+for (let i = 0; i < 3; i++) {
+  using resource = getResource();
+  const fn = () => resource;
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            globalReturn: true,
+          },
+        },
+      },
+    },
+    {
+      code: `
+for (let i = 0; i < 3; i++) {
+  await using resource = getResource();
+  const fn = () => resource;
+}
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            globalReturn: true,
+          },
+        },
+      },
+    },
   ],
   invalid: [],
 });


### PR DESCRIPTION
Fixes #12496

## Summary

The `no-loop-func` rule was flagging functions inside loops that reference `using` and `await using` variables. Since `using` and `await using` declarations are block-scoped (like `const`), creating a new binding per loop iteration, referencing them inside a loop function is safe.

The upstream ESLint base rule already treats `using` and `await using` as constant bindings (see `CONSTANT_BINDINGS` set in `eslint/lib/rules/no-loop-func.js`), but the typescript-eslint override was only checking for `kind === "const"`.

## Changes

- `packages/eslint-plugin/src/rules/no-loop-func.ts`: Added `kind === "using"` and `kind === "await using"` to the safe-constant check alongside `"const"`
- `packages/eslint-plugin/tests/rules/no-loop-func.test.ts`: Added valid test cases for both `using` and `await using` in a `for` loop