### PR TITLE
feat(typescript-estree): throw for invalid import defer syntax

### DIFF
--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-default/fixture.ts
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-default/fixture.ts
@@ -1,0 +1,1 @@
+import defer defaultValue from 'mod';

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-default/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-default/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,6 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > declaration > ImportDeclaration > _error_ > defer-default > TSESTree - Error`]
+TSError
+> 1 | import defer defaultValue from 'mod';
+    |        ^^^^^^^^^^^^^^^^^^ Default imports are not allowed in a deferred import.

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-default/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-default/snapshots/2-Babel-Error.shot
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > declaration > ImportDeclaration > _error_ > defer-default > Babel - Error`]
+BabelError
+> 1 | import defer defaultValue from 'mod';
+    |              ^ Only `import defer * as x from "./module"` is valid. (1:13)
+  

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-default/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-default/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > declaration > ImportDeclaration > _error_ > defer-default > Error Alignment`]
+Both errored

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-named/fixture.ts
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-named/fixture.ts
@@ -1,0 +1,1 @@
+import defer { named } from 'mod';

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-named/snapshots/1-TSESTree-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-named/snapshots/1-TSESTree-Error.shot
@@ -1,0 +1,6 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > declaration > ImportDeclaration > _error_ > defer-named > TSESTree - Error`]
+TSError
+> 1 | import defer { named } from 'mod';
+    |        ^^^^^^^^^^^^^^^ Named imports are not allowed in a deferred import.

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-named/snapshots/2-Babel-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-named/snapshots/2-Babel-Error.shot
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > declaration > ImportDeclaration > _error_ > defer-named > Babel - Error`]
+BabelError
+> 1 | import defer { named } from 'mod';
+    |                ^ Only `import defer * as x from "./module"` is valid. (1:15)
+  

--- a/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-named/snapshots/3-Alignment-Error.shot
+++ b/packages/ast-spec/src/declaration/ImportDeclaration/fixtures/_error_/defer-named/snapshots/3-Alignment-Error.shot
@@ -1,0 +1,4 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AST Fixtures > declaration > ImportDeclaration > _error_ > defer-named > Error Alignment`]
+Both errored

--- a/packages/typescript-estree/src/check-syntax-errors.ts
+++ b/packages/typescript-estree/src/check-syntax-errors.ts
@@ -389,14 +389,35 @@ export function checkSyntaxError(
 
     case SyntaxKind.ImportDeclaration: {
       const { importClause } = node;
+      const importPhase = getImportClausePhaseModifier(importClause);
+
       if (
-        getImportClausePhaseModifier(importClause) === 'type' &&
+        importPhase === 'type' &&
         importClause?.name &&
         importClause.namedBindings
       ) {
         throw createError(
           importClause,
           'A type-only import can specify a default import or named bindings, but not both.',
+        );
+      }
+
+      const isNamedImport =
+        importClause?.namedBindings?.kind === SyntaxKind.NamedImports;
+
+      const isDefaultImport = !!importClause?.name;
+
+      if (importPhase === 'defer' && isNamedImport) {
+        throw createError(
+          importClause,
+          'Named imports are not allowed in a deferred import.',
+        );
+      }
+
+      if (importPhase === 'defer' && isDefaultImport) {
+        throw createError(
+          importClause,
+          'Default imports are not allowed in a deferred import.',
         );
       }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [X] Addresses an existing open issue: fixes #12549 
- [X] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [X] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

Errorsss
