### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] handle union-keyed index access on the left-hand side of nullish assignment

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -50,6 +50,16 @@ function isPossiblyNullish(type: ts.Type): boolean {
     .some(t => isNullishType(t) || isTypeFlagSet(t, ts.TypeFlags.Void));
 }
 
+function isPossiblyNonNullish(type: ts.Type): boolean {
+  return tsutils
+    .unionConstituents(type)
+    .some(
+      t =>
+        !isNullishType(t) &&
+        !isTypeFlagSet(t, ts.TypeFlags.Never | ts.TypeFlags.Void),
+    );
+}
+
 function toStaticValue(
   type: ts.Type,
 ):
@@ -345,6 +355,55 @@ export default createRule<Options, MessageId>({
     }
 
     /**
+     * In a write position (the left-hand side of `obj[key] ??= value`),
+     * the checker resolves `obj[key]` to its *write* type — the intersection
+     * of the types of the properties that `key` may select — which can
+     * collapse to `undefined` or `never` even though *reading* `obj[key]`
+     * may produce a non-nullish value for some of the keys (e.g.
+     * `key: 'a' | 'b'` with `obj: { a?: number; b?: boolean }`).
+     * Only call this for nodes in a write position: in a read position the
+     * checker resolves the *read* type (the union of the per-key property
+     * types, possibly narrowed by control flow analysis), so a nullish
+     * result there is a true positive that must not be suppressed.
+     * https://github.com/typescript-eslint/typescript-eslint/issues/12556
+     */
+    function isPossiblyNonNullishUnionKeyedAccess(
+      node: TSESTree.Expression,
+    ): boolean {
+      if (node.type !== AST_NODE_TYPES.MemberExpression || !node.computed) {
+        return false;
+      }
+      const keyType = getConstrainedTypeAtLocation(services, node.property);
+      // Only a union key collapses the write type to an intersection; with a
+      // single key the write type is just that property's type, which the
+      // regular logic already handles correctly.
+      if (!keyType.isUnion()) {
+        return false;
+      }
+      const objectType = getConstrainedTypeAtLocation(services, node.object);
+      return keyType.types.some(key => {
+        if (key.isNumberLiteral() || key.isStringLiteral()) {
+          const propertyType = getTypeOfPropertyOfName(
+            checker,
+            objectType,
+            key.value.toString(),
+          );
+          if (propertyType) {
+            return isPossiblyNonNullish(propertyType);
+          }
+        }
+        const keyTypeName = getTypeName(checker, key);
+        return checker
+          .getIndexInfosOfType(objectType)
+          .some(
+            info =>
+              getTypeName(checker, info.keyType) === keyTypeName &&
+              isPossiblyNonNullish(info.type),
+          );
+      });
+    }
+
+    /**
      * Checks if a conditional node is necessary:
      * if the type of the node is always true or always false, it's not necessary.
      */
@@ -401,7 +460,10 @@ export default createRule<Options, MessageId>({
       }
     }
 
-    function checkNodeForNullish(node: TSESTree.Expression): void {
+    function checkNodeForNullish(
+      node: TSESTree.Expression,
+      isWritePosition = false,
+    ): void {
       const type = getConstrainedTypeAtLocation(services, node);
 
       // Conditional is always necessary if it involves `any`, `unknown` or a naked type parameter
@@ -418,7 +480,10 @@ export default createRule<Options, MessageId>({
       }
 
       let messageId: MessageId | null = null;
-      if (isTypeFlagSet(type, ts.TypeFlags.Never)) {
+      if (
+        isTypeFlagSet(type, ts.TypeFlags.Never) &&
+        !(isWritePosition && isPossiblyNonNullishUnionKeyedAccess(node))
+      ) {
         messageId = 'never';
       } else if (
         !isPossiblyNullish(type) &&
@@ -441,7 +506,10 @@ export default createRule<Options, MessageId>({
         ) {
           messageId = 'neverNullish';
         }
-      } else if (isAlwaysNullish(type)) {
+      } else if (
+        isAlwaysNullish(type) &&
+        !(isWritePosition && isPossiblyNonNullishUnionKeyedAccess(node))
+      ) {
         messageId = 'alwaysNullish';
       }
 
@@ -915,7 +983,7 @@ export default createRule<Options, MessageId>({
       if (['&&=', '||='].includes(node.operator)) {
         checkNode(node.left);
       } else if (node.operator === '??=') {
-        checkNodeForNullish(node.left);
+        checkNodeForNullish(node.left, /* isWritePosition */ true);
       }
     }
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -1039,6 +1039,29 @@ declare const foo: Foo;
 declare const key: Keys;
 foo[key] ??= 1;
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12556
+    `
+type Fields = {
+  hello?: number;
+  world?: boolean;
+};
+
+let fields: Fields = {};
+
+for (const key of ['hello', 'world'] as const) {
+  fields[key] ??= undefined;
+}
+    `,
+    `
+declare const foo: { bar?: number; baz?: string };
+declare const key: 'bar' | 'baz';
+foo[key] ??= undefined;
+    `,
+    `
+declare const foo: { bar?: number; baz: string };
+declare const key: 'bar' | 'baz';
+foo[key] ??= undefined;
+    `,
     {
       code: `
 declare const foo: { bar?: number };
@@ -3439,6 +3462,76 @@ foo ??= null;
           endColumn: 4,
           endLine: 3,
           line: 3,
+          messageId: 'alwaysNullish',
+        },
+      ],
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12556
+    {
+      code: `
+declare const foo: { bar: number; baz: number };
+declare const key: 'bar' | 'baz';
+foo[key] ??= 1;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 9,
+          endLine: 4,
+          line: 4,
+          messageId: 'neverNullish',
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: { bar: number; baz: string };
+declare const key: 'bar' | 'baz';
+foo[key] ??= 1;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 9,
+          endLine: 4,
+          line: 4,
+          messageId: 'neverNullish',
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: { bar?: undefined; baz?: undefined };
+declare const key: 'bar' | 'baz';
+foo[key] ??= undefined;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 9,
+          endLine: 4,
+          line: 4,
+          messageId: 'alwaysNullish',
+        },
+      ],
+    },
+    {
+      // in a read position the checker uses the read type (union of the
+      // per-key property types), which control flow analysis can narrow —
+      // the union-keyed write suppression must not apply here
+      code: `
+declare const foo: { bar?: number; baz?: number };
+declare const key: 'bar' | 'baz';
+if (foo[key] === undefined) {
+  foo[key] ?? 1;
+}
+      `,
+      errors: [
+        {
+          column: 3,
+          endColumn: 11,
+          endLine: 5,
+          line: 5,
           messageId: 'alwaysNullish',
         },
       ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #12556
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

### Problem

```ts
type Fields = {
  hello?: number;
  world?: boolean;
};

let fields: Fields = {};

for (const key of ['hello', 'world'] as const) {
  fields[key] ??= undefined; // false positive: "always `null` or `undefined`"
}
```

`no-unnecessary-condition` reports `alwaysNullish` even though both fields are optional and may hold non-nullish values.

### Root cause

On the left-hand side of `obj[key] ??= value`, `checker.getTypeAtLocation()` resolves the element access to its *write* type — the **intersection** of the types of the properties that `key` may select — rather than the union a *read* produces. With `key: 'hello' | 'world'` and disjoint optional property types, `(number | undefined) & (boolean | undefined)` collapses to `undefined`, so the rule concludes the left-hand side is always nullish. With a required member in the mix (`{ a?: number; b: string }`) it collapses to `never`, producing a bogus `never` report through the same code path.

This also explains the observations in the issue thread: when the property types share a common constituent, the intersection stays non-empty, so no error is reported.

Note `??` in a plain read position is unaffected — the checker resolves the *read* type there (the union of the per-key property types, possibly narrowed by control flow analysis) — which is why only the assignment form misbehaved. The `neverNullish` branch was already protected against this by the per-key logic in `isNullableMemberExpression` / `isNullablePropertyType`; the `never` and `alwaysNullish` branches lacked the symmetric guard.

### Fix

Adds `isPossiblyNonNullishUnionKeyedAccess()`, mirroring the existing `isNullablePropertyType()` per-key logic (including its index-signature fallback): for a computed member expression whose key is a union, it checks whether reading `obj[k]` for some key `k` can produce a non-nullish value via `getTypeOfPropertyOfName` (which already includes `undefined` for optional properties under `strictNullChecks`). The `never` and `alwaysNullish` reports are suppressed in that case.

The suppression is scoped along two axes:

- **Write position only:** `checkNodeForNullish` gains an `isWritePosition` flag, set only for the left-hand side of `??=`. In a read position the checker resolves the read type — which control flow analysis can legitimately narrow to nullish (e.g. inside `if (foo[key] === undefined)`) — so a nullish result there is a true positive that must keep being reported.
- **Union keys only:** with a single-literal key the write type is just that property's type (no intersection collapse), so the regular logic already handles it.

As a side effect of the `never`-branch guard, `obj[key] ??= x` with disjoint *required* properties (`{ a: number; b: string }`) now correctly falls through and reports `neverNullish` (the read is never nullish) instead of the misleading `never` ("value is `never`").

The sibling `&&=`/`||=` path (`checkNode`) has the analogous write-type collapse for truthiness checks and is left as a follow-up to keep this change scoped to the reported `??=` false positive.

### Tests

Valid (all were false positives before this fix):
- the exact repro from #12556
- disjoint optional fields: `{ bar?: number; baz?: string }` with `key: 'bar' | 'baz'`
- disjoint optional + required: `{ bar?: number; baz: string }` (previously reported `never`)

Invalid (regression coverage):
- shared-type required fields `{ bar: number; baz: number }` → still `neverNullish`
- disjoint required fields `{ bar: number; baz: string }` → now `neverNullish` (previously `never`)
- all-nullish optional fields `{ bar?: undefined; baz?: undefined }` → still `alwaysNullish`
- read position with CFA narrowing: `if (foo[key] === undefined) { foo[key] ?? 1; }` with disjoint optional fields → still `alwaysNullish` (the write-position scoping keeps this true positive)

All 306 tests for the rule pass; the new valid fixtures and the new invalid fixtures fail without the source change (verified by reverting it).
