### PR TITLE
fix(eslint-plugin): [no-unnecessary-type-assertion] clearer message for return-only generic call assertions

### DIFF
--- a/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
+++ b/packages/eslint-plugin/src/rules/no-unnecessary-type-assertion.ts
@@ -72,7 +72,10 @@ export type Options = [
     typesToIgnore?: string[];
   },
 ];
-export type MessageIds = 'contextuallyUnnecessary' | 'unnecessaryAssertion';
+export type MessageIds =
+  | 'contextuallyUnnecessary'
+  | 'unnecessaryAssertion'
+  | 'unnecessaryAssertionOnGenericCall';
 
 export default createRule<Options, MessageIds>({
   name: 'no-unnecessary-type-assertion',
@@ -90,6 +93,8 @@ export default createRule<Options, MessageIds>({
         'This assertion is unnecessary since the receiver accepts the original type of the expression.',
       unnecessaryAssertion:
         'This assertion is unnecessary since it does not change the type of the expression.',
+      unnecessaryAssertionOnGenericCall:
+        'This assertion does not change the type of the expression, but only because the type argument of the generic call is being inferred from it. Consider passing the type argument explicitly instead (e.g. `foo<Type>()`).',
     },
     schema: [
       {
@@ -892,6 +897,68 @@ export default createRule<Options, MessageIds>({
       };
     }
 
+    function collectIdentifierNames(tsNode: ts.Node, names: Set<string>): void {
+      if (ts.isIdentifier(tsNode)) {
+        names.add(tsNode.text);
+        return;
+      }
+      tsNode.forEachChild(child => collectIdentifierNames(child, names));
+    }
+
+    /**
+     * Detects the "type parameter only used in a return position" pattern, e.g.
+     * `declare function get<T = unknown>(): T` called as `get() as Foo`.
+     *
+     * In these cases TypeScript backfills the type argument from the assertion,
+     * so the asserted expression appears to already have the asserted type and
+     * the assertion looks like it "does not change the type". The generic
+     * message is misleading here: the fix is to pass the type argument to the
+     * call explicitly rather than to remove the assertion (which would silently
+     * widen the type back and can break downstream code).
+     *
+     * @see https://github.com/typescript-eslint/typescript-eslint/issues/6951
+     */
+    function isUnnecessaryAssertionOnReturnOnlyGeneric(
+      expression: TSESTree.Expression,
+    ): boolean {
+      const call =
+        expression.type === AST_NODE_TYPES.AwaitExpression
+          ? expression.argument
+          : expression;
+
+      // Only relevant when the type argument was inferred rather than written.
+      if (
+        call.type !== AST_NODE_TYPES.CallExpression ||
+        call.typeArguments != null
+      ) {
+        return false;
+      }
+
+      const tsCall = services.esTreeNodeToTSNodeMap.get(call);
+      const signature = checker.getResolvedSignature(tsCall);
+      const declaration = signature?.getDeclaration();
+      if (declaration == null) {
+        return false;
+      }
+      const { typeParameters } = declaration;
+      if (typeParameters == null || typeParameters.length === 0) {
+        return false;
+      }
+
+      const namesUsedInParameters = new Set<string>();
+      for (const parameter of declaration.parameters) {
+        if (parameter.type != null) {
+          collectIdentifierNames(parameter.type, namesUsedInParameters);
+        }
+      }
+
+      // A type parameter that never appears in a parameter can only be inferred
+      // from the return position (or its default), which is the backfill case.
+      return typeParameters.some(
+        typeParameter => !namesUsedInParameters.has(typeParameter.name.text),
+      );
+    }
+
     function reportDoubleAssertionIfUnnecessary(
       node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
       contextualType: ts.Type | undefined,
@@ -958,6 +1025,15 @@ export default createRule<Options, MessageIds>({
           : !typeAnnotationIsConstAssertion;
 
         if (typeIsUnchanged && wouldSameTypeBeInferred) {
+          if (isUnnecessaryAssertionOnReturnOnlyGeneric(node.expression)) {
+            // Don't offer an autofix: removing the assertion here widens the
+            // type back to the generic default, which can break downstream code.
+            context.report({
+              node,
+              messageId: 'unnecessaryAssertionOnGenericCall',
+            });
+            return;
+          }
           context.report({
             node,
             messageId: 'unnecessaryAssertion',

--- a/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
+++ b/packages/eslint-plugin/tests/rules/no-unnecessary-type-assertion.test.ts
@@ -924,6 +924,13 @@ enum E {
 }
 const x: E | undefined = o?.fn(n => n | 0, 0 as E);
     `,
+    // https://github.com/typescript-eslint/typescript-eslint/issues/6951
+    // the recommended fix for a return-position-only generic: pass the type
+    // argument explicitly instead of asserting the call's result.
+    `
+declare function get<T = unknown>(): T;
+const x = get<string>();
+    `,
   ],
 
   invalid: [
@@ -2893,6 +2900,61 @@ maybeFn?.(s as string | number);
 declare const maybeFn: ((arg: string | number) => void) | undefined;
 declare const s: string;
 maybeFn?.(s);
+      `,
+    },
+    // https://github.com/typescript-eslint/typescript-eslint/issues/6951
+    // Type parameter used only in the return position: TS backfills it from the
+    // assertion, so the assertion looks unnecessary. Report a dedicated message
+    // and offer no autofix (removing the assertion would widen the type back).
+    {
+      code: `
+export type PartyKitStorage = {
+  list<T = unknown>(): Promise<Map<string, T>>;
+};
+declare const db: PartyKitStorage;
+export async function levelGet() {
+  return (await db.list()) as Map<string, Uint8Array>;
+}
+      `,
+      errors: [{ messageId: 'unnecessaryAssertionOnGenericCall' }],
+      output: null,
+    },
+    {
+      code: `
+declare function get<T = unknown>(): T;
+const x = get() as string;
+      `,
+      errors: [{ messageId: 'unnecessaryAssertionOnGenericCall' }],
+      output: null,
+    },
+    // Control: the type parameter is used in a parameter, so it is inferred from
+    // the argument rather than backfilled. The original message/fix still apply.
+    {
+      code: `
+declare function identity<T>(x: T): T;
+declare const s: string;
+const y = identity(s) as string;
+      `,
+      errors: [{ messageId: 'unnecessaryAssertion' }],
+      output: `
+declare function identity<T>(x: T): T;
+declare const s: string;
+const y = identity(s);
+      `,
+    },
+    // Control: the type argument is written explicitly, so the standard message
+    // and autofix are appropriate.
+    {
+      code: `
+export type Store = { get<T = unknown>(): T };
+declare const store: Store;
+const v = store.get<string>() as string;
+      `,
+      errors: [{ messageId: 'unnecessaryAssertion' }],
+      output: `
+export type Store = { get<T = unknown>(): T };
+declare const store: Store;
+const v = store.get<string>();
       `,
     },
   ],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://typescript-eslint.io/contributing/ai-policy/)

## Overview

`no-unnecessary-type-assertion` currently prints the generic "this assertion does not change the type" message for a case where the assertion is actually doing something. When a generic call's type parameter is used only in the return position (e.g. `list<T = unknown>(): Promise<Map<string, T>>`), TypeScript backfills the type argument from a following assertion. So in the issue's repro, `(await db.list()) as Map<string, Uint8Array>` looks type-unchanged to the rule, and the message misleads you into thinking the assertion is pointless.

This adds a dedicated message for that pattern that points at the real fix — pass the type argument to the call explicitly, e.g. `db.list<Uint8Array>()`. I deliberately don't offer an autofix in this case, because removing the assertion would widen the type back to the generic default and can break downstream code.

Detection is narrow and only runs at the existing report site: an (optionally `await`-ed) call, with no explicit type arguments written, whose resolved signature declares a type parameter that never appears in any parameter. A type parameter that isn't referenced by any parameter can only be inferred from the return position (or its default), which is exactly the backfill case.

I kept the scope to the message (and dropping the unsafe autofix) for this pattern. It intentionally leaves the broader false-positive / autofix discussion in #10722 alone.

### Tests

- The issue's repro (`await db.list()` returned as `Map<string, Uint8Array>`) -> new message, no autofix.
- A non-`await`ed variant of the same pattern.
- Control: type parameter used in a parameter (inferred from the argument, not backfilled) -> original message and autofix unchanged.
- Control: explicit type argument already written -> original message and autofix unchanged.
- Valid: the recommended explicit-type-argument form.

:sparkling_heart:
