### PR TITLE
chore(website): lock monaco-editor version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,9 @@
     'globby',
     // ESM only so we can't go higher until we natively run ESM internally.
     'execa',
+    // Monaco editor version should be locked until ts playground will support newer versions.
+    // https://github.com/typescript-eslint/typescript-eslint/pull/11805#issuecomment-4926086764
+    'monaco-editor',
   ],
   ignorePaths: [
     // Integration test package.json's should never be updated as they're purposely fixed tests.

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -79,7 +79,7 @@
     "history": "^4.10.1",
     "mdast-util-from-markdown": "catalog:",
     "mdast-util-mdx": "catalog:",
-    "monaco-editor": "~0.54.0",
+    "monaco-editor": "0.54.0",
     "prismjs": "1.30.0",
     "rimraf": "catalog:",
     "stylelint": "^16.26.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1026,7 +1026,7 @@ importers:
         specifier: 'catalog:'
         version: 3.0.0
       monaco-editor:
-        specifier: ~0.54.0
+        specifier: 0.54.0
         version: 0.54.0
       prismjs:
         specifier: 1.30.0


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

We can't update `moncao-editor` version because of type-level vs. runtime-code issues.

See https://github.com/typescript-eslint/typescript-eslint/pull/11805#issuecomment-4926086764 for more details.
