### PR TITLE
fix: deduplicate type names in unified-signatures error message

### DIFF
--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -80,7 +80,7 @@ export default createRule<Options, MessageIds>({
       omittingSingleParameter:
         '{{failureStringStart}} with an optional parameter.',
       singleParameterDifference:
-        '{{failureStringStart}} taking `{{type1}} | {{type2}}`.',
+        '{{failureStringStart}} taking `{{typeText}}`.',
     },
     schema: [
       {
@@ -139,29 +139,24 @@ export default createRule<Options, MessageIds>({
               ? p1.parameter.typeAnnotation
               : p1.typeAnnotation;
 
-            const type0Members = (
-              context.sourceCode.getText(typeAnnotation0?.typeAnnotation) ?? ''
-            )
-              .split('|')
-              .map(s => s.trim())
-              .filter(Boolean);
-            const type1Members = (
-              context.sourceCode.getText(typeAnnotation1?.typeAnnotation) ?? ''
-            )
-              .split('|')
-              .map(s => s.trim())
-              .filter(Boolean);
-
-            const type0Unique = [...new Set(type0Members)];
-            const type1Unique = [...new Set(type1Members)];
-
-            // Deduplicate type2 against type1 to avoid showing duplicate
-            // type names in the combined error message. E.g. when combining
-            // `number | string` and `string | boolean`, the message should
-            // read `number | string | boolean` not `number | string | string | boolean`.
-            const filteredType1 = type1Unique.filter(
-              m => !type0Unique.includes(m),
-            );
+            const combinedMembers = [
+              ...new Set([
+                ...(
+                  context.sourceCode.getText(typeAnnotation0?.typeAnnotation) ??
+                  ''
+                )
+                  .split('|')
+                  .map(s => s.trim())
+                  .filter(Boolean),
+                ...(
+                  context.sourceCode.getText(typeAnnotation1?.typeAnnotation) ??
+                  ''
+                )
+                  .split('|')
+                  .map(s => s.trim())
+                  .filter(Boolean),
+              ]),
+            ];
 
             context.report({
               loc: p1.loc,
@@ -169,11 +164,7 @@ export default createRule<Options, MessageIds>({
               messageId: 'singleParameterDifference',
               data: {
                 failureStringStart: failureStringStart(lineOfOtherOverload),
-                type1: type0Unique.join(' | '),
-                type2:
-                  filteredType1.length > 0
-                    ? filteredType1.join(' | ')
-                    : type1Unique.join(' | '),
+                typeText: combinedMembers.join(' | '),
               },
             });
             break;

--- a/packages/eslint-plugin/src/rules/unified-signatures.ts
+++ b/packages/eslint-plugin/src/rules/unified-signatures.ts
@@ -139,18 +139,41 @@ export default createRule<Options, MessageIds>({
               ? p1.parameter.typeAnnotation
               : p1.typeAnnotation;
 
+            const type0Members = (
+              context.sourceCode.getText(typeAnnotation0?.typeAnnotation) ?? ''
+            )
+              .split('|')
+              .map(s => s.trim())
+              .filter(Boolean);
+            const type1Members = (
+              context.sourceCode.getText(typeAnnotation1?.typeAnnotation) ?? ''
+            )
+              .split('|')
+              .map(s => s.trim())
+              .filter(Boolean);
+
+            const type0Unique = [...new Set(type0Members)];
+            const type1Unique = [...new Set(type1Members)];
+
+            // Deduplicate type2 against type1 to avoid showing duplicate
+            // type names in the combined error message. E.g. when combining
+            // `number | string` and `string | boolean`, the message should
+            // read `number | string | boolean` not `number | string | string | boolean`.
+            const filteredType1 = type1Unique.filter(
+              m => !type0Unique.includes(m),
+            );
+
             context.report({
               loc: p1.loc,
               node: p1,
               messageId: 'singleParameterDifference',
               data: {
                 failureStringStart: failureStringStart(lineOfOtherOverload),
-                type1: context.sourceCode.getText(
-                  typeAnnotation0?.typeAnnotation,
-                ),
-                type2: context.sourceCode.getText(
-                  typeAnnotation1?.typeAnnotation,
-                ),
+                type1: type0Unique.join(' | '),
+                type2:
+                  filteredType1.length > 0
+                    ? filteredType1.join(' | ')
+                    : type1Unique.join(' | '),
               },
             });
             break;

--- a/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
+++ b/packages/eslint-plugin/tests/rules/unified-signatures.test.ts
@@ -422,8 +422,7 @@ function f(a: number | string): void {}
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            typeText: 'number | string',
           },
           line: 3,
           messageId: 'singleParameterDifference',
@@ -444,8 +443,7 @@ function f(x: any): any {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            typeText: 'number | string',
           },
           line: 3,
           messageId: 'singleParameterDifference',
@@ -466,8 +464,7 @@ function f(x: any): any {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            typeText: 'number | string',
           },
           line: 3,
           messageId: 'singleParameterDifference',
@@ -630,8 +627,7 @@ interface I {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            typeText: 'number | string',
           },
           line: 4,
           messageId: 'singleParameterDifference',
@@ -652,8 +648,7 @@ interface I {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            typeText: 'number | string',
           },
           line: 4,
           messageId: 'singleParameterDifference',
@@ -733,8 +728,7 @@ interface I {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string | boolean',
+            typeText: 'number | string | boolean',
           },
           line: 4,
           messageId: 'singleParameterDifference',
@@ -755,8 +749,7 @@ interface I {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: '[string, boolean]',
+            typeText: 'number | [string, boolean]',
           },
           line: 4,
           messageId: 'singleParameterDifference',
@@ -776,8 +769,7 @@ interface Generic<T> {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'T[]',
-            type2: 'T',
+            typeText: 'T[] | T',
           },
           line: 4,
           messageId: 'singleParameterDifference',
@@ -796,8 +788,7 @@ function f<T>(x: T): void;
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'T[]',
-            type2: 'T',
+            typeText: 'T[] | T',
           },
           line: 3,
           messageId: 'singleParameterDifference',
@@ -816,8 +807,7 @@ function f<T extends number>(x: T): void;
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'T[]',
-            type2: 'T',
+            typeText: 'T[] | T',
           },
           line: 3,
           messageId: 'singleParameterDifference',
@@ -838,8 +828,7 @@ abstract class Foo {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            typeText: 'number | string',
           },
           line: 4,
           messageId: 'singleParameterDifference',
@@ -862,8 +851,7 @@ abstract class C {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            typeText: 'string | number',
           },
           line: 7,
           messageId: 'singleParameterDifference',
@@ -884,8 +872,7 @@ interface Foo {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            typeText: 'string | number',
           },
           line: 4,
           messageId: 'singleParameterDifference',
@@ -906,8 +893,7 @@ interface Foo {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            typeText: 'string | number',
           },
           line: 4,
           messageId: 'singleParameterDifference',
@@ -932,8 +918,7 @@ interface IFoo {
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            typeText: 'string | number',
           },
           line: 8,
           messageId: 'singleParameterDifference',
@@ -1017,8 +1002,7 @@ declare function f(x: boolean): void;
           data: {
             failureStringStart:
               'This overload and the one on line 6 can be combined into one signature',
-            type1: 'number',
-            type2: 'boolean',
+            typeText: 'number | boolean',
           },
           line: 7,
           messageId: 'singleParameterDifference',
@@ -1044,8 +1028,7 @@ declare function f(x: boolean): void;
           data: {
             failureStringStart:
               'This overload and the one on line 5 can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            typeText: 'string | number',
           },
           line: 9,
           messageId: 'singleParameterDifference',
@@ -1071,8 +1054,7 @@ declare function f(x: boolean): void;
           data: {
             failureStringStart:
               'This overload and the one on line 6 can be combined into one signature',
-            type1: 'number',
-            type2: 'boolean',
+            typeText: 'number | boolean',
           },
           line: 10,
           messageId: 'singleParameterDifference',
@@ -1098,8 +1080,7 @@ export function f(x: boolean): void;
           data: {
             failureStringStart:
               'This overload and the one on line 6 can be combined into one signature',
-            type1: 'number',
-            type2: 'boolean',
+            typeText: 'number | boolean',
           },
           line: 10,
           messageId: 'singleParameterDifference',
@@ -1129,8 +1110,7 @@ function f(x: string): void;
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'string',
+            typeText: 'number | string',
           },
           line: 14,
           messageId: 'singleParameterDifference',
@@ -1158,8 +1138,7 @@ interface I {
           data: {
             failureStringStart:
               'This overload and the one on line 7 can be combined into one signature',
-            type1: 'number',
-            type2: 'boolean',
+            typeText: 'number | boolean',
           },
           line: 11,
           messageId: 'singleParameterDifference',
@@ -1179,8 +1158,7 @@ declare function f(x: boolean): unknown;
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'number',
-            type2: 'boolean',
+            typeText: 'number | boolean',
           },
           line: 4,
           messageId: 'singleParameterDifference',
@@ -1228,8 +1206,7 @@ function f(this: string | number): void {}
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            typeText: 'string | number',
           },
           line: 3,
           messageId: 'singleParameterDifference',
@@ -1248,8 +1225,7 @@ function f(this: string | number, a: boolean): void {}
           data: {
             failureStringStart:
               'These overloads can be combined into one signature',
-            type1: 'string',
-            type2: 'number',
+            typeText: 'string | number',
           },
           line: 3,
           messageId: 'singleParameterDifference',


### PR DESCRIPTION
Fixes #000

## Summary

When two overload signatures share a common type in their parameter types, the unified-signatures rule produces an error message with duplicate type names. For example:

```typescript
function f(a: number | string): void;
function f(a: string | boolean): void;
```

Before: "This overload and the one on line 1 can be combined into one signature taking `number | string | string | boolean`."
After: "This overload and the one on line 1 can be combined into one signature taking `number | string | boolean`."

## Changes

- Changed the singleParameterDifference message template from `{{type1}} | {{type2}}` to a single `{{typeText}}` field, computing the combined type string via Set-based deduplication of all union members across both type annotations.
- Updated all 24 test cases from the type1/type2 data format to typeText.