### PR TITLE
docs: fix broken code samples in no-extraneous-class and prefer-function-type

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-extraneous-class.mdx
+++ b/packages/eslint-plugin/docs/rules/no-extraneous-class.mdx
@@ -203,11 +203,11 @@ export class Utilities {
 let mutableCount = 1;
 
 export function getMutableCount() {
-  return mutableField;
+  return mutableCount;
 }
 
 export function incrementCount() {
-  mutableField += 1;
+  mutableCount += 1;
 }
 ```
 

--- a/packages/eslint-plugin/docs/rules/prefer-function-type.mdx
+++ b/packages/eslint-plugin/docs/rules/prefer-function-type.mdx
@@ -51,7 +51,7 @@ type Example = () => string;
 
 ```ts
 function foo(example: () => number): number {
-  return bar();
+  return example();
 }
 ```
 

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-extraneous-class.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/no-extraneous-class.shot
@@ -121,11 +121,11 @@ Correct
 let mutableCount = 1;
 
 export function getMutableCount() {
-  return mutableField;
+  return mutableCount;
 }
 
 export function incrementCount() {
-  mutableField += 1;
+  mutableCount += 1;
 }
 
 Incorrect

--- a/packages/eslint-plugin/tests/docs-eslint-output-snapshots/prefer-function-type.shot
+++ b/packages/eslint-plugin/tests/docs-eslint-output-snapshots/prefer-function-type.shot
@@ -27,7 +27,7 @@ type Example = () => string;
 Correct
 
 function foo(example: () => number): number {
-  return bar();
+  return example();
 }
 
 Correct


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

<!-- Description of what is changed and how the code change does that. -->

Fixes two "✅ Correct" code samples in rule docs that reference undeclared identifiers, so they don't actually compile:

- `no-extraneous-class`: the mutating-variables example declares `let mutableCount = 1;` but the functions reference `mutableField`. Renamed to `mutableCount`, matching the declaration and the "❌ Incorrect" counterpart.
- `prefer-function-type`: the example calls `bar()`, which is never declared; the parameter is `example`. Changed to `example()`, matching the "❌ Incorrect" counterpart.