### PR TITLE
test(typescript-eslint): fix typo in stack trace test description

### DIFF
--- a/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
+++ b/packages/typescript-eslint/tests/getTsconfigRootDirFromStack.test.ts
@@ -39,7 +39,7 @@ describe(getTSConfigRootDirFromStack, () => {
     expect(notEslintConfig.get()).toBeUndefined();
   });
 
-  it('should work in the presence of a messed up strack trace string', () => {
+  it('should work in the presence of a messed up stack trace string', () => {
     const prepareStackTrace = Error.prepareStackTrace;
     const dummyFunction = () => {};
     Error.prepareStackTrace = dummyFunction;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [ ] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->

Corrects `strack trace` to `stack trace` in the `getTsconfigRootDirFromStack` test description.

This only changes the displayed test name and does not affect test behavior.

