### PR TITLE
fix(eslint-plugin): [no-unnecessary-parameter-property-assignment] don't flag computed assignments with a variable key

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts
@@ -46,7 +46,7 @@ export default createRule({
         return null;
       }
 
-      if (node.property.type === AST_NODE_TYPES.Identifier) {
+      if (!node.computed && node.property.type === AST_NODE_TYPES.Identifier) {
         return node.property.name;
       }
       if (node.computed) {

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-parameter-property-assignment.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-parameter-property-assignment.test.ts
@@ -166,6 +166,13 @@ class Foo {
   init2 = (Foo.foo = 1);
 }
     `,
+    `
+class Foo {
+  constructor(public foo: string) {
+    this[foo] = foo;
+  }
+}
+    `,
   ],
   invalid: [
     {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #12566
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [ ] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`getPropertyName` was treating `this[foo]` as `this.foo` because it returned identifier names before checking `computed`

This adds a `!node.computed` guard, so computed variables fall through to `getStaticStringValue`