### PR TITLE
fix(eslint-plugin): [no-unsafe-argument] flag unsafe args to constrained type parameters

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
+++ b/packages/eslint-plugin/src/rules/no-unsafe-argument.ts
@@ -6,6 +6,7 @@ import * as ts from 'typescript';
 
 import {
   createRule,
+  getConstraintInfo,
   getParserServices,
   isRestParameterDeclaration,
   isTypeAnyArrayType,
@@ -64,10 +65,20 @@ class FunctionSignature {
     const paramTypes: ts.Type[] = [];
     let restType: RestType | null = null;
 
+    // The resolved signature instantiates generic type parameters based on the
+    // passed arguments. When an argument is `any`, a type parameter is inferred
+    // as `any` too, which would hide unsafe usages. The uninstantiated target
+    // signature still exposes the type parameters, so we use it to fall back to
+    // their constraints.
+    // https://github.com/typescript-eslint/typescript-eslint/issues/10415
+    const targetParameters = (
+      signature as ts.Signature & { target?: ts.Signature }
+    ).target?.getParameters();
+
     const parameters = signature.getParameters();
     for (let i = 0; i < parameters.length; i += 1) {
       const param = parameters[i];
-      const type = checker.getTypeOfSymbolAtLocation(param, tsNode);
+      let type = checker.getTypeOfSymbolAtLocation(param, tsNode);
 
       const decl = param.getDeclarations()?.[0];
       if (decl && isRestParameterDeclaration(decl)) {
@@ -92,6 +103,20 @@ class FunctionSignature {
           };
         }
         break;
+      }
+
+      const targetParam = targetParameters?.[i];
+      if (targetParam) {
+        const { constraintType, isTypeParameter } = getConstraintInfo(
+          checker,
+          checker.getTypeOfSymbolAtLocation(targetParam, tsNode),
+        );
+        // Only constrained type parameters can be unsafe to receive an `any`.
+        // Unconstrained type parameters accept anything (like `unknown`), so we
+        // leave the inferred type as-is to avoid false positives.
+        if (isTypeParameter && constraintType != null) {
+          type = constraintType;
+        }
       }
 
       paramTypes.push(type);

--- a/packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unsafe-argument.test.ts
@@ -101,6 +101,17 @@ declare function foo<T>(t: T): T;
 const t: T = [];
 foo(t);
     `,
+    // an unconstrained type parameter accepts any type, so passing `any` is safe
+    // https://github.com/typescript-eslint/typescript-eslint/issues/10415
+    `
+declare const foo: <T>(t: T) => void;
+foo(1 as any);
+    `,
+    // the argument is assignable to the type parameter's constraint
+    `
+declare const foo: <T extends number>(t: T) => void;
+foo(1);
+    `,
     `
 function foo(templates: TemplateStringsArray) {}
 foo\`\`;
@@ -533,6 +544,27 @@ foo\`\${arg}\`;
           },
           endColumn: 10,
           line: 5,
+          messageId: 'unsafeArgument',
+        },
+      ],
+    },
+    // a constrained type parameter is inferred as `any` from an `any` argument,
+    // but the argument should still be checked against the constraint
+    // https://github.com/typescript-eslint/typescript-eslint/issues/10415
+    {
+      code: `
+declare const foo: <T extends number>(t: T) => void;
+foo(1 as any);
+      `,
+      errors: [
+        {
+          column: 5,
+          data: {
+            receiver: '`number`',
+            sender: '`any`',
+          },
+          endColumn: 13,
+          line: 3,
           messageId: 'unsafeArgument',
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #10415
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [ ] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

When a parameter's declared type is a generic type parameter, the signature returned by `getResolvedSignature` has already instantiated that type parameter from the call's arguments. If the argument is `any`, the type parameter gets inferred as `any`, so `getTypeOfSymbolAtLocation` reports the parameter type as `any` and the rule never flags the unsafe argument. That's the false negative in #10415: passing `any` to a parameter typed `T extends string` was allowed.

The fix reads the parameter types from the uninstantiated `signature.target`, which still carries the original type parameters. For each non-rest parameter I check whether the target parameter's type is a constrained type parameter (via `getConstraintInfo`) and, if so, check the argument against the constraint instead of the collapsed `any`. Unconstrained type parameters are left alone since they accept anything, so this doesn't introduce false positives there.

One thing worth a reviewer's eye: `signature.target` is marked `@internal`, so I read it through a small cast. It's the most direct way to recover the pre-inference parameters, but if you'd prefer a public-API approach I'm happy to change it.

Tests added in `no-unsafe-argument.test.ts`: one invalid case reproducing the issue plus two valid cases (unconstrained type parameter, and a safe argument to a constrained one) to guard the boundaries.
