### PR TITLE
fix(eslint-plugin): [no-unnecessary-condition] false positive for union-keyed index access on left-hand side of ??= assignment

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts
@@ -49,7 +49,15 @@ function isPossiblyNullish(type: ts.Type): boolean {
     .unionConstituents(type)
     .some(t => isNullishType(t) || isTypeFlagSet(t, ts.TypeFlags.Void));
 }
-
+function isPossiblyNonNullish(type: ts.Type): boolean {
+  return tsutils
+    .unionConstituents(type)
+    .some(
+      t =>
+        !isNullishType(t) &&
+        !isTypeFlagSet(t, ts.TypeFlags.Never | ts.TypeFlags.Void),
+    );
+}
 function toStaticValue(
   type: ts.Type,
 ):
@@ -399,7 +407,43 @@ export default createRule<Options, MessageId>({
       }
     }
 
-    function checkNodeForNullish(node: TSESTree.Expression): void {
+    function isPossiblyNonNullishUnionKeyedAccess(
+      node: TSESTree.Expression,
+    ): boolean {
+      if (node.type !== AST_NODE_TYPES.MemberExpression || !node.computed) {
+        return false;
+      }
+      const keyType = getConstrainedTypeAtLocation(services, node.property);
+      if (!keyType.isUnion()) {
+        return false;
+      }
+      const objectType = getConstrainedTypeAtLocation(services, node.object);
+      return keyType.types.some(key => {
+        if (key.isNumberLiteral() || key.isStringLiteral()) {
+          const propertyType = getTypeOfPropertyOfName(
+            checker,
+            objectType,
+            key.value.toString(),
+          );
+          if (propertyType) {
+            return isPossiblyNonNullish(propertyType);
+          }
+        }
+        const keyTypeName = getTypeName(checker, key);
+        return checker
+          .getIndexInfosOfType(objectType)
+          .some(
+            info =>
+              getTypeName(checker, info.keyType) === keyTypeName &&
+              isPossiblyNonNullish(info.type),
+          );
+      });
+    }
+
+    function checkNodeForNullish(
+      node: TSESTree.Expression,
+      isWritePosition = false,
+    ): void {
       const type = getConstrainedTypeAtLocation(services, node);
 
       // Conditional is always necessary if it involves `any`, `unknown` or a naked type parameter
@@ -416,7 +460,10 @@ export default createRule<Options, MessageId>({
       }
 
       let messageId: MessageId | null = null;
-      if (isTypeFlagSet(type, ts.TypeFlags.Never)) {
+      if (
+        isTypeFlagSet(type, ts.TypeFlags.Never) &&
+        !(isWritePosition && isPossiblyNonNullishUnionKeyedAccess(node))
+      ) {
         messageId = 'never';
       } else if (
         !isPossiblyNullish(type) &&
@@ -439,7 +486,10 @@ export default createRule<Options, MessageId>({
         ) {
           messageId = 'neverNullish';
         }
-      } else if (isAlwaysNullish(type)) {
+      } else if (
+        isAlwaysNullish(type) &&
+        !(isWritePosition && isPossiblyNonNullishUnionKeyedAccess(node))
+      ) {
         messageId = 'alwaysNullish';
       }
 
@@ -913,7 +963,7 @@ export default createRule<Options, MessageId>({
       if (['&&=', '||='].includes(node.operator)) {
         checkNode(node.left);
       } else if (node.operator === '??=') {
-        checkNodeForNullish(node.left);
+        checkNodeForNullish(node.left, /* isWritePosition */ true);
       }
     }
 

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-condition.test.ts
@@ -455,7 +455,27 @@ function foo<T extends object>(arg: T, key: keyof T): void {
   arg[key] ?? 'default';
 }
     `,
-    // Indexing cases
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12556
+    `
+type Fields = {
+  hello?: number;
+  world?: boolean;
+};
+let fields: Fields = {};
+for (const key of ['hello', 'world'] as const) {
+  fields[key] ??= undefined;
+}
+    `,
+    `
+declare const foo: { bar?: number; baz?: string };
+declare const key: 'bar' | 'baz';
+foo[key] ??= undefined;
+    `,
+    `
+declare const foo: { bar?: number; baz: string };
+declare const key: 'bar' | 'baz';
+foo[key] ??= undefined;
+    `,
     `
 declare const arr: object[];
 if (arr[42]) {
@@ -3516,6 +3536,40 @@ foo.bar ??= 1;
         },
       ],
       languageOptions: { parserOptions: optionsWithExactOptionalPropertyTypes },
+
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/12556
+    {
+      code: `
+declare const foo: { bar: number; baz: number };
+declare const key: 'bar' | 'baz';
+foo[key] ??= 1;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 9,
+          endLine: 4,
+          line: 4,
+          messageId: 'neverNullish',
+        },
+      ],
+    },
+    {
+      code: `
+declare const foo: { bar?: undefined; baz?: undefined };
+declare const key: 'bar' | 'baz';
+foo[key] ??= undefined;
+      `,
+      errors: [
+        {
+          column: 1,
+          endColumn: 9,
+          endLine: 4,
+          line: 4,
+          messageId: 'alwaysNullish',
+        },
+      ],
     },
     {
       code: `


### PR DESCRIPTION
Closes #12556 

## PR Checklist

- Addresses an existing open issue: fixes #12556
- That issue was marked as `accepting prs`
- Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

### Problem

```ts
type Fields = {
  hello?: number;
  world?: boolean;
};
let fields: Fields = {};
for (const key of ['hello', 'world'] as const) {
  fields[key] ??= undefined; // false positive: "always null or undefined"
}
```

`no-unnecessary-condition` incorrectly reports `alwaysNullish` on the left-hand side of `??=` when the computed key is a union type and the object properties have different types.

### Root Cause

On the left-hand side of `obj[key] ??= value`, TypeScript's checker resolves `obj[key]` to its **write type** - the intersection of all property types that `key` may select. With `key: 'hello' | 'world'` and disjoint optional property types `number | undefined` and `boolean | undefined`, the intersection collapses to `undefined`, making the rule conclude the left side is always nullish - even though reading `obj[key]` for any single key can produce a non-nullish value.

This also explains why the bug only occurs when properties have **different** types: when types share a common constituent, the intersection remains non-empty.

### Fix

Added `isPossiblyNonNullishUnionKeyedAccess()` -  a helper that detects computed member expressions with union keys and checks whether reading `obj[k]` for any single key `k` can produce a non-nullish value via `getTypeOfPropertyOfName`.

Added `isWritePosition` parameter to `checkNodeForNullish()` - set to `true` only for the left-hand side of `??=`. The suppression applies only in write position because in read position the checker uses the read type (union of per-key types), which control flow analysis can legitimately narrow to nullish.

The `never` and `alwaysNullish` reports are both guarded against this false positive.

### Tests

Added valid cases (were false positives before this fix):
- Exact repro from #12556 (iteration variable over const array)
- Disjoint optional fields: `{ bar?: number; baz?: string }` with union key
- Optional + required mix: `{ bar?: number; baz: string }` with union key

Added invalid cases (regression coverage):
- Required fields with same type → still reports `neverNullish`
- All-nullish optional fields → still reports `alwaysNullish`

All 304 existing tests pass. New cases fail without the source change (verified by reverting).